### PR TITLE
Prevent cmd.exe shell windows popping up in the background when calling subprocess

### DIFF
--- a/spyderlib/interpreter.py
+++ b/spyderlib/interpreter.py
@@ -16,12 +16,11 @@ import os
 import re
 import os.path as osp
 import pydoc
-from subprocess import Popen, PIPE
 from code import InteractiveConsole
 
 # Local imports:
 from spyderlib.utils.dochelpers import isdefined
-from spyderlib.utils import encoding
+from spyderlib.utils import encoding, programs
 from spyderlib.py3compat import is_text_string, getcwd
 from spyderlib.utils.misc import remove_backslashes
 
@@ -211,8 +210,7 @@ has the same effect as typing a particular string at the help> prompt.
         # Execute command
         elif cmd.startswith('!'):
             # System ! command
-            pipe = Popen(cmd[1:], shell=True,
-                         stdin=PIPE, stderr=PIPE, stdout=PIPE)
+            pipe = programs.run_shell_command(cmd[1:])
             txt_out = encoding.transcode( pipe.stdout.read().decode() )
             txt_err = encoding.transcode( pipe.stderr.read().decode().rstrip() )
             if txt_err:

--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -1892,11 +1892,11 @@ class Editor(SpyderPluginWidget):
             else:
                 args = runconf.get_arguments().split()
                 wdir = runconf.get_working_directory()
-                # Handle the case where wdir comes back as an empty string
-                # when the working directory dialog checkbox is unchecked.
-                if not wdir:
-                    wdir = None
-            programs.run_program(WINPDB_PATH, [fname]+args, wdir)
+            # Handle the case where wdir comes back as an empty string
+            # when the working directory dialog checkbox is unchecked.
+            # (subprocess "cwd" default is None, so empty str
+            # must be changed to None in this case.)
+            programs.run_program(WINPDB_PATH, [fname] + args, cwd=wdir or None)
         
     def toggle_eol_chars(self, os_name):
         editor = self.get_current_editor()

--- a/spyderlib/plugins/externalconsole.py
+++ b/spyderlib/plugins/externalconsole.py
@@ -26,7 +26,6 @@ import atexit
 import os
 import os.path as osp
 import sys
-import subprocess
 
 # Local imports
 from spyderlib.config.base import SCIENTIFIC_STARTUP, running_in_mac_app, _
@@ -362,10 +361,9 @@ class ExternalConsoleConfigPage(PluginConfigPage):
             return
         spyder_version = sys.version_info[0]
         try:
-            cmd = [pyexec, "-c", "import sys; print(sys.version_info[0])"]
-            # subprocess.check_output is not present in python2.6 and 3.0
-            process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-            console_version = int(process.communicate()[0])
+            args = ["-c", "import sys; print(sys.version_info[0])"]
+            proc = programs.run_program(pyexec, args)
+            console_version = int(proc.communicate()[0])
         except IOError:
             console_version = spyder_version
         if spyder_version != console_version:

--- a/spyderlib/utils/codeanalysis.py
+++ b/spyderlib/utils/codeanalysis.py
@@ -11,7 +11,6 @@ Source code analysis utilities
 import sys
 import re
 import os
-from subprocess import Popen, PIPE
 import tempfile
 import traceback
 
@@ -144,8 +143,10 @@ def check(args, source_code, filename=None, options=None):
         args.append(tempfd.name)
     else:
         args.append(filename)
-    output = Popen(args, stdout=PIPE, stderr=PIPE
-                   ).communicate()[0].strip().decode().splitlines()
+    cmd = args[0]
+    cmdargs = args[1:]
+    proc = programs.run_program(cmd, cmdargs)
+    output = proc.communicate()[0].strip().decode().splitlines()
     if filename is None:
         os.unlink(tempfd.name)
     results = []

--- a/spyderlib/utils/programs.py
+++ b/spyderlib/utils/programs.py
@@ -23,6 +23,10 @@ from spyderlib.utils import encoding
 from spyderlib.py3compat import PY2, is_text_string
 
 
+class ProgramError(Exception):
+    pass
+
+
 if os.name == 'nt':
     TEMPDIR = tempfile.gettempdir() + osp.sep + 'spyder'
 else:
@@ -55,13 +59,93 @@ def find_program(basename):
             return path
 
 
-def run_program(name, args=[], cwd=None):
-    """Run program in a separate process"""
-    assert isinstance(args, (tuple, list))
-    path = find_program(name)
-    if not path:
-        raise RuntimeError("Program %s was not found" % name)
-    subprocess.Popen([path]+args, cwd=cwd)
+def alter_subprocess_kwargs_by_platform(**kwargs):
+    """Given a dict, populate kwargs to create a generally
+    useful default setup for running subprocess processes
+    on different platforms. For example, `close_fds` is
+    set on posix and creation of a new console window is
+    disabled on Windows.
+
+    This function will alter the given kwargs and return
+    the modified dict."""
+    kwargs.setdefault('close_fds', os.name == 'posix')
+    if os.name == 'nt':
+        CONSOLE_CREATION_FLAGS = 0  # Default value
+        # Add more here..
+        # See: https://msdn.microsoft.com/en-us/library/windows/desktop/ms684863%28v=vs.85%29.aspx
+        CREATE_NO_WINDOW = 0x08000000
+        # We "or" them together
+        CONSOLE_CREATION_FLAGS |= CREATE_NO_WINDOW
+        kwargs.setdefault('creationflags', CONSOLE_CREATION_FLAGS)
+    return kwargs
+
+
+def run_shell_command(cmdstr, **subprocess_kwargs):
+    """ Execute the given shell command. Note that *args and
+    **kwargs will be passed to the subprocess call.
+
+    If 'shell' is given in subprocess_kwargs it must be True,
+    otherwise ProgramError will be raised.
+    .
+    If 'executable' is not given in subprocess_kwargs, it will
+    be set to the value of the SHELL environment variable.
+
+    Note that stdin, stdout and stderr will be set by default
+    to PIPE unless specified in subprocess_kwargs.
+
+    :str cmdstr: The string run as a shell command.
+    :subprocess_kwargs: These will be passed to subprocess.Popen."""
+    if 'shell' in subprocess_kwargs and not subprocess_kwargs['shell']:
+        raise ProgramError(
+                'The "shell" kwarg may be omitted, but if '
+                'provided it must be True.')
+    else:
+        subprocess_kwargs['shell'] = True
+
+    if 'executable' not in subprocess_kwargs:
+        subprocess_kwargs['executable'] = os.getenv('SHELL')
+
+    for stream in ['stdin', 'stdout', 'stderr']:
+        subprocess_kwargs.setdefault(stream, subprocess.PIPE)
+    subprocess_kwargs = alter_subprocess_kwargs_by_platform(
+            **subprocess_kwargs)
+    return subprocess.Popen(cmdstr, **subprocess_kwargs)
+
+
+def run_program(program, args=None, **subprocess_kwargs):
+    """Run program in a separate process.
+
+    NOTE: returns the process object created by
+    `subprocess.Popen()`. This can be used with
+    `proc.communicate()` for example.
+
+    If 'shell' appears in the kwargs, it must be False,
+    otherwise ProgramError will be raised.
+
+    If only the program name is given and not the full path,
+    a lookup will be performed to find the program. If the
+    lookup fails, ProgramError will be raised.
+
+    Note that stdin, stdout and stderr will be set by default
+    to PIPE unless specified in subprocess_kwargs.
+
+    :str program: The name of the program to run.
+    :list args: The program arguments.
+    :subprocess_kwargs: These will be passed to subprocess.Popen."""
+    if 'shell' in subprocess_kwargs and subprocess_kwargs['shell']:
+        raise ProgramError(
+                "This function is only for non-shell programs, "
+                "use run_shell_command() instead.")
+    fullcmd = find_program(program)
+    if not fullcmd:
+        raise ProgramError("Program %s was not found" % program)
+    # As per subprocess, we make a complete list of prog+args
+    fullcmd = [fullcmd] + (args or [])
+    for stream in ['stdin', 'stdout', 'stderr']:
+        subprocess_kwargs.setdefault(stream, subprocess.PIPE)
+    subprocess_kwargs = alter_subprocess_kwargs_by_platform(
+            **subprocess_kwargs)
+    return subprocess.Popen(fullcmd, **subprocess_kwargs)
 
 
 def start_file(filename):
@@ -103,7 +187,7 @@ def run_python_script(package=None, module=None, args=[], p_args=[]):
     assert module is not None
     assert isinstance(args, (tuple, list)) and isinstance(p_args, (tuple, list))
     path = python_script_exists(package, module)
-    subprocess.Popen([sys.executable]+p_args+[path]+args)
+    run_program(sys.executable, p_args + [path] + args)
 
 
 def shell_split(text):
@@ -168,7 +252,7 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
             cmd = encoding.to_fs_from_unicode(cmd)
             wdir = encoding.to_fs_from_unicode(wdir)
         try:
-            subprocess.Popen(cmd, shell=True, cwd=wdir)
+            run_shell_command(cmd, cwd=wdir)
         except WindowsError:
             from spyderlib.qt.QtGui import QMessageBox
             from spyderlib.config.base import _
@@ -302,8 +386,8 @@ def is_module_installed(module_name, version=None, installed_version=None,
                 else:
                     f.write("print(is_module_installed('%s'))" % module_name)
             try:
-                output, _err = subprocess.Popen([interpreter, script],
-                                        stdout=subprocess.PIPE).communicate()
+                proc = run_program(interpreter, [script])
+                output, _err = proc.communicate()
             except subprocess.CalledProcessError:
                 return True
             if output:  # TODO: Check why output could be empty!

--- a/spyderlib/utils/vcs.py
+++ b/spyderlib/utils/vcs.py
@@ -100,10 +100,9 @@ def get_hg_revision(repopath):
            ('eba7273c69df+', '2015+', 'default')
     """
     try:
-        hg = programs.find_program('hg')
-        assert hg is not None and osp.isdir(osp.join(repopath, '.hg'))
-        output, _err = subprocess.Popen([hg, 'id', '-nib', repopath],
-                                        stdout=subprocess.PIPE).communicate()
+        assert osp.isdir(osp.join(repopath, '.hg'))
+        proc = programs.run_program('hg', ['id', '-nib', repopath])
+        output, _err = proc.communicate()
         # output is now: ('eba7273c69df+ 2015+ default\n', None)
         # Split 2 times max to allow spaces in branch names.
         return tuple(output.decode().strip().split(None, 2))
@@ -120,11 +119,8 @@ def get_git_revision(repopath):
     try:
         git = programs.find_program('git')
         assert git is not None and osp.isdir(osp.join(repopath, '.git'))
-
-        # Revision
-        commit = subprocess.Popen([git, 'rev-parse', '--short', 'HEAD'],
-                                  stdout=subprocess.PIPE,
-                                  cwd=repopath).communicate()
+        commit = programs.run_program(git, ['rev-parse', '--short', 'HEAD'],
+                cwd=repopath).communicate()
         commit = commit[0].strip()
         if PY3:
             commit = commit.decode(sys.getdefaultencoding())

--- a/spyderlib/widgets/externalshell/sitecustomize.py
+++ b/spyderlib/widgets/externalshell/sitecustomize.py
@@ -21,6 +21,8 @@ import shlex
 
 PY2 = sys.version[0] == '2'
 
+from spyderlib.utils import programs
+
 
 #==============================================================================
 # sys.argv can be missing when Python is embedded, taking care of it.
@@ -205,7 +207,7 @@ except ImportError:
 
 #==============================================================================
 # Add default filesystem encoding on Linux to avoid an error with
-# Matplotlib 1.5 in Python 2 (Fixes Issue 2793) 
+# Matplotlib 1.5 in Python 2 (Fixes Issue 2793)
 #==============================================================================
 if PY2 and sys.platform.startswith('linux'):
     def _getfilesystemencoding_wrapper():
@@ -866,10 +868,10 @@ def evalsc(command):
             _print(os.getcwd())
     elif command == 'ls':
         if os.name == 'nt':
-            Popen('dir', shell=True, stdin=PIPE)
+            programs.run_shell_command('dir')
             _print('\n')
         else:
-            Popen('ls', shell=True, stdin=PIPE)
+            programs.run_shell_command('ls')
             _print('\n')
     elif command == 'scientific':
         from spyderlib.config import base

--- a/spyderlib/widgets/findinfiles.py
+++ b/spyderlib/widgets/findinfiles.py
@@ -25,10 +25,10 @@ import os
 import re
 import fnmatch
 import os.path as osp
-from subprocess import Popen, PIPE
 import traceback
 
 # Local imports
+from spyderlib.utils import programs
 from spyderlib.utils.vcs import is_hg_installed, get_vcs_root
 from spyderlib.utils.misc import abspardir, get_common_path
 from spyderlib.utils.qthelpers import create_toolbutton, get_filetype_icon
@@ -189,8 +189,7 @@ class SearchThread(QThread):
         return ok
 
     def find_files_in_hg_manifest(self):
-        p = Popen(['hg', 'manifest'], stdout=PIPE,
-                  cwd=self.rootpath, shell=True)
+        p = programs.run_shell_command('hg manifest', cwd=self.rootpath)
         hgroot = get_vcs_root(self.rootpath)
         self.pathlist = [hgroot]
         for path in p.stdout.read().decode().splitlines():

--- a/spyderlib/widgets/internalshell.py
+++ b/spyderlib/widgets/internalshell.py
@@ -21,7 +21,6 @@ builtins.oedit = oedit
 import os
 import threading
 from time import time
-from subprocess import Popen
 
 from spyderlib.qt.QtGui import QMessageBox
 from spyderlib.qt.QtCore import Signal, Slot, QObject, QEventLoop
@@ -32,6 +31,7 @@ from spyderlib.utils.qthelpers import create_action
 from spyderlib.interpreter import Interpreter
 from spyderlib.utils.dochelpers import getargtxt, getsource, getdoc, getobjdir
 from spyderlib.utils.misc import get_error_match
+from spyderlib.utils import programs
 #TODO: remove the CONF object and make it work anyway
 # In fact, this 'CONF' object has nothing to do in package spyderlib.widgets
 # which should not contain anything directly related to Spyder's main app
@@ -298,11 +298,10 @@ class InternalShell(PythonShellWidget):
         editor_path = CONF.get('internal_console', 'external_editor/path')
         goto_option = CONF.get('internal_console', 'external_editor/gotoline')
         try:
+            args = [filename]
             if goto > 0 and goto_option:
-                Popen(r'%s "%s" %s%d' % (editor_path, filename,
-                                         goto_option, goto))
-            else:
-                Popen(r'%s "%s"' % (editor_path, filename))
+                args.append('%s%d'.format(goto_option, goto))
+            programs.run_program(editor_path, args)
         except OSError:
             self.write_error("External editor was not found:"
                              " %s\n" % editor_path)

--- a/spyplugins/ui/pylint/widgets/pylintgui.py
+++ b/spyplugins/ui/pylint/widgets/pylintgui.py
@@ -25,7 +25,6 @@ import os
 import os.path as osp
 import time
 import re
-import subprocess
 
 # Local imports
 from spyderlib import dependencies
@@ -59,13 +58,15 @@ PYLINT_PATH = programs.find_program(PYLINT)
 
 def get_pylint_version():
     """Return pylint version"""
-    global PYLINT_PATH
     if PYLINT_PATH is None:
         return
-    process = subprocess.Popen([PYLINT, '--version'],
-                               stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                               cwd=osp.dirname(PYLINT_PATH),
-                               shell=True if os.name == 'nt' else False)
+    cwd = osp.dirname(PYLINT_PATH)
+    args = ['--version']
+    if os.name == 'nt':
+        cmd = ' '.join([PYLINT] + args)
+        process = programs.run_shell_command(cmd, cwd=cwd)
+    else:
+        process = programs.run_program(PYLINT, args, cwd=cwd)
     lines = to_unicode_from_fs(process.stdout.read()).splitlines()
     if lines:
         regex = '({0}*|pylint-script.py) ([0-9\.]*)'.format(PYLINT)


### PR DESCRIPTION
I had many fights with line-endings!  It looks like some of the patch and diff tools between mercurial and git don't respect the various autocrlf settings in dot files.