### PR TITLE
Keybinding Enhancements

### DIFF
--- a/spyderlib/config.py
+++ b/spyderlib/config.py
@@ -111,8 +111,10 @@ NAME_FILTERS = ['*' + _ext for _ext in VALID_EXT + SHOW_EXT if _ext]+\
 # it to open external files
 OPEN_FILES_PORT = 21128
 
-# Ctrl key
-CTRL = "Meta" if sys.platform == 'darwin' else "Ctrl"
+# OS Specific
+WIN = os.name == 'nt'
+MAC = sys.platform == 'darwin'
+CTRL = "Meta" if MAC else "Ctrl"
 
 
 #==============================================================================
@@ -503,9 +505,9 @@ DEFAULTS = [
               # ---- Editor ----
               # -- In codeeditor
               'editor/code completion': CTRL+'+Space',
-              'editor/duplicate line': "Ctrl+Alt+Up" if os.name == 'nt' else \
+              'editor/duplicate line': "Ctrl+Alt+Up" if WIN else \
                                        "Shift+Alt+Up",
-              'editor/copy line': "Ctrl+Alt+Down" if os.name == 'nt' else \
+              'editor/copy line': "Ctrl+Alt+Down" if WIN else \
                                   "Shift+Alt+Down",
               'editor/delete line': 'Ctrl+D',
               'editor/move line up': "Alt+Up",
@@ -514,6 +516,24 @@ DEFAULTS = [
               'editor/toggle comment': "Ctrl+1",
               'editor/blockcomment': "Ctrl+4",
               'editor/unblockcomment': "Ctrl+5",
+              'editor/start of line': "Meta+A",
+              'editor/end of line': "Meta+E",
+              'editor/previous line': "Meta+P",
+              'editor/next line': "Meta+N",
+              'editor/previous char': "Meta+B",
+              'editor/next char': "Meta+F",
+              'editor/previous word': "Meta+Left",
+              'editor/next word': "Meta+Right",
+              'editor/kill to line end': "Meta+K",
+              'editor/kill to line start': "Meta+U",
+              'editor/yank': 'Meta+Y',
+              'editor/rotate kill ring': 'Shift+Meta+Y',
+              'editor/kill previous word': 'Meta+Backspace',
+              'editor/kill next word': 'Meta+D',
+              'editor/start of document': 'Meta+Less' if not MAC else \
+                                          'Ctrl+Up',
+              'editor/end of document': 'Meta+Greater' if not MAC else \
+                                        'Ctrl+Down',
               # -- In widgets/editor
               'editor/inspect current object': 'Ctrl+I',
               'editor/go to line': 'Ctrl+L',
@@ -525,13 +545,21 @@ DEFAULTS = [
               'editor/find next': "F3",
               'editor/find previous': "Shift+F3",
               'editor/replace text': "Ctrl+H",
+              'editor/undo': 'Ctrl+U',
+              'editor/redo': 'Ctrl+Y',
+              'editor/cut': 'Ctrl+X',
+              'editor/copy': 'Ctrl+C',
+              'editor/paste': 'Ctrl+V',
+              'editor/delete': 'Delete',
+              'editor/select all': "Ctrl+A",
               # -- In plugins/editor
               'editor/show/hide outline': "Ctrl+Alt+O",
               'editor/show/hide project explorer': "Ctrl+Alt+P",
               'editor/new file': "Ctrl+N",
               'editor/open file': "Ctrl+O",
               'editor/save file': "Ctrl+S",
-              'editor/save all': "Ctrl+Shift+S",
+              'editor/save all': "Ctrl+Alt+S",
+              'editor/save as': 'Ctrl+Shift+S',
               'editor/print': "Ctrl+P",
               'editor/close all': "Ctrl+Shift+W",
               'editor/breakpoint': 'F12',
@@ -717,7 +745,7 @@ DEFAULTS = [
 # 2. If you want to *remove* options that are no longer needed in our codebase,
 #    you need to do a MAJOR update in version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '17.0.0'
+CONF_VERSION = '17.1.0'
 
 # XXX: Previously we had load=(not DEV) here but DEV was set to *False*.
 # Check if it *really* needs to be updated or not

--- a/spyderlib/config.py
+++ b/spyderlib/config.py
@@ -530,10 +530,8 @@ DEFAULTS = [
               'editor/rotate kill ring': 'Shift+Meta+Y',
               'editor/kill previous word': 'Meta+Backspace',
               'editor/kill next word': 'Meta+D',
-              'editor/start of document': 'Meta+Less' if not MAC else \
-                                          'Ctrl+Up',
-              'editor/end of document': 'Meta+Greater' if not MAC else \
-                                        'Ctrl+Down',
+              'editor/start of document': 'Ctrl+Up',
+              'editor/end of document': 'Ctrl+Down',
               # -- In widgets/editor
               'editor/inspect current object': 'Ctrl+I',
               'editor/go to line': 'Ctrl+L',

--- a/spyderlib/config.py
+++ b/spyderlib/config.py
@@ -743,7 +743,7 @@ DEFAULTS = [
 # 2. If you want to *remove* options that are no longer needed in our codebase,
 #    you need to do a MAJOR update in version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '17.1.0'
+CONF_VERSION = '18.1.0'
 
 # XXX: Previously we had load=(not DEV) here but DEV was set to *False*.
 # Check if it *really* needs to be updated or not

--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -640,6 +640,8 @@ class Editor(SpyderPluginWidget):
         save_as_action = create_action(self, _("Save &as..."), None,
                 'filesaveas.png', _("Save current file as..."),
                 triggered=self.save_as)
+        self.register_shortcut(save_as_action, "Editor", "Save As")
+
         print_preview_action = create_action(self, _("Print preview..."),
                 tip=_("Print preview..."), triggered=self.print_preview)
         self.print_action = create_action(self, _("&Print..."),
@@ -651,6 +653,7 @@ class Editor(SpyderPluginWidget):
         self.close_action = create_action(self, _("&Close"),
                 icon='fileclose.png', tip=_("Close current file"),
                 triggered=self.close_file)
+
         self.close_all_action = create_action(self, _("C&lose all"),
                 icon='filecloseall.png', tip=_("Close all opened files"),
                 triggered=self.close_all_files)

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -592,33 +592,45 @@ class MainWindow(QMainWindow):
                                             context=Qt.WidgetShortcut)
             self.register_shortcut(self.replace_action, "Editor",
                                    "Replace text")
+
             def create_edit_action(text, tr_text, icon_name):
                 textseq = text.split(' ')
                 method_name = textseq[0].lower()+"".join(textseq[1:])
-                return create_action(self, tr_text,
-                                     shortcut=keybinding(text.replace(' ', '')),
-                                     icon=get_icon(icon_name),
-                                     triggered=self.global_callback,
-                                     data=method_name,
-                                     context=Qt.WidgetShortcut)
+                action = create_action(self, tr_text,
+                                    shortcut=keybinding(text.replace(' ', '')),
+                                    icon=get_icon(icon_name),
+                                    triggered=self.global_callback,
+                                    data=method_name,
+                                    context=Qt.WidgetShortcut)
+                self.register_shortcut(action, "Editor", text)
+                return action
+
             self.undo_action = create_edit_action("Undo", _("Undo"),
                                                   'undo.png')
+
             self.redo_action = create_edit_action("Redo", _("Redo"), 'redo.png')
+
             self.copy_action = create_edit_action("Copy", _("Copy"),
                                                   'editcopy.png')
+
             self.cut_action = create_edit_action("Cut", _("Cut"), 'editcut.png')
+
             self.paste_action = create_edit_action("Paste", _("Paste"),
                                                    'editpaste.png')
+
             self.delete_action = create_edit_action("Delete", _("Delete"),
                                                     'editdelete.png')
+
             self.selectall_action = create_edit_action("Select All",
                                                        _("Select All"),
                                                        'selectall.png')
+
             self.edit_menu_actions = [self.undo_action, self.redo_action,
                                       None, self.cut_action, self.copy_action,
                                       self.paste_action, self.delete_action,
                                       None, self.selectall_action]
-            self.search_menu_actions = [self.find_action, self.find_next_action,
+            self.search_menu_actions = [self.find_action, 
+                                        self.find_next_action,
                                         self.find_previous_action,
                                         self.replace_action]
             self.search_toolbar_actions = [self.find_action,

--- a/spyderlib/widgets/editor.py
+++ b/spyderlib/widgets/editor.py
@@ -547,13 +547,15 @@ class EditorStack(QWidget):
                               name='Go to previous file', parent=self)
         tabshift = create_shortcut(self.go_to_next_file, context='Editor',
                                    name='Go to next file', parent=self)
+
         # Fixed shortcuts
         new_shortcut(QKeySequence.ZoomIn, self, lambda: self.zoom_in.emit())
         new_shortcut("Ctrl+=", self, lambda: self.zoom_in.emit())
         new_shortcut(QKeySequence.ZoomOut, self, lambda: self.zoom_out.emit())
         new_shortcut("Ctrl+0", self, lambda: self.zoom_reset.emit())
-        new_shortcut("Ctrl+W", self, lambda: self.sig_close_file[()].emit())
         new_shortcut("Ctrl+F4", self, lambda: self.sig_close_file[()].emit())
+        new_shortcut("Ctrl+W", self, lambda: self.sig_close_file[()].emit())
+
         # Return configurable ones
         return [inspect, breakpoint, cbreakpoint, gotoline, filelist, tab,
                 tabshift]

--- a/spyderlib/widgets/sourcecode/kill_ring.py
+++ b/spyderlib/widgets/sourcecode/kill_ring.py
@@ -1,0 +1,132 @@
+""" A generic Emacs-style kill ring, as well as a Qt-specific version.
+Copyright (c) 2001-2015, IPython Development Team
+Copyright (c) 2015-, Jupyter Development Team
+All rights reserved.
+"""
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# System library imports
+from spyderlib.qt import QtCore, QtGui
+
+#-----------------------------------------------------------------------------
+# Classes
+#-----------------------------------------------------------------------------
+
+class KillRing(object):
+    """ A generic Emacs-style kill ring.
+    """
+
+    def __init__(self):
+        self.clear()
+
+    def clear(self):
+        """ Clears the kill ring.
+        """
+        self._index = -1
+        self._ring = []
+
+    def kill(self, text):
+        """ Adds some killed text to the ring.
+        """
+        self._ring.append(text)
+
+    def yank(self):
+        """ Yank back the most recently killed text.
+
+        Returns
+        -------
+        A text string or None.
+        """
+        self._index = len(self._ring)
+        return self.rotate()
+
+    def rotate(self):
+        """ Rotate the kill ring, then yank back the new top.
+
+        Returns
+        -------
+        A text string or None.
+        """
+        self._index -= 1
+        if self._index >= 0:
+            return self._ring[self._index]
+        return None
+
+
+class QtKillRing(QtCore.QObject):
+    """ A kill ring attached to Q[Plain]TextEdit.
+    """
+
+    #--------------------------------------------------------------------------
+    # QtKillRing interface
+    #--------------------------------------------------------------------------
+
+    def __init__(self, text_edit):
+        """ Create a kill ring attached to the specified Qt text edit.
+        """
+        assert isinstance(text_edit, (QtGui.QTextEdit, QtGui.QPlainTextEdit))
+        super(QtKillRing, self).__init__()
+
+        self._ring = KillRing()
+        self._prev_yank = None
+        self._skip_cursor = False
+        self._text_edit = text_edit
+
+        text_edit.cursorPositionChanged.connect(self._cursor_position_changed)
+
+    def clear(self):
+        """ Clears the kill ring.
+        """
+        self._ring.clear()
+        self._prev_yank = None
+
+    def kill(self, text):
+        """ Adds some killed text to the ring.
+        """
+        self._ring.kill(text)
+
+    def kill_cursor(self, cursor):
+        """ Kills the text selected by the give cursor.
+        """
+        text = cursor.selectedText()
+        if text:
+            cursor.removeSelectedText()
+            self.kill(text)
+
+    def yank(self):
+        """ Yank back the most recently killed text.
+        """
+        text = self._ring.yank()
+        if text:
+            self._skip_cursor = True
+            cursor = self._text_edit.textCursor()
+            cursor.insertText(text)
+            self._prev_yank = text
+
+    def rotate(self):
+        """ Rotate the kill ring, then yank back the new top.
+        """
+        if self._prev_yank:
+            text = self._ring.rotate()
+            if text:
+                self._skip_cursor = True
+                cursor = self._text_edit.textCursor()
+                cursor.movePosition(QtGui.QTextCursor.Left,
+                                    QtGui.QTextCursor.KeepAnchor,
+                                    n=len(self._prev_yank))
+                cursor.insertText(text)
+                self._prev_yank = text
+
+    #--------------------------------------------------------------------------
+    # Protected interface
+    #--------------------------------------------------------------------------
+
+    #------ Signal handlers ----------------------------------------------------
+
+    def _cursor_position_changed(self):
+        if self._skip_cursor:
+            self._skip_cursor = False
+        else:
+            self._prev_yank = None


### PR DESCRIPTION
Fixes #729
Fixes #1212
Fixes #2047
Fixes #2347

----

Adds the following keybindings, including kill-ring support:

```python
              'editor/start of line': "Meta+A",
              'editor/end of line': "Meta+E",
              'editor/previous line': "Meta+P",
              'editor/next line': "Meta+N",
              'editor/previous char': "Meta+B",
              'editor/next char': "Meta+F",
              'editor/previous word': "Meta+Left",
              'editor/next word': "Meta+Right",
              'editor/kill to line end': "Meta+K",
              'editor/kill to line start': "Meta+U",
              'editor/yank': 'Meta+Y',
              'editor/rotate kill ring': 'Shift+Meta+Y',
              'editor/kill previous word': 'Meta+Backspace',
              'editor/kill next word': 'Meta+D',
              'editor/start of document': 'Ctrl+Up',
              'editor/end of document': 'Ctrl+Down',
```

Also makes the follow existing key sequences configurable:

```python
              'editor/undo': 'Ctrl+U',
              'editor/redo': 'Ctrl+Y',
              'editor/cut': 'Ctrl+X',
              'editor/copy': 'Ctrl+C',
              'editor/paste': 'Ctrl+V',
              'editor/delete': 'Del',
              'editor/select All': "Ctrl+A",
              'editor/save as': 'Ctrl+Shift+S',
```

The only changed shortcut is

```python
              'editor/save all': 'Ctrl+Alt+S',
```