### PR TITLE
Open configuration file with utf-8 encoding on Windows and Python 2 

### DIFF
--- a/spyderlib/userconfig.py
+++ b/spyderlib/userconfig.py
@@ -48,6 +48,8 @@ from spyderlib.utils.programs import check_version
 from spyderlib.py3compat import configparser as cp
 from spyderlib.py3compat import PY2, is_text_string, to_text_string
 
+if PY2:
+    import codecs
 
 #==============================================================================
 # Auxiliary classes
@@ -113,7 +115,7 @@ class DefaultsConfig(cp.ConfigParser):
         def _write_file(fname):
             if PY2:
                 # Python 2
-                with open(fname, 'w') as configfile:
+                with codecs.open(fname, 'w', encoding='utf-8') as configfile:
                     self._write(configfile)
             else:
                 # Python 3
@@ -251,7 +253,8 @@ class UserConfig(DefaultsConfig):
         try:
             if PY2:
                 # Python 2
-                self.read(self.filename())
+                with codecs.open(self.filename(), encoding='utf-8') as configfile:
+                    self.readfp(configfile)
             else:
                 # Python 3
                 self.read(self.filename(), encoding='utf-8')

--- a/spyderlib/userconfig.py
+++ b/spyderlib/userconfig.py
@@ -49,7 +49,7 @@ from spyderlib.py3compat import configparser as cp
 from spyderlib.py3compat import PY2, is_text_string, to_text_string
 
 if PY2:
-    import io
+    import codecs
 
 #==============================================================================
 # Auxiliary classes
@@ -115,7 +115,7 @@ class DefaultsConfig(cp.ConfigParser):
         def _write_file(fname):
             if PY2:
                 # Python 2
-                with io.open(fname, 'w', encoding='utf-8') as configfile:
+                with codecs.open(fname, 'w', encoding='utf-8') as configfile:
                     self._write(configfile)
             else:
                 # Python 3
@@ -256,7 +256,7 @@ class UserConfig(DefaultsConfig):
                 fname = self.filename()
                 if osp.isfile(fname):
                     try:
-                        with io.open(fname, encoding='utf-8') as configfile:
+                        with codecs.open(fname, encoding='utf-8') as configfile:
                             self.readfp(configfile)
                     except IOError:
                         print("Failed reading file", fname)

--- a/spyderlib/userconfig.py
+++ b/spyderlib/userconfig.py
@@ -253,8 +253,13 @@ class UserConfig(DefaultsConfig):
         try:
             if PY2:
                 # Python 2
-                with codecs.open(self.filename(), encoding='utf-8') as configfile:
-                    self.readfp(configfile)
+                fname = self.filename()
+                if osp.isfile(fname):
+                    try:
+                        with codecs.open(fname, encoding='utf-8') as configfile:
+                            self.readfp(configfile)
+                    except IOError:
+                        print("Failed reading file", fname)
             else:
                 # Python 3
                 self.read(self.filename(), encoding='utf-8')

--- a/spyderlib/userconfig.py
+++ b/spyderlib/userconfig.py
@@ -49,7 +49,7 @@ from spyderlib.py3compat import configparser as cp
 from spyderlib.py3compat import PY2, is_text_string, to_text_string
 
 if PY2:
-    import codecs
+    import io
 
 #==============================================================================
 # Auxiliary classes
@@ -115,7 +115,7 @@ class DefaultsConfig(cp.ConfigParser):
         def _write_file(fname):
             if PY2:
                 # Python 2
-                with codecs.open(fname, 'w', encoding='utf-8') as configfile:
+                with io.open(fname, 'w', encoding='utf-8') as configfile:
                     self._write(configfile)
             else:
                 # Python 3
@@ -256,7 +256,7 @@ class UserConfig(DefaultsConfig):
                 fname = self.filename()
                 if osp.isfile(fname):
                     try:
-                        with codecs.open(fname, encoding='utf-8') as configfile:
+                        with io.open(fname, encoding='utf-8') as configfile:
                             self.readfp(configfile)
                     except IOError:
                         print("Failed reading file", fname)


### PR DESCRIPTION
This change is related to issue 2081 for the case when user home directory contains non-ascii characters and Spyder reads/writes INI file into that directory.
This change does NOT resolve the issue 2081 (there are cases with non-ascii working directory and plus some dependencies out of Spyder codebase).
This change seems failsafe.

Fixes #2081