### PR TITLE
Changed the IPython completion option from a checkbox to a combobox

### DIFF
--- a/spyderlib/config.py
+++ b/spyderlib/config.py
@@ -271,7 +271,7 @@ DEFAULTS = [
               'font/italic': False,
               'font/bold': False,
               'show_banner': True,
-              'use_gui_completion': True,
+              'completion_widget': 0,
               'use_pager': False,
               'show_calltips': True,
               'ask_before_closing': True,

--- a/spyderlib/config.py
+++ b/spyderlib/config.py
@@ -715,7 +715,7 @@ DEFAULTS = [
 # 2. If you want to *remove* options that are no longer needed in our codebase,
 #    you need to do a MAJOR update in version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '16.1.0'
+CONF_VERSION = '17.0.0'
 
 # XXX: Previously we had load=(not DEV) here but DEV was set to *False*.
 # Check if it *really* needs to be updated or not

--- a/spyderlib/config.py
+++ b/spyderlib/config.py
@@ -271,7 +271,7 @@ DEFAULTS = [
               'font/italic': False,
               'font/bold': False,
               'show_banner': True,
-              'completion_widget': 0,
+              'completion_type': 0,
               'use_pager': False,
               'show_calltips': True,
               'ask_before_closing': True,

--- a/spyderlib/plugins/ipythonconsole.py
+++ b/spyderlib/plugins/ipythonconsole.py
@@ -161,10 +161,6 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         banner_box = newcb(_("Display initial banner"), 'show_banner',
                       tip=_("This option lets you hide the message shown at\n"
                             "the top of the console when it's opened."))
-        gui_comp_box = newcb(_("Use a completion widget"),
-                             'use_gui_completion',
-                             tip=_("Use a widget instead of plain text "
-                                   "output for tab completion"))
         pager_box = newcb(_("Use a pager to display additional text inside "
                             "the console"), 'use_pager',
                             tip=_("Useful if you don't want to fill the "
@@ -177,11 +173,21 @@ class IPythonConsoleConfigPage(PluginConfigPage):
 
         interface_layout = QVBoxLayout()
         interface_layout.addWidget(banner_box)
-        interface_layout.addWidget(gui_comp_box)
         interface_layout.addWidget(pager_box)
         interface_layout.addWidget(calltips_box)
         interface_layout.addWidget(ask_box)
         interface_group.setLayout(interface_layout)
+
+        comp_group = QGroupBox(_("Completion Widget"))
+        comp_label = QLabel(_("Decide what type of completion to use"))
+        comp_label.setWordWrap(True)
+        completers = [("plain", 0), ("droplist", 1), ("ncurses", 2)]
+        comp_box = self.create_combobox(_("Completion:")+"   ", completers,
+                                        'completion_widget', default=0)
+        comp_layout = QVBoxLayout()
+        comp_layout.addWidget(comp_label)
+        comp_layout.addWidget(comp_box)
+        comp_group.setLayout(comp_layout)
 
         # Background Color Group
         bg_group = QGroupBox(_("Background color"))
@@ -435,8 +441,8 @@ class IPythonConsoleConfigPage(PluginConfigPage):
 
         # --- Tabs organization ---
         tabs = QTabWidget()
-        tabs.addTab(self.create_tab(font_group, interface_group, bg_group,
-                                    source_code_group), _("Display"))
+        tabs.addTab(self.create_tab(font_group, interface_group, comp_group,
+                                    bg_group, source_code_group), _("Display"))
         tabs.addTab(self.create_tab(pylab_group, backend_group, inline_group),
                                     _("Graphics"))
         tabs.addTab(self.create_tab(run_lines_group, run_file_group),

--- a/spyderlib/plugins/ipythonconsole.py
+++ b/spyderlib/plugins/ipythonconsole.py
@@ -178,12 +178,12 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         interface_layout.addWidget(ask_box)
         interface_group.setLayout(interface_layout)
 
-        comp_group = QGroupBox(_("Completion Widget"))
+        comp_group = QGroupBox(_("Completion Type"))
         comp_label = QLabel(_("Decide what type of completion to use"))
         comp_label.setWordWrap(True)
         completers = [("Graphical", 0), ("Terminal", 1), ("Plain", 2)]
         comp_box = self.create_combobox(_("Completion:")+"   ", completers,
-                                        'completion_widget', default=0)
+                                        'completion_type', default=0)
         comp_layout = QVBoxLayout()
         comp_layout.addWidget(comp_label)
         comp_layout.addWidget(comp_box)

--- a/spyderlib/plugins/ipythonconsole.py
+++ b/spyderlib/plugins/ipythonconsole.py
@@ -181,7 +181,7 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         comp_group = QGroupBox(_("Completion Widget"))
         comp_label = QLabel(_("Decide what type of completion to use"))
         comp_label.setWordWrap(True)
-        completers = [("plain", 0), ("droplist", 1), ("ncurses", 2)]
+        completers = [("Graphical", 0), ("Terminal", 1), ("Plain", 2)]
         comp_box = self.create_combobox(_("Completion:")+"   ", completers,
                                         'completion_widget', default=0)
         comp_layout = QVBoxLayout()

--- a/spyderlib/widgets/ipython.py
+++ b/spyderlib/widgets/ipython.py
@@ -682,9 +682,9 @@ class IPythonClient(QWidget, SaveHistoryMixin):
         spy_cfg.IPythonWidget.kind = 'rich'
         
         # Gui completion widget
-        completion_widget_o = CONF.get('ipython_console', 'completion_widget')
+        completion_type_o = CONF.get('ipython_console', 'completion_type')
         completions = {0: "droplist", 1: "ncurses", 2: "plain"}
-        spy_cfg.IPythonWidget.gui_completion = completions[completion_widget_o]
+        spy_cfg.IPythonWidget.gui_completion = completions[completion_type_o]
 
         # Pager
         pager_o = self.get_option('use_pager')

--- a/spyderlib/widgets/ipython.py
+++ b/spyderlib/widgets/ipython.py
@@ -683,7 +683,7 @@ class IPythonClient(QWidget, SaveHistoryMixin):
         
         # Gui completion widget
         completion_widget_o = CONF.get('ipython_console', 'completion_widget')
-        completions = {0: "plain", 1: "droplist", 2: "ncurses"}
+        completions = {0: "droplist", 1: "ncurses", 2: "plain"}
         spy_cfg.IPythonWidget.gui_completion = completions[completion_widget_o]
 
         # Pager

--- a/spyderlib/widgets/ipython.py
+++ b/spyderlib/widgets/ipython.py
@@ -682,9 +682,9 @@ class IPythonClient(QWidget, SaveHistoryMixin):
         spy_cfg.IPythonWidget.kind = 'rich'
         
         # Gui completion widget
-        gui_comp_o = self.get_option('use_gui_completion')
-        completions = {True: 'droplist', False: 'ncurses'}
-        spy_cfg.IPythonWidget.gui_completion = completions[gui_comp_o]
+        completion_widget_o = CONF.get('ipython_console', 'completion_widget')
+        completions = {0: "plain", 1: "droplist", 2: "ncurses"}
+        spy_cfg.IPythonWidget.gui_completion = completions[completion_widget_o]
 
         # Pager
         pager_o = self.get_option('use_pager')


### PR DESCRIPTION
I dislike both the `droplist` and `ncurses` completers. It seems to me to be an omission that there is no way (short of patching the source) to select the `plain` tab completion.

This PR changes the completion checkbox into a combobox which gives the user the option of all three possible completers.