### PR TITLE
Don't add invalid paths to IMG_PATH

### DIFF
--- a/spyderlib/baseconfig.py
+++ b/spyderlib/baseconfig.py
@@ -179,9 +179,9 @@ def add_image_path(path):
         return
     global IMG_PATH
     IMG_PATH.append(path)
-    for _root, dirs, _files in os.walk(path):
-        for dir in dirs:
-            IMG_PATH.append(osp.join(path, dir))
+    for dirpath, dirnames, _filenames in os.walk(path):
+        for dirname in dirnames:
+            IMG_PATH.append(osp.join(dirpath, dirname))
 
 add_image_path(get_module_data_path('spyderlib', relpath='images'))
 


### PR DESCRIPTION
This happens to work today because directories are only one level deep
under images so "path" was always the same as "_root".

Also, rename variables to match os.walk's documentation.