### PR TITLE
Try to avoid crashes on long output into Python console in a short time

### DIFF
--- a/spyderlib/widgets/externalshell/baseshell.py
+++ b/spyderlib/widgets/externalshell/baseshell.py
@@ -291,7 +291,6 @@ class ExternalShellBase(QWidget):
     
     def write_output(self):
         self.shell.write(self.get_stdout(), flush=True)
-        QApplication.processEvents()
         
     def send_to_process(self, qstr):
         raise NotImplementedError


### PR DESCRIPTION
Fixing crashes on very long output being written to the console in a short time.

Fixes #2251