### PR TITLE
Hide menu icons on Mac OS X

### DIFF
--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -79,7 +79,7 @@ from spyderlib.qt.QtGui import (QApplication, QMainWindow, QSplashScreen,
                                 QKeySequence, QDockWidget, QAction,
                                 QDesktopServices)
 from spyderlib.qt.QtCore import (Signal, QPoint, Qt, QSize, QByteArray, QUrl,
-                                 Slot, QTimer)
+                                 Slot, QTimer, QCoreApplication)
 from spyderlib.qt.compat import (from_qvariant, getopenfilename,
                                  getsavefilename)
 # Avoid a "Cannot mix incompatible Qt library" error on Windows platforms
@@ -2781,6 +2781,7 @@ def run_spyder(app, options, args):
     # Open external files with our Mac app
     if running_in_mac_app():
         app.sig_open_external_file.connect(main.open_external_file)
+        QCoreApplication.setAttribute(Qt.AA_DontShowIconsInMenus, True)
 
     # To give focus again to the last focused widget after restoring
     # the window

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -2778,10 +2778,13 @@ def run_spyder(app, options, args):
         for a in args:
             main.open_external_file(a)
 
+    # Don't show icons in menus for Mac
+    if sys.platform == 'darwin':
+        QCoreApplication.setAttribute(Qt.AA_DontShowIconsInMenus, True)
+
     # Open external files with our Mac app
     if running_in_mac_app():
         app.sig_open_external_file.connect(main.open_external_file)
-        QCoreApplication.setAttribute(Qt.AA_DontShowIconsInMenus, True)
 
     # To give focus again to the last focused widget after restoring
     # the window


### PR DESCRIPTION
Fixes #2289. The setting works, but I'm not sure if it's in the right place. Strangely, `running_in_mac_app()` returns `False` on my machine.