### PR TITLE
Run selection enabled even with empty selection

### DIFF
--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -2559,7 +2559,6 @@ class CodeEditor(TextEditBaseWidget):
                                                 nbformat is not None)
         self.ipynb_convert_action.setVisible(self.is_json() and \
                                              nbformat is not None)
-        self.run_selection_action.setEnabled(nonempty_selection)
         self.run_selection_action.setVisible(self.is_python())
         self.gotodef_action.setVisible(self.go_to_definition_enabled \
                                        and self.is_python_like())


### PR DESCRIPTION
The context menu editor action for run selection or current line was disabled in case of empty selection, which is not the expected behavior since it runs the current line when the selection is empty.