### PR TITLE
Fixes #2306: Add a restart method

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -48,6 +48,9 @@ parser.add_option('--test-travis', dest="shutdown_time", default=None,
 
 options, args = parser.parse_args()
 
+# Store variable to be used in self.restart (restart spyder instance)
+os.environ['SPYDER_BOOTSTRAP_ARGS'] = str(sys.argv[1:])
+
 assert options.gui in (None, 'pyqt5', 'pyqt', 'pyside'), \
        "Invalid GUI toolkit option '%s'" % options.gui
 

--- a/spyderlib/config.py
+++ b/spyderlib/config.py
@@ -477,6 +477,7 @@ DEFAULTS = [
               '_/save current layout': "Shift+Alt+S",
               '_/toggle default layout': "Shift+Alt+Home",
               '_/layout preferences': "Shift+Alt+P",
+              '_/restart': "Shift+Ctrl+R",
               '_/quit': "Ctrl+Q",
               # -- In plugins/editor
               '_/debug step over': "Ctrl+F10",

--- a/spyderlib/config.py
+++ b/spyderlib/config.py
@@ -477,7 +477,7 @@ DEFAULTS = [
               '_/save current layout': "Shift+Alt+S",
               '_/toggle default layout': "Shift+Alt+Home",
               '_/layout preferences': "Shift+Alt+P",
-              '_/restart': "Shift+Ctrl+R",
+              '_/restart': "Shift+Alt+R",
               '_/quit': "Ctrl+Q",
               # -- In plugins/editor
               '_/debug step over': "Ctrl+F10",

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -18,7 +18,8 @@ import subprocess
 import sys
 import time
 
-from spyderlib.py3compat import to_text_string
+
+PY2 = sys.version[0] == '2'
 
 
 def _is_pid_running_on_windows(pid):
@@ -60,6 +61,25 @@ def is_pid_running(pid):
         return _is_pid_running_on_windows(pid)
     else:
         return _is_pid_running_on_unix(pid)
+
+
+def to_text_string(obj, encoding=None):
+    """Convert `obj` to (unicode) text string"""
+    if PY2:
+        # Python 2
+        if encoding is None:
+            return unicode(obj)
+        else:
+            return unicode(obj, encoding)
+    else:
+        # Python 3
+        if encoding is None:
+            return str(obj)
+        elif isinstance(obj, str):
+            # In case this function is not used properly, this could happen
+            return obj
+        else:
+            return str(obj, encoding)
 
 
 def main():

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -2666,11 +2666,10 @@ class MainWindow(QMainWindow):
         """Quit and Restart Spyder application"""
         # Get start path to use in restart script
         spyder_start_directory  = get_module_path('spyderlib')
-        spyder_folder = osp.split(spyder_start_directory)[0]
-        restart_script = osp.join(spyder_start_directory, 'spyder_restart.py')
+        restart_script = osp.join(spyder_start_directory, 'restart_app.py')
 
         # Get any initial argument passed when spyder was started
-        # Variables defined in bootstrap.py and spyderlib\start_app.py
+        # Note: Variables defined in bootstrap.py and spyderlib\start_app.py
         env = os.environ.copy()
         bootstrap_args = env.pop('SPYDER_BOOTSTRAP_ARGS', None)
         spyder_args = env.pop('SPYDER_ARGS')
@@ -2690,7 +2689,6 @@ class MainWindow(QMainWindow):
         env['SPYDER_ARGS'] = spyder_args
         env['SPYDER_PID'] = str(pid)
         env['SPYDER_IS_BOOTSTRAP'] = str(is_bootstrap)
-        env['SPYDER_FOLDER'] = spyder_folder
 
         # Build the command and popen arguments depending on the OS
         if os.name == 'nt':
@@ -2711,7 +2709,8 @@ class MainWindow(QMainWindow):
                                  startupinfo=startupinfo)
                 self.console.quit()
         except Exception as error:
-            # Any logger we can use in case there is an error?
+            # If there is an error with subprocess, Spyder should not quit and
+            # the error can be inspected in the internal console
             print(error)
             print(command)
 

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright © 2009-2013 Pierre Raybaut
+# Copyright © 2013-2015 The Spyder Development Team
 # Licensed under the terms of the MIT License
 # (see spyderlib/__init__.py for details)
 
@@ -119,7 +120,7 @@ from spyderlib import __version__, __project_url__, __forum_url__, get_versions
 from spyderlib.baseconfig import (get_conf_path, get_module_data_path,
                                   get_module_source_path, STDERR, DEBUG, DEV,
                                   debug_print, TEST, SUBFOLDER, MAC_APP_NAME,
-                                  running_in_mac_app)
+                                  running_in_mac_app, get_module_path)
 from spyderlib.config import CONF, EDIT_EXT, IMPORT_EXT, OPEN_FILES_PORT
 from spyderlib.cli_options import get_options
 from spyderlib import dependencies
@@ -2662,9 +2663,9 @@ class MainWindow(QMainWindow):
 
     # ---- Quit and restart
     def restart(self):
-        """ """
+        """Quit and Restart Spyder application"""
         # Get start path to use in restart script
-        spyder_start_directory = osp.dirname(osp.abspath(__file__))
+        spyder_start_directory  = get_module_path('spyderlib')
         spyder_folder = osp.split(spyder_start_directory)[0]
         restart_script = osp.join(spyder_start_directory, 'spyder_restart.py')
 
@@ -2679,39 +2680,38 @@ class MainWindow(QMainWindow):
         python = sys.executable
 
         # Check if started with bootstrap.py
-        is_bootstrap = False
         if bootstrap_args is not None:
             spyder_args = bootstrap_args
             is_bootstrap = True
+        else:
+            is_bootstrap = False
 
-        # Pass args as environment variables to restarter subprocess
+        # Pass variables as environment variables (str) to restarter subprocess
         env['SPYDER_ARGS'] = spyder_args
         env['SPYDER_PID'] = str(pid)
         env['SPYDER_IS_BOOTSTRAP'] = str(is_bootstrap)
         env['SPYDER_FOLDER'] = spyder_folder
 
         # Build the command and popen arguments depending on the OS
-        import platform
-        system = platform.system().lower()
-
-        startupinfo = None
-        if system.startswith('win'):
+        if os.name == 'nt':
+            # Hide flashing command prompt
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             shell = False
-        elif system.startswith('linux'):
-            shell = True
-        elif system.startswith('darwin'):
+        else:
+            startupinfo = None
             shell = True
 
         command = '"{0}" "{1}"'
         command = command.format(python, restart_script)
 
         try:
-            subprocess.Popen(command, shell=shell, env=env,
-                             startupinfo=startupinfo)
-            self.console.quit()
+            if self.closing(True):
+                subprocess.Popen(command, shell=shell, env=env,
+                                 startupinfo=startupinfo)
+                self.console.quit()
         except Exception as error:
+            # Any logger we can use in case there is an error?
             print(error)
             print(command)
 

--- a/spyderlib/spyder_restart.py
+++ b/spyderlib/spyder_restart.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Restart Spyder
+
+A helper script to allow for spyder to restart
+"""
+
+import os
+import os.path as osp
+import sys
+import platform
+import subprocess
+import time
+
+from spyderlib.py3compat import to_text_string
+
+
+def main():
+    # Variables defined in spyderlib\spyder.py 'restart()' method
+    spyder_args = os.environ.pop('SPYDER_ARGS', None)
+    pid = os.environ.pop('SPYDER_PID', None)
+    is_bootstrap = os.environ.pop('SPYDER_IS_BOOTSTRAP', None)
+    spyder_folder = os.environ.pop('SPYDER_FOLDER', None)
+
+    if any([not spyder_args, not pid, not is_bootstrap, not spyder_folder]):
+        error = "This script can only be called from within a Spyder instance"
+        raise RuntimeError(error)
+
+    # Fix variables
+    args = eval(spyder_args)
+    args = ' '.join(args)
+    is_bootstrap = eval(is_bootstrap)
+    pid = eval(pid)
+
+    # Fix args
+    # Maybe --new-instance should always be included to cope with corner cases
+    # where someone has one running version without and and another with
+    # If the user the one without (--new...) it would not start
+
+    python = sys.executable
+
+    # Build the command
+    if is_bootstrap:
+        spyder = osp.join(spyder_folder, 'bootstrap.py')
+    else:
+        spyderlib = osp.join(spyder_folder, 'spyderlib')
+        spyder = osp.join(spyderlib, 'start_app.py')
+
+    command = '"{0}" "{1}" {2}'.format(python, spyder, args)
+
+    # Adjust the command depending on the OS
+    system = platform.system().lower()
+    if system.startswith('win'):
+        shell = False
+        is_pid_running = _is_pid_running_on_windows
+    elif system.startswith('linux'):
+        shell = True
+        is_pid_running = _is_pid_running_on_unix
+    elif system.startswith('darwin'):
+        shell = True
+        is_pid_running = _is_pid_running_on_unix
+
+    # Wait for original process to end before launching the new instance
+    while True:
+        if not is_pid_running(pid):
+            break
+        time.sleep(0.2)
+
+    env = os.environ.copy()
+    try:
+        subprocess.Popen(command, shell=shell, env=env)
+    except Exception as error:
+        print(command)
+        print(error)
+        time.sleep(15)
+
+
+def _is_pid_running_on_windows(pid):
+    """Check For the existence of a windows pid."""
+    pid = str(pid)
+    startupinfo = subprocess.STARTUPINFO()
+    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+    process = subprocess.Popen(r'tasklist /fi "PID eq {0}"'.format(pid),
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT,
+                               startupinfo=startupinfo)
+    stdoutdata, stderrdata = process.communicate()
+    stdoutdata = to_text_string(stdoutdata)
+    process.kill()
+    check = pid in stdoutdata
+    return check
+
+
+def _is_pid_running_on_unix(pid):
+    """Check For the existence of a unix pid."""
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    else:
+        return True
+
+
+if __name__ == '__main__':
+    main()

--- a/spyderlib/spyder_restart.py
+++ b/spyderlib/spyder_restart.py
@@ -1,19 +1,64 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
+# Copyright © 2015 The Spyder Development Team
+# Licensed under the terms of the MIT License
+# (see spyderlib/__init__.py for details)
+
 """
 Restart Spyder
 
 A helper script to allow for spyder to restart
 """
 
+import ast
 import os
 import os.path as osp
 import sys
-import platform
 import subprocess
 import time
 
 from spyderlib.py3compat import to_text_string
+
+
+def _is_pid_running_on_windows(pid):
+    """Check if a process is running on windows systems based on the pid."""
+    pid = str(pid)
+
+    # Hide flashing command prompt
+    startupinfo = subprocess.STARTUPINFO()
+    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+    process = subprocess.Popen(r'tasklist /fi "PID eq {0}"'.format(pid),
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT,
+                               startupinfo=startupinfo)
+    stdoutdata, stderrdata = process.communicate()
+    stdoutdata = to_text_string(stdoutdata)
+    process.kill()
+    check = pid in stdoutdata
+
+    return check
+
+
+def _is_pid_running_on_unix(pid):
+    """Check if a process is running on unix systems based on the pid."""
+    try:
+        # On unix systems os.kill with a 0 as second argument only pokes the
+        # process (if it exists) and does not kill it
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    else:
+        return True
+
+
+def is_pid_running(pid):
+    """Check if a process is running based on the pid."""
+    # Adjust the command and/or arguments to subprocess depending on the OS
+    if os.name == 'nt':
+        return _is_pid_running_on_windows(pid)
+    else:
+        return _is_pid_running_on_unix(pid)
 
 
 def main():
@@ -27,16 +72,20 @@ def main():
         error = "This script can only be called from within a Spyder instance"
         raise RuntimeError(error)
 
-    # Fix variables
-    args = eval(spyder_args)
-    args = ' '.join(args)
-    is_bootstrap = eval(is_bootstrap)
-    pid = eval(pid)
+    # Variables were stored as string literals in the environment, so to use
+    # them we need to parse them.
+    is_bootstrap = ast.literal_eval(is_bootstrap)
+    pid = int(pid)
+    args = ast.literal_eval(spyder_args)
 
-    # Fix args
-    # Maybe --new-instance should always be included to cope with corner cases
-    # where someone has one running version without and and another with
-    # If the user the one without (--new...) it would not start
+    # Enforce the --new-instance flag when running spyder
+    if '--' not in args:
+        args.append('--')
+
+    args.append('--new-instance')
+
+    # Arrange arguments
+    args = ' '.join(args)
 
     python = sys.executable
 
@@ -49,23 +98,17 @@ def main():
 
     command = '"{0}" "{1}" {2}'.format(python, spyder, args)
 
-    # Adjust the command depending on the OS
-    system = platform.system().lower()
-    if system.startswith('win'):
+    # Adjust the command and/or arguments to subprocess depending on the OS
+    if os.name == 'nt':
         shell = False
-        is_pid_running = _is_pid_running_on_windows
-    elif system.startswith('linux'):
+    else:
         shell = True
-        is_pid_running = _is_pid_running_on_unix
-    elif system.startswith('darwin'):
-        shell = True
-        is_pid_running = _is_pid_running_on_unix
 
     # Wait for original process to end before launching the new instance
     while True:
         if not is_pid_running(pid):
             break
-        time.sleep(0.2)
+        time.sleep(0.2)  # Throttling control
 
     env = os.environ.copy()
     try:
@@ -74,32 +117,6 @@ def main():
         print(command)
         print(error)
         time.sleep(15)
-
-
-def _is_pid_running_on_windows(pid):
-    """Check For the existence of a windows pid."""
-    pid = str(pid)
-    startupinfo = subprocess.STARTUPINFO()
-    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-    process = subprocess.Popen(r'tasklist /fi "PID eq {0}"'.format(pid),
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.STDOUT,
-                               startupinfo=startupinfo)
-    stdoutdata, stderrdata = process.communicate()
-    stdoutdata = to_text_string(stdoutdata)
-    process.kill()
-    check = pid in stdoutdata
-    return check
-
-
-def _is_pid_running_on_unix(pid):
-    """Check For the existence of a unix pid."""
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-    else:
-        return True
 
 
 if __name__ == '__main__':

--- a/spyderlib/start_app.py
+++ b/spyderlib/start_app.py
@@ -6,6 +6,7 @@ import os
 import os.path as osp
 import random
 import socket
+import sys
 import time
 
 # Local imports
@@ -62,6 +63,9 @@ def main():
 
     # Parse command line options
     options, args = get_options()
+
+    # Store variable to be used in self.restart (restart spyder instance)
+    os.environ['SPYDER_ARGS'] = str(sys.argv[1:])
 
     if CONF.get('main', 'single_instance') and not options.new_instance \
       and not running_in_mac_app():


### PR DESCRIPTION
Fixes #2306

## Description

Add a restart method. Used the restart image as the ones used by the consoles. The shortcut for restarting is set as `Shift+Alt+R`.

## Tasks
- [x] Windows (Py2 & Py3)  (Tested on Windows 7)
- [x] Linux (Py2 & Py3)  (Tested on Ubuntu 14.04)
- [x] OSX (Py2 & Py3)
