### PR TITLE
Handle a connection abort error on shutdown

### DIFF
--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -2646,6 +2646,11 @@ class MainWindow(QMainWindow):
                 # To avoid a traceback after closing on Windows
                 if e.args[0] == eintr:
                     continue
+                # handle a connection abort on close error
+                enotsock = (errno.WSAENOTSOCK if os.name == 'nt'
+                            else errno.ENOTSOCK)
+                if e.args[0] in [errno.ECONNABORTED, enotsock]:
+                    return
                 raise
             fname = req.recv(1024)
             if not self.light:


### PR DESCRIPTION
I was getting the following traceback on shutdown, which is now avoided:

```python
*** End of MainWindow setup ***
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/Users/silvester/anaconda/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/Users/silvester/anaconda/lib/python3.4/threading.py", line 868, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/silvester/workspace/spyder/spyderlib/spyder.py", line 2641, in start_open_files_server
    req, dummy = self.open_files_server.accept()
  File "/Users/silvester/anaconda/lib/python3.4/socket.py", line 187, in accept
    fd, addr = self._accept()
ConnectionAbortedError: [Errno 53] Software caused connection abort
```