### PR TITLE
Add helper functions to determine os

### DIFF
--- a/spyderlib/utils/system.py
+++ b/spyderlib/utils/system.py
@@ -8,9 +8,58 @@
 
 
 import os
+import os.path as osp
+import platform
 
 # Local imports
 from spyderlib.utils import programs
+
+
+__SYSTEM = platform.system.lower()
+
+IS_WIN = os.name == 'nt'
+IS_MAC = __SYSTEM.startswith('darwin')
+IS_LINUX = __SYSTEM.startswith('linux')
+IS_POSIX = not IS_WIN
+
+# Ubuntu
+IS_UBUNTU = False
+if IS_LINUX and osp.isfile('/etc/lsb-release'):
+    release_info = open('/etc/lsb-release').read()
+    if 'Ubuntu' in release_info:
+        IS_UBUNTU = True
+
+
+def is_win():
+    """ """
+    return os.name == 'nt'
+
+
+def is_mac():
+    """ """
+    return __SYSTEM.startswith('darwin')
+
+
+def is_linux():
+    """ """
+    return __SYSTEM.startswith('linux')
+
+
+def is_posix():
+    """ """
+    return not is_win()
+
+
+def is_ubuntu():
+    """ """
+    if is_linux() and osp.isfile('/etc/lsb-release'):
+        release_info = open('/etc/lsb-release').read()
+        if 'Ubuntu' in release_info:
+            return True
+        else:
+            return False
+    else:
+        return False
 
 
 def windows_memory_usage():
@@ -18,16 +67,17 @@ def windows_memory_usage():
     Works on Windows platforms only"""
     from ctypes import windll, Structure, c_uint64, sizeof, byref
     from ctypes.wintypes import DWORD
+
     class MemoryStatus(Structure):
         _fields_ = [('dwLength', DWORD),
-                    ('dwMemoryLoad',DWORD),
+                    ('dwMemoryLoad', DWORD),
                     ('ullTotalPhys', c_uint64),
                     ('ullAvailPhys', c_uint64),
                     ('ullTotalPageFile', c_uint64),
                     ('ullAvailPageFile', c_uint64),
                     ('ullTotalVirtual', c_uint64),
                     ('ullAvailVirtual', c_uint64),
-                    ('ullAvailExtendedVirtual', c_uint64),]
+                    ('ullAvailExtendedVirtual', c_uint64)]
     memorystatus = MemoryStatus()
     # MSDN documetation states that dwLength must be set to MemoryStatus
     # size before calling GlobalMemoryStatusEx
@@ -35,6 +85,7 @@ def windows_memory_usage():
     memorystatus.dwLength = sizeof(memorystatus)
     windll.kernel32.GlobalMemoryStatusEx(byref(memorystatus))
     return float(memorystatus.dwMemoryLoad)
+
 
 def psutil_phymem_usage():
     """
@@ -54,7 +105,7 @@ def psutil_phymem_usage():
 if programs.is_module_installed('psutil', '>=0.3.0'):
     #  Function `psutil.phymem_usage` was introduced in psutil v0.3.0
     memory_usage = psutil_phymem_usage
-elif os.name == 'nt':
+elif is_win():
     # Backup plan for Windows platforms
     memory_usage = windows_memory_usage
 else:

--- a/spyderlib/utils/system.py
+++ b/spyderlib/utils/system.py
@@ -16,50 +16,40 @@ from spyderlib.utils import programs
 
 
 __SYSTEM = platform.system.lower()
-
-IS_WIN = os.name == 'nt'
-IS_MAC = __SYSTEM.startswith('darwin')
-IS_LINUX = __SYSTEM.startswith('linux')
-IS_POSIX = not IS_WIN
-
-# Ubuntu
-IS_UBUNTU = False
-if IS_LINUX and osp.isfile('/etc/lsb-release'):
+__IS_WIN = os.name == 'nt'
+__IS_MAC = __SYSTEM.startswith('darwin')
+__IS_LINUX = __SYSTEM.startswith('linux')
+__IS_POSIX = not __IS_WIN
+__IS_UBUNTU = False
+if __IS_LINUX and osp.isfile('/etc/lsb-release'):
     release_info = open('/etc/lsb-release').read()
     if 'Ubuntu' in release_info:
-        IS_UBUNTU = True
+        __IS_UBUNTU = True
 
 
 def is_win():
     """ """
-    return os.name == 'nt'
+    return __IS_WIN
 
 
 def is_mac():
     """ """
-    return __SYSTEM.startswith('darwin')
+    return __IS_MAC
 
 
 def is_linux():
     """ """
-    return __SYSTEM.startswith('linux')
+    return __IS_LINUX
 
 
 def is_posix():
     """ """
-    return not is_win()
+    return __IS_POSIX
 
 
 def is_ubuntu():
     """ """
-    if is_linux() and osp.isfile('/etc/lsb-release'):
-        release_info = open('/etc/lsb-release').read()
-        if 'Ubuntu' in release_info:
-            return True
-        else:
-            return False
-    else:
-        return False
+    return __IS_UBUNTU
 
 
 def windows_memory_usage():


### PR DESCRIPTION
The idea is to use a unified helper function located in `spyderlib.utils.system` to check OS.

I could include in this PR or in a separate one the changes to the files where the OS is determined in another way.