### PR TITLE
Add a check for updates method

### DIFF
--- a/spyderlib/config.py
+++ b/spyderlib/config.py
@@ -190,7 +190,8 @@ DEFAULTS = [
               'cpu_usage/timeout': 2000,
               'use_custom_margin': True,
               'custom_margin': 0,
-              'show_internal_console_if_traceback': True
+              'show_internal_console_if_traceback': True,
+              'check_updates_on_startup': True
               }),
             ('quick_layouts',
              {

--- a/spyderlib/plugins/configdialog.py
+++ b/spyderlib/plugins/configdialog.py
@@ -757,14 +757,23 @@ class MainConfigPage(GeneralConfigPage):
         debug_layout = QVBoxLayout()
         debug_layout.addWidget(popup_console_box)
         debug_group.setLayout(debug_layout)
+
+        # --- Spyder updates
+        update_group = QGroupBox(_("Updates"))
+        check_updates = newcb(_("Check for updates on startup"),
+                              'check_updates_on_startup')
+        update_layout = QVBoxLayout()
+        update_layout.addWidget(check_updates)
+        update_group.setLayout(update_layout)
         
         vlayout = QVBoxLayout()
         vlayout.addWidget(interface_group)
         vlayout.addWidget(sbar_group)
         vlayout.addWidget(debug_group)
+        vlayout.addWidget(update_group)
         vlayout.addStretch(1)
         self.setLayout(vlayout)
-        
+
     def apply_settings(self, options):
         self.main.apply_settings()
 

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -2690,7 +2690,7 @@ class MainWindow(QMainWindow):
         # Define the custom QMessageBox
         box = MessageCheckBox()
         box.setWindowTitle(_("Spyder updates"))
-        box.set_checkbox_text(_("Check for updates on startup?"))
+        box.set_checkbox_text(_("Check for updates on startup"))
         box.setStandardButtons(QMessageBox.Ok)
         box.setDefaultButton(QMessageBox.Ok)
         box.setIcon(QMessageBox.Information)

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -79,7 +79,7 @@ from spyderlib.qt.QtGui import (QApplication, QMainWindow, QSplashScreen,
                                 QKeySequence, QDockWidget, QAction,
                                 QDesktopServices)
 from spyderlib.qt.QtCore import (Signal, QPoint, Qt, QSize, QByteArray, QUrl,
-                                 Slot, QTimer, QCoreApplication)
+                                 Slot, QTimer, QCoreApplication, QThread)
 from spyderlib.qt.compat import (from_qvariant, getopenfilename,
                                  getsavefilename)
 # Avoid a "Cannot mix incompatible Qt library" error on Windows platforms
@@ -358,7 +358,12 @@ class MainWindow(QMainWindow):
         # Tour  # TODO: Should I consider it a plugin?? or?
         self.tour = None
         self.tours_available = None
-        
+
+        # Check for updates Thread and Worker
+        self.check_updates_action = None
+        self.thread_updates = None
+        self.worker_updates = None
+
         # Preferences
         from spyderlib.plugins.configdialog import (MainConfigPage,
                                                     ColorSchemeConfigPage)
@@ -942,6 +947,10 @@ class MainWindow(QMainWindow):
             support_action = create_action(self,
                                            _("Spyder support..."),
                                            triggered=self.google_group)
+            self.check_updates_action = create_action(self,
+                                                      _("Check for updates"),
+                                                      triggered=self.check_updates)
+
             # Spyder documentation
             doc_path = get_module_data_path('spyderlib', relpath="doc",
                                             attr_name='DOCPATH')
@@ -993,7 +1002,8 @@ class MainWindow(QMainWindow):
 
             self.help_menu_actions = [doc_action, tut_action, self.tours_menu,
                                       None,
-                                      report_action, dep_action, support_action,
+                                      report_action, dep_action,
+                                      support_action, self.check_updates_action,
                                       None]
             # Python documentation
             if get_python_doc_path() is not None:
@@ -1273,8 +1283,12 @@ class MainWindow(QMainWindow):
                 except AttributeError:
                     pass
 
+        # Check for spyder updates
+        if DEV is None and CONF.get('main', 'check_updates_on_startup'):
+            self.check_updates()
+
         self.is_setting_up = False
-        
+
     def load_window_settings(self, prefix, default=False, section='main'):
         """Load window layout settings from userconfig-based configuration
         with *prefix*, under *section*
@@ -2659,6 +2673,93 @@ class MainWindow(QMainWindow):
         frames = self.tours_available[index]
         self.tour.set_tour(index, frames, self)
         self.tour.start_tour()
+
+    # ---- Check for Spyder Updates
+    def _check_updates_ready(self):
+        """Called by WorkerUpdates when ready"""
+        from spyderlib.workers.updates import MessageCheckBox
+
+        update_available = self.worker_updates.update_available
+        latest_release = self.worker_updates.latest_release
+        feedback = self.worker_updates.feedback
+        error_msg = self.worker_updates.error
+
+        url_r = 'https://github.com/spyder-ide/spyder/releases'
+        url_i = 'http://pythonhosted.org/spyder/installation.html'
+
+        # Define the custom QMessageBox
+        box = MessageCheckBox()
+        box.setWindowTitle(_("Spyder updates"))
+        box.set_checkbox_text(_("Check for updates on startup?"))
+        box.setStandardButtons(QMessageBox.Ok)
+        box.setDefaultButton(QMessageBox.Ok)
+        box.setIcon(QMessageBox.Information)
+
+        # Adjust the checkbox depending on the stored configuration
+        section, option = 'main', 'check_updates_on_startup'
+        check_updates = CONF.get(section, option)
+        box.set_checked(check_updates)
+
+        if error_msg is not None:
+            msg = error_msg
+            box.setText(msg)
+            box.set_check_visible(False)
+            box.exec_()
+            check_updates = box.is_checked()
+        else:
+            if update_available:
+                msg = _("<b>Spyder {0} is available!</b> <br><br>Please use "
+                        "your package manager to update Spyder or go to our "
+                        "<a href=\"{1}\">Releases</a> page to download this "
+                        "new version. <br><br>If you are not sure how to "
+                        "proceed to update Spyder please refer to our "
+                        " <a href=\"{2}\">Installation</a> instructions."
+                        "" .format(latest_release, url_r, url_i))
+                box.setText(msg)
+                box.set_check_visible(True)
+                box.exec_()
+                check_updates = box.is_checked()
+            elif feedback:
+                msg = _("Spyder is up to date.")
+                box.setText(msg)
+                box.set_check_visible(False)
+                box.exec_()
+                check_updates = box.is_checked()
+
+        # Update checkbox based on user interaction
+        CONF.set(section, option, check_updates)
+
+        # Enable check_updates_action after the thread has finished
+        self.check_updates_action.setDisabled(False)
+
+    def check_updates(self):
+        """
+        Check for spyder updates on github releases using a QThread.
+        """
+        from spyderlib.workers.updates import WorkerUpdates
+
+        # Disable check_updates_action while the thread is working
+        self.check_updates_action.setDisabled(True)
+
+        # feedback` = False is used on startup, so only positive feedback is
+        # given. `feedback` = True is used when using the menu action, and
+        # gives feeback if updates are, or are not found.
+        feedback = False
+
+        if DEV:
+            feedback = True
+        elif self.thread_updates is not None:
+            self.thread_updates.terminate()
+            feedback = True
+
+        self.thread_updates = QThread(self)
+        self.worker_updates = WorkerUpdates(self, feedback)
+        self.worker_updates.sig_ready.connect(self._check_updates_ready)
+        self.worker_updates.sig_ready.connect(self.thread_updates.quit)
+        self.worker_updates.moveToThread(self.thread_updates)
+        self.thread_updates.started.connect(self.worker_updates.start)
+        self.thread_updates.start()
+
 
 #==============================================================================
 # Utilities to create the 'main' function

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -364,7 +364,7 @@ class MainWindow(QMainWindow):
         self.check_updates_action = None
         self.thread_updates = None
         self.worker_updates = None
-        self.flag_updates_feedback = True
+        self.give_updates_feedback = True
 
         # Preferences
         from spyderlib.plugins.configdialog import (MainConfigPage,
@@ -1287,7 +1287,7 @@ class MainWindow(QMainWindow):
 
         # Check for spyder updates
         if DEV is None and CONF.get('main', 'check_updates_on_startup'):
-            self.flag_updates_feedback = False 
+            self.give_updates_feedback = False 
             self.check_updates()
 
         self.is_setting_up = False
@@ -2685,7 +2685,7 @@ class MainWindow(QMainWindow):
         # feedback` = False is used on startup, so only positive feedback is
         # given. `feedback` = True is used when after startup (when using the
         # menu action, and gives feeback if updates are, or are not found.
-        feedback = self.flag_updates_feedback
+        feedback = self.give_updates_feedback
 
         # Get results from worker
         update_available = self.worker_updates.update_available
@@ -2741,7 +2741,7 @@ class MainWindow(QMainWindow):
         self.check_updates_action.setDisabled(False)
         
         # Provide feeback when clicking menu if check on startup is on
-        self.flag_updates_feedback = True
+        self.give_updates_feedback = True
 
     def check_updates(self):
         """

--- a/spyderlib/utils/programs.py
+++ b/spyderlib/utils/programs.py
@@ -201,6 +201,24 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
         raise NotImplementedError
 
 
+def is_stable_version(version):
+    """
+    A stable version has no letters in the final component, but only numbers.
+
+    Stable version example: 1.2, 1.3.4, 1.0.5
+    Not stable version: 1.2alpha, 1.3.4beta, 0.1.0rc1, 3.0.0dev
+    """
+    if not isinstance(version, tuple):
+        version = version.split('.')
+    last_part = version[-1]
+
+    try:
+        int(last_part)
+        return True
+    except ValueError:
+        return False
+
+
 def check_version(actver, version, cmp_op):
     """
     Check version string of an active module against a required version.
@@ -216,6 +234,13 @@ def check_version(actver, version, cmp_op):
     """
     if isinstance(actver, tuple):
         actver = '.'.join([str(i) for i in actver])
+
+    # A small hack is needed so that LooseVersion understands that for example
+    # version = '3.0.0' is in fact bigger than actver = '3.0.0rc1'
+    if is_stable_version(version) and actver.startswith(version) and\
+      version != actver:
+        version = version + 'z'
+
     try:
         if cmp_op == '>':
             return LooseVersion(actver) > LooseVersion(version)

--- a/spyderlib/workers/updates.py
+++ b/spyderlib/workers/updates.py
@@ -72,11 +72,10 @@ class WorkerUpdates(QObject):
     """
     sig_ready = Signal()
 
-    def __init__(self, parent, feedback):
+    def __init__(self, parent):
         QObject.__init__(self)
         self._parent = parent
-        self.feedback = feedback
-        self.error = feedback
+        self.error = None
         self.latest_release = None
 
     def check_update_available(self, version, releases):

--- a/spyderlib/workers/updates.py
+++ b/spyderlib/workers/updates.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2009-2013 Pierre Raybaut
+# Copyright © 2013-2015 The Spyder Development Team
+# Licensed under the terms of the MIT License
+# (see spyderlib/__init__.py for details)
+
+import json
+
+from spyderlib import __version__
+from spyderlib.baseconfig import _
+from spyderlib.py3compat import PY3
+from spyderlib.qt.QtGui import (QMessageBox, QCheckBox)
+from spyderlib.qt.QtCore import Signal, Qt, QObject
+
+
+class MessageCheckBox(QMessageBox):
+    """
+    A QMessageBox derived widget that includes a QCheckBox under the message
+    and on top of the buttons.
+    """
+    def __init__(self, *args, **kwargs):
+        super(MessageCheckBox, self).__init__(*args, **kwargs)
+
+        self._checkbox = QCheckBox()
+
+        # Access the Layout of the MessageBox to add the Checkbox
+        layout = self.layout()
+        layout.addWidget(self._checkbox, 1, 1, Qt.AlignRight)
+
+    # Methods to access the checkbox
+    def is_checked(self):
+        return self._checkbox.isChecked()
+
+    def set_checked(self, value):
+        return self._checkbox.setChecked(value)
+
+    def set_check_visible(self, value):
+        self._checkbox.setVisible(value)
+
+    def is_check_visible(self):
+        self._checkbox.isVisible()
+
+    def checkbox_text(self):
+        self._checkbox.text()
+
+    def set_checkbox_text(self, text):
+        self._checkbox.setText(text)
+
+
+class WorkerUpdates(QObject):
+    """
+    Worker that checks for releases using the Github API without blocking the
+    Spyder user interface, in case of connections issues.
+    """
+    sig_ready = Signal()
+
+    def __init__(self, parent, feedback):
+        QObject.__init__(self)
+        self._parent = parent
+        self.feedback = feedback
+        self.error = feedback
+        self.latest_release = None
+
+    def is_stable_version(self, version):
+        """
+        A stable version has no letters in the final part, it has only numbers.
+
+        Stable version example: 1.2, 1.3.4, 1.0.5
+        Not stable version: 1.2alpha, 1.3.4beta, 0.1.0rc1, 3.0.0dev
+        """
+        if not isinstance(version, tuple):
+            version = version.split('.')
+        last_part = version[-1]
+
+        try:
+            int(last_part)
+            return True
+        except ValueError:
+            return False
+
+    def check_update_available(self, version, releases):
+        """ """
+        from spyderlib.utils.programs import check_version
+
+        if self.is_stable_version(version):
+            # Remove non stable versions from the list
+            releases = [r for r in releases if self.is_stable_version(r)]
+
+        latest = releases[0]
+        latest_release = releases[0]
+
+        if version.endswith('dev'):
+            return (False, latest_release)
+
+        if self.is_stable_version(latest) and \
+                version.startswith(latest) and latest != version:
+            # Modify the last part so that i.e. 3.0.0 is bigger than 3.0.0rc2
+            parts = latest.split('.')
+            parts = parts[:-1] + [parts[-1] + 'z']
+            latest = '.'.join(parts)
+
+        return (check_version(version, latest, '<'), latest_release)
+
+    def start(self):
+        """ """
+        if PY3:
+            from urllib.request import urlopen
+            from urllib.error import URLError, HTTPError
+        else:
+            from urllib2 import urlopen, URLError, HTTPError
+
+        self.url = 'https://api.github.com/repos/spyder-ide/spyder/releases'
+
+        self.update_available = False
+        self.latest_release = __version__
+
+        error_msg = None
+        try:
+            page = urlopen(self.url)
+            try:
+                data = page.read()
+                if not isinstance(data, str):
+                    data = data.decode()
+                data = json.loads(data)
+                releases = [item['tag_name'].replace('v', '') for item in data]
+                version = __version__
+                result = self.check_update_available(version, releases)
+                self.update_available, self.latest_release = result
+            except Exception as error:
+                #print(error)
+                error_msg = _('Unable to retrieve information.')
+        except HTTPError as error:
+            error_msg = _('Unable to retrieve information.')
+            msg = 'HTTPError = ' + str(error.code)
+            #print(msg)
+        except URLError as error:
+            error_msg = _('Unable to connect to the internet. <br><br>Make '
+                          'sure the connection is working properly.')
+            msg = 'URLError = ' + str(error.reason)
+            #print(msg)
+        except Exception as error:
+            error_msg = _('Unable to check for updates.')
+            msg = error
+            #print(msg)
+
+        self.error = error_msg
+        self.sig_ready.emit()


### PR DESCRIPTION
Fixes #2307 

(Note from @ccordoba12: Please leave *Fixes* instead of *Implements* because that way when I merge the PR, GH will automatically close the corresponding issue. If you don't like *Fixes*, [here](https://help.github.com/articles/closing-issues-via-commit-messages/#keywords-for-closing-issues) are the other words you can use to make this happen)

## Description
Add a method to check for updates querying the Github API, using a QThread and Worker to avoid blocking the GUI.

The method is called on startup if running from installed version and will only display a message if there is an update. If running in `DEV` mode versions it will not be triggered on startup. 

There is also an entry in the Help menu to check for updates at any moment, unlike the one on startup, this action will give feedback also if no updates are available, or if there is some internet error.

## Messages

**Ubuntu**
![image](https://cloud.githubusercontent.com/assets/3627835/7104758/3a8f5f68-e0f7-11e4-863b-83928779fa39.png)

**Ubuntu**
![image](https://cloud.githubusercontent.com/assets/3627835/7104796/babf9698-e0f8-11e4-9df9-0edb1746dbce.png)

**Windows**
![image](https://cloud.githubusercontent.com/assets/3627835/7116177/deb64036-e1ef-11e4-86ba-6697b9a926e9.png)


## New option in the general preferences
This option is on by default and then the user can decide by checking or unchecking the checkbox.

**Windows**
![image](https://cloud.githubusercontent.com/assets/3627835/7116033/6c13ccfc-e1ee-11e4-870e-4a8e0aafb045.png)



## Checklist
- [x] Agree on location in menu
- [x] Agree on message
- [x] Add preferences option to disable this check on startup (**on** by default)
- [x] Adjust check to handle stable and dev/beta cases. 
    - If using a beta release display message if higher beta release or higher stable
    - If using a stable version check only against stable versions
