### PR TITLE
[WIP] Compact Variable Explorer with customizable tooltip

### DIFF
--- a/spyderlib/config.py
+++ b/spyderlib/config.py
@@ -308,6 +308,8 @@ DEFAULTS = [
               'truncate': True,
               'minmax': False,
               'remote_editing': False,
+              'makemetadict/default': True,
+              'makemetadict/custom': False
               }),
             ('editor',
              {

--- a/spyderlib/make_meta_dict_default.py
+++ b/spyderlib/make_meta_dict_default.py
@@ -30,6 +30,9 @@ def make_meta_dict(value):
     the caller, and a default empty dict will be returned.  The exception 
     stacktrace will be printed.    
     """
+    if isinstance(value, (bool, int, float, tuple, list, set, dict)):
+        return {}
+        
     meta = OrderedDict()
     class DudObject():
         pass

--- a/spyderlib/make_meta_dict_default.py
+++ b/spyderlib/make_meta_dict_default.py
@@ -63,6 +63,8 @@ def make_meta_dict(value):
             if html is not None and len(html) > 0:
                 meta['html'] = html
                 meta['value'] = None
+    else:
+        meta.update(make_meta_dict_docstring(value))
     return meta
     
 @contextmanager
@@ -178,6 +180,26 @@ def make_numpy_meta_dict(value):
         meta['value'] = None # if we have a plot we dont need to show the raw data
         
     return meta         
+
+
+def make_meta_dict_docstring(value):
+    try:
+        from spyderlib.utils.inspector.sphinxify import (sphinxify,
+                                                         generate_context)
+        from spyderlib.utils.dochelpers import getdoc
+    except ImportError:
+        return {}
+    
+    doc = getdoc(value)
+    if doc is not None and type(doc) is dict and 'docstring' in doc.keys():
+        try:
+            context = generate_context(name=doc['name'],
+                                       argspec=doc['argspec'],
+                                       note=doc['note'])
+            gen_html = sphinxify(doc['docstring'], context)
+            return {'html': "<hr><div align=left margin-top=0px>" + gen_html + "</div>", 'value': None}
+        except Exception:
+            return {}
     
 def make_pil_meta_dict(value):
     with ignore(Exception):

--- a/spyderlib/make_meta_dict_default.py
+++ b/spyderlib/make_meta_dict_default.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+
+from contextlib import contextmanager
+from collections import OrderedDict
+
+def make_meta_dict(value):
+    """
+    This function is called when the user moves over a variable in the 
+    variable explorer (when in compact mode).  ``value`` is the actual
+    variable in question.  
+    
+    The function should return a dictionary-like object with "simple" meta data
+    to be rendered as a list of key-values.  Note we suggest using an OrderedDict
+    in order to control the order in which the keys are displayed.
+    
+    If an "html" key is present in the dictionary, that data wil be interpreted
+    as raw html and rendered after the simple meta data.  
+    Search for "richtext-html-subset qt" to find out exactly what html is
+    supported.
+    
+    If a "value" key is present in the dictionary, that will replace the
+    value string that would otherwise be shown. Set this to ``None`` to hide
+    the value completely (e.g. if html is sufficient).
+    
+    Note that ``value`` may be a copy or may be the original value, so
+    so do not modify it inplace, but conversely do not rely on "is"
+    comparisons for caching or other comparisons.
+
+    If uncaught exceptions occur during this funciton they will be caught by
+    the caller, and a default empty dict will be returned.  The exception 
+    stacktrace will be printed.    
+    """
+    meta = OrderedDict()
+    class DudObject():
+        pass
+    
+    try:
+        from numpy import ndarray
+        from numpy.ma import MaskedArray
+    except ImportError:
+        ndarray = MaskedArray = DudObject  # analysis:ignore
+        
+    try:
+        from pandas import DataFrame, TimeSeries
+    except ImportError:
+        DataFrame = TimeSeries = DudObject  # analysis:ignore
+
+    try:
+        from PIL import Image
+    except ImportError:
+        Image = DudObject # analysis:ignore
+        
+    if isinstance(value, (ndarray, MaskedArray)):   
+        meta.update(make_numpy_meta_dict(value))
+    elif isinstance(value, DataFrame):
+        meta['html'] = value.describe().to_html()
+        meta['value'] = None
+    elif isinstance(value, Image.Image):
+        meta.update(make_pil_meta_dict(value))
+    elif hasattr(value, '_repr_html_'):
+        html = value._repr_html_()
+        if html is not None and len(html) > 0:
+            meta['html'] = html
+            meta['value'] = None
+    return meta
+    
+@contextmanager
+def ignore(*exceptions):  
+    try:
+        yield
+    except exceptions:
+        pass
+
+def make_numpy_meta_dict(value):
+    """
+    Called from within make_meta_dict_user if value is a numpy array.
+    
+    You can display multiple images, but here we try to guess what kind
+    of graphical representation would best suit the given data.  If you 
+    don't like that you can change it!
+    """
+    from numpy import (array, isnan, nanmax, 
+                       nanmin, nanmean, nan, ma, sum as np_sum)
+    from numpy.ma import MaskedArray
+    meta = OrderedDict()
+    with ignore(Exception):
+        meta['min'] = nanmin(value)                
+    with ignore(Exception):
+        meta['max'] = nanmax(value)
+    with ignore(Exception): 
+        if isinstance(value, MaskedArray):
+            meta['masked'] = str(value.size - value.count())                
+    with ignore(Exception):
+        # next line will throw ValueError if dtype does not support nans
+        test_nan = array(nan, dtype=value.dtype) # analysis:ignore
+        n_nan = np_sum(isnan(value))
+        meta['NaNs'] = n_nan                    
+    with ignore(Exception):
+        meta['mean'] = nanmean(value)
+    with ignore(Exception):
+        n_bytes = value.nbytes
+        if n_bytes < 1024*2:
+            meta['memory'] = str(n_bytes) + 'B' 
+        elif n_bytes < (1024**2)*2:
+            meta['memory'] = str(round(n_bytes/(1024.0), 1)) + 'KB' 
+        else:
+            meta['memory'] = str(round(n_bytes/(1024.0**2), 1)) + 'MB' 
+
+    # Try and get some machinery for making simple plots
+    with ignore(Exception):
+        can_make_images = False
+        from io import BytesIO
+        from PIL import Image, ImageDraw
+        from base64 import b64encode
+        def img_to_html(img, alt_text='data img'):
+            b = BytesIO()  
+            img.save(b, format='png')
+            return '<img alt="' + alt_text +'"'\
+                        + ' src="data:image/png;base64,' \
+                        +  b64encode(b.getvalue()) + '" />'
+        can_make_images = True
+    image_list = []
+    
+    # If we have a 2D array which is bigger than 6x6, make a thumbnail                   
+    with ignore(Exception):
+        if can_make_images and value.ndim == 2 and value.shape[0] > 6 and value.shape[1] > 6:
+            from matplotlib import cm
+            from matplotlib.colors import Normalize
+            if not ma.isMaskedArray(value):
+                value = ma.array(value, mask=isnan(value))  
+            img = Image.fromarray(cm.jet(Normalize()(value), bytes=True))
+            img.thumbnail((128,128))
+            image_list.append(img_to_html(img, "matshow image"))
+            
+    # If we have a long 1d array, then show a simple line plot 
+    # unless the line plot fills more than half the axes area
+    with ignore(Exception):
+        if value.squeeze().ndim == 1 and value.size > 15:
+            from numpy import (linspace, max as np_max, min as np_min, 
+                               corrcoef, arange)
+            img = Image.new("RGBA", (128,128))
+            draw = ImageDraw.Draw(img)
+            value = value.squeeze()
+            value = value - np_min(value)
+            fill_color = (255,0,0,255)
+            draw.line(zip(linspace(0,127,value.size),
+                     127-value * 127./np_max(value)),
+                    fill_color)   
+            filled_count = next(count for count, color in img.getcolors()\
+                                        if color == fill_color)
+            if filled_count < 0.5*img.size[0]*img.size[1]:
+                image_list.append(img_to_html(img,"1d line plot"))
+                meta['corrcoef'] = corrcoef(arange(len(value)),value)[0,1]
+                
+    # If we have a 2xn or nx2 with large n, then do a scatter plot
+    with ignore(Exception):
+        if value.squeeze().ndim == 2 and min(value.shape) == 2 and \
+                max(value.shape) > 15:
+            from numpy import (max as np_max, min as np_min, corrcoef)
+            img = Image.new("RGBA", (128,128))
+            draw = ImageDraw.Draw(img)
+            value = value.squeeze()
+            value = value if value.shape[0] == 2 else value.T
+            value = value - np_min(value, axis=1, keepdims=True)
+            fill_color = (0,0,255,255)
+            draw.point(zip(value[0]*127./np_max(value[0]),
+                     127-value[1]*127./np_max(value[1])),
+                     fill_color)   
+            filled_count = next(count for count, color in img.getcolors()\
+                                        if color == fill_color)
+            if filled_count < 0.5*img.size[0]*img.size[1]:
+                image_list.append(img_to_html(img,"xy scatter plot"))
+                meta['corrcoef'] = corrcoef(value[0],value[1])[0,1]
+        
+    if len(image_list) > 0:
+        meta['html'] = ' '.join(image_list)
+        meta['value'] = None # if we have a plot we dont need to show the raw data
+        
+    return meta         
+    
+def make_pil_meta_dict(value):
+    with ignore(Exception):
+        from io import BytesIO
+        from base64 import b64encode
+        b = BytesIO()
+        value = value.copy()
+        value.thumbnail((128,128))
+        value.save(b, format='png')
+        return {'html': '<img alt="PIL Image"'\
+                    + ' src="data:image/png;base64,' \
+                    +  b64encode(b.getvalue()) + '" />',
+                'value': None}
+        

--- a/spyderlib/make_meta_dict_default.py
+++ b/spyderlib/make_meta_dict_default.py
@@ -58,10 +58,11 @@ def make_meta_dict(value):
     elif isinstance(value, Image.Image):
         meta.update(make_pil_meta_dict(value))
     elif hasattr(value, '_repr_html_'):
-        html = value._repr_html_()
-        if html is not None and len(html) > 0:
-            meta['html'] = html
-            meta['value'] = None
+        with ignore(Exception):
+            html = value._repr_html_()
+            if html is not None and len(html) > 0:
+                meta['html'] = html
+                meta['value'] = None
     return meta
     
 @contextmanager

--- a/spyderlib/plugins/variableexplorer.py
+++ b/spyderlib/plugins/variableexplorer.py
@@ -6,7 +6,8 @@
 
 """Namespace Browser Plugin"""
 
-from spyderlib.qt.QtGui import QStackedWidget, QGroupBox, QVBoxLayout
+from spyderlib.qt.QtGui import (QStackedWidget, QGroupBox, QVBoxLayout, 
+                                QButtonGroup, QLabel)
 from spyderlib.qt.QtCore import Signal
 
 # Local imports
@@ -67,10 +68,44 @@ class VariableExplorerConfigPage(PluginConfigPage):
             display_layout.addWidget(box)
         display_group.setLayout(display_layout)
 
+
+        # METADICT replacement
+        makemeta_group = QGroupBox(_("make_meta_dict replacement"))
+        makemeta_bg = QButtonGroup(makemeta_group)
+        makemeta_label = QLabel(_("This option will override the "
+                                   "default make_meta_dict function which "
+                                   "defines what to display in the tooltip "
+                                   "when you move the cursor over a variable "
+                                   "in the variable explorer.\n"
+                                   "Note changes are not reflect until after "
+                                   "the application has been restarted."))
+        makemeta_label.setWordWrap(True)        
+        def_makemeta_radio = self.create_radiobutton(
+                                        _("Default make_meta_dict function"),
+                                        'makemetadict/default',
+                                        button_group=makemeta_bg)
+        cus_makemeta_radio = self.create_radiobutton(
+                                _("Use make_meta_dict function in script:"),
+                                  'makemetadict/custom',
+                                  button_group=makemeta_bg)
+        makemeta_file = self.create_browsefile('', 'make_meta_dict', '',
+                                                filters=_("Python scripts")+\
+                                                " (*.py)")
+        def_makemeta_radio.toggled.connect(makemeta_file.setDisabled)
+        cus_makemeta_radio.toggled.connect(makemeta_file.setEnabled)
+        
+        makemeta_layout = QVBoxLayout()
+        makemeta_layout.addWidget(makemeta_label)
+        makemeta_layout.addWidget(def_makemeta_radio)
+        makemeta_layout.addWidget(cus_makemeta_radio)
+        makemeta_layout.addWidget(makemeta_file)
+        makemeta_group.setLayout(makemeta_layout)
+        
         vlayout = QVBoxLayout()
         vlayout.addWidget(ar_group)
         vlayout.addWidget(filter_group)
         vlayout.addWidget(display_group)
+        vlayout.addWidget(makemeta_group)
         vlayout.addStretch(1)
         self.setLayout(vlayout)
 

--- a/spyderlib/utils/makemetadict.py
+++ b/spyderlib/utils/makemetadict.py
@@ -16,14 +16,124 @@ def make_meta_dict(value):
         import traceback
         print(traceback.format_exc())
         return {}
-        
+
+#----USER CODE FOLLOWS. TODO: put in a separate file for user to modify
+
 @contextmanager
 def ignore(*exceptions):  
     try:
         yield
     except exceptions:
         pass
- 
+
+def make_numpy_meta_dict(value):
+    """
+    Called from within make_meta_dict_user if value is a numpy array.
+    
+    You can display multiple images, but here we try to guess what kind
+    of graphical representation would best suit the given data.  If you 
+    don't like that you can change it!
+    """
+    from numpy import (array, isnan, nanmax, 
+                       nanmin, nanmean, nan, ma, sum as np_sum)
+    from numpy.ma import MaskedArray
+    meta = OrderedDict()
+    with ignore(Exception):
+        meta['min'] = nanmin(value)                
+    with ignore(Exception):
+        meta['max'] = nanmax(value)
+    with ignore(Exception): 
+        if isinstance(value, MaskedArray):
+            meta['masked'] = str(value.size - value.count())                
+    with ignore(Exception):
+        # next line will throw ValueError if dtype does not support nans
+        test_nan = array(nan, dtype=value.dtype) # analysis:ignore
+        n_nan = np_sum(isnan(value))
+        meta['NaNs'] = n_nan                    
+    with ignore(Exception):
+        meta['mean'] = nanmean(value)
+    with ignore(Exception):
+        n_bytes = value.nbytes
+        if n_bytes < 1024*2:
+            meta['memory'] = str(n_bytes) + 'B' 
+        elif n_bytes < (1024**2)*2:
+            meta['memory'] = str(round(n_bytes/(1024.0), 1)) + 'KB' 
+        else:
+            meta['memory'] = str(round(n_bytes/(1024.0**2), 1)) + 'MB' 
+
+    # Try and get some machinery for making simple plots
+    with ignore(Exception):
+        can_make_images = False
+        from io import BytesIO
+        from PIL import Image, ImageDraw
+        from base64 import b64encode
+        def img_to_html(img, alt_text='data img'):
+            b = BytesIO()  
+            img.save(b, format='png')
+            return '<img alt="' + alt_text +'"'\
+                        + ' src="data:image/png;base64,' \
+                        +  b64encode(b.getvalue()) + '" />'
+        can_make_images = True
+    image_list = []
+    
+    # If we have a 2D array which is bigger than 6x6, make a thumbnail                   
+    with ignore(Exception):
+        if can_make_images and value.ndim == 2 and value.shape[0] > 6 and value.shape[1] > 6:
+            from matplotlib import cm
+            from matplotlib.colors import Normalize
+            if not ma.isMaskedArray(value):
+                value = ma.array(value, mask=isnan(value))  
+            img = Image.fromarray(cm.jet(Normalize()(value), bytes=True))
+            img.thumbnail((128,128))
+            image_list.append(img_to_html(img, "matshow image"))
+            
+    # If we have a long 1d array, then show a simple line plot 
+    # unless the line plot fills more than half the axes area
+    with ignore(Exception):
+        if value.squeeze().ndim == 1 and value.size > 15:
+            from numpy import (linspace, max as np_max, min as np_min, 
+                               corrcoef, arange)
+            img = Image.new("RGBA", (128,128))
+            draw = ImageDraw.Draw(img)
+            value = value.squeeze()
+            value = value - np_min(value)
+            fill_color = (255,0,0,255)
+            draw.line(zip(linspace(0,127,value.size),
+                     127-value * 127./np_max(value)),
+                    fill_color)   
+            filled_count = next(count for count, color in img.getcolors()\
+                                        if color == fill_color)
+            if filled_count < 0.5*img.size[0]*img.size[1]:
+                image_list.append(img_to_html(img,"1d line plot"))
+                meta['corrcoef'] = corrcoef(arange(len(value)),value)[0,1]
+                
+    # If we have a 2xn or nx2 with large n, then do a scatter plot
+    with ignore(Exception):
+        if value.squeeze().ndim == 2 and min(value.shape) == 2 and \
+                max(value.shape) > 15:
+            from numpy import (max as np_max, min as np_min, corrcoef)
+            img = Image.new("RGBA", (128,128))
+            draw = ImageDraw.Draw(img)
+            value = value.squeeze()
+            value = value if value.shape[0] == 2 else value.T
+            value = value - np_min(value, axis=1, keepdims=True)
+            fill_color = (0,0,255,255)
+            draw.point(zip(value[0]*127./np_max(value[0]),
+                     127-value[1]*127./np_max(value[1])),
+                     fill_color)   
+            filled_count = next(count for count, color in img.getcolors()\
+                                        if color == fill_color)
+            if filled_count < 0.5*img.size[0]*img.size[1]:
+                image_list.append(img_to_html(img,"xy scatter plot"))
+                meta['corrcoef'] = corrcoef(value[0],value[1])[0,1]
+        
+    if len(image_list) > 0:
+        meta['html'] = ' '.join(image_list)
+        meta['value'] = None # if we have a plot we dont need to show the raw data
+        
+    return meta         
+    
+    
 def make_meta_dict_user(value):
     """
     This function is called when the user moves over a variable in the 
@@ -39,120 +149,37 @@ def make_meta_dict_user(value):
     Search for "richtext-html-subset qt" to find out exactly what html is
     supported.
     
+    If a "value" key is present in the dictionary, that will replace the
+    value string that would otherwise be shown. Set this to ``None`` to hide
+    the value completely (e.g. if html is sufficient).
+    
     Note that ``value`` may be a copy or may be the original value, so
     so do not modify it inplace, but conversely do not rely on "is"
     comparisons for caching or other comparisons.
-            
-    You can display multiple images, but here we try to guess what kind
-    of graphical representation would best suit the given data.  If you 
-    don't like that you can change it!
     
-    Although this function may be long each bit of it should be kept 
-    fairly independent...you  may want to split it into lots of little
-    functions and then call then explictly call each in turn, wrapped
-    in the lazy ignore(Exception).
     """
     meta = OrderedDict()
     class DudObject():
         pass
     
     try:
-        from numpy import (array, ndarray, isnan, nanmax, 
-                              nanmin, nanmean, nan, ma)
-        from numpy import sum as np_sum
+        from numpy import ndarray
         from numpy.ma import MaskedArray
     except ImportError:
         ndarray = MaskedArray = DudObject  # analysis:ignore
         
-    if isinstance(value, (ndarray, MaskedArray)):   
-        with ignore(Exception):
-            meta['min'] = nanmin(value)                
-        with ignore(Exception):
-            meta['max'] = nanmax(value)
-        if isinstance(value,MaskedArray):
-            with ignore(Exception): 
-                meta['masked'] = str(value.size - value.count())                
-        with ignore(Exception):
-            # next line will throw ValueError if dtype does not support nans
-            test_nan = array(nan, dtype=value.dtype) # analysis:ignore
-            n_nan = np_sum(isnan(value))
-            meta['NaNs'] = n_nan                    
-        with ignore(Exception):
-            meta['mean'] = nanmean(value)
-        with ignore(Exception):
-            n_bytes = value.nbytes
-            if n_bytes < 1024*2:
-                meta['memory'] = str(n_bytes) + 'B' 
-            elif n_bytes < (1024**2)*2:
-                meta['memory'] = str(round(n_bytes/(1024.0), 1)) + 'KB' 
-            else:
-                meta['memory'] = str(round(n_bytes/(1024.0**2), 1)) + 'MB' 
+    try:
+        from pandas import DataFrame, TimeSeries
+    except ImportError:
+        DataFrame = TimeSeries = DudObject  # analysis:ignore
 
-        with ignore(Exception):
-            can_make_images = False
-            from io import BytesIO
-            from PIL import Image, ImageDraw
-            from base64 import b64encode
-            def img_to_html(img, alt_text='data img'):
-                b = BytesIO()  
-                img.save(b, format='png')
-                return '<img alt="' + alt_text +'"'\
-                            + ' src="data:image/png;base64,' \
-                            +  b64encode(b.getvalue()) + '" />'
-            can_make_images = True
-        image_list = []
-        
-        # If we have a 2D array which is bigger than 6x6, make a thumbnail                   
-        with ignore(Exception):
-            if can_make_images and value.ndim == 2 and value.shape[0] > 6 and value.shape[1] > 6:
-                from matplotlib import cm
-                from matplotlib.colors import Normalize
-                if not ma.isMaskedArray(value):
-                    value = ma.array(value, mask=isnan(value))  
-                img = Image.fromarray(cm.jet(Normalize()(value), bytes=True))
-                img.thumbnail((128,128))
-                image_list.append(img_to_html(img, "matshow image"))
-                
-        # If we have a long 1d array, then show a simple line plot 
-        # unless the line plot fills more than half the axes area
-        with ignore(Exception):
-            if value.squeeze().ndim == 1 and value.size > 15:
-                from numpy import (linspace, max as np_max, min as np_min, 
-                                   corrcoef, arange)
-                img = Image.new("RGBA", (128,128))
-                draw = ImageDraw.Draw(img)
-                value = value.squeeze()
-                value = value - np_min(value)
-                fill_color = (255,0,0,255)
-                draw.line(zip(linspace(0,127,value.size),
-                         127-value * 127./np_max(value)),
-                        fill_color)   
-                filled_count = next(count for count, color in img.getcolors()\
-                                            if color == fill_color)
-                if filled_count < 0.5*img.size[0]*img.size[1]:
-                    image_list.append(img_to_html(img,"1d line plot"))
-                    meta['corrcoef'] = corrcoef(arange(len(value)),value)[0,1]
-                    
-        # If we have a 2xn or nx2 with large n, then do a scatter plot
-        with ignore(Exception):
-            if value.squeeze().ndim == 2 and min(value.shape) == 2 and \
-                    max(value.shape) > 15:
-                from numpy import (max as np_max, min as np_min, corrcoef)
-                img = Image.new("RGBA", (128,128))
-                draw = ImageDraw.Draw(img)
-                value = value.squeeze()
-                value = value if value.shape[0] == 2 else value.T
-                value = value - np_min(value, axis=1, keepdims=True)
-                fill_color = (0,0,255,255)
-                draw.point(zip(value[0]*127./np_max(value[0]),
-                         127-value[1]*127./np_max(value[1])),
-                         fill_color)   
-                filled_count = next(count for count, color in img.getcolors()\
-                                            if color == fill_color)
-                if filled_count < 0.5*img.size[0]*img.size[1]:
-                    image_list.append(img_to_html(img,"xy scatter plot"))
-                    meta['corrcoef'] = corrcoef(value[0],value[1])[0,1]
-            
-        if len(image_list) > 0:
-            meta['html'] = ' '.join(image_list)
+    if isinstance(value, (ndarray, MaskedArray)):   
+        meta.update(make_numpy_meta_dict(value))
+    elif isinstance(value, DataFrame):
+        meta['value'] = value.describe().to_html().replace('\n','')
+    elif hasattr(value, '_repr_html_'):
+        html = value._repr_html_()
+        if html is not None and len(html) > 0:
+            meta['html'] = html
+            meta['value'] = None
     return meta

--- a/spyderlib/utils/makemetadict.py
+++ b/spyderlib/utils/makemetadict.py
@@ -1,7 +1,24 @@
 # -*- coding: utf-8 -*-
 
-from contextlib import contextmanager
-from collections import OrderedDict
+
+from importlib import import_module
+import os.path as osp
+from spyderlib.config import CONF
+
+
+# On startup, find the required implementation
+make_meta_dict_inner_func = None
+
+makemetadict_custom = CONF.get('variable_explorer', 'makemetadict/custom', False)
+
+if makemetadict_custom and osp.exists(makemetadict_custom):
+    mod = import_module(makemetadict_custom)
+    make_meta_dict_inner_func = getattr(mod, 'make_meta_dict', None)
+
+if make_meta_dict_inner_func is None:
+    from spyderlib.make_meta_dict_default import make_meta_dict
+    make_meta_dict_inner_func = make_meta_dict
+
 
 def make_meta_dict(value):
     """
@@ -11,195 +28,9 @@ def make_meta_dict(value):
     user (like the startup.py scripts).
     """
     try:
-        return make_meta_dict_user(value)
+        return make_meta_dict_inner_func(value)
     except Exception:
         import traceback
         print(traceback.format_exc())
         return {}
 
-#----USER CODE FOLLOWS. TODO: put in a separate file for user to modify
-
-@contextmanager
-def ignore(*exceptions):  
-    try:
-        yield
-    except exceptions:
-        pass
-
-def make_numpy_meta_dict(value):
-    """
-    Called from within make_meta_dict_user if value is a numpy array.
-    
-    You can display multiple images, but here we try to guess what kind
-    of graphical representation would best suit the given data.  If you 
-    don't like that you can change it!
-    """
-    from numpy import (array, isnan, nanmax, 
-                       nanmin, nanmean, nan, ma, sum as np_sum)
-    from numpy.ma import MaskedArray
-    meta = OrderedDict()
-    with ignore(Exception):
-        meta['min'] = nanmin(value)                
-    with ignore(Exception):
-        meta['max'] = nanmax(value)
-    with ignore(Exception): 
-        if isinstance(value, MaskedArray):
-            meta['masked'] = str(value.size - value.count())                
-    with ignore(Exception):
-        # next line will throw ValueError if dtype does not support nans
-        test_nan = array(nan, dtype=value.dtype) # analysis:ignore
-        n_nan = np_sum(isnan(value))
-        meta['NaNs'] = n_nan                    
-    with ignore(Exception):
-        meta['mean'] = nanmean(value)
-    with ignore(Exception):
-        n_bytes = value.nbytes
-        if n_bytes < 1024*2:
-            meta['memory'] = str(n_bytes) + 'B' 
-        elif n_bytes < (1024**2)*2:
-            meta['memory'] = str(round(n_bytes/(1024.0), 1)) + 'KB' 
-        else:
-            meta['memory'] = str(round(n_bytes/(1024.0**2), 1)) + 'MB' 
-
-    # Try and get some machinery for making simple plots
-    with ignore(Exception):
-        can_make_images = False
-        from io import BytesIO
-        from PIL import Image, ImageDraw
-        from base64 import b64encode
-        def img_to_html(img, alt_text='data img'):
-            b = BytesIO()  
-            img.save(b, format='png')
-            return '<img alt="' + alt_text +'"'\
-                        + ' src="data:image/png;base64,' \
-                        +  b64encode(b.getvalue()) + '" />'
-        can_make_images = True
-    image_list = []
-    
-    # If we have a 2D array which is bigger than 6x6, make a thumbnail                   
-    with ignore(Exception):
-        if can_make_images and value.ndim == 2 and value.shape[0] > 6 and value.shape[1] > 6:
-            from matplotlib import cm
-            from matplotlib.colors import Normalize
-            if not ma.isMaskedArray(value):
-                value = ma.array(value, mask=isnan(value))  
-            img = Image.fromarray(cm.jet(Normalize()(value), bytes=True))
-            img.thumbnail((128,128))
-            image_list.append(img_to_html(img, "matshow image"))
-            
-    # If we have a long 1d array, then show a simple line plot 
-    # unless the line plot fills more than half the axes area
-    with ignore(Exception):
-        if value.squeeze().ndim == 1 and value.size > 15:
-            from numpy import (linspace, max as np_max, min as np_min, 
-                               corrcoef, arange)
-            img = Image.new("RGBA", (128,128))
-            draw = ImageDraw.Draw(img)
-            value = value.squeeze()
-            value = value - np_min(value)
-            fill_color = (255,0,0,255)
-            draw.line(zip(linspace(0,127,value.size),
-                     127-value * 127./np_max(value)),
-                    fill_color)   
-            filled_count = next(count for count, color in img.getcolors()\
-                                        if color == fill_color)
-            if filled_count < 0.5*img.size[0]*img.size[1]:
-                image_list.append(img_to_html(img,"1d line plot"))
-                meta['corrcoef'] = corrcoef(arange(len(value)),value)[0,1]
-                
-    # If we have a 2xn or nx2 with large n, then do a scatter plot
-    with ignore(Exception):
-        if value.squeeze().ndim == 2 and min(value.shape) == 2 and \
-                max(value.shape) > 15:
-            from numpy import (max as np_max, min as np_min, corrcoef)
-            img = Image.new("RGBA", (128,128))
-            draw = ImageDraw.Draw(img)
-            value = value.squeeze()
-            value = value if value.shape[0] == 2 else value.T
-            value = value - np_min(value, axis=1, keepdims=True)
-            fill_color = (0,0,255,255)
-            draw.point(zip(value[0]*127./np_max(value[0]),
-                     127-value[1]*127./np_max(value[1])),
-                     fill_color)   
-            filled_count = next(count for count, color in img.getcolors()\
-                                        if color == fill_color)
-            if filled_count < 0.5*img.size[0]*img.size[1]:
-                image_list.append(img_to_html(img,"xy scatter plot"))
-                meta['corrcoef'] = corrcoef(value[0],value[1])[0,1]
-        
-    if len(image_list) > 0:
-        meta['html'] = ' '.join(image_list)
-        meta['value'] = None # if we have a plot we dont need to show the raw data
-        
-    return meta         
-    
-def make_pil_meta_dict(value):
-    with ignore(Exception):
-        from io import BytesIO
-        from base64 import b64encode
-        b = BytesIO()
-        value = value.copy()
-        value.thumbnail((128,128))
-        value.save(b, format='png')
-        return {'html': '<img alt="PIL Image"'\
-                    + ' src="data:image/png;base64,' \
-                    +  b64encode(b.getvalue()) + '" />',
-                'value': None}
-        
-def make_meta_dict_user(value):
-    """
-    This function is called when the user moves over a variable in the 
-    variable explorer (when in compact mode).  ``value`` is the actual
-    variable in question.  
-    
-    The function should return a dictionary-like object with "simple" meta data
-    to be rendered as a list of key-values.  Note we suggest using an OrderedDict
-    in order to control the order in which the keys are displayed.
-    
-    If an "html" key is present in the dictionary, that data wil be interpreted
-    as raw html and rendered after the simple meta data.  
-    Search for "richtext-html-subset qt" to find out exactly what html is
-    supported.
-    
-    If a "value" key is present in the dictionary, that will replace the
-    value string that would otherwise be shown. Set this to ``None`` to hide
-    the value completely (e.g. if html is sufficient).
-    
-    Note that ``value`` may be a copy or may be the original value, so
-    so do not modify it inplace, but conversely do not rely on "is"
-    comparisons for caching or other comparisons.
-    
-    """
-    meta = OrderedDict()
-    class DudObject():
-        pass
-    
-    try:
-        from numpy import ndarray
-        from numpy.ma import MaskedArray
-    except ImportError:
-        ndarray = MaskedArray = DudObject  # analysis:ignore
-        
-    try:
-        from pandas import DataFrame, TimeSeries
-    except ImportError:
-        DataFrame = TimeSeries = DudObject  # analysis:ignore
-
-    try:
-        from PIL import Image
-    except ImportError:
-        Image = DudObject # analysis:ignore
-        
-    if isinstance(value, (ndarray, MaskedArray)):   
-        meta.update(make_numpy_meta_dict(value))
-    elif isinstance(value, DataFrame):
-        meta['html'] = value.describe().to_html()
-        meta['value'] = None
-    elif isinstance(value, Image.Image):
-        meta.update(make_pil_meta_dict(value))
-    elif hasattr(value, '_repr_html_'):
-        html = value._repr_html_()
-        if html is not None and len(html) > 0:
-            meta['html'] = html
-            meta['value'] = None
-    return meta

--- a/spyderlib/utils/makemetadict.py
+++ b/spyderlib/utils/makemetadict.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
-# TODO: ideally this file should be user-editable like the startup.py file
-
 from contextlib import contextmanager
 from collections import OrderedDict
 
 def make_meta_dict(value):
     """
     This wraps the user's code, giving a stacktrace on errors, but still
-    returning a valid output.
+    returning a valid output.  The idea is that the make_meta_dict_user
+    is actually located in a separate file that can be modified by the
+    user (like the startup.py scripts).
     """
     try:
         return make_meta_dict_user(value)
@@ -31,10 +31,26 @@ def make_meta_dict_user(value):
     variable in question.  
     
     The function should return a dictionary-like object with "simple" meta data
-    to be rendered as a list of key-values.
+    to be rendered as a list of key-values.  Note we suggest using an OrderedDict
+    in order to control the order in which the keys are displayed.
     
     If an "html" key is present in the dictionary, that data wil be interpreted
-    as raw html and rendered after the simple meta data.    
+    as raw html and rendered after the simple meta data.  
+    Search for "richtext-html-subset qt" to find out exactly what html is
+    supported.
+    
+    Note that ``value`` may be a copy or may be the original value, so
+    so do not modify it inplace, but conversely do not rely on "is"
+    comparisons for caching or other comparisons.
+            
+    You can display multiple images, but here we try to guess what kind
+    of graphical representation would best suit the given data.  If you 
+    don't like that you can change it!
+    
+    Although this function may be long each bit of it should be kept 
+    fairly independent...you  may want to split it into lots of little
+    functions and then call then explictly call each in turn, wrapped
+    in the lazy ignore(Exception).
     """
     meta = OrderedDict()
     class DudObject():
@@ -73,19 +89,70 @@ def make_meta_dict_user(value):
                 meta['memory'] = str(round(n_bytes/(1024.0**2), 1)) + 'MB' 
 
         with ignore(Exception):
-            if value.ndim == 2 and value.shape[0] > 6 and value.shape[1] > 6:
-                # we have a 2D array which is bigger than 6x6, so make a thumbnail
-                from io import BytesIO
-                from PIL import Image
-                from base64 import b64encode
+            can_make_images = False
+            from io import BytesIO
+            from PIL import Image, ImageDraw
+            from base64 import b64encode
+            def img_to_html(img, alt_text='data img'):
+                b = BytesIO()  
+                img.save(b, format='png')
+                return '<img alt="' + alt_text +'"'\
+                            + ' src="data:image/png;base64,' \
+                            +  b64encode(b.getvalue()) + '" />'
+            can_make_images = True
+        image_list = []
+        
+        # If we have a 2D array which is bigger than 6x6, make a thumbnail                   
+        with ignore(Exception):
+            if can_make_images and value.ndim == 2 and value.shape[0] > 6 and value.shape[1] > 6:
                 from matplotlib import cm
                 from matplotlib.colors import Normalize
-                b = BytesIO()  
                 if not ma.isMaskedArray(value):
                     value = ma.array(value, mask=isnan(value))  
                 img = Image.fromarray(cm.jet(Normalize()(value), bytes=True))
                 img.thumbnail((128,128))
-                img.save(b, format='png')
-                meta['html'] = '<img alt="2d array" src="data:image/png;base64,' + \
-                                b64encode(b.getvalue()) + '" />'       
+                image_list.append(img_to_html(img, "matshow image"))
+                
+        # If we have a long 1d array, then show a simple line plot 
+        # unless the line plot fills more than half the axes area
+        with ignore(Exception):
+            if value.squeeze().ndim == 1 and value.size > 15:
+                from numpy import (linspace, max as np_max, min as np_min, 
+                                   corrcoef, arange)
+                img = Image.new("RGBA", (128,128))
+                draw = ImageDraw.Draw(img)
+                value = value.squeeze()
+                value = value - np_min(value)
+                fill_color = (255,0,0,255)
+                draw.line(zip(linspace(0,127,value.size),
+                         127-value * 127./np_max(value)),
+                        fill_color)   
+                filled_count = next(count for count, color in img.getcolors()\
+                                            if color == fill_color)
+                if filled_count < 0.5*img.size[0]*img.size[1]:
+                    image_list.append(img_to_html(img,"1d line plot"))
+                    meta['corrcoef'] = corrcoef(arange(len(value)),value)[0,1]
+                    
+        # If we have a 2xn or nx2 with large n, then do a scatter plot
+        with ignore(Exception):
+            if value.squeeze().ndim == 2 and min(value.shape) == 2 and \
+                    max(value.shape) > 15:
+                from numpy import (max as np_max, min as np_min, corrcoef)
+                img = Image.new("RGBA", (128,128))
+                draw = ImageDraw.Draw(img)
+                value = value.squeeze()
+                value = value if value.shape[0] == 2 else value.T
+                value = value - np_min(value, axis=1, keepdims=True)
+                fill_color = (0,0,255,255)
+                draw.point(zip(value[0]*127./np_max(value[0]),
+                         127-value[1]*127./np_max(value[1])),
+                         fill_color)   
+                filled_count = next(count for count, color in img.getcolors()\
+                                            if color == fill_color)
+                if filled_count < 0.5*img.size[0]*img.size[1]:
+                    image_list.append(img_to_html(img,"xy scatter plot"))
+                    meta['corrcoef'] = corrcoef(value[0],value[1])[0,1]
+            
+        if len(image_list) > 0:
+            meta['html'] = ' '.join(image_list)
     return meta

--- a/spyderlib/utils/makemetadict.py
+++ b/spyderlib/utils/makemetadict.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-
-
-from importlib import import_module
 import os.path as osp
 from spyderlib.config import CONF
 
@@ -9,12 +6,28 @@ from spyderlib.config import CONF
 # On startup, find the required implementation
 make_meta_dict_inner_func = None
 
-makemetadict_custom = CONF.get('variable_explorer', 'makemetadict/custom', False)
+mod_custom_path = CONF.get('variable_explorer', 'make_meta_dict', False)
+makemetadict_def = CONF.get('variable_explorer', 'makemetadict/default', False)
 
-if makemetadict_custom and osp.exists(makemetadict_custom):
-    mod = import_module(makemetadict_custom)
-    make_meta_dict_inner_func = getattr(mod, 'make_meta_dict', None)
-
+if not makemetadict_def and osp.exists(str(mod_custom_path)):
+    # Loading a module form file path seems to be messy:
+    # http://stackoverflow.com/a/67692/2399799
+    mod_custom_name, _ = osp.splitext(mod_custom_path)
+    mod = None
+    try:
+        import imp
+        mod = imp.load_source(mod_custom_name, mod_custom_path)
+    except Exception:
+        try:
+            import importlib.machinery
+            mod = importlib.machinery\
+                            .SourceFileLoader(mod_custom_name, mod_custom_path)\
+                            .load_module(mod_custom_name)
+        except Exception:
+            pass  # mod is still None, use default...
+    if mod is not None:
+        make_meta_dict_inner_func = getattr(mod, 'make_meta_dict', None)
+        
 if make_meta_dict_inner_func is None:
     from spyderlib.make_meta_dict_default import make_meta_dict
     make_meta_dict_inner_func = make_meta_dict

--- a/spyderlib/utils/makemetadict.py
+++ b/spyderlib/utils/makemetadict.py
@@ -193,7 +193,8 @@ def make_meta_dict_user(value):
     if isinstance(value, (ndarray, MaskedArray)):   
         meta.update(make_numpy_meta_dict(value))
     elif isinstance(value, DataFrame):
-        meta['value'] = value.describe().to_html().replace('\n','')
+        meta['html'] = value.describe().to_html()
+        meta['value'] = None
     elif isinstance(value, Image.Image):
         meta.update(make_pil_meta_dict(value))
     elif hasattr(value, '_repr_html_'):

--- a/spyderlib/utils/makemetadict.py
+++ b/spyderlib/utils/makemetadict.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+# TODO: ideally this file should be user-editable like the startup.py file
+
+from contextlib import contextmanager
+from collections import OrderedDict
+
+def make_meta_dict(value):
+    """
+    This wraps the user's code, giving a stacktrace on errors, but still
+    returning a valid output.
+    """
+    try:
+        return make_meta_dict_user(value)
+    except Exception:
+        import traceback
+        print(traceback.format_exc())
+        return {}
+        
+@contextmanager
+def ignore(*exceptions):  
+    try:
+        yield
+    except exceptions:
+        pass
+ 
+def make_meta_dict_user(value):
+    """
+    This function is called when the user moves over a variable in the 
+    variable explorer (when in compact mode).  ``value`` is the actual
+    variable in question.  
+    
+    The function should return a dictionary-like object with "simple" meta data
+    to be rendered as a list of key-values.
+    
+    If an "html" key is present in the dictionary, that data wil be interpreted
+    as raw html and rendered after the simple meta data.    
+    """
+    meta = OrderedDict()
+    class DudObject():
+        pass
+    
+    try:
+        from numpy import (array, ndarray, isnan, nanmax, 
+                              nanmin, nanmean, nan, ma)
+        from numpy import sum as np_sum
+        from numpy.ma import MaskedArray
+    except ImportError:
+        ndarray = MaskedArray = DudObject  # analysis:ignore
+        
+    if isinstance(value, (ndarray, MaskedArray)):   
+        with ignore(Exception):
+            meta['min'] = nanmin(value)                
+        with ignore(Exception):
+            meta['max'] = nanmax(value)
+        if isinstance(value,MaskedArray):
+            with ignore(Exception): 
+                meta['masked'] = str(value.size - value.count())                
+        with ignore(Exception):
+            # next line will throw ValueError if dtype does not support nans
+            test_nan = array(nan, dtype=value.dtype) # analysis:ignore
+            n_nan = np_sum(isnan(value))
+            meta['NaNs'] = n_nan                    
+        with ignore(Exception):
+            meta['mean'] = nanmean(value)
+        with ignore(Exception):
+            n_bytes = value.nbytes
+            if n_bytes < 1024*2:
+                meta['memory'] = str(n_bytes) + 'B' 
+            elif n_bytes < (1024**2)*2:
+                meta['memory'] = str(round(n_bytes/(1024.0), 1)) + 'KB' 
+            else:
+                meta['memory'] = str(round(n_bytes/(1024.0**2), 1)) + 'MB' 
+
+        with ignore(Exception):
+            if value.ndim == 2 and value.shape[0] > 6 and value.shape[1] > 6:
+                # we have a 2D array which is bigger than 6x6, so make a thumbnail
+                from io import BytesIO
+                from PIL import Image
+                from base64 import b64encode
+                from matplotlib import cm
+                from matplotlib.colors import Normalize
+                b = BytesIO()  
+                if not ma.isMaskedArray(value):
+                    value = ma.array(value, mask=isnan(value))  
+                img = Image.fromarray(cm.jet(Normalize()(value), bytes=True))
+                img.thumbnail((128,128))
+                img.save(b, format='png')
+                meta['html'] = '<img alt="2d array" src="data:image/png;base64,' + \
+                                b64encode(b.getvalue()) + '" />'       
+    return meta

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -55,6 +55,10 @@ from spyderlib.utils.makemetadict import make_meta_dict
 
 LARGE_NROWS = 5000
 
+def escape_for_html(s):
+    return str(s).replace('&', '&amp;')\
+                 .replace('<','&lt;')\
+                 .replace('>','&gt;')
 
 def display_to_value(value, default_value, ignore_errors=True):
     """Convert back to value"""
@@ -436,14 +440,17 @@ class DictModel(ReadOnlyDictModel):
             value = meta_dict['value'] 
             del meta_dict['value']
         if value is not None:
-            value_str = "<br><br>" + str(value).replace('\n','<br>')
+            value_str = "<br><br>" + escape_for_html(value)\
+                                            .replace('\n','<br>')
         if len(meta_dict) > 0:
-            meta_str = '<br><br>' + ' | '.join(["<b>%s:</b>&nbsp;%s" % (k,v) \
-                                            for k,v in meta_dict.iteritems()])
-            
+            meta_str = '<br><br>'\
+                + ' | '.join(["<b>%s:</b>&nbsp;%s"\
+                              % (escape_for_html(k), escape_for_html(v)) \
+                              for k, v in meta_dict.iteritems()])
+                        
         return _("<h2>%s</h2><b>type:</b> %s | <b>size:</b> %s%s%s%s")\
                     % (self.keys[row], self.types[row], size_str,
-                       meta_str, html_str, value_str )
+                       meta_str, html_str, value_str)
             
 class DictDelegate(QItemDelegate):
     """DictEditor Item Delegate"""

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -633,7 +633,8 @@ class InfoPane(QDialog):
     def __init__(self, parent):
         QDialog.__init__(self, parent)
         self.setAttribute(Qt.WA_DeleteOnClose | Qt.WA_ShowWithoutActivating)        
-        self.setWindowFlags(Qt.Dialog | Qt.FramelessWindowHint) 
+        self.setWindowFlags(Qt.Tool | Qt.FramelessWindowHint \
+                            | Qt.WindowStaysOnTopHint) 
         self.setWindowOpacity(0.9)
         
         self.setPalette(QToolTip.palette())

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -417,7 +417,12 @@ class DictModel(ReadOnlyDictModel):
         except TypeError:
             size_str = self.sizes[row]
 
-        value = self._data[self.keys[row]]['view']
+        value = self._data[self.keys[row]]
+        if self.remote:
+            value = value['view']
+        else:
+            value = str(value)
+            
         if len(value) > 2000:
             value = value[:2000].rstrip() + "..." # QLabel strugles with long strings
 

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -1006,6 +1006,10 @@ class BaseTableView(QTableView):
             self.info_pane = InfoPane(self)
         if state:
            self.info_pane.update_position()
+           self.verticalHeader().setResizeMode(QHeaderView.ResizeToContents)
+        else:
+            self.verticalHeader().setResizeMode(QHeaderView.Interactive)
+            
         self.showRequestedColumns()
         self.resizeColumnsToContents()
 

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -679,7 +679,6 @@ class InfoPane(QDialog):
         parent = self.parent()
         geo = parent.geometry()
         parent_width = geo.width()
-        parent_left = geo.left()
         self_width = 380        
         self_height = 300        
         self.setMinimumSize(self_width, self_height)                
@@ -690,9 +689,9 @@ class InfoPane(QDialog):
             left += geo.left()
             parent = parent.parent()
         window_width = geo.width()
-        
+
         # Work out whether there is more space to the left or right of the parent
-        right_space = window_width - (parent_left + parent_width)    
+        right_space = window_width - (left + parent_width)    
         if right_space > left:
             left += parent_width
             self.main_text.setAlignment(Qt.AlignTop \
@@ -704,6 +703,9 @@ class InfoPane(QDialog):
         self.move(left, top) 
 
     def showText(self, text):
+        # Note that we really out to hook into the move/resize events of all
+        # the ancestors of this widget, but instead we just do this update here..
+        self.update_position()  
         self.main_text.setText(text)
         
 class BaseTableView(QTableView):

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -22,7 +22,7 @@ from spyderlib.qt.QtGui import (QMessageBox, QTableView, QItemDelegate,
                                 QDialog, QDateEdit, QDialogButtonBox, QMenu,
                                 QInputDialog, QDateTimeEdit, QApplication,
                                 QKeySequence, QAbstractItemDelegate, QLabel,
-                                QToolTip, QHeaderView, QImage)
+                                QToolTip, QHeaderView)
 from spyderlib.qt.QtCore import (Qt, QModelIndex, QAbstractTableModel, Signal,
                                  QDateTime, Slot)
 from spyderlib.qt.compat import to_qvariant, from_qvariant, getsavefilename
@@ -41,8 +41,7 @@ from spyderlib.widgets.dicteditorutils import (sort_against, get_size,
                get_human_readable_type, value_to_display, get_color_name,
                is_known_type, FakeObject, Image, ndarray, array, MaskedArray,
                unsorted_unique, try_to_eval, datestr_to_datetime,
-               get_numpy_dtype, is_editable_type, DataFrame, TimeSeries, 
-               make_meta_dict)
+               get_numpy_dtype, is_editable_type, DataFrame, TimeSeries)
 if ndarray is not FakeObject:
     from spyderlib.widgets.arrayeditor import ArrayEditor
 if DataFrame is not FakeObject:
@@ -52,6 +51,7 @@ from spyderlib.widgets.importwizard import ImportWizard
 from spyderlib.py3compat import (to_text_string, to_binary_string,
                                  is_text_string, is_binary_string, getcwd, u)
 
+from spyderlib.utils.makemetadict import make_meta_dict
 
 LARGE_NROWS = 5000
 

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -632,7 +632,7 @@ class DictDelegate(QItemDelegate):
 class InfoPane(QDialog):
     def __init__(self, parent):
         QDialog.__init__(self, parent)
-        self.setAttribute(Qt.WA_DeleteOnClose)        
+        self.setAttribute(Qt.WA_DeleteOnClose | Qt.WA_ShowWithoutActivating)        
         self.setWindowFlags(Qt.Dialog | Qt.FramelessWindowHint) 
         self.setWindowOpacity(0.9)
         
@@ -698,6 +698,10 @@ class BaseTableView(QTableView):
         self.only_show_column = 0 # if None then show all
         self.info_pane = InfoPane(self)
 
+    def resizeEvent(self, event):
+        self.info_pane.update_position()
+        QTableView.resizeEvent(self, event)
+        
     def setModel(self, model):
         QTableView.setModel(self, model)
         if self.only_show_column is not None:

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -479,7 +479,8 @@ class DictDelegate(QItemDelegate):
 
     def createEditor(self, parent, option, index):
         """Overriding method createEditor"""
-        if index.column() < 3:
+        compact = index.model().compact
+        if not compact and index.column() < 3:
             return None
         if self.show_warning(index):
             answer = QMessageBox.warning(self.parent(), _("Warning"),
@@ -986,7 +987,8 @@ class BaseTableView(QTableView):
         if index_clicked.isValid():
             row = index_clicked.row()
             # TODO: Remove hard coded "Value" column number (3 here)
-            index_clicked = index_clicked.child(row, 3)
+            index_clicked = index_clicked.child(row, self.only_show_column
+                                                 if self.model.compact else 3)
             self.edit(index_clicked)
         else:
             event.accept()
@@ -1076,7 +1078,9 @@ class BaseTableView(QTableView):
         if not index.isValid():
             return
         # TODO: Remove hard coded "Value" column number (3 here)
-        self.edit(index.child(index.row(), 3))
+        self.edit(index.child(index.row(), 
+                              self.only_show_column if self.model.compact\
+                              else 3))
 
     @Slot()
     def remove_item(self):

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -645,8 +645,6 @@ class InfoPane(QDialog):
                                     | Qt.AlignRight)
         vlayout.addWidget(self.main_text)
         self.setLayout(vlayout)
-
-        self.position = ('left','top')
         self.update_position()
         
     def update_position(self):
@@ -654,18 +652,25 @@ class InfoPane(QDialog):
         top = 0
         parent = self.parent()
         geo = parent.geometry()
-        w = 300        
-        h = 300        
-        self.setMinimumSize(w, h)                
-        self.setMaximumSize(w, h)
-        if 'left' in self.position:
-            left -= w
-  
+        parent_width = geo.width()
+        parent_left = geo.left()
+        self_width = 300        
+        self_height = 300        
+        self.setMinimumSize(self_width, self_height)                
+        self.setMaximumSize(self_width, self_height)
         while parent:
             geo = parent.geometry()
             top += geo.top()
             left += geo.left()
             parent = parent.parent()
+        window_width = geo.width()
+        
+        # Work out whether there is more space to the left or right of the parent
+        right_space = window_width - (parent_left + parent_width)    
+        if right_space > left:
+            left += parent_width
+        else:
+            left -= self_width
         self.move(left, top) 
 
     def showText(self, text):

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -717,9 +717,10 @@ class InfoPane(QDialog):
 
     def showText(self, text):
         # Note that we really out to hook into the move/resize events of all
-        # the ancestors of this widget, but instead we just do this update here..
+        # the ancestors of this widget, but instead we just do this update here
         self.update_position()  
         self.main_text.setText(text)
+        self.setVisible(len(text) > 0)
         
 class BaseTableView(QTableView):
     """Base dictionary editor table view"""

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -674,11 +674,6 @@ class InfoPane(QDialog):
     def __init__(self, parent):
         QDialog.__init__(self, parent)
         self.setAttribute(Qt.WA_DeleteOnClose | Qt.WA_ShowWithoutActivating)        
-        self.setWindowFlags(Qt.Tool | Qt.FramelessWindowHint \
-                            | Qt.WindowStaysOnTopHint) 
-        self.setWindowOpacity(0.9)
-        
-        self.setPalette(QToolTip.palette())
         vlayout = QVBoxLayout()
         self.main_text = QLabel()
         self.main_text.setWordWrap(True)        
@@ -686,6 +681,14 @@ class InfoPane(QDialog):
         self.setLayout(vlayout)
         self.update_position()
         
+        # Style the dialog to look like a tooltip (more or less)
+        self.setWindowFlags(Qt.Tool | Qt.FramelessWindowHint \
+                            | Qt.WindowStaysOnTopHint) 
+        self.setWindowOpacity(0.9)        
+        self.setPalette(QToolTip.palette())
+        self.setStyleSheet("QDialog {border: 1px solid black}")
+
+
     def update_position(self):
         left = 0
         top = 0

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -667,7 +667,7 @@ class InfoPane(QDialog):
         geo = parent.geometry()
         parent_width = geo.width()
         parent_left = geo.left()
-        self_width = 300        
+        self_width = 380        
         self_height = 300        
         self.setMinimumSize(self_width, self_height)                
         self.setMaximumSize(self_width, self_height)

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -422,20 +422,23 @@ class DictModel(ReadOnlyDictModel):
             value = value[:2000].rstrip() + "..." # QLabel strugles with long strings
 
         meta_dict = get_meta_dict_foo(self.keys[row])
+        html_str = meta_str = value_str = "" 
+        if 'html' in meta_dict:
+            if meta_dict['html'] is not None:
+                html_str = '<br><br>' + meta_dict['html']
+            del meta_dict['html']
+        if 'value' in meta_dict:
+            value = meta_dict['value'] 
+            del meta_dict['value']
+        if value is not None:
+            value_str = "<br><br>" + str(value).replace('\n','<br>')
         if len(meta_dict) > 0:
-            meta_str = ' | '.join(["<b>%s:</b>&nbsp;%s" % (k,v) \
-                                for k,v in meta_dict.iteritems() \
-                                if k != 'html'])
-            meta_str = '<br><br>' + meta_str
-            if 'html' in meta_dict:
-                meta_str += '<br><br>' + meta_dict['html']
-                value = '' # we could show value as well, but there's not much space
-        else:
-            meta_str = ''
-        
-        return _("<h2>%s</h2><b>type:</b> %s | <b>size:</b> %s%s<br><br>%s")\
-                    % (self.keys[row], self.types[row], size_str, meta_str,
-                       value.replace('\n','<br>'))
+            meta_str = '<br><br>' + ' | '.join(["<b>%s:</b>&nbsp;%s" % (k,v) \
+                                            for k,v in meta_dict.iteritems()])
+            
+        return _("<h2>%s</h2><b>type:</b> %s | <b>size:</b> %s%s%s%s")\
+                    % (self.keys[row], self.types[row], size_str,
+                       meta_str, html_str, value_str )
             
 class DictDelegate(QItemDelegate):
     """DictEditor Item Delegate"""

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -715,10 +715,11 @@ class BaseTableView(QTableView):
             for col in xrange(self.model.columnCount()):
                 if col != self.only_show_column:
                     self.setColumnHidden(col,True)
+            self.horizontalHeader().setVisible(False)
         else:
             for col in xrange(self.model.columnCount()):
                 self.setColumnHidden(col,False)  
-        
+            self.horizontalHeader().setVisible(True)
     def setModel(self, model):
         QTableView.setModel(self, model)
         self.showRequestedColumns()

--- a/spyderlib/widgets/dicteditorutils.py
+++ b/spyderlib/widgets/dicteditorutils.py
@@ -29,7 +29,7 @@ class FakeObject(object):
 #----Numpy arrays support
 try:
     from numpy import sum as np_sum
-    from numpy import ndarray, is_nan, nanmax, nanmin, nanmean
+    from numpy import ndarray, isnan, nanmax, nanmin, nanmean
     from numpy import array, matrix #@UnusedImport (object eval)
     from numpy.ma import MaskedArray
 except ImportError:
@@ -176,7 +176,7 @@ def make_meta_dict(value):
             with ignore(Exception): 
                 meta['masked'] = str(value.size - value.count())                
             with ignore(Exception):
-                n_nan = np_sum(is_nan(value))
+                n_nan = np_sum(isnan(value))
                 meta['NaNs'] = n_nan                    
             with ignore(Exception):
                 meta['max'] = nanmax(value)

--- a/spyderlib/widgets/dicteditorutils.py
+++ b/spyderlib/widgets/dicteditorutils.py
@@ -29,7 +29,7 @@ class FakeObject(object):
 #----Numpy arrays support
 try:
     from numpy import sum as np_sum
-    from numpy import ndarray, isnan, nanmax, nanmin, nanmean
+    from numpy import ndarray, isnan, nanmax, nanmin, nanmean, nan
     from numpy import array, matrix #@UnusedImport (object eval)
     from numpy.ma import MaskedArray
 except ImportError:
@@ -163,14 +163,11 @@ def unsorted_unique(lista):
 
 
 @contextmanager
-def ignore(*exceptions):
-    yield
-"""    
+def ignore(*exceptions):  
     try:
         yield
     except exceptions:
         pass
-"""
  
 def make_meta_dict(value):
     meta = OrderedDict()
@@ -183,6 +180,8 @@ def make_meta_dict(value):
             with ignore(Exception): 
                 meta['masked'] = str(value.size - value.count())                
         with ignore(Exception):
+            # next line will throw ValueError if dtype does not support nans
+            test_nan = array(nan, dtype=value.dtype) # analysis:ignore
             n_nan = np_sum(isnan(value))
             meta['NaNs'] = n_nan                    
         with ignore(Exception):
@@ -190,11 +189,11 @@ def make_meta_dict(value):
         with ignore(Exception):
             n_bytes = value.nbytes
             if n_bytes < 1024*2:
-                meta['size'] = str(n_bytes) + 'B' 
+                meta['memory'] = str(n_bytes) + 'B' 
             elif n_bytes < (1024**2)*2:
-                meta['size'] = str(round(n_bytes/(1024.0), 1)) + 'KB' 
+                meta['memory'] = str(round(n_bytes/(1024.0), 1)) + 'KB' 
             else:
-                meta['size'] = str(round(n_bytes/(1024.0**2), 1)) + 'MB' 
+                meta['memory'] = str(round(n_bytes/(1024.0**2), 1)) + 'MB' 
     return meta
     
 #----Display <--> Value

--- a/spyderlib/widgets/dicteditorutils.py
+++ b/spyderlib/widgets/dicteditorutils.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 
 import re
 from contextlib import contextmanager
-
+from collections import OrderedDict
 # Local imports
 from spyderlib.py3compat import (NUMERIC_TYPES, TEXT_TYPES, to_text_string,
                                  is_text_string, is_binary_string, reprlib)
@@ -164,34 +164,37 @@ def unsorted_unique(lista):
 
 @contextmanager
 def ignore(*exceptions):
+    yield
+"""    
     try:
         yield
     except exceptions:
         pass
-    
+"""
+ 
 def make_meta_dict(value):
-    meta = {}
+    meta = OrderedDict()
     if isinstance(value, (ndarray, MaskedArray)):   
+        with ignore(Exception):
+            meta['min'] = nanmin(value)                
+        with ignore(Exception):
+            meta['max'] = nanmax(value)
         if isinstance(value,MaskedArray):
             with ignore(Exception): 
                 meta['masked'] = str(value.size - value.count())                
-            with ignore(Exception):
-                n_nan = np_sum(isnan(value))
-                meta['NaNs'] = n_nan                    
-            with ignore(Exception):
-                meta['max'] = nanmax(value)
-            with ignore(Exception):
-                meta['min'] = nanmin(value)
-            with ignore(Exception):
-                meta['mean'] = nanmean(value)
-            with ignore(Exception):
-                n_bytes = value.nbytes
-                if n_bytes < 1024*2:
-                    meta['size'] = str(n_bytes) + 'B' 
-                elif n_bytes < (1024**2)*2:
-                    meta['size'] = str(int(n_bytes/(1024**2))) + 'KB' 
-                else:
-                    meta['size'] = str(int(n_bytes/(1024**3))) + 'MB' 
+        with ignore(Exception):
+            n_nan = np_sum(isnan(value))
+            meta['NaNs'] = n_nan                    
+        with ignore(Exception):
+            meta['mean'] = nanmean(value)
+        with ignore(Exception):
+            n_bytes = value.nbytes
+            if n_bytes < 1024*2:
+                meta['size'] = str(n_bytes) + 'B' 
+            elif n_bytes < (1024**2)*2:
+                meta['size'] = str(round(n_bytes/(1024.0), 1)) + 'KB' 
+            else:
+                meta['size'] = str(round(n_bytes/(1024.0**2), 1)) + 'MB' 
     return meta
     
 #----Display <--> Value

--- a/spyderlib/widgets/externalshell/monitor.py
+++ b/spyderlib/widgets/externalshell/monitor.py
@@ -155,6 +155,7 @@ class Monitor(threading.Thread):
                        "setlocal": self.setlocal,
                        "is_array": self.is_array,
                        "is_image": self.is_image,
+                       "get_meta_dict": self.get_meta_dict,
                        "get_globals_keys": self.get_globals_keys,
                        "getmodcomplist": self.getmodcomplist,
                        "getcdlistdir": _getcdlistdir,
@@ -384,6 +385,15 @@ class Monitor(threading.Thread):
         return module_completion(name, path)
                 
     #------ Other
+    def get_meta_dict(self, name):
+        """Returns dict with min/max/nans etc. for the given object"""
+        from spyderlib.widgets.dicteditorutils import make_meta_dict
+        try:
+            ns = self.get_current_namespace()
+            return make_meta_dict(ns[name])
+        except Exception:
+            return {}
+            
     def is_array(self, name):
         """Return True if object is an instance of class numpy.ndarray"""
         ns = self.get_current_namespace()

--- a/spyderlib/widgets/externalshell/monitor.py
+++ b/spyderlib/widgets/externalshell/monitor.py
@@ -36,7 +36,7 @@ if DEBUG_MONITOR:
 
 REMOTE_SETTINGS = ('check_all', 'exclude_private', 'exclude_uppercase',
                    'exclude_capitalized', 'exclude_unsupported',
-                   'excluded_names', 'truncate', 'minmax',
+                   'excluded_names', 'truncate', 'minmax', 'compact',
                    'remote_editing', 'autorefresh')
 
 def get_remote_data(data, settings, mode, more_excluded_names=None):
@@ -75,7 +75,8 @@ def make_remote_view(data, settings, more_excluded_names=None):
                            more_excluded_names=more_excluded_names)
     remote = {}
     for key, value in list(data.items()):
-        view = value_to_display(value, truncate=settings['truncate'],
+        view = value_to_display(value, truncate=settings['truncate'] \
+                                        and not settings['compact'],
                                 minmax=settings['minmax'])
         remote[key] = {'type':  get_human_readable_type(value),
                        'size':  get_size(value),

--- a/spyderlib/widgets/externalshell/monitor.py
+++ b/spyderlib/widgets/externalshell/monitor.py
@@ -388,13 +388,10 @@ class Monitor(threading.Thread):
     #------ Other
     def get_meta_dict(self, name):
         """Returns dict with min/max/nans etc. for the given object"""
-        from spyderlib.widgets.dicteditorutils import make_meta_dict
-        try:
-            ns = self.get_current_namespace()
-            return make_meta_dict(ns[name])
-        except Exception:
-            return {}
-            
+        from spyderlib.utils.makemetadict import make_meta_dict
+        ns = self.get_current_namespace()
+        return make_meta_dict(ns[name]) if name in ns else {}
+        
     def is_array(self, name):
         """Return True if object is an instance of class numpy.ndarray"""
         ns = self.get_current_namespace()

--- a/spyderlib/widgets/externalshell/namespacebrowser.py
+++ b/spyderlib/widgets/externalshell/namespacebrowser.py
@@ -78,7 +78,7 @@ class NamespaceBrowser(QWidget):
               exclude_uppercase=None, exclude_capitalized=None,
               exclude_unsupported=None, excluded_names=None,
               truncate=None, minmax=None, remote_editing=None,
-              autorefresh=None):
+              autorefresh=None, compact=None):
         """Setup the namespace browser"""
         assert self.shellwidget is not None
         
@@ -90,6 +90,7 @@ class NamespaceBrowser(QWidget):
         self.excluded_names = excluded_names
         self.truncate = truncate
         self.minmax = minmax
+        self.compact = compact
         self.remote_editing = remote_editing
         self.autorefresh = autorefresh
         

--- a/spyderlib/widgets/externalshell/namespacebrowser.py
+++ b/spyderlib/widgets/externalshell/namespacebrowser.py
@@ -94,7 +94,7 @@ class NamespaceBrowser(QWidget):
         self.autorefresh = autorefresh
         
         if self.editor is not None:
-            self.editor.setup_menu(truncate, minmax)
+            self.editor.setup_menu()
             self.exclude_private_action.setChecked(exclude_private)
             self.exclude_uppercase_action.setChecked(exclude_uppercase)
             self.exclude_capitalized_action.setChecked(exclude_capitalized)

--- a/spyderlib/widgets/externalshell/namespacebrowser.py
+++ b/spyderlib/widgets/externalshell/namespacebrowser.py
@@ -112,7 +112,7 @@ class NamespaceBrowser(QWidget):
                                               minmax=minmax)
         else:
             self.editor = RemoteDictEditorTableView(self, None,
-                            truncate=truncate, minmax=minmax,
+                            truncate=truncate, minmax=minmax, compact=True, 
                             remote_editing=remote_editing,
                             get_value_func=self.get_value,
                             set_value_func=self.set_value,
@@ -133,7 +133,6 @@ class NamespaceBrowser(QWidget):
                             show_image_func=self.show_image)
         self.editor.sig_option_changed.connect(self.sig_option_changed.emit)
         self.editor.sig_files_dropped.connect(self.import_data)
-        self.editor.setCompactMode(True)
         
         # Setup layout
         hlayout = QHBoxLayout()

--- a/spyderlib/widgets/externalshell/namespacebrowser.py
+++ b/spyderlib/widgets/externalshell/namespacebrowser.py
@@ -122,6 +122,7 @@ class NamespaceBrowser(QWidget):
                             is_list_func=self.is_list,
                             get_len_func=self.get_len,
                             is_array_func=self.is_array,
+                            get_meta_dict_func=self.get_meta_dict,
                             is_image_func=self.is_image,
                             is_dict_func=self.is_dict,
                             is_data_frame_func=self.is_data_frame,
@@ -363,7 +364,11 @@ class NamespaceBrowser(QWidget):
     def get_len(self, name):
         """Return sequence length"""
         return communicate(self._get_sock(), "len(%s)" % name)
-        
+
+    def get_meta_dict(self, name):
+        """Return dict of meta data"""
+        return communicate(self._get_sock(), 'get_meta_dict("%s")' % name)
+            
     def is_array(self, name):
         """Return True if variable is a NumPy array"""
         return communicate(self._get_sock(), 'is_array("%s")' % name)

--- a/spyderlib/widgets/externalshell/namespacebrowser.py
+++ b/spyderlib/widgets/externalshell/namespacebrowser.py
@@ -133,7 +133,7 @@ class NamespaceBrowser(QWidget):
                             show_image_func=self.show_image)
         self.editor.sig_option_changed.connect(self.sig_option_changed.emit)
         self.editor.sig_files_dropped.connect(self.import_data)
-        
+        self.editor.setCompactMode(True)
         
         # Setup layout
         hlayout = QHBoxLayout()


### PR DESCRIPTION
*Copied and edited from original post: https://github.com/spyder-ide/spyder/issues/2353*

I've noticed that most of the time my *variable explorer* is not visible on screen (it's "behind" some other widget tab).   The main reason for this is that its "area-to-usefulness" ratio is not that good...each variable takes up a lot of space vertically and you need to set the width of the widget to be pretty wide in order be able to see the value properly. 

It occurs to me that there are 3 usage cases for the widget: 
* find a variable that you can't remember the name of or aren't sure if you've currently got
* check the value/type/size/min/max of a variable...or get a plot of it.
* edit a variable

For the *first* usage, you normally only need to be able to see the names of the variables, so a nice compact list is probably sufficient. However I do note that in some cases you may actually need to do a visual "search" by some heuristic combination of name +value/size/type etc. This heuristic visual search is not really that easy using the current editor, not to mention that it hides many kinds of objects (or else shows you hundreds you don't care about).  [A nice, but complicated UI for dealing with this less common task would be a fancy search system a bit like gmail where you say something like "size>100, dtype:int name:_old", ideally with auto-complete helping you to fill out your query, and instant results....but that's not what I am suggesting here...instead....] to address this heuristic visual search task, it would need to be possible to toggle between the full and compact modes.

For the *second* case you are generally interested in a single variable at a given time (if you wanted to compare multiple values it's currently not really that easy unless the variables happen to be adjacent in the list), so you could have a tooltip showing you the info that you care about. Indeed since this tooltip is generated on request for a single variable you could perform a computation that takes up to about 100-200ms without the user noticing.   You also get quite a bit of space to display the data because it's the data for a single variable at a given time.  I suggest that the script for generating the tooltip data is exposed to the user so they can fully customize it to render data in a way that is convenient for them (i.e. in the same way users can customize their startup scripts.  However, that's not to say that you can't write something fairly simple which guesses what kind of plotting and summary data would be of interest to a "generic" user, .e.g. matshow large 2d arrays, lineplot long 1d arrays, describe data frames etc. And you can show more than one plot/table if you want.

For the *third* usage case, the editing, you either double click the variable name and launch a separate widget (as you currently do), or if the variable is simple enough you can edit it inline in a similar manner to the current tool, except that the edittext would replace the name cell rather than the value cell (because the value column is not showing).

So...with the above in mind I have forged ahead and had a go at implementing something.

It is still a bit rough around the edges but it does do most of what I describe above.  I have submitted this as a PR so that it can more easily be commented on and examined.

![image](https://cloud.githubusercontent.com/assets/4244876/7335193/355674dc-eba6-11e4-85ca-852ef78613be.png)

(As discussed in https://github.com/spyder-ide/spyder/issues/2353, there is a plan to make all toolbars toggle-able)

For reference, in Matlab you can (under certain circumstances) get a tooltip when you mouse over a var in the editor itself:

![image](https://cloud.githubusercontent.com/assets/4244876/7339197/ca67a9a8-ec5d-11e4-899c-d2a2e25fe92d.png)

It also offers the following choice of columns in the variable editor: ``Value, Size, Bytes, Class, Min, Max, Range, Mean, Median, Mode, Var, Std``.  But there's no obvious way to arrange your screen in such a way as to actually make space for all those columns,


**Update: features implemented so far...**
![image](https://cloud.githubusercontent.com/assets/4244876/7350288/4b295166-ecf6-11e4-8927-1dbafc5564a8.png)
Easily toggle between compact and full mode.

![image](https://cloud.githubusercontent.com/assets/4244876/7350302/780b78e4-ecf6-11e4-923c-b40b72a465f8.png)
Edit simple values inline (and launch edit dialog for more complex values).

![image](https://cloud.githubusercontent.com/assets/4244876/7350361/bc614168-ecf6-11e4-8458-ea0f2d601f72.png)
Provide a custom function for generating meta data and html.

In addition to the matshow example above, default function shows things like:
![image](https://cloud.githubusercontent.com/assets/4244876/7350501/8f99bfa6-ecf7-11e4-85a6-45415c9448e5.png)
DataFrame.describe.to_html()   

![image](https://cloud.githubusercontent.com/assets/4244876/7350574/df4ba9ec-ecf7-11e4-8886-9bfd04ae6454.png)
simple lineplot of 1d data   

![image](https://cloud.githubusercontent.com/assets/4244876/7350607/17d8227c-ecf8-11e4-83b5-09390247273b.png)
sphinx doc for objects that dont fall into other categories and have docstrings

**TODOs:**   
* It would be good to make the tooltip reszing a bit better, possibly providing the option of pinning it with ``Alt`` or something and then having scrollbars to navigate longer content like the docstrings.
* Ideally it would be good to implement canceling and timeout for the metadata generation.  This would help users with their own custom version of the ``make_meta_dict`` function, but also in cases where the default version of the function is causing the program to hang because the object in question is large.
* It would be nice to hook up a custom filter function in addition to the custom ``make_meta_dict`` function.  Otherwise the user would be forced to turn off the filters in order to find the custom objects for which they have implemented representation code. (Note that this filtering has to be separate from the actual generation of the representation because we assume the representation is a costly process and should only be done in full when required, i.e. not just as a test of feasibility).

