### PR TITLE
Add drag support for dockwidgets sharing same position

### DIFF
--- a/spyderlib/plugins/__init__.py
+++ b/spyderlib/plugins/__init__.py
@@ -65,8 +65,6 @@ class TabFilter(QObject):
     This filter also holds the methods needed for the detection of a drag and
     the movement of tabs.
     """
-    sig_tab_moved = Signal(int, int)
-
     def __init__(self, dock_tabbar, main):
         QObject.__init__(self)
         self.dock_tabbar = dock_tabbar
@@ -84,8 +82,8 @@ class TabFilter(QObject):
 
     def _get_plugins(self):
         """
-        Get a list of all the plugins references in the QTabBar to which this
-        event filter was attached.
+        Get a list of all plugin references in the QTabBar to which this
+        event filter is attached.
         """
         plugins = []
         for index in range(self.dock_tabbar.count()):
@@ -95,7 +93,9 @@ class TabFilter(QObject):
 
     def _fix_cursor(self, from_index, to_index):
         """Fix mouse cursor position to adjust for different tab sizes."""
+        # The direction is +1 (moving to the right) or -1 (moving to the left)
         direction = abs(to_index - from_index)/(to_index - from_index)
+
         tab_width = self.dock_tabbar.tabRect(to_index).width()
         tab_x_min = self.dock_tabbar.tabRect(to_index).x()
         tab_x_max = tab_x_min + tab_width
@@ -114,7 +114,11 @@ class TabFilter(QObject):
             cursor.setPos(new_pos)
 
     def eventFilter(self,  obj,  event):
-        """Filter mouse press events."""
+        """Filter mouse press events.
+
+        Events that are captured and not propagated return True. Events that
+        are not captured and are propagated return False.
+        """
         event_type = event.type()
         if event_type == QEvent.MouseButtonPress:
             self.tab_pressed(event)
@@ -155,7 +159,6 @@ class TabFilter(QObject):
 
         from_index, to_index = self.from_index, self.to_index
         if from_index != to_index and from_index != -1 and to_index != -1:
-            self.sig_tab_moved.emit(from_index, to_index)
             self.move_tab(from_index, to_index)
             self._fix_cursor(from_index, to_index)
             self.from_index = to_index
@@ -182,9 +185,11 @@ class TabFilter(QObject):
 
     def show_tab_menu(self):
         """Show the context menu assigned to tabs."""
+        pass
 
     def show_nontab_menu(self):
         """Show the context menu assigned to nontabs section."""
+        pass
 
 
 class SpyderDockWidget(QDockWidget):

--- a/spyderlib/plugins/__init__.py
+++ b/spyderlib/plugins/__init__.py
@@ -134,7 +134,7 @@ class TabFilter(QObject):
         self.moving = False
 
     def move_tab(self, start_tab, end_tab):
-        """Move a tab from a start to and end position ."""
+        """Move a tab from a start to and end position."""
         plugins = self._get_plugins()
         start_plugin = self._get_plugin(start_tab)
         end_plugin = self._get_plugin(end_tab)
@@ -212,17 +212,19 @@ class SpyderDockWidget(QDockWidget):
 
     plugin_closed = Signal()
 
-    def __init__(self, *args, **kwargs):
-        super(SpyderDockWidget, self).__init__(*args, **kwargs)
+    def __init__(self, title, parent):
+        super(SpyderDockWidget, self).__init__(title, parent)
         if sys.platform == 'darwin':
             self.setStyleSheet(self.DARWIN_STYLE)
 
         # Needed for the installation of the event filter
-        self.title = args[0]
-        self.main = args[1]
+        self.title = title
+        self.main = parent
         self.dock_tabbar = None
 
-        # Update the QTabBar everytime dockwidget visibility changes
+        # To track dockwidget changes the filter is installed when dockwidget
+        # visibility changes. This installs the filter on startup and also
+        # on dockwidgets that are undocked and then docked to a new location.
         self.visibilityChanged.connect(self.install_tab_event_filter)
 
     def closeEvent(self, event):
@@ -247,6 +249,7 @@ class SpyderDockWidget(QDockWidget):
                     break
         if dock_tabbar is not None:
             self.dock_tabbar = dock_tabbar
+            # Install filter only once per QTabBar
             if getattr(self.dock_tabbar, 'filter', None) is None:
                 self.dock_tabbar.filter = TabFilter(self.dock_tabbar,
                                                     self.main)

--- a/spyderlib/plugins/__init__.py
+++ b/spyderlib/plugins/__init__.py
@@ -154,10 +154,8 @@ class SpyderDockWidget(QDockWidget):
                 if title == self.title:
                     bar = tabbar
                     break
-        if self.bar is None and bar is not None:
+        if bar is not None:
             self.bar = bar
-            #self.bar.setAcceptDrops(True)
-
             if getattr(self.bar, 'filter', None) is None:
                 self.bar.filter = TabFilter(self.bar, self.main)
                 self.bar.installEventFilter(self.bar.filter)

--- a/spyderlib/plugins/__init__.py
+++ b/spyderlib/plugins/__init__.py
@@ -137,9 +137,9 @@ class TabFilter(QObject):
 
         if event.button() == Qt.RightButton:
             if self.from_index == -1:
-                self.show_nontab_menu()
+                self.show_nontab_menu(event)
             else:
-                self.show_tab_menu()
+                self.show_tab_menu(event)
 
     def tab_moved(self, event):
         """Method called when a tab from a QTabBar has been moved."""
@@ -183,13 +183,14 @@ class TabFilter(QObject):
             self.main.tabify_plugins(plugins[i], plugins[i+1])
         from_plugin.dockwidget.raise_()
 
-    def show_tab_menu(self):
+    def show_tab_menu(self, event):
         """Show the context menu assigned to tabs."""
-        pass
+        self.show_nontab_menu(event)
 
-    def show_nontab_menu(self):
+    def show_nontab_menu(self, event):
         """Show the context menu assigned to nontabs section."""
-        pass
+        menu = self.main.createPopupMenu()
+        menu.exec_(self.dock_tabbar.mapToGlobal(event.pos()))
 
 
 class SpyderDockWidget(QDockWidget):


### PR DESCRIPTION
## Description

This related to dockwidgets that are tabified. Dockwidgets, when tabified, are put inside a QTabBar, but there is no access method to this bar, so to get it and process the event an eventFilter plus some search is needed. I added all the logic inside the event filter class.. but not sure if it is the best approach.

I attach a [video](http://youtu.be/wfvJupX4T5U) so you get the idea. 
