### PR TITLE
Automatically add parens for function completions

### DIFF
--- a/spyderlib/widgets/sourcecode/base.py
+++ b/spyderlib/widgets/sourcecode/base.py
@@ -79,6 +79,7 @@ class CompletionWidget(QListWidget):
                      'class': 'class',
                      'module': 'module'}
 
+        self.type_list = types
         if any(types):
             for (c, t) in zip(completion_list, types):
                 icon = icons_map.get(t, 'no_match')
@@ -155,6 +156,11 @@ class CompletionWidget(QListWidget):
         if (key in (Qt.Key_Return, Qt.Key_Enter) and self.enter_select) \
            or key == Qt.Key_Tab:
             self.item_selected()
+            if self.type_list[self.currentRow()] not in ['class', 'function',
+                                                         'method']:
+                return
+            if self.textedit.close_parentheses_enabled:
+                self.textedit.handle_close_parentheses('')
         elif key in (Qt.Key_Return, Qt.Key_Enter,
                      Qt.Key_Left, Qt.Key_Right) or text in ('.', ':'):
             self.hide()

--- a/spyderlib/widgets/sourcecode/base.py
+++ b/spyderlib/widgets/sourcecode/base.py
@@ -67,6 +67,9 @@ class CompletionWidget(QListWidget):
         completion_list = [c[0] for c in completion_list]
         if len(completion_list) == 1 and not automatic:
             self.textedit.insert_completion(completion_list[0])
+            if self.textedit.close_parentheses_enabled:
+                if types[0] in ['class', 'function', 'method']:
+                    self.textedit.handle_close_parentheses('')
             return
 
         self.completion_list = completion_list

--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -2572,20 +2572,8 @@ class CodeEditor(TextEditBaseWidget):
             self.stdkey_end(shift, ctrl)
         elif text == '(' and not self.has_selected_text():
             self.hide_completion_widget()
-            position = self.get_position('cursor')
-            s_trailing_text = self.get_text('cursor', 'eol').strip()
-            if self.close_parentheses_enabled and \
-              (len(s_trailing_text) == 0 or \
-              s_trailing_text[0] in (',', ')', ']', '}')):
-                self.insert_text('()')
-                cursor = self.textCursor()
-                cursor.movePosition(QTextCursor.PreviousCharacter)
-                self.setTextCursor(cursor)
-            else:
-                self.insert_text(text)
-            if self.is_python_like() and self.get_text('sol', 'cursor') and \
-              self.calltips:
-                self.sig_show_object_info.emit(position)
+            if self.close_parentheses_enabled:
+                self.handle_close_parentheses(text)
         elif text in ('[', '{') and not self.has_selected_text() \
           and self.close_parentheses_enabled:
             s_trailing_text = self.get_text('cursor', 'eol').strip()
@@ -2653,6 +2641,22 @@ class CodeEditor(TextEditBaseWidget):
             TextEditBaseWidget.keyPressEvent(self, event)
             if self.is_completion_widget_visible() and text:
                 self.completion_text += text
+
+    def handle_close_parentheses(self, text):
+        if not self.close_parentheses_enabled:
+            return
+        position = self.get_position('cursor')
+        rest = self.get_text('cursor', 'eol').rstrip()
+        if not rest or rest[0] in (',', ')', ']', '}'):
+            self.insert_text('()')
+            cursor = self.textCursor()
+            cursor.movePosition(QTextCursor.PreviousCharacter)
+            self.setTextCursor(cursor)
+        else:
+            self.insert_text(text)
+        if self.is_python_like() and self.get_text('sol', 'cursor') and \
+                self.calltips:
+            self.sig_show_object_info.emit(position)
 
     def mouseMoveEvent(self, event):
         """Underline words when pressing <CONTROL>"""


### PR DESCRIPTION
Fixes #680.  Automatically appends parens to completions that are known to be a `function`, `method`, or `class`, respecting the same rules as the standard auto parens in the code editor.