### PR TITLE
PR: [WIP] Add support for editor tab reordering

### DIFF
--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -105,12 +105,12 @@ class EditorConfigPage(PluginConfigPage):
                                     text=_("Text and margin font style"),
                                     fontfilters=QFontComboBox.MonospacedFonts)
         newcb = self.create_checkbox
-        fpsorting_box = newcb(_("Sort files according to full path"),
-                              'fullpath_sorting')
+#        fpsorting_box = newcb(_("Sort files according to full path"),
+#                              'fullpath_sorting')
         showtabbar_box = newcb(_("Show tab bar"), 'show_tab_bar')
 
         interface_layout = QVBoxLayout()
-        interface_layout.addWidget(fpsorting_box)
+#        interface_layout.addWidget(fpsorting_box)
         interface_layout.addWidget(showtabbar_box)
         interface_group.setLayout(interface_layout)
         

--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -105,12 +105,9 @@ class EditorConfigPage(PluginConfigPage):
                                     text=_("Text and margin font style"),
                                     fontfilters=QFontComboBox.MonospacedFonts)
         newcb = self.create_checkbox
-#        fpsorting_box = newcb(_("Sort files according to full path"),
-#                              'fullpath_sorting')
         showtabbar_box = newcb(_("Show tab bar"), 'show_tab_bar')
 
         interface_layout = QVBoxLayout()
-#        interface_layout.addWidget(fpsorting_box)
         interface_layout.addWidget(showtabbar_box)
         interface_group.setLayout(interface_layout)
         

--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -1200,7 +1200,10 @@ class Editor(SpyderPluginWidget):
                 editorstack.rename_in_data(index, filename)
 
     def tabs_reordered(self, start, end):
-        """ """
+        """
+        When tabs are reordered in a stackeditor this method adjusts tabs
+        in all the stackkeditors
+        """
         if start < 0 or end < 0:
             return
         else:
@@ -1211,7 +1214,7 @@ class Editor(SpyderPluginWidget):
                 data = editorstack.data
                 editorstack.blockSignals(True)
     
-                for i in range(start, end, sign*1):
+                for i in range(start, end, sign):
                     editorstack.tabbar.moveTab(i, i+sign)
                     data[i], data[i+sign] = data[i+sign], data[i]
     

--- a/spyderlib/widgets/editor.py
+++ b/spyderlib/widgets/editor.py
@@ -1948,14 +1948,15 @@ class EditorStack(QWidget):
         pos = event.pos()
         self.moving_end_tab = self.tabbar.tabAt(pos)
 
+        if self.moving_start_tab is not self.moving_end_tab:
+            # This signal is connected to the Editor plugin and fires
+            # a method that reorders ALL openned editorstacks
+            self.sig_tabs_reordered.emit(self.moving_start_tab,
+                                         self.moving_end_tab)
+            self.moving_start_tab = self.moving_end_tab
+
     def tab_released(self, event):
         """ """
-        if self.moving_end_tab is not None:
-            if self.moving_start_tab is not self.moving_end_tab:
-                # This signal is connected to the Editor plugin and fires
-                # a method that reorders ALL openned editorstacks
-                self.sig_tabs_reordered.emit(self.moving_start_tab,
-                                             self.moving_end_tab)
         QApplication.restoreOverrideCursor()
         self.moving_tab = False
 

--- a/spyderlib/widgets/editor.py
+++ b/spyderlib/widgets/editor.py
@@ -978,7 +978,6 @@ class EditorStack(QWidget):
         self.fullpath_sorting_enabled = state
         if self.data:
             finfo = self.data[self.get_stack_index()]
-#            self.data.sort(key=self.__get_sorting_func())
             new_index = self.data.index(finfo)
             self.__repopulate_stack()
             self.set_stack_index(new_index)
@@ -1060,7 +1059,6 @@ class EditorStack(QWidget):
 
     def add_to_data(self, finfo, set_current):
         self.data.append(finfo)
-#        self.data.sort(key=self.__get_sorting_func())
         index = self.data.index(finfo)
         fname, editor = finfo.filename, finfo.editor
         self.tabs.insertTab(index, editor, get_filetype_icon(fname),
@@ -1098,7 +1096,6 @@ class EditorStack(QWidget):
         set_new_index = index == self.get_stack_index()
         current_fname = self.get_current_filename()
         finfo.filename = new_filename
-#        self.data.sort(key=self.__get_sorting_func())
         new_index = self.data.index(finfo)
         self.__repopulate_stack()
         if set_new_index:

--- a/spyderlib/widgets/tabs.py
+++ b/spyderlib/widgets/tabs.py
@@ -105,6 +105,8 @@ class TabBar(QTabBar):
 
 class TabFilter(QObject):
     """
+    This event filter is installed on the QTabBar of BaseTabs to allow for
+    reordering of tabs in the editorstacks.
     """
     def __init__(self, editor_stack):
         QObject.__init__(self)
@@ -133,7 +135,7 @@ class BaseTabs(QTabWidget):
         QTabWidget.__init__(self, parent)
         
         self.setUsesScrollButtons(True)
-        self.filter = TabFilter(parent)
+        self.filter = TabFilter(parent)  # Need to keep reference
         self.tabBar().installEventFilter(self.filter)
         self.corner_widgets = {}
         self.menu_use_tooltips = menu_use_tooltips

--- a/spyderlib/widgets/tabs.py
+++ b/spyderlib/widgets/tabs.py
@@ -13,7 +13,7 @@
 
 from spyderlib.qt.QtGui import (QTabWidget, QMenu, QDrag, QApplication,
                                 QTabBar, QWidget, QHBoxLayout)
-from spyderlib.qt.QtCore import Signal, Qt, QPoint, QMimeData, QByteArray, QObject, QEvent
+from spyderlib.qt.QtCore import Signal, Qt, QPoint, QMimeData, QByteArray
 
 import os.path as osp
 
@@ -101,29 +101,6 @@ class TabBar(QTabBar):
             self.sig_move_tab.emit(index_from, index_to)
             event.acceptProposedAction()
         QTabBar.dropEvent(self, event)
-        
-
-class TabFilter(QObject):
-    """
-    This event filter is installed on the QTabBar of BaseTabs to allow for
-    reordering of tabs in the editorstacks.
-    """
-    def __init__(self, editor_stack):
-        QObject.__init__(self)
-        self.editor_stack = editor_stack
-
-    def eventFilter(self,  obj,  event):
-        event_type = event.type()
-        if event_type == QEvent.MouseButtonPress:
-            self.editor_stack.tab_pressed(event)
-            return True
-        if event_type == QEvent.MouseMove:
-            self.editor_stack.tab_moved(event)
-            return True
-        if event_type == QEvent.MouseButtonRelease:
-            self.editor_stack.tab_released(event)
-            return True
-        return False
 
         
 class BaseTabs(QTabWidget):
@@ -135,8 +112,6 @@ class BaseTabs(QTabWidget):
         QTabWidget.__init__(self, parent)
         
         self.setUsesScrollButtons(True)
-        self.filter = TabFilter(parent)  # Need to keep reference
-        self.tabBar().installEventFilter(self.filter)
         self.corner_widgets = {}
         self.menu_use_tooltips = menu_use_tooltips
         


### PR DESCRIPTION
## Description
Any reordering event will reorder ALL editorstacks opened, so everything remains in sync. Since the editor was sorting by default, I disabled all instances were this was happenning, now we need to discuss what other options should we offer, including sorting and also extra ones (Delete tabs to the right, to the left, delete all tabs except this etc...)

My take on this is that new files should be opened in the order of opening (what happens now with this PR) and if the user wants to order them by some measure, it should be an active action from the user in the context menu.

The [video](http://youtu.be/tbjJ-uM61P0)

## Todo
- [x] Make tabs moving dynamic (move tabs while dragging)
- [x] Erase sorting in preferences
- [x] Disable tab refresh when deleting a tab
- [ ] Add support for tab scrolling when dragging with many tabs open (going to the right or left end should move the tabs)
- [ ] Remove all code reference to fullpath sorting in the calling and creation of Editors?
- [ ] Check nothing is broken!

**For another PR**
- Offer sorting options
- Offer additional options (Delete tabs to the right, to the left, delete all tabs except)?
- Adapt editor preferences panel sorting options
