### PR TITLE
PR: Fix EOL status bug.

### DIFF
--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -871,13 +871,13 @@ class Editor(SpyderPluginWidget):
         
         self.win_eol_action = create_action(self,
                            _("Carriage return and line feed (Windows)"),
-                           toggled=lambda: self.toggle_eol_chars('nt'))
+                           toggled=lambda checked: self.toggle_eol_chars('nt', checked))
         self.linux_eol_action = create_action(self,
                            _("Line feed (UNIX)"),
-                           toggled=lambda: self.toggle_eol_chars('posix'))
+                           toggled=lambda checked: self.toggle_eol_chars('posix', checked))
         self.mac_eol_action = create_action(self,
                            _("Carriage return (Mac)"),
-                           toggled=lambda: self.toggle_eol_chars('mac'))
+                           toggled=lambda checked: self.toggle_eol_chars('mac', checked))
         eol_action_group = QActionGroup(self)
         eol_actions = (self.win_eol_action, self.linux_eol_action,
                        self.mac_eol_action)
@@ -1852,10 +1852,11 @@ class Editor(SpyderPluginWidget):
                     wdir = None
             programs.run_program(WINPDB_PATH, [fname]+args, wdir)
         
-    def toggle_eol_chars(self, os_name):
-        editor = self.get_current_editor()
-        if self.__set_eol_chars:
-            editor.set_eol_chars(sourcecode.get_eol_chars_from_os_name(os_name))
+    def toggle_eol_chars(self, os_name, checked):
+        if checked:
+            editor = self.get_current_editor()
+            if self.__set_eol_chars:
+                editor.set_eol_chars(sourcecode.get_eol_chars_from_os_name(os_name))
 
     @Slot(bool)
     def toggle_show_blanks(self, checked):

--- a/spyderlib/widgets/editor.py
+++ b/spyderlib/widgets/editor.py
@@ -1634,6 +1634,9 @@ class EditorStack(QWidget):
         self.refresh_save_all_action.emit()
         # Refreshing eol mode
         eol_chars = finfo.editor.get_line_separator()
+        self.refresh_eol(eol_chars)
+
+    def refresh_eol(self, eol_chars):
         os_name = sourcecode.get_os_name_from_eol_chars(eol_chars)
         self.refresh_eol_chars.emit(os_name)
 
@@ -1746,6 +1749,7 @@ class EditorStack(QWidget):
         editor.zoom_in.connect(lambda: self.zoom_in.emit())
         editor.zoom_out.connect(lambda: self.zoom_out.emit())
         editor.zoom_reset.connect(lambda: self.zoom_reset.emit())
+        editor.eol_chars_changed.connect(lambda eol_chars: self.refresh_eol(eol_chars))
         if self.outlineexplorer is not None:
             # Removing editor reference from outline explorer settings:
             editor.destroyed.connect(lambda obj=editor:

--- a/spyderlib/widgets/mixins.py
+++ b/spyderlib/widgets/mixins.py
@@ -119,8 +119,9 @@ class BaseEditMixin(object):
         is_document_modified = eol_chars is not None and self.eol_chars is not None
         self.eol_chars = eol_chars
         if is_document_modified:
-            self.document().setModified(False)
             self.document().setModified(True)
+            if self.eol_chars_changed is not None:
+                self.eol_chars_changed.emit(eol_chars)
         
     def get_line_separator(self):
         """Return line separator based on current EOL mode"""

--- a/spyderlib/widgets/mixins.py
+++ b/spyderlib/widgets/mixins.py
@@ -116,9 +116,11 @@ class BaseEditMixin(object):
         if not is_text_string(text): # testing for QString (PyQt API#1)
             text = to_text_string(text)
         eol_chars = sourcecode.get_eol_chars(text)
-        if eol_chars is not None and self.eol_chars is not None:
-            self.document().setModified(True)
+        is_document_modified = eol_chars is not None and self.eol_chars is not None
         self.eol_chars = eol_chars
+        if is_document_modified:
+            self.document().setModified(False)
+            self.document().setModified(True)
         
     def get_line_separator(self):
         """Return line separator based on current EOL mode"""

--- a/spyderlib/widgets/sourcecode/base.py
+++ b/spyderlib/widgets/sourcecode/base.py
@@ -216,6 +216,7 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
     zoom_out = Signal()
     zoom_reset = Signal()
     focus_changed = Signal()
+    eol_chars_changed = Signal(str)
     
     def __init__(self, parent=None):
         QPlainTextEdit.__init__(self, parent)


### PR DESCRIPTION
There were three root causes for the symptoms described in the original issue.

1) Incorrect EOL menu item state

Editor.toggle_eol_chars was being called when the associated widget was both checked and unchecked (apparently, Qt, like most windowing systems, automatically raises a toggled event for the previously selected radio button when a new radio button is toggled).  However, toggle_eol_chars appears to assume it is only invoked in the case when the toggled event's checked attribute is True.

When the user selects a new EOL menu item, toggle_eol_chars is invoked twice: once for the radio button being unchecked and once for the radio button being checked.  Thus, BaseEditMixin.set_eol_chars is also invoked twice: once with the new EOL and once with the old EOL.  set_eol_chars eventually causes the refresh_eol_chars signal to be emitted (via EditorStack.modification_changed).  Thus, Editor.refresh_eol_chars is invoked twice with different EOLs.  As with toggle_eol_chars, refresh_eol_chars assumes it is only invoked for the new EOL, as evidenced by the fact that it only ever calls setChecked(True) on the associated EOL menu item.

The fix is to ensure toggle_eol_chars only handles the checked case.

2) Stale status bar EOL value

BaseEditMixin.set_eol_chars invokes self.document().setModified(True) _before_ setting self.eol_chars to the new EOL.  Setting the document's modified flag causes EditorStack.modification_changed to be invoked synchronously.  modification_changed emits the refresh_eol_chars signal based on the current value of self.eol_chars.  Because self.eol_chars at this point still references the old EOL, the status bar signal handler uses a stale value to update the UI.

The fix is to ensure self.eol_chars is set to the new EOL before invoking self.document().setModified(True).

3) No EOL menu item updates while document state is modified

BaseEditMixin.set_eol_chars invokes self.document().setModified(True), which subsequently causes a refresh_eol_chars signal to be emitted, which subsequently causes Editor.refresh_eol_chars to be invoked to update the EOL menu item checked state.  If the document state is already marked as modified, invoking setModified(True) again does not cause the editor's modificationChanged event to be raised again.  Thus, Editor.refresh_eol_chars is not called and the EOL menu items are not updated again until the document state changes from modified to unmodified (e.g. by saving the document).

The fix is to force the document to think its being moved from the unmodified state to the modified state by first calling setModified(False) before calling setModified(True).  _This smells really bad._  Unfortunately, I don't know enough about the Qt API to know if there's a better way to force the refresh_eol_chars signal to be raised in this case.  My naive understanding of this part of the code would suggest that it might be better to extract a new method on EditorStack responsible for setting eol_chars.  That new method could emit the refresh_eol_chars signal as part of changing the EOL.  It seems the emission of that signal should be independent of the document modification state changing.  I'm hoping one of the committers can improve this portion of the fix.
