### PR TITLE
Print git revision and branch in bootstrap.py instead of mercurial

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -100,8 +100,8 @@ if sys.excepthook != sys.__excepthook__:
 
 # --- Continue
 
-from spyderlib.utils.vcs import get_hg_revision
-print("Revision %s:%s, Branch: %s" % get_hg_revision(DEVPATH))
+from spyderlib.utils.vcs import get_git_revision
+print("Revision %s, Branch: %s" % get_git_revision(DEVPATH))
 
 sys.path.insert(0, DEVPATH)
 print("01. Patched sys.path with %s" % DEVPATH)

--- a/spyderlib/__init__.py
+++ b/spyderlib/__init__.py
@@ -67,7 +67,7 @@ def get_versions(reporev=True):
     revision = None
     if reporev:
         from spyderlib.utils import vcs
-        revision = vcs.get_git_revision(os.path.dirname(__dir__))
+        revision, branch = vcs.get_git_revision(os.path.dirname(__dir__))
 
     if not sys.platform == 'darwin':  # To avoid a crash with our Mac app
         system = platform.system()

--- a/spyderlib/utils/vcs.py
+++ b/spyderlib/utils/vcs.py
@@ -132,7 +132,10 @@ def get_git_revision(repopath):
         branches = subprocess.Popen([git, 'branch'],
                                      stdout=subprocess.PIPE,
                                      cwd=repopath).communicate()
-        branches = branches[0].split('\n')
+        branches = branches[0]
+        if PY3:
+            branches = str(branches)
+        branches = branches.split('\n')
         active_branch = [b for b in branches if b.startswith('*')]
         if len(active_branch) != 1:
             branch = None

--- a/spyderlib/utils/vcs.py
+++ b/spyderlib/utils/vcs.py
@@ -8,6 +8,7 @@
 
 from __future__ import print_function
 
+import sys
 import os.path as osp
 import subprocess
 
@@ -38,7 +39,7 @@ SUPPORTED = [
 class ActionToolNotFound(RuntimeError):
     """Exception to transmit information about supported tools for
        failed attempt to execute given action"""
-       
+
     def __init__(self, vcsname, action, tools):
         RuntimeError.__init__(self)
         self.vcsname = vcsname
@@ -124,9 +125,9 @@ def get_git_revision(repopath):
         commit = subprocess.Popen([git, 'rev-parse', '--short', 'HEAD'],
                                   stdout=subprocess.PIPE,
                                   cwd=repopath).communicate()
-        commit = commit[0][:-1]
+        commit = commit[0].strip()
         if PY3:
-            commit = str(commit)[2:-1]
+            commit = commit.decode(sys.getdefaultencoding())
 
         # Branch
         branches = subprocess.Popen([git, 'branch'],
@@ -134,7 +135,7 @@ def get_git_revision(repopath):
                                      cwd=repopath).communicate()
         branches = branches[0]
         if PY3:
-            branches = str(branches)
+            branches = branches.decode(sys.getdefaultencoding())
         branches = branches.split('\n')
         active_branch = [b for b in branches if b.startswith('*')]
         if len(active_branch) != 1:

--- a/spyderlib/utils/vcs.py
+++ b/spyderlib/utils/vcs.py
@@ -113,22 +113,35 @@ def get_hg_revision(repopath):
 
 def get_git_revision(repopath):
     """Return Git revision for the repository located at repopath
-       Result is the latest commit hash, with None on error
+       Result is a tuple (latest commit hash, branch), with None values on
+       error
     """
     try:
         git = programs.find_program('git')
         assert git is not None and osp.isdir(osp.join(repopath, '.git'))
+
+        # Revision
         commit = subprocess.Popen([git, 'rev-parse', '--short', 'HEAD'],
                                   stdout=subprocess.PIPE,
                                   cwd=repopath).communicate()
+        commit = commit[0][:-1]
         if PY3:
-            commit = str(commit[0][:-1])
-            commit = commit[2:-1]
+            commit = str(commit)[2:-1]
+
+        # Branch
+        branches = subprocess.Popen([git, 'branch'],
+                                     stdout=subprocess.PIPE,
+                                     cwd=repopath).communicate()
+        branches = branches[0].split('\n')
+        active_branch = [b for b in branches if b.startswith('*')]
+        if len(active_branch) != 1:
+            branch = None
         else:
-            commit = commit[0][:-1]
-        return commit
+            branch = active_branch[0].split(None, 1)[1]
+
+        return commit, branch
     except (subprocess.CalledProcessError, AssertionError, AttributeError):
-        return None
+        return None, None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
bootstrap.py still searched for a mercurial revision number. Now it uses git.

I added the search for the branch name.