### PR TITLE
Open preferences dialog even if a plugin raises errors

### DIFF
--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -34,6 +34,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import traceback
 
 
 #==============================================================================
@@ -2599,9 +2600,12 @@ class MainWindow(QMainWindow):
                        self.onlinehelp, self.explorer, self.findinfiles
                        ]+self.thirdparty_plugins:
             if plugin is not None:
-                widget = plugin.create_configwidget(dlg)
-                if widget is not None:
-                    dlg.add_page(widget)
+                try:
+                    widget = plugin.create_configwidget(dlg)
+                    if widget is not None:
+                        dlg.add_page(widget)
+                except Exception:
+                    traceback.print_exc(file=sys.stderr)
         if self.prefs_index is not None:
             dlg.set_current_index(self.prefs_index)
         dlg.show()


### PR DESCRIPTION
If a (third-party) plugin fails to create its preferences page, it prevents the dialog to be created at all.

This PR allows to skip plugins that raise errors. The errors are still displayed in the intenal console, but the loop can continue (show must go on!).