### PR TITLE
Reset spyder and restart from within running application

### DIFF
--- a/spyderlib/plugins/configdialog.py
+++ b/spyderlib/plugins/configdialog.py
@@ -132,38 +132,23 @@ class ConfigDialog(QDialog):
         self.contents_widget = QListWidget()
         self.button_reset = QPushButton(_('Reset to defaults'))
 
-        bbox = QDialogButtonBox(QDialogButtonBox.Ok|QDialogButtonBox.Apply
-                                |QDialogButtonBox.Cancel)
+        bbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Apply |
+                                QDialogButtonBox.Cancel)
         self.apply_btn = bbox.button(QDialogButtonBox.Apply)
 
         # Widgets setup
-
-        
         # Destroying the C++ object right after closing the dialog box,
         # otherwise it may be garbage-collected in another QThread
         # (e.g. the editor's analysis thread in Spyder), thus leading to
         # a segmentation fault on UNIX or an application crash on Windows
         self.setAttribute(Qt.WA_DeleteOnClose)
-
-        self.button_reset = QPushButton(_("Reset to defaults"))
-        self.contents_widget = QListWidget()
+        self.setWindowTitle(_('Preferences'))
+        self.setWindowIcon(ima.icon('configure'))
         self.contents_widget.setMovement(QListView.Static)
         self.contents_widget.setSpacing(1)
-
-        bbox = QDialogButtonBox(QDialogButtonBox.Ok|QDialogButtonBox.Apply
-                                |QDialogButtonBox.Cancel)
-        self.apply_btn = bbox.button(QDialogButtonBox.Apply)
-        bbox.accepted.connect(self.accept)
-        bbox.rejected.connect(self.reject)
-        bbox.clicked.connect(self.button_clicked)
-        
-        self.pages_widget = QStackedWidget()
-        self.pages_widget.currentChanged.connect(self.current_page_changed)
-
-        self.contents_widget.currentRowChanged.connect(
-                                             self.pages_widget.setCurrentIndex)
         self.contents_widget.setCurrentRow(0)
 
+        # Layout
         hsplitter = QSplitter()
         hsplitter.addWidget(self.contents_widget)
         hsplitter.addWidget(self.pages_widget)
@@ -179,14 +164,6 @@ class ConfigDialog(QDialog):
 
         self.setLayout(vlayout)
 
-        self.setWindowTitle(_('Preferences'))
-        self.setWindowIcon(ima.icon('configure'))
-
-        self.button_reset.clicked.connect(self.main.reset_spyder)
-
-        # Ensures that the config is present on spyder first run
-        CONF.set('main', 'interface_language', load_lang_conf())
-        
         # Signals and slots
         self.button_reset.clicked.connect(self.main.reset_spyder)
         self.pages_widget.currentChanged.connect(self.current_page_changed)
@@ -195,7 +172,10 @@ class ConfigDialog(QDialog):
         bbox.accepted.connect(self.accept)
         bbox.rejected.connect(self.reject)
         bbox.clicked.connect(self.button_clicked)
-         
+
+        # Ensures that the config is present on spyder first run
+        CONF.set('main', 'interface_language', load_lang_conf())
+
     def get_current_index(self):
         """Return current page index"""
         return self.contents_widget.currentRow()

--- a/spyderlib/plugins/configdialog.py
+++ b/spyderlib/plugins/configdialog.py
@@ -128,7 +128,6 @@ class ConfigDialog(QDialog):
     def __init__(self, parent=None):
         QDialog.__init__(self, parent)
 
-        self._parent = parent
         self.main = parent
 
         # Widgets

--- a/spyderlib/plugins/configdialog.py
+++ b/spyderlib/plugins/configdialog.py
@@ -24,11 +24,9 @@ import spyderlib.utils.icon_manager as ima
 
 from spyderlib.baseconfig import (_, running_in_mac_app, LANGUAGE_CODES,
                                   save_lang_conf, load_lang_conf)
-from spyderlib.baseconfig import _, running_in_mac_app
 from spyderlib.config import CONF
 from spyderlib.guiconfig import (CUSTOM_COLOR_SCHEME_NAME,
                                  set_default_color_scheme)
-from spyderlib.utils.qthelpers import get_icon, get_std_icon
 from spyderlib.userconfig import NoDefault
 from spyderlib.widgets.colors import ColorLayout
 from spyderlib.widgets.sourcecode import syntaxhighlighters as sh
@@ -108,7 +106,6 @@ class ConfigPage(QWidget):
                     break  # Ensure a single popup is displayed
             self.set_modified(False)
 
-    
     def load_from_conf(self):
         """Load settings from configuration file"""
         raise NotImplementedError

--- a/spyderlib/plugins/configdialog.py
+++ b/spyderlib/plugins/configdialog.py
@@ -149,6 +149,7 @@ class ConfigDialog(QDialog):
         # a segmentation fault on UNIX or an application crash on Windows
         self.setAttribute(Qt.WA_DeleteOnClose)
 
+        self.button_reset = QPushButton(_("Reset to defaults"))
         self.contents_widget = QListWidget()
         self.contents_widget.setMovement(QListView.Static)
         self.contents_widget.setSpacing(1)
@@ -184,6 +185,8 @@ class ConfigDialog(QDialog):
 
         self.setWindowTitle(_('Preferences'))
         self.setWindowIcon(ima.icon('configure'))
+
+        self.button_reset.clicked.connect(self.main.reset_spyder)
 
         # Ensures that the config is present on spyder first run
         CONF.set('main', 'interface_language', load_lang_conf())

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -10,7 +10,7 @@ Restart Spyder
 
 A helper script that allows to restart (and also reset) Spyder from within the
 running application.
-my """
+"""
 
 import ast
 import os

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -237,7 +237,7 @@ def main():
     # Before launching a new Spyder instance we need to make sure that the
     # previous one has closed. We wait for a fixed and "reasonable" amount of
     # time and check, otherwise an error is launched
-    wait_time = 60*5 if IS_WINDOWS else 60*3 # Seconds
+    wait_time = 90 if IS_WINDOWS else 30  # Seconds
     for counter in range(int(wait_time/SLEEP_TIME)):
         if not is_pid_running(pid):
             break

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -17,6 +17,7 @@ import os.path as osp
 import subprocess
 import sys
 import time
+import traceback
 
 
 PY2 = sys.version[0] == '2'
@@ -157,7 +158,7 @@ def main():
             pid_reset = p.pid
         except Exception as error:
             print(command)
-            print(error)
+            traceback.print_exc()
             time.sleep(15)
 
         # Wait for reset process to end before restarting

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -21,7 +21,7 @@ import time
 
 PY2 = sys.version[0] == '2'
 CLOSE_ERROR, RESET_ERROR, RESTART_ERROR = list(range(3))
-
+SLEEP_TIME = 0.2
 
 def _is_pid_running_on_windows(pid):
     """Check if a process is running on windows systems based on the pid."""
@@ -69,7 +69,7 @@ def launch_error_message(type_, error=None):
 
     Parameters
     ----------
-    type : int [CLOSE_ERROR, RESET_ERROR, RESTART_ERROR]
+    type_ : int [CLOSE_ERROR, RESET_ERROR, RESTART_ERROR]
     """
     from spyderlib.baseconfig import _
     from spyderlib.qt.QtGui import QMessageBox, QDialog
@@ -180,10 +180,10 @@ def main():
     shell = os.name != 'nt'
 
     # Wait for original process to end before launching the new instance
-    for counter in range(1500):  # This is equivalent to ~ 5 minute (1500*0.2)
+    for counter in range(range(60*5/SLEEP_TIME)):  # Number in seconds (60*5)
         if not is_pid_running(pid):
             break
-        time.sleep(0.2)  # Throttling control
+        time.sleep(SLEEP_TIME)  # Throttling control
     else:
         # The old spyder instance took too long to close and restart aborts
         launch_error_message(type_=CLOSE_ERROR)
@@ -207,10 +207,10 @@ def main():
             launch_error_message(type_=RESET_ERROR, error=error)
 
         # Wait for reset process to end before restarting
-        for counter in range(300):  # This is ~= 1 minute (300*0.2)
+        for counter in range(60/SLEEP_TIME):  # Number in seconds (60)
             if not is_pid_running(pid_reset):
                 break
-            time.sleep(0.2)  # Throttling control
+            time.sleep(SLEEP_TIME)  # Throttling control
         else:
             # The rest subprocess took too long and it is killed
             p.kill()

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -21,7 +21,8 @@ import time
 
 PY2 = sys.version[0] == '2'
 CLOSE_ERROR, RESET_ERROR, RESTART_ERROR = list(range(3))
-SLEEP_TIME = 0.2
+SLEEP_TIME = 0.2  # Seconds
+
 
 def _is_pid_running_on_windows(pid):
     """Check if a process is running on windows systems based on the pid."""
@@ -189,7 +190,6 @@ def main():
         launch_error_message(type_=CLOSE_ERROR)
 
     env = os.environ.copy()
-
 
     # Reset spyder if needed
     # -------------------------------------------------------------------------

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -219,7 +219,7 @@ def main():
     # Restart
     # -------------------------------------------------------------------------
     try:
-        p = subprocess.Popen(command, shell=shell, env=env)
+        subprocess.Popen(command, shell=shell, env=env)
     except Exception as error:
         launch_error_message(type_=RESTART_ERROR, error=error)
 

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -153,6 +153,7 @@ def main():
         # Try to reset
         try:
             p = subprocess.Popen(command_reset, shell=shell)
+            p.communicate()
             pid_reset = p.pid
         except Exception as error:
             print(command)

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -193,8 +193,6 @@ def main():
 
     # Reset spyder if needed
     # -------------------------------------------------------------------------
-    reset_ok = True
-
     if reset:
         command_reset = '"{0}" "{1}" {2}'.format(python, spyder, args_reset)
 
@@ -214,18 +212,15 @@ def main():
         else:
             # The rest subprocess took too long and it is killed
             p.kill()
-            reset_ok = False
+            launch_error_message(type_=RESET_ERROR)
 
     # Restart
     # -------------------------------------------------------------------------
-    if reset_ok:
-        try:
-            p = subprocess.Popen(command, shell=shell, env=env)
-        except Exception as error:
-            p.kill()
-            launch_error_message(type_=RESTART_ERROR, error=error)
-    else:
-        launch_error_message(type_=RESET_ERROR)
+    try:
+        p = subprocess.Popen(command, shell=shell, env=env)
+    except Exception as error:
+        p.kill()
+        launch_error_message(type_=RESTART_ERROR, error=error)
 
 
 if __name__ == '__main__':

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -181,7 +181,8 @@ def main():
     shell = os.name != 'nt'
 
     # Wait for original process to end before launching the new instance
-    for counter in range(60*5/SLEEP_TIME):  # Number in seconds (60*5)
+    wait_time = 60*5  # Seconds
+    for counter in range(int(wait_time/SLEEP_TIME)):
         if not is_pid_running(pid):
             break
         time.sleep(SLEEP_TIME)  # Throttling control
@@ -191,21 +192,22 @@ def main():
 
     env = os.environ.copy()
 
-    # Reset spyder if needed
+    # Reset Spyder (if required)
     # -------------------------------------------------------------------------
     if reset:
         command_reset = '"{0}" "{1}" {2}'.format(python, spyder, args_reset)
 
         try:
             p = subprocess.Popen(command_reset, shell=shell)
+        except Exception as error:
+            launch_error_message(type_=RESET_ERROR, error=error)
+        else:
             p.communicate()
             pid_reset = p.pid
-        except Exception as error:
-            p.kill()
-            launch_error_message(type_=RESET_ERROR, error=error)
 
         # Wait for reset process to end before restarting
-        for counter in range(60/SLEEP_TIME):  # Number in seconds (60)
+        wait_time = 60  # Seconds
+        for counter in range(int(wait_time/SLEEP_TIME)):
             if not is_pid_running(pid_reset):
                 break
             time.sleep(SLEEP_TIME)  # Throttling control
@@ -219,7 +221,6 @@ def main():
     try:
         p = subprocess.Popen(command, shell=shell, env=env)
     except Exception as error:
-        p.kill()
         launch_error_message(type_=RESTART_ERROR, error=error)
 
 

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -21,12 +21,12 @@ import time
 
 
 from spyderlib.baseconfig import _, get_image_path
+from spyderlib.py3compat import to_text_string
 from spyderlib.qt.QtCore import Qt, QTimer
 from spyderlib.qt.QtGui import (QColor, QMessageBox, QPixmap, QSplashScreen,
                                 QWidget, QApplication)
 from spyderlib.utils import icon_manager as ima
 from spyderlib.utils.qthelpers import qapplication
-
 
 PY2 = sys.version[0] == '2'
 IS_WINDOWS = os.name == 'nt'
@@ -73,27 +73,6 @@ def is_pid_running(pid):
         return _is_pid_running_on_windows(pid)
     else:
         return _is_pid_running_on_unix(pid)
-
-
-# Note: Copied from py3compat because we can't rely on Spyder
-# being installed when using bootstrap.py
-def to_text_string(obj, encoding=None):
-    """Convert `obj` to (unicode) text string"""
-    if PY2:
-        # Python 2
-        if encoding is None:
-            return unicode(obj)
-        else:
-            return unicode(obj, encoding)
-    else:
-        # Python 3
-        if encoding is None:
-            return str(obj)
-        elif isinstance(obj, str):
-            # In case this function is not used properly, this could happen
-            return obj
-        else:
-            return str(obj, encoding)
 
 
 class Restarter(QWidget):

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -266,7 +266,7 @@ def main():
         # Before launching a new Spyder instance we need to make sure that the
         # reset subprocess has closed. We wait for a fixed and "reasonable"
         # amount of time and check, otherwise an error is launched.
-        wait_time = 60  # Seconds
+        wait_time = 20  # Seconds
         for counter in range(int(wait_time/SLEEP_TIME)):
             if not is_pid_running(pid_reset):
                 break

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -181,7 +181,7 @@ def main():
     shell = os.name != 'nt'
 
     # Wait for original process to end before launching the new instance
-    for counter in range(range(60*5/SLEEP_TIME)):  # Number in seconds (60*5)
+    for counter in range(60*5/SLEEP_TIME):  # Number in seconds (60*5)
         if not is_pid_running(pid):
             break
         time.sleep(SLEEP_TIME)  # Throttling control

--- a/spyderlib/restart_app.py
+++ b/spyderlib/restart_app.py
@@ -20,7 +20,7 @@ import time
 
 
 PY2 = sys.version[0] == '2'
-CLOSE_ERROR, RESET_ERROR, RESTART_ERROR = list(range(3))
+CLOSE_ERROR, RESET_ERROR, RESTART_ERROR = list(range(1, 4, 1))
 SLEEP_TIME = 0.2  # Seconds
 
 

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -2755,6 +2755,7 @@ class MainWindow(QMainWindow):
         env['SPYDER_PID'] = str(pid)
         env['SPYDER_IS_BOOTSTRAP'] = str(is_bootstrap)
         env['SPYDER_RESET'] = str(reset)
+        env['PYTHONPATH'] = ':'.join(sys.path)
 
         # Build the command and popen arguments depending on the OS
         if os.name == 'nt':

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -2726,11 +2726,11 @@ class MainWindow(QMainWindow):
     def restart(self, reset=False):
         """
         Quit and Restart Spyder application.
-        
+
         If reset True it allows to reset spyder on restart.
         """
         # Get start path to use in restart script
-        spyder_start_directory  = get_module_path('spyderlib')
+        spyder_start_directory = get_module_path('spyderlib')
         restart_script = osp.join(spyder_start_directory, 'restart_app.py')
 
         # Get any initial argument passed when spyder was started
@@ -2755,10 +2755,12 @@ class MainWindow(QMainWindow):
         env['SPYDER_PID'] = str(pid)
         env['SPYDER_IS_BOOTSTRAP'] = str(is_bootstrap)
         env['SPYDER_RESET'] = str(reset)
-        if os.name == 'nt':
-            env['PYTHONPATH'] = ';'.join(sys.path)
-        else:
-            env['PYTHONPATH'] = ':'.join(sys.path)
+
+        if DEV:
+            if os.name == 'nt':
+                env['PYTHONPATH'] = ';'.join(sys.path)
+            else:
+                env['PYTHONPATH'] = ':'.join(sys.path)
 
         # Build the command and popen arguments depending on the OS
         if os.name == 'nt':

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -2755,7 +2755,10 @@ class MainWindow(QMainWindow):
         env['SPYDER_PID'] = str(pid)
         env['SPYDER_IS_BOOTSTRAP'] = str(is_bootstrap)
         env['SPYDER_RESET'] = str(reset)
-        env['PYTHONPATH'] = ':'.join(sys.path)
+        if os.name == 'nt':
+            env['PYTHONPATH'] = ';'.join(sys.path)
+        else:
+            env['PYTHONPATH'] = ':'.join(sys.path)
 
         # Build the command and popen arguments depending on the OS
         if os.name == 'nt':

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -677,9 +677,9 @@ class MainWindow(QMainWindow):
                                                   module_completion.reset(),
                                         tip=_("Refresh list of module names "
                                               "available in PYTHONPATH"))
-            reset_spyder_action = create_action(self,
-                                        _("Reset Spyder to factory defaults"),
-                                        triggered=lambda: self.reset_spyder())
+            reset_spyder_action = create_action(
+                self, _("Reset Spyder to factory defaults"),
+                triggered=lambda: self.reset_spyder())
             self.tools_menu_actions = [prefs_action, spyder_path_action]
             if WinUserEnvDialog is not None:
                 winenv_action = create_action(self,

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -679,7 +679,7 @@ class MainWindow(QMainWindow):
                                               "available in PYTHONPATH"))
             reset_spyder_action = create_action(
                 self, _("Reset Spyder to factory defaults"),
-                triggered=lambda: self.reset_spyder())
+                triggered=self.reset_spyder)
             self.tools_menu_actions = [prefs_action, spyder_path_action]
             if WinUserEnvDialog is not None:
                 winenv_action = create_action(self,


### PR DESCRIPTION
Fixes #2401

---
## Description

Adds a new entry on the tools menu for reseting spyder from within the application

![image](https://cloud.githubusercontent.com/assets/3627835/7512668/d03c19e6-f4ae-11e4-80ad-d95629b7d853.png)

Or as an option in preferences... decision pending
![image](https://cloud.githubusercontent.com/assets/3627835/8108713/6a8733b4-1052-11e5-9b39-ab0da5a4f6b9.png)
After clicking a message box will ask to confirm, probably the message can be more explanatory so the user knows what he\she is about to do.

![image](https://cloud.githubusercontent.com/assets/3627835/7512683/e64dc1f8-f4ae-11e4-9bd0-79419e8f921f.png)

## Todo

- [x] Agree on location of option
- [x] Agree on text of the new option
