### PR TITLE
Add option to toggle toolbars visibility

### DIFF
--- a/spyderlib/config.py
+++ b/spyderlib/config.py
@@ -197,7 +197,6 @@ DEFAULTS = [
               'custom_margin': 0,
               'show_internal_console_if_traceback': True,
               'check_updates_on_startup': True,
-              'last_visible_toolbars': [],
               'toolbars_visible': True,
               }),
             ('quick_layouts',
@@ -486,6 +485,7 @@ DEFAULTS = [
               '_/save current layout': "Shift+Alt+S",
               '_/toggle default layout': "Shift+Alt+Home",
               '_/layout preferences': "Shift+Alt+P",
+              '_/show toolbars': "Ctrl+Shift+T",
               '_/restart': "Shift+Alt+R",
               '_/quit': "Ctrl+Q",
               # -- In plugins/editor

--- a/spyderlib/config.py
+++ b/spyderlib/config.py
@@ -196,7 +196,9 @@ DEFAULTS = [
               'use_custom_margin': True,
               'custom_margin': 0,
               'show_internal_console_if_traceback': True,
-              'check_updates_on_startup': True
+              'check_updates_on_startup': True,
+              'last_visible_toolbars': [],
+              'toolbars_visible': True,
               }),
             ('quick_layouts',
              {

--- a/spyderlib/config.py
+++ b/spyderlib/config.py
@@ -485,7 +485,7 @@ DEFAULTS = [
               '_/save current layout': "Shift+Alt+S",
               '_/toggle default layout': "Shift+Alt+Home",
               '_/layout preferences': "Shift+Alt+P",
-              '_/show toolbars': "Ctrl+Shift+T",
+              '_/show toolbars': "Alt+Shift+T",
               '_/restart': "Shift+Alt+R",
               '_/quit': "Ctrl+Q",
               # -- In plugins/editor

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -1922,30 +1922,27 @@ class MainWindow(QMainWindow):
             action = plugin.toggle_view_action
             action.setChecked(plugin.dockwidget.isVisible())
 
-    # --- Other
+    # --- Show/Hide toolbars
     def _update_show_toolbars_action(self):
-        """ """
+        """Update the text displayed in the menu entry."""
         if self.toolbars_visible:
             text = _("Hide toolbars")
             tip = _("Hide toolbars")
-#            icon = ima.icon('maximize')
         else:
             text = _("Show toolbars")
             tip = _("Show toolbars")
-#            icon = ima.icon('unmaximize')
         self.show_toolbars_action.setText(text)
         self.show_toolbars_action.setToolTip(tip)
-#        self.show_toolbars_actionsetIcon(icon)
 
     def save_visible_toolbars(self):
-        """ """
+        """Saves the name of the visible toolbars in the .ini file."""
         toolbars = []
         for toolbar in self.visible_toolbars:
             toolbars.append(toolbar.objectName())
         CONF.set('main', 'last_visible_toolbars', toolbars)
 
     def get_visible_toolbars(self):
-        """ """
+        """Collects the visible toolbars."""
         toolbars = []
         for toolbar in self.toolbarslist:
             if toolbar.toggleViewAction().isChecked():
@@ -1953,14 +1950,14 @@ class MainWindow(QMainWindow):
         self.visible_toolbars = toolbars
 
     def load_last_visible_toolbars(self):
-        """ """
+        """Loads the last visible toolbars from the .ini file."""
         toolbars_names = CONF.get('main', 'last_visible_toolbars', default=[])
 
         if toolbars_names:
             dic = {}
             for toolbar in self.toolbarslist:
                 dic[toolbar.objectName()] = toolbar
-    
+
             toolbars = []
             for name in toolbars_names:
                 if name in dic:
@@ -1971,7 +1968,7 @@ class MainWindow(QMainWindow):
         self._update_show_toolbars_action()
 
     def show_toolbars(self):
-        """ """
+        """Show/Hides toolbars."""
         value = not self.toolbars_visible
         CONF.set('main', 'toolbars_visible', value)
         if value:
@@ -1986,6 +1983,7 @@ class MainWindow(QMainWindow):
         self.toolbars_visible = value
         self._update_show_toolbars_action()
 
+    # --- Other
     def plugin_focus_changed(self):
         """Focus has changed from one plugin to another"""
         if self.light:

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -350,6 +350,7 @@ class MainWindow(QMainWindow):
 
         # Actions
         self.lock_dockwidgets_action = None
+        self.toggle_toolbars_action = None
         self.close_dockwidget_action = None
         self.find_action = None
         self.find_next_action = None
@@ -397,6 +398,7 @@ class MainWindow(QMainWindow):
 
         # Toolbars
         self.toolbarslist = []
+        self.visible_toolbars = []
         self.main_toolbar = None
         self.main_toolbar_actions = []
         self.file_toolbar = None
@@ -1125,7 +1127,11 @@ class MainWindow(QMainWindow):
                                          self.close_dockwidget_action,
                                          self.maximize_action,
                                          None))
+            self.toggle_toolbars_action = create_action(self,
+                                    _("Toggle toolbar visibility"),
+                                    toggled=self.toggle_toolbars)
             self.view_menu.addMenu(self.toolbars_menu)
+            self.view_menu.addAction(self.toggle_toolbars_action)
             add_actions(self.view_menu, (None,
                                          self.quick_layout_menu,
                                          self.toggle_previous_layout_action,
@@ -1382,6 +1388,7 @@ class MainWindow(QMainWindow):
         """Tabify plugin dockwigdets"""
         self.tabifyDockWidget(first.dockwidget, second.dockwidget)
 
+    # --- Layouts 
     def setup_layout(self, default=False):
         """Setup window layout"""
         prefix = ('lightwindow' if self.light else 'window') + '/'
@@ -1908,6 +1915,19 @@ class MainWindow(QMainWindow):
         for plugin in self.widgetlist:
             action = plugin.toggle_view_action
             action.setChecked(plugin.dockwidget.isVisible())
+
+    # --- Other
+    def toggle_toolbars(self, value):
+        """ """
+        if not value:
+            self.visible_toolbars = []
+            for toolbar in self.toolbarslist:
+                if toolbar.toggleViewAction().isChecked():         
+                    self.visible_toolbars.append(toolbar)
+
+        for toolbar in self.visible_toolbars:
+            toolbar.toggleViewAction().setChecked(value)
+            toolbar.setVisible(value)
 
     def plugin_focus_changed(self):
         """Focus has changed from one plugin to another"""


### PR DESCRIPTION
Related to #2353 

## Description
Adds a toggle toolbars visibility button on view menu. Visibility on (action checked) visibility off (action unchecekd).

The last visible toolbars are updated only when using the toggle action. 

![image](https://cloud.githubusercontent.com/assets/3627835/7566442/1cb35172-f7f7-11e4-9eed-4c8de3a09cd2.png)

## Todo
- [x] Saves last visible toolbars when using the toggle button
- [x] Update config
- [x] Add a shortcut (`Ctrl+Shift+T`)
- [x] Add docstrings
