### PR TITLE
PR: Use right python.exe to run Spyder when multiple versions of Python are installled on Windows

### DIFF
--- a/scripts/spyder.bat
+++ b/scripts/spyder.bat
@@ -1,2 +1,6 @@
 @echo off
-python "%~dpn0" %*
+IF EXIST "%~dpn0\..\..\python.exe" (
+	"%~dpn0\..\..\python.exe" "%~dpn0" %*
+) ELSE (
+	python.exe "%~dpn0" %*
+)


### PR DESCRIPTION
Use right python.exe to run spyder when multiple versions of python installed on windows
