### PR TITLE
Match for pylint when parsing pylint output

### DIFF
--- a/spyderplugins/widgets/pylintgui.py
+++ b/spyderplugins/widgets/pylintgui.py
@@ -61,7 +61,8 @@ def get_pylint_version():
                                shell=True if os.name == 'nt' else False)
     lines = to_unicode_from_fs(process.stdout.read()).splitlines()
     if lines:
-        match = re.match('(pylint3?|pylint-script.py) ([0-9\.]*)', lines[0])
+        regex = '({0}|pylint-script.py) ([0-9\.]*)'.format(PYLINT)
+        match = re.match(regex, lines[0])
         if match is not None:
             return match.groups()[1]
 


### PR DESCRIPTION
Pylint program is invoked using PYLINT, which can now be pylint, pylint3, python3-pylint. Fix the regex to just search for PYLINT.