### PR TITLE
Remove unnecessary changes to detected kernel json file when connecting to external kernels

### DIFF
--- a/spyderlib/plugins/ipythonconsole.py
+++ b/spyderlib/plugins/ipythonconsole.py
@@ -1058,8 +1058,6 @@ class IPythonConsole(SpyderPluginWidget):
         # Verifying if the connection file exists
         cf = osp.basename(cf)
         try:
-            if not cf.startswith('kernel') and not cf.endswith('json'):
-                cf = to_text_string('kernel-' + cf + '.json')
             find_connection_file(cf, profile='default')
         except (IOError, UnboundLocalError):
             QMessageBox.critical(self, _('IPython'),


### PR DESCRIPTION
Fixes #2468

----

It is unnecessary to prefix the connection file with `kernel-` and add the `.json` extension. IPython's [find_connection_file](https://github.com/jupyter/jupyter_client/blob/1c77df8fe707171504c4a761093041c7ff130c86/jupyter_client/connect.py#L136) already does that for you.

Besides, by doing it forcibly, we prevent the use of kernel files named otherwise than kernel-*.json, which occurs quite often  when connecting to a remote kernel.