### PR TITLE
Stop using IPython.lib.kernel 0.13.2 shim and add initial support for Jupyter

### DIFF
--- a/spyderlib/plugins/ipythonconsole.py
+++ b/spyderlib/plugins/ipythonconsole.py
@@ -33,7 +33,7 @@ import spyderlib.utils.icon_manager as ima
 
 # IPython imports
 from IPython.core.application import get_ipython_dir
-from IPython.lib.kernel import find_connection_file
+from IPython.kernel.connect import find_connection_file
 from IPython.qt.manager import QtKernelManager
 
 # Ssh imports

--- a/spyderlib/plugins/ipythonconsole.py
+++ b/spyderlib/plugins/ipythonconsole.py
@@ -1007,7 +1007,7 @@ class IPythonConsole(SpyderPluginWidget):
                                          hostname=None, sshkey=None,
                                          password=None):
         """Create kernel manager and client"""
-        cf = find_connection_file(connection_file, profile='default')
+        cf = find_connection_file(connection_file)
         kernel_manager = QtKernelManager(connection_file=cf, config=None)
         kernel_client = kernel_manager.client()
         kernel_client.load_connection_file()
@@ -1058,7 +1058,7 @@ class IPythonConsole(SpyderPluginWidget):
         # Verifying if the connection file exists
         cf = osp.basename(cf)
         try:
-            find_connection_file(cf, profile='default')
+            find_connection_file(cf)
         except (IOError, UnboundLocalError):
             QMessageBox.critical(self, _('IPython'),
                                  _("Unable to connect to IPython <b>%s") % cf)


### PR DESCRIPTION
- `find_connection_file` was being imported from `IPython.lib.kernel` which is a shim to `IPython.kernel.connect` since 1.0. Therefore, this does not change anything for IPython 1.0 to 3.2. We are just using a more direct path.

- Starting with IPython 4.0, 
    - `IPython.lib.kernel` is a shim to `ipykernel.connect`
    - `IPython.kernel.connect` is a shim as well, which first imports everything from `ipykernel.connect` and then everything from `jupyter_client.connect`. The latter sets the default directory for connection files from `~/.ipython/profile_*/security` to `JUPYTER_DATA_DIR`, which is the correct behavior.