### PR TITLE
Fix "pip install ." because of new Spyder 3 theme

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,8 @@ recursive-include spyderlib *.pot *.po *.svg *.png *.css *.qss
 recursive-include spyderlibplugins *.pot *.po *.svg *.png
 recursive-include doc *.py *.rst *.png *.ico *.
 recursive-include app_example *.py *.pyw *.bat *.qm *.svg *.png
+include spyderlib/fonts/spyder.ttf
+include spyderlib/fonts/spyder-charmap.json
 include scripts/*
 include img_src/*.ico
 include img_src/spyder.png


### PR DESCRIPTION
Fix the issue in the PyPI installer that was reported in the qtawesome issue https://github.com/spyder-ide/qtawesome/issues/24.