### PR TITLE
Fixed array copy on Python3

### DIFF
--- a/spyderlib/widgets/arrayeditor.py
+++ b/spyderlib/widgets/arrayeditor.py
@@ -33,7 +33,7 @@ from spyderlib.baseconfig import _
 from spyderlib.guiconfig import get_font, new_shortcut
 from spyderlib.utils.qthelpers import (add_actions, create_action, keybinding,
                                        qapplication)
-from spyderlib.py3compat import io, to_text_string, is_text_string,PY3
+from spyderlib.py3compat import io, to_text_string, is_text_string, PY3
 
 # Note: string and unicode data types will be formatted with '%s' (see below)
 SUPPORTED_FORMATS = {
@@ -419,8 +419,8 @@ class ArrayView(QTableView):
         else:
             output = io.StringIO()
         np.savetxt(output,
-                  _data[row_min:row_max+1, col_min:col_max+1],
-                  delimiter='\t')
+                   _data[row_min:row_max+1, col_min:col_max+1],
+                   delimiter='\t')
         contents = output.getvalue().decode('utf-8')
         output.close()
         return contents

--- a/spyderlib/widgets/arrayeditor.py
+++ b/spyderlib/widgets/arrayeditor.py
@@ -33,7 +33,7 @@ from spyderlib.baseconfig import _
 from spyderlib.guiconfig import get_font, new_shortcut
 from spyderlib.utils.qthelpers import (add_actions, create_action, keybinding,
                                        qapplication)
-from spyderlib.py3compat import io, to_text_string, is_text_string
+from spyderlib.py3compat import io, to_text_string, is_text_string,PY3
 
 # Note: string and unicode data types will be formatted with '%s' (see below)
 SUPPORTED_FORMATS = {
@@ -414,11 +414,10 @@ class ArrayView(QTableView):
         """Copy an array portion to a unicode string"""
         row_min, row_max, col_min, col_max = get_idx_rect(cell_range)
         _data = self.model().get_data()
-        import sys
-        if sys.version_info[0] < 3:
-            output = io.StringIO()
-        else:
+        if PY3:
             output = io.BytesIO()
+        else:
+            output = io.StringIO()
         np.savetxt(output,
                   _data[row_min:row_max+1, col_min:col_max+1],
                   delimiter='\t')

--- a/spyderlib/widgets/arrayeditor.py
+++ b/spyderlib/widgets/arrayeditor.py
@@ -414,11 +414,15 @@ class ArrayView(QTableView):
         """Copy an array portion to a unicode string"""
         row_min, row_max, col_min, col_max = get_idx_rect(cell_range)
         _data = self.model().get_data()
-        output = io.StringIO()
+        import sys
+        if sys.version_info[0] < 3:
+            output = io.StringIO()
+        else:
+            output = io.BytesIO()
         np.savetxt(output,
                   _data[row_min:row_max+1, col_min:col_max+1],
                   delimiter='\t')
-        contents = output.getvalue()
+        contents = output.getvalue().decode('utf-8')
         output.close()
         return contents
 


### PR DESCRIPTION
Under Python3, the array copy operation (going to variable
explorer, opening an array variable, selecting a chunk,
right clicking, and selecting "copy") failed to work. This
change fixes it at the cost of introducing a version check.

It has been tested under Python 3.4.3 and 2.7.9.