### PR TITLE
Fix issues in Python3/PyQt5.5

### DIFF
--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -459,7 +459,8 @@ class Editor(SpyderPluginWidget):
         # Editor's splitter state
         state = self.get_option('splitter_state', None)
         if state is not None:
-            self.splitter.restoreState( QByteArray().fromHex(str(state)) )
+            self.splitter.restoreState( QByteArray().fromHex(
+                    str(state).encode('utf-8')) )
         
         self.recent_files = self.get_option('recent_files', [])
         

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -1357,7 +1357,8 @@ class MainWindow(QMainWindow):
         if not self.light:
             # Window layout
             if hexstate:
-                self.restoreState( QByteArray().fromHex(str(hexstate)) )
+                self.restoreState( QByteArray().fromHex(
+                        str(hexstate).encode('utf-8')) )
                 # [Workaround for Issue 880]
                 # QDockWidget objects are not painted if restored as floating
                 # windows, so we must dock them before showing the mainwindow.

--- a/spyderlib/widgets/editor.py
+++ b/spyderlib/widgets/editor.py
@@ -2063,7 +2063,8 @@ class EditorSplitter(QSplitter):
             editorstack.set_current_filename(cfname)
         hexstate = settings.get('hexstate')
         if hexstate is not None:
-            self.restoreState( QByteArray().fromHex(str(hexstate)) )
+            self.restoreState( QByteArray().fromHex(
+                    str(hexstate).encode('utf-8')) )
         sizes = settings.get('sizes')
         if sizes is not None:
             self.setSizes(sizes)
@@ -2243,7 +2244,8 @@ class EditorMainWindow(QMainWindow):
             self.move( QPoint(*pos) )
         hexstate = settings.get('hexstate')
         if hexstate is not None:
-            self.restoreState( QByteArray().fromHex(str(hexstate)) )
+            self.restoreState( QByteArray().fromHex(
+                    str(hexstate).encode('utf-8')) )
         if settings.get('is_maximized'):
             self.setWindowState(Qt.WindowMaximized)
         if settings.get('is_fullscreen'):

--- a/spyderlib/widgets/sourcecode/base.py
+++ b/spyderlib/widgets/sourcecode/base.py
@@ -1093,10 +1093,16 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         # This feature is disabled on MacOS, see Issue 1510
         if sys.platform != 'darwin':
             if event.modifiers() & Qt.ControlModifier:
-                if event.delta() < 0:
-                    self.zoom_out.emit()
-                elif event.delta() > 0:
-                    self.zoom_in.emit()
+                if hasattr(event, 'angleDelta'):
+                    if event.angleDelta().y() < 0:
+                        self.zoom_out.emit()
+                    elif event.angleDelta().y() > 0:
+                        self.zoom_in.emit()
+                elif hasattr(event, 'delta'):
+                    if event.delta() < 0:
+                        self.zoom_out.emit()
+                    elif event.delta() > 0:
+                        self.zoom_in.emit()
                 return
         QPlainTextEdit.wheelEvent(self, event)
         self.highlight_current_cell()


### PR DESCRIPTION
Fixes #2573 

----

Fix issue that codes like QByteArray().fromHex(str(state)) raise Type Error in Python3/PyQt5.5

A Type Error is raised when codes like QByteArray().fromHex(str(state)) are called.

It seems the error is because in python3, str(state) will return an string while the QByteArray().fromHex expect an hex array. 
I search the whole project of spyder and modifed codes like  QByteArray().fromHex(str(state)) to QByteArray().fromHex(str(state).encode('utf-8')). The encode method of string will return a byte array in python3 and a string in python2. 

I'm not familiar with  PyQt and the source code of spyder. Feel free to reject my pull request if you have a better solution for this issue.