### PR TITLE
Make "copy" work better with numpy arrays

### DIFF
--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -49,7 +49,7 @@ from spyderlib.widgets.texteditor import TextEditor
 from spyderlib.widgets.importwizard import ImportWizard
 from spyderlib.py3compat import (to_text_string, to_binary_string,
                                  is_text_string, is_binary_string, getcwd, u,
-                                 PY3,io)
+                                 PY3, io)
 
 
 LARGE_NROWS = 5000
@@ -1084,13 +1084,12 @@ class BaseTableView(QTableView):
             except ImportError:
                 pass # skip this part
             else:
-                if isinstance(obj,np.ndarray):
+                if isinstance(obj, np.ndarray):
                     if PY3:
                         output = io.BytesIO()
                     else:
                         output = io.StringIO()
-                    np.savetxt(output,obj,
-                               delimiter='\t')
+                    np.savetxt(output,obj, delimiter='\t')
                 obj = output.getvalue().decode('utf-8')
                     
             clipl.append(to_text_string(obj))

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -1089,7 +1089,7 @@ class BaseTableView(QTableView):
                         output = io.BytesIO()
                     else:
                         output = io.StringIO()
-                    np.savetxt(output,obj, delimiter='\t')
+                    np.savetxt(output, obj, delimiter='\t')
                 obj = output.getvalue().decode('utf-8')
                     
             clipl.append(to_text_string(obj))

--- a/spyderlib/widgets/dicteditor.py
+++ b/spyderlib/widgets/dicteditor.py
@@ -48,7 +48,8 @@ if DataFrame is not FakeObject:
 from spyderlib.widgets.texteditor import TextEditor
 from spyderlib.widgets.importwizard import ImportWizard
 from spyderlib.py3compat import (to_text_string, to_binary_string,
-                                 is_text_string, is_binary_string, getcwd, u)
+                                 is_text_string, is_binary_string, getcwd, u,
+                                 PY3,io)
 
 
 LARGE_NROWS = 5000
@@ -1075,7 +1076,24 @@ class BaseTableView(QTableView):
         for idx in self.selectedIndexes():
             if not idx.isValid():
                 continue
-            clipl.append(to_text_string(self.delegate.get_value(idx)))
+            obj = self.delegate.get_value(idx)
+            # check if it's a numpy array, and if so make sure to copy the whole
+            # thing in a tab separated format
+            try:
+                import numpy as np
+            except ImportError:
+                pass # skip this part
+            else:
+                if isinstance(obj,np.ndarray):
+                    if PY3:
+                        output = io.BytesIO()
+                    else:
+                        output = io.StringIO()
+                    np.savetxt(output,obj,
+                               delimiter='\t')
+                obj = output.getvalue().decode('utf-8')
+                    
+            clipl.append(to_text_string(obj))
         clipboard.setText(u('\n').join(clipl))
     
     def import_from_string(self, text, title=None):


### PR DESCRIPTION
Previously, if you go to variable explorer, right clicked
on a (large) numpy array and clicked copy if copied in the form
`[[1.0, 2.0 ... 3.0 ]]` (i.e. with dots in place of the middle
of the array)

Now it copies the whole array with as a tab separated string.
This is more useful since you can paste directly into Spyder
or into a spreadsheet, and no data is omitted.

The downside is that the clipboard can get quite large