### PR TITLE
Improved selectAll/selectColumn/selectRow

### DIFF
--- a/spyderlib/widgets/arrayeditor.py
+++ b/spyderlib/widgets/arrayeditor.py
@@ -375,6 +375,15 @@ class ArrayView(QTableView):
                             lambda val: self.load_more_data(val, columns=True))
         self.verticalScrollBar().valueChanged.connect(
                                lambda val: self.load_more_data(val, rows=True))
+        
+        # In the event that an entire row or column is selected
+        # we are probably interested in all the data (not just the
+        # data already fetched). Therefore, load it all
+        # (Note - ideally it would be better to do this by overriding
+        # "selectRow" and "selectColumn" in the QTableView, but
+        # they aren't virtual)
+        self.horizontalHeader().sectionClicked.connect(self.load_all_rows_select_column)
+        self.verticalHeader().sectionClicked.connect(self.load_all_columns_select_row)
     
     def load_more_data(self, value, rows=False, columns=False):
         if rows and value == self.verticalScrollBar().maximum():
@@ -428,6 +437,33 @@ class ArrayView(QTableView):
         cliptxt = self._sel_to_text( self.selectedIndexes() )
         clipboard = QApplication.clipboard()
         clipboard.setText(cliptxt)
+       
+    def load_all_rows(self):
+        while self.model().can_fetch_more(rows=True):
+            self.model().fetch_more(rows=True)
+            
+    @Slot(int)
+    def load_all_rows_select_column(self, column):
+        self.load_all_rows()
+        self.selectColumn(column)
+
+    def load_all_columns(self):
+        while self.model().can_fetch_more(columns=True):
+            self.model().fetch_more(columns=True)
+            
+    @Slot(int)
+    def load_all_columns_select_row(self, row):
+        self.load_all_columns()
+        self.selectRow(row)
+    
+    def selectAll(self):
+        """If we select everything then we probably intended to 
+        select the entire array (and hence must load any unloaded data)"""
+        self.load_all_rows()
+        self.load_all_columns()
+
+        QTableView.selectAll(self)
+        
 
 
 class ArrayEditorWidget(QWidget):


### PR DESCRIPTION
The reason for this change is that if you went to the array editor and used the top left square to select everything, it only selected the currently loaded data. For large arrays that was a subset of the whole thing (because extra data is fetched on demand). It wasn't obvious that it had done this unless you scrolled to check what it had selected, or copied the selection and found it was smaller than expected.

With this change, all the necessary data is fetched when the entire array/entire column/entire row is selected, which is probably the desired behaviour.

I'm not 100% happy with how I've had to do this (the method for selecting columns or rows seems a bit more effort than it should be, and will probably fail if there's a way to do the same thing with the keyboard). However, I couldn't see a better way.