### PR TITLE
Homogenize variable explorer UI

### DIFF
--- a/spyderlib/plugins/ipythonconsole.py
+++ b/spyderlib/plugins/ipythonconsole.py
@@ -911,7 +911,7 @@ class IPythonConsole(SpyderPluginWidget):
 
         # Connect to our variable explorer
         if kernel_widget is not None and self.variableexplorer is not None:
-            nsb = self.variableexplorer.currentWidget()
+            nsb = self.variableexplorer.current_widget()
             # When the autorefresh button is active, our kernels
             # start to consume more and more CPU during time
             # Fix Issue 1450

--- a/spyderlib/plugins/variableexplorer.py
+++ b/spyderlib/plugins/variableexplorer.py
@@ -7,7 +7,7 @@
 """Namespace Browser Plugin"""
 
 from spyderlib.qt.QtGui import QGroupBox, QStackedWidget, QVBoxLayout, QWidget
-from spyderlib.qt.QtCore import Signal
+from spyderlib.qt.QtCore import Signal, Slot
 import spyderlib.utils.icon_manager as ima
 
 # Local imports
@@ -110,14 +110,27 @@ class VariableExplorer(QWidget, SpyderPluginMixin):
         for name in REMOTE_SETTINGS:
             settings[name] = CONF.get(VariableExplorer.CONF_SECTION, name)
         return settings
-        
-    #------ Public API ---------------------------------------------------------
+
+    # ----- Stack accesors ----------------------------------------------------
+    def set_current_widget(self, nsb):
+        self.stack.setCurrentWidget(nsb)
+
     def current_widget(self):
         return self.stack.currentWidget()
 
+    def count(self):
+        return self.stack.count()
+
+    def remove_widget(self, nsb):
+        self.stack.removeWidget(nsb)
+
+    def add_widget(self, nsb):
+        self.stack.addWidget(nsb)
+
+    # ----- Public API --------------------------------------------------------
     def add_shellwidget(self, shellwidget):
         shellwidget_id = id(shellwidget)
-        # Add shell only once: this method may be called two times in a row 
+        # Add shell only once: this method may be called two times in a row
         # by the External console plugin (dev. convenience)
         from spyderlib.widgets.externalshell import systemshell
         if isinstance(shellwidget, systemshell.ExternalSystemShell):
@@ -127,7 +140,7 @@ class VariableExplorer(QWidget, SpyderPluginMixin):
             nsb.set_shellwidget(shellwidget)
             nsb.setup(**VariableExplorer.get_settings())
             nsb.sig_option_changed.connect(self.sig_option_changed.emit)
-            self.stack.addWidget(nsb)
+            self.add_widget(nsb)
             self.shellwidgets[shellwidget_id] = nsb
             self.set_shellwidget_from_id(shellwidget_id)
             return nsb
@@ -137,22 +150,22 @@ class VariableExplorer(QWidget, SpyderPluginMixin):
         # that shell was not a Python-based console (it was a terminal)
         if shellwidget_id in self.shellwidgets:
             nsb = self.shellwidgets.pop(shellwidget_id)
-            self.stack.removeWidget(nsb)
+            self.remove_widget(nsb)
             nsb.close()
     
     def set_shellwidget_from_id(self, shellwidget_id):
         if shellwidget_id in self.shellwidgets:
             nsb = self.shellwidgets[shellwidget_id]
-            self.stack.setCurrentWidget(nsb)
+            self.set_current_widget(nsb)
             if self.isvisible:
                 nsb.visibility_changed(True)
-            
+
     def import_data(self, fname):
         """Import data in current namespace"""
         if self.count():
-            nsb = self.currentWidget()
+            nsb = self.current_widget()
             nsb.refresh_table()
-            nsb.import_data(fname)
+            nsb.import_data(filename=fname)
             if self.dockwidget and not self.ismaximized:
                 self.dockwidget.setVisible(True)
                 self.dockwidget.raise_()
@@ -162,7 +175,7 @@ class VariableExplorer(QWidget, SpyderPluginMixin):
         """DockWidget visibility has changed"""
         SpyderPluginMixin.visibility_changed(self, enable)
         for nsb in list(self.shellwidgets.values()):
-            nsb.visibility_changed(enable and nsb is self.stack.currentWidget())
+            nsb.visibility_changed(enable and nsb is self.current_widget())
     
     #------ SpyderPluginWidget API ---------------------------------------------
     def get_plugin_title(self):
@@ -178,7 +191,7 @@ class VariableExplorer(QWidget, SpyderPluginMixin):
         Return the widget to give focus to when
         this plugin's dockwidget is raised on top-level
         """
-        return self.stack.currentWidget()
+        return self.current_widget()
         
     def closing_plugin(self, cancelable=False):
         """Perform actions before parent main window is closed"""

--- a/spyderlib/widgets/externalshell/namespacebrowser.py
+++ b/spyderlib/widgets/externalshell/namespacebrowser.py
@@ -437,6 +437,7 @@ class NamespaceBrowser(QWidget):
         """Collapse"""
         self.sig_collapse.emit()
 
+    # FIXME: This method raises an error when called from the button in the UI
     @Slot(list)
     def import_data(self, filenames=None):
         """Import data from text file"""

--- a/spyderlib/widgets/externalshell/namespacebrowser.py
+++ b/spyderlib/widgets/externalshell/namespacebrowser.py
@@ -135,20 +135,35 @@ class NamespaceBrowser(QWidget):
         self.editor.sig_option_changed.connect(self.sig_option_changed.emit)
         self.editor.sig_files_dropped.connect(self.import_data)
         
-        
+        # Menu
+        options_button = create_toolbutton(self, text=_('Options'),
+                                           icon=ima.icon('tooloptions'))
+        options_button.setPopupMode(QToolButton.InstantPopup)
+        menu = QMenu(self)
+        editor = self.editor
+        actions = [self.exclude_private_action, self.exclude_uppercase_action,
+                   self.exclude_capitalized_action,
+                   self.exclude_unsupported_action, None,
+                   editor.truncate_action]
+        if is_module_installed('numpy'):
+            actions.append(editor.minmax_action)
+        add_actions(menu, actions)
+        options_button.setMenu(menu)
+
         # Setup layout
-        hlayout = QHBoxLayout()
-        vlayout = QVBoxLayout()
+        layout = QVBoxLayout()
+        blayout = QHBoxLayout()
         toolbar = self.setup_toolbar(exclude_private, exclude_uppercase,
                                      exclude_capitalized, exclude_unsupported,
                                      autorefresh)
-        vlayout.setAlignment(Qt.AlignTop)
         for widget in toolbar:
-            vlayout.addWidget(widget)
-        hlayout.addWidget(self.editor)
-        hlayout.addLayout(vlayout)
-        self.setLayout(hlayout)
-        hlayout.setContentsMargins(0, 0, 0, 0)
+            blayout.addWidget(widget)
+        blayout.addStretch()
+        blayout.addWidget(options_button)
+        layout.addLayout(blayout)
+        layout.addWidget(self.editor)
+        self.setLayout(layout)
+        layout.setContentsMargins(0, 0, 0, 0)
 
         self.sig_option_changed.connect(self.option_changed)
         
@@ -225,21 +240,6 @@ class NamespaceBrowser(QWidget):
                 toggled=lambda state:
                 self.sig_option_changed.emit('exclude_unsupported', state))
         self.exclude_unsupported_action.setChecked(exclude_unsupported)
-        
-        options_button = create_toolbutton(self, text=_('Options'),
-                                           icon=ima.icon('tooloptions'))
-        toolbar.append(options_button)
-        options_button.setPopupMode(QToolButton.InstantPopup)
-        menu = QMenu(self)
-        editor = self.editor
-        actions = [self.exclude_private_action, self.exclude_uppercase_action,
-                   self.exclude_capitalized_action,
-                   self.exclude_unsupported_action, None,
-                   editor.truncate_action]
-        if is_module_installed('numpy'):
-            actions.append(editor.minmax_action)
-        add_actions(menu, actions)
-        options_button.setMenu(menu)
         
         self.setup_in_progress = False
         
@@ -553,4 +553,3 @@ class NamespaceBrowser(QWidget):
                             _("<b>Unable to save current workspace</b>"
                               "<br><br>Error message:<br>%s") % error_message)
         self.save_button.setEnabled(self.filename is not None)
-        


### PR DESCRIPTION
## Description

The "toolbar"  is now horizontal and the options button is aligned to the right, like other plugins.
Also now the variable explorer margins are updated when selection this option for panes inside the preferences

### Before

![before-varex](https://cloud.githubusercontent.com/assets/3627835/9028016/4a080832-3930-11e5-9916-0ff455acb92c.png)

### After
![after-varex](https://cloud.githubusercontent.com/assets/3627835/9028008/ce3b6776-392f-11e5-9a74-dfb732e62230.png)

## Todo
- [x] Make buttons horizontal
- [x] Align options menu to the right