### PR TITLE
Revert auto open parens on completion

### DIFF
--- a/spyderlib/widgets/sourcecode/base.py
+++ b/spyderlib/widgets/sourcecode/base.py
@@ -67,13 +67,6 @@ class CompletionWidget(QListWidget):
         completion_list = [c[0] for c in completion_list]
         if len(completion_list) == 1 and not automatic:
             self.textedit.insert_completion(completion_list[0])
-            try:
-                if self.textedit.close_parentheses_enabled:
-                    if types[0] in ['class', 'function', 'method']:
-                        self.textedit.handle_close_parentheses('')
-            except AttributeError:
-                pass
-            return
 
         self.completion_list = completion_list
         self.clear()
@@ -162,14 +155,6 @@ class CompletionWidget(QListWidget):
         if (key in (Qt.Key_Return, Qt.Key_Enter) and self.enter_select) \
            or key == Qt.Key_Tab:
             self.item_selected()
-            if self.type_list[self.currentRow()] not in ['class', 'function',
-                                                         'method']:
-                return
-            try:
-                if self.textedit.close_parentheses_enabled:
-                    self.textedit.handle_close_parentheses('')
-            except AttributeError:
-                pass
         elif key in (Qt.Key_Return, Qt.Key_Enter,
                      Qt.Key_Left, Qt.Key_Right) or text in ('.', ':'):
             self.hide()


### PR DESCRIPTION
Since we can't properly tell exactly when it is warranted, prefer consistent behavior and do not automatically insert open parentheses.  Fixes #2581.