### PR TITLE
Show call tips at right position when there are multiple screens

### DIFF
--- a/spyderlib/widgets/calltip.py
+++ b/spyderlib/widgets/calltip.py
@@ -198,7 +198,7 @@ class CallTipWidget(QtGui.QLabel):
 
         vertical = 'bottom'
         horizontal = 'Right'
-        if point.y() + tip_height > screen_rect.height():
+        if point.y() + tip_height > screen_rect.height() + screen_rect.y():
             point_ = text_edit.mapToGlobal(cursor_rect.topRight())
             # If tip is still off screen, check if point is in top or bottom
             # half of screen.
@@ -211,7 +211,7 @@ class CallTipWidget(QtGui.QLabel):
                     vertical = 'top'
             else:
                 vertical = 'top'
-        if point.x() + tip_width > screen_rect.width():
+        if point.x() + tip_width > screen_rect.width() + screen_rect.x():
             point_ = text_edit.mapToGlobal(cursor_rect.topRight())
             # If tip is still off-screen, check if point is in the right or
             # left half of the screen.


### PR DESCRIPTION
Fixes #2596

There is a similar problem of ipython console's auto-completion droplist. That can be fixed by https://github.com/cy18/ipython/commit/cd9551183d8d025c77a3c09a6ec772270624bb80. But the IPython.qt has been deprecated in the master branch of IPython.