### PR TITLE
object inspector "list index out of range" with jedi

### DIFF
--- a/spyderlib/widgets/calltip.py
+++ b/spyderlib/widgets/calltip.py
@@ -162,7 +162,7 @@ class CallTipWidget(QtGui.QLabel):
             self._hide_timer.stop()
             # Logic to decide how much time to show the calltip depending
             # on the amount of text present
-            if len(wrapped_tiplines) == 1:
+            if len(wrapped_tiplines) == 1 and '(' in wrapped_tiplines[0]:
                 args = wrapped_tiplines[0].split('(')[1]
                 nargs = len(args.split(','))
                 if nargs == 1:


### PR DESCRIPTION
When trying to inspect
```python
from lxml import etree
etree()
```
I got "list index out of range" in the debug console, and no output in Object inspector.

After this change I get no error and some output in Object inspector.