### PR TITLE
PR: Use pygments in introspection

### DIFF
--- a/profiling.txt
+++ b/profiling.txt
@@ -28,3 +28,4 @@ When Explorer widget is disabled (.spyder.ini): 30ms
 
 => Workspace lack of performance solved too! -> was due to a CONF.get within a
    loop... duh...
+

--- a/spyderlib/utils/introspection/fallback_plugin.py
+++ b/spyderlib/utils/introspection/fallback_plugin.py
@@ -15,12 +15,14 @@ import os.path as osp
 import re
 import time
 
+from pygments.token import Token
+
 from spyderlib.utils.debug import log_dt
 from spyderlib.utils import sourcecode, encoding
 from spyderlib.utils.introspection.manager import (
     DEBUG_EDITOR, LOG_FILENAME, IntrospectionPlugin)
 from spyderlib.utils.introspection.utils import (
-    get_parent_until, memoize)
+    get_parent_until, memoize, find_lexer_for_filename, get_keywords)
 
 
 class FallbackPlugin(IntrospectionPlugin):
@@ -37,23 +39,51 @@ class FallbackPlugin(IntrospectionPlugin):
         if not info['obj']:
             return
         items = []
-        base = info['obj']
-        tokens = set(re.findall(info['id_regex'], info['source_code']))
-        items = [item for item in tokens if
-                 item.startswith(base) and len(item) > len(base)]
-        if '.' in base:
-            start = base.rfind('.') + 1
-        else:
-            start = 0
+        line = info['line'].strip()
+        is_from = line.startswith('from')
+        if ((line.startswith('import') or is_from and ' import' not in line)
+                and info['is_python_like']):
+            items += module_completion(info['line'], [info['filename']])
+            return [(i, 'module') for i in sorted(items)]
+        elif is_from and info['is_python_like']:
+            items += module_completion(info['line'], [info['filename']])
+            return [(i, '') for i in sorted(items)]
+        elif info['obj']:
+            obj = info['obj']
+            if info['context']:
+                lexer = find_lexer_for_filename(info['filename'])
+                # get a list of token matches for the current object
+                tokens = lexer.get_tokens(info['source_code'])
+                for (context, token) in tokens:
+                    token = token.strip()
+                    if (context in info['context']and
+                            token.startswith(obj) and
+                            obj != token):
+                        items.append(token)
+                # add in keywords if not in a string
+                if context not in Token.Literal.String:
+                    try:
+                        keywords = get_keywords(lexer)
+                        items.extend(k for k in keywords if k.startswith(obj))
+                    except Exception:
+                        pass
+            else:
+                tokens = set(re.findall(info['id_regex'], info['source_code']))
+                items = [item for item in tokens if
+                     item.startswith(obj) and len(item) > len(obj)]
+                if '.' in obj:
+                    start = obj.rfind('.') + 1
+                else:
+                    start = 0
 
-        items = [i[start:len(base)] + i[len(base):].split('.')[0]
-                 for i in items]
-        # get path completions
-        # get last word back to a space or a quote character
-        match = re.search('''[ "\']([\w\.\\\\/]+)\Z''', info['line'])
-        if match:
-            items += _complete_path(match.groups()[0])
-        return [(i, '') for i in sorted(items)]
+                items = [i[start:len(obj)] + i[len(obj):].split('.')[0]
+                     for i in items]
+            # get path completions
+            # get last word back to a space or a quote character
+            match = re.search('''[ "\']([\w\.\\\\/]+)\Z''', info['line'])
+            if match:
+                items += _complete_path(match.groups()[0])
+            return [(i, '') for i in sorted(items)]
 
     def get_definition(self, info):
         """
@@ -62,6 +92,8 @@ class FallbackPlugin(IntrospectionPlugin):
         This is used to find the path of python-like modules
         (e.g. cython and enaml) for a goto definition
         """
+        if not info['is_python_like']:
+            return
         token = info['obj']
         lines = info['lines']
         source_code = info['source_code']
@@ -88,7 +120,7 @@ class FallbackPlugin(IntrospectionPlugin):
             if (not source_file or
                     not osp.splitext(source_file)[-1] in exts):
                 line_nr = get_definition_with_regex(source_code, token,
-                                                         line_nr)
+                                                    line_nr)
                 return filename, line_nr
             mod_name = osp.basename(source_file).split('.')[0]
             if mod_name == token or mod_name == '__init__':
@@ -200,7 +232,6 @@ def get_definition_with_regex(source, token, start_line=-1):
                     'self.{0}{1}[^=!<>]*=[^=]',
                     '{0}{1}[^=!<>]*=[^=]']
         matches = get_matches(patterns, source, token, start_line)
-
     # find the one closest to the start line (prefer before the start line)
     if matches:
         min_dist = len(source.splitlines())
@@ -296,25 +327,25 @@ if __name__ == '__main__':
     code += '\nlog_dt'
 
     path, line = p.get_definition(CodeInfo('definition', code, len(code),
-        __file__))
+        __file__, is_python_like=True))
     assert path.endswith('fallback_plugin.py')
 
     code += '\np.get_completions'
     path, line = p.get_definition(CodeInfo('definition', code, len(code),
-        'dummy.txt'))
-    assert path == 'dummy.txt'
+        'dummy.py', is_python_like=True))
+    assert path == 'dummy.py'
     assert 'def get_completions(' in code.splitlines()[line - 1]
 
     code += '\npython_like_mod_finder'
     path, line = p.get_definition(CodeInfo('definition', code, len(code),
-        'dummy.txt'))
-    assert path == 'dummy.txt'
+        'dummy.py', is_python_like=True))
+    assert path == 'dummy.py'
     # FIXME: we need to prioritize def over =
     assert 'def python_like_mod_finder' in code.splitlines()[line - 1]
 
     code += 'python_like_mod_finder'
     resp = p.get_definition(CodeInfo('definition', code, len(code),
-        'dummy.txt'))
+        'dummy.py'))
     assert resp is None
 
     code = """
@@ -325,7 +356,7 @@ if __name__ == '__main__':
     t = Test()
     t.foo"""
     path, line = p.get_definition(CodeInfo('definition', code, len(code),
-        'dummy.txt'))
+        'dummy.py', is_python_like=True))
     assert line == 4
 
     ext = python_like_exts()
@@ -350,25 +381,43 @@ if __name__ == '__main__':
 
     code = 'import re\n\nre'
     path, line = p.get_definition(CodeInfo('definition', code, len(code),
-        'dummy.txt'))
-    assert path == 'dummy.txt' and line == 1
+        'dummy.py', is_python_like=True))
+    assert path == 'dummy.py' and line == 1
 
     code = 'self.proxy.widget; self.p'
-    comp = p.get_completions(CodeInfo('completions', code, len(code)))
-    assert comp[0] == ('proxy', '')
+    comp = p.get_completions(CodeInfo('completions', code, len(code), 'dummy.py'))
+    assert ('proxy', '') in comp, comp
 
     code = 'self.sigMessageReady.emit; self.s'
-    comp = p.get_completions(CodeInfo('completions', code, len(code)))
-    assert comp == [('sigMessageReady', '')]
+    comp = p.get_completions(CodeInfo('completions', code, len(code), 'dummy.py'))
+    assert ('sigMessageReady', '') in comp
 
-    code = encoding.to_unicode('álfa;á')
-    comp = p.get_completions(CodeInfo('completions', code, len(code)))
-    assert comp == [(encoding.to_unicode('álfa'), '')]
+<<<<<<< HEAD
+=======
+    code = 'from numpy import one'
+    comp = p.get_completions(CodeInfo('completions', code, len(code), 'dummy.py', is_python_like=True))
+    assert ('ones', '') in comp
 
+    comp = p.get_completions(CodeInfo('completions', code, len(code), 'dummy.txt'))
+    assert not comp, comp
+
+    code = 'from numpy.testing import (asse'
+    comp = p.get_completions(CodeInfo('completions', code, len(code), 'dummy.py', is_python_like=True))
+    assert ('assert_equal', '') in comp
+
+    code = 'bob = 1; bo'
+    comp = p.get_completions(CodeInfo('completions', code, len(code), 'dummy.m'))
+    assert ('bob', '') in comp
+
+    code = 'functi'    
+    comp = p.get_completions(CodeInfo('completions', code, len(code), 'dummy.sh'))
+    assert ('function', '') in comp, comp
+
+>>>>>>> 1993154... Use pygments in introspection
     code = '''
 def test(a, b):
     pass
 test(1,'''
     path, line = p.get_definition(CodeInfo('definition', code, len(code),
-        'dummy.txt'))
+        'dummy.py', is_python_like=True))
     assert line == 2

--- a/spyderlib/utils/introspection/fallback_plugin.py
+++ b/spyderlib/utils/introspection/fallback_plugin.py
@@ -392,19 +392,6 @@ if __name__ == '__main__':
     comp = p.get_completions(CodeInfo('completions', code, len(code), 'dummy.py'))
     assert ('sigMessageReady', '') in comp
 
-<<<<<<< HEAD
-=======
-    code = 'from numpy import one'
-    comp = p.get_completions(CodeInfo('completions', code, len(code), 'dummy.py', is_python_like=True))
-    assert ('ones', '') in comp
-
-    comp = p.get_completions(CodeInfo('completions', code, len(code), 'dummy.txt'))
-    assert not comp, comp
-
-    code = 'from numpy.testing import (asse'
-    comp = p.get_completions(CodeInfo('completions', code, len(code), 'dummy.py', is_python_like=True))
-    assert ('assert_equal', '') in comp
-
     code = 'bob = 1; bo'
     comp = p.get_completions(CodeInfo('completions', code, len(code), 'dummy.m'))
     assert ('bob', '') in comp
@@ -413,7 +400,6 @@ if __name__ == '__main__':
     comp = p.get_completions(CodeInfo('completions', code, len(code), 'dummy.sh'))
     assert ('function', '') in comp, comp
 
->>>>>>> 1993154... Use pygments in introspection
     code = '''
 def test(a, b):
     pass

--- a/spyderlib/utils/introspection/jedi_plugin.py
+++ b/spyderlib/utils/introspection/jedi_plugin.py
@@ -266,7 +266,7 @@ def test(a, b):
     pass
 test(1,'''
     path, line = p.get_definition(CodeInfo('definition', code, len(code),
-        'dummy.txt'))
+        'dummy.txt', is_python_like=True))
     assert line == 2
 
     docs = p.get_info(CodeInfo('info', code, len(code), __file__))

--- a/spyderlib/utils/introspection/rope_plugin.py
+++ b/spyderlib/utils/introspection/rope_plugin.py
@@ -311,8 +311,9 @@ def test(a, b):
     pass
 test(1,'''
     path, line = p.get_definition(CodeInfo('definition', code, len(code),
-        'dummy.txt'))
+        'dummy.txt', is_python_like=True))
     assert line == 2
 
-    docs = p.get_info(CodeInfo('info', code, len(code), __file__))
+    docs = p.get_info(CodeInfo('info', code, len(code), __file__,
+        is_python_like=True))
     assert 'Test docstring' in docs['docstring']

--- a/spyderlib/utils/syntaxhighlighters.py
+++ b/spyderlib/utils/syntaxhighlighters.py
@@ -46,21 +46,22 @@ COLOR_SCHEME_NAMES = CONF.get('color_schemes', 'names')
 # different lexers than Pygments' autodetection suggests.  Keys are file
 # extensions or tuples of extensions, values are Pygments lexer names.
 CUSTOM_EXTENSION_LEXER = {'.ipynb': 'json',
+                          '.txt': 'text',
                           '.nt': 'bat',
                           '.scss': 'css',
                           '.m': 'matlab',
                           ('.properties', '.session', '.inf', '.reg', '.url',
                            '.cfg', '.cnf', '.aut', '.iss'): 'ini'}
 # Convert custom extensions into a one-to-one mapping for easier lookup.
-_custom_extension_lexer_mapping = {}
+custom_extension_lexer_mapping = {}
 for key, value in CUSTOM_EXTENSION_LEXER.items():
     # Single key is mapped unchanged.
     if is_text_string(key):
-        _custom_extension_lexer_mapping[key] = value
+        custom_extension_lexer_mapping[key] = value
     # Tuple of keys is iterated over and each is mapped to value.
     else:
         for k in key:
-            _custom_extension_lexer_mapping[k] = value
+            custom_extension_lexer_mapping[k] = value
 
 
 #==============================================================================
@@ -969,8 +970,8 @@ def guess_pygments_highlighter(filename):
     except ImportError:
         return TextSH
     root, ext = os.path.splitext(filename)
-    if ext in _custom_extension_lexer_mapping:
-        lexer = get_lexer_by_name(_custom_extension_lexer_mapping[ext])
+    if ext in custom_extension_lexer_mapping:
+        lexer = get_lexer_by_name(custom_extension_lexer_mapping[ext])
     else:
         try:
             lexer = get_lexer_for_filename(filename)


### PR DESCRIPTION
Uses the Pygments lexer in introspection instead of the previous regex-based approach.  This will help completions in non-python-like files.  We will do a better job of finding the right object to complete, and finding suitable objects within the same syntax type for completion.