### PR TITLE
Fixed PyQt5 detection without QT_API env var

### DIFF
--- a/spyderlib/qt/__init__.py
+++ b/spyderlib/qt/__init__.py
@@ -15,17 +15,7 @@ assert os.environ['QT_API'] in ('pyqt5', 'pyqt', 'pyside')
 API = os.environ['QT_API']
 API_NAME = {'pyqt5': 'PyQt5', 'pyqt': 'PyQt4', 'pyside': 'PySide'}[API]
 
-PYQT5 = False
-
-if API == 'pyqt5':
-    try:
-        from PyQt5.QtCore import PYQT_VERSION_STR as __version__
-        is_old_pyqt = False
-        is_pyqt46 = False
-        PYQT5 = True
-    except ImportError:
-        pass
-elif API == 'pyqt':
+if API == 'pyqt':
     # Spyder 2.3 is compatible with both #1 and #2 PyQt API,
     # but to avoid issues with IPython and other Qt plugins
     # we choose to support only API #2 for 2.4+
@@ -46,9 +36,16 @@ elif API == 'pyqt':
 
         from PyQt4.QtCore import PYQT_VERSION_STR as __version__ # analysis:ignore
     except ImportError:
-        # Switching to PySide
-        API = os.environ['QT_API'] = 'pyside'
-        API_NAME = 'PySide'
+        # Trying PyQt5 before switching to PySide (at this point, PyQt4 may 
+        # not be installed but PyQt5 or Pyside could still be if the QT_API 
+        # environment variable hasn't been set-up)
+        try:
+            import PyQt5  # analysis:ignore
+            API = os.environ['QT_API'] = 'pyqt5'
+            API_NAME = 'PyQt5'
+        except ImportError:
+            API = os.environ['QT_API'] = 'pyside'
+            API_NAME = 'PySide'
     else:
         is_old_pyqt = __version__.startswith(('4.4', '4.5', '4.6', '4.7'))
         is_pyqt46 = __version__.startswith('4.6')
@@ -57,6 +54,17 @@ elif API == 'pyqt':
             API_NAME += (" (API v%d)" % sip.getapi('QString'))
         except AttributeError:
             pass
+        from PyQt4 import uic  # analysis:ignore
+
+PYQT5 = False
+if API == 'pyqt5':
+    try:
+        from PyQt5.QtCore import PYQT_VERSION_STR as __version__
+        from PyQt5 import uic  # analysis:ignore
+        PYQT5 = True
+        is_old_pyqt = is_pyqt46 = False
+    except ImportError:
+        pass
 
 if API == 'pyside':
     try:


### PR DESCRIPTION
When QT_API environment variable has not been set properly, which is safe to assume when using PyQt5 for the first time, importing the `spyderlib.qt` package will fail. This change allows PyQt5 to be imported and used if QT_API has not been set and if both PyQt4 and PySide packages are not installed.