### PR TITLE
Fix tabbar issue in OSX

### DIFF
--- a/spyderlib/plugins/__init__.py
+++ b/spyderlib/plugins/__init__.py
@@ -131,6 +131,7 @@ class TabFilter(QObject):
     def tab_pressed(self, event):
         """Method called when a tab from a QTabBar has been pressed."""
         self.from_index = self.dock_tabbar.tabAt(event.pos())
+        self.dock_tabbar.setCurrentIndex(self.from_index)
 
         if event.button() == Qt.RightButton:
             if self.from_index == -1:


### PR DESCRIPTION
Fixes #2598

## Description
I think now the user can switch the tab when clicking, however when moving tabs the displaced tab will retain a weird color until it has been selected again. I am not sure why, but at least this PR will fix the main issue.




