### PR TITLE
PR: Generate widgets' toolbars from the actions in their context menu & make toolbars toggleable

### DIFF
--- a/spyderlib/plugins/__init__.py
+++ b/spyderlib/plugins/__init__.py
@@ -401,8 +401,9 @@ class SpyderPluginMixin(object):
     def register_toolbar(self, toolbar):
         """registerd toolbars can be toggled on/off.
         Should be a WidgetInnerToolbar ..or subclass"""
-        self.main.toolbarslist.append(toolbar)
+        self.main.toolbars_list_inner.append(toolbar)
         toolbar.setVisible(self.main.get_toolbars_visible())
+        toolbar.toggleViewAction().setChecked(self.main.get_toolbars_visible())
         
     def register_shortcut(self, qaction_or_qshortcut, context, name,
                           default=NoDefault):

--- a/spyderlib/plugins/__init__.py
+++ b/spyderlib/plugins/__init__.py
@@ -400,7 +400,7 @@ class SpyderPluginMixin(object):
     
     def register_toolbar(self, toolbar):
         """registerd toolbars can be toggled on/off.
-        Should be a QHBoxLayout ..or subclass"""
+        Should be a WidgetInnerToolbar ..or subclass"""
         self.main.toolbarslist.append(toolbar)
         
     def register_shortcut(self, qaction_or_qshortcut, context, name,

--- a/spyderlib/plugins/__init__.py
+++ b/spyderlib/plugins/__init__.py
@@ -402,6 +402,7 @@ class SpyderPluginMixin(object):
         """registerd toolbars can be toggled on/off.
         Should be a WidgetInnerToolbar ..or subclass"""
         self.main.toolbarslist.append(toolbar)
+        toolbar.setVisible(self.main.get_toolbars_visible())
         
     def register_shortcut(self, qaction_or_qshortcut, context, name,
                           default=NoDefault):

--- a/spyderlib/plugins/__init__.py
+++ b/spyderlib/plugins/__init__.py
@@ -398,6 +398,11 @@ class SpyderPluginMixin(object):
         """Apply configuration file's plugin settings"""
         raise NotImplementedError
     
+    def register_toolbar(self, toolbar):
+        """registerd toolbars can be toggled on/off.
+        Should be a QHBoxLayout ..or subclass"""
+        self.main.toolbarslist.append(toolbar)
+        
     def register_shortcut(self, qaction_or_qshortcut, context, name,
                           default=NoDefault):
         """

--- a/spyderlib/plugins/explorer.py
+++ b/spyderlib/plugins/explorer.py
@@ -40,8 +40,7 @@ class Explorer(ExplorerWidget, SpyderPluginMixin):
     def __init__(self, parent=None):
         ExplorerWidget.__init__(self, parent=parent,
                                 name_filters=self.get_option('name_filters'),
-                                show_all=self.get_option('show_all'),
-                                show_icontext=self.get_option('show_icontext'))
+                                show_all=self.get_option('show_all'))
         SpyderPluginMixin.__init__(self, parent)
 
         self.register_toolbar(self.toolbar)

--- a/spyderlib/plugins/explorer.py
+++ b/spyderlib/plugins/explorer.py
@@ -44,6 +44,7 @@ class Explorer(ExplorerWidget, SpyderPluginMixin):
                                 show_icontext=self.get_option('show_icontext'))
         SpyderPluginMixin.__init__(self, parent)
 
+        self.register_toolbar(self.toolbar)
         # Initialize plugin
         self.initialize_plugin()
         

--- a/spyderlib/plugins/help.py
+++ b/spyderlib/plugins/help.py
@@ -55,7 +55,7 @@ except (ImportError, TypeError):
 
 # To add sphinx dependency to the Dependencies dialog
 SPHINX_REQVER = '>=0.6.6'
-dependencies.add("sphinx", _("Rich text help on the Object Inspector"),
+dependencies.add("sphinx", _("Rich text help"),
                  required_version=SPHINX_REQVER)
 
 
@@ -68,29 +68,29 @@ class ObjectComboBox(EditableComboBox):
 
     def __init__(self, parent):
         EditableComboBox.__init__(self, parent)
-        self.object_inspector = parent
+        self.help = parent
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.tips = {True: '', False: ''}
 
     def is_valid(self, qstr=None):
         """Return True if string is valid"""
-        if not self.object_inspector.source_is_console():
+        if not self.help.source_is_console():
             return True
         if qstr is None:
             qstr = self.currentText()
         if not re.search('^[a-zA-Z0-9_\.]*$', str(qstr), 0):
             return False
         objtxt = to_text_string(qstr)
-        if self.object_inspector.get_option('automatic_import'):
-            shell = self.object_inspector.internal_shell
+        if self.help.get_option('automatic_import'):
+            shell = self.help.internal_shell
             if shell is not None:
                 return shell.is_defined(objtxt, force_import=True)
-        shell = self.object_inspector.get_shell()
+        shell = self.help.get_shell()
         if shell is not None:
             try:
                 return shell.is_defined(objtxt)
             except socket.error:
-                shell = self.object_inspector.get_shell()
+                shell = self.help.get_shell()
                 try:
                     return shell.is_defined(objtxt)
                 except socket.error:
@@ -116,7 +116,7 @@ class ObjectComboBox(EditableComboBox):
                     self.valid.emit(False, False)
 
 
-class ObjectInspectorConfigPage(PluginConfigPage):
+class HelpConfigPage(PluginConfigPage):
     def setup_page(self):
         # Fonts group
         plain_text_font_group = self.create_fontgroup(option=None,
@@ -127,7 +127,7 @@ class ObjectInspectorConfigPage(PluginConfigPage):
 
         # Connections group
         connections_group = QGroupBox(_("Automatic connections"))
-        connections_label = QLabel(_("The Object Inspector can automatically "
+        connections_label = QLabel(_("This pane can automatically "
                                      "show an object's help information after "
                                      "a left parenthesis is written next to it. "
                                      "Below you can decide to which plugin "
@@ -523,11 +523,11 @@ class Help(SpyderPluginWidget):
     #------ SpyderPluginWidget API ---------------------------------------------
     def get_plugin_title(self):
         """Return widget title"""
-        return _('Object inspector')
+        return _('Help')
 
     def get_plugin_icon(self):
         """Return widget icon"""
-        return ima.icon('inspector')
+        return ima.icon('help')
 
     def get_focus_widget(self):
         """

--- a/spyderlib/plugins/help.py
+++ b/spyderlib/plugins/help.py
@@ -46,8 +46,9 @@ else:
 
 # Check if we can import Sphinx to activate rich text mode
 try:
-    from spyderlib.utils.help.sphinxify import (CSS_PATH, sphinxify, warning,
-                                                generate_context, usage)
+    from spyderlib.utils.help.sphinxify import (CSS_PATH, sphinxify,
+                                                     warning, generate_context,
+                                                     usage)
     sphinx_version = programs.get_module_version('sphinx')
 except (ImportError, TypeError):
     sphinxify = sphinx_version = None  # analysis:ignore
@@ -427,6 +428,7 @@ class Help(SpyderPluginWidget):
             source_mode_group.setExclusive(True)
             source_mode_group.addAction(self.console_action)
             source_mode_group.addAction(self.editor_action)
+            self.console_action.setChecked(True)
             add_actions(source_menu, [self.console_action, self.editor_action])
             self.common_actions.append(source_menu)
 
@@ -444,13 +446,6 @@ class Help(SpyderPluginWidget):
         display_mode_group.setExclusive(True)
         display_mode_group.addAction(self.plain_text_action)
         display_mode_group.addAction(self.rich_text_action)
-
-        if self.rich_help:
-            self.switch_to_rich_text()
-        else:
-            self.switch_to_plain_text()
-        self.plain_text_action.setChecked(not self.rich_help)
-        self.rich_text_action.setChecked(self.rich_help)
         self.rich_text_action.setEnabled(sphinxify is not None)
         display_menu = QMenu(_('Display'), parent=self)
         add_actions(display_menu, [self.plain_text_action, self.rich_text_action,
@@ -475,7 +470,8 @@ class Help(SpyderPluginWidget):
         add_actions(self.plain_text.editor.readonly_menu, self.common_actions)  
         
         self.toolbar = context_menu_to_toolbar(self, self.rich_text.menu)
-        
+        context_menu_to_toolbar(menu=self.plain_text.editor.readonly_menu,
+                                 old=self.toolbar)
         
         #self.source_combo.currentIndexChanged.connect(self.source_is_console)
         
@@ -496,6 +492,7 @@ class Help(SpyderPluginWidget):
         layout.addWidget(self.plain_text)
         layout.addWidget(self.rich_text)
         self.setLayout(layout)
+        
         self.register_toolbar(self.toolbar)
         
         # Add worker thread for handling rich text rendering
@@ -514,7 +511,15 @@ class Help(SpyderPluginWidget):
         view.page().setLinkDelegationPolicy(QWebPage.DelegateAllLinks)
         view.linkClicked.connect(self.handle_link_clicks)
 
+        self.plain_text_action.setChecked(not self.rich_help)
+        self.rich_text_action.setChecked(self.rich_help)
+        if self.rich_help:
+            self.switch_to_rich_text()
+        else:
+            self.switch_to_plain_text()
+        
         self._starting_up = True
+        
 
     #------ SpyderPluginWidget API ---------------------------------------------
     def get_plugin_title(self):
@@ -594,11 +599,11 @@ class Help(SpyderPluginWidget):
         return self._source_is_console
 
     def switch_to_editor_source(self):
-        raise NotImplementedError()
+        pass
 
     def switch_to_console_source(self):
-        raise NotImplementedError()
-        
+        pass
+    
     def source_toggled_console(self, v):
         self._source_is_console = v
         
@@ -612,15 +617,15 @@ class Help(SpyderPluginWidget):
             pass
             #self.combo.show()
             #self.object_edit.hide()
-            #self.show_source_action.setEnabled(True)
-            #self.auto_import_action.setEnabled(True)
+            self.show_source_action.setEnabled(True)
+            self.auto_import_action.setEnabled(True)
         else:
             # Editor
             pass
             #self.combo.hide()
             #self.object_edit.show()
-            #self.show_source_action.setDisabled(True)
-            #self.auto_import_action.setDisabled(True)
+            self.show_source_action.setDisabled(True)
+            self.auto_import_action.setDisabled(True)
         #self.restore_text()
 
     def save_text(self, callback):
@@ -700,14 +705,17 @@ class Help(SpyderPluginWidget):
         self.rich_help = False
         self.plain_text.show()
         self.rich_text.hide()
+        self.toolbar.select_mode(1)
         self.plain_text_action.setChecked(True)
 
     def switch_to_rich_text(self):
         """Switch to rich text mode"""
+        self.toolbar.select_mode(0)
         self.rich_help = True
         self.plain_text.hide()
         self.rich_text.show()
         self.rich_text_action.setChecked(True)
+
         self.show_source_action.setChecked(False)
 
     def set_plain_text(self, text, is_code):
@@ -823,23 +831,21 @@ class Help(SpyderPluginWidget):
 
     def set_object_text(self, text, force_refresh=False, ignore_unknown=False):
         """Set object analyzed by Help"""
-        return
-        # TODO: reimplement this
         if (self.locked and not force_refresh):
             return
         self.switch_to_console_source()
 
-        add_to_combo = True
-        if text is None:
-            text = to_text_string(self.combo.currentText())
-            add_to_combo = False
+        #add_to_combo = True
+        #if text is None:
+        #    text = to_text_string(self.combo.currentText())
+        #    add_to_combo = False
 
         found = self.show_help(text, ignore_unknown=ignore_unknown)
         if ignore_unknown and not found:
             return
 
-        if add_to_combo:
-            self.combo.add_text(text)
+        #if add_to_combo:
+        #    self.combo.add_text(text)
         if found:
             self.save_history()
 
@@ -872,7 +878,7 @@ class Help(SpyderPluginWidget):
             self.dockwidget.blockSignals(False)
 
     def __eventually_raise_help(self, text, force=False):
-        index = self.source_combo.currentIndex()
+        index = 0# self.source_combo.currentIndex()
         if hasattr(self.main, 'tabifiedDockWidgets'):
             # 'QMainWindow.tabifiedDockWidgets' was introduced in PyQt 4.5
             if self.dockwidget and (force or self.dockwidget.isVisible()) \
@@ -897,6 +903,7 @@ class Help(SpyderPluginWidget):
 
     def save_history(self):
         """Save history to a text file in user home directory"""
+        return # TODO: reimplement this
         open(self.LOG_PATH, 'w').write("\n".join( \
                 [to_text_string(self.combo.itemText(index))
                  for index in range(self.combo.count())] ))

--- a/spyderlib/plugins/outlineexplorer.py
+++ b/spyderlib/plugins/outlineexplorer.py
@@ -35,7 +35,7 @@ class OutlineExplorer(OutlineExplorerWidget, SpyderPluginMixin):
                                        show_all_files=show_all_files,
                                        show_comments=show_comments)
         SpyderPluginMixin.__init__(self, parent)
-
+        self.register_toolbar(self.toolbar)
         # Initialize plugin
         self.initialize_plugin()
         

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -411,6 +411,7 @@ class MainWindow(QMainWindow):
         # Toolbars
         self.visible_toolbars = []
         self.toolbarslist = []
+        self.toolbars_list_inner = []
         self.main_toolbar = None
         self.main_toolbar_actions = []
         self.file_toolbar = None
@@ -1932,11 +1933,10 @@ class MainWindow(QMainWindow):
             self.save_visible_toolbars()
         else:
             self.get_visible_toolbars()
-
-        for toolbar in self.visible_toolbars:
+        for toolbar in self.visible_toolbars + self.toolbars_list_inner:
             toolbar.toggleViewAction().setChecked(value)
             toolbar.setVisible(value)
-
+            
         self.toolbars_visible = value
         self._update_show_toolbars_action()
 

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -2069,6 +2069,8 @@ class MainWindow(QMainWindow):
         for toolbar in self.toolbarslist:
             action = toolbar.toggleViewAction()
             name = toolbar.objectName()
+            if name is None:
+                continue
             try:
                 pos = order.index(name)
             except ValueError:

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -1873,6 +1873,13 @@ class MainWindow(QMainWindow):
             action.setChecked(plugin.dockwidget.isVisible())
 
     # --- Show/Hide toolbars
+    def get_toolbars_visible(self):
+        try:
+            return self.toolbars_visible
+        except AttributeError:
+            self.toolbars_visible = CONF.get('main', 'toolbars_visible')
+            return self.toolbars_visible
+            
     def _update_show_toolbars_action(self):
         """Update the text displayed in the menu entry."""
         if self.toolbars_visible:

--- a/spyderlib/utils/qthelpers.py
+++ b/spyderlib/utils/qthelpers.py
@@ -306,9 +306,13 @@ def set_item_user_text(item, text):
     item.setData(0, Qt.UserRole, to_qvariant(text))
 
 
-def context_menu_to_toolbar(parent, menu):
+def context_menu_to_toolbar(parent=None, menu=None, old=None):
     """dont forget you may need to call something like .update_menu()
-    before passing in the menu."""    
+    before passing in the menu.
+    `old` can be a `WidgetInnerToolbar` previously returned by this
+    method, in which case the `.replace` method will be used rather
+    than creating a fresh `WidgetInnerToolbar`.
+    """    
     actions = (a for a in menu.actions() if not a.isSeparator())
     buttons = []
     non_icon_buttons = []
@@ -320,7 +324,11 @@ def context_menu_to_toolbar(parent, menu):
             new_button.setDefaultAction(action)
             buttons.append(new_button) 
         
-    return WidgetInnerToolbar(buttons, non_icon_buttons)
+    if old:
+        old.replace(buttons, non_icon_buttons)
+        return old
+    else:
+        return WidgetInnerToolbar(buttons, non_icon_buttons, parent=parent)
 
 def create_bookmark_action(parent, url, title, icon=None, shortcut=None):
     """Create bookmark action"""

--- a/spyderlib/utils/qthelpers.py
+++ b/spyderlib/utils/qthelpers.py
@@ -307,7 +307,7 @@ def set_item_user_text(item, text):
 
 
 def context_menu_to_toolbar(parent, menu):
-    """dont forget you may need to callsomehting like .update_menu()
+    """dont forget you may need to call something like .update_menu()
     before passing in the menu."""    
     actions = (a for a in menu.actions() if not a.isSeparator())
     buttons = []

--- a/spyderlib/utils/qthelpers.py
+++ b/spyderlib/utils/qthelpers.py
@@ -26,6 +26,8 @@ from spyderlib.config.base import get_image_path, running_in_mac_app
 from spyderlib.config.gui import get_shortcut
 from spyderlib.utils import programs
 from spyderlib.py3compat import is_text_string, to_text_string
+from spyderlib.widgets.helperwidgets import WidgetInnerToolbar
+
 
 # Note: How to redirect a signal from widget *a* to widget *b* ?
 # ----
@@ -303,6 +305,22 @@ def set_item_user_text(item, text):
     """Set QTreeWidgetItem user role string"""
     item.setData(0, Qt.UserRole, to_qvariant(text))
 
+
+def context_menu_to_toolbar(parent, menu):
+    """dont forget you may need to callsomehting like .update_menu()
+    before passing in the menu."""    
+    actions = (a for a in menu.actions() if not a.isSeparator())
+    buttons = []
+    non_icon_buttons = []
+    for action in actions:                    
+        if action.icon().isNull():
+            non_icon_buttons.append(action)
+        else:
+            new_button = create_toolbutton(parent)
+            new_button.setDefaultAction(action)
+            buttons.append(new_button) 
+        
+    return WidgetInnerToolbar(buttons, non_icon_buttons)
 
 def create_bookmark_action(parent, url, title, icon=None, shortcut=None):
     """Create bookmark action"""

--- a/spyderlib/utils/qthelpers.py
+++ b/spyderlib/utils/qthelpers.py
@@ -310,7 +310,7 @@ def context_menu_to_toolbar(parent=None, menu=None, old=None):
     """dont forget you may need to call something like .update_menu()
     before passing in the menu.
     `old` can be a `WidgetInnerToolbar` previously returned by this
-    method, in which case the `.replace` method will be used rather
+    method, in which case the `.add_mode` method will be used rather
     than creating a fresh `WidgetInnerToolbar`.
     """    
     actions = (a for a in menu.actions() if not a.isSeparator())
@@ -325,7 +325,7 @@ def context_menu_to_toolbar(parent=None, menu=None, old=None):
             buttons.append(new_button) 
         
     if old:
-        old.replace(buttons, non_icon_buttons)
+        old.add_mode(buttons, non_icon_buttons)
         return old
     else:
         return WidgetInnerToolbar(buttons, non_icon_buttons, parent=parent)

--- a/spyderlib/utils/qthelpers.py
+++ b/spyderlib/utils/qthelpers.py
@@ -26,7 +26,6 @@ from spyderlib.config.base import get_image_path, running_in_mac_app
 from spyderlib.config.gui import get_shortcut
 from spyderlib.utils import programs
 from spyderlib.py3compat import is_text_string, to_text_string
-from spyderlib.widgets.helperwidgets import WidgetInnerToolbar
 
 
 # Note: How to redirect a signal from widget *a* to widget *b* ?
@@ -376,6 +375,7 @@ def context_menu_to_toolbar(parent=None, menu=None, old=None):
     TODO: it would make more sense to use createWidget(self) on all actions
     rather than accepting a mixture of buttons and actions.
     """    
+    from spyderlib.widgets.helperwidgets import WidgetInnerToolbar
     actions = (a for a in menu.actions() if not a.isSeparator())
     buttons = []
     non_icon_buttons = []

--- a/spyderlib/widgets/browser.py
+++ b/spyderlib/widgets/browser.py
@@ -34,6 +34,7 @@ class WebView(QWebView):
         self.zoom_in_action = create_action(self, _("Zoom in"),
                                             icon=ima.icon('zoom_in'),
                                             triggered=self.zoom_in)
+        self.build_context_menu()
         
     def find_text(self, text, changed=True,
                   forward=True, case=False, words=False,
@@ -97,8 +98,8 @@ class WebView(QWebView):
         import webbrowser
         webbrowser.open(to_text_string(self.url().toString()))
         
-    def contextMenuEvent(self, event):
-        menu = QMenu(self)
+    def build_context_menu(self):
+        self.menu = QMenu(self)
         actions = [self.pageAction(QWebPage.Back),
                    self.pageAction(QWebPage.Forward), None,
                    self.pageAction(QWebPage.SelectAll),
@@ -108,8 +109,10 @@ class WebView(QWebView):
             settings = self.page().settings()
             settings.setAttribute(QWebSettings.DeveloperExtrasEnabled, True)
             actions += [None, self.pageAction(QWebPage.InspectElement)]
-        add_actions(menu, actions)
-        menu.popup(event.globalPos())
+        add_actions(self.menu, actions)
+
+    def contextMenuEvent(self, event):
+        self.menu.popup(event.globalPos())
         event.accept()
                 
 
@@ -266,6 +269,10 @@ class FrameWebView(QFrame):
     def setHtml(self, html_text, base_url):
         self._webview.setHtml(html_text, base_url)
 
+    @property
+    def menu(self):
+        return self._webview.menu
+        
     def url(self):
         return self._webview.url()
 

--- a/spyderlib/widgets/editortools.py
+++ b/spyderlib/widgets/editortools.py
@@ -18,8 +18,7 @@ import spyderlib.utils.icon_manager as ima
 
 # Local import
 from spyderlib.config.base import _, STDOUT
-from spyderlib.utils.qthelpers import (create_action, create_toolbutton,
-                                       set_item_user_text,
+from spyderlib.utils.qthelpers import (create_action, set_item_user_text,
                                        context_menu_to_toolbar)
 from spyderlib.widgets.onecolumntree import OneColumnTree
 from spyderlib.py3compat import to_text_string

--- a/spyderlib/widgets/editortools.py
+++ b/spyderlib/widgets/editortools.py
@@ -23,6 +23,7 @@ from spyderlib.utils.qthelpers import (create_action, create_toolbutton,
                                        set_item_user_text)
 from spyderlib.widgets.onecolumntree import OneColumnTree
 from spyderlib.py3compat import to_text_string
+from spyderlib.widgets.helperwidgets import WidgetInnerToolbar
 
 
 #===============================================================================
@@ -512,14 +513,11 @@ class OutlineExplorerWidget(QWidget):
                                            toggled=self.toggle_visibility)
         self.visibility_action.setChecked(True)
         
-        btn_layout = QHBoxLayout()
-        btn_layout.setAlignment(Qt.AlignLeft)
-        for btn in self.setup_buttons():
-            btn_layout.addWidget(btn)
-
+        self.toolbar = WidgetInnerToolbar(self.setup_buttons())
+        
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addLayout(btn_layout)
+        layout.addWidget(self.toolbar)
         layout.addWidget(self.treewidget)
         self.setLayout(layout)
 

--- a/spyderlib/widgets/editortools.py
+++ b/spyderlib/widgets/editortools.py
@@ -534,18 +534,25 @@ class OutlineExplorerWidget(QWidget):
                 self.outlineexplorer_is_visible.emit()
         
     def setup_buttons(self):
-        fromcursor_btn = create_toolbutton(self,
-                             icon=ima.icon('fromcursor'),
-                             tip=_('Go to cursor position'),
-                             triggered=self.treewidget.go_to_cursor_position)
-        collapse_btn = create_toolbutton(self)
-        collapse_btn.setDefaultAction(self.treewidget.collapse_selection_action)
-        expand_btn = create_toolbutton(self)
-        expand_btn.setDefaultAction(self.treewidget.expand_selection_action)
-        restore_btn = create_toolbutton(self)
-        restore_btn.setDefaultAction(self.treewidget.restore_action)
-        return (fromcursor_btn, collapse_btn, expand_btn, restore_btn)
-        
+        """Reuses the actions from the context menu of the treewidget as
+        buttons for a toolbar.
+        """
+        self.treewidget.update_menu()
+        actions = (a for a in self.treewidget.menu.actions()
+                   if not a.isSeparator())
+        buttons = []
+        non_icon_buttons = []
+        for action in actions:                    
+            if action.icon().isNull():
+                non_icon_buttons.append(action)
+            else:
+                new_button = create_toolbutton(self)
+                new_button.setDefaultAction(action)
+                buttons.append(new_button) 
+        if non_icon_buttons:
+            pass # TODO: buttons should get a continuation dropdown for these
+        return buttons
+                
     def set_current_editor(self, editor, fname, update, clear):
         if clear:
             self.remove_editor(editor)

--- a/spyderlib/widgets/editortools.py
+++ b/spyderlib/widgets/editortools.py
@@ -532,26 +532,6 @@ class OutlineExplorerWidget(QWidget):
             if state:
                 self.outlineexplorer_is_visible.emit()
         
-    def setup_buttons(self):
-        """Reuses the actions from the context menu of the treewidget as
-        buttons for a toolbar.
-        """
-        self.treewidget.update_menu()
-        actions = (a for a in self.treewidget.menu.actions()
-                   if not a.isSeparator())
-        buttons = []
-        non_icon_buttons = []
-        for action in actions:                    
-            if action.icon().isNull():
-                non_icon_buttons.append(action)
-            else:
-                new_button = create_toolbutton(self)
-                new_button.setDefaultAction(action)
-                buttons.append(new_button) 
-        if non_icon_buttons:
-            pass # TODO: buttons should get a continuation dropdown for these
-        return buttons
-                
     def set_current_editor(self, editor, fname, update, clear):
         if clear:
             self.remove_editor(editor)

--- a/spyderlib/widgets/editortools.py
+++ b/spyderlib/widgets/editortools.py
@@ -11,8 +11,7 @@ from __future__ import print_function
 import re
 import os.path as osp
 
-from spyderlib.qt.QtGui import (QWidget, QTreeWidgetItem,  QHBoxLayout,
-                                QVBoxLayout)
+from spyderlib.qt.QtGui import (QWidget, QTreeWidgetItem, QVBoxLayout)
 from spyderlib.qt.QtCore import Qt, Signal, Slot
 from spyderlib.qt.compat import from_qvariant
 import spyderlib.utils.icon_manager as ima
@@ -20,10 +19,11 @@ import spyderlib.utils.icon_manager as ima
 # Local import
 from spyderlib.config.base import _, STDOUT
 from spyderlib.utils.qthelpers import (create_action, create_toolbutton,
-                                       set_item_user_text)
+                                       set_item_user_text,
+                                       context_menu_to_toolbar)
 from spyderlib.widgets.onecolumntree import OneColumnTree
 from spyderlib.py3compat import to_text_string
-from spyderlib.widgets.helperwidgets import WidgetInnerToolbar
+
 
 
 #===============================================================================
@@ -513,7 +513,8 @@ class OutlineExplorerWidget(QWidget):
                                            toggled=self.toggle_visibility)
         self.visibility_action.setChecked(True)
         
-        self.toolbar = WidgetInnerToolbar(self.setup_buttons())
+        self.treewidget.update_menu()
+        self.toolbar = context_menu_to_toolbar(self, self.treewidget.menu)
         
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)

--- a/spyderlib/widgets/explorer.py
+++ b/spyderlib/widgets/explorer.py
@@ -1001,16 +1001,13 @@ class ExplorerWidget(QWidget):
     open_dir = Signal(str)
 
     def __init__(self, parent=None, name_filters=['*.py', '*.pyw'],
-                 show_all=False, show_cd_only=None, show_icontext=True):
+                 show_all=False, show_cd_only=None):
         QWidget.__init__(self, parent)
 
         # Widgets
         self.treewidget = ExplorerTreeWidget(self, show_cd_only=show_cd_only)
         
         # Actions
-        icontext_action = create_action(self, _("Show icons and text"))
-        icontext_action.setChecked(show_icontext)
-
         previous_action = create_action(self, text=_("Previous"),
                             icon=ima.icon('ArrowBack'),
                             triggered=self.treewidget.go_to_previous_directory)
@@ -1028,14 +1025,12 @@ class ExplorerWidget(QWidget):
         # Setup widgets
         self.treewidget.setup(name_filters=name_filters, show_all=show_all)
         self.treewidget.chdir(getcwd())
-        self.treewidget.common_actions += [None, icontext_action, None, 
+        self.treewidget.common_actions += [None, 
                                            previous_action, next_action,
                                            parent_action]
 
         self.treewidget.update_menu()
         self.toolbar = context_menu_to_toolbar(self, self.treewidget.menu)
-        #icontext_action.connect(self.toolbar.toggle_icontext) #TODO: connect this properly
-        self.toolbar.toggle_icontext(show_icontext)
         
         layout = QVBoxLayout()
         layout.addWidget(self.toolbar)

--- a/spyderlib/widgets/helperwidgets.py
+++ b/spyderlib/widgets/helperwidgets.py
@@ -70,17 +70,6 @@ class WidgetInnerToolbar(QWidget):
     def objectName(self):
         return None
 
-    @Slot(bool)
-    def toggle_icontext(self, value):
-        print("TODO")
-        # TODO: actually make this work
-        # for widget in something:
-        #     if widget is not self.button_menu:
-        #         if state:
-        #             widget.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
-        #         else:
-        #             widget.setToolButtonStyle(Qt.ToolButtonIconOnly)
-
         
 class HelperToolButton(QToolButton):
     """Subclasses QToolButton, to provide a simple tooltip on mousedown.

--- a/spyderlib/widgets/helperwidgets.py
+++ b/spyderlib/widgets/helperwidgets.py
@@ -9,13 +9,14 @@ Helper widgets.
 """
 
 # Third party imports
-from spyderlib.qt.QtCore import QPoint, QSize, Qt
+from spyderlib.qt.QtCore import QPoint, QSize, Qt, Slot
 from spyderlib.qt.QtGui import (QToolButton, QToolTip,
                                 QStyledItemDelegate, QApplication,
                                 QTextDocument, QStyleOptionViewItem,
                                 QAbstractTextDocumentLayout, QStyle,
-                                QVBoxLayout, QSpacerItem, QHBoxLayout,
-                                QMessageBox, QCheckBox, QWidget, QMenu,
+                                QVBoxLayout, QSpacerItem, QPainter,
+                                QHBoxLayout, QMessageBox, QCheckBox,
+                                QWidget, QMenu, QLineEdit,
                                 QStackedWidget, QSizePolicy, QAction)
 
 
@@ -230,6 +231,99 @@ class HTMLDelegate(QStyledItemDelegate):
         doc.setTextWidth(options.rect.width())
 
         return QSize(doc.idealWidth(), doc.size().height())
+
+
+class IconLineEdit(QLineEdit):
+    """Custom QLineEdit that includes an icon representing the validation."""
+
+    def __init__(self, *args, **kwargs):
+        super(IconLineEdit, self).__init__(*args, **kwargs)
+
+        self._status = True
+        self._status_set = True
+        self._valid_icon = ima.icon('todo')
+        self._invalid_icon = ima.icon('warning')
+        self._set_icon = ima.icon('todo_list')
+        self._application_style = QApplication.style().objectName()
+        self._refresh()
+        self._paint_count = 0
+        self._icon_visible = False
+
+    def _refresh(self):
+        """After an application style change, the paintEvent updates the
+        custom defined stylesheet.
+        """
+        padding = self.height()
+        css_base = """QLineEdit {{
+                                 border: none;
+                                 padding-right: {padding}px;
+                                 }}
+                   """
+        css_oxygen = """QLineEdit {{background: transparent;
+                                   border: none;
+                                   padding-right: {padding}px;
+                                   }}
+                     """
+        if self._application_style == 'oxygen':
+            css_template = css_oxygen
+        else:
+            css_template = css_base
+
+        css = css_template.format(padding=padding)
+        self.setStyleSheet(css)
+        self.update()
+
+    def hide_status_icon(self):
+        """Show the status icon."""
+        self._icon_visible = False
+        self.repaint()
+        self.update()
+
+    def show_status_icon(self):
+        """Hide the status icon."""
+        self._icon_visible = True
+        self.repaint()
+        self.update()
+
+    def update_status(self, value, value_set):
+        """Update the status and set_status to update the icons to display."""
+        self._status = value
+        self._status_set = value_set
+        self.repaint()
+        self.update()
+
+    def paintEvent(self, event):
+        """Qt Override.
+
+        Include a validation icon to the left of the line edit.
+        """
+        super(IconLineEdit, self).paintEvent(event)
+        painter = QPainter(self)
+
+        rect = self.geometry()
+        space = int((rect.height())/6)
+        h = rect.height() - space
+        w = rect.width() - h
+
+        if self._icon_visible:
+            if self._status and self._status_set:
+                pixmap = self._set_icon.pixmap(h, h)
+            elif self._status:
+                pixmap = self._valid_icon.pixmap(h, h)
+            else:
+                pixmap = self._invalid_icon.pixmap(h, h)
+
+            painter.drawPixmap(w, space, pixmap)
+
+        application_style = QApplication.style().objectName()
+        if self._application_style != application_style:
+            self._application_style = application_style
+            self._refresh()
+
+        # Small hack to gurantee correct padding on Spyder start
+        if self._paint_count < 5:
+            self._paint_count += 1
+            self._refresh()
 
 
 def test_msgcheckbox():

--- a/spyderlib/widgets/helperwidgets.py
+++ b/spyderlib/widgets/helperwidgets.py
@@ -69,6 +69,18 @@ class WidgetInnerToolbar(QWidget):
         
     def objectName(self):
         return None
+
+    @Slot(bool)
+    def toggle_icontext(self, value):
+        print("TODO")
+        # TODO: actually make this work
+        # for widget in something:
+        #     if widget is not self.button_menu:
+        #         if state:
+        #             widget.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        #         else:
+        #             widget.setToolButtonStyle(Qt.ToolButtonIconOnly)
+
         
 class HelperToolButton(QToolButton):
     """Subclasses QToolButton, to provide a simple tooltip on mousedown.

--- a/spyderlib/widgets/helperwidgets.py
+++ b/spyderlib/widgets/helperwidgets.py
@@ -16,7 +16,7 @@ from spyderlib.qt.QtGui import (QToolButton, QToolTip,
                                 QAbstractTextDocumentLayout, QStyle,
                                 QVBoxLayout, QSpacerItem, QHBoxLayout,
                                 QMessageBox, QCheckBox, QWidget, QMenu,
-                                QStackedWidget, QSizePolicy)
+                                QStackedWidget, QSizePolicy, QAction)
 
 
 # Local imports
@@ -62,7 +62,7 @@ class WidgetInnerToolbar(QWidget):
         switch between using modes using .select_mode(index).
         """
         # TODO: fix import issues, so this isn't local
-        from spyderlib.utils.qthelpers import add_actions        
+        from spyderlib.utils.qthelpers import add_actions     
         
         layout = QHBoxLayout()
         layout.setAlignment(Qt.AlignLeft)

--- a/spyderlib/widgets/helperwidgets.py
+++ b/spyderlib/widgets/helperwidgets.py
@@ -28,11 +28,11 @@ class WidgetInnerToolbar(QWidget):
     """A light-weight toolbar-like widget which can be toggled on/off like
     a proper toolbar. Usage: Layout.addWidget(WidgetInnerToolbar)"""
     
-    def __init__(self, buttons, non_icon_buttons=None):
+    def __init__(self, buttons, non_icon_buttons=None, parent=None):
         """Expects a sequence of buttons, each of which is made using
         the helper function called create_toolbutton."""
         # TODO: fix import issues, so this isn't local
-        from spyderlib.utils.qthelpers import create_action, add_actions
+        from spyderlib.utils.qthelpers import create_action
                                                
         QWidget.__init__(self)
         self._layout = QHBoxLayout()
@@ -40,9 +40,28 @@ class WidgetInnerToolbar(QWidget):
         self._layout.setAlignment(Qt.AlignLeft)
         self._layout.setContentsMargins(0, 0, 0, 0)
 
+        self.replace(buttons, non_icon_buttons)
+        
+        self._parent = parent or QObject()
+        self._toggle_view_action = create_action(self._parent,
+                                                 "toggle WidgetInnerToolbar",
+                                                 toggled=self.toggleEvent)
+        self._toggle_view_action.setChecked(True)
+    
+    def replace(self, buttons, non_icon_buttons=None):
+        """If you want to change the toolbar after creating it use this method.
+        It should work the same as init.
+        """
+        # TODO: fix import issues, so this isn't local
+        from spyderlib.utils.qthelpers import add_actions
+        
+        # clear layout ..I think this is the right way to do it?
+        while self._layout.count():
+            self._layout.takeAt(0).widget().deleteLater()
+        
         for btn in buttons:
             self._layout.addWidget(btn)
-        
+            
         if non_icon_buttons:
             self._button_menu = QToolButton(self)
             self._menu = QMenu(self)
@@ -52,13 +71,7 @@ class WidgetInnerToolbar(QWidget):
             self._button_menu.setMenu(self._menu)
             self._layout.addStretch()
             self._layout.addWidget(self._button_menu)
-
-        self._dummy_parent = QObject()
-        self._toggle_view_action = create_action(self._dummy_parent,
-                                                 "toggle WidgetInnerToolbar",
-                                                 toggled=self.toggleEvent)
-        self._toggle_view_action.setChecked(True)
-    
+            
     @Slot(bool)
     def toggleEvent(self, v):
         """handler for toggle_view_action"""

--- a/spyderlib/widgets/helperwidgets.py
+++ b/spyderlib/widgets/helperwidgets.py
@@ -15,29 +15,44 @@ from spyderlib.qt.QtGui import (QToolButton, QToolTip,
                                 QTextDocument, QStyleOptionViewItem,
                                 QAbstractTextDocumentLayout, QStyle,
                                 QVBoxLayout, QSpacerItem, QHBoxLayout,
-                                QMessageBox, QCheckBox, QWidget)
-from spyderlib.utils.qthelpers import create_action
+                                QMessageBox, QCheckBox, QWidget, QMenu)
+
 
 # Local imports
 from spyderlib.config.base import _
 from spyderlib.utils import icon_manager as ima
 from spyderlib.utils.qthelpers import get_std_icon
+import spyderlib.utils.icon_manager as ima
 
 class WidgetInnerToolbar(QWidget):
     """A light-weight toolbar-like widget which can be toggled on/off like
     a proper toolbar. Usage: Layout.addWidget(WidgetInnerToolbar)"""
     
-    def __init__(self, buttons):
+    def __init__(self, buttons, non_icon_buttons=None):
         """Expects a sequence of buttons, each of which is made using
         the helper function called create_toolbutton."""
+        # TODO: fix import issues, so this isn't local
+        from spyderlib.utils.qthelpers import create_action, add_actions
+                                               
         QWidget.__init__(self)
         self._layout = QHBoxLayout()
         self.setLayout(self._layout)
         self._layout.setAlignment(Qt.AlignLeft)
         self._layout.setContentsMargins(0, 0, 0, 0)
-        
+
         for btn in buttons:
             self._layout.addWidget(btn)
+        
+        if non_icon_buttons:
+            self._button_menu = QToolButton(self)
+            self._menu = QMenu(self)
+            add_actions(self._menu, non_icon_buttons)
+            self._button_menu.setIcon(ima.icon('tooloptions'))
+            self._button_menu.setPopupMode(QToolButton.InstantPopup)
+            self._button_menu.setMenu(self._menu)
+            self._layout.addStretch()
+            self._layout.addWidget(self._button_menu)
+
         self._dummy_parent = QObject()
         self._toggle_view_action = create_action(self._dummy_parent,
                                                  "toggle WidgetInnerToolbar",

--- a/spyderlib/widgets/onecolumntree.py
+++ b/spyderlib/widgets/onecolumntree.py
@@ -4,7 +4,7 @@
 # Licensed under the terms of the MIT License
 # (see spyderlib/__init__.py for details)
 
-from spyderlib.qt.QtCore import Slot
+from spyderlib.qt.QtCore import Slot, Qt
 from spyderlib.qt.QtGui import QTreeWidget, QMenu
 import spyderlib.utils.icon_manager as ima
 
@@ -19,6 +19,9 @@ class OneColumnTree(QTreeWidget):
         QTreeWidget.__init__(self, parent)
         self.setItemsExpandable(True)
         self.setColumnCount(1)
+        self.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.customContextMenuRequested.connect(self.contextMenuEvent)
+        
         self.itemActivated.connect(self.activated)
         self.itemClicked.connect(self.clicked)
         # Setup context menu
@@ -202,9 +205,20 @@ class OneColumnTree(QTreeWidget):
         for index, item in enumerate(items):
             self.insertTopLevelItem(index, item)
         self.restore_expanded_state()
-                     
-    def contextMenuEvent(self, event):
-        """Override Qt method"""
+            
+    def mouseReleaseEvent(self, event):
+        """ http://stackoverflow.com/a/31317570/2399799 """
+        if event.button() != Qt.RightButton:
+            super(OneColumnTree, self).mouseReleaseEvent(event)
+            
+    def contextMenuEvent(self, pos):
+        """See the following two lines in __init__:
+            self.setContextMenuPolicy(Qt.CustomContextMenu)
+            self.customContextMenuRequested.connect(self.contextMenuEvent)
+            and...
+            https://wiki.python.org/moin/PyQt/Creating%20a%20context
+                                                %20menu%20for%20a%20tree%20view
+        """
         self.update_menu()
-        self.menu.popup(event.globalPos())
+        self.menu.popup(self.viewport().mapToGlobal(pos))
         


### PR DESCRIPTION
**the below description has been updated several times...**

This is one of the things discussed in issue #2353.
Also relevant is: [pending pull #2288](https://github.com/spyder-ide/spyder/pull/2288) and [merged pull #2426](https://github.com/spyder-ide/spyder/pull/2426).

TODO:
- [x] basic class/factory methods to make the context-menu => togglable-toolbar possible
- [x] refactor File Explorer widget with new system
- [x] refactor Outline Explorer widget with new system
- [x] refactor Help (previously known as "Object Inspector") widget with new system - requires support for multiple toolbar "modes" (`qtstacked`) and combo boxes (custom `ComboAction`, subclassed from `QWidgetAction`)...there are a few bugs still with the OI.
- [ ] refactor Variable Explorer widget with new system - a more difficult job, lets leave it for now  
  apply to other widgets?

I have created a helper widget called `WidgetInnerToolbar` and a utility function for constructing instances of that widget from a context menu - `context_menu_to_toolbar`.  For the Object Inspector I had to add some more features, such as support for switching between multiple toolbar "modes" and supporting arbitrary subclasses of `QWidgetAction`, such as the custom made `ComboAction`.

The idea is that `WidgetInnerToolbar` can be registered as a nearly-proper toolbar using the new `register_toolbar` method of `SpyderPluginMixin`.  It then takes part in the global toggling on/off of toolbars.  It also seems a lot neater to collect together all the actions in one place (the context-menu) and then use that to populate other places (the toolbar).  I decided to do it this way round because in all cases the widgets seemed to have a "main child" widget that already had its own context-menu, so it seemed easier to add to that and then build the toolbar from the amalgamated context-menu.

This is what the file explorer's context-menu and toolbar look like (note the name|size|type bit is not actually part of the toolbar  -I should probably have cropped it out here):
![image](https://cloud.githubusercontent.com/assets/4244876/10245752/868d8eb0-6902-11e5-8211-cd567db8b81c.png)

This is what the outline explorer looks like (with toolbar hidden/showing):

![image](https://cloud.githubusercontent.com/assets/4244876/10002623/23cd0d92-60a0-11e5-815e-4dcd817f4f3a.png)

And this is the help widget's toolbar and context menu. Note there are two modes: source/plain-text and rich-text.
![image](https://cloud.githubusercontent.com/assets/4244876/10245684/cc191018-6901-11e5-8666-9175eb35c862.png)
