### PR TITLE
ENH: Allow develop install mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,10 @@ import shutil
 from distutils.core import setup
 from distutils.command.build import build
 from distutils.command.install_data import install_data
+try:
+    import setuptools  # allows python setup.py develop
+except ImportError:
+    pass
 
 # Check for Python 3
 PY3 = sys.version_info[0] == 3


### PR DESCRIPTION
Small enhancement that allows doing:
```
python setup.py develop
```
In this mode, any local changes are immediately reflected on next launch without having to modify paths, which is nice.