### PR TITLE
Read correctly the run config for profiling

### DIFF
--- a/spyderplugins/p_profiler.py
+++ b/spyderplugins/p_profiler.py
@@ -130,7 +130,7 @@ class Profiler(ProfilerWidget, SpyderPluginMixin):
             self.dockwidget.raise_()
         pythonpath = self.main.get_spyder_pythonpath()
         runconf = runconfig.get_run_configuration(filename)
-        wdir, args = None, None
+        wdir, args = None, []
         if runconf is not None:
             if runconf.wdir_enabled:
                 wdir = runconf.wdir


### PR DESCRIPTION
Fixes #2736

When the profiler is run from the top menu or from a shortcut, and if the run config has disabled command line arguments, the profiler should be called with `args=[]` instead of `args=None`, to ensure that no argument will be given to the script.