### PR TITLE
Add dependencies to pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,14 @@ env:
 
 matrix:
   include:
-    # Linux using apt-get/pip packages
+    # Linux using pip packages
     - python: "2.7"
-      env: USE_QT_API=PyQt4 USE_CONDA=false
+      env: USE_QT_API=PySide USE_CONDA=false
       os: linux
     - python: "3.4"
-      env: USE_QT_API=PyQt4 USE_CONDA=false
+      env: USE_QT_API=PySide USE_CONDA=false
       os: linux
-    # Linux using miniconda
+    # Linux using conda packages
     - python: "2.7"
       env: USE_QT_API=PyQt4 USE_CONDA=true
       os: linux
@@ -33,12 +33,9 @@ matrix:
     - python: "3.5"
       env: USE_QT_API=PyQt5 USE_CONDA=true
       os: linux
-    #- python: "2.7"
-    #  env: USE_QT_API=PySide USE_CONDA=false
-    #  os: linux
 
 before_install:
-  - sudo apt-get update
+  #- sudo apt-get update
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,10 @@ matrix:
     - python: "3.5"
       env: USE_QT_API=PyQt5 USE_CONDA=true
       os: linux
-    #- python: "2.7"
-    #  env: USE_QT_API=PySide USE_CONDA=true
-    #  os: linux
     # Linux using apt-get/pip packages
-    #- python: "2.7"
-    #  env: USE_QT_API=PyQt4 USE_CONDA=false
-    #  os: linux
+    - python: "2.7"
+      env: USE_QT_API=PyQt4 USE_CONDA=false
+      os: linux
     #- python: "2.7"
     #  env: USE_QT_API=PySide USE_CONDA=false
     #  os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,8 @@ before_install:
 
 install:
   - ./continuous_integration/travis_install.sh;
+  - if [ "$USE_CONDA" = true ]; then source activate test-environment; fi
   - export PATH="$HOME/miniconda/bin:$PATH";
-  - source activate test-environment;
-  - QT_API=$USE_QT_API;
 
 script:
   - ./continuous_integration/build_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# After changing this file, check it on http://yaml-online-parser.appspot.com/
+# https://travis-ci.org/spyder-ide/spyder
 
 language: python
 sudo: false
@@ -36,7 +36,6 @@ matrix:
       os: linux
 
 before_install:
-  #- sudo apt-get update
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ matrix:
     - python: "2.7"
       env: USE_QT_API=PyQt4 USE_CONDA=false
       os: linux
+    - python: "3.4"
+      env: USE_QT_API=PyQt4 USE_CONDA=false
+      os: linux
     # Linux using miniconda
     - python: "2.7"
       env: USE_QT_API=PyQt4 USE_CONDA=true
@@ -31,9 +34,6 @@ matrix:
       env: USE_QT_API=PyQt5 USE_CONDA=true
       os: linux
     #- python: "2.7"
-    #  env: USE_QT_API=PySide USE_CONDA=false
-    #  os: linux
-    #- python: "3.4"
     #  env: USE_QT_API=PySide USE_CONDA=false
     #  os: linux
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # After changing this file, check it on http://yaml-online-parser.appspot.com/
 
 language: python
+sudo: false
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ matrix:
   include:
     # Linux using pip packages
     - python: "2.7"
-      env: USE_QT_API=PySide USE_CONDA=false
+      env: USE_QT_API=PyQt4 USE_CONDA=false
       os: linux
     - python: "3.4"
-      env: USE_QT_API=PySide USE_CONDA=false
+      env: USE_QT_API=PyQt4 USE_CONDA=false
       os: linux
     # Linux using conda packages
     - python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ env:
 
 matrix:
   include:
+    # Linux using apt-get/pip packages
+    - python: "2.7"
+      env: USE_QT_API=PyQt4 USE_CONDA=false
+      os: linux
     # Linux using miniconda
     - python: "2.7"
       env: USE_QT_API=PyQt4 USE_CONDA=true
@@ -25,10 +29,6 @@ matrix:
       os: linux
     - python: "3.5"
       env: USE_QT_API=PyQt5 USE_CONDA=true
-      os: linux
-    # Linux using apt-get/pip packages
-    - python: "2.7"
-      env: USE_QT_API=PyQt4 USE_CONDA=false
       os: linux
     #- python: "2.7"
     #  env: USE_QT_API=PySide USE_CONDA=false

--- a/README.md
+++ b/README.md
@@ -56,17 +56,6 @@ You can read the Spyder documentation at:
 http://pythonhosted.org/spyder/
 
 
-## Running from source
-
-The fastest way to run Spyder is to get the source code, install PyQt
-or PySide, and run:
-
-    python bootstrap.py
-    
-You may want to do this for fixing bugs in Spyder, adding new
-features, learning how Spyder works or just getting a taste of it.
-
-
 ## Installation
 
 This section explains how to install the latest stable release of
@@ -120,6 +109,17 @@ existing installation
 
 For more details on supported platforms, please refer to our
 [installation instructions](http://pythonhosted.org/spyder/installation.html).
+
+
+## Running from source
+
+The fastest way to run Spyder is to get the source code, install PyQt
+or PySide, and run:
+
+    python bootstrap.py
+    
+You may want to do this for fixing bugs in Spyder, adding new
+features, learning how Spyder works or just getting a taste of it.
 
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -122,41 +122,39 @@ features, learning how Spyder works or just getting a taste of it.
 ## Dependencies
 
 **Important note**: Most if not all the dependencies listed below come
-with *Python(x,y)*, *WinPython* and *Anaconda*, so you don't need to install
+with *Anaconda*, *WinPython* and *Python(x,y)*, so you don't need to install
 them separately when installing one of these Scientific Python
 distributions.
 
 ### Build dependencies
 
 When installing Spyder from its source package, the only requirement is to have
-a Python version greater than 2.6 (Python 3.2 is not supported anymore).
+a Python version greater than 2.7 (Python 3.2 is not supported anymore).
 
 ### Runtime dependencies
 
-* **Python** 2.6, 2.7, 3.3 or 3.4
-* **PyQt4** 4.6+, **PySide** 1.2.0+ or **PyQt5** 5.2+ (PyQt4 is recommended)
-
-### Recommended modules
-
-* **IPython** 3.0- or **qtconsole** 4.0+ (enhanced Python interpreter)
-* **Rope** v0.9.4+ and/or **Jedi** 0.8 + (editor code completion, calltips
-  and go-to-definition)
-* **Pyflakes** v0.5.0+ (real-time code analysis)
-* **Sphinx** v0.6+ (object inspector's rich text mode)
-* **Matplotlib** v1.0+ (2D/3D plotting)
-* **Pandas** v0.13.1+ (DataFrame and Series support)
-* **Numpy** (N-dimensional arrays)
-* **Scipy** (signal/image processing)
+* **Python** 2.7, 3.3, 3.4 or 3.5
+* **PyQt4** 4.6+, **PyQt5** 5.2+ or **PySide** 1.2.0+. PyQt4 is recommended.
+* **IPython** 3.0 or **qtconsole** 4.0+. Enhanced Python interpreter.
+* **Rope** v0.9.4+ and/or **Jedi** 0.8.1. Editor code completion, calltips
+  and go-to-definition.
+* **Pyflakes** v0.5.0+. Real-time code analysis)
+* **Sphinx** v0.6+. Object Inspector's rich text mode.
+* **Pygments** v1.6+. Syntax highlighting for all file types it supports.
+* **Pylint** v0.25+. Static code analysis.
+* **Pep8** v0.6+. Style analysis.
+* **Psutil** v0.3+. CPU and memory usage on the status bar.
+* **Nbconvert** 4.0+. Manipulation of notebooks in the Editor.
 
 **Note**: To get IPython in Ubuntu you need to install `ipython-qtconsole`,
 on Fedora `ipython-gui` and on Gentoo `ipython` with the `qt4` USE flag.
 
 ### Optional modules
 
-* **Pygments** v1.6+ (syntax highlighting for all file types it supports).
-* **Pylint** v0.25+ (static code analysis).
-* **Pep8** v0.6+ (style analysis).
-* **Psutil** v0.3+ (CPU and memory usage on the status bar)
+* **Matplotlib** v1.0+. 2D/3D plotting.
+* **Pandas** v0.13.1+. DataFrame and Series support.
+* **Numpy**. N-dimensional arrays.
+* **SymPy**. Symbolic mathematics.
 
 
 ## More information

--- a/README.md
+++ b/README.md
@@ -89,31 +89,28 @@ The easiest way to install Spyder is:
 
 ### Cross-platform way from source
 
-You can install Spyder from its zip source package named `spyder-x.y.z.zip`,
-found [here](https://github.com/spyder-ide/spyder/releases). Then you need to
-use the standard Python `setup.py` script:
+You can also install Spyder with the `pip` package manager, which comes by
+default with most Python installations. For that you need to use the
+command:
 
-    python setup.py install
+    pip install spyder
 
-Note that `setup.py` is not able to uninstall previous versions of Python
-packages: it simply copies files on top of an existing installation. So the
-best way to install from source is to use the `pip` package manager:
-
-    pip install .
-
-Note the dot (`.`) at the end of this command. `pip` can also install Spyder
-from the [Python package index](http://pypi.python.org/pypi) *and* upgrade an
-existing installation
+To upgrade Spyder to its latest version, if it was installed before, you need
+to run
 
     pip install --upgrade spyder
 
 For more details on supported platforms, please refer to our
 [installation instructions](http://pythonhosted.org/spyder/installation.html).
 
+**Important note**: This does not install the graphical Python libraries (i.e.
+PyQt4, PyQt5 or PySide) that Spyder depend on. Those have to be installed
+separately after installing Python.
+
 
 ## Running from source
 
-The fastest way to run Spyder is to get the source code, install PyQt
+The fastest way to run Spyder is to get the source code, install PyQt4, PyQt5
 or PySide, and run:
 
     python bootstrap.py

--- a/continuous_integration/build_test.sh
+++ b/continuous_integration/build_test.sh
@@ -19,4 +19,6 @@ if [ "$USE_CONDA" = true ] ; then
     else
         conda build spyder
     fi
+else
+    python setup.py bdist_wheel --universal
 fi

--- a/continuous_integration/build_test.sh
+++ b/continuous_integration/build_test.sh
@@ -20,5 +20,8 @@ if [ "$USE_CONDA" = true ] ; then
         conda build spyder
     fi
 else
+    # Print basic testing info
+    pip --version
+
     python setup.py bdist_wheel --universal
 fi

--- a/continuous_integration/conda-recipes/spyder/meta.yaml
+++ b/continuous_integration/conda-recipes/spyder/meta.yaml
@@ -30,12 +30,6 @@ requirements:
     - six
     - python.app      [osx]
 
-test:
-  commands:
-    - spyder -h
-  imports:
-    - spyderlib
-
 about:
   home: https://github.com/spyder-ide/spyder
   license: MIT

--- a/continuous_integration/modules_test.sh
+++ b/continuous_integration/modules_test.sh
@@ -68,6 +68,9 @@ for f in spyderlib/*/*/*.py; do
     if [[ $f == spyderlib/utils/introspection/__init__.py ]]; then
         continue
     fi
+    if [[ $f == spyderlib/widgets/externalshell/systemshell.py ]]; then
+        continue
+    fi
     if [[ $f == spyderlib/widgets/externalshell/inputhooks.py ]]; then
         continue
     fi

--- a/continuous_integration/run_test.sh
+++ b/continuous_integration/run_test.sh
@@ -16,6 +16,7 @@ if [ "$USE_QT_API" = "PyQt4" ]; then
     EXTRA_PACKAGES+=" matplotlib"
 fi
 
+# Install our builds of Spyder
 if [ "$USE_CONDA" = true ] ; then
     # Move to a tmp dir
     mkdir ~/tmp
@@ -31,10 +32,12 @@ if [ "$USE_CONDA" = true ] ; then
     if [ "$TRAVIS_PYTHON_VERSION" = "3.5" ]; then
         pip install jedi==0.8.1
     fi
+else
+    pip install -U dist/spyder-*.whl
+fi
 
-    # Testing that the app starts and runs
-    spyder
-    if [ $? -ne 0 ]; then
-        exit 1
-    fi
+# Testing that the app starts and runs
+spyder
+if [ $? -ne 0 ]; then
+    exit 1
 fi

--- a/continuous_integration/run_test.sh
+++ b/continuous_integration/run_test.sh
@@ -5,16 +5,19 @@ set -ex
 # Tell Spyder we're testing the app in Travis
 export TEST_TRAVIS_APP=True
 
+
 # Extra packages to install besides Spyder regular dependencies
 # We install them here and not in travis_install.sh to see if
 # Spyder is correctly pulling its deps (some of them are shared
 # with mpl)
 export EXTRA_PACKAGES="pandas sympy pillow"
 
+
 # Don't install mpl for PyQt5 because it pulls PyQt4
 if [ "$USE_QT_API" = "PyQt4" ]; then
     EXTRA_PACKAGES+=" matplotlib"
 fi
+
 
 # Install our builds of Spyder
 if [ "$USE_CONDA" = true ] ; then
@@ -33,8 +36,9 @@ if [ "$USE_CONDA" = true ] ; then
         pip install jedi==0.8.1
     fi
 else
-    pip install -U dist/spyder-*.whl
+    pip install dist/spyder-*.whl
 fi
+
 
 # Testing that the app starts and runs
 spyder

--- a/continuous_integration/travis_install.sh
+++ b/continuous_integration/travis_install.sh
@@ -137,6 +137,6 @@ if [ "$USE_CONDA" = true ] ; then
     export SOURCE=`source activate test-environment`
     install_conda;
 else
-    export EXTRA_PACKAGES="matplotlib pandas sympy"
+    export EXTRA_PACKAGES="matplotlib pandas sympy pyzmq pillow"
     install_apt_pip;
 fi

--- a/continuous_integration/travis_install.sh
+++ b/continuous_integration/travis_install.sh
@@ -64,67 +64,35 @@ install_conda()
 
 install_pyside()
 {
-    # Currently support for python 2.7, 3.3, 3.4
+    # Currently support Python 2.7 and 3.4
     # http://stackoverflow.com/questions/24489588/how-can-i-install-pyside-on-travis
-    sudo apt-get install libqt4-dev;
-    pip install --upgrade pip;
-    pip install PySide --no-index --find-links=$WHEELHOUSE_URI;  
+    # sudo apt-get install libqt4-dev;
+
+    pip install -U setuptools;
+    pip install -U pip;
+    pip install --no-index --trusted-host $WHEELHOUSE_URI --find-links=http://$WHEELHOUSE_URI/ pyside;
+
     # Travis CI servers use virtualenvs, so we need to finish the install by the following
     POSTINSTALL=$(find ~/virtualenv/ -type f -name "pyside_postinstall.py";)
     python $POSTINSTALL -install;
 }
 
 
-install_qt4()
-{
-    # Install Qt and then update the Matplotlib settings
-    sudo apt-get install -q libqt4-dev pyqt4-dev-tools;
-
-    if [[ $PY_VERSION == 2.7* ]]; then
-        sudo apt-get install python-dev
-        sudo apt-get install -q python-qt4
-    else
-        sudo apt-get install python3-dev
-        sudo apt-get install -q python3-pyqt4
-    fi
-
-    # http://stackoverflow.com/a/9716100
-    LIBS=( PyQt4 sip.so )
-
-    VAR=( $(which -a python$PY_VERSION) )
-
-    GET_PYTHON_LIB_CMD="from distutils.sysconfig import get_python_lib; print (get_python_lib())"
-    LIB_VIRTUALENV_PATH=$(python -c "$GET_PYTHON_LIB_CMD")
-    LIB_SYSTEM_PATH=$(${VAR[-1]} -c "$GET_PYTHON_LIB_CMD")
-
-    for LIB in ${LIBS[@]}
-    do
-        sudo ln -sf $LIB_SYSTEM_PATH/$LIB $LIB_VIRTUALENV_PATH/$LIB
-    done
-}
-
-
 install_qt5()
 {
-    #sudo apt-get install -qq python-sip python-qt5 python-sphinx --fix-missing;
-    #sudo apt-get install -qq python3-sip python3-pyqt5 --fix-missing;    
     echo "Not supported yet"
 }
 
 
-install_apt_pip()
+install_pip()
 {
     # Test for different Qt bindings
     if [ "$USE_QT_API" = "PyQt5" ]; then
         install_qt5
-    elif [ "$USE_QT_API" = "PyQt4" ]; then
-        install_qt4;
     elif [ "$USE_QT_API" = "PySide" ]; then
         install_pyside;
     fi
 
-    pip install -U pip;
-    pip install -U setuptools;
     pip install --no-index --trusted-host $WHEELHOUSE_URI --find-links=http://$WHEELHOUSE_URI/ $EXTRA_PACKAGES;
 }
 
@@ -139,5 +107,5 @@ if [ "$USE_CONDA" = true ] ; then
     install_conda;
 else
     export EXTRA_PACKAGES="matplotlib pandas sympy pyzmq pillow"
-    install_apt_pip;
+    install_pip;
 fi

--- a/continuous_integration/travis_install.sh
+++ b/continuous_integration/travis_install.sh
@@ -122,10 +122,7 @@ install_apt_pip()
         install_pyside;
     fi
 
-    if [ "$PY_VERSION" = "2.7" ]; then
-        EXTRA_PACKAGES+=" rope"
-    fi
-    pip install -U $EXTRA_PACKAGES
+    pip install --no-index --find-links=$WHEELHOUSE_URI $EXTRA_PACKAGES;
 }
 
 
@@ -138,8 +135,6 @@ if [ "$USE_CONDA" = true ] ; then
     export SOURCE=`source activate test-environment`
     install_conda;
 else
-    export EXTRA_PACKAGES="IPython jedi matplotlib pandas pep8 psutil pyflakes pygments pylint sphinx sympy"
+    export EXTRA_PACKAGES="matplotlib pandas sympy"
     install_apt_pip;
 fi
-
-#sleep 60;

--- a/continuous_integration/travis_install.sh
+++ b/continuous_integration/travis_install.sh
@@ -122,6 +122,8 @@ install_apt_pip()
         install_pyside;
     fi
 
+    pip install -U pip;
+    pip install -U setuptools;
     pip install --no-index --find-links=$WHEELHOUSE_URI $EXTRA_PACKAGES;
 }
 

--- a/continuous_integration/travis_install.sh
+++ b/continuous_integration/travis_install.sh
@@ -83,8 +83,9 @@ install_qt4()
     if [[ $PY_VERSION == 2.7* ]]; then
         sudo apt-get install python-dev
         sudo apt-get install -q python-qt4
-    else  
+    else
         sudo apt-get install python3-dev
+        sudo apt-get install -q python3-pyqt4
     fi
 
     # http://stackoverflow.com/a/9716100
@@ -105,16 +106,16 @@ install_qt4()
 
 install_qt5()
 {
+    #sudo apt-get install -qq python-sip python-qt5 python-sphinx --fix-missing;
+    #sudo apt-get install -qq python3-sip python3-pyqt5 --fix-missing;    
     echo "Not supported yet"
 }
 
 
 install_apt_pip()
-{  
+{
     # Test for different Qt bindings
     if [ "$USE_QT_API" = "PyQt5" ]; then
-        #sudo apt-get install -qq python-sip python-qt5 python-sphinx --fix-missing;
-        #sudo apt-get install -qq python3-sip python3-pyqt5 --fix-missing;
         install_qt5
     elif [ "$USE_QT_API" = "PyQt4" ]; then
         install_qt4;

--- a/continuous_integration/travis_install.sh
+++ b/continuous_integration/travis_install.sh
@@ -124,7 +124,7 @@ install_apt_pip()
 
     pip install -U pip;
     pip install -U setuptools;
-    pip install --no-index --find-links=$WHEELHOUSE_URI $EXTRA_PACKAGES;
+    pip install --no-index --trusted-host $WHEELHOUSE_URI --find-links=$WHEELHOUSE_URI $EXTRA_PACKAGES;
 }
 
 

--- a/continuous_integration/travis_install.sh
+++ b/continuous_integration/travis_install.sh
@@ -124,7 +124,7 @@ install_apt_pip()
 
     pip install -U pip;
     pip install -U setuptools;
-    pip install --no-index --trusted-host $WHEELHOUSE_URI --find-links=http://$WHEELHOUSE_URI $EXTRA_PACKAGES/;
+    pip install --no-index --trusted-host $WHEELHOUSE_URI --find-links=http://$WHEELHOUSE_URI/ $EXTRA_PACKAGES;
 }
 
 

--- a/continuous_integration/travis_install.sh
+++ b/continuous_integration/travis_install.sh
@@ -78,25 +78,14 @@ install_pyside()
 }
 
 
-install_qt5()
-{
-    echo "Not supported yet"
-}
-
-
 install_pip()
 {
-    # Test for different Qt bindings
-    #if [ "$USE_QT_API" = "PyQt5" ]; then
-    #    install_qt5
-    #elif [ "$USE_QT_API" = "PySide" ]; then
-    #    install_pyside;
-    #fi
-
-    if [ "$USE_QT_API" = "PyQt4" ]; then
-        conda install pyqt;
-    else
+    if [ "$USE_QT_API" = "PyQt5" ]; then
         conda install pyqt5;
+    elif [ "$USE_QT_API" = "PyQt4" ]; then
+        conda install pyqt;
+    elif [ "$USE_QT_API" = "PySide" ]; then
+        install_pyside;
     fi
 
     pip install --no-index --trusted-host $WHEELHOUSE_URI --find-links=http://$WHEELHOUSE_URI/ $EXTRA_PACKAGES;

--- a/continuous_integration/travis_install.sh
+++ b/continuous_integration/travis_install.sh
@@ -3,7 +3,7 @@
 set -ex
 
 PY_VERSION=$TRAVIS_PYTHON_VERSION
-WHEELHOUSE_URI=http://travis-wheels.scikit-image.org/
+WHEELHOUSE_URI=travis-wheels.scikit-image.org
 
 #==============================================================================
 # Utility functions
@@ -124,7 +124,7 @@ install_apt_pip()
 
     pip install -U pip;
     pip install -U setuptools;
-    pip install --no-index --trusted-host $WHEELHOUSE_URI --find-links=$WHEELHOUSE_URI $EXTRA_PACKAGES;
+    pip install --no-index --trusted-host $WHEELHOUSE_URI --find-links=http://$WHEELHOUSE_URI $EXTRA_PACKAGES/;
 }
 
 

--- a/continuous_integration/travis_install.sh
+++ b/continuous_integration/travis_install.sh
@@ -53,9 +53,8 @@ install_conda()
     if [ "$USE_CONDA" = true ]; then
         conda install jinja2;
         conda install conda-build;
+        conda create -q -n test-environment python=$PY_VERSION;
     fi
-
-    conda create -q -n test-environment python=$PY_VERSION;
 
     # Test environments for different Qt bindings
     if [ "$USE_QT_API" = "PyQt5" ]; then

--- a/continuous_integration/travis_install.sh
+++ b/continuous_integration/travis_install.sh
@@ -98,6 +98,7 @@ install_pip()
         conda install pyqt;
     else
         conda install pyqt5;
+    fi
 
     pip install --no-index --trusted-host $WHEELHOUSE_URI --find-links=http://$WHEELHOUSE_URI/ $EXTRA_PACKAGES;
 }

--- a/continuous_integration/travis_install.sh
+++ b/continuous_integration/travis_install.sh
@@ -50,8 +50,10 @@ install_conda()
     conda update -q conda;
 
     # Installing conda-build and jinja2 to do build tests
-    conda install jinja2;
-    conda install conda-build;
+    if [ "$USE_CONDA" = true ]; then
+        conda install jinja2;
+        conda install conda-build;
+    fi
 
     conda create -q -n test-environment python=$PY_VERSION;
 
@@ -66,7 +68,6 @@ install_pyside()
 {
     # Currently support Python 2.7 and 3.4
     # http://stackoverflow.com/questions/24489588/how-can-i-install-pyside-on-travis
-    # sudo apt-get install libqt4-dev;
 
     pip install -U setuptools;
     pip install -U pip;
@@ -87,11 +88,16 @@ install_qt5()
 install_pip()
 {
     # Test for different Qt bindings
-    if [ "$USE_QT_API" = "PyQt5" ]; then
-        install_qt5
-    elif [ "$USE_QT_API" = "PySide" ]; then
-        install_pyside;
-    fi
+    #if [ "$USE_QT_API" = "PyQt5" ]; then
+    #    install_qt5
+    #elif [ "$USE_QT_API" = "PySide" ]; then
+    #    install_pyside;
+    #fi
+
+    if [ "$USE_QT_API" = "PyQt4" ]; then
+        conda install pyqt;
+    else
+        conda install pyqt5;
 
     pip install --no-index --trusted-host $WHEELHOUSE_URI --find-links=http://$WHEELHOUSE_URI/ $EXTRA_PACKAGES;
 }
@@ -102,10 +108,10 @@ install_pip()
 #==============================================================================
 download_code;
 
-if [ "$USE_CONDA" = true ] ; then
-    export SOURCE=`source activate test-environment`
-    install_conda;
-else
+# Use conda even to test pip!
+install_conda;
+
+if [ "$USE_CONDA" = false ]; then
     export EXTRA_PACKAGES="matplotlib pandas sympy pyzmq pillow"
     install_pip;
 fi

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ import shutil
 
 from distutils.core import setup
 from distutils.command.build import build
+from distutils.command.install import install
 from distutils.command.install_data import install_data
 
 
@@ -45,23 +46,6 @@ if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,3)):
 NAME = 'spyder'
 LIBNAME = 'spyderlib'
 from spyderlib import __version__, __project_url__
-
-
-#==============================================================================
-# This is necessary to prevent an error while installing Spyder with pip
-# See http://stackoverflow.com/a/18961843/438386
-#==============================================================================
-with_setuptools = False
-if 'USE_SETUPTOOLS' in os.environ or 'pip' in __file__ or \
-  'VIRTUAL_ENV' in os.environ:
-    try:
-        from setuptools.command.install import install
-        with_setuptools = True
-    except:
-        with_setuptools = False
-
-if not with_setuptools:
-    from distutils.command.install import install  # analysis:ignore
 
 
 #==============================================================================

--- a/setup.py
+++ b/setup.py
@@ -308,7 +308,7 @@ if any(arg == 'bdist_wheel' for arg in sys.argv):
     import setuptools     # analysis:ignore
 
 install_requires = [
-    'rope>=0.9.4',
+    'rope_py3k' if PY3 else 'rope>=0.9.4',
     'jedi==0.8.1',
     'pyflakes',
     'pygments',

--- a/setup.py
+++ b/setup.py
@@ -267,9 +267,9 @@ if WINDOWS_INSTALLER:
 
 
 #==============================================================================
-# Main setup
+# Setup arguments
 #==============================================================================
-setup(name=NAME,
+setup_args = dict(name=NAME,
       version=__version__,
       description='Scientific PYthon Development EnviRonment',
       long_description=WININST_MSG + \
@@ -289,7 +289,6 @@ editor, Python console, etc.""",
       package_data={LIBNAME: get_package_data(LIBNAME, EXTLIST),
                     'spyderplugins':
                     get_package_data('spyderplugins', EXTLIST)},
-      requires=["rope (>=0.9.2)", "sphinx (>=0.6.0)", "PyQt4 (>=4.4)"],
       scripts=[osp.join('scripts', fname) for fname in SCRIPTS],
       data_files=get_data_files(),
       options={"bdist_wininst":
@@ -308,7 +307,45 @@ editor, Python console, etc.""",
                    'Operating System :: Unix',
                    'Programming Language :: Python :: 2.7',
                    'Programming Language :: Python :: 3',
+                   'Programming Language :: Python :: 3.3'
                    'Development Status :: 5 - Production/Stable',
                    'Topic :: Scientific/Engineering',
                    'Topic :: Software Development :: Widget Sets'],
       cmdclass=CMDCLASS)
+
+
+#==============================================================================
+# Setuptools deps
+#==============================================================================
+if any(arg == 'bdist_wheel' for arg in sys.argv):
+    import setuptools     # analysis:ignore
+
+install_requires = [
+    'rope>=0.9.4',
+    'jedi==0.8.1',
+    'pyflakes',
+    'pygments',
+    'qtconsole',
+    'nbconvert',
+    'sphinx',
+    'pep8',
+    'pylint',
+    'psutil'
+]
+
+if 'setuptools' in sys.modules:
+    setup_args['install_requires'] = install_requires
+
+    setup_args['entry_points'] = {
+        'gui_scripts': [
+            'spyder = spyderlib.start_app:main'
+        ]
+    }
+
+    setup_args.pop('scripts', None)
+
+
+#==============================================================================
+# Main setup
+#==============================================================================
+setup(**setup_args)

--- a/setup.py
+++ b/setup.py
@@ -320,13 +320,8 @@ install_requires = [
     'psutil'
 ]
 
-setup_requires = [
-    'sphinx'
-]
-
 if 'setuptools' in sys.modules:
     setup_args['install_requires'] = install_requires
-    setup_args['setup_requires'] = setup_requires
 
     setup_args['entry_points'] = {
         'gui_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2009-2010 Pierre Raybaut
+# Copyright © 2009- The Spyder Development Team
 # Licensed under the terms of the MIT License
 # (see spyderlib/__init__.py for details)
 
@@ -24,8 +24,21 @@ from distutils.core import setup
 from distutils.command.build import build
 from distutils.command.install_data import install_data
 
+
 # Check for Python 3
 PY3 = sys.version_info[0] == 3
+
+
+#------------------------------------------------------------------------------
+# Minimal Python version sanity check
+# Taken from the notebook setup.py -- Modified BSD License
+#------------------------------------------------------------------------------
+v = sys.version_info
+if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,3)):
+    error = "ERROR: Spyder requires Python version 2.7 or 3.3 or above."
+    print(error, file=sys.stderr)
+    sys.exit(1)
+
 
 # This is necessary to prevent an error while installing Spyder with pip
 # See http://stackoverflow.com/a/18961843/438386

--- a/setup.py
+++ b/setup.py
@@ -320,8 +320,13 @@ install_requires = [
     'psutil'
 ]
 
+setup_requires = [
+    'sphinx'
+]
+
 if 'setuptools' in sys.modules:
     setup_args['install_requires'] = install_requires
+    setup_args['setup_requires'] = setup_requires
 
     setup_args['entry_points'] = {
         'gui_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,11 @@ from distutils.command.install import install
 from distutils.command.install_data import install_data
 
 
+#==============================================================================
 # Check for Python 3
+#==============================================================================
 PY3 = sys.version_info[0] == 3
+
 
 #==============================================================================
 # Minimal Python version sanity check

--- a/spyderlib/dependencies.py
+++ b/spyderlib/dependencies.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2013 Pierre Raybaut
+# Copyright © 2009- The Spyder Development Team
 # Licensed under the terms of the MIT License
 # (see spyderlib/__init__.py for details)
 
-"""Module checking Spyder optional runtime dependencies"""
+"""Module checking Spyder runtime dependencies"""
 
 
 import os
@@ -14,7 +14,7 @@ from spyderlib.utils import programs
 
 
 class Dependency(object):
-    """Spyder's optional dependency
+    """Spyder's dependency
 
     version may starts with =, >=, > or < to specify the exact requirement ;
     multiple conditions may be separated by ';' (e.g. '>=0.13;<1.0')"""
@@ -60,7 +60,7 @@ class Dependency(object):
 DEPENDENCIES = []
 
 def add(modname, features, required_version, installed_version=None):
-    """Add Spyder optional dependency"""
+    """Add Spyder dependency"""
     global DEPENDENCIES
     for dependency in DEPENDENCIES:
         if dependency.modname == modname:
@@ -78,7 +78,7 @@ def check(modname):
         raise RuntimeError("Unkwown dependency %s" % modname)
 
 def status():
-    """Return a complete status of Optional Dependencies"""
+    """Return a complete status of Dependencies"""
     maxwidth = 0
     col1 = []
     col2 = []

--- a/spyderlib/qt/QtCore.py
+++ b/spyderlib/qt/QtCore.py
@@ -27,3 +27,5 @@ else:
     import PySide.QtCore
     __version__ = PySide.QtCore.__version__                   # analysis:ignore
     from PySide.QtCore import *                               # analysis:ignore
+
+    from PySide.QtGui import QItemSelection, QItemSelectionRange  # analysis:ignore

--- a/spyderlib/qt/QtGui.py
+++ b/spyderlib/qt/QtGui.py
@@ -21,3 +21,4 @@ elif os.environ['QT_API'] == 'pyqt':
 else:
     from PySide.QtGui import *                                # analysis:ignore
     QStyleOptionViewItem = QStyleOptionViewItemV4             # analysis:ignore
+    del QItemSelection, QItemSelectionRange                   # analysis:ignore

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2009-2013 Pierre Raybaut
-# Copyright © 2013-2015 The Spyder Development Team
+# Copyright © 2009- The Spyder Development Team
 # Licensed under the terms of the MIT License
 # (see spyderlib/__init__.py for details)
 
@@ -956,8 +955,8 @@ class MainWindow(QMainWindow):
 
             self.set_splash(_("Setting up main window..."))
 
-            # Help menu            
-            dep_action = create_action(self, _("Optional dependencies..."),
+            # Help menu
+            dep_action = create_action(self, _("Dependencies..."),
                                        triggered=self.show_dependencies,
                                        icon=ima.icon('advanced'))
             report_action = create_action(self,
@@ -2349,7 +2348,7 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def show_dependencies(self):
-        """Show Spyder's Optional Dependencies dialog box"""
+        """Show Spyder's Dependencies dialog box"""
         from spyderlib.widgets.dependencies import DependenciesDialog
         dlg = DependenciesDialog(None)
         dlg.set_data(dependencies.DEPENDENCIES)
@@ -2388,7 +2387,7 @@ class MainWindow(QMainWindow):
 * Python Version: %s
 * Qt Versions: %s, %s %s on %s
 
-## Optional dependencies
+## Dependencies
 ```
 %s
 ```

--- a/spyderlib/widgets/dependencies.py
+++ b/spyderlib/widgets/dependencies.py
@@ -127,24 +127,17 @@ class DependenciesDialog(QDialog):
     def __init__(self, parent):
         QDialog.__init__(self, parent)
         self.setWindowTitle("Spyder %s: %s" % (__version__,
-                                               _("Optional Dependencies")))
+                                               _("Dependencies")))
         self.setWindowIcon(ima.icon('tooloptions'))
         self.setModal(True)
 
         self.view = DependenciesTableView(self, [])
 
-        important_mods = ['rope', 'pyflakes', 'IPython', 'matplotlib']
         self.label = QLabel(_("Spyder depends on several Python modules to "
-                              "provide additional functionality for its "
-                              "plugins. The table below shows the required "
+                              "provide the right functionality for all its "
+                              "panes. The table below shows the required "
                               "and installed versions (if any) of all of "
-                              "them.<br><br>"
-                              "Although Spyder can work without any of these "
-                              "modules, it's strongly recommended that at "
-                              "least you try to install <b>%s</b> and "
-                              "<b>%s</b> to have a much better experience.")
-                              % (', '.join(important_mods[:-1]),
-                                 important_mods[-1]))
+                              "them."))
         self.label.setWordWrap(True)
         self.label.setAlignment(Qt.AlignJustify)
         self.label.setContentsMargins(5, 8, 12, 10)

--- a/spyderlib/widgets/dependencies.py
+++ b/spyderlib/widgets/dependencies.py
@@ -133,11 +133,16 @@ class DependenciesDialog(QDialog):
 
         self.view = DependenciesTableView(self, [])
 
+        opt_mods = ['Matplotlib', 'Pandas', 'SymPy']
         self.label = QLabel(_("Spyder depends on several Python modules to "
                               "provide the right functionality for all its "
                               "panes. The table below shows the required "
                               "and installed versions (if any) of all of "
-                              "them."))
+                              "them.<br><br>"
+                              "<b>Note</b>: You can safely use Spyder "
+                              "without the following modules installed: "
+                              "<b>%s</b> and <b>%s</b>")
+                              % (', '.join(opt_mods[:-1]), opt_mods[-1]))
         self.label.setWordWrap(True)
         self.label.setAlignment(Qt.AlignJustify)
         self.label.setContentsMargins(5, 8, 12, 10)

--- a/spyderlib/widgets/dependencies.py
+++ b/spyderlib/widgets/dependencies.py
@@ -133,7 +133,7 @@ class DependenciesDialog(QDialog):
 
         self.view = DependenciesTableView(self, [])
 
-        opt_mods = ['Matplotlib', 'Pandas', 'SymPy']
+        opt_mods = ['NumPy', 'Matplotlib', 'Pandas', 'SymPy']
         self.label = QLabel(_("Spyder depends on several Python modules to "
                               "provide the right functionality for all its "
                               "panes. The table below shows the required "

--- a/spyderlib/widgets/externalshell/systemshell.py
+++ b/spyderlib/widgets/externalshell/systemshell.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2009-2010 Pierre Raybaut
+# Copyright © 2009- The Spyder Development Team
 # Licensed under the terms of the MIT License
 # (see spyderlib/__init__.py for details)
 
@@ -50,13 +50,17 @@ class ExternalSystemShell(ExternalShellBase):
 
     def get_icon(self):
         return ima.icon('cmdprompt')
-    
+
+    def finish_process(self):
+        while not self.process.waitForFinished(100):
+            self.process.kill();
+
     def create_process(self):
         self.shell.clear()
-            
+
         self.process = QProcess(self)
         self.process.setProcessChannelMode(QProcess.MergedChannels)
-        
+
         # PYTHONPATH (in case we use Python in this terminal, e.g. py2exe)
         env = [to_text_string(_path)
                for _path in self.process.systemEnvironment()]
@@ -152,12 +156,17 @@ class ExternalSystemShell(ExternalShellBase):
 #            self.send_ctrl_to_process('c')
 
 
+#==============================================================================
+# Tests
+#==============================================================================
 def test():
     import os.path as osp
     from spyderlib.utils.qthelpers import qapplication
-    app = qapplication()
+    app = qapplication(test_time=5)
     shell = ExternalSystemShell(wdir=osp.dirname(__file__),
                                 light_background=False)
+
+    app.aboutToQuit.connect(shell.finish_process)
 
     from spyderlib.qt.QtGui import QFont
     from spyderlib.config.main import CONF

--- a/spyderlib/widgets/varexp/utils.py
+++ b/spyderlib/widgets/varexp/utils.py
@@ -22,6 +22,19 @@ from spyderlib.config.base import _
 
 
 #==============================================================================
+# Dependencies
+#==============================================================================
+PANDAS_REQVER = '>=0.13.1'
+dependencies.add('pandas',  _("View and edit DataFrames and Series in the "
+                              "Variable Explorer"),
+                 required_version=PANDAS_REQVER)
+
+NUMPY_REQVER = '>=1.7'
+dependencies.add("numpy", _("View and edit two and three dimensional arrays "
+                            "in the Variable Explorer"),
+                 required_version=NUMPY_REQVER)
+
+#==============================================================================
 # FakeObject
 #==============================================================================
 class FakeObject(object):
@@ -64,10 +77,6 @@ def get_numpy_dtype(obj):
 #==============================================================================
 # Pandas support
 #==============================================================================
-PANDAS_REQVER = '>=0.13.1'
-dependencies.add('pandas',  _("View and edit DataFrames and Series in the "
-                              "Variable Explorer"),
-                 required_version=PANDAS_REQVER)
 if programs.is_module_installed('pandas', PANDAS_REQVER):
     from pandas import DataFrame, Series
 else:


### PR DESCRIPTION
Fixes #2574

----

Times have changed :-) Now pip is a decent package manager, so it's time for us to demand all modules we really depend on (like `rope`, `pyflakes` and `sphinx`) as real dependencies.

This PR also wants to fix:

- [x] Tests for pip (now they only work for conda)
- [x] The *Optional dependencies* dialog, which will become just the *Dependencies* one. 