### PR TITLE
Fix runfile argument parsing error by using shlex

### DIFF
--- a/spyderlib/widgets/externalshell/sitecustomize.py
+++ b/spyderlib/widgets/externalshell/sitecustomize.py
@@ -16,6 +16,7 @@ import pdb
 import bdb
 import time
 import traceback
+import shlex
 
 
 #==============================================================================
@@ -775,7 +776,7 @@ def runfile(filename, args=None, wdir=None, namespace=None, post_mortem=False):
     namespace['__file__'] = filename
     sys.argv = [filename]
     if args is not None:
-        for arg in args.split():
+        for arg in shlex.split(args):
             sys.argv.append(arg)
     if wdir is not None:
         try:


### PR DESCRIPTION
Changed `sitecustomize.runfile()` to parse arguments using `shlex` instead of `string.split()`. This allows users to run scripts with arguments containing escaped spaces in ipython.

Fixes #2010 