### PR TITLE
Move the spyder script to the right place if it isn't present in the site Scripts directory

### DIFF
--- a/scripts/spyder_win_post_install.py
+++ b/scripts/spyder_win_post_install.py
@@ -95,7 +95,7 @@ except NameError:
                   file=sys.stderr)
             sys.exit(1)
         from win32com.shell import shell, shellcon
-        
+
         path_names = ['CSIDL_COMMON_STARTMENU', 'CSIDL_STARTMENU',
                       'CSIDL_COMMON_APPDATA', 'CSIDL_LOCAL_APPDATA',
                       'CSIDL_APPDATA', 'CSIDL_COMMON_DESKTOPDIRECTORY',
@@ -131,6 +131,8 @@ def install():
     python = osp.abspath(osp.join(sys.prefix, 'python.exe'))
     pythonw = osp.abspath(osp.join(sys.prefix, 'pythonw.exe'))
     script = osp.abspath(osp.join(sys.prefix, 'scripts', 'spyder'))
+    if not osp.exists(script): # if not installed to the site scripts dir
+        script = osp.abspath(osp.join(osp.dirname(osp.abspath(__file__)), 'spyder'))
     workdir = "%HOMEDRIVE%%HOMEPATH%"
     import distutils.sysconfig
     lib_dir = distutils.sysconfig.get_python_lib(plat_specific=1)


### PR DESCRIPTION
The post install script assumes the ```spyder``` script is in the site scripts directory, but it isn't always installed there, i.e if spyder was installed using ```pip install --user spyder``` 

If the user then runs spyder_win_post_install.py -install manually, the shortcuts will be created pointing to a non-existent script.