### PR TITLE
Restore the insertion of the "(" character when parameter close_parentheses_enabled is False

### DIFF
--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -2603,6 +2603,8 @@ class CodeEditor(TextEditBaseWidget):
             self.hide_completion_widget()
             if self.close_parentheses_enabled:
                 self.handle_close_parentheses(text)
+            else:
+                self.insert_text(text)
         elif text in ('[', '{') and not self.has_selected_text() \
           and self.close_parentheses_enabled:
             s_trailing_text = self.get_text('cursor', 'eol').strip()


### PR DESCRIPTION
Fixes #2795

----

Restore the insertion of the "(" character when parameter close_parentheses_enabled is False.
 
I suspect some patch destroyed the functionnality formerly in handle_close_parentheses(text)

This is the simple fix, maybe a more complete fix would remove unused path in def  handle_close_parentheses()