### PR TITLE
Remove imports from widgets/__init__ because they are making Spyder crash

### DIFF
--- a/spyderlib/widgets/__init__.py
+++ b/spyderlib/widgets/__init__.py
@@ -13,12 +13,3 @@ Widgets defined in this module may be used in any other Qt-based application
 They are also used in Spyder through the Plugin interface
 (see spyderlib.plugins)
 """
-
-from spyderlib.widgets.variableexplorer import arrayeditor
-from spyderlib.widgets.variableexplorer import collectionseditor
-from spyderlib.widgets.variableexplorer import dataframeeditor
-from spyderlib.widgets.variableexplorer import objecteditor
-from spyderlib.widgets.variableexplorer import texteditor
-
-# For compatibility with Spyder 2
-dicteditor = collectionseditor


### PR DESCRIPTION
- Crashes happened when pandas or numpy were not installed because dataframeeditor and arrayeditor import them directly.
- It seems we can't improve further this situation, but at least API changes are documented.

----

I made this PR to let @goanpeca and @PierreRaybaut know about this change. Leaving those imports in `widgets/__init__` to maintain compatibility with Spyder 2 would make Spyder 3 to hard depend on Pandas and NumPy, but we can't afford that for this simple change :-)