### PR TITLE
Use PyQt5 as default API

### DIFF
--- a/spyderlib/qt/__init__.py
+++ b/spyderlib/qt/__init__.py
@@ -15,6 +15,18 @@ assert os.environ['QT_API'] in ('pyqt5', 'pyqt', 'pyside')
 API = os.environ['QT_API']
 API_NAME = {'pyqt5': 'PyQt5', 'pyqt': 'PyQt4', 'pyside': 'PySide'}[API]
 
+is_old_pyqt = is_pyqt46 = False
+PYQT5 = True
+
+if API == 'pyqt5':
+    try:
+        from PyQt5.QtCore import PYQT_VERSION_STR as __version__
+        from PyQt5 import uic  # analysis:ignore
+    except ImportError:
+        PYQT5 = False
+        API = os.environ['QT_API'] = 'pyqt'
+        API_NAME = 'PyQt4'
+
 if API == 'pyqt':
     # Spyder 2.3 is compatible with both #1 and #2 PyQt API,
     # but to avoid issues with IPython and other Qt plugins
@@ -36,16 +48,8 @@ if API == 'pyqt':
 
         from PyQt4.QtCore import PYQT_VERSION_STR as __version__ # analysis:ignore
     except ImportError:
-        # Trying PyQt5 before switching to PySide (at this point, PyQt4 may 
-        # not be installed but PyQt5 or Pyside could still be if the QT_API 
-        # environment variable hasn't been set-up)
-        try:
-            import PyQt5  # analysis:ignore
-            API = os.environ['QT_API'] = 'pyqt5'
-            API_NAME = 'PyQt5'
-        except ImportError:
-            API = os.environ['QT_API'] = 'pyside'
-            API_NAME = 'PySide'
+        API = os.environ['QT_API'] = 'pyside'
+        API_NAME = 'PySide'
     else:
         is_old_pyqt = __version__.startswith(('4.4', '4.5', '4.6', '4.7'))
         is_pyqt46 = __version__.startswith('4.6')
@@ -56,20 +60,8 @@ if API == 'pyqt':
             pass
         from PyQt4 import uic  # analysis:ignore
 
-PYQT5 = False
-if API == 'pyqt5':
-    try:
-        from PyQt5.QtCore import PYQT_VERSION_STR as __version__
-        from PyQt5 import uic  # analysis:ignore
-        PYQT5 = True
-        is_old_pyqt = is_pyqt46 = False
-    except ImportError:
-        pass
-
 if API == 'pyside':
     try:
         from PySide import __version__  # analysis:ignore
     except ImportError:
         raise ImportError("Spyder requires PySide or PyQt to be installed")
-    else:
-        is_old_pyqt = is_pyqt46 = False

--- a/spyderlib/qt/__init__.py
+++ b/spyderlib/qt/__init__.py
@@ -9,7 +9,7 @@
 
 import os
 
-os.environ.setdefault('QT_API', 'pyqt')
+os.environ.setdefault('QT_API', 'pyqt5')
 assert os.environ['QT_API'] in ('pyqt5', 'pyqt', 'pyside')
 
 API = os.environ['QT_API']


### PR DESCRIPTION
i think i did this once.

you stated then that it wasn’t ready, but that’s been some time ago and there are now PyQt5 travis tests.

also 3.0 should really ship like that.