### PR TITLE
PR: Crashing on shortcut assignment with PyQt5

### DIFF
--- a/spyderlib/plugins/shortcuts.py
+++ b/spyderlib/plugins/shortcuts.py
@@ -789,8 +789,9 @@ class ShortcutsConfigPage(GeneralConfigPage):
         self.setTabOrder(self.finder, self.reset_btn)
 
         # Signals and slots
+        #    Qt5 'dataChanged' has 3 parameters
         self.table.proxy_model.dataChanged.connect(
-                     lambda i1, i2, opt='': self.has_been_modified(opt))
+                     lambda i1, i2, roles=[], opt='': self.has_been_modified(opt))
         self.reset_btn.clicked.connect(self.reset_to_default)
 
     def check_settings(self):

--- a/spyderlib/plugins/shortcuts.py
+++ b/spyderlib/plugins/shortcuts.py
@@ -789,9 +789,13 @@ class ShortcutsConfigPage(GeneralConfigPage):
         self.setTabOrder(self.finder, self.reset_btn)
 
         # Signals and slots
-        #    Qt5 'dataChanged' has 3 parameters
-        self.table.proxy_model.dataChanged.connect(
-                     lambda i1, i2, roles=[], opt='': self.has_been_modified(opt))
+        if PYQT5:
+            # Qt5 'dataChanged' has 3 parameters
+            self.table.proxy_model.dataChanged.connect(
+                lambda i1, i2, roles, opt='': self.has_been_modified(opt))
+        else:
+            self.table.proxy_model.dataChanged.connect(
+                lambda i1, i2, opt='': self.has_been_modified(opt))
         self.reset_btn.clicked.connect(self.reset_to_default)
 
     def check_settings(self):


### PR DESCRIPTION
fix crash on shortcut assignment (Qt5 'dataChanged' signal has 3 parameters)