### PR TITLE
PR: Remove font groups from plugins and move to general preferences

### DIFF
--- a/spyderlib/config/gui.py
+++ b/spyderlib/config/gui.py
@@ -49,35 +49,35 @@ def get_family(families):
 
 
 FONT_CACHE = {}
-def get_font(section, option=None):
+
+
+def get_font(section='main', option='font', font_size_delta=0):
     """Get console font properties depending on OS and user options"""
     font = FONT_CACHE.get((section, option))
+
     if font is None:
-        if option is None:
-            option = 'font'
-        else:
-            option += '/font'
         families = CONF.get(section, option+"/family", None)
+
         if families is None:
             return QFont()
+
         family = get_family(families)
         weight = QFont.Normal
         italic = CONF.get(section, option+'/italic', False)
+
         if CONF.get(section, option+'/bold', False):
             weight = QFont.Bold
-        size = CONF.get(section, option+'/size', 9)
+
+        size = CONF.get(section, option+'/size', 9) + font_size_delta
         font = QFont(family, size, weight)
         font.setItalic(italic)
         FONT_CACHE[(section, option)] = font
+
     return font
 
 
-def set_font(font, section, option=None):
+def set_font(font, section='main', option='font'):
     """Set font"""
-    if option is None:
-        option = 'font'
-    else:
-        option += '/font'
     CONF.set(section, option+'/family', to_text_string(font.family()))
     CONF.set(section, option+'/size', float(font.pointSize()))
     CONF.set(section, option+'/italic', int(font.italic()))

--- a/spyderlib/config/gui.py
+++ b/spyderlib/config/gui.py
@@ -50,7 +50,6 @@ def get_family(families):
 
 FONT_CACHE = {}
 
-
 def get_font(section='main', option='font', font_size_delta=0):
     """Get console font properties depending on OS and user options"""
     font = FONT_CACHE.get((section, option))
@@ -73,6 +72,8 @@ def get_font(section='main', option='font', font_size_delta=0):
         font.setItalic(italic)
         FONT_CACHE[(section, option)] = font
 
+    size = CONF.get(section, option+'/size', 9) + font_size_delta
+    font.setPointSize(size)
     return font
 
 

--- a/spyderlib/config/main.py
+++ b/spyderlib/config/main.py
@@ -174,7 +174,8 @@ else:
     BIG = 12
     MEDIUM = SMALL = 9
 
-DEFAULT_SMALL_DELTA = MEDIUM - SMALL
+DEFAULT_SMALL_DELTA = SMALL - MEDIUM
+DEFAULT_LARGE_DELTA = SMALL - BIG
 
 # =============================================================================
 #  Defaults

--- a/spyderlib/config/main.py
+++ b/spyderlib/config/main.py
@@ -174,10 +174,11 @@ else:
     BIG = 12
     MEDIUM = SMALL = 9
 
+DEFAULT_SMALL_DELTA = MEDIUM - SMALL
 
-#==============================================================================
-# Defaults
-#==============================================================================
+# =============================================================================
+#  Defaults
+# =============================================================================
 DEFAULTS = [
             ('main',
              {
@@ -205,6 +206,15 @@ DEFAULTS = [
               'show_internal_console_if_traceback': True,
               'check_updates_on_startup': True,
               'toolbars_visible': True,
+              # Global Spyder fonts
+              'font/family': MONOSPACE,
+              'font/size': MEDIUM,
+              'font/italic': False,
+              'font/bold': False,
+              'rich_font/family': SANS_SERIF,
+              'rich_font/size': BIG,
+              'rich_font/italic': False,
+              'rich_font/bold': False,
               }),
             ('quick_layouts',
              {
@@ -228,10 +238,6 @@ DEFAULTS = [
               'max_line_count': 300,
               'working_dir_history': 30,
               'working_dir_adjusttocontents': False,
-              'font/family': MONOSPACE,
-              'font/size': MEDIUM,
-              'font/italic': False,
-              'font/bold': False,
               'wrap': True,
               'calltips': True,
               'codecompletion/auto': False,
@@ -244,10 +250,6 @@ DEFAULTS = [
             ('console',
              {
               'max_line_count': 500,
-              'font/family': MONOSPACE,
-              'font/size': MEDIUM,
-              'font/italic': False,
-              'font/bold': False,
               'wrap': True,
               'single_tab': True,
               'calltips': True,
@@ -273,10 +275,6 @@ DEFAULTS = [
               }),
             ('ipython_console',
              {
-              'font/family': MONOSPACE,
-              'font/size': MEDIUM,
-              'font/italic': False,
-              'font/bold': False,
               'show_banner': True,
               'completion_type': 0,
               'use_pager': False,
@@ -321,10 +319,6 @@ DEFAULTS = [
               'printer_header/font/size': MEDIUM,
               'printer_header/font/italic': False,
               'printer_header/font/bold': False,
-              'font/family': MONOSPACE,
-              'font/size': MEDIUM,
-              'font/italic': False,
-              'font/bold': False,
               'wrap': False,
               'wrapflag': True,
               'code_analysis/pyflakes': True,
@@ -368,10 +362,6 @@ DEFAULTS = [
              {
               'enable': True,
               'max_entries': 100,
-              'font/family': MONOSPACE,
-              'font/size': MEDIUM,
-              'font/italic': False,
-              'font/bold': False,
               'wrap': True,
               'go_to_eof': True,
               }),
@@ -379,14 +369,6 @@ DEFAULTS = [
              {
               'enable': True,
               'max_history_entries': 20,
-              'font/family': MONOSPACE,
-              'font/size': SMALL,
-              'font/italic': False,
-              'font/bold': False,
-              'rich_text/font/family': SANS_SERIF,
-              'rich_text/font/size': BIG,
-              'rich_text/font/italic': False,
-              'rich_text/font/bold': False,
               'wrap': True,
               'connect/editor': False,
               'connect/python_console': False,
@@ -413,27 +395,6 @@ DEFAULTS = [
               'name_filters': NAME_FILTERS,
               'show_all': False,
               'show_hscrollbar': True
-              }),
-            ('arrayeditor',
-             {
-              'font/family': MONOSPACE,
-              'font/size': SMALL,
-              'font/italic': False,
-              'font/bold': False,
-              }),
-            ('texteditor',
-             {
-              'font/family': MONOSPACE,
-              'font/size': MEDIUM,
-              'font/italic': False,
-              'font/bold': False,
-              }),
-            ('dicteditor',
-             {
-              'font/family': MONOSPACE,
-              'font/size': SMALL,
-              'font/italic': False,
-              'font/bold': False,
               }),
             ('explorer',
              {
@@ -745,7 +706,7 @@ DEFAULTS = [
 # 2. If you want to *remove* options that are no longer needed in our codebase,
 #    you need to do a MAJOR update in version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '23.0.0'
+CONF_VERSION = '24.0.0'
 
 # XXX: Previously we had load=(not DEV) here but DEV was set to *False*.
 # Check if it *really* needs to be updated or not

--- a/spyderlib/plugins/__init__.py
+++ b/spyderlib/plugins/__init__.py
@@ -255,6 +255,7 @@ class SpyderPluginMixin(object):
     CONF_SECTION = None
     CONFIGWIDGET_CLASS = None
     FONT_SIZE_DELTA = 0
+    RICH_FONT_SIZE_DELTA = 0
     IMG_PATH = 'images'
     ALLOWED_AREAS = Qt.AllDockWidgetAreas
     LOCATION = Qt.LeftDockWidgetArea
@@ -461,9 +462,10 @@ class SpyderPluginMixin(object):
         All plugins in Spyder use a global font. This is a convenience method
         in case some plugins will have a delta size based on the default size.
         """
+
         if rich_text:
             option = 'rich_font'
-            font_size_delta = 0
+            font_size_delta = self.RICH_FONT_SIZE_DELTA
         else:
             option = 'font'
             font_size_delta = self.FONT_SIZE_DELTA
@@ -483,7 +485,7 @@ class SpyderPluginMixin(object):
 
     def update_font(self):
         """ """
-        print("Launched!")
+        pass
 
     def __show_message(self, message, timeout=0):
         """Show message in main window's status bar"""

--- a/spyderlib/plugins/__init__.py
+++ b/spyderlib/plugins/__init__.py
@@ -47,7 +47,6 @@ class PluginConfigPage(SpyderConfigPage):
         self.get_option = plugin.get_option
         self.set_option = plugin.set_option
         self.get_font = plugin.get_plugin_font
-        self.set_font = plugin.set_plugin_font
         self.apply_settings = plugin.apply_plugin_settings
         SpyderConfigPage.__init__(self, parent)
     
@@ -255,6 +254,7 @@ class SpyderPluginMixin(object):
     """
     CONF_SECTION = None
     CONFIGWIDGET_CLASS = None
+    FONT_SIZE_DELTA = 0
     IMG_PATH = 'images'
     ALLOWED_AREAS = Qt.AllDockWidgetAreas
     LOCATION = Qt.LeftDockWidgetArea
@@ -453,14 +453,37 @@ class SpyderPluginMixin(object):
     def get_option(self, option, default=NoDefault):
         """Get a plugin option from configuration file"""
         return CONF.get(self.CONF_SECTION, option, default)
-    
-    def get_plugin_font(self, option=None):
-        """Return plugin font option"""
-        return get_font(self.CONF_SECTION, option)
-    
-    def set_plugin_font(self, font, option=None):
-        """Set plugin font option"""
-        set_font(font, self.CONF_SECTION, option)
+
+    def get_plugin_font(self, rich_text=False):
+        """
+        Return plugin font option.
+
+        All plugins in Spyder use a global font. This is a convenience method
+        in case some plugins will have a delta size based on the default size.
+        """
+        if rich_text:
+            option = 'rich_font'
+            font_size_delta = 0
+        else:
+            option = 'font'
+            font_size_delta = self.FONT_SIZE_DELTA
+
+        return get_font(option=option, font_size_delta=font_size_delta)
+
+    def set_plugin_font(self):
+        """
+        Set plugin font option.
+
+        Note: All plugins in Spyder use a global font. To define a different
+        size, the plugin must define a 'FONT_SIZE_DELTA' class variable.
+        """
+        raise Exception("Plugins font is based on the general settings, "
+                        "and cannot be set directly on the plugin."
+                        "This method is deprecated.")
+
+    def update_font(self):
+        """ """
+        print("Launched!")
 
     def __show_message(self, message, timeout=0):
         """Show message in main window's status bar"""

--- a/spyderlib/plugins/configdialog.py
+++ b/spyderlib/plugins/configdialog.py
@@ -738,6 +738,38 @@ class MainConfigPage(GeneralConfigPage):
         newcb = self.create_checkbox
 
         # --- Interface
+        general_group = QGroupBox(_("General"))
+        languages = LANGUAGE_CODES.items()
+        language_choices = sorted([(val, key) for key, val in languages])
+        language_combo = self.create_combobox(_('Language'), language_choices,
+                                              'interface_language',
+                                              restart=True)
+        single_instance_box = newcb(_("Use a single instance"),
+                                    'single_instance',
+                                    tip=_("Set this to open external<br> "
+                                          "Python files in an already running "
+                                          "instance (Requires a restart)"))
+        prompt_box = newcb(_("Prompt when exiting"), 'prompt_on_exit')
+        popup_console_box = newcb(_("Pop up internal console when internal "
+                                    "errors appear"),
+                                  'show_internal_console_if_traceback')
+        check_updates = newcb(_("Check for updates on startup"),
+                              'check_updates_on_startup')
+
+        # Decide if it's possible to activate or not single instance mode
+        if running_in_mac_app():
+            self.set_option("single_instance", True)
+            single_instance_box.setEnabled(False)
+
+        general_layout = QVBoxLayout()
+        general_layout.addWidget(language_combo)
+        general_layout.addWidget(single_instance_box)
+        general_layout.addWidget(prompt_box)
+        general_layout.addWidget(popup_console_box)
+        general_layout.addWidget(check_updates)
+        general_group.setLayout(general_layout)
+
+        # --- Theme
         interface_group = QGroupBox(_("Interface"))
         styles = [str(txt) for txt in list(QStyleFactory.keys())]
         # Don't offer users the possibility to change to a different
@@ -755,17 +787,7 @@ class MainConfigPage(GeneralConfigPage):
         icons_combo = self.create_combobox(_('Icon theme'), icon_choices,
                                            'icon_theme', restart=True)
 
-        languages = LANGUAGE_CODES.items()
-        language_choices = sorted([(val, key) for key, val in languages])
-        language_combo = self.create_combobox(_('Language'), language_choices,
-                                              'interface_language',
-                                              restart=True)
 
-        single_instance_box = newcb(_("Use a single instance"),
-                                    'single_instance',
-                                    tip=_("Set this to open external<br> "
-                                          "Python files in an already running "
-                                          "instance (Requires a restart)"))
         vertdock_box = newcb(_("Vertical title bars in panes"),
                              'vertical_dockwidget_titlebars')
         verttabs_box = newcb(_("Vertical tabs in panes"),
@@ -784,12 +806,6 @@ class MainConfigPage(GeneralConfigPage):
         margins_layout = QHBoxLayout()
         margins_layout.addWidget(margin_box)
         margins_layout.addWidget(margin_spin)
-        prompt_box = newcb(_("Prompt when exiting"), 'prompt_on_exit')
-
-        # Decide if it's possible to activate or not single instance mode
-        if running_in_mac_app():
-            self.set_option("single_instance", True)
-            single_instance_box.setEnabled(False)
 
         # Layout interface
         comboboxes_layout = QHBoxLayout()
@@ -798,20 +814,16 @@ class MainConfigPage(GeneralConfigPage):
         cbs_layout.addWidget(style_combo.combobox, 0, 1)
         cbs_layout.addWidget(icons_combo.label, 1, 0)
         cbs_layout.addWidget(icons_combo.combobox, 1, 1)
-        cbs_layout.addWidget(language_combo.label, 2, 0)
-        cbs_layout.addWidget(language_combo.combobox, 2, 1)
         comboboxes_layout.addLayout(cbs_layout)
         comboboxes_layout.addStretch(1)
         
         interface_layout = QVBoxLayout()
         interface_layout.addLayout(comboboxes_layout)
-        interface_layout.addWidget(single_instance_box)
         interface_layout.addWidget(vertdock_box)
         interface_layout.addWidget(verttabs_box)
         interface_layout.addWidget(animated_box)
         interface_layout.addWidget(tear_off_box)
         interface_layout.addLayout(margins_layout)
-        interface_layout.addWidget(prompt_box)
         interface_group.setLayout(interface_layout)
 
         # --- Status bar
@@ -859,26 +871,7 @@ class MainConfigPage(GeneralConfigPage):
         sbar_layout.addLayout(cpu_memory_layout)
         sbar_group.setLayout(sbar_layout)
 
-        # --- Debugging
-        debug_group = QGroupBox(_("Debugging"))
-        popup_console_box = newcb(_("Pop up internal console when internal "
-                                    "errors appear"),
-                                  'show_internal_console_if_traceback')
-        
-        debug_layout = QVBoxLayout()
-        debug_layout.addWidget(popup_console_box)
-        debug_group.setLayout(debug_layout)
-
-        # --- Spyder updates
-        update_group = QGroupBox(_("Updates"))
-        check_updates = newcb(_("Check for updates on startup"),
-                              'check_updates_on_startup')
-        update_layout = QVBoxLayout()
-        update_layout.addWidget(check_updates)
-        update_group.setLayout(update_layout)
-
         # --- Theme and fonts
-        # Fonts group
         plain_text_font_group = self.create_fontgroup(
             option='font',
             text=_("Plain text font style"),
@@ -888,18 +881,16 @@ class MainConfigPage(GeneralConfigPage):
             option='rich_font',
             text=_("Rich text font style"))
 
-        fonts_layout = QVBoxLayout()
-        fonts_layout.addWidget(plain_text_font_group)
-        fonts_layout.addWidget(rich_text_font_group)
-
+        tabs = QTabWidget()
+        tabs.addTab(self.create_tab(general_group, sbar_group),
+                    _("General"))
+        tabs.addTab(self.create_tab(plain_text_font_group,
+                                    rich_text_font_group,
+                                    interface_group),
+                    _("Appearance"))
+        
         vlayout = QVBoxLayout()
-        vlayout.addWidget(interface_group)
-        vlayout.addWidget(sbar_group)
-        vlayout.addWidget(debug_group)
-        vlayout.addWidget(update_group)
-        vlayout.addLayout(fonts_layout)
-        vlayout.addStretch(1)
-
+        vlayout.addWidget(tabs)
         self.setLayout(vlayout)
 
     def get_font(self, option):

--- a/spyderlib/plugins/configdialog.py
+++ b/spyderlib/plugins/configdialog.py
@@ -25,7 +25,7 @@ import spyderlib.utils.icon_manager as ima
 from spyderlib.config.base import (_, running_in_mac_app, LANGUAGE_CODES,
                                    save_lang_conf, load_lang_conf)
 from spyderlib.config.main import CONF, is_gtk_desktop
-from spyderlib.config.gui import (CUSTOM_COLOR_SCHEME_NAME, get_font,
+from spyderlib.config.gui import (CUSTOM_COLOR_SCHEME_NAME, get_font, set_font,
                                   set_default_color_scheme)
 from spyderlib.config.user import NoDefault
 from spyderlib.utils import syntaxhighlighters as sh
@@ -880,12 +880,12 @@ class MainConfigPage(GeneralConfigPage):
         # --- Theme and fonts
         # Fonts group
         plain_text_font_group = self.create_fontgroup(
-            option='plain_text',
+            option='font',
             text=_("Plain text font style"),
             fontfilters=QFontComboBox.MonospacedFonts)
 
         rich_text_font_group = self.create_fontgroup(
-            option='rich_text',
+            option='rich_font',
             text=_("Rich text font style"))
 
         fonts_layout = QVBoxLayout()
@@ -902,13 +902,18 @@ class MainConfigPage(GeneralConfigPage):
 
         self.setLayout(vlayout)
 
-    def get_font(self, option=None):
+    def get_font(self, option):
         """Return global font used in Spyder."""
-        return get_font(self.CONF_SECTION, option)
+        return get_font(option=option)
 
-    def set_font(self, font=None, option=None):
+    def set_font(self, font, option):
         """Set global font used in Spyder."""
-        print("Not setting font for now")
+        set_font(font, option=option)
+
+        # Update fonts in all plugins
+        plugins = self.main.widgetlist + self.main.thirdparty_plugins
+        for plugin in plugins:
+            plugin.update_font()
 
     def apply_settings(self, options):
         self.main.apply_settings()

--- a/spyderlib/plugins/configdialog.py
+++ b/spyderlib/plugins/configdialog.py
@@ -25,7 +25,7 @@ import spyderlib.utils.icon_manager as ima
 from spyderlib.config.base import (_, running_in_mac_app, LANGUAGE_CODES,
                                    save_lang_conf, load_lang_conf)
 from spyderlib.config.main import CONF, is_gtk_desktop
-from spyderlib.config.gui import (CUSTOM_COLOR_SCHEME_NAME,
+from spyderlib.config.gui import (CUSTOM_COLOR_SCHEME_NAME, get_font,
                                   set_default_color_scheme)
 from spyderlib.config.user import NoDefault
 from spyderlib.utils import syntaxhighlighters as sh
@@ -876,14 +876,39 @@ class MainConfigPage(GeneralConfigPage):
         update_layout = QVBoxLayout()
         update_layout.addWidget(check_updates)
         update_group.setLayout(update_layout)
-        
+
+        # --- Theme and fonts
+        # Fonts group
+        plain_text_font_group = self.create_fontgroup(
+            option='plain_text',
+            text=_("Plain text font style"),
+            fontfilters=QFontComboBox.MonospacedFonts)
+
+        rich_text_font_group = self.create_fontgroup(
+            option='rich_text',
+            text=_("Rich text font style"))
+
+        fonts_layout = QVBoxLayout()
+        fonts_layout.addWidget(plain_text_font_group)
+        fonts_layout.addWidget(rich_text_font_group)
+
         vlayout = QVBoxLayout()
         vlayout.addWidget(interface_group)
         vlayout.addWidget(sbar_group)
         vlayout.addWidget(debug_group)
         vlayout.addWidget(update_group)
+        vlayout.addLayout(fonts_layout)
         vlayout.addStretch(1)
+
         self.setLayout(vlayout)
+
+    def get_font(self, option=None):
+        """Return global font used in Spyder."""
+        return get_font(self.CONF_SECTION, option)
+
+    def set_font(self, font=None, option=None):
+        """Set global font used in Spyder."""
+        print("Not setting font for now")
 
     def apply_settings(self, options):
         self.main.apply_settings()

--- a/spyderlib/plugins/console.py
+++ b/spyderlib/plugins/console.py
@@ -114,7 +114,12 @@ class Console(SpyderPluginWidget):
         this plugin's dockwidget is raised on top-level
         """
         return self.shell
-        
+
+    def update_font(self):
+        """ """
+        font = self.get_plugin_font()
+        self.shell.set_font(font)
+
     def closing_plugin(self, cancelable=False):
         """Perform actions before parent main window is closed"""
         self.dialog_manager.close_all()
@@ -150,10 +155,6 @@ class Console(SpyderPluginWidget):
                             _("Buffer..."), None,
                             tip=_("Set maximum line count"),
                             triggered=self.change_max_line_count)
-        font_action = create_action(self,
-                            _("&Font..."), None,
-                            ima.icon('font'), _("Set shell font style"),
-                            triggered=self.change_font)
         exteditor_action = create_action(self,
                             _("External editor path..."), None, None,
                             _("Set external editor executable path"),
@@ -177,7 +178,7 @@ class Console(SpyderPluginWidget):
         
         option_menu = QMenu(_('Internal console settings'), self)
         option_menu.setIcon(ima.icon('tooloptions'))
-        add_actions(option_menu, (buffer_action, font_action, wrap_action,
+        add_actions(option_menu, (buffer_action, wrap_action,
                                   calltips_action, codecompletion_action,
                                   codecompenter_action, exteditor_action))
                     
@@ -270,16 +271,7 @@ class Console(SpyderPluginWidget):
         """Execute lines and give focus to shell"""
         self.shell.execute_lines(to_text_string(lines))
         self.shell.setFocus()
-    
-    @Slot()
-    def change_font(self):
-        """Change console font"""
-        font, valid = QFontDialog.getFont(self.get_plugin_font(),
-                       self, _("Select a new font"))
-        if valid:
-            self.shell.set_font(font)
-            self.set_plugin_font(font)
-    
+
     @Slot()
     def change_max_line_count(self):
         "Change maximum line count"""

--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -16,7 +16,7 @@ from spyderlib.qt.QtGui import (QVBoxLayout, QPrintDialog, QSplitter, QToolBar,
                                 QAction, QApplication, QDialog, QWidget,
                                 QPrinter, QActionGroup, QInputDialog, QMenu,
                                 QAbstractPrintDialog, QGroupBox, QTabWidget,
-                                QLabel, QFontComboBox, QHBoxLayout,
+                                QLabel, QHBoxLayout,
                                 QKeySequence, QGridLayout)
 from spyderlib.qt.QtCore import Signal, QByteArray, Qt, Slot
 from spyderlib.qt.compat import to_qvariant, from_qvariant, getopenfilenames
@@ -102,9 +102,6 @@ class EditorConfigPage(PluginConfigPage):
                                     self.plugin.edit_template)
         
         interface_group = QGroupBox(_("Interface"))
-#        font_group = self.create_fontgroup(option=None,
-#                                    text=_("Text and margin font style"),
-#                                    fontfilters=QFontComboBox.MonospacedFonts)
         newcb = self.create_checkbox
         fpsorting_box = newcb(_("Sort files according to full path"),
                               'fullpath_sorting')
@@ -1046,7 +1043,18 @@ class Editor(SpyderPluginWidget):
         if not editorstack.data:
             self.__load_temp_file()
         self.main.add_dockwidget(self)
-    
+
+    def update_font(self):
+        """ """
+        font = self.get_plugin_font()
+        color_scheme = get_color_scheme(self.get_option('color_scheme_name'))
+        for editorstack in self.editorstacks:
+            editorstack.set_default_font(font, color_scheme)
+            completion_size = CONF.get('editor_appearance',
+                                       'completion/size')
+            for finfo in editorstack.data:
+                comp_widget = finfo.editor.completion_widget
+                comp_widget.setup_appearance(completion_size, font)
         
     #------ Focus tabwidget
     def __get_focus_editorstack(self):
@@ -2210,8 +2218,6 @@ class Editor(SpyderPluginWidget):
             # --- syntax highlight and text rendering settings
             color_scheme_n = 'color_scheme_name'
             color_scheme_o = get_color_scheme(self.get_option(color_scheme_n))
-            font_n = 'plugin_font'
-            font_o = self.get_plugin_font()
             currentline_n = 'highlight_current_line'
             currentline_o = self.get_option(currentline_n)
             currentcell_n = 'highlight_current_cell'
@@ -2224,15 +2230,7 @@ class Editor(SpyderPluginWidget):
             focus_to_editor_o = self.get_option(focus_to_editor_n)
             
             for editorstack in self.editorstacks:
-                if font_n in options:
-                    scs = color_scheme_o if color_scheme_n in options else None
-                    editorstack.set_default_font(font_o, scs)
-                    completion_size = CONF.get('editor_appearance',
-                                               'completion/size')
-                    for finfo in editorstack.data:
-                        comp_widget = finfo.editor.completion_widget
-                        comp_widget.setup_appearance(completion_size, font_o)
-                elif color_scheme_n in options:
+                if color_scheme_n in options:
                     editorstack.set_color_scheme(color_scheme_o)
                 if currentline_n in options:
                     editorstack.set_highlight_current_line_enabled(

--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -102,9 +102,9 @@ class EditorConfigPage(PluginConfigPage):
                                     self.plugin.edit_template)
         
         interface_group = QGroupBox(_("Interface"))
-        font_group = self.create_fontgroup(option=None,
-                                    text=_("Text and margin font style"),
-                                    fontfilters=QFontComboBox.MonospacedFonts)
+#        font_group = self.create_fontgroup(option=None,
+#                                    text=_("Text and margin font style"),
+#                                    fontfilters=QFontComboBox.MonospacedFonts)
         newcb = self.create_checkbox
         fpsorting_box = newcb(_("Sort files according to full path"),
                               'fullpath_sorting')
@@ -332,7 +332,7 @@ class EditorConfigPage(PluginConfigPage):
         eol_group.setLayout(eol_layout)
         
         tabs = QTabWidget()
-        tabs.addTab(self.create_tab(font_group, interface_group, display_group),
+        tabs.addTab(self.create_tab(interface_group, display_group),
                     _("Display"))
         tabs.addTab(self.create_tab(introspection_group, analysis_group),
                     _("Code Introspection/Analysis"))

--- a/spyderlib/plugins/explorer.py
+++ b/spyderlib/plugins/explorer.py
@@ -19,7 +19,7 @@ import os.path as osp
 
 # Local imports
 from spyderlib.config.base import _
-from spyderlib.utils.qthelpers import create_action
+from spyderlib.config.main import DEFAULT_SMALL_DELTA
 from spyderlib.widgets.explorer import ExplorerWidget
 from spyderlib.plugins import SpyderPluginMixin
 from spyderlib.py3compat import to_text_string
@@ -28,6 +28,7 @@ from spyderlib.py3compat import to_text_string
 class Explorer(ExplorerWidget, SpyderPluginMixin):
     """File and Directories Explorer DockWidget"""
     CONF_SECTION = 'explorer'
+    FONT_SIZE_DELTA = DEFAULT_SMALL_DELTA
     open_terminal = Signal(str)
     open_interpreter = Signal(str)
     edit = Signal(str)
@@ -47,7 +48,7 @@ class Explorer(ExplorerWidget, SpyderPluginMixin):
         # Initialize plugin
         self.initialize_plugin()
         
-        self.set_font(self.get_plugin_font())
+        self.update_font()
         
     #------ SpyderPluginWidget API ---------------------------------------------    
     def get_plugin_title(self):
@@ -63,11 +64,6 @@ class Explorer(ExplorerWidget, SpyderPluginMixin):
     
     def get_plugin_actions(self):
         """Return a list of actions related to plugin"""
-        # Font
-        font_action = create_action(self, _("&Font..."), None, ima.icon('font'),
-                                    _("Set font style"),
-                                    triggered=self.change_font)
-        self.treewidget.common_actions.append(font_action)
         return []
     
     def register_plugin(self):
@@ -104,22 +100,13 @@ class Explorer(ExplorerWidget, SpyderPluginMixin):
     def closing_plugin(self, cancelable=False):
         """Perform actions before parent main window is closed"""
         return True
-        
+
+    def update_font(self):
+        font = self.get_plugin_font()
+        self.setFont(font)
+        self.treewidget.setFont(font)
+
     #------ Public API ---------------------------------------------------------        
     def chdir(self, directory):
         """Set working directory"""
         self.treewidget.chdir(directory)
-    
-    @Slot()
-    def change_font(self):
-        """Change font"""
-        font, valid = QFontDialog.getFont(self.get_plugin_font(), self,
-                                          _("Select a new font"))
-        if valid:
-            self.set_font(font)
-            self.set_plugin_font(font)
-            
-    def set_font(self, font):
-        """Set explorer widget font"""
-        self.setFont(font)
-        self.treewidget.setFont(font)

--- a/spyderlib/plugins/explorer.py
+++ b/spyderlib/plugins/explorer.py
@@ -11,15 +11,14 @@
 # pylint: disable=R0911
 # pylint: disable=R0201
 
-from spyderlib.qt.QtGui import QFontDialog
-from spyderlib.qt.QtCore import Signal, Slot
+from spyderlib.qt.QtCore import Signal
 import spyderlib.utils.icon_manager as ima
 
 import os.path as osp
 
 # Local imports
 from spyderlib.config.base import _
-from spyderlib.config.main import DEFAULT_SMALL_DELTA
+from spyderlib.config.main import DEFAULT_LARGE_DELTA
 from spyderlib.widgets.explorer import ExplorerWidget
 from spyderlib.plugins import SpyderPluginMixin
 from spyderlib.py3compat import to_text_string
@@ -28,7 +27,7 @@ from spyderlib.py3compat import to_text_string
 class Explorer(ExplorerWidget, SpyderPluginMixin):
     """File and Directories Explorer DockWidget"""
     CONF_SECTION = 'explorer'
-    FONT_SIZE_DELTA = DEFAULT_SMALL_DELTA
+    RICH_FONT_SIZE_DELTA = DEFAULT_LARGE_DELTA*2
     open_terminal = Signal(str)
     open_interpreter = Signal(str)
     edit = Signal(str)
@@ -102,7 +101,7 @@ class Explorer(ExplorerWidget, SpyderPluginMixin):
         return True
 
     def update_font(self):
-        font = self.get_plugin_font()
+        font = self.get_plugin_font(rich_text=True)
         self.setFont(font)
         self.treewidget.setFont(font)
 

--- a/spyderlib/plugins/externalconsole.py
+++ b/spyderlib/plugins/externalconsole.py
@@ -15,7 +15,7 @@
 from spyderlib.qt import PYQT5
 from spyderlib.qt.QtGui import (QVBoxLayout, QMessageBox, QInputDialog,
                                 QLineEdit, QPushButton, QGroupBox, QLabel,
-                                QTabWidget, QFontComboBox, QHBoxLayout,
+                                QTabWidget, QHBoxLayout,
                                 QButtonGroup, QWidget)
 from spyderlib.qt.QtCore import Signal, Slot, Qt
 from spyderlib.qt.compat import getopenfilename
@@ -65,8 +65,6 @@ class ExternalConsoleConfigPage(PluginConfigPage):
 
     def setup_page(self):
         interface_group = QGroupBox(_("Interface"))
-#        font_group = self.create_fontgroup(option=None, text=None,
-#                                    fontfilters=QFontComboBox.MonospacedFonts)
         newcb = self.create_checkbox
         singletab_box = newcb(_("One tab per script"), 'single_tab')
         showtime_box = newcb(_("Show elapsed time"), 'show_elapsed_time')
@@ -1104,11 +1102,19 @@ class ExternalConsole(SpyderPluginWidget):
             shellwidget.update_time_label_visibility()
         self.main.last_console_plugin_focus_was_python = True
         self.update_plugin_title.emit()
-    
+
+    def update_font(self):
+        """ """
+        font = self.get_plugin_font()
+        for shellwidget in self.shellwidgets:
+            shellwidget.shell.set_font(font)
+            completion_size = CONF.get('shell_appearance',
+                                       'completion/size')
+            comp_widget = shellwidget.shell.completion_widget
+            comp_widget.setup_appearance(completion_size, font)
+
     def apply_plugin_settings(self, options):
         """Apply configuration file's plugin settings"""
-        font_n = 'plugin_font'
-        font_o = self.get_plugin_font()
         showtime_n = 'show_elapsed_time'
         showtime_o = self.get_option(showtime_n)
         icontext_n = 'show_icontext'
@@ -1128,12 +1134,6 @@ class ExternalConsole(SpyderPluginWidget):
         mlc_n = 'max_line_count'
         mlc_o = self.get_option(mlc_n)
         for shellwidget in self.shellwidgets:
-            if font_n in options:
-                shellwidget.shell.set_font(font_o)
-                completion_size = CONF.get('shell_appearance',
-                                           'completion/size')
-                comp_widget = shellwidget.shell.completion_widget
-                comp_widget.setup_appearance(completion_size, font_o)
             if showtime_n in options:
                 shellwidget.set_elapsed_time_visible(showtime_o)
             if icontext_n in options:

--- a/spyderlib/plugins/externalconsole.py
+++ b/spyderlib/plugins/externalconsole.py
@@ -65,8 +65,8 @@ class ExternalConsoleConfigPage(PluginConfigPage):
 
     def setup_page(self):
         interface_group = QGroupBox(_("Interface"))
-        font_group = self.create_fontgroup(option=None, text=None,
-                                    fontfilters=QFontComboBox.MonospacedFonts)
+#        font_group = self.create_fontgroup(option=None, text=None,
+#                                    fontfilters=QFontComboBox.MonospacedFonts)
         newcb = self.create_checkbox
         singletab_box = newcb(_("One tab per script"), 'single_tab')
         showtime_box = newcb(_("Show elapsed time"), 'show_elapsed_time')
@@ -325,7 +325,7 @@ class ExternalConsoleConfigPage(PluginConfigPage):
                                                     interpreter=interpreter))
 
         tabs = QTabWidget()
-        tabs.addTab(self.create_tab(font_group, interface_group, display_group,
+        tabs.addTab(self.create_tab(interface_group, display_group,
                                     bg_group),
                     _("Display"))
         tabs.addTab(self.create_tab(monitor_group, source_group),

--- a/spyderlib/plugins/help.py
+++ b/spyderlib/plugins/help.py
@@ -118,11 +118,11 @@ class ObjectComboBox(EditableComboBox):
 class HelpConfigPage(PluginConfigPage):
     def setup_page(self):
         # Fonts group
-        plain_text_font_group = self.create_fontgroup(option=None,
-                                    text=_("Plain text font style"),
-                                    fontfilters=QFontComboBox.MonospacedFonts)
-        rich_text_font_group = self.create_fontgroup(option='rich_text',
-                                text=_("Rich text font style"))
+#        plain_text_font_group = self.create_fontgroup(option=None,
+#                                    text=_("Plain text font style"),
+#                                    fontfilters=QFontComboBox.MonospacedFonts)
+#        rich_text_font_group = self.create_fontgroup(option='rich_text',
+#                                text=_("Rich text font style"))
 
         # Connections group
         connections_group = QGroupBox(_("Automatic connections"))
@@ -187,8 +187,6 @@ class HelpConfigPage(PluginConfigPage):
 
         # Final layout
         vlayout = QVBoxLayout()
-        vlayout.addWidget(rich_text_font_group)
-        vlayout.addWidget(plain_text_font_group)
         vlayout.addWidget(connections_group)
         vlayout.addWidget(features_group)
         vlayout.addWidget(sourcecode_group)

--- a/spyderlib/plugins/help.py
+++ b/spyderlib/plugins/help.py
@@ -24,7 +24,7 @@ import sys
 from spyderlib import dependencies
 from spyderlib.config.base import get_conf_path, get_module_source_path, _
 from spyderlib.config.ipython import IPYTHON_QT_INSTALLED
-from spyderlib.config.main import CONF
+from spyderlib.config.main import CONF, DEFAULT_SMALL_DELTA
 from spyderlib.config.gui import get_color_scheme, get_font, set_font
 from spyderlib.utils import programs
 from spyderlib.utils.qthelpers import (create_toolbutton, add_actions,
@@ -117,13 +117,6 @@ class ObjectComboBox(EditableComboBox):
 
 class HelpConfigPage(PluginConfigPage):
     def setup_page(self):
-        # Fonts group
-#        plain_text_font_group = self.create_fontgroup(option=None,
-#                                    text=_("Plain text font style"),
-#                                    fontfilters=QFontComboBox.MonospacedFonts)
-#        rich_text_font_group = self.create_fontgroup(option='rich_text',
-#                                text=_("Rich text font style"))
-
         # Connections group
         connections_group = QGroupBox(_("Automatic connections"))
         connections_label = QLabel(_("This pane can automatically "
@@ -352,6 +345,9 @@ class Help(SpyderPluginWidget):
     CONF_SECTION = 'help'
     CONFIGWIDGET_CLASS = HelpConfigPage
     LOG_PATH = get_conf_path(CONF_SECTION)
+    FONT_SIZE_DELTA = DEFAULT_SMALL_DELTA
+
+    # Signals
     focus_changed = Signal()
 
     def __init__(self, parent):
@@ -553,27 +549,27 @@ class Help(SpyderPluginWidget):
                 self.switch_to_rich_text()
             self.show_intro_message()
 
+    def update_font(self):
+        """ """
+        color_scheme = get_color_scheme(self.get_option('color_scheme_name'))
+        font = self.get_plugin_font()
+        rich_font = self.get_plugin_font(rich_text=True)
+
+        self.set_plain_text_font(font, color_scheme=color_scheme)
+        self.set_rich_text_font(rich_font)
+
     def apply_plugin_settings(self, options):
         """Apply configuration file's plugin settings"""
         color_scheme_n = 'color_scheme_name'
         color_scheme_o = get_color_scheme(self.get_option(color_scheme_n))
-        font_n = 'plugin_font'
-        font_o = self.get_plugin_font()
         connect_n = 'connect_to_oi'
-        rich_font_n = 'rich_text'
-        rich_font_o = self.get_plugin_font('rich_text')
         wrap_n = 'wrap'
         wrap_o = self.get_option(wrap_n)
         self.wrap_action.setChecked(wrap_o)
         math_n = 'math'
         math_o = self.get_option(math_n)
 
-        if font_n in options:
-            scs = color_scheme_o if color_scheme_n in options else None
-            self.set_plain_text_font(font_o, color_scheme=scs)
-        if rich_font_n in options:
-            self.set_rich_text_font(rich_font_o)
-        elif color_scheme_n in options:
+        if color_scheme_n in options:
             self.set_plain_text_color_scheme(color_scheme_o)
         if wrap_n in options:
             self.toggle_wrap_mode(wrap_o)

--- a/spyderlib/plugins/history.py
+++ b/spyderlib/plugins/history.py
@@ -44,9 +44,9 @@ class HistoryConfigPage(PluginConfigPage):
         wrap_mode_box = self.create_checkbox(_("Wrap lines"), 'wrap')
         go_to_eof_box = self.create_checkbox(
                         _("Scroll automatically to last entry"), 'go_to_eof')
-        font_group = self.create_fontgroup(option=None,
-                                    text=_("Font style"),
-                                    fontfilters=QFontComboBox.MonospacedFonts)
+#        font_group = self.create_fontgroup(option=None,
+#                                    text=_("Font style"),
+#                                    fontfilters=QFontComboBox.MonospacedFonts)
         names = CONF.get('color_schemes', 'names')
         choices = list(zip(names, names))
         cs_combo = self.create_combobox(_("Syntax color scheme: "),
@@ -63,7 +63,6 @@ class HistoryConfigPage(PluginConfigPage):
         sourcecode_group.setLayout(sourcecode_layout)
         
         vlayout = QVBoxLayout()
-        vlayout.addWidget(font_group)
         vlayout.addWidget(settings_group)
         vlayout.addWidget(sourcecode_group)
         vlayout.addStretch(1)

--- a/spyderlib/plugins/history.py
+++ b/spyderlib/plugins/history.py
@@ -8,7 +8,7 @@
 
 from spyderlib.qt import PYQT5
 from spyderlib.qt.QtGui import (QVBoxLayout, QFontDialog, QInputDialog,
-                                QToolButton, QMenu, QFontComboBox, QGroupBox,
+                                QToolButton, QMenu, QGroupBox,
                                 QHBoxLayout, QWidget)
 from spyderlib.qt.QtCore import Signal, Slot
 import spyderlib.utils.icon_manager as ima
@@ -44,9 +44,6 @@ class HistoryConfigPage(PluginConfigPage):
         wrap_mode_box = self.create_checkbox(_("Wrap lines"), 'wrap')
         go_to_eof_box = self.create_checkbox(
                         _("Scroll automatically to last entry"), 'go_to_eof')
-#        font_group = self.create_fontgroup(option=None,
-#                                    text=_("Font style"),
-#                                    fontfilters=QFontComboBox.MonospacedFonts)
         names = CONF.get('color_schemes', 'names')
         choices = list(zip(names, names))
         cs_combo = self.create_combobox(_("Syntax color scheme: "),
@@ -184,6 +181,13 @@ class HistoryLog(SpyderPluginWidget):
         self.main.add_dockwidget(self)
 #        self.main.console.set_historylog(self)
         self.main.console.shell.refresh.connect(self.refresh_plugin)
+
+    def update_font(self):
+        """ """
+        color_scheme = get_color_scheme(self.get_option('color_scheme_name'))
+        font = self.get_plugin_font()
+        for editor in self.editors:
+            editor.set_font(font, color_scheme)
 
     def apply_plugin_settings(self, options):
         """Apply configuration file's plugin settings"""

--- a/spyderlib/plugins/ipythonconsole.py
+++ b/spyderlib/plugins/ipythonconsole.py
@@ -155,8 +155,8 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         mpl_present = programs.is_module_installed("matplotlib")
         
         # --- Display ---
-        font_group = self.create_fontgroup(option=None, text=None,
-                                    fontfilters=QFontComboBox.MonospacedFonts)
+#        font_group = self.create_fontgroup(option=None, text=None,
+#                                    fontfilters=QFontComboBox.MonospacedFonts)
 
         # Interface Group
         interface_group = QGroupBox(_("Interface"))
@@ -459,7 +459,7 @@ class IPythonConsoleConfigPage(PluginConfigPage):
 
         # --- Tabs organization ---
         tabs = QTabWidget()
-        tabs.addTab(self.create_tab(font_group, interface_group, comp_group,
+        tabs.addTab(self.create_tab(interface_group, comp_group,
                                     bg_group, source_code_group), _("Display"))
         tabs.addTab(self.create_tab(pylab_group, backend_group, inline_group),
                                     _("Graphics"))

--- a/spyderlib/plugins/ipythonconsole.py
+++ b/spyderlib/plugins/ipythonconsole.py
@@ -24,7 +24,7 @@ import sys
 from spyderlib.qt import PYQT5
 from spyderlib.qt.QtGui import (QVBoxLayout, QHBoxLayout, QFormLayout, 
                                 QMessageBox, QGroupBox, QDialogButtonBox,
-                                QDialog, QTabWidget, QFontComboBox, 
+                                QDialog, QTabWidget, 
                                 QCheckBox, QApplication, QLabel,QLineEdit,
                                 QPushButton, QKeySequence, QWidget,
                                 QGridLayout)
@@ -154,10 +154,6 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         newcb = self.create_checkbox
         mpl_present = programs.is_module_installed("matplotlib")
         
-        # --- Display ---
-#        font_group = self.create_fontgroup(option=None, text=None,
-#                                    fontfilters=QFontComboBox.MonospacedFonts)
-
         # Interface Group
         interface_group = QGroupBox(_("Interface"))
         banner_box = newcb(_("Display initial banner"), 'show_banner',
@@ -655,6 +651,12 @@ class IPythonConsole(SpyderPluginWidget):
     def on_first_registration(self):
         """Action to be performed on first plugin registration"""
         self.main.tabify_plugins(self.main.extconsole, self)
+
+    def update_font(self):
+        """ """
+        font = self.get_plugin_font()
+        for client in self.clients:
+            client.set_font(font)        
 
     def apply_plugin_settings(self, options):
         """Apply configuration file's plugin settings"""

--- a/spyderlib/widgets/externalshell/pythonshell.py
+++ b/spyderlib/widgets/externalshell/pythonshell.py
@@ -670,10 +670,9 @@ def test():
                                 mpl_backend=0,
                                 light_background=False)
 
-    from spyderlib.qt.QtGui import QFont
-    from spyderlib.config.main import CONF
-    font = QFont(CONF.get('console', 'font/family')[0])
-    font.setPointSize(10)
+    from spyderlib.config.gui import get_font
+    
+    font = get_font()
     shell.shell.set_font(font)
 
     shell.shell.toggle_wrap_mode(True)

--- a/spyderlib/widgets/variableexplorer/arrayeditor.py
+++ b/spyderlib/widgets/variableexplorer/arrayeditor.py
@@ -33,6 +33,7 @@ import numpy as np
 # Local imports
 from spyderlib.config.base import _
 from spyderlib.config.gui import get_font, new_shortcut
+from spyderlib.config.main import DEFAULT_SMALL_DELTA
 from spyderlib.utils.qthelpers import (add_actions, create_action, keybinding,
                                        qapplication)
 from spyderlib.py3compat import (PY3, io, to_text_string, is_text_string,
@@ -270,7 +271,7 @@ class ArrayModel(QAbstractTableModel):
             color = QColor.fromHsvF(hue, self.sat, self.val, self.alp)
             return to_qvariant(color)
         elif role == Qt.FontRole:
-            return to_qvariant(get_font('arrayeditor'))
+            return to_qvariant(get_font(font_size_delta=DEFAULT_SMALL_DELTA))
         return to_qvariant()
 
     def setData(self, index, value, role=Qt.EditRole):
@@ -357,7 +358,7 @@ class ArrayDelegate(QItemDelegate):
             return
         elif value is not np.ma.masked:
             editor = QLineEdit(parent)
-            editor.setFont(get_font('arrayeditor'))
+            editor.setFont(get_font(font_size_delta=DEFAULT_SMALL_DELTA))
             editor.setAlignment(Qt.AlignCenter)
             if is_number(self.dtype):
                 editor.setValidator(QDoubleValidator(editor))

--- a/spyderlib/widgets/variableexplorer/collectionseditor.py
+++ b/spyderlib/widgets/variableexplorer/collectionseditor.py
@@ -35,6 +35,7 @@ from spyderlib.utils.qthelpers import mimedata2url
 
 # Local import
 from spyderlib.config.base import _
+from spyderlib.config.main import DEFAULT_SMALL_DELTA
 from spyderlib.config.gui import get_font
 from spyderlib.utils.misc import fix_reference_name
 from spyderlib.utils.qthelpers import add_actions, create_action, qapplication
@@ -298,16 +299,16 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
             return to_qvariant( self.get_bgcolor(index) )
         elif role == Qt.FontRole:
             if index.column() < 3:
-                return to_qvariant(get_font('dicteditor_header'))
+                return to_qvariant(get_font(font_size_delta=DEFAULT_SMALL_DELTA))
             else:
-                return to_qvariant(get_font('dicteditor'))
+                return to_qvariant(get_font(font_size_delta=DEFAULT_SMALL_DELTA))
         return to_qvariant()
     
     def headerData(self, section, orientation, role=Qt.DisplayRole):
         """Overriding method headerData"""
         if role != Qt.DisplayRole:
             if role == Qt.FontRole:
-                return to_qvariant(get_font('dicteditor_header'))
+                return to_qvariant(get_font(font_size_delta=DEFAULT_SMALL_DELTA))
             else:
                 return to_qvariant()
         i_column = int(section)
@@ -472,13 +473,13 @@ class CollectionsDelegate(QItemDelegate):
         elif isinstance(value, datetime.datetime):
             editor = QDateTimeEdit(value, parent)
             editor.setCalendarPopup(True)
-            editor.setFont(get_font('dicteditor'))
+            editor.setFont(get_font(font_size_delta=DEFAULT_SMALL_DELTA))
             return editor
         #---editor = QDateEdit
         elif isinstance(value, datetime.date):
             editor = QDateEdit(value, parent)
             editor.setCalendarPopup(True)
-            editor.setFont(get_font('dicteditor'))
+            editor.setFont(get_font(font_size_delta=DEFAULT_SMALL_DELTA))
             return editor
         #---editor = TextEditor
         elif is_text_string(value) and len(value)>40:
@@ -489,7 +490,7 @@ class CollectionsDelegate(QItemDelegate):
         #---editor = QLineEdit
         elif is_editable_type(value):
             editor = QLineEdit(parent)
-            editor.setFont(get_font('dicteditor'))
+            editor.setFont(get_font(font_size_delta=DEFAULT_SMALL_DELTA))
             editor.setAlignment(Qt.AlignLeft)
             editor.returnPressed.connect(self.commitAndCloseEditor)
             return editor


### PR DESCRIPTION
Fixes #2438

----

# Description
AFAIK Spyder aimed to be in its origin a collection of loosely coupled plugins working together to make up for a coherent scientific and development environment. This decoupling is evident in the large (I would even say massive) amount of configuration options that a Plugin has.

We should strive to make the preferences dialog in Spyder more accessible by reducing redundant options.

PR #2861, was a step in that direction and this is the continuation.

# Screenshots
The fonts should be set now globally in the general preferences. 

### General / General (it can use a better name :-)  )
![image](https://cloud.githubusercontent.com/assets/3627835/12027328/1f3fd3e8-ad9b-11e5-82a6-320c154f9220.png)

### General / Theme (Appearance?)
![image](https://cloud.githubusercontent.com/assets/3627835/12029315/38ce17ac-adbe-11e5-968c-b476b0c66737.png)


# Todo
- [x] Remove font groups preferences from other plugins (Console, IPython, Help, Editor, History)
- [x] Split general preferences in two tabs
- [x] Add fonts to general preferences
- [x] Update logic to update the plugins font on font update
