### PR TITLE
Remove official support for PySide

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Spyder is a Python development environment with a lot of features:
 
 * **History log**
 
-Spyder may also be used as a PyQt4/PySide extension library (module 
+Spyder may also be used as a PyQt5/PyQt4 extension library (module 
 `spyderlib`). For example, the Python interactive shell widget used in
-Spyder may be embedded in your own PyQt4/PySide application.
+Spyder may be embedded in your own PyQt5/PyQt4 application.
 
 
 ## Documentation
@@ -105,14 +105,14 @@ For more details on supported platforms, please refer to our
 [installation instructions](http://pythonhosted.org/spyder/installation.html).
 
 **Important note**: This does not install the graphical Python libraries (i.e.
-PyQt4, PyQt5 or PySide) that Spyder depend on. Those have to be installed
-separately after installing Python.
+PyQt5 or PyQt4) that Spyder depend on. Those have to be installed separately
+after installing Python.
 
 
 ## Running from source
 
 The fastest way to run Spyder is to get the source code using git, install
-PyQt4, PyQt5 or PySide, and run these commands:
+PyQt5 or PyQt4, and run these commands:
 
 1. `pip install qtawesome` or `conda install -c spyder-ide qtawesome`
 2. `cd /your/spyder/git-clone`
@@ -137,7 +137,7 @@ a Python version greater than 2.7 (Python 3.2 is not supported anymore).
 ### Runtime dependencies
 
 * **Python** 2.7 or 3.3+
-* **PyQt4** 4.6+, **PyQt5** 5.2+ or **PySide** 1.2.0+: PyQt4 is recommended.
+* **PyQt5** 5.2+ or **PyQt4** 4.6+: PyQt5 is recommended.
 * **IPython** 3.0 or **qtconsole**: Enhanced Python interpreter.
 * **Rope** and/or **Jedi** 0.8.1: Editor code completion, calltips
   and go-to-definition.

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -33,7 +33,7 @@ Type `python bootstrap.py -- --help` to read about Spyder
 options.""")
 parser.add_option('--gui', default=None,
                   help="GUI toolkit: pyqt5 (for PyQt5), pyqt (for PyQt4) or "
-                       "pyside (for PySide)")
+                       "pyside (for PySide, deprecated)")
 parser.add_option('--hide-console', action='store_true',
                   default=False, help="Hide parent console window (Windows only)")
 parser.add_option('--test', dest="test", action='store_true', default=False,
@@ -117,7 +117,8 @@ if options.gui is None:
             print("02. PyQt4 is detected, selecting")
             os.environ['QT_API'] = 'pyqt'
         except ImportError:
-            print("02. No PyQt5 or PyQt4 detected, using PySide if available")
+            print("02. No PyQt5 or PyQt4 detected, using PySide if available "
+                  "(deprecated)")
 else:
     print ("02. Skipping GUI toolkit detection")
     os.environ['QT_API'] = options.gui

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -109,15 +109,15 @@ print("01. Patched sys.path with %s" % DEVPATH)
 if options.gui is None:
     try:
         import PyQt5  # analysis:ignore
-        print("02. PyQt5 is detected, selecting (experimental)")
+        print("02. PyQt5 is detected, selecting")
         os.environ['QT_API'] = 'pyqt5'
     except ImportError:
         try:
-            import PySide  # analysis:ignore
-            print("02. PySide is detected, selecting")
-            os.environ['QT_API'] = 'pyside'
+            import PyQt4  # analysis:ignore
+            print("02. PyQt4 is detected, selecting")
+            os.environ['QT_API'] = 'pyqt'
         except ImportError:
-            print("02. No PyQt5 or PySide detected, using PyQt4 if available")
+            print("02. No PyQt5 or PyQt4 detected, using PySide if available")
 else:
     print ("02. Skipping GUI toolkit detection")
     os.environ['QT_API'] = options.gui

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -155,8 +155,9 @@ The minimal requirements to run Spyder are
 
 * `Python <http://www.python.org/>`_ 2.6+
   
-* `PyQt4 <http://www.riverbankcomputing.co.uk/software/pyqt/download>`_ >= v4.6 or
-  `PySide <http://pyside.org/>`_ >=1.2.0 (PyQt4 is recommended).
+* `PyQt5 <https://www.riverbankcomputing.com/software/pyqt/download5>`_ >= v5.2 or
+  `PyQt4 <https://www.riverbankcomputing.com/software/pyqt/download>`_ >=4.6.0
+  (PyQt5 is recommended).
 
 
 Recommended modules

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -75,6 +75,6 @@ Key features:
 * :doc:`projectexplorer` (support Pydev project import)
 
 
-Spyder may also be used as a PyQt4 or PySide extension library 
-(module 'spyderlib'). For example, the Python interactive shell widget 
-used in Spyder may be embedded in your own PyQt4 or PySide application.
+Spyder may also be used as a PyQt5 or PyQt4 extension library 
+(module 'spyderlib'). For example, the Python interactive shell widget
+used in Spyder may be embedded in your own PyQt5 or PyQt4 application.

--- a/setup.py
+++ b/setup.py
@@ -248,15 +248,15 @@ setup_args = dict(name=NAME,
       long_description=WININST_MSG + \
 """Spyder is an interactive Python development environment providing
 MATLAB-like features in a simple and light-weighted software.
-It also provides ready-to-use pure-Python widgets to your PyQt4 or
-PySide application: source code editor with syntax highlighting and
+It also provides ready-to-use pure-Python widgets to your PyQt5 or
+PyQt4 application: source code editor with syntax highlighting and
 code introspection/analysis features, NumPy array editor, dictionary
 editor, Python console, etc.""",
       download_url='%s/files/%s-%s.zip' % (__project_url__, NAME, __version__),
       author="The Spyder Development Team",
       url=__project_url__,
       license='MIT',
-      keywords='PyQt4 PySide editor shell console widgets IDE',
+      keywords='PyQt5 PyQt4 editor shell console widgets IDE',
       platforms=['any'],
       packages=get_packages(),
       package_data={LIBNAME: get_package_data(LIBNAME, EXTLIST),

--- a/spyderlib/__init__.py
+++ b/spyderlib/__init__.py
@@ -80,7 +80,7 @@ def get_versions(reporev=True):
         'python': platform.python_version(),  # "2.7.3"
         'bitness': 64 if sys.maxsize > 2**32 else 32,
         'qt': spyderlib.qt.QtCore.__version__,
-        'qt_api': spyderlib.qt.API_NAME,      # PySide or PyQt4
+        'qt_api': spyderlib.qt.API_NAME,      # PyQt5 or PyQt4
         'qt_api_ver': spyderlib.qt.__version__,
         'system': system,   # Linux, Windows, ...
         'revision': revision,  # '9fdf926eccce'

--- a/spyderlib/qt/__init__.py
+++ b/spyderlib/qt/__init__.py
@@ -5,7 +5,7 @@
 # Licensed under the terms of the MIT License
 # (see spyderlib/__init__.py for details)
 
-"""Transitional package (PyQt4 --> PySide)"""
+"""Spyder Qt Shim"""
 
 import os
 

--- a/spyderlib/requirements.py
+++ b/spyderlib/requirements.py
@@ -35,8 +35,7 @@ def check_path():
 
 def check_qt():
     """Check Qt binding requirements"""
-    qt_infos = dict(pyqt5=("PyQt5", "5.2"), pyqt=("PyQt4", "4.6"),
-                    pyside=("PySide", "1.2.0"))
+    qt_infos = dict(pyqt5=("PyQt5", "5.2"), pyqt=("PyQt4", "4.6"))
     try:
         from spyderlib import qt
         package_name, required_ver = qt_infos[qt.API]
@@ -51,5 +50,4 @@ def check_qt():
                      "%s %s+ or\n"
                      "%s %s+\n\n"
                      "is required to run Spyder"
-                     % (qt_infos['pyqt'] + qt_infos['pyside'] + \
-                        qt_infos['pyqt5']))
+                     % (qt_infos['pyqt5'] + qt_infos['pyqt']))

--- a/spyderlib/requirements.py
+++ b/spyderlib/requirements.py
@@ -47,7 +47,6 @@ def check_qt():
     except ImportError:
         show_warning("Please check Spyder installation requirements:\n\n"
                      "%s %s+ or\n"
-                     "%s %s+ or\n"
                      "%s %s+\n\n"
                      "is required to run Spyder"
                      % (qt_infos['pyqt5'] + qt_infos['pyqt']))


### PR DESCRIPTION
This removes references to PySide in our official docs, in our Readme and in `setup.py`.

However, there is (and will always be) support for PySide in `bootstrap.py` and in our Qt shim, in case people want to keep using it.

Reasons to do this:
1. PySide future is uncertain and very little is happening with it currently.
2.  Now that we've moved to support PyQt5 officially (see PR #2879), I want to reduce the number of bindings we support so it be easier to maintain Spyder.
3. PySide support is currently broken in master (Preferences is crashing with it)
4. Nobody has helped to support it (besides Pierre and me).

This was not only my decision, all @spyder-ide/core-developers agreed with it.