### PR TITLE
Move to use Jupyter imports and remove support for IPython 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ a Python version greater than 2.7 (Python 3.2 is not supported anymore).
 
 * **Python** 2.7 or 3.3+
 * **PyQt5** 5.2+ or **PyQt4** 4.6+: PyQt5 is recommended.
-* **IPython** 3.0 or **qtconsole**: Enhanced Python interpreter.
+* **qtconsole**: Enhanced Python interpreter.
 * **Rope** and/or **Jedi** 0.8.1: Editor code completion, calltips
   and go-to-definition.
 * **Pyflakes**: Real-time code analysis.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -165,16 +165,9 @@ Recommended modules
 
 We recommend you to install these modules to get the most out of Spyder:
 
-* `IPython <http://ipython.org/install.html#downloads>`_ 3.0 or less, or
-  `qtconsole <http://jupyter.org/qtconsole/stable/>`_ 4.0 or higher -- for an
+* `qtconsole <http://jupyter.org/qtconsole/stable/>`_ 4.0 or higher -- for an
   enhanced Python interpreter.
-  
- .. note::
-  
-    - On *Ubuntu* you need to install ``ipython-qtconsole``.
-    - On *Fedora*, ``ipython-gui``
-    - And on *Gentoo* ``ipython`` with the ``qt4`` USE flag
-  
+
 * `sphinx <http://sphinx.pocoo.org>`_ >= v0.6  -- for the Help pane rich
   text mode and to get our documentation.
 

--- a/spyderlib/config/ipython.py
+++ b/spyderlib/config/ipython.py
@@ -14,43 +14,27 @@ from spyderlib.config.base import _
 
 
 # Constants
-IPYTHON_REQVER = '>=3.0'
-ZMQ_REQVER = '>=13.0.0'
 QTCONSOLE_REQVER = '>=4.0'
+ZMQ_REQVER = ">=13.0.0"
 
 
 # Dependencies
-dependencies.add("IPython", _("IPython Console integration"),
-                 required_version=IPYTHON_REQVER)
-dependencies.add("zmq", _("IPython Console integration"),
-                 required_version=ZMQ_REQVER)
-
-
-# Jupyter 4.0 requirements
-ipy4_installed = programs.is_module_installed('IPython', '>=4.0')
-if ipy4_installed:
-    dependencies.add("qtconsole", _("IPython Console integration"),
-                     required_version=QTCONSOLE_REQVER)
+dependencies.add("qtconsole", _("Jupyter Qtconsole integration"),
+                 required_version=QTCONSOLE_REQVER)
 
 
 # Auxiliary functions
 def is_qtconsole_installed():
-    ipyqt_installed = programs.is_module_installed('IPython.qt',
-                                                   version=IPYTHON_REQVER)
     pyzmq_installed = programs.is_module_installed('zmq', version=ZMQ_REQVER)
     pygments_installed = programs.is_module_installed('pygments')
+    qtconsole_installed = programs.is_module_installed('qtconsole',
+                                                       version=QTCONSOLE_REQVER)
 
-    if ipyqt_installed and pyzmq_installed and pygments_installed:
-        if ipy4_installed:
-            if programs.is_module_installed('qtconsole'):
-                return True
-            else:
-                return False
-        else:
-            return True
+    if pyzmq_installed and pygments_installed and qtconsole_installed:
+        return True
     else:
         return False
 
 
 # Main check for IPython presence
-IPYTHON_QT_INSTALLED = is_qtconsole_installed()
+QTCONSOLE_INSTALLED = is_qtconsole_installed()

--- a/spyderlib/config/ipython.py
+++ b/spyderlib/config/ipython.py
@@ -16,11 +16,14 @@ from spyderlib.config.base import _
 # Constants
 QTCONSOLE_REQVER = '>=4.0'
 ZMQ_REQVER = ">=13.0.0"
+NBCONVERT_REQVER = ">=4.0"
 
 
 # Dependencies
 dependencies.add("qtconsole", _("Jupyter Qtconsole integration"),
                  required_version=QTCONSOLE_REQVER)
+dependencies.add("nbconvert", _("Manipulate Jupyter notebooks on the Editor"),
+                 required_version=NBCONVERT_REQVER)
 
 
 # Auxiliary functions

--- a/spyderlib/plugins/help.py
+++ b/spyderlib/plugins/help.py
@@ -23,7 +23,7 @@ import sys
 # Local imports
 from spyderlib import dependencies
 from spyderlib.config.base import get_conf_path, get_module_source_path, _
-from spyderlib.config.ipython import IPYTHON_QT_INSTALLED
+from spyderlib.config.ipython import QTCONSOLE_INSTALLED
 from spyderlib.config.main import CONF
 from spyderlib.config.gui import get_color_scheme, get_font, set_font
 from spyderlib.utils import programs
@@ -39,7 +39,7 @@ from spyderlib.py3compat import to_text_string, get_meth_class_inst
 
 #XXX: Hardcoded dependency on optional IPython plugin component
 #     that requires the hack to make this work without IPython
-if IPYTHON_QT_INSTALLED:
+if QTCONSOLE_INSTALLED:
     from spyderlib.widgets.ipython import IPythonControlWidget
 else:
     IPythonControlWidget = None  # analysis:ignore
@@ -145,7 +145,7 @@ class HelpConfigPage(PluginConfigPage):
                                           'connect/python_console')
         ipython_box = self.create_checkbox(_("IPython Console"),
                                            'connect/ipython_console')
-        ipython_box.setEnabled(IPYTHON_QT_INSTALLED)
+        ipython_box.setEnabled(QTCONSOLE_INSTALLED)
 
         connections_layout = QVBoxLayout()
         connections_layout.addWidget(connections_label)

--- a/spyderlib/plugins/ipythonconsole.py
+++ b/spyderlib/plugins/ipythonconsole.py
@@ -32,10 +32,10 @@ from spyderlib.qt.compat import getopenfilename
 from spyderlib.qt.QtCore import Signal, Slot, Qt
 import spyderlib.utils.icon_manager as ima
 
-# IPython imports
+# Jupyter imports
 from IPython.core.application import get_ipython_dir
 from IPython.kernel.connect import find_connection_file
-from IPython.qt.manager import QtKernelManager
+from qtconsole.manager import QtKernelManager
 
 # Ssh imports
 from zmq.ssh import tunnel as zmqtunnel

--- a/spyderlib/plugins/ipythonconsole.py
+++ b/spyderlib/plugins/ipythonconsole.py
@@ -32,9 +32,9 @@ from spyderlib.qt.compat import getopenfilename
 from spyderlib.qt.QtCore import Signal, Slot, Qt
 import spyderlib.utils.icon_manager as ima
 
-# Jupyter imports
+# IPython/Jupyter imports
 from IPython.core.application import get_ipython_dir
-from IPython.kernel.connect import find_connection_file
+from jupyter_client.connect import find_connection_file
 from qtconsole.manager import QtKernelManager
 
 # Ssh imports

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -126,7 +126,7 @@ from spyderlib.config.main import (CONF, EDIT_EXT, IMPORT_EXT, OPEN_FILES_PORT,
                                    is_gtk_desktop)
 from spyderlib.cli_options import get_options
 from spyderlib import dependencies
-from spyderlib.config.ipython import IPYTHON_QT_INSTALLED
+from spyderlib.config.ipython import QTCONSOLE_INSTALLED
 from spyderlib.config.user import NoDefault
 from spyderlib.utils import encoding, programs
 from spyderlib.utils.iofuncs import load_session, save_session, reset_session
@@ -908,7 +908,7 @@ class MainWindow(QMainWindow):
         self.variableexplorer.register_plugin()
 
         # IPython console
-        if IPYTHON_QT_INSTALLED:
+        if QTCONSOLE_INSTALLED:
             self.set_splash(_("Loading IPython console..."))
             from spyderlib.plugins.ipythonconsole import IPythonConsole
             self.ipyconsole = IPythonConsole(self)

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -72,18 +72,6 @@ except ImportError:
 
 
 #==============================================================================
-# Don't show IPython ShimWarning's to our users
-# TODO: Move to Jupyter imports in 3.1
-#==============================================================================
-try:
-    import warnings
-    from IPython.utils.shimmodule import ShimWarning
-    warnings.simplefilter('ignore', ShimWarning)
-except:
-    pass
-
-
-#==============================================================================
 # Qt imports
 #==============================================================================
 from spyderlib.qt import PYQT5

--- a/spyderlib/widgets/explorer.py
+++ b/spyderlib/widgets/explorer.py
@@ -36,9 +36,9 @@ from spyderlib.py3compat import (PY2, to_text_string, to_binary_string, getcwd,
                                  str_lower)
 
 try:
-    from IPython.nbconvert import PythonExporter as nbexporter
+    from nbconvert import PythonExporter as nbexporter
 except:
-    nbexporter = None      # analysis:ignore
+    nbexporter = None    # analysis:ignore
 
 
 def fixpath(path):

--- a/spyderlib/widgets/externalshell/start_ipython_kernel.py
+++ b/spyderlib/widgets/externalshell/start_ipython_kernel.py
@@ -10,14 +10,6 @@
 import sys
 import os.path as osp
 
-# TODO: Move to Jupyter imports in 3.1
-try:
-    import warnings
-    from IPython.utils.shimmodule import ShimWarning
-    warnings.simplefilter('ignore', ShimWarning)
-except:
-    pass
-
 
 def sympy_config(mpl_backend):
     """Sympy configuration"""

--- a/spyderlib/widgets/externalshell/start_ipython_kernel.py
+++ b/spyderlib/widgets/externalshell/start_ipython_kernel.py
@@ -184,7 +184,7 @@ __name__ = '__main__'
 sys.path.insert(0, '')
 
 # Fire up the kernel instance.
-from IPython.kernel.zmq.kernelapp import IPKernelApp
+from ipykernel.kernelapp import IPKernelApp
 ipk_temp = IPKernelApp.instance()
 ipk_temp.config = kernel_config()
 ipk_temp.initialize()

--- a/spyderlib/widgets/externalshell/start_ipython_kernel.py
+++ b/spyderlib/widgets/externalshell/start_ipython_kernel.py
@@ -32,11 +32,11 @@ def kernel_config():
     """Create a config object with IPython kernel options"""
     import os
 
-    from IPython.config.loader import Config, load_pyconfig_files
     from IPython.core.application import get_ipython_dir
     from spyderlib.config.main import CONF
     from spyderlib.utils.programs import is_module_installed
-    
+    from traitlets.config.loader import Config, load_pyconfig_files
+
     # ---- IPython config ----
     try:
         profile_path = osp.join(get_ipython_dir(), 'profile_default')

--- a/spyderlib/widgets/ipython.py
+++ b/spyderlib/widgets/ipython.py
@@ -25,12 +25,12 @@ from spyderlib.qt.QtGui import (QTextEdit, QKeySequence, QWidget, QMenu,
 from spyderlib.qt.QtCore import Signal, Slot, Qt
 import spyderlib.utils.icon_manager as ima
 
-# Jupyter imports
-from qtconsole.rich_jupyter_widget import RichJupyterWidget
-from qtconsole.ansi_code_processor import ANSI_OR_SPECIAL_PATTERN
+# IPython/Jupyter imports
 from IPython.core.application import get_ipython_dir
 from IPython.core.oinspect import call_tip
-from IPython.config.loader import Config, load_pyconfig_files
+from qtconsole.rich_jupyter_widget import RichJupyterWidget
+from qtconsole.ansi_code_processor import ANSI_OR_SPECIAL_PATTERN
+from traitlets.config.loader import Config, load_pyconfig_files
 
 # Local imports
 from spyderlib.config.base import (get_conf_path, get_image_path,

--- a/spyderlib/widgets/ipython.py
+++ b/spyderlib/widgets/ipython.py
@@ -25,12 +25,9 @@ from spyderlib.qt.QtGui import (QTextEdit, QKeySequence, QWidget, QMenu,
 from spyderlib.qt.QtCore import Signal, Slot, Qt
 import spyderlib.utils.icon_manager as ima
 
-# IPython imports
-try:
-    from qtconsole.rich_jupyter_widget import RichJupyterWidget as RichIPythonWidget
-except ImportError:
-    from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
-from IPython.qt.console.ansi_code_processor import ANSI_OR_SPECIAL_PATTERN
+# Jupyter imports
+from qtconsole.rich_jupyter_widget import RichJupyterWidget
+from qtconsole.ansi_code_processor import ANSI_OR_SPECIAL_PATTERN
 from IPython.core.application import get_ipython_dir
 from IPython.core.oinspect import call_tip
 from IPython.config.loader import Config, load_pyconfig_files
@@ -167,7 +164,7 @@ class IPythonPageControlWidget(QTextEdit, BaseEditMixin):
 #-----------------------------------------------------------------------------
 # Shell widget
 #-----------------------------------------------------------------------------
-class IPythonShellWidget(RichIPythonWidget):
+class IPythonShellWidget(RichJupyterWidget):
     """
     Spyder's IPython shell widget
 

--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -59,14 +59,10 @@ from spyderlib.widgets.arraybuilder import SHORTCUT_INLINE, SHORTCUT_TABLE
 from spyderlib.py3compat import to_text_string
 
 try:
-    try:   # Ipython 4
-        import nbformat as nbformat
-        from nbconvert import PythonExporter as nbexporter  
-    except ImportError:  # Ipython 3
-        import IPython.nbformat as nbformat
-        from IPython.nbconvert import PythonExporter as nbexporter
-except ImportError:
-    nbformat = None                      # analysis:ignore
+    import nbformat as nbformat
+    from nbconvert import PythonExporter as nbexporter
+except:
+    nbformat = None  # analysis:ignore
 
 # %% This line is for cell execution testing
 # For debugging purpose:


### PR DESCRIPTION
We are already requiring Jupyter packages (i.e. `qtconsole` and `nbconvert`) since beta2, so this reflects that in our code too.

Besides, we can express more easily and directly our dependencies by using Jupyter packages instead of the big and monolithic IPython.