### PR TITLE
PR: Synchronize entry in Working Directory toolbar with console's current working directory

### DIFF
--- a/spyderlib/plugins/workingdirectory.py
+++ b/spyderlib/plugins/workingdirectory.py
@@ -339,6 +339,7 @@ class WorkingDirectory(QToolBar, SpyderPluginMixin):
         self.refresh_plugin()
         if refresh_explorer:
             self.set_explorer_cwd.emit(directory)
+            self.set_as_current_console_wd()
         self.refresh_findinfiles.emit()
     
     @Slot()


### PR DESCRIPTION
Changing the directory in the interface tree will now affect consoles' cwd. 

This fixes #2910.