### PR TITLE
PR: Enable 'Save All' if there are files to be saved

### DIFF
--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -1334,11 +1334,10 @@ class Editor(SpyderPluginWidget):
                 action.setEnabled(enable)
                 
     def refresh_save_all_action(self):
-        state = False
-        editorstack = self.editorstacks[0]
-        if editorstack.get_stack_count() > 1:
-            state = state or any([finfo.editor.document().isModified()
-                                  for finfo in editorstack.data])
+        """Enable 'Save All' if there are files to be saved"""
+        editorstack = self.get_current_editorstack()
+        state = any(finfo.editor.document().isModified()
+                    for finfo in editorstack.data)
         self.save_all_action.setEnabled(state)
             
     def update_warning_menu(self):


### PR DESCRIPTION
At the moment 'Save All' is enabled if editor stack 0 has more than one file open and if one of the files opened in editor stack 0 has been changed. However, the 'Save All' action saves all changed files in the current editor stack (not editor stack 0), with no condition on the number of files opened.

This change ensures that 'Save All' is enabled precisely when 'Save All' would do something, that is, when the current editor stack has a file that has been changed.