### PR TITLE
PR: Support 'alias mode' for generating the .app bundle in OSX

### DIFF
--- a/create_app.py
+++ b/create_app.py
@@ -86,7 +86,7 @@ INCLUDES = get_stdlib_modules()
 EDIT_EXT = [ext[1:] for ext in EDIT_EXT]
 
 OPTIONS = {
-    'argv_emulation': True,
+    'argv_emulation': False,
     'compressed' : False,
     'optimize': 0,
     'packages': PACKAGES,

--- a/create_app.py
+++ b/create_app.py
@@ -23,6 +23,7 @@ import os
 import os.path as osp
 import subprocess
 import sys
+import re
 
 from IPython.core.completerlib import module_list
 
@@ -105,9 +106,47 @@ setup(
     options={'py2app': OPTIONS}
 )
 
+
+ALIAS_MODE = ('--alias' in sys.argv) or ('-A' in sys.argv)
+if ALIAS_MODE:
+    APP_MAIN_SCRIPT_BASENAME = os.path.basename(APP_MAIN_SCRIPT)
+    bundle_name = os.path.splitext(APP_MAIN_SCRIPT_BASENAME)[0] + '.app'
+    bundle_path = 'dist/' + bundle_name
+
+    # In alias mode, iconfile is a symlink. Replace it with a copy of the real file.
+    os.remove(bundle_path + '/Contents/Resources/' + os.path.basename(OPTIONS['iconfile']))
+    shutil.copy(OPTIONS['iconfile'], bundle_path + '/Contents/Resources/')
+
+    # Copy the launch script into the app bundle
+    shutil.copy(APP_MAIN_SCRIPT, bundle_path + '/Contents/Resources/' + APP_MAIN_SCRIPT_BASENAME)
+    
+    # Change __boot__.py to point to the relocated main script
+    # Also, remove _path_inject() line that points to the developer's environment.
+    boot_path = bundle_path + '/Contents/Resources/__boot__.py'
+    for line in fileinput.input(boot_path, inplace=True):
+        line = re.sub('^DEFAULT_SCRIPT=.*$', 'DEFAULT_SCRIPT="' + APP_MAIN_SCRIPT_BASENAME + '"', line)
+        line = re.sub('^_path_inject.*$', '', line)
+        print(line, end='')
+
+    # sym-link to the environment site-packages directory
+    # This seems to be necessary for Spyder's subprocesses like IPython to work properly.
+    site_packages_path = sys.prefix + '/lib/python2.7/site-packages'
+    os.symlink(site_packages_path, bundle_path + '/Contents/Resources/lib/python2.7/site-packages')
+
+    # Remove site.py because it wants to use site-packages.zip,
+    # which doesn't exist in alias mode
+    os.remove(bundle_path + '/Contents/Resources/site.py')
+    os.remove(bundle_path + '/Contents/Resources/site.pyc')
+    os.remove(bundle_path + '/Contents/Resources/lib/python2.7/site.pyc')
+
+    # Remove script for app
+    os.remove(APP_MAIN_SCRIPT)
+
+    # The post-processing steps below are not necessary in alias mode
+    sys.exit(0)
+
 # Remove script for app
 os.remove(APP_MAIN_SCRIPT)
-
 
 #==============================================================================
 # Post-app creation

--- a/spyderlib/spyder.py
+++ b/spyderlib/spyder.py
@@ -2997,7 +2997,7 @@ def run_spyder(app, options, args):
 
     # Open external files with our Mac app
     if running_in_mac_app():
-        app.sig_open_external_file.connect(main.open_external_file)
+        app.open_external_file.connect(main.open_external_file)
 
     # To give focus again to the last focused widget after restoring
     # the window

--- a/spyderlib/widgets/externalshell/start_ipython_kernel.py
+++ b/spyderlib/widgets/externalshell/start_ipython_kernel.py
@@ -8,6 +8,7 @@
 (see spyderlib/widgets/externalshell/pythonshell.py)"""
 
 import sys
+import os
 import os.path as osp
 
 
@@ -181,7 +182,7 @@ __name__ = '__main__'
 
 # Add current directory to sys.path (like for any standard Python interpreter
 # executed in interactive mode):
-sys.path.insert(0, '')
+sys.path.insert(0, os.getcwd())
 
 # Fire up the kernel instance.
 from ipykernel.kernelapp import IPKernelApp


### PR DESCRIPTION
On OSX, `py2app` has the ability to create an app in 'alias mode', in which the generated app is just a bare-bones wrapper to launch code from the user's python environment.  This is useful when launching Spyder from an Anaconda environment, for example.  (See ContinuumIO/anaconda-issues#634.)

To generate the alias-mode app, use this command:

```
python create_app.py py2app --alias
```

Then try it out:

```
open dist/Spyder-Py2.app
```

I did not edit the `conda.recipe`, but I think it might be a good idea to do so.  For now, you can find an example recipe that generates the alias-mode app in a separate PR: conda/conda-recipes#560

BTW, To get this to work, I had to make a few bug fixes.  Please review those commits carefully.  In particular, you should scrutinize b81e6d0:

```
    start_ipython_kernel: Add current directory to ipython sys.path as an absolute path, not ''
```

For some reason, the ipython kernel was not starting properly in my build.  Some obscure code in `setuptools.pkg_resources` was raising a `ValueError`, complaining about the current directory.  By changing it to an absolute path instead, the error disappeared.  But using `os.getcwd()` is not quite the same as `''` in this context, because in the resulting ipython kernel, the user won't be able to change the effective `sys.path` by merely typing `cd`.
