### PR TITLE
PR: Make backspace move to parent directory in file explorer

### DIFF
--- a/spyderlib/widgets/explorer.py
+++ b/spyderlib/widgets/explorer.py
@@ -371,6 +371,8 @@ class DirView(QTreeView):
             self.rename()
         elif event.key() == Qt.Key_Delete:
             self.delete()
+        elif event.key() == Qt.Key_Backspace:
+            self.go_to_parent_directory()
         else:
             QTreeView.keyPressEvent(self, event)
 


### PR DESCRIPTION
Very simple but needed change to avoid using the mouse :-) when moving within the file explorer

Pressing backspace triggers `go_to_parent_directory` as many OS file managers do.