### PR TITLE
PR: Rename variables (by refactoring) with rope

### DIFF
--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -1959,7 +1959,7 @@ class Editor(SpyderPluginWidget):
     def rename_variable(self):
         """Open rename variable dialog box."""
         editorstack = self.get_current_editorstack()
-        if editorstack is not None:
+        if editorstack:
             editorstack.rename_variable()
 
     #------ Cursor position history management

--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -933,6 +933,9 @@ class Editor(SpyderPluginWidget):
         fixindentation_action = create_action(self, _("Fix indentation"),
                       tip=_("Replace tab characters by space characters"),
                       triggered=self.fix_indentation)
+        rename_action = create_action(self, _("Rename"),
+                                      tip=_("Rename a variable"),
+                                      triggered=self.rename_variable)
 
         gotoline_action = create_action(self, _("Go to line..."),
                                         icon=ima.icon('gotoline'),
@@ -1006,7 +1009,8 @@ class Editor(SpyderPluginWidget):
         self.main.debug_toolbar_actions += debug_toolbar_actions
         
         source_menu_actions = [eol_menu, self.showblanks_action,
-                               trailingspaces_action, fixindentation_action]
+                               trailingspaces_action, fixindentation_action,
+                               rename_action]
         self.main.source_menu_actions += source_menu_actions
         
         source_toolbar_actions = [self.todo_list_action,
@@ -1948,6 +1952,13 @@ class Editor(SpyderPluginWidget):
         editorstack = self.get_current_editorstack()
         editorstack.fix_indentation()
                     
+    @Slot()
+    def rename_variable(self):
+        """Open rename variable dialog box."""
+        editorstack = self.get_current_editorstack()
+        if editorstack is not None:
+            editorstack.rename_variable()
+
     #------ Cursor position history management
     def update_cursorpos_actions(self):
         self.previous_edit_cursor_action.setEnabled(

--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -933,9 +933,11 @@ class Editor(SpyderPluginWidget):
         fixindentation_action = create_action(self, _("Fix indentation"),
                       tip=_("Replace tab characters by space characters"),
                       triggered=self.fix_indentation)
-        rename_action = create_action(self, _("Rename"),
-                                      tip=_("Rename a variable"),
-                                      triggered=self.rename_variable)
+
+        self.rename_action = create_action(self, _("Rename"),
+                                           tip=_("Rename a variable"),
+                                           triggered=self.rename_variable)
+        self.rename_action.setEnabled(False) # cf. register_editorstack()
 
         gotoline_action = create_action(self, _("Go to line..."),
                                         icon=ima.icon('gotoline'),
@@ -1010,7 +1012,7 @@ class Editor(SpyderPluginWidget):
         
         source_menu_actions = [eol_menu, self.showblanks_action,
                                trailingspaces_action, fixindentation_action,
-                               rename_action]
+                               self.rename_action]
         self.main.source_menu_actions += source_menu_actions
         
         source_toolbar_actions = [self.todo_list_action,
@@ -1119,6 +1121,7 @@ class Editor(SpyderPluginWidget):
             editorstack.sig_editor_cursor_position_changed.connect(
                                  self.cursorpos_status.cursor_position_changed)
             editorstack.refresh_eol_chars.connect(self.eol_status.eol_changed)
+            self.rename_action.setEnabled(editorstack.introspector.can_rename())
 
         editorstack.set_help(self.help)
         editorstack.set_io_actions(self.new_action, self.open_action,

--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -934,9 +934,9 @@ class Editor(SpyderPluginWidget):
                       tip=_("Replace tab characters by space characters"),
                       triggered=self.fix_indentation)
 
-        self.rename_action = create_action(self, _("Rename"),
-                                           tip=_("Rename a variable"),
-                                           triggered=self.rename_variable)
+        self.rename_action = create_action(self, _("Rename identifier"),
+                      tip=_("Rename a variable, function or class"),
+                      triggered=self.rename_identifier)
         self.rename_action.setEnabled(False) # cf. register_editorstack()
 
         gotoline_action = create_action(self, _("Go to line..."),
@@ -1956,11 +1956,11 @@ class Editor(SpyderPluginWidget):
         editorstack.fix_indentation()
                     
     @Slot()
-    def rename_variable(self):
-        """Open rename variable dialog box."""
+    def rename_identifier(self):
+        """Open rename identifier dialog box."""
         editorstack = self.get_current_editorstack()
         if editorstack:
-            editorstack.rename_variable()
+            editorstack.rename_identifier()
 
     #------ Cursor position history management
     def update_cursorpos_actions(self):

--- a/spyderlib/utils/introspection/manager.py
+++ b/spyderlib/utils/introspection/manager.py
@@ -131,6 +131,10 @@ class PluginManager(QObject):
         else:
             raise NotImplementedError
 
+    def can_rename(self):
+        """Whether at least one plugin can do a rename."""
+        return bool(self.rename_identifier)
+
     def validate(self):
         for plugin in self.plugins.values():
             plugin.request('validate')
@@ -233,6 +237,10 @@ class IntrospectionManager(QObject):
     def rename(self, code, position, new_name):
         """Returns code with identifier renamed."""
         return self.plugin_manager.rename(code, position, new_name)
+
+    def can_rename(self):
+        """Whether this object can do a rename."""
+        return self.plugin_manager.can_rename()
 
     def validate(self):
         """Validate the plugins"""

--- a/spyderlib/utils/introspection/manager.py
+++ b/spyderlib/utils/introspection/manager.py
@@ -230,6 +230,10 @@ class IntrospectionManager(QObject):
         info = self._get_code_info('info', position, auto=auto)
         self.plugin_manager.send_request(info)
 
+    def rename(self, code, position, new_name):
+        """Returns code with identifier renamed."""
+        return self.plugin_manager.rename(code, position, new_name)
+
     def validate(self):
         """Validate the plugins"""
         self.plugin_manager.validate()

--- a/spyderlib/utils/introspection/manager.py
+++ b/spyderlib/utils/introspection/manager.py
@@ -66,6 +66,13 @@ class PluginManager(QObject):
         self.pending = None
         self.pending_request = None
         self.waiting = False
+        try:
+            # This import is here to avoid circular imports
+            from spyderlib.utils.introspection.rope_plugin import (
+                rename_identifier)
+            self.rename_identifier = rename_identifier
+        except (ImportError, NameError):
+            self.rename_identifier = None
 
     def send_request(self, info):
         """Handle an incoming request from the user."""
@@ -110,6 +117,19 @@ class PluginManager(QObject):
             self.ids[request_id] = plugin.name
         self.timer.stop()
         self.timer.singleShot(LEAD_TIME_SEC * 1000, self._handle_timeout)
+
+    def rename(self, code, position, new_name):
+        """Returns code with identifier renamed.
+        This functionality is only implemented in the rope plugin. If
+        rope is not installed then an NotImplementedException is raised.
+        code (str): old source code
+        position (int): position of identifier to be renamed
+        new_name (str): new name of identifier
+        """
+        if self.rename_identifier:
+            return self.rename_identifier(code, position, new_name)
+        else:
+            raise NotImplementedError
 
     def validate(self):
         for plugin in self.plugins.values():

--- a/spyderlib/utils/introspection/rope_plugin.py
+++ b/spyderlib/utils/introspection/rope_plugin.py
@@ -30,8 +30,13 @@ try:
     except ImportError:
         # rope is not installed
         pass
+    import rope.base.change
+    import rope.base.exceptions
     import rope.base.libutils
+    import rope.base.project
+    import rope.base.resources
     import rope.contrib.codeassist
+    import rope.refactor.rename
 except ImportError:
     pass
 
@@ -251,25 +256,6 @@ class RopePlugin(IntrospectionPlugin):
             except RuntimeError:
                 pass
 
-    def rename(self, code, position, new_name):
-        """
-        Returns code with identifier renamed using Rope
-        code (str): old source code
-        position (int): position of identifier to be renamed
-        new_name (str): new name of identifier
-        """
-        import os
-        temp_filename = 'ropefile-{}.py'.format(os.getpid())
-        temp_module = self.project.root.create_file(temp_filename)
-        temp_module.write(code)
-        from rope.refactor.rename import Rename
-        renamer = Rename(self.project, temp_module, position)
-        changes = renamer.get_changes(new_name)
-        self.project.do(changes)
-        result = temp_module.read()
-        temp_module.remove()
-        return result
-
     # ---- Private API -------------------------------------------------------
 
     def create_rope_project(self, root_path):
@@ -300,6 +286,84 @@ class RopePlugin(IntrospectionPlugin):
         """Close the Rope project"""
         if self.project is not None:
             self.project.close()
+
+
+# ---- Refactoring -------------------------------------------------------
+
+class FakeResource(rope.base.resources.Resource):
+    """Resource for rope project which is held in memory."""
+    def __init__(self, project):
+        super(FakeResource, self).__init__(project, '<string>')
+        self.contents = ''
+
+    def read(self):
+        return self.contents
+
+    def read_bytes(self):
+        return self.contents
+        
+    def write(self, contents):
+        self.contents = contents
+
+    def exists(self):
+        return False
+        
+
+class FakeProject(rope.base.project._Project):
+    """Rope project with one resource held in memory."""
+    def __init__(self):
+        super(FakeProject, self).__init__(fscommands=None)
+
+    def get_resource(self, resource_name=None):
+        """Get a resource in a project.
+
+        A `FakeProject` has only one resource, which is retrieved by
+        passing `None` for `resource_name`. Any other name results in
+        a `exceptions.ResourceNotFound` exception.
+        """
+        if resource_name:
+            raise rope.base.exceptions.ResourceNotFoundError(
+                      'Unknown resource ' + resource_name)
+        else:
+            return FakeResource(self)
+
+    def get_file(self, path):
+        """Get the file with `path`.
+
+        Overrides method in parent class to always raise
+        `NotImplementedError`.
+        """
+        raise NotImplementedError
+
+    def get_folder(self, path):
+        """Get the folder with `path`.
+
+        Overrides method in parent class to always raise
+        `NotImplementedError`.
+        """
+        raise NotImplementedError
+
+    def get_files(self):
+        return []
+
+
+def rename_identifier(code, position, new_name):
+    """
+    Returns code with identifier renamed using Rope
+    code (str): old source code
+    position (int): position of identifier to be renamed
+    new_name (str): new name of identifier
+    """
+    project = FakeProject()
+    module = project.get_resource()
+    module.write(code)
+    renamer = rope.refactor.rename.Rename(project, module, position)
+    changes = renamer.get_changes(new_name, resources=[module])
+    for change in changes.changes:
+        assert isinstance(change, rope.base.change.ChangeContents)
+        assert change.resource == module
+        module.write(change.new_contents)
+    return module.read()
 
 
 if __name__ == '__main__':
@@ -338,5 +402,5 @@ test(1,'''
     assert 'Test docstring' in docs['docstring']
 
     code = 'a = 1; b = 2 * a'
-    newcode = p.rename(code, 0, 'x')
+    newcode = rename_identifier(code, 0, 'x')
     assert newcode == 'x = 1; b = 2 * x'

--- a/spyderlib/widgets/editor.py
+++ b/spyderlib/widgets/editor.py
@@ -1771,12 +1771,12 @@ class EditorStack(QWidget):
         finfo = self.data[index]
         finfo.editor.fix_indentation()
 
-    def rename_variable(self, index=None):
-        """Open rename variable dialog box."""
+    def rename_identifier(self, index=None):
+        """Open rename identifier dialog box."""
         if index is None:
             index = self.get_stack_index()
         finfo = self.data[index]
-        res = finfo.editor.open_rename_variable_dialog()
+        res = finfo.editor.open_rename_identifier_dialog()
         if res:
             try:
                 new_code = self.introspector.rename(*res)

--- a/spyderlib/widgets/editor.py
+++ b/spyderlib/widgets/editor.py
@@ -1771,6 +1771,16 @@ class EditorStack(QWidget):
         finfo = self.data[index]
         finfo.editor.fix_indentation()
 
+    def rename_variable(self, index=None):
+        """Open rename variable dialog box."""
+        if index is None:
+            index = self.get_stack_index()
+        finfo = self.data[index]
+        res = finfo.editor.open_rename_variable_dialog()
+        if res:
+            new_code = self.introspector.rename(*res)
+            finfo.editor.change_text(new_code)
+
     #------ Run
     def run_selection(self):
         """Run selected text or current line in console"""

--- a/spyderlib/widgets/editor.py
+++ b/spyderlib/widgets/editor.py
@@ -1778,8 +1778,14 @@ class EditorStack(QWidget):
         finfo = self.data[index]
         res = finfo.editor.open_rename_variable_dialog()
         if res:
-            new_code = self.introspector.rename(*res)
-            finfo.editor.change_text(new_code)
+            try:
+                new_code = self.introspector.rename(*res)
+            except Exception as err:
+                msg = _('Error encountered during rename:')
+                msg += '<br />' + str(err)
+                QMessageBox.critical(self, _('Rename'), msg)
+            else:
+                finfo.editor.change_text(new_code)
 
     #------ Run
     def run_selection(self):

--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -935,9 +935,13 @@ class CodeEditor(TextEditBaseWidget):
 
     def change_text(self, new_text):
         """Replace contents by new text"""
-        self.setPlainText(new_text)
-        self.document().setModified(True)
-
+        cursor = self.textCursor()
+        old_position = cursor.position()
+        cursor.select(QTextCursor.Document)
+        cursor.insertText(new_text)
+        cursor.setPosition(old_position)
+        self.setTextCursor(cursor)
+        
     def get_current_object(self):
         """Return current object (string) """
         source_code = to_text_string(self.toPlainText())

--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -917,6 +917,13 @@ class CodeEditor(TextEditBaseWidget):
         Returns (source_code, offset, new_name) on success, None otherwise.
         """
         old_name = self.get_current_word()
+        if (not self.is_python_like()
+            or not old_name
+            or sourcecode.is_keyword(to_text_string(old_name))
+            or (self.has_selected_text() and self.get_selected_text() != old_name)
+            or self.in_comment_or_string()):
+            QMessageBox.information(self, _('Rename'), _('Cannot rename here'))
+            return
         msg = _("Enter new name for '{}':").format(old_name)
         new_name, ok = QInputDialog.getText(self, _('Rename'), msg,
                                             text=old_name)

--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -910,6 +910,27 @@ class CodeEditor(TextEditBaseWidget):
             self.setPlainText(text_after)
             self.document().setModified(True)
 
+    def open_rename_variable_dialog(self):
+        """
+        Open rename variable dialog box and return result.
+
+        Returns (source_code, offset, new_name) on success, None otherwise.
+        """
+        old_name = self.get_current_word()
+        msg = "Enter new name for '{}':".format(old_name)
+        new_name, ok = QInputDialog.getText(self, 'Rename', msg, text=old_name)
+        if ok and new_name and new_name != old_name:
+            source_code = to_text_string(self.toPlainText())
+            offset = self.get_position('cursor')
+            return (source_code, offset, new_name)
+        else:
+            return None
+
+    def change_text(self, new_text):
+        """Replace contents by new text"""
+        self.setPlainText(new_text)
+        self.document().setModified(True)
+
     def get_current_object(self):
         """Return current object (string) """
         source_code = to_text_string(self.toPlainText())

--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -917,14 +917,14 @@ class CodeEditor(TextEditBaseWidget):
         Returns (source_code, offset, new_name) on success, None otherwise.
         """
         old_name = self.get_current_word()
-        msg = "Enter new name for '{}':".format(old_name)
-        new_name, ok = QInputDialog.getText(self, 'Rename', msg, text=old_name)
+        msg = _("Enter new name for '{}':").format(old_name)
+        new_name, ok = QInputDialog.getText(self, _('Rename'), msg,
+                                            text=old_name)
         if ok and new_name and new_name != old_name:
             source_code = to_text_string(self.toPlainText())
             offset = self.get_position('cursor')
             return (source_code, offset, new_name)
-        else:
-            return None
+        return None
 
     def change_text(self, new_text):
         """Replace contents by new text"""

--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -910,9 +910,9 @@ class CodeEditor(TextEditBaseWidget):
             self.setPlainText(text_after)
             self.document().setModified(True)
 
-    def open_rename_variable_dialog(self):
+    def open_rename_identifier_dialog(self):
         """
-        Open rename variable dialog box and return result.
+        Open rename identifier dialog box and return result.
 
         Returns (source_code, offset, new_name) on success, None otherwise.
         """


### PR DESCRIPTION
I don't think this is quite ready to be merged yet (and given that you are in beta testing, you may prefer to wait till the next release), but I thought it would be good to solicit feedback. I implemented a basic "rename variable" functionality via rope. This is part of issues #415 and #1937.

I'm quite a beginner with Spyder and GitHub and Python GUI so please don't hesitate to comment.
# User experience
1. You put the cursor on the variable that you want to rename:
   ![rename1](https://cloud.githubusercontent.com/assets/7941918/12705008/bee25f40-c85f-11e5-93bb-e6b8256f0f93.png)
2. You select `Rename` from the `Edit` menu:
   ![rename2](https://cloud.githubusercontent.com/assets/7941918/12705016/eb2a98c4-c85f-11e5-84eb-64e0dd4f51b4.png)
3. You type the new name in the variable box:
   ![rename3](https://cloud.githubusercontent.com/assets/7941918/12705023/1c9de9b0-c860-11e5-8506-31b8d123e463.png)
4. And Spyder renames the variable: 
   ![rename4](https://cloud.githubusercontent.com/assets/7941918/12705027/2d573770-c860-11e5-95aa-6cf11cf3b262.png)

In this example, both occurrences of the variable `num` in the function `double` are renamed to `arg`. Note that the variable `num` in the main block is not renamed (which I think is the correct behaviour) even though it is highlighted in yellow at step 1.
# Implementation
1. In `Editor.get_plugin_actions()`, create the new menu item and connect it to `Editor.rename_variable()`.
2. In `Editor.rename_variable()`, find the current editor stack and call its `rename_variable()`.
3. In `EditorStack.rename_variable()`, find the current editor and call its `open_rename_variable_dialog()`.
4. In `CodeEditor.open_rename_variable_dialog()`, find the word currently highlighted and ask the user for the new variable name. Return this information, or `None` if the user cancels.
5. Back in `EditorStack.rename_variable()`, assuming that the user did not cancel, find the associated `PluginManager` and call its `rename()`.
6. `PluginManager.rename()` searches through all registered introspection plugins for one that implements a `rename()` member function and calls it.
7. Only `RopePlugin` has a `rename()` member function. It saves the current buffer contents in a temporary file and uses the rope library to get the new code with the renamed variable.
8. The new code is returned to `EditorStack.rename_variable()` which calls `CodeEditor.change_text()` which replaces the old code with the new code.
# Questions and to do
- Everything is done synchronously. This is easier to implement, but it may also be confusing for the user: otherwise it may be that the user tries to rename a variable, nothing seems to happen for a second so the user continues editing, but then the rename function suddenly returns, the contents of the buffer is replaced with the result, and the user loses the edits. However, is there a possibility of interference with other plugin actions executed in a different thread (I don't check `plugin.busy`)?
- If it is better done asynchronously, I guess it should wait until #2932 is merged.
- Should I have used Qt signals?
- Is it okay to save the contents to a temporary file? The rope library seems to be written with files in mind, but it may be possible to work around it.
- The rename functionality in rope comes with many options; I should check them and maybe expose them to the user. In particular, rope can do a rename over multiple files. Could this work with Spyder projects (which, as I understand it, are going to be re-implemented)? 
- After renaming the variable, the cursor is moved to the top of the file which is probably annoying for the user.
- It needs to be made more robust: what if the user clicks on 'Rename' if the cursor is on Python keyword or anything else that is not an identifier? What if the file being edited is not Python? What if the new name the user types in is not a valid identifier? What if rope is not installed? What if in `RopePlugin`, `project` is `None` (can this happen?)? What if rope throws an exception for any reason? All this needs to be handled gracefully.
