### PR TITLE
Editor: Fix code completions when working with bootstrap

### DIFF
--- a/spyderlib/utils/introspection/plugin_client.py
+++ b/spyderlib/utils/introspection/plugin_client.py
@@ -12,7 +12,7 @@ import imp
 import sys
 
 # Local imports
-from spyderlib.config.base import debug_print, DEV
+from spyderlib.config.base import debug_print
 from spyderlib.utils.bsdsocket import read_packet, write_packet
 from spyderlib.qt.QtGui import QApplication
 from spyderlib.qt.QtCore import (
@@ -55,9 +55,14 @@ class PluginClient(QObject):
         self.process.setWorkingDirectory(os.path.dirname(__file__))
         processEnvironment = QProcessEnvironment()
         env = self.process.systemEnvironment()
-        if DEV:
-            python_path = imp.find_module('spyderlib')[1]
-            env.append("PYTHONPATH=%s" % osp.dirname(python_path))
+        python_path = osp.dirname(imp.find_module('spyderlib')[1])
+        # Use the current version of the plugin provider if possible.
+        try:
+            provider_path = osp.dirname(imp.find_module(self.plugin_name)[1])
+            python_path = osp.pathsep.join([python_path, provider_path])
+        except ImportError:
+            pass
+        env.append("PYTHONPATH=%s" % python_path)
         for envItem in env:
             envName, separator, envValue = envItem.partition('=')
             processEnvironment.insert(envName, envValue)

--- a/spyderlib/utils/introspection/plugin_client.py
+++ b/spyderlib/utils/introspection/plugin_client.py
@@ -7,11 +7,12 @@
 import socket
 import errno
 import os
+import os.path as osp
 import imp
 import sys
 
 # Local imports
-from spyderlib.config.base import debug_print
+from spyderlib.config.base import debug_print, DEV
 from spyderlib.utils.bsdsocket import read_packet, write_packet
 from spyderlib.qt.QtGui import QApplication
 from spyderlib.qt.QtCore import (
@@ -54,14 +55,9 @@ class PluginClient(QObject):
         self.process.setWorkingDirectory(os.path.dirname(__file__))
         processEnvironment = QProcessEnvironment()
         env = self.process.systemEnvironment()
-        python_path = imp.find_module('spyderlib')[1]
-        # Use the current version of the plugin provider if possible.
-        try:
-            provider_path = imp.find_module(self.plugin_name)[1]
-            python_path = os.sep.join([python_path, provider_path])
-        except ImportError:
-            pass
-        env.append("PYTHONPATH=%s" % python_path)
+        if DEV:
+            python_path = imp.find_module('spyderlib')[1]
+            env.append("PYTHONPATH=%s" % osp.dirname(python_path))
         for envItem in env:
             envName, separator, envValue = envItem.partition('=')
             processEnvironment.insert(envName, envValue)


### PR DESCRIPTION
@blink1073, this fixes completions for me when using bootstrap.

I think the solution is the right one because we should only touch `PYTHONPATH` for the `QProcess` that starts `plugin_server` when using bootstrap. In other situations `plugin_server` should be able to find `spyderlib` (the only third-party module it needs) in `site-packages`.

Please review and let me know what you think about this one, given that now you're our Editor completion expert :-)