### PR TITLE
PR: Remove Jedi special code in tests and other minor fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,10 @@
 
 environment:
   matrix:
-    #- PYTHON:         "C:\\Python27_64"
-    #  PYTHON_VERSION: "2.7"
-    #  PYTHON_ARCH:    "64"
-    #  USE_QT_API:     "PyQt4"
+    - PYTHON:         "C:\\Python27_64"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH:    "64"
+      USE_QT_API:     "PyQt4"
 
     - PYTHON:         "C:\\Python35_64"
       PYTHON_VERSION: "3.5"

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - pyqt
     - rope
     - pyflakes
-    - jedi            0.8*   [py27 or py34]
+    - jedi
     - qtconsole
     - nbconvert
     - pygments

--- a/continuous_integration/appveyor/run_test.bat
+++ b/continuous_integration/appveyor/run_test.bat
@@ -15,12 +15,6 @@ cd C:\projects\tmp
 REM Install the package we created
 conda install -q -y --use-local spyder==3.0.0b2
 
-REM Install missing deps
-if %PYTHON_VERSION%==3.5 (
-    pip install jedi
-    pip install pylint
-)
-
 REM Install extra packages
 conda install -q -y %EXTRA_PACKAGES%
 

--- a/continuous_integration/conda-recipes/qtconsole/meta.yaml
+++ b/continuous_integration/conda-recipes/qtconsole/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: qtconsole
-  version: 4.1.1
+  version: 4.2.0
 
 build:
   number: 99
 
 source:
-  fn:  qtconsole-4.1.1.tar.gz
-  url: https://pypi.python.org/packages/source/q/qtconsole/qtconsole-4.1.1.tar.gz
-  md5: 12f474ab467d2945249d149d2d32f208
+  fn:  qtconsole-4.2.0.tar.gz
+  url: https://pypi.python.org/packages/source/q/qtconsole/qtconsole-4.2.0.tar.gz
+  md5: d08f3f75d2fd7cfa2c863dac0c045d87
 
 requirements:
   build:

--- a/continuous_integration/conda-recipes/spyder/meta.yaml
+++ b/continuous_integration/conda-recipes/spyder/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - sphinx
     - pep8
     - psutil
-    - pylint                 [not win]
+    - pylint
     - qtawesome
     - python.app             [osx]
 

--- a/continuous_integration/conda-recipes/spyder/meta.yaml
+++ b/continuous_integration/conda-recipes/spyder/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - {% if environ.get('USE_QT_API') == 'PyQt4' %} pyqt {% else %} pyqt5 {% endif %}
     - rope
     - pyflakes
-    - jedi                  [py27 or py34]
+    - jedi
     - qtconsole
     - nbconvert
     - pygments

--- a/continuous_integration/travis/run_test.sh
+++ b/continuous_integration/travis/run_test.sh
@@ -30,11 +30,6 @@ if [ "$USE_CONDA" = true ] ; then
 
     # Install extra packages
     conda install -q $EXTRA_PACKAGES
-
-    # Jedi is not available in conda
-    if [ "$TRAVIS_PYTHON_VERSION" = "3.5" ]; then
-        pip install jedi
-    fi
 else
     cd $FULL_SPYDER_CLONE
     pip install dist/spyder-*.whl


### PR DESCRIPTION
Now that #2932 is in, we can safely remove some code that we were using just for Jedi 0.8.1