### PR TITLE
Fix bug in get encoding from "coding" comment line

### DIFF
--- a/spyderlib/utils/encoding.py
+++ b/spyderlib/utils/encoding.py
@@ -110,8 +110,6 @@ def get_coding(text):
             # sometimes we find a false encoding that can result in errors
             if codec in CODECS:
                 return codec
-            else:
-                return None
     return None
 
 def decode(text):

--- a/spyderlib/utils/encoding.py
+++ b/spyderlib/utils/encoding.py
@@ -106,10 +106,10 @@ def get_coding(text):
     for line in text.splitlines()[:2]:
         result = CODING_RE.search(to_text_string(line))
         if result:
-            c = result.group(1)
+            codec = result.group(1)
             # sometimes we find a false encoding that can result in errors
-            if c in CODECS:
-                return c
+            if codec in CODECS:
+                return codec
             else:
                 return None
     return None

--- a/spyderlib/utils/encoding.py
+++ b/spyderlib/utils/encoding.py
@@ -106,7 +106,12 @@ def get_coding(text):
     for line in text.splitlines()[:2]:
         result = CODING_RE.search(to_text_string(line))
         if result:
-            return result.group(1)
+            c = result.group(1)
+            # sometimes we find a false encoding that can result in errors
+            if c in CODECS:
+                return c
+            else:
+                return None
     return None
 
 def decode(text):


### PR DESCRIPTION
The get_coding function can return an encoding that is not valid. This caused spyder to crash during startup. This pull request makes sure only valid encodings are returned.

An example text which returns an invalid encoding:

`# Try decoding as utf-8 bytestring        return __builtins__.unicode(msg, encoding="utf-8")    except:        pass    try:        # Try guessing system default encoding and decode as such        import locale        return __builtins__.unicode(msg, encoding=locale.getpreferredencoding())    except:        pass    try:        # Attempt using filesystem encoding        import sys        return __builtins__.unicode(msg, encoding=sys.getfilesystemencoding())    except: `
