### PR TITLE
Implement a new Async Server approach based on pyzmq to get completions on the Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,17 +139,18 @@ a Python version greater than 2.7 (Python 3.2 is not supported anymore).
 * **Python** 2.7 or 3.3+
 * **PyQt5** 5.2+ or **PyQt4** 4.6+: PyQt5 is recommended.
 * **qtconsole**: Enhanced Python interpreter.
-* **Rope** and **Jedi**: Editor code completion, calltips
+* **Rope** and **Jedi**: Editor code completion, calltips.
   and go-to-definition.
 * **Pyflakes**: Real-time code analysis.
-* **Sphinx**: Rich text mode for the Help pane
+* **Sphinx**: Rich text mode for the Help pane.
 * **Pygments**: Syntax highlighting for all file types it supports.
 * **Pylint**: Static code analysis.
 * **Pep8**: Style analysis.
 * **Psutil**: CPU and memory usage on the status bar.
 * **Nbconvert**: Manipulation of notebooks in the Editor.
-* **Qtawesome**: To have an icon theme based on FontAwesome
-* **Pickleshare**: Show import completions on the Python consoles
+* **Qtawesome**: To have an icon theme based on FontAwesome.
+* **Pickleshare**: Show import completions on the Python consoles.
+* **PyZMQ**: Run introspection services asynchronously.
 
 ### Optional dependencies
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ a Python version greater than 2.7 (Python 3.2 is not supported anymore).
 * **Python** 2.7 or 3.3+
 * **PyQt5** 5.2+ or **PyQt4** 4.6+: PyQt5 is recommended.
 * **qtconsole**: Enhanced Python interpreter.
-* **Rope** and **Jedi**: Editor code completion, calltips.
+* **Rope** and **Jedi**: Editor code completion, calltips
   and go-to-definition.
 * **Pyflakes**: Real-time code analysis.
 * **Sphinx**: Rich text mode for the Help pane.

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - psutil
     - pylint
     - qtawesome
+    - pyzmq
     - python.app             [osx]
 
 about:

--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,8 @@ install_requires = [
     'pylint',
     'psutil',
     'qtawesome',
-    'pickleshare'
+    'pickleshare',
+    'pyzmq'
 ]
 
 if 'setuptools' in sys.modules:

--- a/spyderlib/utils/introspection/manager.py
+++ b/spyderlib/utils/introspection/manager.py
@@ -132,6 +132,8 @@ class PluginManager(QObject):
     def _finalize(self, response):
         self.waiting = False
         self.pending = None
+        if not self.info:
+            return
         delta = time.time() - self._start_time
         debug_print('%s request from %s finished: "%s" in %.1f sec'
             % (self.info.name, response['name'],

--- a/spyderlib/utils/introspection/manager.py
+++ b/spyderlib/utils/introspection/manager.py
@@ -132,15 +132,14 @@ class PluginManager(QObject):
     def _finalize(self, response):
         self.waiting = False
         self.pending = None
-        if not self.info:
-            return
-        delta = time.time() - self._start_time
-        debug_print('%s request from %s finished: "%s" in %.1f sec'
-            % (self.info.name, response['name'],
-               str(response['result'])[:100], delta))
-        response['info'] = self.info
-        self.introspection_complete.emit(response)
-        self.info = None
+        if self.info:
+            delta = time.time() - self._start_time
+            debug_print('%s request from %s finished: "%s" in %.1f sec'
+                % (self.info.name, response['name'],
+                   str(response['result'])[:100], delta))
+            response['info'] = self.info
+            self.introspection_complete.emit(response)
+            self.info = None
         if self.pending_request:
             info = self.pending_request
             self.pending_request = None

--- a/spyderlib/utils/introspection/plugin_client.py
+++ b/spyderlib/utils/introspection/plugin_client.py
@@ -22,7 +22,7 @@ from spyderlib.qt.QtCore import (
 
 
 # Heartbeat timer in milliseconds
-HEATBEAT = 5000
+HEARTBEAT = 5000
 
 
 class AsyncClient(QObject):
@@ -58,7 +58,7 @@ class AsyncClient(QObject):
         # Set up the heartbeat timer.
         self.timer = QTimer(self)
         self.timer.timeout.connect(self._heartbeat)
-        self.timer.start(HEATBEAT)
+        self.timer.start(HEARTBEAT)
 
     def run(self):
         """Handle the connection with the server.

--- a/spyderlib/utils/introspection/plugin_client.py
+++ b/spyderlib/utils/introspection/plugin_client.py
@@ -4,165 +4,193 @@
 # Licensed under the terms of the MIT License
 # (see spyderlib/__init__.py for details)
 
-import socket
-import errno
 import os
 import os.path as osp
 import imp
 import sys
 
+import zmq
+
 # Local imports
 from spyderlib.config.base import debug_print, get_module_path
-from spyderlib.utils.bsdsocket import read_packet, write_packet
 from spyderlib.qt.QtGui import QApplication
 from spyderlib.qt.QtCore import (
-    QThread, QProcess, Signal, QObject, QProcessEnvironment
+    QSocketNotifier, QProcess, Signal, QObject, QProcessEnvironment,
+    QTimer
 )
-from spyderlib.utils.introspection.utils import connect_to_port
 
 
-class PluginClient(QObject):
+# Heartbeat timer in milliseconds
+HEATBEAT = 5000
+
+
+class AsyncClient(QObject):
 
     """
-    A class which handles a connection to a plugin through a QProcess.
+    A class which handles a connection to a client through a QProcess.
     """
 
-    # Emitted when the plugin has initialized.
+    # Emitted when the client has initialized.
     initialized = Signal()
 
-    # Emitted when the plugin has failed to load.
+    # Emitted when the client errors.
     errored = Signal()
 
     # Emitted when a request response is received.
-    request_handled = Signal(object)
+    received = Signal(object)
 
-    def __init__(self, plugin_name, executable=None):
-        super(PluginClient, self).__init__()
-        self.plugin_name = plugin_name
+    def __init__(self, executable, target, extra_args=None, libs=None,
+                 cwd=None, env=None):
+        super(AsyncClient, self).__init__()
         self.executable = executable or sys.executable
-        self.start()
-
-    def start(self):
-        """Start a new connection with the plugin.
-        """
-        self._initialized = False
-        plugin_name = self.plugin_name
-        self.sock, server_port = connect_to_port()
-        self.sock.listen(2)
+        self.extra_args = extra_args
+        self.target = target
+        self.libs = libs
+        self.cwd = cwd
+        self.env = env
+        self.is_initialized = False
+        self.closing = False
+        self.request_num = 0
+        self.context = zmq.Context()
         QApplication.instance().aboutToQuit.connect(self.close)
 
+        # Set up the heartbeat timer.
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self._heartbeat)
+        self.timer.start(HEATBEAT)
+
+    def run(self):
+        """Handle the connection with the server.
+        """
+        # Set up the zmq port.
+        self.socket = self.context.socket(zmq.PAIR)
+        self.port = self.socket.bind_to_random_port('tcp://*')
+
+        # Set up the process.
         self.process = QProcess(self)
-        self.process.setWorkingDirectory(os.path.dirname(__file__))
+        if self.cwd:
+            self.process.setWorkingDirectory(self.cwd)
+        p_args = ['-u', self.target, str(self.port)]
+        if self.extra_args is not None:
+            p_args += self.extra_args
+
+        # Set up environment variables.
         processEnvironment = QProcessEnvironment()
         env = self.process.systemEnvironment()
-        python_path = osp.dirname(get_module_path('spyderlib'))
-        # Use the current version of the plugin provider if possible.
-        try:
-            provider_path = osp.dirname(imp.find_module(self.plugin_name)[1])
-            python_path = osp.pathsep.join([python_path, provider_path])
-        except ImportError:
-            pass
-        env.append("PYTHONPATH=%s" % python_path)
+        if self.env and 'PYTHONPATH' not in self.env:
+            python_path = osp.dirname(get_module_path('spyderlib'))
+            # Add the libs to the python path.
+            for lib in self.libs:
+                try:
+                    path = osp.dirname(imp.find_module(lib)[1])
+                    python_path = osp.pathsep.join([python_path, path])
+                except ImportError:
+                    pass
+            env.append("PYTHONPATH=%s" % python_path)
+        if self.env:
+            env.update(self.env)
         for envItem in env:
             envName, separator, envValue = envItem.partition('=')
             processEnvironment.insert(envName, envValue)
         self.process.setProcessEnvironment(processEnvironment)
-        p_args = ['-u', 'plugin_server.py', str(server_port), plugin_name]
 
-        self.listener = PluginListener(self.sock)
-        self.listener.request_handled.connect(self.request_handled.emit)
-        self.listener.initialized.connect(self._on_initialized)
-        self.listener.start()
-
+        # Start the process and wait for started.
         self.process.start(self.executable, p_args)
         self.process.finished.connect(self._on_finished)
         running = self.process.waitForStarted()
         if not running:
-            raise IOError('Could not start plugin %s' % plugin_name)
+            raise IOError('Could not start %s' % self)
 
-    def send(self, request):
-        """Send a request to the plugin.
+        # Set up the socket notifer.
+        fid = self.socket.getsockopt(zmq.FD)
+        self.notifier = QSocketNotifier(fid, QSocketNotifier.Read, self)
+        self.notifier.activated.connect(self._on_msg_received)
+
+    def request(self, func_name, *args, **kwargs):
+        """Send a request to the server.
+
+        The response will be a dictionary with the following fields:
+
+        func_name, args, kwargs, request_num
+
+        It will also have a 'result' field with the object returned by
+        the function call or or an 'error' field with a traceback.
         """
-        if not self._initialized:
+        if not self.is_initialized:
             return
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.connect(("127.0.0.1", self.client_port))
-        request['plugin_name'] = self.plugin_name
-        write_packet(sock, request)
-        sock.close()
+        self.request_num += 1
+        request = dict(func_name=func_name,
+                       args=args,
+                       kwargs=kwargs,
+                       request_num=self.request_num)
+        try:
+            self.socket.send_pyobj(request)
+        except zmq.ZMQError:
+            pass
+        return self.request_num
 
     def close(self):
-        self.process.kill()
-        self.process.waitForFinished(200)
-        self.sock.close()
-
-    def _on_initialized(self, port):
-        debug_print('Initialized %s' % self.plugin_name)
-        self._initialized = True
-        self.client_port = port
-        self.initialized.emit()
+        self.closing = True
+        self.timer.stop()
+        self.request('server_quit')
+        self.process.waitForFinished(1000)
+        self.context.destroy(0)
 
     def _on_finished(self):
-        debug_print('finished %s %s' % (self.plugin_name, self._initialized))
-        if self._initialized:
-            self.start()
+        if self.closing:
+            return
+        if self.is_initialized:
+            debug_print('Restarting %s' % self)
+            self.is_initialized = False
+            self.notifier.setEnabled(False)
+            self.run()
         else:
-            self._initialized = False
+            debug_print('Errored %s' % self)
             debug_print(self.process.readAllStandardOutput())
             debug_print(self.process.readAllStandardError())
             self.errored.emit()
 
-
-class PluginListener(QThread):
-
-    """A plugin response listener.
-    """
-
-    # Emitted when the plugin has intitialized.
-    initialized = Signal(int)
-
-    # Emitted when a request response has been received.
-    request_handled = Signal(object)
-
-    def __init__(self, sock):
-        super(PluginListener, self).__init__()
-        self.sock = sock
-        self._initialized = False
-
-    def run(self):
-        while True:
+    def _on_msg_received(self):
+        self.notifier.setEnabled(False)
+        while 1:
             try:
-                conn, _addr = self.sock.accept()
-            except socket.error as e:
-                badfd = errno.WSAEBADF if os.name == 'nt' else errno.EBADF
-                extra = errno.WSAENOTSOCK if os.name == 'nt' else badfd
-                if e.args[0] in [errno.ECONNABORTED, badfd, extra]:
-                    return
-                # See Issue 1275 for details on why errno EINTR is
-                # silently ignored here.
-                eintr = errno.WSAEINTR if os.name == 'nt' else errno.EINTR
-                if e.args[0] == eintr:
-                    continue
-                raise
-            if not self._initialized:
-                server_port = read_packet(conn)
-                if isinstance(server_port, int):
-                    self._initialized = True
-                    self.initialized.emit(server_port)
-            else:
-                self.request_handled.emit(read_packet(conn))
+                resp = self.socket.recv_pyobj(flags=zmq.NOBLOCK)
+            except zmq.ZMQError:
+                self.notifier.setEnabled(True)
+                return
+            if not self.is_initialized:
+                self.is_initialized = True
+                debug_print('Initialized %s' % self)
+                self.initialized.emit()
+                continue
+            self.received.emit(resp)
+
+    def _heartbeat(self):
+        if not self.is_initialized:
+            return
+        self.socket.send_pyobj('server_heartbeat')
+
+
+class PluginClient(AsyncClient):
+
+    def __init__(self, plugin_name, executable=None, env=None):
+        cwd = os.path.dirname(__file__)
+        super(PluginClient, self).__init__(executable=executable,
+            target='plugin_server.py', cwd=cwd, env=env,
+            extra_args=[plugin_name], libs=[plugin_name])
 
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)
     plugin = PluginClient('jedi')
+    plugin.run()
 
     def handle_return(value):
         print(value)
-        if value['method'] == 'foo':
+        if value['func_name'] == 'foo':
             app.quit()
         else:
-            plugin.send(dict(method='foo'))
+            plugin.request('foo')
 
     def handle_errored():
         print('errored')
@@ -170,11 +198,10 @@ if __name__ == '__main__':
 
     def start():
         print('start')
-        plugin.send(dict(method='validate'))
+        plugin.request('validate')
 
     plugin.errored.connect(handle_errored)
-
-    plugin.request_handled.connect(handle_return)
+    plugin.received.connect(handle_return)
     plugin.initialized.connect(start)
 
     app.exec_()

--- a/spyderlib/utils/introspection/plugin_server.py
+++ b/spyderlib/utils/introspection/plugin_server.py
@@ -4,101 +4,76 @@
 # Licensed under the terms of the MIT License
 # (see spyderlib/__init__.py for details)
 
-import threading
-import socket
-import errno
-import os
 import sys
-import time
-import atexit
+import traceback
 
-# Local imports
-from spyderlib.utils.introspection.utils import connect_to_port
-from spyderlib.py3compat import Queue
-from spyderlib.utils.bsdsocket import read_packet, write_packet
+import zmq
 
 
-# Timeout in seconds
-TIMEOUT = 60
+# Timeout in milliseconds
+TIMEOUT = 10000
 
 
-class PluginServer(object):
+class AsyncServer(object):
+
+    """
+    Introspection server, provides a separate process
+    for interacting with an object.
+    """
+
+    def __init__(self, port, *args):
+        self.port = port
+        self.object = self.initialize(*args)
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.PAIR)
+        self.socket.connect("tcp://localhost:%s" % port)
+        self.socket.send_pyobj(port)
+
+    def initialize(self, plugin_name):
+        """Initialize the object and return it.
+        """
+        return object()
+
+    def run(self):
+        """Handle requests from the client.
+        """
+        while 1:
+            events = self.socket.poll(TIMEOUT)
+            if events == 0:
+                print('Timed out')
+                return
+            request = self.socket.recv_pyobj()
+            if request['func_name'] == 'server_quit':
+                print('Quitting')
+                sys.stdout.flush()
+                return
+            try:
+                func = getattr(self.object, request['func_name'])
+                args = request.get('args', [])
+                kwargs = request.get('kwargs', {})
+                request['result'] = func(*args, **kwargs)
+            except Exception:
+                request['error'] = traceback.format_exc()
+            self.socket.send_pyobj(request)
+
+
+class PluginServer(AsyncServer):
 
     """
     Introspection plugin server, provides a separate process
-    for interacting with the plugin.
+    for interacting with a plugin.
     """
 
-    def __init__(self, client_port, plugin_name):
+    def initialize(self, plugin_name):
+        """Initialize the object and return it.
+        """
         mod_name = plugin_name + '_plugin'
         mod = __import__('spyderlib.utils.introspection.' + mod_name,
                          fromlist=[mod_name])
         cls = getattr(mod, '%sPlugin' % plugin_name.capitalize())
         plugin = cls()
         plugin.load_plugin()
-        self.tlast = time.time()
-        self.plugin = plugin
-
-        self._client_port = int(client_port)
-        sock, self.server_port = connect_to_port()
-        sock.listen(2)
-        atexit.register(sock.close)
-        self._server_sock = sock
-
-        self.queue = Queue.Queue()
-        self._listener = threading.Thread(target=self.listen)
-        self._listener.setDaemon(True)
-        self._listener.start()
-
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.connect(("127.0.0.1", self._client_port))
-        write_packet(sock, self.server_port)
-        sock.close()
-
-    def listen(self):
-        """Listen for requests"""
-        while True:
-            try:
-                conn, _addr = self._server_sock.accept()
-            except socket.error as e:
-                badfd = errno.WSAEBADF if os.name == 'nt' else errno.EBADF
-                extra = errno.WSAENOTSOCK if os.name == 'nt' else badfd
-                if e.args[0] in [errno.ECONNABORTED, badfd, extra]:
-                    return
-                # See Issue 1275 for details on why errno EINTR is
-                # silently ignored here.
-                eintr = errno.WSAEINTR if os.name == 'nt' else errno.EINTR
-                if e.args[0] == eintr:
-                    continue
-                raise
-            self.queue.put(read_packet(conn))
-
-    def run(self):
-        """Handle requests"""
-        while 1:
-            # Get most recent request
-            request = None
-            while 1:
-                try:
-                    request = self.queue.get(True, 0.01)
-                except Queue.Empty:
-                    break
-            if request is None:
-                if time.time() - self.tlast > TIMEOUT:
-                    sys.exit('Program timed out')
-                continue
-            self.tlast = time.time()
-            try:
-                method = getattr(self.plugin, request['method'])
-                args = request.get('args', [])
-                kwargs = request.get('kwargs', {})
-                request['result'] = method(*args, **kwargs)
-            except Exception as e:
-                request['error'] = str(e)
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.connect(("127.0.0.1", self._client_port))
-            write_packet(sock, request)
-            sock.close()
+        return plugin
 
 
 if __name__ == '__main__':

--- a/spyderlib/utils/introspection/utils.py
+++ b/spyderlib/utils/introspection/utils.py
@@ -13,8 +13,6 @@ import os
 import pickle
 import os.path as osp
 import re
-import socket
-import errno
 
 from spyderlib.utils.misc import memoize
 
@@ -226,24 +224,6 @@ def get_parent_until(path):
         except ImportError:
             break
     return '.'.join(reversed(items))
-
-
-def connect_to_port(base_port=20128):
-    """Connect and bind to the next available port."""
-    while 1:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        try:
-            sock.bind(("127.0.0.1", base_port))
-        except Exception as e:
-            if e.errno == errno.EADDRINUSE:
-                base_port += 1
-                continue
-            else:
-                raise
-        else:
-            break
-    return sock, base_port
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements streamlined async server for introspection, fixes #3033, fixes #3041.

Uses a single port for communication that is managed by zmq.
Uses socket notification rather than a thread in the client.
Adds a heartbeat to keep the server alive.
The main classes will be moved elsewhere and used for code analysis background tasks after beta3.