### PR TITLE
sitecustomize: import matplotlib only when needed

### DIFF
--- a/spyderlib/widgets/externalshell/sitecustomize.py
+++ b/spyderlib/widgets/externalshell/sitecustomize.py
@@ -20,6 +20,8 @@ import shlex
 
 
 PY2 = sys.version[0] == '2'
+IS_EXT_INTERPRETER = os.environ.get('EXTERNAL_INTERPRETER', '').lower() == "true"
+IS_IPYTHON = os.environ.get("IPYTHON_KERNEL", "").lower() == "true"
 
 
 #==============================================================================
@@ -168,8 +170,6 @@ if os.name == 'nt':
 #==============================================================================
 # Settings for our MacOs X app
 #==============================================================================
-IS_EXT_INTERPRETER = os.environ.get('EXTERNAL_INTERPRETER', '').lower() == "true"
-
 if sys.platform == 'darwin':
     from spyderlib.config.base import MAC_APP_NAME
     if MAC_APP_NAME in __file__:
@@ -219,10 +219,11 @@ if PY2 and sys.platform.startswith('linux'):
 # This prevents a kernel crash with the inline backend in our IPython
 # consoles on Linux and Python 3 (Fixes Issue 2257)
 #==============================================================================
-try:
-    import matplotlib
-except ImportError:
-    matplotlib = None   # analysis:ignore
+if IS_IPYTHON and sys.version[0] == '3' and sys.platform.startswith('linux'):
+    try:
+        import matplotlib
+    except ImportError:
+        matplotlib = None   # analysis:ignore
 
 
 #==============================================================================
@@ -324,8 +325,6 @@ else:
 #==============================================================================
 # Matplotlib settings
 #==============================================================================
-IS_IPYTHON = os.environ.get("IPYTHON_KERNEL", "").lower() == "true"
-
 if matplotlib is not None:
     if not IS_IPYTHON:
         mpl_backend = os.environ.get("SPY_MPL_BACKEND", "")


### PR DESCRIPTION
This PR simply aims at fixing Issue 2257 without importing ``matplotlib`` systematically.

It's really not a good thing to import systematically ``matplotlib`` when executing *any* script from Spyder. Importing ``matplotlib`` is not innocuous at all: it clutters unnecessarily ``sys.path`` and ``sys.modules`` and it affects execution speed. Changes made on ``sitecustomize.py`` should be done very carefully, keeping in mind that executing a script within or outside Spyder should be as close as possible.

So, in this case, I strongly recommend to import ``matplotlib`` only when necessary, that is (according to Issue 2257) when the following criteria are met:

  * IPython console
  * Python 3
  * Linux

In the proposed commit, I just need confirmation that ``IS_IPYTHON`` is the right test for checking if we are "in our IPython consoles" (as stated in the comment above).