### PR TITLE
Fix interrupt handling on Windows

### DIFF
--- a/spyderlib/app/spyder.py
+++ b/spyderlib/app/spyder.py
@@ -285,8 +285,7 @@ class MainWindow(QMainWindow):
                 import win32api
                 win32api.SetConsoleCtrlHandler(signal_handler, True)
             except ImportError:
-                version = '.'.join(map(str, sys.version_info[:2]))
-                raise Exception('pywin32 not installed for Python ' + version)
+                pass
         else:
             signal.signal(signal.SIGTERM, signal_handler)
 

--- a/spyderlib/app/spyder.py
+++ b/spyderlib/app/spyder.py
@@ -274,7 +274,7 @@ class MainWindow(QMainWindow):
 
         self.debug_print("Start of MainWindow constructor")
 
-        def signal_handler(signum, frame):
+        def signal_handler(signum, frame=None):
             """Handler for signals."""
             sys.stdout.write('Handling signal: %s\n' % signum)
             sys.stdout.flush()


### PR DESCRIPTION
The Windows `SetConsoleCtrlHandler` was only sending one argument to the function.