### PR TITLE
Add some indentation tests

### DIFF
--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -2924,44 +2924,6 @@ class TestWidget(QSplitter):
         self.classtree.set_current_editor(self.editor, filename, False, False)
 
 
-class TestIndent(CodeEditor):
-    def __init__(self, parent=None):
-        CodeEditor.__init__(self, parent)
-        self.setup_editor(linenumbers=True, markers=True, tab_mode=False,
-                          font=QFont("Courier New", 10),
-                          show_blanks=True, color_scheme='Zenburn',
-                          language='Python')
-        self.tmp_filename = "test_spyder.tmp"
-
-    def test_fix_indent(self):
-            text = self._get_indent_fix("this_tuple = (1, 2)\n")
-            assert text == "this_tuple = (1, 2)\n", repr(text)
-
-            text = self._get_indent_fix("def function():\n    # Comment\n")
-            assert text == "def function():\n    # Comment\n    ", repr(text)
-
-            # fails
-            text = self._get_indent_fix("\ndef function():\n")
-            assert text == "\ndef function():\n    ", repr(text)
-
-#            text = self._get_indent_fix("def function():\n# Comment\n")
-#            assert text == "def function():\n# Comment\n    ", repr(text)
-#
-#            text = self._get_indent_fix("def function():\n")
-#            assert text == "def function():\n    ", repr(text)
-#
-#            text = self._get_indent_fix("open_parenthesis(\n")
-#            assert text == "open_parenthesis(\n    ", repr(text)
-
-    def _get_indent_fix(self, text):
-        self.set_text(text)
-        cursor = self.textCursor()
-        cursor.movePosition(QTextCursor.End)
-        self.setTextCursor(cursor)
-        self.fix_indent()
-        return to_text_string(self.toPlainText())
-
-
 def test(fname):
     from spyderlib.utils.qthelpers import qapplication
     app = qapplication(test_time=5)
@@ -2976,10 +2938,6 @@ def test(fname):
     results = check_with_pyflakes(source_code, fname) + \
               check_with_pep8(source_code, fname)
     win.editor.process_code_analysis(results)
-
-    win_indent = TestIndent()
-    win_indent.show()
-    win_indent.test_fix_indent()
 
     sys.exit(app.exec_())
 

--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -2929,7 +2929,8 @@ class TestIndent(CodeEditor):
         CodeEditor.__init__(self, parent)
         self.setup_editor(linenumbers=True, markers=True, tab_mode=False,
                           font=QFont("Courier New", 10),
-                          show_blanks=True, color_scheme='Zenburn')
+                          show_blanks=True, color_scheme='Zenburn',
+                          language='Python')
         self.tmp_filename = "test_spyder.tmp"
 
     def test_fix_indent(self):
@@ -2940,8 +2941,8 @@ class TestIndent(CodeEditor):
             assert text == "def function():\n    # Comment\n    ", repr(text)
 
             # fails
-#            text = self._get_indent_fix("\ndef function():\n")  # Works in editor...
-#            assert text == "\ndef function():\n    ", repr(text)
+            text = self._get_indent_fix("\ndef function():\n")
+            assert text == "\ndef function():\n    ", repr(text)
 
 #            text = self._get_indent_fix("def function():\n# Comment\n")
 #            assert text == "def function():\n# Comment\n    ", repr(text)

--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -2924,6 +2924,43 @@ class TestWidget(QSplitter):
         self.classtree.set_current_editor(self.editor, filename, False, False)
 
 
+class TestIndent(CodeEditor):
+    def __init__(self, parent=None):
+        CodeEditor.__init__(self, parent)
+        self.setup_editor(linenumbers=True, markers=True, tab_mode=False,
+                          font=QFont("Courier New", 10),
+                          show_blanks=True, color_scheme='Zenburn')
+        self.tmp_filename = "test_spyder.tmp"
+
+    def test_fix_indent(self):
+            text = self._get_indent_fix("this_tuple = (1, 2)\n")
+            assert text == "this_tuple = (1, 2)\n", repr(text)
+
+            text = self._get_indent_fix("def function():\n    # Comment\n")
+            assert text == "def function():\n    # Comment\n    ", repr(text)
+
+            # fails
+#            text = self._get_indent_fix("\ndef function():\n")  # Works in editor...
+#            assert text == "\ndef function():\n    ", repr(text)
+
+#            text = self._get_indent_fix("def function():\n# Comment\n")
+#            assert text == "def function():\n# Comment\n    ", repr(text)
+#
+#            text = self._get_indent_fix("def function():\n")
+#            assert text == "def function():\n    ", repr(text)
+#
+#            text = self._get_indent_fix("open_parenthesis(\n")
+#            assert text == "open_parenthesis(\n    ", repr(text)
+
+    def _get_indent_fix(self, text):
+        self.set_text(text)
+        cursor = self.textCursor()
+        cursor.movePosition(QTextCursor.End)
+        self.setTextCursor(cursor)
+        self.fix_indent()
+        return to_text_string(self.toPlainText())
+
+
 def test(fname):
     from spyderlib.utils.qthelpers import qapplication
     app = qapplication(test_time=5)
@@ -2938,6 +2975,10 @@ def test(fname):
     results = check_with_pyflakes(source_code, fname) + \
               check_with_pep8(source_code, fname)
     win.editor.process_code_analysis(results)
+
+    win_indent = TestIndent()
+    win_indent.show()
+    win_indent.test_fix_indent()
 
     sys.exit(app.exec_())
 

--- a/spyderlib/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyderlib/widgets/sourcecode/tests/test_autoindent.py
@@ -70,5 +70,11 @@ def test_open_parenthesis():
     assert text == "open_parenthesis(\n    ", repr(text)
 
 
+@pytest.mark.xfail
+def test_brackets_alone():
+    text = get_indent_fix("def function():\n    print []\n")
+    assert text == "def function():\n    print []\n    ", repr(text)
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyderlib/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyderlib/widgets/sourcecode/tests/test_autoindent.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2009- The Spyder Development Team
+# Licensed under the terms of the MIT License
+#
+
+"""
+Tests for the autoindent features
+"""
+
+# Third party imports
+from qtpy.QtGui import QTextCursor
+import pytest
+
+# Local imports
+from spyderlib.utils.qthelpers import qapplication
+from spyderlib.py3compat import to_text_string
+from spyderlib.widgets.sourcecode.codeeditor import CodeEditor
+
+
+# --- Fixtures
+# -----------------------------------------------------------------------------
+def get_indent_fix(text):
+    app = qapplication()
+    editor = CodeEditor(parent=None)
+    editor.setup_editor(language='Python')
+
+    editor.set_text(text)
+    cursor = editor.textCursor()
+    cursor.movePosition(QTextCursor.End)
+    editor.setTextCursor(cursor)
+    editor.fix_indent()
+    return to_text_string(editor.toPlainText())
+
+
+# --- Tests
+# -----------------------------------------------------------------------------
+def test_simple_tuple():
+    text = get_indent_fix("this_tuple = (1, 2)\n")
+    assert text == "this_tuple = (1, 2)\n"
+
+
+def test_def_with_newline():
+    text = get_indent_fix("\ndef function():\n")
+    assert text == "\ndef function():\n    ", repr(text)
+
+
+def test_def_with_indented_comment():
+    text = get_indent_fix("def function():\n    # Comment\n")
+    assert text == "def function():\n    # Comment\n    ", repr(text)
+
+
+# --- Failing tests
+# -----------------------------------------------------------------------------
+@pytest.mark.xfail
+def test_simple_def():
+    text = get_indent_fix("def function():\n")
+    assert text == "def function():\n    ", repr(text)
+
+
+@pytest.mark.xfail
+def test_def_with_unindented_comment():
+    text = get_indent_fix("def function():\n# Comment\n")
+    assert text == "def function():\n# Comment\n    ", repr(text)
+
+
+@pytest.mark.xfail
+def test_open_parenthesis():
+    text = get_indent_fix("open_parenthesis(\n")
+    assert text == "open_parenthesis(\n    ", repr(text)
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
I added some tests to check for the indentation function.

It is motivated by a new but that was introduced lately, the cursor is placed at the same column as an opened parenthesis even if no text is entered after the parenthesis (this is my last commented test case).

## TODO:
- [ ] Add more non-regressiàon tests
- [ ] Correct failed tests
- [ ] Add new failed tests and correct them

This way of testing works but isn't practical at all, it would be really better to use libs like pytest for this. Those tests don't need the QApplication to run, only its creation so it doesn't have the same problem other tests have. Some hints were stated in #2268