### PR TITLE
Note failure to import `qtpy` in message about missing PyQt libraries

### DIFF
--- a/spyderlib/requirements.py
+++ b/spyderlib/requirements.py
@@ -45,8 +45,10 @@ def check_qt():
                          "%s %s+ is required (found v%s)."
                          % (package_name, required_ver, actual_ver))
     except ImportError:
-        show_warning("Please check Spyder installation requirements:\n\n"
+        show_warning("Failed to import qtpy.\n"
+                     "Please check Spyder installation requirements:\n\n"
+                     "qtpy and either\n"
                      "%s %s+ or\n"
                      "%s %s+\n\n"
-                     "is required to run Spyder"
+                     "are required to run Spyder."
                      % (qt_infos['pyqt5'] + qt_infos['pyqt']))


### PR DESCRIPTION
I installed `PyQt5` and `spyder` from source, but `setuptools` did not install `qtpy`. When opening `spyder`, the failure message suggests that `PyQt*` is missing, whereas it was only `qtpy` that was missing. This behavior can be reproduced with `pip uninstall qtpy` in an environment where `spyder` is already working correctly.