### PR TITLE
PR: Fix automatic insertion of colon

### DIFF
--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -2306,6 +2306,18 @@ class CodeEditor(TextEditBaseWidget):
                     return True
         return False
 
+    def __has_colon_not_in_brackets(self, text):
+        """
+        Return whether a string has a colon which is not between brackets.
+        This function returns True if the given string has a colon which is
+        not between a pair of (round, square or curly) brackets. It assumes
+        that the brackets in the string are balanced.
+        """
+        for pos, char in enumerate(text):
+            if char == ':' and not self.__unmatched_braces_in_line(text[:pos]):
+                return True
+        return False
+
     def autoinsert_colons(self):
         """Decide if we want to autoinsert colons"""
         line_text = self.get_text('sol', 'cursor')
@@ -2318,6 +2330,8 @@ class CodeEditor(TextEditBaseWidget):
         elif self.__forbidden_colon_end_char(line_text):
             return False
         elif self.__unmatched_braces_in_line(line_text):
+            return False
+        elif self.__has_colon_not_in_brackets(line_text):
             return False
         else:
             return True

--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -2300,6 +2300,10 @@ class CodeEditor(TextEditBaseWidget):
                 match = self.find_brace_match(line_pos+pos, char, forward=True)
                 if (match is None) or (match > line_pos+len(text)):
                     return True
+            if char in [')', ']', '}']:
+                match = self.find_brace_match(line_pos+pos, char, forward=False)
+                if (match is None) or (match < line_pos):
+                    return True
         return False
 
     def autoinsert_colons(self):

--- a/spyderlib/widgets/sourcecode/tests/test_autocolon.py
+++ b/spyderlib/widgets/sourcecode/tests/test_autocolon.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2009- The Spyder Development Team
+# Licensed under the terms of the MIT License
+#
+
+"""
+Tests for the automatic insertion of colons in the editor
+"""
+
+# Third party imports
+from qtpy.QtGui import QTextCursor
+import pytest
+
+# Local imports
+from spyderlib.utils.qthelpers import qapplication
+from spyderlib.widgets.sourcecode.codeeditor import CodeEditor
+
+
+# --- Fixtures
+# -----------------------------------------------------------------------------
+def construct_editor(text):
+    app = qapplication()
+    editor = CodeEditor(parent=None)
+    editor.setup_editor(language='Python')
+    editor.set_text(text)
+    cursor = editor.textCursor()
+    cursor.movePosition(QTextCursor.End)
+    editor.setTextCursor(cursor)
+    return editor
+
+
+# --- Tests
+# -----------------------------------------------------------------------------
+def test_no_auto_colon_after_simple_statement():
+    editor = construct_editor("x = 1")
+    assert editor.autoinsert_colons() == False
+
+def test_auto_colon_after_if_statement():
+    editor = construct_editor("if x == 1")
+    assert editor.autoinsert_colons() == True
+    
+def test_no_auto_colon_if_not_at_end_of_line():
+    editor = construct_editor("if x == 1")
+    cursor = editor.textCursor()
+    cursor.movePosition(QTextCursor.Left)
+    editor.setTextCursor(cursor)
+    assert editor.autoinsert_colons() == False
+
+def test_no_auto_colon_if_unterminated_string():    
+    editor = construct_editor("if x == '1") 
+    assert editor.autoinsert_colons() == False
+
+def test_no_auto_colon_in_comment():
+    editor = construct_editor("if x == 1 # comment")
+    assert editor.autoinsert_colons() == False
+
+def test_no_auto_colon_if_already_ends_in_colon():
+    editor = construct_editor("if x == 1:") 
+    assert editor.autoinsert_colons() == False
+
+def test_no_auto_colon_if_ends_in_backslash():
+    editor = construct_editor("if x == 1 \\") 
+    assert editor.autoinsert_colons() == False
+
+def test_no_auto_colon_in_one_line_if_statement():
+    editor = construct_editor("if x < 0: x = 0") 
+    assert editor.autoinsert_colons() == False
+
+def test_auto_colon_even_if_colon_inside_brackets():
+    editor = construct_editor("if text[:-1].endswith('bla')")
+    assert editor.autoinsert_colons() == True
+
+def test_no_auto_colon_in_listcomp_over_two_lines():
+    editor = construct_editor("ns = [ n for ns in range(10) \n if n < 5 ]")
+    assert editor.autoinsert_colons() == False
+
+    
+# --- Failing tests
+# -----------------------------------------------------------------------------
+@pytest.mark.xfail
+def test_auto_colon_even_if_colon_inside_quotes():
+    editor = construct_editor("if text == ':'")
+    assert editor.autoinsert_colons() == True
+
+@pytest.mark.xfail
+def test_no_auto_colon_in_listcomp_over_three_lines():
+    editor = construct_editor("ns = [ n \n for ns in range(10) \n if n < 5 ]")
+    cursor = editor.textCursor()
+    cursor.movePosition(QTextCursor.Up)
+    cursor.movePosition(QTextCursor.EndOfLine)
+    editor.setTextCursor(cursor)
+    assert editor.autoinsert_colons() == False
+
+@pytest.mark.xfail
+def test_auto_colon_in_two_if_statements_on_one_line():
+    editor = construct_editor("if x < 0: x = 0; if x == 0") 
+    assert editor.autoinsert_colons() == True
+    
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
This PR prevents the automatic insertion of a colon at the end of one-line if statements like:
````python
if True: print "Yes!"
````
It also prevents the automatic insertion of a colon at the second line of two-line list comprehensions like:
```python
yes_list = [x for x in [None, None, None, "Yes!"]
            if x is not None]
```
Fixes #872