### PR TITLE
Fix undefined `backends` when starting IPython kernel

### DIFF
--- a/spyderlib/widgets/externalshell/start_ipython_kernel.py
+++ b/spyderlib/widgets/externalshell/start_ipython_kernel.py
@@ -92,7 +92,7 @@ def kernel_config():
                                          "%matplotlib {0}".format(mpl_backend))
 
         # Inline backend configuration
-        if backends[backend_o] == 'inline':
+        if mpl_backend == 'inline':
            # Figure format
            format_o = CONF.get('ipython_console',
                                'pylab/inline/figure_format', 0)


### PR DESCRIPTION
Fixes  #3206.

I couldn't reproduce the error but the fix is quite obvious.