### PR TITLE
Fix icon name in conda windows build script.

### DIFF
--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -6,7 +6,7 @@ IF NOT EXIST (%MENU_DIR%) mkdir %MENU_DIR%
 
 copy %SRC_DIR%\img_src\spyder.ico %MENU_DIR%\
 if errorlevel 1 exit 1
-copy %SRC_DIR%\img_src\spyder_light.ico %MENU_DIR%\
+copy %SRC_DIR%\img_src\spyder_reset.ico %MENU_DIR%\
 if errorlevel 1 exit 1
 copy %RECIPE_DIR%\menu-windows.json %MENU_DIR%\spyder_shortcut.json
 if errorlevel 1 exit 1


### PR DESCRIPTION
This fix is necessary to make a conda build on windows. You could maybe consider to also build the beta releases on conda-forge :)

