### PR TITLE
PR: Allow empty wdir option to run_python_script_in_terminal

### DIFF
--- a/spyderlib/utils/programs.py
+++ b/spyderlib/utils/programs.py
@@ -252,7 +252,11 @@ def get_python_args(fname, python_args, interact, debug, end_args):
 
 def run_python_script_in_terminal(fname, wdir, args, interact,
                                   debug, python_args):
-    """Run Python script in an external system terminal"""
+    """
+    Run Python script in an external system terminal.
+
+    :str wdir: working directory, may be empty.
+    """
     
     # If fname has spaces on it it can't be ran on Windows, so we have to
     # enclose it in quotes. Also wdir can come with / as os.sep, so we
@@ -285,25 +289,30 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
                                    "an external terminal"),
                                  QMessageBox.Ok)
     elif os.name == 'posix':
-        cmd = 'gnome-terminal'
-        if is_program_installed(cmd):
-            run_program(cmd, ['--working-directory', wdir, '-x'] + p_args,
-                        cwd=wdir)
-            return
-        cmd = 'konsole'
-        if is_program_installed(cmd):
-            run_program(cmd, ['--workdir', wdir, '-e'] + p_args,
-                        cwd=wdir)
-            return
-        cmd = 'xfce4-terminal'
-        if is_program_installed(cmd):
-            run_program(cmd, ['--working-directory', wdir, '-x'] + p_args,
-                        cwd=wdir)
-            return
-        cmd = 'xterm'
-        if is_program_installed(cmd):
-            run_program(cmd, ['-e'] + p_args + [wdir])
-            return		
+        programs = [{'cmd': 'gnome-terminal',
+                     'wdir-option': '--working-directory',
+                     'execute-option': '-x'},
+                    {'cmd': 'konsole',
+                     'wdir-option': '--workdir',
+                     'execute-option': '-e'},
+                    {'cmd': 'xfce4-terminal',
+                     'wdir-option': '--working-directory',
+                     'execute-option': '-x'},
+                    {'cmd': 'xterm',
+                     'wdir-option': None,
+                     'execute-option': '-e'},]
+        for program in programs:
+            if is_program_installed(program['cmd']):
+                arglist = []
+                if program['wdir-option'] and wdir:
+                    arglist += [program['wdir-option'], wdir]
+                arglist.append(program['execute-option'])
+                arglist += p_args
+                if wdir:
+                    run_program(program['cmd'], arglist, cwd=wdir)
+                else:
+                    run_program(program['cmd'], arglist)
+                return
         # TODO: Add a fallback to OSX
     else:
         raise NotImplementedError

--- a/spyderlib/utils/tests/test_programs.py
+++ b/spyderlib/utils/tests/test_programs.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2009- The Spyder Development Team
+# Licensed under the terms of the MIT License
+
+"""Tests for programs.py"""
+
+import time
+
+import pytest
+
+from spyderlib.utils.programs import run_python_script_in_terminal
+
+def test_run_python_script_in_terminal(tmpdir):
+    scriptpath = tmpdir.join('write-done.py')
+    outfilepath = tmpdir.join('out.txt')
+    script = ("with open('out.txt', 'w') as f:\n"
+              "    f.write('done')\n")
+    scriptpath.write(script)
+    run_python_script_in_terminal(scriptpath.strpath, tmpdir.strpath, '',
+                                  False, False, '')
+    time.sleep(1) # wait for script to finish
+    res = outfilepath.read()
+    assert res == 'done'
+
+def test_run_python_script_in_terminal_with_wdir_empty(tmpdir):
+    scriptpath = tmpdir.join('write-done.py')
+    outfilepath = tmpdir.join('out.txt')
+    script = ("with open('{}', 'w') as f:\n"
+              "    f.write('done')\n").format(outfilepath.strpath)
+    scriptpath.write(script)
+    run_python_script_in_terminal(scriptpath.strpath, '', '', False, False, '')
+    time.sleep(1) # wait for script to finish
+    res = outfilepath.read()
+    assert res == 'done'
+
+    
+if __name__ == '__main__':
+    pytest.main()
+    


### PR DESCRIPTION
Fixes #3155: Executing a python script in external terminal without
specifying a working directory leads to wdir = '', which is not handled
correctly.

In the previous version, the working directory was passed as an option
to the script if xterm is used. This did not make sense to me, so I
removed that.