### PR TITLE
Variable explorer: Disregard list1 when sorting list1 against list2

### DIFF
--- a/spyderlib/widgets/variableexplorer/tests/test_utils.py
+++ b/spyderlib/widgets/variableexplorer/tests/test_utils.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2009- The Spyder Development Team
+# Licensed under the terms of the MIT License
+
+"""
+Tests for utils.py
+"""
+
+# Third party imports
+import pytest
+
+# Local imports
+from spyderlib.widgets.variableexplorer.utils import sort_against
+
+
+# --- Tests
+# -----------------------------------------------------------------------------
+def test_sort_against():
+    lista = [5, 6, 7]
+    listb = [2, 3, 1]
+    res = sort_against(lista, listb)
+    assert res == [7, 5, 6]
+
+def test_sort_against_is_stable():
+    lista = [3, 0, 1]
+    listb = [1, 1, 1]
+    res = sort_against(lista, listb)
+    assert res == lista
+    
+
+if __name__ == "__main__":
+    pytest.main()

--- a/spyderlib/widgets/variableexplorer/utils.py
+++ b/spyderlib/widgets/variableexplorer/utils.py
@@ -214,13 +214,18 @@ def is_editable_type(value):
 #==============================================================================
 # Sorting
 #==============================================================================
-def sort_against(lista, listb, reverse=False):
-    """Arrange lista items in the same order as sorted(listb)"""
+def sort_against(list1, list2, reverse=False):
+    """
+    Arrange items of list1 in the same order as sorted(list2).
+
+    In other words, apply to list1 the permutation which takes list2 
+    to sorted(list2, reverse).
+    """
     try:
         return [item for _, item in 
-                sorted(zip(listb, lista), key=lambda x: x[0], reverse=reverse)]
+                sorted(zip(list2, list1), key=lambda x: x[0], reverse=reverse)]
     except:
-        return lista
+        return list1
 
 
 def unsorted_unique(lista):

--- a/spyderlib/widgets/variableexplorer/utils.py
+++ b/spyderlib/widgets/variableexplorer/utils.py
@@ -217,7 +217,8 @@ def is_editable_type(value):
 def sort_against(lista, listb, reverse=False):
     """Arrange lista items in the same order as sorted(listb)"""
     try:
-        return [item for _, item in sorted(zip(listb, lista), reverse=reverse)]
+        return [item for _, item in 
+                sorted(zip(listb, lista), key=lambda x: x[0], reverse=reverse)]
     except:
         return lista
 


### PR DESCRIPTION
Fixes #2995.