### PR TITLE
PR: Feature/darkstyle

### DIFF
--- a/spyderlib/app/spyder.py
+++ b/spyderlib/app/spyder.py
@@ -73,7 +73,7 @@ except ImportError:
 #==============================================================================
 # Qt imports
 #==============================================================================
-from qtpy import API, PYQT5
+from qtpy import API, PYSIDE, PYQT4, PYQT5
 from qtpy.compat import from_qvariant, getopenfilename, getsavefilename
 from qtpy.QtCore import (QByteArray, QCoreApplication, QPoint, QSize, Qt,
                          QThread, QTimer, QUrl, Signal, Slot)
@@ -293,6 +293,32 @@ class MainWindow(QMainWindow):
             mac_style = open(osp.join(spy_path, 'app', 'mac_stylesheet.qss')).read()
             mac_style = mac_style.replace('$IMAGE_PATH', img_path)
             self.setStyleSheet(mac_style)
+
+        # Load light/dark theme
+        dark = None
+        try:
+            import qdarkstyle
+            dark = CONF.get('main', 'background_color_theme') == 'dark'
+        except ImportError:
+            pass
+
+        if dark:
+            if PYSIDE:
+                style_sheet = qdarkstyle.load_stylesheet()
+            elif PYQT4:
+                style_sheet = qdarkstyle.load_stylesheet(pyside=False)
+            elif PYQT5:
+                style_sheet = qdarkstyle.load_stylesheet_pyqt5()
+            qapp.setStyleSheet(style_sheet)
+
+            # Set ipython console and python console to dark themes
+            CONF.set('console', 'light_background', False)
+            CONF.set('ipython_console', 'light_color', False)
+            CONF.set('ipython_console', 'dark_color', True)
+        else:
+            CONF.set('console', 'light_background', True)
+            CONF.set('ipython_console', 'light_color', True)
+            CONF.set('ipython_console', 'dark_color', False)
 
         # Shortcut management data
         self.shortcut_data = []

--- a/spyderlib/config/main.py
+++ b/spyderlib/config/main.py
@@ -62,6 +62,7 @@ DEFAULTS = [
             ('main',
              {
               'icon_theme': 'spyder 3',
+              'background_color_theme': 'light',
               'single_instance': True,
               'open_files_port': OPEN_FILES_PORT,
               'tear_off_menus': False,

--- a/spyderlib/plugins/configdialog.py
+++ b/spyderlib/plugins/configdialog.py
@@ -829,6 +829,13 @@ class MainConfigPage(GeneralConfigPage):
         icon_choices = list(zip(themes, [theme.lower() for theme in themes]))
         icons_combo = self.create_combobox(_('Icon theme'), icon_choices,
                                            'icon_theme', restart=True)
+
+        try:
+            import qdarkstyle
+            darkstyle_available = True
+        except ImportError:
+            darkstyle_available = False
+
         background_colors = ['Light', 'Dark']
         background_color_choices = list(
             zip(background_colors,
@@ -864,8 +871,11 @@ class MainConfigPage(GeneralConfigPage):
         cbs_layout.addWidget(style_combo.combobox, 0, 1)
         cbs_layout.addWidget(icons_combo.label, 1, 0)
         cbs_layout.addWidget(icons_combo.combobox, 1, 1)
-        cbs_layout.addWidget(background_color_combo.label, 2, 0)
-        cbs_layout.addWidget(background_color_combo.combobox, 2, 1)
+
+        if darkstyle_available:
+            cbs_layout.addWidget(background_color_combo.label, 2, 0)
+            cbs_layout.addWidget(background_color_combo.combobox, 2, 1)
+
         comboboxes_layout.addLayout(cbs_layout)
         comboboxes_layout.addStretch(1)
         

--- a/spyderlib/plugins/configdialog.py
+++ b/spyderlib/plugins/configdialog.py
@@ -836,14 +836,15 @@ class MainConfigPage(GeneralConfigPage):
         except ImportError:
             darkstyle_available = False
 
-        background_colors = ['Light', 'Dark']
-        background_color_choices = list(
-            zip(background_colors,
-                [theme.lower() for theme in background_colors]))
-        background_color_combo = self.create_combobox(_('Theme'),
-                                                      background_color_choices,
-                                                      'background_color_theme',
-                                                      restart=True)
+        if darkstyle_available:
+            background_colors = ['Light', 'Dark']
+            background_color_choices = list(
+                zip(background_colors,
+                    [theme.lower() for theme in background_colors]))
+            background_color_combo = self.create_combobox(_('Theme'),
+                                                          background_color_choices,
+                                                          'background_color_theme',
+                                                          restart=True)
 
         vertdock_box = newcb(_("Vertical title bars in panes"),
                              'vertical_dockwidget_titlebars')

--- a/spyderlib/plugins/configdialog.py
+++ b/spyderlib/plugins/configdialog.py
@@ -829,7 +829,14 @@ class MainConfigPage(GeneralConfigPage):
         icon_choices = list(zip(themes, [theme.lower() for theme in themes]))
         icons_combo = self.create_combobox(_('Icon theme'), icon_choices,
                                            'icon_theme', restart=True)
-
+        background_colors = ['Light', 'Dark']
+        background_color_choices = list(
+            zip(background_colors,
+                [theme.lower() for theme in background_colors]))
+        background_color_combo = self.create_combobox(_('Theme'),
+                                                      background_color_choices,
+                                                      'background_color_theme',
+                                                      restart=True)
 
         vertdock_box = newcb(_("Vertical title bars in panes"),
                              'vertical_dockwidget_titlebars')
@@ -857,6 +864,8 @@ class MainConfigPage(GeneralConfigPage):
         cbs_layout.addWidget(style_combo.combobox, 0, 1)
         cbs_layout.addWidget(icons_combo.label, 1, 0)
         cbs_layout.addWidget(icons_combo.combobox, 1, 1)
+        cbs_layout.addWidget(background_color_combo.label, 2, 0)
+        cbs_layout.addWidget(background_color_combo.combobox, 2, 1)
         comboboxes_layout.addLayout(cbs_layout)
         comboboxes_layout.addStretch(1)
         

--- a/spyderlib/plugins/externalconsole.py
+++ b/spyderlib/plugins/externalconsole.py
@@ -107,16 +107,16 @@ class ExternalConsoleConfigPage(PluginConfigPage):
         display_group.setLayout(display_layout)
         
         # Background Color Group
-        bg_group = QGroupBox(_("Background color"))
-        bg_label = QLabel(_("This option will be applied the next time "
-                            "a Python console or a terminal is opened."))
-        bg_label.setWordWrap(True)
-        lightbg_box = newcb(_("Light background (white color)"),
-                            'light_background')
-        bg_layout = QVBoxLayout()
-        bg_layout.addWidget(bg_label)
-        bg_layout.addWidget(lightbg_box)
-        bg_group.setLayout(bg_layout)
+#        bg_group = QGroupBox(_("Background color"))
+#        bg_label = QLabel(_("This option will be applied the next time "
+#                            "a Python console or a terminal is opened."))
+#        bg_label.setWordWrap(True)
+#        lightbg_box = newcb(_("Light background (white color)"),
+#                            'light_background')
+#        bg_layout = QVBoxLayout()
+#        bg_layout.addWidget(bg_label)
+#        bg_layout.addWidget(lightbg_box)
+#        bg_group.setLayout(bg_layout)
 
         # Advanced settings
         source_group = QGroupBox(_("Source code"))
@@ -321,8 +321,7 @@ class ExternalConsoleConfigPage(PluginConfigPage):
                                                     interpreter=interpreter))
 
         tabs = QTabWidget()
-        tabs.addTab(self.create_tab(interface_group, display_group,
-                                    bg_group),
+        tabs.addTab(self.create_tab(interface_group, display_group),
                     _("Display"))
         tabs.addTab(self.create_tab(monitor_group, source_group),
                     _("Introspection"))

--- a/spyderlib/plugins/ipythonconsole.py
+++ b/spyderlib/plugins/ipythonconsole.py
@@ -182,16 +182,16 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         comp_layout.addWidget(comp_box)
         comp_group.setLayout(comp_layout)
 
-        # Background Color Group
-        bg_group = QGroupBox(_("Background color"))
-        light_radio = self.create_radiobutton(_("Light background"),
-                                              'light_color')
-        dark_radio = self.create_radiobutton(_("Dark background"),
-                                             'dark_color')
-        bg_layout = QVBoxLayout()
-        bg_layout.addWidget(light_radio)
-        bg_layout.addWidget(dark_radio)
-        bg_group.setLayout(bg_layout)
+#        # Background Color Group
+#        bg_group = QGroupBox(_("Background color"))
+#        light_radio = self.create_radiobutton(_("Light background"),
+#                                              'light_color')
+#        dark_radio = self.create_radiobutton(_("Dark background"),
+#                                             'dark_color')
+#        bg_layout = QVBoxLayout()
+#        bg_layout.addWidget(light_radio)
+#        bg_layout.addWidget(dark_radio)
+#        bg_group.setLayout(bg_layout)
 
         # Source Code Group
         source_code_group = QGroupBox(_("Source code"))
@@ -451,7 +451,7 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         # --- Tabs organization ---
         tabs = QTabWidget()
         tabs.addTab(self.create_tab(interface_group, comp_group,
-                                    bg_group, source_code_group), _("Display"))
+                                    source_code_group), _("Display"))
         tabs.addTab(self.create_tab(pylab_group, backend_group, inline_group),
                                     _("Graphics"))
         tabs.addTab(self.create_tab(run_lines_group, run_file_group),

--- a/spyderlib/widgets/sourcecode/base.py
+++ b/spyderlib/widgets/sourcecode/base.py
@@ -292,6 +292,9 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
                 style = "QPlainTextEdit#%s {background: %s; color: %s;}" % \
                         (self.objectName(), background.name(), foreground.name())
                 self.setStyleSheet(style)
+        # FIXME: Temporal edit for darstyle
+        self.setStyleSheet("QPlainTextEdit {background-color: %s;}" %
+                           (background.name()))
 
 
     #------Extra selections


### PR DESCRIPTION
Related to #2350

# Description
Add a dark theme based on [qdarkstyle](https://pypi.python.org/pypi/QDarkStyle)

# Requires to work
`pip install qdarkstyle`

# Screenshots

**New option**

![image](https://cloud.githubusercontent.com/assets/3627835/16792728/d3dc2c80-4890-11e6-9742-6518ec767e74.png)

**Emacs** (good for demo!!)
![image](https://cloud.githubusercontent.com/assets/3627835/16792746/fa4088d0-4890-11e6-9190-4136e74f37d7.png)

**Emacs Qt5** (good for demo!!)
![image](https://cloud.githubusercontent.com/assets/3627835/16793185/84bd9392-4894-11e6-9e96-6e5702213353.png)

# Tips for demo
- `pip install qdarkstyle`
- Hide INTERNAL CONSOLE
- Hide HELP plugin
- To switch:
   - If on light mode, first change the syntax color to Emacs then apply then change background theme and restart
   - If on dark mode, first change the syntax color to Spyder then apply then change background theme and restart

# Todo
- [x] Add new background color theme option in the general section
- [x] Remove background color options for consoles in the preferences
- [x] Automatically set background color options or consoles based on theme
- [x] Hides the option if `qdarkstyle` is not installed 
- [ ] Allow customization of `Help` plugin based on ____
- [ ] Apply editor color scheme to Ipython console
