### PR TITLE
Some improvements to our file switcher

### DIFF
--- a/spyderlib/widgets/fileswitcher.py
+++ b/spyderlib/widgets/fileswitcher.py
@@ -457,9 +457,9 @@ class FileSwitcher(QDialog):
 
     # --- Helper methods: Outline explorer
     def get_symbol_list(self):
-        """Get the object explorer data."""
+        """Get the list of symbols present in the file."""
         try:
-            oedata = self.get_editor().highlighter.get_outlineexplorer_data()
+            oedata = self.get_editor().get_outlineexplorer_data()
         except AttributeError:
             oedata = {}
         return oedata

--- a/spyderlib/widgets/fileswitcher.py
+++ b/spyderlib/widgets/fileswitcher.py
@@ -541,7 +541,7 @@ class FileSwitcher(QDialog):
                 results.append((score_value, line, text, rich_text,
                                 fold_level, icons[index], token))
 
-        template_1 = '<code>{0}<big>{1}</big></code>'
+        template_1 = '<code>{0}</code>{1}'
 
         for (score, line, text, rich_text, fold_level, icon,
              token) in sorted(results):

--- a/spyderlib/widgets/fileswitcher.py
+++ b/spyderlib/widgets/fileswitcher.py
@@ -504,6 +504,9 @@ class FileSwitcher(QDialog):
             self.list.addItem(item)
             self.filtered_path.append(path)
 
+        # To adjust the delegate layout for KDE themes
+        self.list.files_list = True
+
         # Move selected item in list accordingly and update list size
         if current_path in self.filtered_path:
             self.set_current_row(self.filtered_path.index(current_path))
@@ -552,6 +555,9 @@ class FileSwitcher(QDialog):
             item = QListWidgetItem(icon, textline)
             item.setSizeHint(QSize(0, 16))
             self.list.addItem(item)
+
+        # To adjust the delegate layout for KDE themes
+        self.list.files_list = False
 
         # Move selected item in list accordingly
         # NOTE: Doing this is causing two problems:

--- a/spyderlib/widgets/fileswitcher.py
+++ b/spyderlib/widgets/fileswitcher.py
@@ -496,7 +496,7 @@ class FileSwitcher(QDialog):
             index = result[1]
             text = result[-1]
             path = paths[index]
-            item = QListWidgetItem(self.tabs.tabIcon(index), text)
+            item = QListWidgetItem(ima.icon('FileIcon'), text)
             item.setToolTip(path)
             item.setSizeHint(QSize(0, 25))
             self.list.addItem(item)

--- a/spyderlib/widgets/fileswitcher.py
+++ b/spyderlib/widgets/fileswitcher.py
@@ -546,14 +546,14 @@ class FileSwitcher(QDialog):
                 results.append((score_value, line, text, rich_text,
                                 fold_level, icons[index], token))
 
-        template_1 = '<code>{0}</code>{1}'
+        template = '{0}{1}'
 
         for (score, line, text, rich_text, fold_level, icon,
              token) in sorted(results):
             fold_space = '&nbsp;'*(fold_level)
             line_number = line + 1
             self.filtered_symbol_lines.append(line_number)
-            textline = template_1.format(fold_space, rich_text)
+            textline = template.format(fold_space, rich_text)
             item = QListWidgetItem(icon, textline)
             item.setSizeHint(QSize(0, 16))
             self.list.addItem(item)

--- a/spyderlib/widgets/fileswitcher.py
+++ b/spyderlib/widgets/fileswitcher.py
@@ -487,9 +487,7 @@ class FileSwitcher(QDialog):
                 if trying_for_line_number:
                     text_item += " [{0:} {1:}]".format(self.line_count[index],
                                                        _("lines"))
-                text_item += "<br><i>{0:}</i>".format(
-                    short_paths[index])
-
+                text_item += "<br><i>{0:}</i>".format(short_paths[index])
                 results.append((score_value, index, text_item))
 
         # Sort the obtained scores and populate the list widget
@@ -512,7 +510,7 @@ class FileSwitcher(QDialog):
             self.set_current_row(self.filtered_path.index(current_path))
         elif self.filtered_path:
             self.set_current_row(0)
-        self.fix_size(short_paths)
+        self.fix_size(short_paths, extra=200)
 
         # If a line number is searched look for it
         self.line_number = line_number

--- a/spyderlib/widgets/fileswitcher.py
+++ b/spyderlib/widgets/fileswitcher.py
@@ -483,7 +483,7 @@ class FileSwitcher(QDialog):
         for index, score in enumerate(scores):
             text, rich_text, score_value = score
             if score_value != -1:
-                text_item = '<big>' + rich_text + '</big>'
+                text_item = '<big>' + rich_text.replace('&', '') + '</big>'
                 if trying_for_line_number:
                     text_item += " [{0:} {1:}]".format(self.line_count[index],
                                                        _("lines"))

--- a/spyderlib/widgets/fileswitcher.py
+++ b/spyderlib/widgets/fileswitcher.py
@@ -364,7 +364,10 @@ class FileSwitcher(QDialog):
         self.move(left, top + self.tabs.tabBar().geometry().height() + 1)
 
     def fix_size(self, content, extra=50):
-        """Adjusts the width of the file switcher, based on the content."""
+        """
+        Adjusts the width and height of the file switcher,
+        based on its content.
+        """
         # Update size of dialog based on longest shortened path
         strings = []
         if content:
@@ -373,8 +376,20 @@ class FileSwitcher(QDialog):
                 label.setTextFormat(Qt.PlainText)
                 strings.append(label.text())
                 fm = label.fontMetrics()
-            max_width = max([fm.width(s)*1.3 for s in strings])
+
+            # Max width
+            max_width = max([fm.width(s) * 1.3 for s in strings])
             self.list.setMinimumWidth(max_width + extra)
+
+            # Max height
+            if len(strings) < 8:
+                max_entries = len(strings)
+            else:
+                max_entries = 8
+            max_height = fm.height() * max_entries * 2.5
+            self.list.setMinimumHeight(max_height)
+
+            # Set position according to size
             self.set_dialog_position()
 
     # --- Helper methods: List widget

--- a/spyderlib/widgets/fileswitcher.py
+++ b/spyderlib/widgets/fileswitcher.py
@@ -443,7 +443,11 @@ class FileSwitcher(QDialog):
     # --- Helper methods: Outline explorer
     def get_symbol_list(self):
         """Get the object explorer data."""
-        return self.get_editor().highlighter.get_outlineexplorer_data()
+        try:
+            oedata = self.get_editor().highlighter.get_outlineexplorer_data()
+        except AttributeError:
+            oedata = {}
+        return oedata
 
     # --- Handlers
     def item_selection_changed(self):

--- a/spyderlib/widgets/fileswitcher.py
+++ b/spyderlib/widgets/fileswitcher.py
@@ -541,16 +541,14 @@ class FileSwitcher(QDialog):
                 results.append((score_value, line, text, rich_text,
                                 fold_level, icons[index], token))
 
-        template_1 = '<code>{0}<big>{1} {2}</big></code>'
-        template_2 = '<br><code>{0}</code><i>[Line {1}]</i>'
+        template_1 = '<code>{0}<big>{1}</big></code>'
 
         for (score, line, text, rich_text, fold_level, icon,
              token) in sorted(results):
             fold_space = '&nbsp;'*(fold_level)
             line_number = line + 1
             self.filtered_symbol_lines.append(line_number)
-            textline = template_1.format(fold_space, token, rich_text)
-            textline += template_2.format(fold_space, line_number)
+            textline = template_1.format(fold_space, rich_text)
             item = QListWidgetItem(icon, textline)
             item.setSizeHint(QSize(0, 16))
             self.list.addItem(item)

--- a/spyderlib/widgets/helperwidgets.py
+++ b/spyderlib/widgets/helperwidgets.py
@@ -137,7 +137,6 @@ class HTMLDelegate(QStyledItemDelegate):
 
         doc = QTextDocument()
         doc.setHtml(options.text)
-        doc.setTextWidth(options.rect.width())
 
         return QSize(doc.idealWidth(), doc.size().height())
 

--- a/spyderlib/widgets/helperwidgets.py
+++ b/spyderlib/widgets/helperwidgets.py
@@ -124,11 +124,14 @@ class HTMLDelegate(QStyledItemDelegate):
         painter.save()
         if style.objectName() in ['oxygen', 'qtcurve', 'breeze']:
             if options.widget.files_list:
-                painter.translate(textRect.topLeft() + QPoint(2, -9))
+                painter.translate(textRect.topLeft() + QPoint(4, -9))
             else:
-                painter.translate(textRect.topLeft() + QPoint(2, 0))
+                painter.translate(textRect.topLeft())
         else:
-            painter.translate(textRect.topLeft() + QPoint(2, 4))
+            if options.widget.files_list:
+                painter.translate(textRect.topLeft() + QPoint(4, 4))
+            else:
+                painter.translate(textRect.topLeft() + QPoint(2, 4))
         doc.documentLayout().draw(painter, ctx)
         painter.restore()
 

--- a/spyderlib/widgets/helperwidgets.py
+++ b/spyderlib/widgets/helperwidgets.py
@@ -122,13 +122,14 @@ class HTMLDelegate(QStyledItemDelegate):
 
         textRect = style.subElementRect(QStyle.SE_ItemViewItemText, options)
         painter.save()
-        if style.objectName() == 'oxygen':
-            painter.translate(textRect.topLeft() + QPoint(5, -9))
+        if style.objectName() in ['oxygen', 'qtcurve', 'breeze']:
+            if options.widget.files_list:
+                painter.translate(textRect.topLeft() + QPoint(2, -9))
+            else:
+                painter.translate(textRect.topLeft() + QPoint(2, 0))
         else:
-            painter.translate(textRect.topLeft())
-            painter.setClipRect(textRect.translated(-textRect.topLeft()))
+            painter.translate(textRect.topLeft() + QPoint(2, 4))
         doc.documentLayout().draw(painter, ctx)
-
         painter.restore()
 
     def sizeHint(self, option, index):

--- a/spyderlib/widgets/helperwidgets.py
+++ b/spyderlib/widgets/helperwidgets.py
@@ -142,7 +142,7 @@ class HTMLDelegate(QStyledItemDelegate):
         doc = QTextDocument()
         doc.setHtml(options.text)
 
-        return QSize(doc.idealWidth(), doc.size().height())
+        return QSize(doc.idealWidth(), doc.size().height() - 2)
 
 
 class IconLineEdit(QLineEdit):

--- a/spyderlib/widgets/helperwidgets.py
+++ b/spyderlib/widgets/helperwidgets.py
@@ -122,16 +122,21 @@ class HTMLDelegate(QStyledItemDelegate):
 
         textRect = style.subElementRect(QStyle.SE_ItemViewItemText, options)
         painter.save()
-        if style.objectName() in ['oxygen', 'qtcurve', 'breeze']:
-            if options.widget.files_list:
-                painter.translate(textRect.topLeft() + QPoint(4, -9))
+
+        # Adjustments for the file switcher
+        if hasattr(options.widget, 'files_list'):
+            if style.objectName() in ['oxygen', 'qtcurve', 'breeze']:
+                if options.widget.files_list:
+                    painter.translate(textRect.topLeft() + QPoint(4, -9))
+                else:
+                    painter.translate(textRect.topLeft())
             else:
-                painter.translate(textRect.topLeft())
+                if options.widget.files_list:
+                    painter.translate(textRect.topLeft() + QPoint(4, 4))
+                else:
+                    painter.translate(textRect.topLeft() + QPoint(2, 4))
         else:
-            if options.widget.files_list:
-                painter.translate(textRect.topLeft() + QPoint(4, 4))
-            else:
-                painter.translate(textRect.topLeft() + QPoint(2, 4))
+            painter.translate(textRect.topLeft() + QPoint(0, -3))
         doc.documentLayout().draw(painter, ctx)
         painter.restore()
 

--- a/spyderlib/widgets/sourcecode/codeeditor.py
+++ b/spyderlib/widgets/sourcecode/codeeditor.py
@@ -1521,6 +1521,10 @@ class CodeEditor(TextEditBaseWidget):
             else:
                 self.highlighter.rehighlight()
 
+    def get_outlineexplorer_data(self):
+        """Get data provided by the Outline Explorer"""
+        return self.highlighter.get_outlineexplorer_data()
+
     def set_font(self, font, color_scheme=None):
         """Set font"""
         # Note: why using this method to set color scheme instead of


### PR DESCRIPTION
Fixes #3274 

----

* This improves our file swticher to make it more similar to the Sublime and VisualCode ones. In particular, I decided to:
    * Remove line numbers for symbols. This way users can see much more symbols in the dialog.
    * Use the system font for symbols (it was used already for files).
    * Remove tokens for symbols (i.e. `def`, `class`, etc).
    * Make the initial dialog size to be about the same for files and symbols.
    * Use FontAwesome icon for files instead of the one assigned to the Editor tabs.
* I was a bit dissatisfied with the way the switcher looked before, but now I think it looks quite good :-)
* Pinging @goanpeca and @Nodd about it.

----

## Before

![seleccion_002](https://cloud.githubusercontent.com/assets/365293/17714688/60a70234-63c6-11e6-9af9-0f0e7359053b.png)

![seleccion_003](https://cloud.githubusercontent.com/assets/365293/17714715/823c0304-63c6-11e6-9fde-c796a62a8fcd.png)

## After

![seleccion_004](https://cloud.githubusercontent.com/assets/365293/17714742/a7285eec-63c6-11e6-8f70-9bc5854d090f.png)

![seleccion_005](https://cloud.githubusercontent.com/assets/365293/17714766/c886a3e6-63c6-11e6-81c2-03a032f83a5a.png)
