### PR TITLE
Remove icons from tabs for the Editor and IPython Console

### DIFF
--- a/spyderlib/plugins/history.py
+++ b/spyderlib/plugins/history.py
@@ -13,8 +13,8 @@ import sys
 # Third party imports
 from qtpy import PYQT5
 from qtpy.QtCore import Signal, Slot
-from qtpy.QtWidgets import (QFontDialog, QGroupBox, QHBoxLayout, QInputDialog,
-                            QMenu, QToolButton, QVBoxLayout, QWidget)
+from qtpy.QtWidgets import (QGroupBox, QHBoxLayout, QInputDialog, QMenu,
+                            QToolButton, QVBoxLayout, QWidget)
 
 
 # Local imports
@@ -78,7 +78,6 @@ class HistoryLog(SpyderPluginWidget):
         
         self.editors = []
         self.filenames = []
-        self.icons = []
         if PYQT5:        
             SpyderPluginWidget.__init__(self, parent, main = parent)
         else:
@@ -203,11 +202,9 @@ class HistoryLog(SpyderPluginWidget):
         """
         filename = self.filenames.pop(index_from)
         editor = self.editors.pop(index_from)
-        icon = self.icons.pop(index_from)
         
         self.filenames.insert(index_to, filename)
         self.editors.insert(index_to, editor)
-        self.icons.insert(index_to, icon)
         
     #------ Public API ---------------------------------------------------------
     def add_history(self, filename):
@@ -221,10 +218,8 @@ class HistoryLog(SpyderPluginWidget):
         editor = codeeditor.CodeEditor(self)
         if osp.splitext(filename)[1] == '.py':
             language = 'py'
-            icon = ima.icon('python')
         else:
             language = 'bat'
-            icon = ima.icon('cmdprompt')
         editor.setup_editor(linenumbers=False, language=language,
                             scrollflagarea=False)
         editor.focus_changed.connect(lambda: self.focus_changed.emit())
@@ -239,11 +234,9 @@ class HistoryLog(SpyderPluginWidget):
         
         self.editors.append(editor)
         self.filenames.append(filename)
-        self.icons.append(icon)
         index = self.tabwidget.addTab(editor, osp.basename(filename))
         self.find_widget.set_editor(editor)
         self.tabwidget.setTabToolTip(index, filename)
-        self.tabwidget.setTabIcon(index, icon)
         self.tabwidget.setCurrentIndex(index)
         
     def append_to_history(self, filename, command):

--- a/spyderlib/plugins/ipythonconsole.py
+++ b/spyderlib/plugins/ipythonconsole.py
@@ -1160,8 +1160,7 @@ class IPythonConsole(SpyderPluginWidget):
     def add_tab(self, widget, name):
         """Add tab"""
         self.clients.append(widget)
-        index = self.tabwidget.addTab(widget, ima.icon('ipython_console'),
-                                      name)
+        index = self.tabwidget.addTab(widget, name)
         self.tabwidget.setCurrentIndex(index)
         if self.dockwidget and not self.ismaximized:
             self.dockwidget.setVisible(True)

--- a/spyderlib/widgets/editor.py
+++ b/spyderlib/widgets/editor.py
@@ -32,14 +32,12 @@ from spyderlib.config.base import _, DEBUG, STDERR, STDOUT
 from spyderlib.config.gui import (config_shortcut, fixed_shortcut,
                                   RUN_CELL_SHORTCUT,
                                   RUN_CELL_AND_ADVANCE_SHORTCUT)
-from spyderlib.config.utils import get_edit_extensions
 from spyderlib.py3compat import qbytearray_to_str, to_text_string, u
 from spyderlib.utils import icon_manager as ima
 from spyderlib.utils import (codeanalysis, encoding, sourcecode,
                              syntaxhighlighters)
 from spyderlib.utils.qthelpers import (add_actions, create_action,
-                                       create_toolbutton, get_filetype_icon,
-                                       mimedata2url)
+                                       create_toolbutton, mimedata2url)
 from spyderlib.widgets.editortools import OutlineExplorerWidget
 from spyderlib.widgets.fileswitcher import FileSwitcher
 from spyderlib.widgets.findreplace import FindReplace
@@ -978,8 +976,7 @@ class EditorStack(QWidget):
         self.data.sort(key=self.__get_sorting_func())
         index = self.data.index(finfo)
         fname, editor = finfo.filename, finfo.editor
-        self.tabs.insertTab(index, editor, get_filetype_icon(fname),
-                            self.get_tab_text(fname))
+        self.tabs.insertTab(index, editor, self.get_tab_text(fname))
         self.set_stack_title(index, False)
         if set_current:
             self.set_stack_index(index)
@@ -991,14 +988,13 @@ class EditorStack(QWidget):
         self.tabs.blockSignals(True)
         self.tabs.clear()
         for finfo in self.data:
-            icon = get_filetype_icon(finfo.filename)
             if finfo.newly_created:
                 is_modified = True
             else:
                 is_modified = None
             tab_text = self.get_tab_text(finfo.filename, is_modified)
             tab_tip = self.get_tab_tip(finfo.filename)
-            index = self.tabs.addTab(finfo.editor, icon, tab_text)
+            index = self.tabs.addTab(finfo.editor, tab_text)
             self.tabs.setTabToolTip(index, tab_tip)
         self.tabs.blockSignals(False)
         self.update_fileswitcher_dlg()

--- a/spyderlib/widgets/tabs.py
+++ b/spyderlib/widgets/tabs.py
@@ -12,7 +12,6 @@
 # pylint: disable=R0201
 
 # Standard library imports
-import os.path as osp
 import sys
 
 # Third party imports
@@ -24,11 +23,9 @@ from qtpy.QtWidgets import (QApplication, QHBoxLayout, QMenu, QTabBar,
 # Local imports
 from spyderlib.config.base import _
 from spyderlib.config.gui import fixed_shortcut
-from spyderlib.py3compat import PY2, to_text_string
+from spyderlib.py3compat import PY2
 from spyderlib.utils import icon_manager as ima
-from spyderlib.utils.misc import get_common_path
-from spyderlib.utils.qthelpers import (add_actions, create_action,
-                                       create_toolbutton)
+from spyderlib.utils.qthelpers import add_actions, create_toolbutton
 
 
 class TabBar(QTabBar):
@@ -141,52 +138,7 @@ class BaseTabs(QTabWidget):
             corner_widgets = {}
         corner_widgets.setdefault(Qt.TopLeftCorner, [])
         corner_widgets.setdefault(Qt.TopRightCorner, [])
-        self.browse_button = create_toolbutton(self,
-                                          icon=ima.icon('browse_tab'),
-                                          tip=_("Browse tabs"))
-        self.browse_tabs_menu = QMenu(self)
-        self.browse_button.setMenu(self.browse_tabs_menu)
-        self.browse_button.setPopupMode(self.browse_button.InstantPopup)
-        self.browse_tabs_menu.aboutToShow.connect(self.update_browse_tabs_menu)
-        corner_widgets[Qt.TopLeftCorner] += [self.browse_button]
-
         self.set_corner_widgets(corner_widgets)
-        
-    def update_browse_tabs_menu(self):
-        """Update browse tabs menu"""
-        self.browse_tabs_menu.clear()
-        names = []
-        dirnames = []
-        for index in range(self.count()):
-            if self.menu_use_tooltips:
-                text = to_text_string(self.tabToolTip(index))
-            else:
-                text = to_text_string(self.tabText(index))
-            names.append(text)
-            if osp.isfile(text):
-                # Testing if tab names are filenames
-                dirnames.append(osp.dirname(text))
-        offset = None
-        
-        # If tab names are all filenames, removing common path:
-        if len(names) == len(dirnames):
-            common = get_common_path(dirnames)
-            if common is None:
-                offset = None
-            else:
-                offset = len(common)+1
-                if offset <= 3:
-                    # Common path is not a path but a drive letter...
-                    offset = None
-                
-        for index, text in enumerate(names):
-            tab_action = create_action(self, text[offset:],
-                                       icon=self.tabIcon(index),
-                                       toggled=lambda state, index=index:
-                                               self.setCurrentIndex(index),
-                                       tip=self.tabToolTip(index))
-            tab_action.setChecked(index == self.currentIndex())
-            self.browse_tabs_menu.addAction(tab_action)
         
     def set_corner_widgets(self, corner_widgets):
         """


### PR DESCRIPTION
This

* ~~Removes the left corner button from tabs, which contained a menu to browse them.~~ 
* Removes icons from our tabs (except for the Python Console, where they are useful because we have several types of tabs).

We talked about this with @goanpeca during SciPy and we think this helps to simplify how Spyder looks by removing visual clutter from the interface. It also improves our UI because the icons for the IPython console and Python files on the Editor are a bit ugly.

----

![seleccion_001](https://cloud.githubusercontent.com/assets/365293/17719442/28c4206c-63e0-11e6-89f8-144a207c28a6.png)

![seleccion_002](https://cloud.githubusercontent.com/assets/365293/17719443/2b8a1626-63e0-11e6-83ae-2998d7411ecb.png)
