### PR TITLE
Fix "Quit Spyder" action on OS X

### DIFF
--- a/spyderlib/app/spyder.py
+++ b/spyderlib/app/spyder.py
@@ -323,7 +323,7 @@ class MainWindow(QMainWindow):
                                         triggered=self.load_session,
                                         tip=_("Load Spyder session"))
         self.save_session_action = create_action(self,
-                                        _("Save session and quit..."),
+                                        _("Save session..."),
                                         None, ima.icon('filesaveas'),
                                         triggered=self.save_session,
                                         tip=_("Save current session "

--- a/spyderlib/plugins/editor.py
+++ b/spyderlib/plugins/editor.py
@@ -777,8 +777,8 @@ class Editor(SpyderPluginWidget):
         self.register_shortcut(debug_return_action, "_", "Debug Step Return",
                                add_sc_to_tip=True)
 
-        debug_exit_action = create_action(self, _("Exit"),
-               icon=ima.icon('stop_debug'), tip=_("Exit Debug"),
+        debug_exit_action = create_action(self, _("Stop"),
+               icon=ima.icon('stop_debug'), tip=_("Stop debugging"),
                triggered=lambda: self.debug_command("exit"))
         self.register_shortcut(debug_exit_action, "_", "Debug Exit",
                                add_sc_to_tip=True)


### PR DESCRIPTION
Fixes #3288 

----

- We had a couple of actions that contained the strings "quit" and
"exit" in their names, and that was interfering with the "Quit
Spyder" action.
- That's because Qt creates automatically that action based
on any action in the main application menus that contains those
substrings.