### PR TITLE
Avoid eval() when reading config file

### DIFF
--- a/spyder/config/tests/test_user.py
+++ b/spyder/config/tests/test_user.py
@@ -31,6 +31,11 @@ def userconfig(tmpdir, monkeypatch):
 def test_userconfig_get_string_from_inifile(userconfig):
     assert userconfig.get('section', 'option') == 'value'
 
+def test_userconfig_get_does_not_eval_functions(userconfig):
+    # regression test for issue #3354
+    userconfig.set('section', 'option', 'print("foo")')
+    assert userconfig.get('section', 'option') == 'print("foo")'
+
 def test_userconfig_set_with_string(userconfig):
     userconfig.set('section', 'option', 'new value')
     with open(userconfig.filename()) as inifile:

--- a/spyder/config/tests/test_user.py
+++ b/spyder/config/tests/test_user.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Tests for config/user.py
+"""
+
+# Third party imports
+import pytest
+
+# Local imports
+from spyder.config.user import UserConfig
+from spyder.py3compat import PY2
+
+@pytest.fixture
+def userconfig(tmpdir, monkeypatch):
+    monkeypatch.setattr('spyder.config.user.get_conf_path', lambda: str(tmpdir))
+    inifile = tmpdir.join('foo.ini')
+    iniContents = '[main]\nversion = 1.0.0\n\n'
+    if PY2: # strings are quoted in Python2 but not in Python3
+        iniContents += "[section]\noption = 'value'\n\n"
+    else:
+        iniContents += "[section]\noption = value\n\n"
+    inifile.write(iniContents)
+    return UserConfig('foo', defaults={}, subfolder=True,
+                      version='1.0.0', raw_mode=True)
+
+def test_userconfig_get_string_from_inifile(userconfig):
+    assert userconfig.get('section', 'option') == 'value'
+
+def test_userconfig_set_with_string(userconfig):
+    userconfig.set('section', 'option', 'new value')
+    with open(userconfig.filename()) as inifile:
+        iniContents = inifile.read()
+    expected = '[main]\nversion = 1.0.0\n\n'
+    if PY2:
+        expected += "[section]\noption = 'new value'\n\n"
+    else:
+        expected += "[section]\noption = new value\n\n"
+    assert iniContents == expected
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/spyder/config/user.py
+++ b/spyder/config/user.py
@@ -13,6 +13,7 @@ It's based on the ConfigParser module (present in the standard library).
 from __future__ import print_function
 
 # Std imports
+import ast
 import os
 import re
 import os.path as osp
@@ -20,7 +21,6 @@ import shutil
 import time
 
 # Local imports
-from spyder import __version__
 from spyder.config.base import (get_conf_path, get_home_dir,
                                 get_module_source_path, TEST)
 from spyder.utils.programs import check_version
@@ -378,9 +378,10 @@ class UserConfig(DefaultsConfig):
                 return default
             
         value = cp.ConfigParser.get(self, section, option, raw=self.raw)
+        # Use type of default_value to parse value correctly
         default_value = self.get_default(section, option)
         if isinstance(default_value, bool):
-            value = eval(value)
+            value = ast.literal_eval(value)
         elif isinstance(default_value, float):
             value = float(value)
         elif isinstance(default_value, int):
@@ -393,8 +394,8 @@ class UserConfig(DefaultsConfig):
                     pass
             try:
                 # lists, tuples, ...
-                value = eval(value)
-            except:
+                value = ast.literal_eval(value)
+            except (SyntaxError, ValueError):
                 pass
         return value
 

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -6,14 +6,13 @@
 """Tests for programs.py"""
 
 import os
-import time
 
 import pytest
 
 from spyder.utils.programs import run_python_script_in_terminal
 
 @pytest.mark.skipif(os.name == 'nt', reason='gets stuck on Windows') # FIXME
-def test_run_python_script_in_terminal(tmpdir):
+def test_run_python_script_in_terminal(tmpdir, qtbot):
     scriptpath = tmpdir.join('write-done.py')
     outfilepath = tmpdir.join('out.txt')
     script = ("with open('out.txt', 'w') as f:\n"
@@ -21,19 +20,19 @@ def test_run_python_script_in_terminal(tmpdir):
     scriptpath.write(script)
     run_python_script_in_terminal(scriptpath.strpath, tmpdir.strpath, '',
                                   False, False, '')
-    time.sleep(1) # wait for script to finish
+    qtbot.wait(1000) # wait for script to finish
     res = outfilepath.read()
     assert res == 'done'
 
 @pytest.mark.skipif(os.name == 'nt', reason='gets stuck on Windows') # FIXME
-def test_run_python_script_in_terminal_with_wdir_empty(tmpdir):
+def test_run_python_script_in_terminal_with_wdir_empty(tmpdir, qtbot):
     scriptpath = tmpdir.join('write-done.py')
     outfilepath = tmpdir.join('out.txt')
     script = ("with open('{}', 'w') as f:\n"
               "    f.write('done')\n").format(outfilepath.strpath)
     scriptpath.write(script)
     run_python_script_in_terminal(scriptpath.strpath, '', '', False, False, '')
-    time.sleep(1) # wait for script to finish
+    qtbot.wait(1000) # wait for script to finish
     res = outfilepath.read()
     assert res == 'done'
 


### PR DESCRIPTION
Using `eval()` has unintended side-effects, and may be considered a security risk. Instead, do nothing if we expect a string, and use `ast.literal_eval()` for other types (list, tuple, etc.). Also add tests.
    
Fixes #3354. That issue also talks about problems with IPython startup configuration, which I will leave for @ccordoba12. 
