### PR TITLE
Allow plugins with no dockwidgets

### DIFF
--- a/spyder/plugins/__init__.py
+++ b/spyder/plugins/__init__.py
@@ -518,6 +518,8 @@ class SpyderPluginMixin(object):
     
     def toggle_view(self, checked):
         """Toggle view"""
+        if not self.dockwidget:
+            return
         if checked:
             self.dockwidget.show()
             self.dockwidget.raise_()

--- a/spyder/plugins/__init__.py
+++ b/spyder/plugins/__init__.py
@@ -37,6 +37,7 @@ from spyder.config.user import NoDefault
 from spyder.py3compat import configparser, is_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import create_action, toggle_actions
+from spyder.plugins.configdialog import PluginConfigPage  # Plugin compatibility
 
 
 class TabFilter(QObject):

--- a/spyder/plugins/__init__.py
+++ b/spyder/plugins/__init__.py
@@ -37,7 +37,6 @@ from spyder.config.user import NoDefault
 from spyder.py3compat import configparser, is_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import create_action, toggle_actions
-from spyder.plugins.configdialog import PluginConfigPage  # Plugin compatibility
 
 
 class TabFilter(QObject):


### PR DESCRIPTION
- ~~Restore plugin compatibility (`PluginConfigPage` was removed from `__init__.py`)~~
- Allow plugins with no dockwidgets (set to None for example, the attribute must exist for now)