### PR TITLE
PR: Add hanging Indentation to the Editor

### DIFF
--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -1912,25 +1912,40 @@ class CodeEditor(TextEditBaseWidget):
         cursor = self.textCursor()
         block_nb = cursor.blockNumber()
         # find the line that contains our scope
-        diff = 0
+        diff_paren = 0
+        diff_brack = 0
+        diff_curly = 0
         add_indent = False
         prevline = None
         for prevline in range(block_nb-1, -1, -1):
             cursor.movePosition(QTextCursor.PreviousBlock)
             prevtext = to_text_string(cursor.block().text()).rstrip()
-            if (self.is_python_like() and not prevtext.strip().startswith('#') \
-              and prevtext) or prevtext:
-                if prevtext.strip().endswith(')'):
+            
+            if ((self.is_python_like() 
+                 and not prevtext.strip().startswith('#')
+                 and prevtext) 
+                or prevtext):
+                    
+                if (prevtext.strip().endswith(')')
+                    or prevtext.strip().endswith(']')
+                    or prevtext.strip().endswith('}')):
+                
                     comment_or_string = True  # prevent further parsing
+                    
                 elif prevtext.strip().endswith(':') and self.is_python_like():
                     add_indent = True
                     comment_or_string = True
-                if prevtext.count(')') > prevtext.count('('):
-                    diff = prevtext.count(')') - prevtext.count('(')
-                    continue
-                elif diff:
-                    diff += prevtext.count(')') - prevtext.count('(')
-                    if not diff:
+                if (prevtext.count(')') > prevtext.count('(')):
+                    diff_paren = prevtext.count(')') - prevtext.count('(')
+                elif (prevtext.count(']') > prevtext.count('[')):
+                    diff_brack = prevtext.count(']') - prevtext.count('[')
+                elif (prevtext.count('}') > prevtext.count('{')):
+                    diff_curly = prevtext.count('}') - prevtext.count('{')
+                elif diff_paren or diff_brack or diff_curly:
+                    diff_paren += prevtext.count(')') - prevtext.count('(')
+                    diff_brack += prevtext.count(']') - prevtext.count('[')
+                    diff_curly += prevtext.count('}') - prevtext.count('{')
+                    if not (diff_paren or diff_brack or diff_curly):
                         break
                 else:
                     break
@@ -1963,25 +1978,33 @@ class CodeEditor(TextEditBaseWidget):
                 else:
                     correct_indent -= len(self.indent_chars)
             elif len(re.split(r'\(|\{|\[', prevtext)) > 1:
-                rlmap = {")":"(", "]":"[", "}":"{"}
-                for par in rlmap:
-                    i_right = prevtext.rfind(par)
-                    if i_right != -1:
-                        prevtext = prevtext[:i_right]
-                        for _i in range(len(prevtext.split(par))):
-                            i_left = prevtext.rfind(rlmap[par])
-                            if i_left != -1:
-                                prevtext = prevtext[:i_left]
-                            else:
-                                break
-                else:
-                    if prevtext.strip():
-                        if len(re.split(r'\(|\{|\[', prevtext)) > 1:
-                            #correct indent only if there are still opening brackets
-                            prevexpr = re.split(r'\(|\{|\[', prevtext)[-1]
-                            correct_indent = len(prevtext)-len(prevexpr)
+                # Hanging indent
+                # find out if the last one is (, {, or []})
+                if re.search(r'[\(|\{|\[]\s*$', prevtext) is not None:
+                    if self.indent_chars == '\t':
+                        correct_indent += 8
                     else:
-                        correct_indent = len(prevtext)
+                        correct_indent += len(self.indent_chars) * 2
+                else:
+                    rlmap = {")":"(", "]":"[", "}":"{"}
+                    for par in rlmap:
+                        i_right = prevtext.rfind(par)
+                        if i_right != -1:
+                            prevtext = prevtext[:i_right]
+                            for _i in range(len(prevtext.split(par))):
+                                i_left = prevtext.rfind(rlmap[par])
+                                if i_left != -1:
+                                    prevtext = prevtext[:i_left]
+                                else:
+                                    break
+                    else:
+                        if prevtext.strip():
+                            if len(re.split(r'\(|\{|\[', prevtext)) > 1:
+                                #correct indent only if there are still opening brackets
+                                prevexpr = re.split(r'\(|\{|\[', prevtext)[-1]
+                                correct_indent = len(prevtext)-len(prevexpr)
+                            else:
+                                correct_indent = len(prevtext)
 
         if (forward and indent >= correct_indent) or \
            (not forward and indent <= correct_indent):

--- a/spyder/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyder/widgets/sourcecode/tests/test_autoindent.py
@@ -24,26 +24,12 @@ def get_indent_fix(text, indent_chars=" " * 4):
     app = qapplication()
     editor = CodeEditor(parent=None)
     editor.setup_editor(language='Python', indent_chars=indent_chars)
-    cursor = editor.textCursor()
 
-    if len(text) == 0:
-        editor.set_text(text)
-        return editor.toPlainText()
-    
-    texts = text.split('\n')
-    n = len(texts)
-    
-    # fix_indent needs to be done after every line
-    for ii in range(n):
-        text1 = texts[ii]
-        if ii < n-1:
-            text1 = text1 + '\n'
-        
-        editor.set_text(editor.toPlainText() + text1)
-        cursor.movePosition(QTextCursor.End)
-        editor.setTextCursor(cursor)
-        editor.fix_indent()
-        
+    editor.set_text(text)
+    cursor = editor.textCursor()
+    cursor.movePosition(QTextCursor.End)
+    editor.setTextCursor(cursor)
+    editor.fix_indent()
     return to_text_string(editor.toPlainText())
 
 
@@ -60,12 +46,12 @@ def test_def_with_newline():
 
 
 def test_def_with_indented_comment():
-    text = get_indent_fix("def function():\n# Comment\n")
+    text = get_indent_fix("def function():\n    # Comment\n")
     assert text == "def function():\n    # Comment\n    ", repr(text)
 
 
 def test_brackets_alone():
-    text = get_indent_fix("def function():\nprint []\n")
+    text = get_indent_fix("def function():\n    print []\n")
     assert text == "def function():\n    print []\n    ", repr(text)
 
 
@@ -111,9 +97,8 @@ def test_align_on_curly():
 # -----------------------------------------------------------------------------
 @pytest.mark.xfail
 def test_def_with_unindented_comment():
-    # No difference with test_def_with_indented_comment
     text = get_indent_fix("def function():\n# Comment\n")
-    assert text == "def function():\n    # Comment\n    ", repr(text)
+    assert text == "def function():\n# Comment\n    ", repr(text)
 
 
 # --- Tabs tests
@@ -127,15 +112,15 @@ def test_def_with_unindented_comment():
          "test with indented comment"),
         ("def function():\n\tprint []\n", "def function():\n\tprint []\n\t",
          "test brackets alone"),
-        ("\na = {\n", "\na = {\n\t ", "indentation after opening bracket"),
+        ("\na = {\n", "\na = {\n\t\t", "indentation after opening bracket"),
         ("def function():\n", "def function():\n\t", "test simple def"),
+        ("open_parenthesis(\n", "open_parenthesis(\n\t\t",
+         "open parenthesis"),
 
         # Failing test
         pytest.mark.xfail(
             ("def function():\n# Comment\n", "def function():\n# Comment\n\t",
              "test_def_with_unindented_comment")),
-        pytest.mark.xfail(("open_parenthesis(\n", "open_parenthesis(\n\t\t\t\ŧ ",
-                           "open parenthesis")),
     ])
 def test_indentation_with_tabs(text_input, expected, test_text):
     text = get_indent_fix(text_input, indent_chars="\t")


### PR DESCRIPTION
Fixes #3480 

----

This commit has an option for hanging indent at menu - python - Preferences - Editor - Advanced settings - Hanging indentation. It is unchecked by default, but when checked, allows hanging indentation, as follows:

```
def long_function_name(
        var1, var2):
    print("This works. Yeah!")

if long_function_name(
        var1, var2):
    print("also works")
```

The case I found not working is the following, where the subsequent line is indented one step too much:

```
if long_array_name[
        var1]:
            print("this does not work yet")
```

But such cases are rarer for me, so it would be useful even as it stands now. I haven't found why this happens, and I would appreciate help.

I checked the following and they work as expected, too:
- the new option is saved after quitting, and
- the default behavior, vertical alignment, is recovered when the new option is unchecked.

Please let me know if there are other issues. 
