### PR TITLE
PR: Change fixed shortcuts for configurable ones

### DIFF
--- a/spyder/config/gui.py
+++ b/spyder/config/gui.py
@@ -101,7 +101,11 @@ def set_shortcut(context, name, keystr):
 
 
 def fixed_shortcut(keystr, parent, action):
-    """Define a fixed shortcut according to a keysequence string"""
+    """
+    DEPRECATED: This function will be removed in Spyder 4.0
+
+    Define a fixed shortcut according to a keysequence string
+    """
     sc = QShortcut(QKeySequence(keystr), parent, action)
     sc.setContext(Qt.WidgetWithChildrenShortcut)
     return sc
@@ -115,7 +119,8 @@ def config_shortcut(action, context, name, parent):
     our shortcuts preferences page
     """
     keystr = get_shortcut(context, name)
-    qsc = fixed_shortcut(keystr, parent, action)
+    qsc = QShortcut(QKeySequence(keystr), parent, action)
+    qsc.setContext(Qt.WidgetWithChildrenShortcut)
     sc = Shortcut(data=(qsc, context, name))
     return sc
 

--- a/spyder/config/gui.py
+++ b/spyder/config/gui.py
@@ -16,7 +16,6 @@ Important note regarding shortcuts:
 
 # Standard library imports
 from collections import namedtuple
-import sys
 
 # Third party imports
 from qtpy.QtCore import Qt
@@ -28,14 +27,6 @@ from spyder.config.main import CONF
 from spyder.config.user import NoDefault
 from spyder.py3compat import to_text_string
 from spyder.utils import syntaxhighlighters as sh
-
-
-# Run cell shortcuts
-if sys.platform == 'darwin':
-    RUN_CELL_SHORTCUT = Qt.META + Qt.Key_Return
-else:
-    RUN_CELL_SHORTCUT = Qt.CTRL + Qt.Key_Return
-RUN_CELL_AND_ADVANCE_SHORTCUT = Qt.SHIFT + Qt.Key_Return
 
 
 # To save metadata about widget shortcuts (needed to build our

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -54,6 +54,12 @@ WIN = os.name == 'nt'
 MAC = sys.platform == 'darwin'
 CTRL = "Meta" if MAC else "Ctrl"
 
+# Run cell shortcuts
+if sys.platform == 'darwin':
+    RUN_CELL_SHORTCUT = 'Meta+Return'
+else:
+    RUN_CELL_SHORTCUT = 'Ctrl+Return'
+RUN_CELL_AND_ADVANCE_SHORTCUT = 'Shift+Return'
 
 # =============================================================================
 #  Defaults
@@ -410,6 +416,8 @@ DEFAULTS = [
               'editor/zoom reset': "Ctrl+0",
               'editor/close file 1': "Ctrl+W",
               'editor/close file 2': "Ctrl+F4",
+              'editor/run cell': RUN_CELL_SHORTCUT,
+              'editor/run cell and advance': RUN_CELL_AND_ADVANCE_SHORTCUT,
               # -- In plugins/editor.py
               'editor/show/hide outline': "Ctrl+Alt+O",
               'editor/show/hide project explorer': "Ctrl+Alt+P",

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -349,6 +349,7 @@ DEFAULTS = [
               '_/find next': "F3",
               '_/find previous': "Shift+F3",
               '_/replace text': "Ctrl+R",
+              '_/hide find and replace': "Escape",
               # ---- Editor ----
               # -- In widgets/sourcecode/codeeditor.py
               'editor/code completion': CTRL+'+Space',
@@ -403,6 +404,12 @@ DEFAULTS = [
               'editor/last edit location': "Ctrl+Alt+Shift+Left",
               'editor/previous cursor position': "Ctrl+Alt+Left",
               'editor/next cursor position': "Ctrl+Alt+Right",
+              'editor/zoom in 1': "Ctrl++",
+              'editor/zoom in 2': "Ctrl+=",
+              'editor/zoom out': "Ctrl+-",
+              'editor/zoom reset': "Ctrl+0",
+              'editor/close file 1': "Ctrl+W",
+              'editor/close file 2': "Ctrl+F4",
               # -- In plugins/editor.py
               'editor/show/hide outline': "Ctrl+Alt+O",
               'editor/show/hide project explorer': "Ctrl+Alt+P",
@@ -415,7 +422,15 @@ DEFAULTS = [
               # ---- In Pylint ----
               'pylint/run analysis': "F8",
               # ---- In Profiler ----
-              'profiler/run profiler': "F10"
+              'profiler/run profiler': "F10",
+              # ---- In widgets/ipythonconsole/shell.py ----
+              'ipython_console/new tab': "Ctrl+T",
+              'ipython_console/reset namespace': "Ctrl+Alt+R",
+              # ---- In widgets/arraybuider.py ----
+              'array_builder/enter array inline': "Ctrl+Alt+M",
+              'array_builder/enter array table': "Ctrl+M",
+              # ---- In widgets/variableexplorer/aarayeditor.py ----
+              'variable_explorer/copy': 'Ctrl+C',
               }),
             ('color_schemes',
              {

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -30,9 +30,8 @@ from qtpy.QtWidgets import (QAction, QActionGroup, QApplication, QDialog,
 
 # Local imports
 from spyder.config.base import _, get_conf_path
-from spyder.config.gui import (RUN_CELL_SHORTCUT,
-                               RUN_CELL_AND_ADVANCE_SHORTCUT)
-from spyder.config.main import CONF
+from spyder.config.main import (CONF, RUN_CELL_SHORTCUT,
+                                RUN_CELL_AND_ADVANCE_SHORTCUT)
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
                                  get_filter)
 from spyder.py3compat import getcwd, PY2, qbytearray_to_str, to_text_string

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -29,9 +29,7 @@ from qtpy.QtWidgets import (QAction, QApplication, QHBoxLayout, QMainWindow,
 
 # Local imports
 from spyder.config.base import _, DEBUG, STDERR, STDOUT
-from spyder.config.gui import (config_shortcut, fixed_shortcut,
-                               RUN_CELL_SHORTCUT,
-                               RUN_CELL_AND_ADVANCE_SHORTCUT)
+from spyder.config.gui import config_shortcut
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
                                  get_filter)
 from spyder.py3compat import qbytearray_to_str, to_text_string, u
@@ -471,9 +469,6 @@ class EditorStack(QWidget):
                                       context="Editor",
                                       name="Next cursor position",
                                       parent=self)
-        fixed_shortcut(QKeySequence(RUN_CELL_SHORTCUT), self, self.run_cell)
-        fixed_shortcut(QKeySequence(RUN_CELL_AND_ADVANCE_SHORTCUT), self,
-                       self.run_cell_and_advance)
         zoom_in_1 = config_shortcut(lambda : self.zoom_in.emit(),
                                       context="Editor",
                                       name="zoom in 1",
@@ -498,13 +493,21 @@ class EditorStack(QWidget):
                                       context="Editor",
                                       name="close file 2",
                                       parent=self)
+        run_cell = config_shortcut(self.run_cell,
+                                      context="Editor",
+                                      name="run cell",
+                                      parent=self)
+        run_cell_and_advance = config_shortcut(self.run_cell_and_advance,
+                                      context="Editor",
+                                      name="run cell and advance",
+                                      parent=self)
 
         # Return configurable ones
         return [inspect, set_breakpoint, set_cond_breakpoint, gotoline, tab,
                 tabshift, run_selection, new_file, open_file, save_file,
                 save_all, save_as, close_all, prev_edit_pos, prev_cursor,
                 next_cursor, zoom_in_1, zoom_in_2, zoom_out, zoom_reset,
-                close_file_1, close_file_2]
+                close_file_1, close_file_2, run_cell, run_cell_and_advance]
 
     def get_shortcut_data(self):
         """

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -22,7 +22,7 @@ from qtpy import is_pyqt46
 from qtpy.compat import getsavefilename
 from qtpy.QtCore import (QByteArray, QFileInfo, QObject, QPoint, QSize, Qt,
                          QThread, QTimer, Signal, Slot)
-from qtpy.QtGui import QFont, QKeySequence
+from qtpy.QtGui import QFont
 from qtpy.QtWidgets import (QAction, QApplication, QHBoxLayout, QMainWindow,
                             QMessageBox, QMenu, QSplitter, QVBoxLayout,
                             QWidget)
@@ -471,23 +471,40 @@ class EditorStack(QWidget):
                                       context="Editor",
                                       name="Next cursor position",
                                       parent=self)
-
-        # --- Fixed shortcuts
-        fixed_shortcut(QKeySequence.ZoomIn, self, lambda: self.zoom_in.emit())
-        fixed_shortcut("Ctrl+=", self, lambda: self.zoom_in.emit())
-        fixed_shortcut(QKeySequence.ZoomOut, self, lambda: self.zoom_out.emit())
-        fixed_shortcut("Ctrl+0", self, lambda: self.zoom_reset.emit())
-        fixed_shortcut("Ctrl+W", self, self.close_file)
-        fixed_shortcut("Ctrl+F4", self, self.close_file)
         fixed_shortcut(QKeySequence(RUN_CELL_SHORTCUT), self, self.run_cell)
         fixed_shortcut(QKeySequence(RUN_CELL_AND_ADVANCE_SHORTCUT), self,
                        self.run_cell_and_advance)
+        zoom_in_1 = config_shortcut(lambda : self.zoom_in.emit(),
+                                      context="Editor",
+                                      name="zoom in 1",
+                                      parent=self)
+        zoom_in_2 = config_shortcut(lambda : self.zoom_in.emit(),
+                                      context="Editor",
+                                      name="zoom in 2",
+                                      parent=self)
+        zoom_out = config_shortcut(lambda : self.zoom_out.emit(),
+                                      context="Editor",
+                                      name="zoom out",
+                                      parent=self)
+        zoom_reset = config_shortcut(lambda: self.zoom_reset.emit(),
+                                      context="Editor",
+                                      name="zoom reset",
+                                      parent=self)
+        close_file_1 = config_shortcut(self.close_file,
+                                      context="Editor",
+                                      name="close file 1",
+                                      parent=self)
+        close_file_2 = config_shortcut(self.close_file,
+                                      context="Editor",
+                                      name="close file 2",
+                                      parent=self)
 
         # Return configurable ones
         return [inspect, set_breakpoint, set_cond_breakpoint, gotoline, tab,
                 tabshift, run_selection, new_file, open_file, save_file,
                 save_all, save_as, close_all, prev_edit_pos, prev_cursor,
-                next_cursor]
+                next_cursor, zoom_in_1, zoom_in_2, zoom_out, zoom_reset,
+                close_file_1, close_file_2]
 
     def get_shortcut_data(self):
         """

--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -22,7 +22,7 @@ from qtpy.QtWidgets import (QCheckBox, QGridLayout, QHBoxLayout, QLabel,
 
 # Local imports
 from spyder.config.base import _
-from spyder.config.gui import config_shortcut, fixed_shortcut
+from spyder.config.gui import config_shortcut
 from spyder.py3compat import to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import create_toolbutton, get_icon
@@ -157,10 +157,10 @@ class FindReplace(QWidget):
         togglereplace = config_shortcut(self.toggle_replace_widgets,
                                         context='_', name='Replace text',
                                         parent=parent)
-        # Fixed
-        fixed_shortcut("Escape", self, self.hide)
+        hide = config_shortcut(self.hide, context='_', name='hide find and replace',
+                               parent=self)
 
-        return [findnext, findprev, togglefind, togglereplace]
+        return [findnext, findprev, togglefind, togglereplace, hide]
 
     def get_shortcut_data(self):
         """

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -15,10 +15,9 @@ from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QMessageBox
 
 from spyder.config.base import _
-from spyder.config.gui import config_shortcut, fixed_shortcut
+from spyder.config.gui import config_shortcut
 from spyder.py3compat import to_text_string
 from spyder.utils import programs
-from spyder.widgets.arraybuilder import SHORTCUT_INLINE, SHORTCUT_TABLE
 from spyder.widgets.ipythonconsole import (ControlWidget, DebuggingWidget,
                                            HelpWidget, NamepaceBrowserWidget,
                                            PageControlWidget)
@@ -154,16 +153,20 @@ These commands were executed:
                                   parent=self)
         clear_console = config_shortcut(self.clear_console, context='Console',
                                         name='Clear shell', parent=self)
+        new_tab = config_shortcut(lambda: self.new_client.emit(),
+                                  context='ipython_console', name='new tab', parent=self)
+        reset_namespace = config_shortcut(lambda: self.reset_namespace(),
+                                          context='ipython_console',
+                                          name='reset namespace', parent=self)
+        array_inline = config_shortcut(lambda: self.enter_array_inline(),
+                                       context='array_builder',
+                                       name='enter array inline', parent=self)
+        array_table = config_shortcut(lambda: self.enter_array_table(),
+                                      context='array_builder',
+                                      name='enter array table', parent=self)
 
-        # Fixed shortcuts
-        fixed_shortcut("Ctrl+T", self, lambda: self.new_client.emit())
-        fixed_shortcut("Ctrl+Alt+R", self, lambda: self.reset_namespace())
-        fixed_shortcut(SHORTCUT_INLINE, self,
-                       lambda: self._control.enter_array_inline())
-        fixed_shortcut(SHORTCUT_TABLE, self,
-                       lambda: self._control.enter_array_table())
-
-        return [inspect, clear_console]
+        return [inspect, clear_console, new_tab, reset_namespace,
+                array_inline, array_table]
 
     # --- To communicate with the kernel
     def silent_execute(self, code):

--- a/spyder/widgets/shell.py
+++ b/spyder/widgets/shell.py
@@ -28,7 +28,7 @@ from qtpy.QtWidgets import QApplication, QMenu, QMessageBox, QToolTip
 
 # Local import
 from spyder.config.base import _, DEBUG, get_conf_path, STDERR
-from spyder.config.gui import config_shortcut, get_shortcut, fixed_shortcut
+from spyder.config.gui import config_shortcut, get_shortcut
 from spyder.config.main import CONF
 from spyder.py3compat import (builtins, is_string, is_text_string,
                               PY3, to_text_string)
@@ -36,7 +36,6 @@ from spyder.utils import encoding
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import (add_actions, create_action, keybinding,
                                     restore_keyevent)
-from spyder.widgets.arraybuilder import SHORTCUT_INLINE, SHORTCUT_TABLE
 from spyder.widgets.mixins import (GetHelpMixin, SaveHistoryMixin,
                                    TracebackLinksMixin)
 from spyder.widgets.sourcecode.base import ConsoleBaseWidget
@@ -688,13 +687,17 @@ class PythonShellWidget(TracebackLinksMixin, ShellBaseWidget,
         self.shortcuts = self.create_shortcuts()
 
     def create_shortcuts(self):
-        fixed_shortcut(SHORTCUT_INLINE, self, lambda: self.enter_array_inline())
-        fixed_shortcut(SHORTCUT_TABLE, self, lambda: self.enter_array_table())
+        array_inline = config_shortcut(lambda: self.enter_array_inline(),
+                                       context='array_builder',
+                                       name='enter array inline', parent=self)
+        array_table = config_shortcut(lambda: self.enter_array_table(),
+                                      context='array_builder',
+                                      name='enter array table', parent=self)
         inspectsc = config_shortcut(self.inspect_current_object,
                                     context='Console',
                                     name='Inspect current object',
                                     parent=self)
-        return [inspectsc]
+        return [inspectsc, array_inline, array_table]
         
     def get_shortcut_data(self):
         """

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -55,7 +55,6 @@ from spyder.utils import encoding, sourcecode
 from spyder.utils.dochelpers import getobj
 from spyder.utils.qthelpers import add_actions, create_action, mimedata2url
 from spyder.utils.sourcecode import ALL_LANGUAGES, CELL_LANGUAGES
-from spyder.widgets.arraybuilder import SHORTCUT_INLINE, SHORTCUT_TABLE
 from spyder.widgets.editortools import PythonCFM
 from spyder.widgets.sourcecode.base import TextEditBaseWidget
 from spyder.widgets.sourcecode.kill_ring import QtKillRing
@@ -609,10 +608,12 @@ class CodeEditor(TextEditBaseWidget):
                                  name='delete', parent=self)
         select_all = config_shortcut(self.selectAll, context='Editor',
                                      name='Select All', parent=self)
-
-        # Fixed shortcuts
-        fixed_shortcut(SHORTCUT_INLINE, self, lambda: self.enter_array_inline())
-        fixed_shortcut(SHORTCUT_TABLE, self, lambda: self.enter_array_table())
+        array_inline = config_shortcut(lambda: self.enter_array_inline(),
+                                       context='array_builder',
+                                       name='enter array inline', parent=self)
+        array_table = config_shortcut(lambda: self.enter_array_table(),
+                                      context='array_builder',
+                                      name='enter array table', parent=self)
 
         return [codecomp, duplicate_line, copyline, deleteline, movelineup,
                 movelinedown, gotodef, toggle_comment, blockcomment,
@@ -620,7 +621,7 @@ class CodeEditor(TextEditBaseWidget):
                 prev_char, next_char, prev_word, next_word, kill_line_end,
                 kill_line_start, yank, kill_ring_rotate, kill_prev_word,
                 kill_next_word, start_doc, end_doc, undo, redo, cut, copy,
-                paste, delete, select_all]
+                paste, delete, select_all, array_inline, array_table]
 
     def get_shortcut_data(self):
         """

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -44,10 +44,9 @@ from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
 
 # Local imports
 from spyder.config.base import get_conf_path, _, DEBUG
-from spyder.config.gui import (config_shortcut, fixed_shortcut, get_shortcut,
-                               RUN_CELL_SHORTCUT,
-                               RUN_CELL_AND_ADVANCE_SHORTCUT)
-from spyder.config.main import CONF
+from spyder.config.gui import config_shortcut, get_shortcut
+from spyder.config.main import (CONF, RUN_CELL_SHORTCUT,
+                                RUN_CELL_AND_ADVANCE_SHORTCUT)
 from spyder.py3compat import to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils import syntaxhighlighters as sh

--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -23,7 +23,7 @@ from qtpy.QtWidgets import (QApplication, QHBoxLayout, QMenu, QTabBar,
 
 # Local imports
 from spyder.config.base import _
-from spyder.config.gui import fixed_shortcut
+from spyder.config.gui import config_shortcut
 from spyder.py3compat import PY2, to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.misc import get_common_path
@@ -293,12 +293,14 @@ class Tabs(BaseTabs):
                                           self.move_tab_from_another_tabwidget)
         self.setTabBar(tab_bar)
 
-        fixed_shortcut("Ctrl+Tab", parent, lambda: self.tab_navigate(1))
-        fixed_shortcut("Shift+Ctrl+Tab", parent, lambda: self.tab_navigate(-1))
-        fixed_shortcut("Ctrl+W", parent,
-                       lambda: self.sig_close_tab.emit(self.currentIndex()))
-        fixed_shortcut("Ctrl+F4", parent,
-                       lambda: self.sig_close_tab.emit(self.currentIndex()))
+        config_shortcut(lambda: self.tab_navigate(1), context='editor',
+                        name='go to next file', parent=parent)
+        config_shortcut(lambda: self.tab_navigate(-1), context='editor',
+                        name='go to previous file', parent=parent)
+        config_shortcut(lambda: self.sig_close_tab.emit(self.currentIndex()),
+                        context='editor', name='close file 1', parent=parent)
+        config_shortcut(lambda: self.sig_close_tab.emit(self.currentIndex()),
+                        context='editor', name='close file 2', parent=parent)
 
     def tab_navigate(self, delta=1):
         """Ctrl+Tab"""

--- a/spyder/widgets/variableexplorer/arrayeditor.py
+++ b/spyder/widgets/variableexplorer/arrayeditor.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 from qtpy.compat import from_qvariant, to_qvariant
 from qtpy.QtCore import (QAbstractTableModel, QItemSelection,
                          QItemSelectionRange, QModelIndex, Qt, Slot)
-from qtpy.QtGui import QColor, QCursor, QDoubleValidator, QKeySequence
+from qtpy.QtGui import QColor, QCursor, QDoubleValidator
 from qtpy.QtWidgets import (QAbstractItemDelegate, QApplication, QCheckBox,
                             QComboBox, QDialog, QDialogButtonBox, QGridLayout,
                             QHBoxLayout, QInputDialog, QItemDelegate, QLabel,
@@ -32,7 +32,7 @@ import numpy as np
 # Local imports
 from spyder.config.base import _
 from spyder.config.fonts import DEFAULT_SMALL_DELTA
-from spyder.config.gui import get_font, fixed_shortcut
+from spyder.config.gui import get_font, config_shortcut
 from spyder.py3compat import (io, is_binary_string, is_string,
                               is_text_string, PY3, to_binary_string,
                               to_text_string)
@@ -399,7 +399,8 @@ class ArrayView(QTableView):
         self.viewport().resize(min(total_width, 1024), self.height())
         self.shape = shape
         self.menu = self.setup_menu()
-        fixed_shortcut(QKeySequence.Copy, self, self.copy)
+        config_shortcut(self.copy, context='variable_explorer', name='copy',
+                        parent=self)
         self.horizontalScrollBar().valueChanged.connect(
                             lambda val: self.load_more_data(val, columns=True))
         self.verticalScrollBar().valueChanged.connect(

--- a/spyder/widgets/variableexplorer/dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/dataframeeditor.py
@@ -18,7 +18,7 @@ from pandas import DataFrame, Series
 from qtpy import API
 from qtpy.compat import from_qvariant, to_qvariant
 from qtpy.QtCore import QAbstractTableModel, QModelIndex, Qt, Slot
-from qtpy.QtGui import QColor, QCursor, QKeySequence
+from qtpy.QtGui import QColor, QCursor
 from qtpy.QtWidgets import (QApplication, QCheckBox, QDialogButtonBox, QDialog,
                             QGridLayout, QHBoxLayout, QInputDialog, QLineEdit,
                             QMenu, QMessageBox, QPushButton, QTableView)
@@ -27,7 +27,7 @@ import numpy as np
 # Local imports
 from spyder.config.base import _
 from spyder.config.fonts import DEFAULT_SMALL_DELTA
-from spyder.config.gui import get_font, fixed_shortcut
+from spyder.config.gui import get_font, config_shortcut
 from spyder.py3compat import io, is_text_string, PY2, to_text_string
 from spyder.utils import encoding
 from spyder.utils import icon_manager as ima
@@ -409,7 +409,8 @@ class DataFrameView(QTableView):
         self.header_class = self.horizontalHeader()
         self.header_class.sectionClicked.connect(self.sortByColumn)
         self.menu = self.setup_menu()
-        fixed_shortcut(QKeySequence.Copy, self, self.copy)
+        config_shortcut(self.copy, context='variable_explorer', name='copy',
+                        parent=self)
         self.horizontalScrollBar().valueChanged.connect(
                             lambda val: self.load_more_data(val, columns=True))
         self.verticalScrollBar().valueChanged.connect(


### PR DESCRIPTION
Fixes #3395 
Fixes #3415

----

The idea of this PR is to remove fixed_shortcuts and leave only config_shortcuts as suggested by @ccordoba12 

I have encounter several issues:
- Some fixed_shortcuts use QKeySequence (copy, zoom in, and zoom out), I replaced by the corresponding shortcuts (Ctrl+c Ctrl++, Ctrl+-), because It is not possible to import QKeySequence in spyder/config/main.py
- `RUN_CELL_SHORTCUT` and `RUN_CELL_AND_ADVANCE_SHORTCUT` variables in spyder/config/gui.py are platform dependent (I moved that code to spyder/config/main.py but I change Qt imports to strings)
- Some actions have two shortcuts, I created two different configurations keys (example: `editor/close file 1`  `'editor/close file 2`) There is another workaround? should shortcuts have several options?
- It's ok to remove `fixed_shortcut()` function? how plugins should register shortcuts? (there is already an issue about this #3254 )