### PR TITLE
Pin conda-build to 2.0.0

### DIFF
--- a/continuous_integration/appveyor/install.ps1
+++ b/continuous_integration/appveyor/install.ps1
@@ -99,7 +99,7 @@ function UpdateConda ($python_home) {
 function main () {
     InstallMiniconda $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
     UpdateConda $env:PYTHON
-    InstallCondaPackages $env:PYTHON "conda-build pytest pytest-cov mock"
+    InstallCondaPackages $env:PYTHON "conda-build=2.0.0 pytest pytest-cov mock"
     InstallPipPackages $env:PYTHON "pytest-qt"
 }
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -51,8 +51,7 @@ install_conda()
 
     # Install testing dependencies
     if [ "$USE_CONDA" = true ]; then
-        #echo 'conda-build ==1.18.1' > $HOME/miniconda/conda-meta/pinned;
-        conda install conda-build;
+        conda install conda-build=2.0.0;
         conda create -q -n test-environment python=$PY_VERSION;
         conda install -q -y -n test-environment pytest pytest-cov mock
     fi


### PR DESCRIPTION
* This avoids errors when conda-build is updated.
* We don't need anything fancy from conda-build, so there's no need for us to live in its bleeding edge :-)