### PR TITLE
PR: Remember format for floats in dataframe editor

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -178,6 +178,8 @@ DEFAULTS = [
               'autorefresh': False,
               'autorefresh/timeout': 2000,
               'check_all': CHECK_ALL,
+              'dataframe_format': '.3g', # no percent sign to avoid problems
+                                         # with ConfigParser's interpolation
               'excluded_names': EXCLUDED_NAMES,
               'exclude_private': True,
               'exclude_uppercase': True,

--- a/spyder/plugins/tests/test_variableexplorer.py
+++ b/spyder/plugins/tests/test_variableexplorer.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+
+"""
+Tests for variableexplorer.py
+"""
+
+import pytest
+
+from spyder.plugins.variableexplorer import VariableExplorer
+
+def test_get_settings(monkeypatch):
+    def mock_get(section, option):
+        assert section == 'sect'
+        if option == 'remote1': return 'remote1val'
+        if option == 'remote2': return 'remote2val'
+        if option == 'dataframe_format': return '3d'
+        
+    monkeypatch.setattr(VariableExplorer, 'CONF_SECTION', 'sect')
+    monkeypatch.setattr('spyder.plugins.variableexplorer.REMOTE_SETTINGS', 
+                        ['remote1', 'remote2'])
+    monkeypatch.setattr('spyder.plugins.variableexplorer.CONF.get', mock_get)
+    
+    settings = VariableExplorer.get_settings()
+    expected = {'remote1': 'remote1val', 'remote2': 'remote2val',
+                'dataframe_format': '%3d'}
+    assert settings == expected
+
+
+if __name__ == "__main__":
+    pytest.main()
+    

--- a/spyder/plugins/variableexplorer.py
+++ b/spyder/plugins/variableexplorer.py
@@ -104,13 +104,23 @@ class VariableExplorer(QWidget, SpyderPluginMixin):
     @staticmethod
     def get_settings():
         """
-        Return Variable Explorer settings dictionary
-        (i.e. namespace browser settings according to Spyder's configuration file)
+        Retrieve all Variable Explorer configuration settings
+        
+        Specifically, return the settings in CONF_SECTION with keys in 
+        REMOTE_SETTINGS, and the setting 'dataframe_format'.
+        
+        Returns:
+            dict: settings
         """
         settings = {}
 #        CONF.load_from_ini() # necessary only when called from another process
         for name in REMOTE_SETTINGS:
             settings[name] = CONF.get(VariableExplorer.CONF_SECTION, name)
+
+        # dataframe_format is stored without percent sign in config
+        # to avoid interference with ConfigParser's interpolation
+        name = 'dataframe_format'
+        settings[name] = '%' + CONF.get(VariableExplorer.CONF_SECTION, name)
         return settings
 
     # ----- Stack accesors ----------------------------------------------------
@@ -131,6 +141,12 @@ class VariableExplorer(QWidget, SpyderPluginMixin):
 
     # ----- Public API --------------------------------------------------------
     def add_shellwidget(self, shellwidget):
+        """
+        Register shell with variable explorer.
+
+        This function opens a new NamespaceBrowser for browsing the variables
+        in the shell.
+        """
         shellwidget_id = id(shellwidget)
         # Add shell only once: this method may be called two times in a row
         # by the External console plugin (dev. convenience)

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -467,6 +467,7 @@ class CollectionsDelegate(QItemDelegate):
             if not editor.setup_and_check(value, title=key):
                 return
             editor.dataModel.set_format(index.model().dataframe_format)
+            editor.sig_option_changed.connect(self.change_option)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
                                             key=key, readonly=readonly))
             return None
@@ -516,6 +517,17 @@ class CollectionsDelegate(QItemDelegate):
                      lambda eid=id(editor): self.editor_rejected(eid))
         editor.show()
         
+    @Slot(str, object)
+    def change_option(self, option_name, new_value):
+        """
+        Change configuration option
+
+        This function is called when a `sig_option_changed` signal is received.
+        At the moment, this signal can only come from a DataFrameEditor.
+        """
+        assert option_name == 'dataframe_format'
+        self.parent().set_dataframe_format(new_value)
+
     def editor_accepted(self, editor_id):
         data = self._editors[editor_id]
         if not data['readonly']:

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -466,6 +466,7 @@ class CollectionsDelegate(QItemDelegate):
             editor = DataFrameEditor()
             if not editor.setup_and_check(value, title=key):
                 return
+            editor.dataModel.set_format(index.model().dataframe_format)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
                                             key=key, readonly=readonly))
             return None

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -80,13 +80,14 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
     ROWS_TO_LOAD = 50
 
     def __init__(self, parent, data, title="", names=False, truncate=True,
-                 minmax=False, remote=False):
+                 minmax=False, dataframe_format=None, remote=False):
         QAbstractTableModel.__init__(self, parent)
         if data is None:
             data = {}
         self.names = names
         self.truncate = truncate
         self.minmax = minmax
+        self.dataframe_format = dataframe_format
         self.remote = remote
         self.header0 = None
         self._data = None
@@ -883,6 +884,17 @@ class BaseTableView(QTableView):
         self.sig_option_changed.emit('minmax', state)
         self.model.minmax = state
 
+    @Slot(str)
+    def set_dataframe_format(self, new_format):
+        """
+        Set format to use in DataframeEditor
+
+        Args:
+            new_format (string): e.g. "%.3f"
+        """
+        self.sig_option_changed.emit('dataframe_format', new_format)
+        self.model.dataframe_format = new_format
+
     @Slot()
     def edit_item(self):
         """Edit item"""
@@ -1340,7 +1352,8 @@ class RemoteCollectionsDelegate(CollectionsDelegate):
 
 class RemoteCollectionsEditorTableView(BaseTableView):
     """DictEditor table view"""
-    def __init__(self, parent, data, truncate=True, minmax=False,
+    def __init__(self, parent, data, truncate=True,
+                 minmax=False, dataframe_format=None,
                  get_value_func=None, set_value_func=None,
                  new_value_func=None, remove_values_func=None,
                  copy_value_func=None, is_list_func=None, get_len_func=None,
@@ -1377,6 +1390,7 @@ class RemoteCollectionsEditorTableView(BaseTableView):
         self.readonly = False
         self.model = CollectionsModel(self, data, names=True,
                                       truncate=truncate, minmax=minmax,
+                                      dataframe_format=dataframe_format,
                                       remote=True)
         self.setModel(self.model)
         self.delegate = RemoteCollectionsDelegate(self, get_value_func,

--- a/spyder/widgets/variableexplorer/dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/dataframeeditor.py
@@ -17,7 +17,7 @@ Pandas DataFrame Editor Dialog
 from pandas import DataFrame, Series
 from qtpy import API
 from qtpy.compat import from_qvariant, to_qvariant
-from qtpy.QtCore import QAbstractTableModel, QModelIndex, Qt, Slot
+from qtpy.QtCore import QAbstractTableModel, QModelIndex, Qt, Signal, Slot
 from qtpy.QtGui import QColor, QCursor, QKeySequence
 from qtpy.QtWidgets import (QApplication, QCheckBox, QDialogButtonBox, QDialog,
                             QGridLayout, QHBoxLayout, QInputDialog, QLineEdit,
@@ -501,7 +501,16 @@ class DataFrameView(QTableView):
 
 
 class DataFrameEditor(QDialog):
-    """ Data Frame Editor Dialog """
+    """
+    Dialog for displaying and editing DataFrame and related objects
+
+    Signals
+    -------
+    sig_option_changed(str, object): Raised if an option is changed.
+       Arguments are name of option and its new value.
+    """
+    sig_option_changed = Signal(str, object)
+
     def __init__(self, parent=None):
         QDialog.__init__(self, parent)
         # Destroying the C++ object right after closing the dialog box,
@@ -580,7 +589,12 @@ class DataFrameEditor(QDialog):
         self.bgcolor_global.setEnabled(not self.is_series and state > 0)
 
     def change_format(self):
-        """Change display format"""
+        """
+        Ask user for display format for floats and use it.
+
+        This function also checks whether the format is valid and emits
+        `sig_option_changed`.
+        """
         format, valid = QInputDialog.getText(self, _('Format'),
                                              _("Float formatting"),
                                              QLineEdit.Normal,
@@ -594,6 +608,7 @@ class DataFrameEditor(QDialog):
                                      _("Format (%s) is incorrect") % format)
                 return
             self.dataModel.set_format(format)
+            self.sig_option_changed.emit('dataframe_format', format)
 
     def get_value(self):
         """Return modified Dataframe -- this is *not* a copy"""

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -84,6 +84,9 @@ class NamespaceBrowser(QWidget):
         self.remote_editing = None
         self.autorefresh = None
         
+        # Other setting
+        self.dataframe_format = None
+
         self.editor = None
         self.exclude_private_action = None
         self.exclude_uppercase_action = None
@@ -99,9 +102,15 @@ class NamespaceBrowser(QWidget):
     def setup(self, check_all=None, exclude_private=None,
               exclude_uppercase=None, exclude_capitalized=None,
               exclude_unsupported=None, excluded_names=None,
-              truncate=None, minmax=None, remote_editing=None,
-              autorefresh=None):
-        """Setup the namespace browser"""
+              truncate=None, minmax=None, dataframe_format=None,
+              remote_editing=None, autorefresh=None):
+        """
+        Setup the namespace browser with provided settings
+
+        Args:
+            dataframe_format (string): default floating-point format for 
+                DataFrame editor
+        """
         assert self.shellwidget is not None
         
         self.check_all = check_all
@@ -114,6 +123,7 @@ class NamespaceBrowser(QWidget):
         self.minmax = minmax
         self.remote_editing = remote_editing
         self.autorefresh = autorefresh
+        self.dataframe_format = dataframe_format
         
         if self.editor is not None:
             self.editor.setup_menu(truncate, minmax)

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -127,6 +127,7 @@ class NamespaceBrowser(QWidget):
         
         if self.editor is not None:
             self.editor.setup_menu(truncate, minmax)
+            self.editor.set_dataframe_format(dataframe_format)
             self.exclude_private_action.setChecked(exclude_private)
             self.exclude_uppercase_action.setChecked(exclude_uppercase)
             self.exclude_capitalized_action.setChecked(exclude_capitalized)
@@ -138,6 +139,7 @@ class NamespaceBrowser(QWidget):
 
         self.editor = RemoteCollectionsEditorTableView(self, None,
                         truncate=truncate, minmax=minmax,
+                        dataframe_format=dataframe_format,
                         remote_editing=remote_editing,
                         get_value_func=self.get_value,
                         set_value_func=self.set_value,

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -35,6 +35,16 @@ def test_create_dataframeeditor_with_correct_format(qtbot, monkeypatch):
     editor.delegate.createEditor(None, None, editor.model.createIndex(0, 3))
     mockDataFrameEditor_instance.dataModel.set_format.assert_called_once_with('%10d')
 
+def test_accept_sig_option_changed_from_dataframeeditor(qtbot, monkeypatch):
+    df = pandas.DataFrame(['foo', 'bar'])
+    editor = CollectionsEditorTableView(None, {'df': df})
+    editor.set_dataframe_format('%10d')
+    assert editor.model.dataframe_format == '%10d'
+    editor.delegate.createEditor(None, None, editor.model.createIndex(0, 3))
+    dataframe_editor = next(iter(editor.delegate._editors.values()))['editor']
+    dataframe_editor.sig_option_changed.emit('dataframe_format', '%5f')
+    assert editor.model.dataframe_format == '%5f'
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -31,6 +31,7 @@ def test_create_dataframeeditor_with_correct_format(qtbot, monkeypatch):
                         MockDataFrameEditor)
     df = pandas.DataFrame(['foo', 'bar'])
     editor = CollectionsEditorTableView(None, {'df': df})
+    qtbot.addWidget(editor)
     editor.set_dataframe_format('%10d')
     editor.delegate.createEditor(None, None, editor.model.createIndex(0, 3))
     mockDataFrameEditor_instance.dataModel.set_format.assert_called_once_with('%10d')
@@ -38,10 +39,12 @@ def test_create_dataframeeditor_with_correct_format(qtbot, monkeypatch):
 def test_accept_sig_option_changed_from_dataframeeditor(qtbot, monkeypatch):
     df = pandas.DataFrame(['foo', 'bar'])
     editor = CollectionsEditorTableView(None, {'df': df})
+    qtbot.addWidget(editor)
     editor.set_dataframe_format('%10d')
     assert editor.model.dataframe_format == '%10d'
     editor.delegate.createEditor(None, None, editor.model.createIndex(0, 3))
     dataframe_editor = next(iter(editor.delegate._editors.values()))['editor']
+    qtbot.addWidget(dataframe_editor)
     dataframe_editor.sig_option_changed.emit('dataframe_format', '%5f')
     assert editor.model.dataframe_format == '%5f'
 

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+
+"""
+Tests for collectionseditor.py
+"""
+
+# Standard library imports
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock # Python 2
+
+# Third party imports
+import pandas
+import pytest
+
+# Local imports
+from spyder.widgets.variableexplorer.collectionseditor import (
+    CollectionsEditorTableView)
+
+# --- Tests
+# -----------------------------------------------------------------------------
+
+def test_create_dataframeeditor_with_correct_format(qtbot, monkeypatch):
+    MockDataFrameEditor = Mock()
+    mockDataFrameEditor_instance = MockDataFrameEditor()
+    monkeypatch.setattr('spyder.widgets.variableexplorer.collectionseditor.DataFrameEditor',
+                        MockDataFrameEditor)
+    df = pandas.DataFrame(['foo', 'bar'])
+    editor = CollectionsEditorTableView(None, {'df': df})
+    editor.set_dataframe_format('%10d')
+    editor.delegate.createEditor(None, None, editor.model.createIndex(0, 3))
+    mockDataFrameEditor_instance.dataModel.set_format.assert_called_once_with('%10d')
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/spyder/widgets/variableexplorer/tests/test_namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/tests/test_namespacebrowser.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+
+"""
+Tests for namespacebrowser.py
+"""
+
+# Standard library imports
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock # Python 2
+
+# Third party imports
+import pytest
+
+# Local imports
+from spyder.widgets.variableexplorer.namespacebrowser import NamespaceBrowser
+
+def test_setup_sets_dataframe_format(qtbot):
+    browser = NamespaceBrowser(None)
+    browser.set_shellwidget(Mock())
+    browser.setup(exclude_private=True, exclude_uppercase=True,
+                  exclude_capitalized=True, exclude_unsupported=True,
+                  truncate=False, minmax=False, dataframe_format='%10.5f',
+                  autorefresh=False)
+    assert browser.editor.model.dataframe_format == '%10.5f'
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -470,7 +470,6 @@ def make_remote_view(data, settings, more_excluded_names=None):
     Make a remote view of dictionary *data*
     -> globals explorer
     """
-    assert all([name in REMOTE_SETTINGS for name in settings])
     data = get_remote_data(data, settings, mode='editable',
                            more_excluded_names=more_excluded_names)
     remote = {}


### PR DESCRIPTION
This pull request is to make Spyder remember the format that the user sets for floats in the DataFrameEditor by storing it in the user configuration settings. Fixes #2728.

- A new config setting `dataframe_format` is introduced in the variable explorer section in the user config. This setting contains the format, without the leading `%` character (e.g., if the format is `'%.3f'` then the setting is stored as `'.3f'`). The reason for this is that it is apparently impossible to have a config setting with a `%` character, because this is used in `ConfigParser` for interpolation.
- This setting is passed (after adding a `%` character in the front) from the `VariableExplorer` plugin via the `NamespaceBrowser` and `CollectionEditor` widgets to the `DataFrameEditor` widget, where it is used to set the format for floats.
- If the user changes the format in the `DataFrameEditor` widget, then this information is passed back using a `sig_option_changed` signal via `CollectionEditor` and `NamespaceBrowser` to `VariableExplorer`. There the leading `%` character is stripped and the format is stored in the user config.