### PR TITLE
PR: Change deprecated funtion QInputDialog.getInteger for QInputDialog.getInt

### DIFF
--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -275,7 +275,7 @@ class Console(SpyderPluginWidget):
     @Slot()
     def change_max_line_count(self):
         "Change maximum line count"""
-        mlc, valid = QInputDialog.getInteger(self, _('Buffer'),
+        mlc, valid = QInputDialog.getInt(self, _('Buffer'),
                                            _('Maximum line count'),
                                            self.get_option('max_line_count'),
                                            0, 1000000)

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -1715,7 +1715,7 @@ class Editor(SpyderPluginWidget):
     def change_max_recent_files(self):
         "Change max recent files entries"""
         editorstack = self.get_current_editorstack()
-        mrf, valid = QInputDialog.getInteger(editorstack, _('Editor'),
+        mrf, valid = QInputDialog.getInt(editorstack, _('Editor'),
                                _('Maximum number of recent files'),
                                self.get_option('max_recent_files'), 1, 35)
         if valid:

--- a/spyder/plugins/history.py
+++ b/spyder/plugins/history.py
@@ -257,7 +257,7 @@ class HistoryLog(SpyderPluginWidget):
     @Slot()
     def change_history_depth(self):
         "Change history max entries"""
-        depth, valid = QInputDialog.getInteger(self, _('History'),
+        depth, valid = QInputDialog.getInt(self, _('History'),
                                        _('Maximum entries'),
                                        self.get_option('max_entries'),
                                        10, 10000)

--- a/spyder_pylint/pylint.py
+++ b/spyder_pylint/pylint.py
@@ -157,7 +157,7 @@ class Pylint(PylintWidget, SpyderPluginMixin):
     @Slot()
     def change_history_depth(self):
         "Change history max entries"""
-        depth, valid = QInputDialog.getInteger(self, _('History'),
+        depth, valid = QInputDialog.getInt(self, _('History'),
                                        _('Maximum entries'),
                                        self.get_option('max_entries'),
                                        10, 10000)


### PR DESCRIPTION
Fixes #3519 

This also was causing error in maximum lines in console and history deep