### PR TITLE
Fix autoindentation after data structures.

### DIFF
--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -1957,8 +1957,10 @@ class CodeEditor(TextEditBaseWidget):
                                 break
                 else:
                     if prevtext.strip():
-                        prevexpr = re.split(r'\(|\{|\[', prevtext)[-1]
-                        correct_indent = len(prevtext)-len(prevexpr)
+                        if len(re.split(r'\(|\{|\[', prevtext)) > 1:
+                            #correct indent only if there are still opening brackets
+                            prevexpr = re.split(r'\(|\{|\[', prevtext)[-1]
+                            correct_indent = len(prevtext)-len(prevexpr)
                     else:
                         correct_indent = len(prevtext)
 

--- a/spyder/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyder/widgets/sourcecode/tests/test_autoindent.py
@@ -49,6 +49,9 @@ def test_def_with_indented_comment():
     text = get_indent_fix("def function():\n    # Comment\n")
     assert text == "def function():\n    # Comment\n    ", repr(text)
 
+def test_brackets_alone():
+    text = get_indent_fix("def function():\n    print []\n")
+    assert text == "def function():\n    print []\n    ", repr(text)
 
 # --- Failing tests
 # -----------------------------------------------------------------------------
@@ -68,12 +71,6 @@ def test_def_with_unindented_comment():
 def test_open_parenthesis():
     text = get_indent_fix("open_parenthesis(\n")
     assert text == "open_parenthesis(\n    ", repr(text)
-
-
-@pytest.mark.xfail
-def test_brackets_alone():
-    text = get_indent_fix("def function():\n    print []\n")
-    assert text == "def function():\n    print []\n    ", repr(text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1373 

When a structure is defined in the same line, the autoindent was failing