### PR TITLE
Load default settings if there is any error in spyder.ini

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -591,10 +591,14 @@ DEFAULTS = [
 CONF_VERSION = '29.0.0'
 
 # Main configuration instance
-CONF = UserConfig('spyder', defaults=DEFAULTS, load=(not TEST),
-                  version=CONF_VERSION, subfolder=SUBFOLDER, backup=True,
-                  raw_mode=True)
-
+try:
+    CONF = UserConfig('spyder', defaults=DEFAULTS, load=(not TEST),
+                      version=CONF_VERSION, subfolder=SUBFOLDER, backup=True,
+                      raw_mode=True)
+except:
+    CONF = UserConfig('spyder', defaults=DEFAULTS, load=False,
+                      version=CONF_VERSION, subfolder=SUBFOLDER, backup=True,
+                      raw_mode=True)
 
 # Removing old .spyder.ini location:
 old_location = osp.join(get_home_dir(), '.spyder.ini')


### PR DESCRIPTION
Fixes #3127 

----

This will prevent Spyder to crash and force users to run

    spyder --reset

to come back to a clean state :-)