### PR TITLE
PR: Fix some errors of Indentation with tabs

### DIFF
--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -382,6 +382,7 @@ class BaseEditMixin(object):
     def get_block_indentation(self, block_nb):
         """Return line indentation (character number)"""
         text = to_text_string(self.document().findBlockByNumber(block_nb).text())
+        text = text.replace("\t", " "*4)
         return len(text)-len(text.lstrip())
     
     def get_selection_bounds(self):

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -1926,11 +1926,12 @@ class CodeEditor(TextEditBaseWidget):
                 else:
                     break
 
-        if not prevline:
-            return False
+        if prevline:
+            correct_indent = self.get_block_indentation(prevline)
+        else:
+            correct_indent = 0
 
         indent = self.get_block_indentation(block_nb)
-        correct_indent = self.get_block_indentation(prevline)
 
         if add_indent:
             if self.indent_chars == '\t':

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -1933,16 +1933,25 @@ class CodeEditor(TextEditBaseWidget):
         correct_indent = self.get_block_indentation(prevline)
 
         if add_indent:
-            correct_indent += len(self.indent_chars)
+            if self.indent_chars == '\t':
+                correct_indent += 4
+            else:
+                correct_indent += len(self.indent_chars)
 
         if not comment_or_string:
             if prevtext.endswith(':') and self.is_python_like():
                 # Indent
-                correct_indent += len(self.indent_chars)
+                if self.indent_chars == '\t':
+                    correct_indent += 4
+                else:
+                    correct_indent += len(self.indent_chars)
             elif (prevtext.endswith('continue') or prevtext.endswith('break') \
               or prevtext.endswith('pass')) and self.is_python_like():
                 # Unindent
-                correct_indent -= len(self.indent_chars)
+                if self.indent_chars == '\t':
+                    correct_indent -= 4
+                else:
+                    correct_indent -= len(self.indent_chars)
             elif len(re.split(r'\(|\{|\[', prevtext)) > 1:
                 rlmap = {")":"(", "]":"[", "}":"{"}
                 for par in rlmap:
@@ -1974,7 +1983,12 @@ class CodeEditor(TextEditBaseWidget):
             cursor.movePosition(QTextCursor.StartOfBlock)
             cursor.setPosition(cursor.position()+indent, QTextCursor.KeepAnchor)
             cursor.removeSelectedText()
-            cursor.insertText(self.indent_chars[0]*correct_indent)
+            if self.indent_chars == '\t':
+                indent_text = '\t' * (correct_indent // 4) \
+                            + ' ' * (correct_indent % 4)
+            else:
+                indent_text = ' '*correct_indent
+            cursor.insertText(indent_text)
             return True
 
     @Slot()

--- a/spyder/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyder/widgets/sourcecode/tests/test_autoindent.py
@@ -93,6 +93,8 @@ def test_open_parenthesis():
              "test_def_with_unindented_comment")),
         pytest.mark.xfail(("open_parenthesis(\n", "open_parenthesis(\n\t\t\t\ŧ ",
                            "open parenthesis")),
+        pytest.mark.xfail(("\na = {\n", "\na = {\n\t ",
+                           "indentation after opening bracket")),
     ])
 def test_indentation_with_tabs(text_input, expected, test_text):
     text = get_indent_fix(text_input, indent_chars="\t")

--- a/spyder/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyder/widgets/sourcecode/tests/test_autoindent.py
@@ -84,6 +84,7 @@ def test_open_parenthesis():
          "test with indented comment"),
         ("def function():\n\tprint []\n", "def function():\n\tprint []\n\t",
          "test brackets alone"),
+        ("\na = {\n", "\na = {\n\t ", "indentation after opening bracket"),
 
         # Failing test
         pytest.mark.xfail(("def function():\n", "def function():\n\t",
@@ -93,8 +94,6 @@ def test_open_parenthesis():
              "test_def_with_unindented_comment")),
         pytest.mark.xfail(("open_parenthesis(\n", "open_parenthesis(\n\t\t\t\ŧ ",
                            "open parenthesis")),
-        pytest.mark.xfail(("\na = {\n", "\na = {\n\t ",
-                           "indentation after opening bracket")),
     ])
 def test_indentation_with_tabs(text_input, expected, test_text):
     text = get_indent_fix(text_input, indent_chars="\t")

--- a/spyder/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyder/widgets/sourcecode/tests/test_autoindent.py
@@ -20,10 +20,10 @@ from spyder.widgets.sourcecode.codeeditor import CodeEditor
 
 # --- Fixtures
 # -----------------------------------------------------------------------------
-def get_indent_fix(text):
+def get_indent_fix(text, indent_chars=" " * 4):
     app = qapplication()
     editor = CodeEditor(parent=None)
-    editor.setup_editor(language='Python')
+    editor.setup_editor(language='Python', indent_chars=indent_chars)
 
     editor.set_text(text)
     cursor = editor.textCursor()
@@ -71,6 +71,32 @@ def test_def_with_unindented_comment():
 def test_open_parenthesis():
     text = get_indent_fix("open_parenthesis(\n")
     assert text == "open_parenthesis(\n    ", repr(text)
+
+
+# --- Tabs tests
+# -----------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "text_input, expected, test_text",
+    [
+        ("this_tuple = (1, 2)\n", "this_tuple = (1, 2)\n", "simple tuple"),
+        ("\ndef function():\n", "\ndef function():\n\t", "def with new line"),
+        ("def function():\n\t# Comment\n", "def function():\n\t# Comment\n\t",
+         "test with indented comment"),
+        ("def function():\n\tprint []\n", "def function():\n\tprint []\n\t",
+         "test brackets alone"),
+
+        # Failing test
+        pytest.mark.xfail(("def function():\n", "def function():\n\t",
+                           "test simple def")),
+        pytest.mark.xfail(
+            ("def function():\n# Comment\n", "def function():\n# Comment\n\t",
+             "test_def_with_unindented_comment")),
+        pytest.mark.xfail(("open_parenthesis(\n", "open_parenthesis(\n\t\t\t\ŧ ",
+                           "open parenthesis")),
+    ])
+def test_indentation_with_tabs(text_input, expected, test_text):
+    text = get_indent_fix(text_input, indent_chars="\t")
+    assert text == expected, test_text
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyder/widgets/sourcecode/tests/test_autoindent.py
@@ -60,14 +60,13 @@ def test_open_parenthesis():
     assert text == "open_parenthesis(\n                 ", repr(text)
 
 
-# --- Failing tests
-# -----------------------------------------------------------------------------
-@pytest.mark.xfail
 def test_simple_def():
     text = get_indent_fix("def function():\n")
     assert text == "def function():\n    ", repr(text)
 
 
+# --- Failing tests
+# -----------------------------------------------------------------------------
 @pytest.mark.xfail
 def test_def_with_unindented_comment():
     text = get_indent_fix("def function():\n# Comment\n")
@@ -86,10 +85,9 @@ def test_def_with_unindented_comment():
         ("def function():\n\tprint []\n", "def function():\n\tprint []\n\t",
          "test brackets alone"),
         ("\na = {\n", "\na = {\n\t ", "indentation after opening bracket"),
+        ("def function():\n", "def function():\n\t", "test simple def"),
 
         # Failing test
-        pytest.mark.xfail(("def function():\n", "def function():\n\t",
-                           "test simple def")),
         pytest.mark.xfail(
             ("def function():\n# Comment\n", "def function():\n# Comment\n\t",
              "test_def_with_unindented_comment")),

--- a/spyder/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyder/widgets/sourcecode/tests/test_autoindent.py
@@ -49,9 +49,16 @@ def test_def_with_indented_comment():
     text = get_indent_fix("def function():\n    # Comment\n")
     assert text == "def function():\n    # Comment\n    ", repr(text)
 
+
 def test_brackets_alone():
     text = get_indent_fix("def function():\n    print []\n")
     assert text == "def function():\n    print []\n    ", repr(text)
+
+
+def test_open_parenthesis():
+    text = get_indent_fix("open_parenthesis(\n")
+    assert text == "open_parenthesis(\n                 ", repr(text)
+
 
 # --- Failing tests
 # -----------------------------------------------------------------------------
@@ -65,12 +72,6 @@ def test_simple_def():
 def test_def_with_unindented_comment():
     text = get_indent_fix("def function():\n# Comment\n")
     assert text == "def function():\n# Comment\n    ", repr(text)
-
-
-@pytest.mark.xfail
-def test_open_parenthesis():
-    text = get_indent_fix("open_parenthesis(\n")
-    assert text == "open_parenthesis(\n    ", repr(text)
 
 
 # --- Tabs tests


### PR DESCRIPTION
Fixes #3508 

----------------

- Added some test for indenting with tabs, I used the 3dr way that I mencioned in #3651 (but didn't change spaces indentation tests)
- Added test for #3508 
- Change how `correct_indent` is calculated, when using tabs It will be calculated with spaces (each tab 4 spaces) and then convert it to tabs and reminder to spaces

I think this could be improved if the option `tab_stop_width` is defined in terms of spaces instead of pixels.