### PR TITLE
Free memory when closing a Variable Explorer editor

### DIFF
--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -19,6 +19,7 @@ Collections (i.e. dictionary, list and tuple) editor widget and dialog
 # Standard library imports
 from __future__ import print_function
 import datetime
+import gc
 import sys
 import warnings
 
@@ -519,9 +520,15 @@ class CollectionsDelegate(QItemDelegate):
             conv_func = data.get('conv', lambda v: v)
             self.set_value(index, conv_func(value))
         self._editors.pop(editor_id)
+        self.free_memory()
         
     def editor_rejected(self, editor_id):
         self._editors.pop(editor_id)
+        self.free_memory()
+
+    def free_memory(self):
+        """Free memory after closing an editor."""
+        gc.collect()
 
     def commitAndCloseEditor(self):
         """Overriding method commitAndCloseEditor"""


### PR DESCRIPTION
Fixes #3513.

----

This doesn't completely solve #3513, but it's the best I could come up with. Unfortunately, I don't know how things could be improved :-/

* Pros:
  - It prevents Spyder to fully eat your RAM when inspecting several large variables.
* Cons:
  - It doesn't free RAM for the *first* variable you inspect. A trick to make Spyder freeing that memory is to create a small variable (e.g. an empty dataframe), and then open and close it.