### PR TITLE
PR: Refactor and simplify NamespaceBrowser widget

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -176,8 +176,6 @@ DEFAULTS = [
               }),
             ('variable_explorer',
              {
-              'autorefresh': False,
-              'autorefresh/timeout': 2000,
               'check_all': CHECK_ALL,
               'excluded_names': EXCLUDED_NAMES,
               'exclude_private': True,
@@ -588,7 +586,7 @@ DEFAULTS = [
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '29.0.0'
+CONF_VERSION = '30.0.0'
 
 # Main configuration instance
 try:

--- a/spyder/plugins/externalconsole.py
+++ b/spyder/plugins/externalconsole.py
@@ -689,8 +689,6 @@ class ExternalConsole(SpyderPluginWidget):
         self.tabwidget.setTabIcon(index, icon)
         if self.help is not None:
             self.help.set_shell(shell.shell)
-        if self.variableexplorer is not None:
-            self.variableexplorer.add_shellwidget(shell)
 
     def process_finished(self, shell_id):
         index = self.get_shell_index_from_id(shell_id)

--- a/spyder/plugins/externalconsole.py
+++ b/spyder/plugins/externalconsole.py
@@ -557,8 +557,6 @@ class ExternalConsole(SpyderPluginWidget):
             umr_enabled = CONF.get('main_interpreter', 'umr/enabled')
             umr_namelist = CONF.get('main_interpreter', 'umr/namelist')
             umr_verbose = CONF.get('main_interpreter', 'umr/verbose')
-            ar_timeout = CONF.get('variable_explorer', 'autorefresh/timeout')
-            ar_state = CONF.get('variable_explorer', 'autorefresh')
 
             sa_settings = None
             shellwidget = ExternalPythonShell(self, fname, wdir,
@@ -575,8 +573,6 @@ class ExternalConsole(SpyderPluginWidget):
                            mpl_backend=mpl_backend, qt_api=qt_api,
                            merge_output_channels=merge_output_channels,
                            colorize_sys_stderr=colorize_sys_stderr,
-                           autorefresh_timeout=ar_timeout,
-                           autorefresh_state=ar_state,
                            light_background=light_background,
                            menu_actions=self.menu_actions,
                            show_buttons_inside=False,

--- a/spyder/plugins/variableexplorer.py
+++ b/spyder/plugins/variableexplorer.py
@@ -23,13 +23,6 @@ from spyder.widgets.variableexplorer.utils import REMOTE_SETTINGS
 
 class VariableExplorerConfigPage(PluginConfigPage):
     def setup_page(self):
-        ar_group = QGroupBox(_("Autorefresh"))
-        ar_box = self.create_checkbox(_("Enable autorefresh"),
-                                      'autorefresh')
-        ar_spin = self.create_spinbox(_("Refresh interval: "),
-                                      _(" ms"), 'autorefresh/timeout',
-                                      min_=100, max_=1000000, step=100)
-        
         filter_group = QGroupBox(_("Filter"))
         filter_data = [
             ('exclude_private', _("Exclude private references")),
@@ -53,12 +46,7 @@ class VariableExplorerConfigPage(PluginConfigPage):
                             )
         display_boxes = [self.create_checkbox(text, option, tip=tip)
                          for option, text, tip in display_data]
-        
-        ar_layout = QVBoxLayout()
-        ar_layout.addWidget(ar_box)
-        ar_layout.addWidget(ar_spin)
-        ar_group.setLayout(ar_layout)
-        
+
         filter_layout = QVBoxLayout()
         for box in filter_boxes:
             filter_layout.addWidget(box)
@@ -70,7 +58,6 @@ class VariableExplorerConfigPage(PluginConfigPage):
         display_group.setLayout(display_layout)
 
         vlayout = QVBoxLayout()
-        vlayout.addWidget(ar_group)
         vlayout.addWidget(filter_group)
         vlayout.addWidget(display_group)
         vlayout.addStretch(1)
@@ -202,6 +189,3 @@ class VariableExplorer(QWidget, SpyderPluginMixin):
         """Apply configuration file's plugin settings"""
         for nsb in list(self.shellwidgets.values()):
             nsb.setup(**VariableExplorer.get_settings())
-        ar_timeout = self.get_option('autorefresh/timeout')
-        for shellwidget in self.main.extconsole.shellwidgets:
-            shellwidget.set_autorefresh_timeout(ar_timeout)

--- a/spyder/plugins/variableexplorer.py
+++ b/spyder/plugins/variableexplorer.py
@@ -132,11 +132,6 @@ class VariableExplorer(QWidget, SpyderPluginMixin):
     # ----- Public API --------------------------------------------------------
     def add_shellwidget(self, shellwidget):
         shellwidget_id = id(shellwidget)
-        # Add shell only once: this method may be called two times in a row
-        # by the External console plugin (dev. convenience)
-        from spyder.widgets.externalshell import systemshell
-        if isinstance(shellwidget, systemshell.ExternalSystemShell):
-            return
         if shellwidget_id not in self.shellwidgets:
             nsb = NamespaceBrowser(self)
             nsb.set_shellwidget(shellwidget)

--- a/spyder/plugins/variableexplorer.py
+++ b/spyder/plugins/variableexplorer.py
@@ -154,8 +154,6 @@ class VariableExplorer(QWidget, SpyderPluginMixin):
         if shellwidget_id in self.shellwidgets:
             nsb = self.shellwidgets[shellwidget_id]
             self.set_current_widget(nsb)
-            if self.isvisible:
-                nsb.visibility_changed(True)
 
     def import_data(self, fname):
         """Import data in current namespace"""
@@ -167,13 +165,6 @@ class VariableExplorer(QWidget, SpyderPluginMixin):
                 self.dockwidget.setVisible(True)
                 self.dockwidget.raise_()
 
-    #------ SpyderPluginMixin API ---------------------------------------------
-    def visibility_changed(self, enable):
-        """DockWidget visibility has changed"""
-        SpyderPluginMixin.visibility_changed(self, enable)
-        for nsb in list(self.shellwidgets.values()):
-            nsb.visibility_changed(enable and nsb is self.current_widget())
-    
     #------ SpyderPluginWidget API ---------------------------------------------
     def get_plugin_title(self):
         """Return widget title"""

--- a/spyder/widgets/ipythonconsole/namespacebrowser.py
+++ b/spyder/widgets/ipythonconsole/namespacebrowser.py
@@ -44,9 +44,6 @@ class NamepaceBrowserWidget(RichJupyterWidget):
 
     def configure_namespacebrowser(self):
         """Configure associated namespace browser widget"""
-        # Tell it that we are connected to client
-        self.namespacebrowser.is_ipyclient = True
-
         # Update namespace view
         self.sig_namespace_view.connect(lambda data:
             self.namespacebrowser.process_remote_view(data))

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1338,8 +1338,7 @@ class RemoteCollectionsEditorTableView(BaseTableView):
     """DictEditor table view"""
     def __init__(self, parent, data, minmax=False,
                  shellwidget=None,
-                 oedit_func=None, plot_func=None, imshow_func=None,
-                 show_image_func=None, remote_editing=False):
+                 oedit_func=None, remote_editing=False):
         BaseTableView.__init__(self, parent)
 
         self.remote_editing_enabled = None
@@ -1347,9 +1346,6 @@ class RemoteCollectionsEditorTableView(BaseTableView):
         self.var_properties = {}
 
         self.oedit = oedit_func
-        self.plot = plot_func
-        self.imshow = imshow_func
-        self.show_image = show_image_func
         
         self.dictfilter = None
         self.model = None
@@ -1422,6 +1418,16 @@ class RemoteCollectionsEditorTableView(BaseTableView):
     def get_array_ndim(self, name):
         """Return array's ndim"""
         return self.var_properties[name]['array_ndim']
+
+    def plot(self, name, funcname):
+        self.shellwidget.execute("%%varexp --%s %s" % (funcname, name))
+
+    def imshow(self, name):
+        self.shellwidget.execute("%%varexp --imshow %s" % name)
+
+    def show_image(self, name):
+        command = "%s.show()" % name
+        self.shellwidget.execute(command)
 
     def setup_menu(self, minmax):
         """Setup context menu"""

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1533,10 +1533,15 @@ def remote_editor_test():
     from spyder.utils.qthelpers import qapplication
     app = qapplication()
 
-    from spyder.plugins.variableexplorer import VariableExplorer
-    from spyder.widgets.variableexplorer.utils import make_remote_view
+    from spyder.config.main import CONF
+    from spyder.widgets.variableexplorer.utils import (make_remote_view,
+                                                       REMOTE_SETTINGS)
 
-    remote = make_remote_view(get_test_data(), VariableExplorer.get_settings())
+    settings = {}
+    for name in REMOTE_SETTINGS:
+        settings[name] = CONF.get('variable_explorer', name)
+
+    remote = make_remote_view(get_test_data(), settings)
     dialog = CollectionsEditor()
     dialog.setup(remote, remote=True)
     dialog.show()

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -706,7 +706,7 @@ class BaseTableView(QTableView):
                      None, resize_action])
         return menu
     
-    #------ Remote/local API ---------------------------------------------------
+    #------ Remote/local API --------------------------------------------------
     def remove_values(self, keys):
         """Remove values from data"""
         raise NotImplementedError
@@ -762,7 +762,7 @@ class BaseTableView(QTableView):
     def show_image(self, key):
         """Show image (item is a PIL image)"""
         raise NotImplementedError
-    #---------------------------------------------------------------------------
+    #--------------------------------------------------------------------------
             
     def refresh_menu(self):
         """Refresh context menu"""
@@ -1123,7 +1123,7 @@ class CollectionsEditorTableView(BaseTableView):
         self.setup_table()
         self.menu = self.setup_menu(minmax)
     
-    #------ Remote/local API ---------------------------------------------------
+    #------ Remote/local API --------------------------------------------------
     def remove_values(self, keys):
         """Remove values from data"""
         data = self.model.get_data()
@@ -1204,8 +1204,8 @@ class CollectionsEditorTableView(BaseTableView):
         """Show image (item is a PIL image)"""
         data = self.model.get_data()
         data[key].show()
-    #---------------------------------------------------------------------------
-        
+    #--------------------------------------------------------------------------
+
     def refresh_menu(self):
         """Refresh context menu"""
         data = self.model.get_data()
@@ -1309,7 +1309,9 @@ class CollectionsEditor(QDialog):
         return self.data_copy
 
 
-#----Remote versions of CollectionsDelegate and CollectionsEditorTableView
+#==============================================================================
+# Remote versions of CollectionsDelegate and CollectionsEditorTableView
+#==============================================================================
 class RemoteCollectionsDelegate(CollectionsDelegate):
     """CollectionsEditor Item Delegate"""
     def __init__(self, parent=None):
@@ -1351,6 +1353,7 @@ class RemoteCollectionsEditorTableView(BaseTableView):
         self.setup_table()
         self.menu = self.setup_menu(minmax)
 
+    #------ Remote/local API --------------------------------------------------
     def get_value(self, name):
         value = self.shellwidget.get_value(name)
         # Reset temporal variable where value is saved to
@@ -1422,6 +1425,7 @@ class RemoteCollectionsEditorTableView(BaseTableView):
         command = "from spyder.widgets.variableexplorer.objecteditor import oedit; " \
                   "oedit('%s', modal=False, namespace=locals());" % name
         self.shellwidget.send_to_process(command)
+    #--------------------------------------------------------------------------
 
     def setup_menu(self, minmax):
         """Setup context menu"""

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1338,8 +1338,7 @@ class RemoteCollectionsEditorTableView(BaseTableView):
     """DictEditor table view"""
     def __init__(self, parent, data, minmax=False,
                  shellwidget=None,
-                 remove_values_func=None,
-                 copy_value_func=None, is_list_func=None, get_len_func=None,
+                 is_list_func=None, get_len_func=None,
                  is_array_func=None, is_image_func=None, is_dict_func=None,
                  get_array_shape_func=None, get_array_ndim_func=None,
                  oedit_func=None, plot_func=None, imshow_func=None,
@@ -1349,9 +1348,6 @@ class RemoteCollectionsEditorTableView(BaseTableView):
 
         self.remote_editing_enabled = None
         self.shellwidget = shellwidget
-
-        self.remove_values = remove_values_func
-        self.copy_value = copy_value_func
 
         self.is_data_frame = is_data_frame_func
         self.is_series = is_series_func
@@ -1392,6 +1388,15 @@ class RemoteCollectionsEditorTableView(BaseTableView):
     def new_value(self, name, value):
         value = serialize_object(value)
         self.shellwidget.set_value(name, value)
+        self.shellwidget.refresh_namespacebrowser()
+
+    def remove_values(self, names):
+        for name in names:
+            self.shellwidget.remove_value(name)
+        self.shellwidget.refresh_namespacebrowser()
+
+    def copy_value(self, orig_name, new_name):
+        self.shellwidget.copy_value(orig_name, new_name)
         self.shellwidget.refresh_namespacebrowser()
 
     def setup_menu(self, minmax):

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1309,14 +1309,6 @@ class CollectionsEditor(QDialog):
         return self.data_copy
 
 
-class DictEditor(CollectionsEditor):
-    def __init__(self, parent=None):
-        warnings.warn("`DictEditor` has been renamed to `CollectionsEditor` in "
-                      "Spyder 3. Please use `CollectionsEditor` instead",
-                      RuntimeWarning)
-        CollectionsEditor.__init__(self, parent)
-
-
 #----Remote versions of CollectionsDelegate and CollectionsEditorTableView
 class RemoteCollectionsDelegate(CollectionsDelegate):
     """CollectionsEditor Item Delegate"""

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1336,17 +1336,14 @@ class RemoteCollectionsDelegate(CollectionsDelegate):
 
 class RemoteCollectionsEditorTableView(BaseTableView):
     """DictEditor table view"""
-    def __init__(self, parent, data, minmax=False,
-                 shellwidget=None,
-                 oedit_func=None, remote_editing=False):
+    def __init__(self, parent, data, minmax=False, shellwidget=None,
+                 remote_editing=False):
         BaseTableView.__init__(self, parent)
 
         self.remote_editing_enabled = None
         self.shellwidget = shellwidget
         self.var_properties = {}
 
-        self.oedit = oedit_func
-        
         self.dictfilter = None
         self.model = None
         self.delegate = None
@@ -1428,6 +1425,11 @@ class RemoteCollectionsEditorTableView(BaseTableView):
     def show_image(self, name):
         command = "%s.show()" % name
         self.shellwidget.execute(command)
+
+    def oedit(self, name):
+        command = "from spyder.widgets.variableexplorer.objecteditor import oedit; " \
+                  "oedit('%s', modal=False, namespace=locals());" % name
+        self.shellwidget.send_to_process(command)
 
     def setup_menu(self, minmax):
         """Setup context menu"""

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -20,12 +20,10 @@ Collections (i.e. dictionary, list and tuple) editor widget and dialog
 from __future__ import print_function
 import datetime
 import sys
-import warnings
 
 # Third party imports
 import ipykernel.pickleutil
 from ipykernel.serialize import serialize_object
-
 from qtpy.compat import getsavefilename, to_qvariant
 from qtpy.QtCore import (QAbstractTableModel, QDateTime, QModelIndex, Qt,
                          Signal, Slot)
@@ -1355,6 +1353,7 @@ class RemoteCollectionsEditorTableView(BaseTableView):
 
     #------ Remote/local API --------------------------------------------------
     def get_value(self, name):
+        """Get the value of a variable"""
         value = self.shellwidget.get_value(name)
         # Reset temporal variable where value is saved to
         # save memory
@@ -1362,16 +1361,19 @@ class RemoteCollectionsEditorTableView(BaseTableView):
         return value
 
     def new_value(self, name, value):
+        """Create new value in data"""
         value = serialize_object(value)
         self.shellwidget.set_value(name, value)
         self.shellwidget.refresh_namespacebrowser()
 
     def remove_values(self, names):
+        """Remove values from data"""
         for name in names:
             self.shellwidget.remove_value(name)
         self.shellwidget.refresh_namespacebrowser()
 
     def copy_value(self, orig_name, new_name):
+        """Copy value"""
         self.shellwidget.copy_value(orig_name, new_name)
         self.shellwidget.refresh_namespacebrowser()
 
@@ -1412,16 +1414,20 @@ class RemoteCollectionsEditorTableView(BaseTableView):
         return self.var_properties[name]['array_ndim']
 
     def plot(self, name, funcname):
+        """Plot item"""
         self.shellwidget.execute("%%varexp --%s %s" % (funcname, name))
 
     def imshow(self, name):
+        """Show item's image"""
         self.shellwidget.execute("%%varexp --imshow %s" % name)
 
     def show_image(self, name):
+        """Show image (item is a PIL image)"""
         command = "%s.show()" % name
         self.shellwidget.execute(command)
 
     def oedit(self, name):
+        """Edit item"""
         command = "from spyder.widgets.variableexplorer.objecteditor import oedit; " \
                   "oedit('%s', modal=False, namespace=locals());" % name
         self.shellwidget.send_to_process(command)

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1338,26 +1338,14 @@ class RemoteCollectionsEditorTableView(BaseTableView):
     """DictEditor table view"""
     def __init__(self, parent, data, minmax=False,
                  shellwidget=None,
-                 is_list_func=None, get_len_func=None,
-                 is_array_func=None, is_image_func=None, is_dict_func=None,
-                 get_array_shape_func=None, get_array_ndim_func=None,
                  oedit_func=None, plot_func=None, imshow_func=None,
-                 is_data_frame_func=None, is_series_func=None,
                  show_image_func=None, remote_editing=False):
         BaseTableView.__init__(self, parent)
 
         self.remote_editing_enabled = None
         self.shellwidget = shellwidget
+        self.var_properties = {}
 
-        self.is_data_frame = is_data_frame_func
-        self.is_series = is_series_func
-        self.is_list = is_list_func
-        self.get_len = get_len_func
-        self.is_array = is_array_func
-        self.is_image = is_image_func
-        self.is_dict = is_dict_func
-        self.get_array_shape = get_array_shape_func
-        self.get_array_ndim = get_array_ndim_func
         self.oedit = oedit_func
         self.plot = plot_func
         self.imshow = imshow_func
@@ -1398,6 +1386,42 @@ class RemoteCollectionsEditorTableView(BaseTableView):
     def copy_value(self, orig_name, new_name):
         self.shellwidget.copy_value(orig_name, new_name)
         self.shellwidget.refresh_namespacebrowser()
+
+    def is_list(self, name):
+        """Return True if variable is a list or a tuple"""
+        return self.var_properties[name]['is_list']
+
+    def is_dict(self, name):
+        """Return True if variable is a dictionary"""
+        return self.var_properties[name]['is_dict']
+
+    def get_len(self, name):
+        """Return sequence length"""
+        return self.var_properties[name]['len']
+
+    def is_array(self, name):
+        """Return True if variable is a NumPy array"""
+        return self.var_properties[name]['is_array']
+
+    def is_image(self, name):
+        """Return True if variable is a PIL.Image image"""
+        return self.var_properties[name]['is_image']
+
+    def is_data_frame(self, name):
+        """Return True if variable is a DataFrame"""
+        return self.var_properties[name]['is_data_frame']
+
+    def is_series(self, name):
+        """Return True if variable is a Series"""
+        return self.var_properties[name]['is_series']
+
+    def get_array_shape(self, name):
+        """Return array's shape"""
+        return self.var_properties[name]['array_shape']
+
+    def get_array_ndim(self, name):
+        """Return array's ndim"""
+        return self.var_properties[name]['array_ndim']
 
     def setup_menu(self, minmax):
         """Setup context menu"""

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -69,7 +69,6 @@ class NamespaceBrowser(QWidget):
         self.exclude_unsupported_action = None
 
         self.filename = None
-        self.var_properties = {}
 
     def setup(self, check_all=None, exclude_private=None,
               exclude_uppercase=None, exclude_capitalized=None,
@@ -104,15 +103,6 @@ class NamespaceBrowser(QWidget):
                         minmax=minmax,
                         remote_editing=remote_editing,
                         shellwidget=self.shellwidget,
-                        is_list_func=self.is_list,
-                        get_len_func=self.get_len,
-                        is_array_func=self.is_array,
-                        is_image_func=self.is_image,
-                        is_dict_func=self.is_dict,
-                        is_data_frame_func=self.is_data_frame,
-                        is_series_func=self.is_series,
-                        get_array_shape_func=self.get_array_shape,
-                        get_array_ndim_func=self.get_array_ndim,
                         oedit_func=self.oedit,
                         plot_func=self.plot, imshow_func=self.imshow,
                         show_image_func=self.show_image)
@@ -253,45 +243,9 @@ class NamespaceBrowser(QWidget):
 
     def set_var_properties(self, properties):
         """Set properties of variables"""
-        self.var_properties = properties
+        self.editor.var_properties = properties
 
     #------ Remote commands ------------------------------------
-    def is_list(self, name):
-        """Return True if variable is a list or a tuple"""
-        return self.var_properties[name]['is_list']
-
-    def is_dict(self, name):
-        """Return True if variable is a dictionary"""
-        return self.var_properties[name]['is_dict']
-
-    def get_len(self, name):
-        """Return sequence length"""
-        return self.var_properties[name]['len']
-
-    def is_array(self, name):
-        """Return True if variable is a NumPy array"""
-        return self.var_properties[name]['is_array']
-
-    def is_image(self, name):
-        """Return True if variable is a PIL.Image image"""
-        return self.var_properties[name]['is_image']
-
-    def is_data_frame(self, name):
-        """Return True if variable is a DataFrame"""
-        return self.var_properties[name]['is_data_frame']
-
-    def is_series(self, name):
-        """Return True if variable is a Series"""
-        return self.var_properties[name]['is_series']
-
-    def get_array_shape(self, name):
-        """Return array's shape"""
-        return self.var_properties[name]['array_shape']
-
-    def get_array_ndim(self, name):
-        """Return array's ndim"""
-        return self.var_properties[name]['array_ndim']
-
     def plot(self, name, funcname):
         self.shellwidget.execute("%%varexp --%s %s" % (funcname, name))
 

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -205,22 +205,6 @@ class NamespaceBrowser(QWidget):
         self.shellwidget.set_namespace_view_settings()
         self.refresh_table()
 
-    def visibility_changed(self, enable):
-        """Notify the widget whether its container (the namespace browser
-        plugin is visible or not"""
-        # This is slowing down Spyder a lot if too much data is present in
-        # the Variable Explorer, and users give focus to it after being hidden.
-        # This also happens when the Variable Explorer is visible and users
-        # give focus to Spyder after using another application (like Chrome
-        # or Firefox).
-        # That's why we've decided to remove this feature
-        # Fixes Issue 2593
-        #
-        # self.is_visible = enable
-        # if enable:
-        #     self.refresh_table()
-        pass
-
     def get_view_settings(self):
         """Return dict editor view settings"""
         settings = {}
@@ -228,7 +212,6 @@ class NamespaceBrowser(QWidget):
             settings[name] = getattr(self, name)
         return settings
 
-    @Slot()
     def refresh_table(self):
         """Refresh variable table"""
         if self.is_visible and self.isVisible():

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -104,8 +104,6 @@ class NamespaceBrowser(QWidget):
                         minmax=minmax,
                         remote_editing=remote_editing,
                         shellwidget=self.shellwidget,
-                        remove_values_func=self.remove_values,
-                        copy_value_func=self.copy_value,
                         is_list_func=self.is_list,
                         get_len_func=self.get_len,
                         is_array_func=self.is_array,
@@ -258,15 +256,6 @@ class NamespaceBrowser(QWidget):
         self.var_properties = properties
 
     #------ Remote commands ------------------------------------
-    def remove_values(self, names):
-        for name in names:
-            self.shellwidget.remove_value(name)
-        self.refresh_table()
-
-    def copy_value(self, orig_name, new_name):
-        self.shellwidget.copy_value(orig_name, new_name)
-        self.refresh_table()
-
     def is_list(self, name):
         """Return True if variable is a list or a tuple"""
         return self.var_properties[name]['is_list']

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -12,7 +12,6 @@ This is the main widget used in the Variable Explorer plugin
 
 # Standard library imports
 import os.path as osp
-import socket
 
 # Third library imports (qtpy)
 from qtpy.compat import getsavefilename, getopenfilenames
@@ -38,9 +37,6 @@ from spyder.utils.misc import fix_reference_name
 from spyder.utils.programs import is_module_installed
 from spyder.utils.qthelpers import (add_actions, create_action,
                                     create_toolbutton)
-from spyder.widgets.externalshell.monitor import (
-    communicate, monitor_copy_global, monitor_del_global, monitor_get_global,
-    monitor_load_globals, monitor_save_globals, monitor_set_global)
 from spyder.widgets.variableexplorer.collectionseditor import (
     RemoteCollectionsEditorTableView)
 from spyder.widgets.variableexplorer.importwizard import ImportWizard
@@ -90,9 +86,6 @@ class NamespaceBrowser(QWidget):
         self.exclude_unsupported_action = None
 
         self.filename = None
-
-        # For IPython clients
-        self.is_ipyclient = False
         self.var_properties = {}
 
     def setup(self, check_all=None, exclude_private=None,
@@ -187,22 +180,8 @@ class NamespaceBrowser(QWidget):
     def setup_toolbar(self, exclude_private, exclude_uppercase,
                       exclude_capitalized, exclude_unsupported, autorefresh):
         """Setup toolbar"""
-        self.setup_in_progress = True                          
-                          
+        self.setup_in_progress = True
         toolbar = []
-
-        # There is no need of refreshes for ipyclients
-        if not self.is_ipyclient:
-            refresh_button = create_toolbutton(self, text=_('Refresh'),
-                                               icon=ima.icon('reload'),
-                                               triggered=self.refresh_table)
-            self.auto_refresh_button = create_toolbutton(self,
-                                              text=_('Refresh periodically'),
-                                              icon=ima.icon('auto_reload'),
-                                              toggled=self.toggle_auto_refresh)
-            self.auto_refresh_button.setChecked(autorefresh)
-        else:
-            refresh_button = self.auto_refresh_button = None
 
         load_button = create_toolbutton(self, text=_('Import data'),
                                         icon=ima.icon('fileimport'),
@@ -216,12 +195,8 @@ class NamespaceBrowser(QWidget):
                                            icon=ima.icon('filesaveas'),
                                            triggered=self.save_data)
 
-        if self.is_ipyclient:
-            toolbar += [load_button, self.save_button, save_as_button]
-        else:
-            toolbar += [refresh_button, self.auto_refresh_button, load_button,
-                        self.save_button, save_as_button]
-        
+        toolbar += [load_button, self.save_button, save_as_button]
+
         self.exclude_private_action = create_action(self,
                 _("Exclude private references"),
                 tip=_("Exclude references which name starts"
@@ -260,13 +235,8 @@ class NamespaceBrowser(QWidget):
     def option_changed(self, option, value):
         """Option has changed"""
         setattr(self, to_text_string(option), value)
-        if self.is_ipyclient:
-            self.shellwidget.set_namespace_view_settings()
-            self.refresh_table()
-        else:
-            settings = self.get_view_settings()
-            communicate(self._get_sock(),
-                        'set_remote_view_settings()', settings=[settings])
+        self.shellwidget.set_namespace_view_settings()
+        self.refresh_table()
 
     def visibility_changed(self, enable):
         """Notify the widget whether its container (the namespace browser
@@ -284,18 +254,6 @@ class NamespaceBrowser(QWidget):
         #     self.refresh_table()
         pass
 
-    @Slot(bool)
-    def toggle_auto_refresh(self, state):
-        """Toggle auto refresh state"""
-        self.autorefresh = state
-        if not self.setup_in_progress and not self.is_ipyclient:
-            communicate(self._get_sock(),
-                        "set_monitor_auto_refresh(%r)" % state)
-
-    def _get_sock(self):
-        """Return socket connection"""
-        return self.shellwidget.introspection_socket
-
     def get_view_settings(self):
         """Return dict editor view settings"""
         settings = {}
@@ -307,18 +265,7 @@ class NamespaceBrowser(QWidget):
     def refresh_table(self):
         """Refresh variable table"""
         if self.is_visible and self.isVisible():
-            if self.is_ipyclient:
-                self.shellwidget.refresh_namespacebrowser()
-            else:
-                if self.shellwidget.is_running():
-                    sock = self._get_sock()
-                    if sock is None:
-                        return
-                    try:
-                        communicate(sock, "refresh()")
-                    except socket.error:
-                        # Process was terminated before calling this method
-                        pass
+            self.shellwidget.refresh_namespacebrowser()
 
     def process_remote_view(self, remote_view):
         """Process remote view"""
@@ -331,138 +278,71 @@ class NamespaceBrowser(QWidget):
 
     #------ Remote commands ------------------------------------
     def get_value(self, name):
-        if self.is_ipyclient:
-            value = self.shellwidget.get_value(name)
-
-            # Reset temporal variable where value is saved to
-            # save memory
-            self.shellwidget._kernel_value = None
-        else:
-            value = monitor_get_global(self._get_sock(), name)
-            if value is None:
-                if communicate(self._get_sock(), '%s is not None' % name):
-                    import pickle
-                    msg = to_text_string(_("Object <b>%s</b> is not picklable")
-                                         % name)
-                    raise pickle.PicklingError(msg)
+        value = self.shellwidget.get_value(name)
+        # Reset temporal variable where value is saved to
+        # save memory
+        self.shellwidget._kernel_value = None
         return value
-        
+
     def set_value(self, name, value):
-        if self.is_ipyclient:
-            value = serialize_object(value)
-            self.shellwidget.set_value(name, value)
-        else:
-            monitor_set_global(self._get_sock(), name, value)
+        value = serialize_object(value)
+        self.shellwidget.set_value(name, value)
         self.refresh_table()
-        
+
     def remove_values(self, names):
         for name in names:
-            if self.is_ipyclient:
-                self.shellwidget.remove_value(name)
-            else:
-                monitor_del_global(self._get_sock(), name)
+            self.shellwidget.remove_value(name)
         self.refresh_table()
-        
+
     def copy_value(self, orig_name, new_name):
-        if self.is_ipyclient:
-            self.shellwidget.copy_value(orig_name, new_name)
-        else:
-            monitor_copy_global(self._get_sock(), orig_name, new_name)
+        self.shellwidget.copy_value(orig_name, new_name)
         self.refresh_table()
-        
+
     def is_list(self, name):
         """Return True if variable is a list or a tuple"""
-        if self.is_ipyclient:
-            return self.var_properties[name]['is_list']
-        else:
-            return communicate(self._get_sock(),
-                               'isinstance(%s, (tuple, list))' % name)
-        
+        return self.var_properties[name]['is_list']
+
     def is_dict(self, name):
         """Return True if variable is a dictionary"""
-        if self.is_ipyclient:
-            return self.var_properties[name]['is_dict']
-        else:
-            return communicate(self._get_sock(), 'isinstance(%s, dict)' % name)
-        
+        return self.var_properties[name]['is_dict']
+
     def get_len(self, name):
         """Return sequence length"""
-        if self.is_ipyclient:
-            return self.var_properties[name]['len']
-        else:
-            return communicate(self._get_sock(), "len(%s)" % name)
-        
+        return self.var_properties[name]['len']
+
     def is_array(self, name):
         """Return True if variable is a NumPy array"""
-        if self.is_ipyclient:
-            return self.var_properties[name]['is_array']
-        else:
-            return communicate(self._get_sock(), 'is_array("%s")' % name)
-        
+        return self.var_properties[name]['is_array']
+
     def is_image(self, name):
         """Return True if variable is a PIL.Image image"""
-        if self.is_ipyclient:
-            return self.var_properties[name]['is_image']
-        else:
-            return communicate(self._get_sock(), 'is_image("%s")' % name)
+        return self.var_properties[name]['is_image']
 
     def is_data_frame(self, name):
         """Return True if variable is a DataFrame"""
-        if self.is_ipyclient:
-            return self.var_properties[name]['is_data_frame']
-        else:
-            return communicate(self._get_sock(),
-                               "isinstance(globals()['%s'], DataFrame)" % name)
+        return self.var_properties[name]['is_data_frame']
 
     def is_series(self, name):
         """Return True if variable is a Series"""
-        if self.is_ipyclient:
-            return self.var_properties[name]['is_series']
-        else:
-            return communicate(self._get_sock(),
-                               "isinstance(globals()['%s'], Series)" % name)
+        return self.var_properties[name]['is_series']
 
     def get_array_shape(self, name):
         """Return array's shape"""
-        if self.is_ipyclient:
-            return self.var_properties[name]['array_shape']
-        else:
-            return communicate(self._get_sock(), "%s.shape" % name)
-        
+        return self.var_properties[name]['array_shape']
+
     def get_array_ndim(self, name):
         """Return array's ndim"""
-        if self.is_ipyclient:
-            return self.var_properties[name]['array_ndim']
-        else:
-            return communicate(self._get_sock(), "%s.ndim" % name)
-        
+        return self.var_properties[name]['array_ndim']
+
     def plot(self, name, funcname):
-        if self.is_ipyclient:
-            self.shellwidget.execute("%%varexp --%s %s" % (funcname, name))
-        else:
-            command = "import spyder.pyplot; "\
-                  "__fig__ = spyder.pyplot.figure(); "\
-                  "__items__ = getattr(spyder.pyplot, '%s')(%s); "\
-                  "spyder.pyplot.show(); "\
-                  "del __fig__, __items__;" % (funcname, name)
-            self.shellwidget.send_to_process(command)
-        
+        self.shellwidget.execute("%%varexp --%s %s" % (funcname, name))
+
     def imshow(self, name):
-        if self.is_ipyclient:
-            self.shellwidget.execute("%%varexp --imshow %s" % name)
-        else:
-            command = "import spyder.pyplot; " \
-                  "__fig__ = spyder.pyplot.figure(); " \
-                  "__items__ = spyder.pyplot.imshow(%s); " \
-                  "spyder.pyplot.show(); del __fig__, __items__;" % name
-            self.shellwidget.send_to_process(command)
-        
+        self.shellwidget.execute("%%varexp --imshow %s" % name)
+
     def show_image(self, name):
         command = "%s.show()" % name
-        if self.is_ipyclient:
-            self.shellwidget.execute(command)
-        else:
-            self.shellwidget.send_to_process(command)
+        self.shellwidget.execute(command)
 
     def oedit(self, name):
         command = "from spyder.widgets.variableexplorer.objecteditor import oedit; " \
@@ -538,13 +418,8 @@ class NamespaceBrowser(QWidget):
             else:
                 QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
                 QApplication.processEvents()
-                if self.is_ipyclient:
-                    error_message = self.shellwidget.load_data(self.filename,
-                                                               ext)
-                    self.shellwidget._kernel_reply = None
-                else:
-                    error_message = monitor_load_globals(self._get_sock(),
-                                                         self.filename, ext)
+                error_message = self.shellwidget.load_data(self.filename, ext)
+                self.shellwidget._kernel_reply = None
                 QApplication.restoreOverrideCursor()
                 QApplication.processEvents()
     
@@ -571,13 +446,10 @@ class NamespaceBrowser(QWidget):
                 return False
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
         QApplication.processEvents()
-        if self.is_ipyclient:
-            error_message = self.shellwidget.save_namespace(self.filename)
-            self.shellwidget._kernel_reply = None
-        else:
-            settings = self.get_view_settings()
-            error_message = monitor_save_globals(self._get_sock(), settings,
-                                             filename)
+
+        error_message = self.shellwidget.save_namespace(self.filename)
+        self.shellwidget._kernel_reply = None
+
         QApplication.restoreOverrideCursor()
         QApplication.processEvents()
         if error_message is not None:

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -99,11 +99,11 @@ class NamespaceBrowser(QWidget):
             self.refresh_table()
             return
 
-        self.editor = RemoteCollectionsEditorTableView(self, None,
+        self.editor = RemoteCollectionsEditorTableView(self,
+                        data=None,
                         minmax=minmax,
-                        remote_editing=remote_editing,
                         shellwidget=self.shellwidget,
-                        oedit_func=self.oedit)
+                        remote_editing=remote_editing)
         self.editor.sig_option_changed.connect(self.sig_option_changed.emit)
         self.editor.sig_files_dropped.connect(self.import_data)
 
@@ -242,12 +242,6 @@ class NamespaceBrowser(QWidget):
     def set_var_properties(self, properties):
         """Set properties of variables"""
         self.editor.var_properties = properties
-
-    #------ Remote commands ------------------------------------
-    def oedit(self, name):
-        command = "from spyder.widgets.variableexplorer.objecteditor import oedit; " \
-                  "oedit('%s', modal=False, namespace=locals());" % name
-        self.shellwidget.send_to_process(command)
 
     #------ Set, load and save data -------------------------------------------
     def set_data(self, data):

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -103,9 +103,7 @@ class NamespaceBrowser(QWidget):
                         minmax=minmax,
                         remote_editing=remote_editing,
                         shellwidget=self.shellwidget,
-                        oedit_func=self.oedit,
-                        plot_func=self.plot, imshow_func=self.imshow,
-                        show_image_func=self.show_image)
+                        oedit_func=self.oedit)
         self.editor.sig_option_changed.connect(self.sig_option_changed.emit)
         self.editor.sig_files_dropped.connect(self.import_data)
 
@@ -246,16 +244,6 @@ class NamespaceBrowser(QWidget):
         self.editor.var_properties = properties
 
     #------ Remote commands ------------------------------------
-    def plot(self, name, funcname):
-        self.shellwidget.execute("%%varexp --%s %s" % (funcname, name))
-
-    def imshow(self, name):
-        self.shellwidget.execute("%%varexp --imshow %s" % name)
-
-    def show_image(self, name):
-        command = "%s.show()" % name
-        self.shellwidget.execute(command)
-
     def oedit(self, name):
         command = "from spyder.widgets.variableexplorer.objecteditor import oedit; " \
                   "oedit('%s', modal=False, namespace=locals());" % name

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -60,7 +60,6 @@ class NamespaceBrowser(QWidget):
         self.excluded_names = None
         self.minmax = None
         self.remote_editing = None
-        self.autorefresh = None
         
         self.editor = None
         self.exclude_private_action = None
@@ -73,8 +72,7 @@ class NamespaceBrowser(QWidget):
     def setup(self, check_all=None, exclude_private=None,
               exclude_uppercase=None, exclude_capitalized=None,
               exclude_unsupported=None, excluded_names=None,
-              minmax=None, remote_editing=None,
-              autorefresh=None):
+              minmax=None, remote_editing=None):
         """Setup the namespace browser"""
         assert self.shellwidget is not None
         
@@ -86,7 +84,6 @@ class NamespaceBrowser(QWidget):
         self.excluded_names = excluded_names
         self.minmax = minmax
         self.remote_editing = remote_editing
-        self.autorefresh = autorefresh
         
         if self.editor is not None:
             self.editor.setup_menu(minmax)
@@ -94,8 +91,6 @@ class NamespaceBrowser(QWidget):
             self.exclude_uppercase_action.setChecked(exclude_uppercase)
             self.exclude_capitalized_action.setChecked(exclude_capitalized)
             self.exclude_unsupported_action.setChecked(exclude_unsupported)
-            if self.auto_refresh_button is not None:
-                self.auto_refresh_button.setChecked(autorefresh)
             self.refresh_table()
             return
 
@@ -111,8 +106,7 @@ class NamespaceBrowser(QWidget):
         layout = QVBoxLayout()
         blayout = QHBoxLayout()
         toolbar = self.setup_toolbar(exclude_private, exclude_uppercase,
-                                     exclude_capitalized, exclude_unsupported,
-                                     autorefresh)
+                                     exclude_capitalized, exclude_unsupported)
         for widget in toolbar:
             blayout.addWidget(widget)
 
@@ -145,7 +139,7 @@ class NamespaceBrowser(QWidget):
         shellwidget.set_namespacebrowser(self)
 
     def setup_toolbar(self, exclude_private, exclude_uppercase,
-                      exclude_capitalized, exclude_unsupported, autorefresh):
+                      exclude_capitalized, exclude_unsupported):
         """Setup toolbar"""
         self.setup_in_progress = True
         toolbar = []

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -444,8 +444,7 @@ def globalsfilter(input_dict, check_all=False, filters=None,
 #==============================================================================
 REMOTE_SETTINGS = ('check_all', 'exclude_private', 'exclude_uppercase',
                    'exclude_capitalized', 'exclude_unsupported',
-                   'excluded_names', 'minmax', 'remote_editing',
-                   'autorefresh')
+                   'excluded_names', 'minmax', 'remote_editing')
 
 
 def get_remote_data(data, settings, mode, more_excluded_names=None):


### PR DESCRIPTION
This PR also removes the connection between the Variable Explorer and the Python Console. This starts the process of moving that console out of Spyder because it's unmaintained.