### PR TITLE
PR: Remove logic to delete last dir separator (\, /) in find and replace widget

### DIFF
--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -269,6 +269,17 @@ class PathComboBox(EditableComboBox):
         self.valid.emit(True, True)
         self.open_dir.emit(self.selected_text)
 
+    def add_current_text(self):
+        """
+        Add current text to combo box history (convenient method).
+        If path ends in os separator ("\" windows, "/" unix) remove it.
+        """
+        text = self.currentText()
+        if osp.isdir(text) and text:
+            if text[-1] == os.sep:
+                text = text[:-1]
+        self.add_text(text)
+
 
 class UrlComboBox(PathComboBox):
     """

--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -114,9 +114,6 @@ class BaseComboBox(QComboBox):
     def add_current_text(self):
         """Add current text to combo box history (convenient method)"""
         text = self.currentText()
-        if osp.isdir(text):
-            if text[-1] == os.sep:
-                text = text[:-1]
         self.add_text(text)
 
     def add_current_text_if_valid(self):


### PR DESCRIPTION
Fixes #3141