### PR TITLE
Utils: Make is_module_installed to catch all errors when importing a module

### DIFF
--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -436,7 +436,7 @@ def is_module_installed(module_name, version=None, installed_version=None,
         if installed_version is None:
             try:
                 actver = get_module_version(module_name)
-            except ImportError:
+            except:
                 # Module is not installed
                 return False
         else:


### PR DESCRIPTION
Fixes #3738

----

This will avoid simple crashes when importing a module fails with errors other than `ImportError`