### PR TITLE
Improve highlighter decorator regexp

### DIFF
--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -290,7 +290,9 @@ def make_python_patterns(additional_keywords=[], additional_builtins=[]):
     kw = r"\b" + any("keyword", kwlist) + r"\b"
     builtin = r"([^.'\"\\#]\b|^)" + any("builtin", builtinlist) + r"\b"
     comment = any("comment", [r"#[^\n]*"])
-    instance = any("instance", [r"\bself\b",r"^\s*@[a-zA-Z.]*"])
+    instance = any("instance", [r"\bself\b",
+                                (r"^\s*@([a-zA-Z_][a-zA-Z0-9_]*)"
+                                     r"(.[a-zA-Z_][a-zA-Z0-9_]*)*")])
     number = any("number",
                  [r"\b[+-]?[0-9]+[lLjJ]?\b",
                   r"\b[+-]?0[xX][0-9A-Fa-f]+[lL]?\b",


### PR DESCRIPTION
In  #3654 I didn't take in account that decorators are variables separated by points, and variables contain letters, numbers and underscores, and should start by a letter or underscore

Some decorators weren't detected:
```
@decorator_with_underscore
@decorator12
```
and others were detected and shouldn't be detected:
```
@.decorator
@decorator..points
@decorator.
```



