### PR TITLE
PR: Only show base filename in Python console titles

### DIFF
--- a/spyder/plugins/externalconsole.py
+++ b/spyder/plugins/externalconsole.py
@@ -712,8 +712,8 @@ class ExternalConsole(SpyderPluginWidget):
             fname = self.filenames[index]
             if fname:
                 # solve issue 1165
-                filename = osp.basename(fname)
-                title += ' - ' + to_text_string(filename)
+                fname = osp.basename(fname)
+                title += ' - ' + to_text_string(fname)
         return title
     
     def get_plugin_icon(self):

--- a/spyder/plugins/externalconsole.py
+++ b/spyder/plugins/externalconsole.py
@@ -711,7 +711,9 @@ class ExternalConsole(SpyderPluginWidget):
             index = self.tabwidget.currentIndex()
             fname = self.filenames[index]
             if fname:
-                title += ' - ' + to_text_string(fname)
+                # solve issue 1165
+                filename = osp.basename(fname)
+                title += ' - ' + to_text_string(filename)
         return title
     
     def get_plugin_icon(self):


### PR DESCRIPTION
Fixes #1165 

----

Okay, we're talking about this, right?

![seleccion_012](https://cloud.githubusercontent.com/assets/5307894/20856168/ae2fe178-b8d6-11e6-9cac-2929618cdb08.png)

This is the result of PR
![seleccion_013](https://cloud.githubusercontent.com/assets/5307894/20856175/ee38ab9c-b8d6-11e6-9020-77b8ed8caa53.png)

Thanks @ccordoba12 