### PR TITLE
PR: Redefinition of upper/lower shortcuts was not updated in Edit menu

### DIFF
--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -914,14 +914,18 @@ class Editor(SpyderPluginWidget):
                 triggered=self.unindent, context=Qt.WidgetShortcut)
 
         self.text_uppercase_action = create_action(self,
-                _("Toggle Uppercase"), "Ctrl+Shift+U",
+                _("Toggle Uppercase"),
                 tip=_("Change to uppercase current line or selection"),
                 triggered=self.text_uppercase, context=Qt.WidgetShortcut)
+        self.register_shortcut(self.text_uppercase_action, context="Editor",
+                               name="transform to uppercase")
 
         self.text_lowercase_action = create_action(self,
-                _("Toggle Lowercase"), "Ctrl+U",
+                _("Toggle Lowercase"),
                 tip=_("Change to lowercase current line or selection"),
                 triggered=self.text_lowercase, context=Qt.WidgetShortcut)
+        self.register_shortcut(self.text_lowercase_action, context="Editor",
+                               name="transform to lowercase")
         # ----------------------------------------------------------------------
         
         self.win_eol_action = create_action(self,


### PR DESCRIPTION
Fixes #3755 

![upperlower](https://cloud.githubusercontent.com/assets/5307894/20903680/491da97e-bb0a-11e6-8ed4-e912ba234a10.gif)
