### PR TITLE
PR: Catch error raised in isbinaryornot when trying to open a directory

### DIFF
--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -249,4 +249,7 @@ def is_text_file(filename):
     """
     Test if the given path is a text-like file.
     """
-    return not is_binary(filename)
+    try:
+        return not is_binary(filename)
+    except IsADirectoryError:
+        return False

--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -251,5 +251,5 @@ def is_text_file(filename):
     """
     try:
         return not is_binary(filename)
-    except IsADirectoryError:
+    except (OSError, IOError):
         return False


### PR DESCRIPTION
After #3640 an error was caused when right clicking over a directory in project explorer (I didn't notice while doing #3640, sorry :disappointed:)

```
>>> Traceback (most recent call last):
  File "/home/rlaverde/code/spyder/spyder/widgets/explorer.py", line 404, in contextMenuEvent
    self.update_menu()
  File "/home/rlaverde/code/spyder/spyder/widgets/explorer.py", line 383, in update_menu
    add_actions(self.menu, self.create_context_menu_actions())
  File "/home/rlaverde/code/spyder/spyder/widgets/explorer.py", line 370, in create_context_menu_actions
    actions += self.create_file_manage_actions(fnames)
  File "/home/rlaverde/code/spyder/spyder/widgets/explorer.py", line 270, in create_file_manage_actions
    only_valid = all([encoding.is_text_file(_fn) for _fn in fnames])
  File "/home/rlaverde/code/spyder/spyder/widgets/explorer.py", line 270, in <listcomp>
    only_valid = all([encoding.is_text_file(_fn) for _fn in fnames])
  File "/home/rlaverde/code/spyder/spyder/utils/encoding.py", line 252, in is_text_file
    return not is_binary(filename)
  File "/home/rlaverde/code/spyder/spyder/utils/external/binaryornot/check.py", line 32, in is_binary
    chunk = get_starting_chunk(filename)
  File "/home/rlaverde/code/spyder/spyder/utils/external/binaryornot/helpers.py", line 32, in get_starting_chunk
    with open(filename, 'rb') as f:
IsADirectoryError: [Errno 21] Is a directory: '/home/rlaverde/code/spyder/spyder/defaults'
```