### PR TITLE
PR: Closing tour does not freeze Spyder on windows

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -946,9 +946,6 @@ class MainWindow(QMainWindow):
 
         self.tours_menu.addActions(self.tour_menu_actions)
 
-        if not DEV:
-            self.tours_menu = None
-
         self.help_menu_actions = [doc_action, tut_action, self.tours_menu,
                                   None, report_action, dep_action,
                                   self.check_updates_action, support_action,

--- a/spyder/app/tour.py
+++ b/spyder/app/tour.py
@@ -917,7 +917,6 @@ class AnimatedTour(QWidget):
 
     def _close_canvas(self):
         """ """
-        self._set_modal(False, [self.tips])
         self.tips.hide()
         self.canvas.fade_out(self.canvas.hide)
 


### PR DESCRIPTION
Fixes #3452 

The issue is solved. I have some comments: 

- What I did was deleting the ```self._set_modal(False, [self.tips])``` call when closing the tour, this affects only windows. However I am not exactly sure why it was needed before. 

![image](https://cloud.githubusercontent.com/assets/3608776/20949134/d7181daa-bbe5-11e6-8515-ec9c17e964ef.png)

- Also deleted the option that makes the tour available only in DEV mode. 
