### PR TITLE
PR: Make running a file with single quotes on its path not to throw an error on Windows

### DIFF
--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -160,6 +160,7 @@ def remove_backslashes(path):
             path = path[:-1]
         # Replacing backslashes by slashes
         path = path.replace('\\', '/')
+        path = path.replace('/\'', '\\\'')
     return path
 
 


### PR DESCRIPTION
Fixes #3788 