### PR TITLE
Patch Jedi to get completions for compiled objects in Numpy and Matplotlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ a Python version greater than 2.7 (Python 3.2 is not supported anymore).
 * **QtPy** 1.1.0+: Abstracion layer for Python Qt bindings so that Spyder can run on PyQt4
   and PyQt5.
 * **Chardet**: Character encoding auto-detection in Python.
+* **Numpydoc**: Used by Jedi to get return types for functions with Numpydoc docstrings.
 
 ### Optional dependencies
 

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ machine:
     CONDA_DEPENDENCIES_FLAGS: "--quiet"
     CONDA_DEPENDENCIES: >
       rope jedi pyflakes sphinx pygments pylint pep8 psutil nbconvert qtawesome pickleshare
-      qtpy pyzmq chardet mock nomkl pandas pytest pytest-cov
+      qtpy pyzmq chardet mock nomkl pandas pytest pytest-cov numpydoc
     PIP_DEPENDENCIES: "coveralls pytest-qt"
 
 dependencies:

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ machine:
     CONDA_DEPENDENCIES_FLAGS: "--quiet"
     CONDA_DEPENDENCIES: >
       rope jedi pyflakes sphinx pygments pylint pep8 psutil nbconvert qtawesome pickleshare
-      qtpy pyzmq chardet mock nomkl pandas pytest pytest-cov numpydoc
+      qtpy pyzmq chardet mock nomkl pandas pytest pytest-cov numpydoc matplotlib
     PIP_DEPENDENCIES: "coveralls pytest-qt"
 
 dependencies:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - qtpy >=1.1.0
     - pyzmq
     - chardet >=2.0.0
+    - numpydoc
 
 about:
   home: https://github.com/spyder-ide/spyder

--- a/continuous_integration/conda-recipes/spyder/meta.yaml
+++ b/continuous_integration/conda-recipes/spyder/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - qtawesome
     - qtpy
     - chardet >=2.0.0
+    - numpydoc
 
 about:
   home: https://github.com/spyder-ide/spyder

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -196,6 +196,9 @@ The requirements to run Spyder are:
 
 * `Chardet <https://github.com/chardet/chardet>`_ >=2.0.0-- Character encoding auto-detection
   in Python.
+  
+* `Numpydoc <https://github.com/numpy/numpydoc>`_ Used by Jedi to get return types for
+  functions with Numpydoc docstrings.
 
 Optional modules
 ~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -285,6 +285,7 @@ install_requires = [
     'pickleshare',
     'pyzmq',
     'chardet>=2.0.0',
+    'numpydoc',
 ]
 
 if 'setuptools' in sys.modules:

--- a/spyder/docstrings.py
+++ b/spyder/docstrings.py
@@ -1,0 +1,286 @@
+"""
+Docstrings are another source of information for functions and classes.
+:mod:`jedi.evaluate.dynamic` tries to find all executions of functions, while
+the docstring parsing is much easier. There are two different types of
+docstrings that |jedi| understands:
+
+- `Sphinx <http://sphinx-doc.org/markup/desc.html#info-field-lists>`_
+- `Epydoc <http://epydoc.sourceforge.net/manual-fields.html>`_
+
+For example, the sphinx annotation ``:type foo: str`` clearly states that the
+type of ``foo`` is ``str``.
+
+As an addition to parameter searching, this module also provides return
+annotations.
+"""
+
+from ast import literal_eval
+import re
+from itertools import chain
+from textwrap import dedent
+from jedi.evaluate.cache import memoize_default
+from jedi.parser import Parser, load_grammar
+from jedi.parser.tree import Class
+from jedi.common import indent_block
+from jedi.evaluate.iterable import Array, FakeSequence, AlreadyEvaluated
+
+
+DOCSTRING_PARAM_PATTERNS = [
+    r'\s*:type\s+%s:\s*([^\n]+)',  # Sphinx
+    r'\s*:param\s+(\w+)\s+%s:[^\n]+',  # Sphinx param with type
+    r'\s*@type\s+%s:\s*([^\n]+)',  # Epydoc
+]
+
+DOCSTRING_RETURN_PATTERNS = [
+    re.compile(r'\s*:rtype:\s*([^\n]+)', re.M),  # Sphinx
+    re.compile(r'\s*@rtype:\s*([^\n]+)', re.M),  # Epydoc
+]
+
+REST_ROLE_PATTERN = re.compile(r':[^`]+:`([^`]+)`')
+
+
+try:
+    from numpydoc.docscrape import NumpyDocString
+except ImportError:
+    def _search_param_in_numpydocstr(docstr, param_str):
+        return []
+
+    def _search_return_in_numpydocstr(docstr):
+        return []
+else:
+    def _search_param_in_numpydocstr(docstr, param_str):
+        """Search `docstr` (in numpydoc format) for type(-s) of `param_str`."""
+        params = NumpyDocString(docstr)._parsed_data['Parameters']
+        for p_name, p_type, p_descr in params:
+            if p_name == param_str:
+                m = re.match('([^,]+(,[^,]+)*?)(,[ ]*optional)?$', p_type)
+                if m:
+                    p_type = m.group(1)
+                return _expand_typestr(p_type)
+        return []
+
+    def _search_return_in_numpydocstr(docstr):
+        r"""
+        Search `docstr` (in numpydoc format) for type(-s) of `param_str`.
+
+        """
+        doc = NumpyDocString(docstr)
+        returns = doc._parsed_data['Returns']
+        returns += doc._parsed_data['Yields']
+        found = []
+        for p_name, p_type, p_descr in returns:
+            if not p_type:
+                p_type = p_name
+                p_name = ''
+
+            m = re.match('([^,]+(,[^,]+)*?)$', p_type)
+            if m:
+                p_type = m.group(1)
+            found.extend(_expand_typestr(p_type))
+        return found
+
+
+def _expand_typestr(p_type):
+    """
+    Attempts to interpret the possible types
+    """
+    # Check if alternative types are specified
+    if re.search('\\bor\\b', p_type):
+        types = [t.strip() for t in p_type.split('or')]
+    # Check if type has a set of valid literal values
+    elif p_type.startswith('{'):
+        # python2 does not support literal set evals
+        # workaround this by using lists instead
+        p_type = p_type.replace('{', '[').replace('}', ']')
+        types = set(type(x).__name__ for x in literal_eval(p_type))
+        types = list(types)
+    # Otherwise just return the typestr wrapped in a list
+    else:
+        types = [p_type]
+    return types
+
+
+def _search_param_in_docstr(docstr, param_str):
+    """
+    Search `docstr` for type(-s) of `param_str`.
+
+    >>> _search_param_in_docstr(':type param: int', 'param')
+    ['int']
+    >>> _search_param_in_docstr('@type param: int', 'param')
+    ['int']
+    >>> _search_param_in_docstr(
+    ...   ':type param: :class:`threading.Thread`', 'param')
+    ['threading.Thread']
+    >>> bool(_search_param_in_docstr('no document', 'param'))
+    False
+    >>> _search_param_in_docstr(':param int param: some description', 'param')
+    ['int']
+
+    """
+    # look at #40 to see definitions of those params
+
+    # Check for Sphinx/Epydoc params
+    patterns = [re.compile(p % re.escape(param_str))
+                for p in DOCSTRING_PARAM_PATTERNS]
+
+    found = None
+    for pattern in patterns:
+        match = pattern.search(docstr)
+        if match:
+            found = [_strip_rst_role(match.group(1))]
+            break
+    if found is not None:
+        return found
+
+    # Check for numpy style params
+    found = _search_param_in_numpydocstr(docstr, param_str)
+    if found is not None:
+        return found
+
+    return []
+
+
+def _strip_rst_role(type_str):
+    """
+    Strip off the part looks like a ReST role in `type_str`.
+
+    >>> _strip_rst_role(':class:`ClassName`')  # strip off :class:
+    'ClassName'
+    >>> _strip_rst_role(':py:obj:`module.Object`')  # works with domain
+    'module.Object'
+    >>> _strip_rst_role('ClassName')  # do nothing when not ReST role
+    'ClassName'
+
+    See also:
+    http://sphinx-doc.org/domains.html#cross-referencing-python-objects
+
+    """
+    match = REST_ROLE_PATTERN.match(type_str)
+    if match:
+        return match.group(1)
+    else:
+        return type_str
+
+
+def _evaluate_for_statement_string(evaluator, string, module):
+    if string is None:
+        return []
+
+    code = dedent("""
+    def pseudo_docstring_stuff():
+        # Create a pseudo function for docstring statements.
+    %s
+    """)
+
+    for element in re.findall('((?:\w+\.)*\w+)\.', string):
+        # Try to import module part in dotted name.
+        # (e.g., 'threading' in 'threading.Thread').
+        string = 'import %s\n' % element + string
+
+    # Take the default grammar here, if we load the Python 2.7 grammar here, it
+    # will be impossible to use `...` (Ellipsis) as a token. Docstring types
+    # don't need to conform with the current grammar.
+    p = Parser(load_grammar(), code % indent_block(string))
+    try:
+        pseudo_cls = p.module.subscopes[0]
+        # First pick suite, then simple_stmt (-2 for DEDENT) and then the node,
+        # which is also not the last item, because there's a newline.
+        stmt = pseudo_cls.children[-1].children[-2].children[-2]
+    except (AttributeError, IndexError):
+        type_list = []
+    else:
+        # Use the module of the param.
+        # TODO this module is not the module of the param in case of a function
+        # call. In that case it's the module of the function call.
+        # stuffed with content from a function call.
+        pseudo_cls.parent = module
+        type_list = _execute_types_in_stmt(evaluator, stmt)
+    return type_list
+
+
+def _execute_types_in_stmt(evaluator, stmt):
+    """
+    Executing all types or general elements that we find in a statement. This
+    doesn't include tuple, list and dict literals, because the stuff they
+    contain is executed. (Used as type information).
+    """
+    definitions = evaluator.eval_element(stmt)
+    types_list = [_execute_array_values(evaluator, d) for d in definitions]
+    type_list = list(chain.from_iterable(types_list))
+    return type_list
+
+
+def _execute_array_values(evaluator, array):
+    """
+    Tuples indicate that there's not just one return value, but the listed
+    ones.  `(str, int)` means that it returns a tuple with both types.
+    """
+    if isinstance(array, Array):
+        values = []
+        for types in array.py__iter__():
+            objects = set(chain.from_iterable(_execute_array_values(evaluator, typ) for typ in types))
+            values.append(AlreadyEvaluated(objects))
+        return [FakeSequence(evaluator, values, array.type)]
+    else:
+        return evaluator.execute(array)
+
+
+@memoize_default(None, evaluator_is_first_arg=True)
+def follow_param(evaluator, param):
+    """
+    Determines a set of potential types for `param` using docstring hints
+
+    :type evaluator: jedi.evaluate.Evaluator
+    :type param: jedi.parser.tree.Param
+
+    :rtype: list
+    """
+    def eval_docstring(docstr):
+        param_str = str(param.name)
+        return set(
+            [p for string in _search_param_in_docstr(docstr, param_str)
+                for p in _evaluate_for_statement_string(evaluator, string, module)]
+        )
+    func = param.parent_function
+    module = param.get_parent_until()
+
+    docstr = func.raw_doc
+    types = eval_docstring(docstr)
+    if func.name.value == '__init__':
+        cls = func.get_parent_until(Class)
+        if cls.type == 'classdef':
+            types |= eval_docstring(cls.raw_doc)
+
+    return types
+
+
+@memoize_default(None, evaluator_is_first_arg=True)
+def find_return_types(evaluator, func):
+    """
+    Determines a set of potential return types for `func` using docstring hints
+
+    :type evaluator: jedi.evaluate.Evaluator
+    :type param: jedi.parser.tree.Param
+
+    :rtype: list
+    """
+    def search_return_in_docstr(docstr):
+        # Check for Sphinx/Epydoc return hint
+        for p in DOCSTRING_RETURN_PATTERNS:
+            match = p.search(docstr)
+            if match:
+                return [_strip_rst_role(match.group(1))]
+        found = []
+        if not found:
+            # Check for numpy style return hint
+            found = _search_return_in_numpydocstr(docstr)
+        return found
+
+    docstr = func.raw_doc
+    module = func.get_parent_until()
+    types = []
+    for type_str in search_return_in_docstr(docstr):
+        type_ = _evaluate_for_statement_string(evaluator, type_str, module)
+        types.extend(type_)
+    return types
+

--- a/spyder/utils/introspection/docstrings.py
+++ b/spyder/utils/introspection/docstrings.py
@@ -62,7 +62,6 @@ else:
     def _search_return_in_numpydocstr(docstr):
         r"""
         Search `docstr` (in numpydoc format) for type(-s) of `param_str`.
-
         """
         doc = NumpyDocString(docstr)
         returns = doc._parsed_data['Returns']
@@ -115,7 +114,6 @@ def _search_param_in_docstr(docstr, param_str):
     False
     >>> _search_param_in_docstr(':param int param: some description', 'param')
     ['int']
-
     """
     # look at #40 to see definitions of those params
 
@@ -153,7 +151,6 @@ def _strip_rst_role(type_str):
 
     See also:
     http://sphinx-doc.org/domains.html#cross-referencing-python-objects
-
     """
     match = REST_ROLE_PATTERN.match(type_str)
     if match:

--- a/spyder/utils/introspection/docstrings.py
+++ b/spyder/utils/introspection/docstrings.py
@@ -18,6 +18,7 @@ from ast import literal_eval
 import re
 from itertools import chain
 from textwrap import dedent
+from jedi import debug
 from jedi.evaluate.cache import memoize_default
 from jedi.parser import Parser, load_grammar
 from jedi.parser.tree import Class
@@ -279,5 +280,6 @@ def find_return_types(evaluator, func):
     for type_str in search_return_in_docstr(docstr):
         type_ = _evaluate_for_statement_string(evaluator, type_str, module)
         types.extend(type_)
+    debug.dbg('DOC!!!!!!!!!!!!!! wow types?: %s in %s',types, func)
     return types
 

--- a/spyder/utils/introspection/jedi_patch.py
+++ b/spyder/utils/introspection/jedi_patch.py
@@ -33,8 +33,8 @@ def apply():
 
     # [2] Adding type returns for compiled objects in jedi
     # Patching jedi.evaluate.compiled.CompiledObject...
-    from jedi.evaluate.compiled import \
-        CompiledObject, builtin, _create_from_name, debug
+    from jedi.evaluate.compiled import (
+        CompiledObject, builtin, _create_from_name, debug)
 
     class CompiledObject(CompiledObject):
         # ...adding docstrings int _execute_function...
@@ -46,11 +46,10 @@ def apply():
             types = docstrings.find_return_types(evaluator, self)
             if types:
                 for result in types:
-                    debug.dbg('BC!!!!!!!!!!!!!! wow types?: %s in %s', result, self)
+                    debug.dbg('docstrings type return: %s in %s', result, self)
                     yield result
             # end patch
             for name in self._parse_function_doc()[1].split():
-                debug.dbg('BC!!!!!!!!!!!!!! wow parse?: %s in %s', name, self)
                 try:
                     bltn_obj = _create_from_name(builtin, builtin, name)
                 except AttributeError:
@@ -111,8 +110,8 @@ def apply():
 
     # [4] Fixing introspection for matplotlib Axes objects
     # Patching jedi.evaluate.precedence...
-    from jedi.evaluate.representation import \
-        tree, InstanceName, Instance, compiled, FunctionExecution, InstanceElement
+    from jedi.evaluate.representation import (
+        tree, InstanceName, Instance, compiled, FunctionExecution, InstanceElement)
 
     def get_instance_el(evaluator, instance, var, is_class_var=False):
         """

--- a/spyder/utils/introspection/jedi_patch.py
+++ b/spyder/utils/introspection/jedi_patch.py
@@ -12,6 +12,7 @@ Patching jedi:
 [2] Adding type returns for compiled objects in jedi
 """
 
+
 def apply():
     """Monkey patching jedi
 
@@ -25,23 +26,27 @@ def apply():
     # [1] Adding numpydoc type returns to docstrings
     from spyder.utils.introspection import docstrings
     jedi.evaluate.representation.docstrings = docstrings
-    
-    #[2] Adding type returns for compiled objects in jedi
+
+    # [2] Adding type returns for compiled objects in jedi
     # Patching jedi.evaluate.compiled.CompiledObject...
-    from jedi.evaluate.compiled import CompiledObject, builtin, _create_from_name
-    class PatchedCompiledObject(CompiledObject):
+    from jedi.evaluate.compiled import \
+        CompiledObject, builtin, _create_from_name, debug
+
+    class CompiledObject(CompiledObject):
         # ...adding docstrings int _execute_function...
         def _execute_function(self, evaluator, params):
             if self.type != 'funcdef':
                 return
-            #patching docstrings here
+            # patching docstrings here
             from spyder.utils.introspection import docstrings
             types = docstrings.find_return_types(evaluator, self)
             if types:
                 for result in types:
+                    debug.dbg('BC!!!!!!!!!!!!!! wow types?: %s in %s', result, self)
                     yield result
-            #end patch
+            # end patch
             for name in self._parse_function_doc()[1].split():
+                debug.dbg('BC!!!!!!!!!!!!!! wow parse?: %s in %s', name, self)
                 try:
                     bltn_obj = _create_from_name(builtin, builtin, name)
                 except AttributeError:
@@ -52,10 +57,74 @@ def apply():
                         continue
                     for result in evaluator.execute(bltn_obj, params):
                         yield result
+
         # ...docstrings needs a raw_doc property
         @property
         def raw_doc(self):
             return self.doc
 
-    jedi.evaluate.compiled.CompiledObject = PatchedCompiledObject
+    jedi.evaluate.compiled.CompiledObject = CompiledObject
+
+    from jedi.evaluate.precedence import tree, calculate
+
+    def calculate_children(evaluator, children):
+        """
+        Calculate a list of children with operators.
+        """
+        iterator = iter(children)
+        types = evaluator.eval_element(next(iterator))
+        for operator in iterator:
+            try:
+                right = next(iterator)
+                if tree.is_node(operator, 'comp_op'):  # not in / is not
+                    operator = ' '.join(str(c.value) for c in operator.children)
+
+                # handle lazy evaluation of and/or here.
+                if operator in ('and', 'or'):
+                    left_bools = set([left.py__bool__() for left in types])
+                    if left_bools == set([True]):
+                        if operator == 'and':
+                            types = evaluator.eval_element(right)
+                    elif left_bools == set([False]):
+                        if operator != 'and':
+                            types = evaluator.eval_element(right)
+                    # Otherwise continue, because of uncertainty.
+                else:
+                    types = calculate(evaluator, types, operator,
+                                      evaluator.eval_element(right))
+            except StopIteration:
+                debug.warning('calculate_children StopIteration %s', types)
+        debug.dbg('calculate_children types %s', types)
+        return types
+
+    jedi.evaluate.precedence.calculate_children = calculate_children
+
+    from jedi.evaluate.representation import \
+        tree, InstanceName, Instance, compiled, FunctionExecution, InstanceElement
+
+    def get_instance_el(evaluator, instance, var, is_class_var=False):
+        """
+        Returns an InstanceElement if it makes sense, otherwise leaves the object
+        untouched.
+
+        Basically having an InstanceElement is context information. That is needed
+        in quite a lot of cases, which includes Nodes like ``power``, that need to
+        know where a self name comes from for example.
+        """
+        if isinstance(var, tree.Name):
+            parent = get_instance_el(evaluator, instance, var.parent, is_class_var)
+            return InstanceName(var, parent)
+        # PATCH: compiled objects can be None
+        elif var is None:
+            return var
+        elif var.type != 'funcdef' \
+                and isinstance(var, (Instance, compiled.CompiledObject, tree.Leaf,
+                               tree.Module, FunctionExecution)):
+            return var
+
+        var = evaluator.wrap(var)
+        return InstanceElement(evaluator, instance, var, is_class_var)
+
+    jedi.evaluate.representation.get_instance_el = get_instance_el
+
     return jedi

--- a/spyder/utils/introspection/jedi_patch.py
+++ b/spyder/utils/introspection/jedi_patch.py
@@ -10,6 +10,10 @@ Patching jedi:
 [1] Adding numpydoc type returns to docstrings
 
 [2] Adding type returns for compiled objects in jedi
+
+[3] Fixing introspection for matplotlib Axes objects
+
+[4] Fixing None for parents in matplotlib Figure objects
 """
 
 
@@ -64,7 +68,9 @@ def apply():
             return self.doc
 
     jedi.evaluate.compiled.CompiledObject = CompiledObject
-
+    
+    # [3] Fixing introspection for matplotlib Axes objects
+    # Patching jedi.evaluate.precedence...
     from jedi.evaluate.precedence import tree, calculate
 
     def calculate_children(evaluator, children):
@@ -74,7 +80,7 @@ def apply():
         iterator = iter(children)
         types = evaluator.eval_element(next(iterator))
         for operator in iterator:
-            try:
+            try:# PATCH: Catches StopIteration error
                 right = next(iterator)
                 if tree.is_node(operator, 'comp_op'):  # not in / is not
                     operator = ' '.join(str(c.value) for c in operator.children)
@@ -99,6 +105,8 @@ def apply():
 
     jedi.evaluate.precedence.calculate_children = calculate_children
 
+    # [4] Fixing introspection for matplotlib Axes objects
+    # Patching jedi.evaluate.precedence...
     from jedi.evaluate.representation import \
         tree, InstanceName, Instance, compiled, FunctionExecution, InstanceElement
 

--- a/spyder/utils/introspection/jedi_patch.py
+++ b/spyder/utils/introspection/jedi_patch.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Patching jedi:
+
+[1] Adding numpydoc type returns to docstrings
+
+[2] Adding type returns for compiled objects in jedi
+"""
+
+def apply():
+    """Monkey patching jedi
+
+    See [1] and [2] module docstring."""
+    from spyder.utils.programs import is_module_installed
+    if is_module_installed('jedi', '=0.9.0'):
+        import jedi
+    else:
+        raise ImportError("jedi %s can't be patched" % jedi.__version__)
+
+    # [1] Adding numpydoc type returns to docstrings
+    from spyder.utils.introspection import docstrings
+    jedi.evaluate.representation.docstrings = docstrings
+    
+    #[2] Adding type returns for compiled objects in jedi
+    # Patching jedi.evaluate.compiled.CompiledObject...
+    class PatchedCompiledObject(jedi.evaluate.compiled.CompiledObject):
+        # ...adding docstrings int _execute_function...
+        def _execute_function(self, evaluator, params):
+            if self.type != 'funcdef':
+                return
+            #patching docstrings here
+            from spyder.utils.introspection import docstrings
+            types = docstrings.find_return_types(evaluator, self)
+            if types:
+                for result in types:
+                    yield result
+            #end patch
+            for name in self._parse_function_doc()[1].split():
+                try:
+                    bltn_obj = _create_from_name(builtin, builtin, name)
+                except AttributeError:
+                    continue
+                else:
+                    if isinstance(bltn_obj, CompiledObject) and bltn_obj.obj is None:
+                        # We want everything except None.
+                        continue
+                    for result in evaluator.execute(bltn_obj, params):
+                        yield result
+        # ...docstrings needs a raw_doc property
+        @property
+        def raw_doc(self):
+            return self.doc
+
+    jedi.evaluate.compiled.CompiledObject = PatchedCompiledObject
+    return jedi

--- a/spyder/utils/introspection/jedi_patch.py
+++ b/spyder/utils/introspection/jedi_patch.py
@@ -28,7 +28,8 @@ def apply():
     
     #[2] Adding type returns for compiled objects in jedi
     # Patching jedi.evaluate.compiled.CompiledObject...
-    class PatchedCompiledObject(jedi.evaluate.compiled.CompiledObject):
+    from jedi.evaluate.compiled import CompiledObject, builtin, _create_from_name
+    class PatchedCompiledObject(CompiledObject):
         # ...adding docstrings int _execute_function...
         def _execute_function(self, evaluator, params):
             if self.type != 'funcdef':

--- a/spyder/utils/introspection/jedi_patch.py
+++ b/spyder/utils/introspection/jedi_patch.py
@@ -65,7 +65,11 @@ def apply():
         # ...docstrings needs a raw_doc property
         @property
         def raw_doc(self):
-            return self.doc
+            try:
+                doc = unicode(self.doc)
+            except NameError: # python 3
+                doc = self.doc
+            return doc
 
     jedi.evaluate.compiled.CompiledObject = CompiledObject
     

--- a/spyder/utils/introspection/jedi_plugin.py
+++ b/spyder/utils/introspection/jedi_plugin.py
@@ -22,7 +22,9 @@ from spyder.utils.introspection.utils import get_parent_until
 from spyder.utils.introspection.manager import JEDI_REQVER
 
 try:
+    import spyder.docstrings
     import jedi
+    jedi.evaluate.representation.docstrings = spyder.docstrings
 except ImportError:
     jedi = None
 

--- a/spyder/utils/introspection/jedi_plugin.py
+++ b/spyder/utils/introspection/jedi_plugin.py
@@ -22,14 +22,14 @@ from spyder.utils.introspection.utils import get_parent_until
 from spyder.utils.introspection.manager import JEDI_REQVER
 
 try:
-    import jedi
-    try: #patching jedi
+    try:
         from spyder.utils.introspection import jedi_patch
         jedi = jedi_patch.apply()
-    except ImportError: #patch failed
-        pass
+    except ImportError:
+        import jedi
 except ImportError:
     jedi = None
+
 
 class JediPlugin(IntrospectionPlugin):
     """
@@ -53,8 +53,8 @@ class JediPlugin(IntrospectionPlugin):
         """Return a list of (completion, type) tuples"""
         completions = self.get_jedi_object('completions', info)
         if DEBUG_EDITOR:
-            log_last_error(LOG_FILENAME, str("!!!!!!!!!!!!1yo" + str(completions)[:100]))
-        debug_print("!!!!!!!!!!!!1yo" + str(completions)[:100])
+            log_last_error(LOG_FILENAME, str("comp: " + str(completions)[:100]))
+        debug_print("comp: " + str(completions)[:100])
         completions = [(c.name, c.type) for c in completions]
         debug_print(str(completions)[:100])
         return completions

--- a/spyder/utils/introspection/jedi_plugin.py
+++ b/spyder/utils/introspection/jedi_plugin.py
@@ -52,6 +52,9 @@ class JediPlugin(IntrospectionPlugin):
     def get_completions(self, info):
         """Return a list of (completion, type) tuples"""
         completions = self.get_jedi_object('completions', info)
+        if DEBUG_EDITOR:
+            log_last_error(LOG_FILENAME, str("!!!!!!!!!!!!1yo" + str(completions)[:100]))
+        debug_print("!!!!!!!!!!!!1yo" + str(completions)[:100])
         completions = [(c.name, c.type) for c in completions]
         debug_print(str(completions)[:100])
         return completions

--- a/spyder/utils/introspection/test/__init__.py
+++ b/spyder/utils/introspection/test/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Testing introspection utilities used by Spyder
+"""

--- a/spyder/utils/introspection/test/test_jedi_plugin.py
+++ b/spyder/utils/introspection/test/test_jedi_plugin.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+
+"""Tests for sourcecode.py"""
+
+import os
+import sys
+
+import pytest
+
+from spyder.utils.introspection.manager import CodeInfo
+from spyder.utils.introspection import jedi_plugin
+
+
+p = jedi_plugin.JediPlugin()
+p.load_plugin()
+
+
+    source_code = "import numpy; numpy.ones("
+    docs = p.get_info(CodeInfo('info', source_code, len(source_code)))
+
+    assert docs['calltip'].startswith('ones(') and docs['name'] == 'ones'
+
+    source_code = "import n"
+    completions = p.get_completions(CodeInfo('completions', source_code,
+        len(source_code)))
+    assert ('numpy', 'module') in completions
+
+    source_code = "import pandas as pd; pd.DataFrame"
+    path, line_nr = p.get_definition(CodeInfo('definition', source_code,
+        len(source_code)))
+    assert 'frame.py' in path
+
+    source_code = 'from .utils import CodeInfo'
+    path, line_nr = p.get_definition(CodeInfo('definition', source_code,
+        len(source_code), __file__))
+    assert 'utils.py' in path and 'introspection' in path
+
+    code = '''
+def test(a, b):
+    """Test docstring"""
+    pass
+test(1,'''
+    path, line = p.get_definition(CodeInfo('definition', code, len(code),
+        'dummy.txt', is_python_like=True))
+    assert line == 2
+
+    docs = p.get_info(CodeInfo('info', code, len(code), __file__))
+    assert 'Test docstring' in docs['docstring']
+    
+    
+    
+    
+    
+def test_get_primary_at():
+    code = 'import functools\nfunctools.partial'
+    assert sourcecode.get_primary_at(code, len(code)) == 'functools.partial'
+
+
+def test_get_identifiers():
+    code = 'import functools\nfunctools.partial'
+    assert set(sourcecode.get_identifiers(code)) == set(['import', 'functools',
+                                                         'functools.partial'])
+
+
+def test_split_source():
+    code = 'import functools\nfunctools.partial'
+    assert sourcecode.split_source(code) == ['import functools', 'functools.partial']
+    code = code.replace('\n', '\r\n')
+    assert sourcecode.split_source(code) == ['import functools', 'functools.partial']
+
+
+def test_path_components():
+    if sys.platform.startswith('linux'):
+        path_components0 = ['','','documents','test','test.py']        
+    else:
+        path_components0 = ['c:','','documents','test','test.py']        
+    path0 = os.path.join(*path_components0)
+    assert sourcecode.path_components(path0) == path_components0
+
+
+def test_differentiate_prefix():
+    if sys.platform.startswith('linux'):
+        path_components0 = ['','','documents','test','test.py']
+        path_components1 = ['','','documents','projects','test','test.py']
+    else:
+        path_components0 = ['c:','','documents','test','test.py']
+        path_components1 = ['c:','','documents','projects','test','test.py']
+    diff_path0 = os.path.join(*['test'])
+    diff_path1 = os.path.join(*['projects','test'])
+    assert sourcecode.differentiate_prefix(
+                        path_components0, path_components1) ==  diff_path0
+    assert sourcecode.differentiate_prefix(
+                        path_components1, path_components0) ==  diff_path1
+
+
+if __name__ == '__main__':
+    pytest.main()
+

--- a/spyder/utils/introspection/test/test_jedi_plugin.py
+++ b/spyder/utils/introspection/test/test_jedi_plugin.py
@@ -14,6 +14,7 @@ from spyder.utils.introspection import jedi_plugin
 
 p = jedi_plugin.JediPlugin()
 p.load_plugin()
+jedi_plugin.jedi.set_debug_function()
 
 
 def test_get_info():
@@ -36,8 +37,8 @@ def test_get_definition():
     assert 'frame.py' in path
 
 
-def test_get_definition_filename():
-    source_code = 'from .utils import CodeInfo'
+def test_get_path():
+    source_code = 'from spyder.utils.introspection.manager import CodeInfo'
     path, line_nr = p.get_definition(CodeInfo('definition', source_code,
                                               len(source_code), __file__))
     assert 'utils.py' in path and 'introspection' in path

--- a/spyder/utils/introspection/test/test_jedi_plugin.py
+++ b/spyder/utils/introspection/test/test_jedi_plugin.py
@@ -3,99 +3,81 @@
 # Copyright © Spyder Project Contributors
 # Licensed under the terms of the MIT License
 
-"""Tests for sourcecode.py"""
+"""Tests for jedi_plugin.py"""
 
-import os
-import sys
+from textwrap import dedent
 
 import pytest
 
 from spyder.utils.introspection.manager import CodeInfo
 from spyder.utils.introspection import jedi_plugin
 
-
 p = jedi_plugin.JediPlugin()
 p.load_plugin()
 
 
+def test_get_info():
     source_code = "import numpy; numpy.ones("
     docs = p.get_info(CodeInfo('info', source_code, len(source_code)))
-
     assert docs['calltip'].startswith('ones(') and docs['name'] == 'ones'
 
+
+def test_get_completions():
     source_code = "import n"
     completions = p.get_completions(CodeInfo('completions', source_code,
-        len(source_code)))
+                                             len(source_code)))
     assert ('numpy', 'module') in completions
 
+
+def test_get_definition():
     source_code = "import pandas as pd; pd.DataFrame"
     path, line_nr = p.get_definition(CodeInfo('definition', source_code,
-        len(source_code)))
+                                              len(source_code)))
     assert 'frame.py' in path
 
+
+def test_get_definition_filename():
     source_code = 'from .utils import CodeInfo'
     path, line_nr = p.get_definition(CodeInfo('definition', source_code,
-        len(source_code), __file__))
+                                              len(source_code), __file__))
     assert 'utils.py' in path and 'introspection' in path
 
-    code = '''
-def test(a, b):
-    """Test docstring"""
-    pass
-test(1,'''
-    path, line = p.get_definition(CodeInfo('definition', code, len(code),
-        'dummy.txt', is_python_like=True))
+
+def test_get_docstring():
+    source_code = dedent('''
+    def test(a, b):
+        """Test docstring"""
+        pass
+    test(1,''')
+    path, line = p.get_definition(CodeInfo('definition', source_code,
+                                           len(source_code), 'dummy.txt',
+                                           is_python_like=True))
     assert line == 2
 
-    docs = p.get_info(CodeInfo('info', code, len(code), __file__))
+    docs = p.get_info(CodeInfo('info', source_code, len(source_code),
+                               __file__))
     assert 'Test docstring' in docs['docstring']
-    
-    
-    
-    
-    
-def test_get_primary_at():
-    code = 'import functools\nfunctools.partial'
-    assert sourcecode.get_primary_at(code, len(code)) == 'functools.partial'
 
 
-def test_get_identifiers():
-    code = 'import functools\nfunctools.partial'
-    assert set(sourcecode.get_identifiers(code)) == set(['import', 'functools',
-                                                         'functools.partial'])
+def test_numpy_returns():
+    source_code = dedent('''
+    import numpy as np
+    x = np.array([1,2,3])
+    x.a''')
+    completions = p.get_completions(CodeInfo('completions', source_code,
+                                             len(source_code)))
+    assert ('argmax', 'function') in completions
 
 
-def test_split_source():
-    code = 'import functools\nfunctools.partial'
-    assert sourcecode.split_source(code) == ['import functools', 'functools.partial']
-    code = code.replace('\n', '\r\n')
-    assert sourcecode.split_source(code) == ['import functools', 'functools.partial']
-
-
-def test_path_components():
-    if sys.platform.startswith('linux'):
-        path_components0 = ['','','documents','test','test.py']        
-    else:
-        path_components0 = ['c:','','documents','test','test.py']        
-    path0 = os.path.join(*path_components0)
-    assert sourcecode.path_components(path0) == path_components0
-
-
-def test_differentiate_prefix():
-    if sys.platform.startswith('linux'):
-        path_components0 = ['','','documents','test','test.py']
-        path_components1 = ['','','documents','projects','test','test.py']
-    else:
-        path_components0 = ['c:','','documents','test','test.py']
-        path_components1 = ['c:','','documents','projects','test','test.py']
-    diff_path0 = os.path.join(*['test'])
-    diff_path1 = os.path.join(*['projects','test'])
-    assert sourcecode.differentiate_prefix(
-                        path_components0, path_components1) ==  diff_path0
-    assert sourcecode.differentiate_prefix(
-                        path_components1, path_components0) ==  diff_path1
+def test_matplotlib_returns():
+    source_code = dedent('''
+    import matplotlib.pyplot as plt
+    fig = plt.figure()
+    fig.''')
+    completions = p.get_completions(CodeInfo('completions', source_code,
+                                             len(source_code)))
+    assert ('add_axes', 'function') in completions
 
 
 if __name__ == '__main__':
     pytest.main()
-

--- a/spyder/utils/introspection/test/test_jedi_plugin.py
+++ b/spyder/utils/introspection/test/test_jedi_plugin.py
@@ -32,9 +32,9 @@ p.load_plugin()
 
 
 def test_get_info():
-    source_code = "import os; os.fwalk("
+    source_code = "import os; os.walk("
     docs = p.get_info(CodeInfo('info', source_code, len(source_code)))
-    assert docs['calltip'].startswith('fwalk(') and docs['name'] == 'fwalk'
+    assert docs['calltip'].startswith('walk(') and docs['name'] == 'walk'
 
 
 def test_get_completions():
@@ -45,7 +45,7 @@ def test_get_completions():
 
 
 def test_get_definition():
-    source_code = "import os; os.fwalk"
+    source_code = "import os; os.walk"
     path, line_nr = p.get_definition(CodeInfo('definition', source_code,
                                               len(source_code)))
     assert 'os.py' in path

--- a/spyder/utils/introspection/test/test_jedi_plugin.py
+++ b/spyder/utils/introspection/test/test_jedi_plugin.py
@@ -98,16 +98,5 @@ def test_matplotlib_fig_returns():
     assert ('add_axes', 'function') in completions
 
 
-@pytest.mark.skipif(not(matplotlib and numpydoc),
-                    reason="matplotlib required")
-def test_matplotlib_ax_returns():
-    source_code = dedent('''
-    import matplotlib.pyplot as plt
-    fig = plt.figure()
-    fig.''')
-    completions = p.get_completions(CodeInfo('completions', source_code,
-                                             len(source_code)))
-    assert ('add_axes', 'function') in completions
-
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
This pull request uses code from davidhalter/jedi#796 to add completions of returns that are in numpydoc doc format.  This pull fixes #2162 for numpy and matplotlib.

In order for this to work you need the "numpydoc" module installed

Here is some "test" code to copy into the Spyder editor.

    import numpy as np
    import matplotlib.pyplot as plt
    
    x = np.array([1,2,3])
    y = np.ones()
    y.                        # works
    x.                        # works
    w = x + y
    w.                        # works
    v = y.transpose()         # finds the docstring with Ctrl-i and params pop-up
    v.                        # works
    
    fig = plt.figure()
    fig.                      # works
    fig.add_axes()            # finds the docstring with Ctrl-i and params pop-up
    
    ax = plt.subplot(111)
    ax.                       # works (fails on python 2.7...that will have to wait for numpydoc in matplotlib)
    ax.set_title()            # finds the docstring with Ctrl-i and params pop-up