### PR TITLE
PR: Make Spyder documentation keyboard shortcut configurable

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -915,9 +915,11 @@ class MainWindow(QMainWindow):
             spyder_doc = 'http://pythonhosted.org/spyder'
         else:
             spyder_doc = file_uri(spyder_doc)
-        doc_action = create_action( self, _("Spyder documentation"), shortcut="F1", 
+        doc_action = create_action( self, _("Spyder documentation"),
                                     icon=ima.icon('DialogHelpButton'),
                                     triggered=lambda : programs.start_file(spyder_doc))
+        self.register_shortcut(doc_action, "_",
+                               "spyder documentation")
 
         if self.help is not None:
             tut_action = create_action(self, _("Spyder tutorial"),

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -915,9 +915,10 @@ class MainWindow(QMainWindow):
             spyder_doc = 'http://pythonhosted.org/spyder'
         else:
             spyder_doc = file_uri(spyder_doc)
-        doc_action = create_action( self, _("Spyder documentation"),
-                                    icon=ima.icon('DialogHelpButton'),
-                                    triggered=lambda : programs.start_file(spyder_doc))
+        doc_action = create_action(self, _("Spyder documentation"),
+                                   icon=ima.icon('DialogHelpButton'),
+                                   triggered=lambda:
+                                   programs.start_file(spyder_doc))
         self.register_shortcut(doc_action, "_",
                                "spyder documentation")
 

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -327,6 +327,7 @@ DEFAULTS = [
               '_/save current layout': "Shift+Alt+S",
               '_/layout preferences': "Shift+Alt+P",
               '_/show toolbars': "Alt+Shift+T",
+              '_/spyder documentation': "F1",
               '_/restart': "Shift+Alt+R",
               '_/quit': "Ctrl+Q",
               # -- In plugins/editor


### PR DESCRIPTION
Fixes #3818

Removed shortcut for opening spyder documentation from /app/mainwindow.py
Registered shortcut for opening spyder documentation in /app/mainwindow.py
Created default configuration for opening spyder documentaion in /config/main.py