### PR TITLE
PR: Make conda respect channel priority in CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ machine:
     # Environment variables used by astropy helpers
     TRAVIS_OS_NAME: "linux"
     CONDA_DEPENDENCIES_FLAGS: "--quiet"
+    CONDA_CHANNEL_PRIORITY: "True"
     CONDA_DEPENDENCIES: >
       rope jedi pyflakes sphinx pygments pylint pep8 psutil nbconvert qtawesome pickleshare
       qtpy pyzmq chardet mock nomkl pandas pytest pytest-cov


### PR DESCRIPTION
This prevents fetching several unnecessary packages from conda-forge