### PR TITLE
PR: Show kernel initialization errors in the IPython console

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -301,6 +301,10 @@ class MainWindow(QMainWindow):
             mac_style = mac_style.replace('$IMAGE_PATH', img_path)
             self.setStyleSheet(mac_style)
 
+        # Create our TEMPDIR
+        if not osp.isdir(programs.TEMPDIR):
+            os.mkdir(programs.TEMPDIR)
+
         # Shortcut management data
         self.shortcut_data = []
 

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -440,6 +440,7 @@ DEFAULTS = [
               # ---- In widgets/ipythonconsole/shell.py ----
               'ipython_console/new tab': "Ctrl+T",
               'ipython_console/reset namespace': "Ctrl+Alt+R",
+              'ipython_console/restart kernel': "Ctrl+.",
               # ---- In widgets/arraybuider.py ----
               'array_builder/enter array inline': "Ctrl+Alt+M",
               'array_builder/enter array table': "Ctrl+M",

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -1386,6 +1386,7 @@ class IPythonConsole(SpyderPluginWidget):
         return cf
 
     def process_started(self, client):
+        client.kernel_stderr = None
         if self.help is not None:
             self.help.set_shell(client.shellwidget)
         if self.variableexplorer is not None:

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -730,18 +730,13 @@ class IPythonConsole(SpyderPluginWidget):
 
     def get_plugin_actions(self):
         """Return a list of actions related to plugin."""
-        main_create_client_action = create_action(self,
-                                _("Open an &IPython console"),
-                                None, ima.icon('ipython_console'),
-                                triggered=self.create_new_client)
-
         create_client_action = create_action(self,
-                                _("Open a new console"),
+                                _("Open an &IPython console"),
                                 icon=ima.icon('ipython_console'),
                                 triggered=self.create_new_client,
                                 context=Qt.WidgetWithChildrenShortcut)
         self.register_shortcut(create_client_action, context="ipython_console",
-                               name="Restart kernel")
+                               name="New tab")
 
         restart_action = create_action(self, _("Restart kernel"),
                                        icon=ima.icon('restart'),
@@ -757,7 +752,7 @@ class IPythonConsole(SpyderPluginWidget):
         
         # Add the action to the 'Consoles' menu on the main window
         main_consoles_menu = self.main.consoles_menu_actions
-        main_consoles_menu.insert(0, main_create_client_action)
+        main_consoles_menu.insert(0, create_client_action)
         main_consoles_menu += [MENU_SEPARATOR, restart_action,
                                connect_to_kernel_action]
         

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -730,11 +730,12 @@ class IPythonConsole(SpyderPluginWidget):
 
     def get_plugin_actions(self):
         """Return a list of actions related to plugin."""
-        create_client_action = create_action(self,
-                                _("Open an &IPython console"),
-                                icon=ima.icon('ipython_console'),
-                                triggered=self.create_new_client,
-                                context=Qt.WidgetWithChildrenShortcut)
+        create_client_action = create_action(
+                                   self,
+                                   _("Open an &IPython console"),
+                                   icon=ima.icon('ipython_console'),
+                                   triggered=self.create_new_client,
+                                   context=Qt.WidgetWithChildrenShortcut)
         self.register_shortcut(create_client_action, context="ipython_console",
                                name="New tab")
 
@@ -1302,7 +1303,7 @@ class IPythonConsole(SpyderPluginWidget):
 
     def create_kernel_manager_and_kernel_client(self, connection_file,
                                                 stderr_file):
-        """Create kernel manager and client"""
+        """Create kernel manager and client."""
         # Kernel manager
         kernel_manager = QtKernelManager(connection_file=connection_file,
                                          config=None, autorestart=True)

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -1400,7 +1400,6 @@ class IPythonConsole(SpyderPluginWidget):
         return cf
 
     def process_started(self, client):
-        client.kernel_stderr = None
         if self.help is not None:
             self.help.set_shell(client.shellwidget)
         if self.variableexplorer is not None:

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -1310,7 +1310,7 @@ class IPythonConsole(SpyderPluginWidget):
         kernel_manager._kernel_spec = self.create_kernel_spec()
 
         # Save stderr in a file to read it later in case of errors
-        stderr = codecs.open(stderr_file, 'x', encoding='utf-8')
+        stderr = codecs.open(stderr_file, 'w', encoding='utf-8')
         kernel_manager.start_kernel(stderr=stderr)
 
         # Kernel client

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -396,9 +396,6 @@ def is_module_installed(module_name, version=None, installed_version=None,
     in a determined interpreter
     """
     if interpreter:
-        if not osp.isdir(TEMPDIR):
-            os.mkdir(TEMPDIR)
-        
         if osp.isfile(interpreter) and ('python' in interpreter):
             checkver = inspect.getsource(check_version)
             get_modver = inspect.getsource(get_module_version)

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -107,6 +107,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
         # --- Widgets
         self.shellwidget = ShellWidget(config=config_options,
+                                       ipyclient=self,
                                        additional_options=additional_options,
                                        interpreter_versions=interpreter_versions,
                                        external_kernel=external_kernel,
@@ -153,8 +154,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         if give_focus:
             self.get_control().setFocus()
 
-        # Connect shellwidget to the client
-        self.shellwidget.set_ipyclient(self)
+        # Set exit callback
+        self.shellwidget.set_exit_action()
 
         # To save history
         self.shellwidget.executing.connect(self.add_to_history)

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -31,6 +31,7 @@ from spyder.config.base import (_, get_conf_path, get_image_path,
                                 get_module_source_path)
 from spyder.config.gui import get_font, get_shortcut
 from spyder.utils import icon_manager as ima
+from spyder.utils import sourcecode
 from spyder.utils.programs import TEMPDIR
 from spyder.utils.qthelpers import (add_actions, create_action,
                                     create_toolbutton)
@@ -195,7 +196,12 @@ class ClientWidget(QWidget, SaveHistoryMixin):
             self.shellwidget.write_to_stdin('exit')
 
     def show_kernel_error(self, error):
-        """Show kernel initialization errors in infowidget"""
+        """Show kernel initialization errors in infowidget."""
+        # Replace end of line chars with <br>
+        eol = sourcecode.get_eol_chars(error)
+        if eol:
+            error = error.replace(eol, '<br>')
+
         # Don't break lines in hyphens
         # From http://stackoverflow.com/q/7691569/438386
         error = error.replace('-', '&#8209')

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -330,6 +330,9 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         if result == QMessageBox.Yes:
             sw = self.shellwidget
             if sw.kernel_manager:
+                if self.infowidget.isVisible():
+                    self.infowidget.hide()
+                    sw.show()
                 try:
                     sw.kernel_manager.restart_kernel()
                 except RuntimeError as e:

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -101,7 +101,6 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         # --- Other attrs
         self.options_button = None
         self.stop_button = None
-        self.kernel_stderr = None
         self.stop_icon = ima.icon('stop')
         self.history = []
 
@@ -357,9 +356,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         stderr = codecs.open(self.stderr_file, 'r', encoding='utf-8').read()
 
         if stderr:
-            if self.kernel_stderr is None:
-                self.kernel_stderr = stderr
-                self.show_kernel_error('<tt>%s</tt>' % stderr)
+            self.show_kernel_error('<tt>%s</tt>' % stderr)
         else:
             self.shellwidget._append_html("<br>%s<hr><br>" % msg,
                                           before_prompt=False)

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -240,13 +240,15 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         return self.menu_actions
 
     def get_toolbar_buttons(self):
-        """Return toolbar buttons list"""
+        """Return toolbar buttons list."""
         buttons = []
         # Code to add the stop button
         if self.stop_button is None:
-            self.stop_button = create_toolbutton(self, text=_("Stop"),
-                                             icon=self.stop_icon,
-                                             tip=_("Stop the current command"))
+            self.stop_button = create_toolbutton(
+                                   self,
+                                   text=_("Stop"),
+                                   icon=self.stop_icon,
+                                   tip=_("Stop the current command"))
             self.disable_stop_button()
             # set click event handler
             self.stop_button.clicked.connect(self.stop_button_click_handler)

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -341,8 +341,9 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                         before_prompt=True
                     )
                 else:
+                    sw.reset(clear=True)
                     sw._append_html(_("<br>Restarting kernel...\n<hr><br>"),
-                        before_prompt=True,
+                        before_prompt=False,
                     )
             else:
                 sw._append_plain_text(

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -239,18 +239,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
     def get_options_menu(self):
         """Return options menu"""
-        restart_action = create_action(self, _("Restart kernel"),
-                                       shortcut=QKeySequence("Ctrl+."),
-                                       icon=ima.icon('restart'),
-                                       triggered=self.restart_kernel,
-                                       context=Qt.WidgetWithChildrenShortcut)
-
         # Main menu
-        if self.menu_actions is not None:
-            actions = [restart_action, None] + self.menu_actions
-        else:
-            actions = [restart_action]
-        return actions
+        return self.menu_actions
 
     def get_toolbar_buttons(self):
         """Return toolbar buttons list"""

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -116,8 +116,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         self.infowidget = WebView(self)
         self.set_infowidget_font()
         self.loading_page = self._create_loading_page()
-        self.infowidget.setHtml(self.loading_page,
-                                QUrl.fromLocalFile(CSS_PATH))
+        self.show_loading_page()
 
         # --- Layout
         vlayout = QVBoxLayout()
@@ -218,6 +217,10 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         self.infowidget.setHtml(page)
         self.shellwidget.hide()
         self.infowidget.show()
+
+    def show_loading_page(self):
+        self.infowidget.setHtml(self.loading_page,
+                                QUrl.fromLocalFile(CSS_PATH))
 
     def get_name(self):
         """Return client name"""

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -112,11 +112,10 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                                        interpreter_versions=interpreter_versions,
                                        external_kernel=external_kernel,
                                        local_kernel=True)
-        self.shellwidget.hide()
         self.infowidget = WebView(self)
         self.set_infowidget_font()
         self.loading_page = self._create_loading_page()
-        self.show_loading_page()
+        self._show_loading_page()
 
         # --- Layout
         vlayout = QVBoxLayout()
@@ -137,7 +136,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         # As soon as some content is printed in the console, stop
         # our loading animation
         document = self.get_control().document()
-        document.contentsChange.connect(self._stop_loading_animation)
+        document.contentsChange.connect(self._hide_loading_page)
 
     #------ Public API --------------------------------------------------------
     @property
@@ -217,10 +216,6 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         self.infowidget.setHtml(page)
         self.shellwidget.hide()
         self.infowidget.show()
-
-    def show_loading_page(self):
-        self.infowidget.setHtml(self.loading_page,
-                                QUrl.fromLocalFile(CSS_PATH))
 
     def get_name(self):
         """Return client name"""
@@ -419,11 +414,18 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                                            message=message)
         return page
 
-    def _stop_loading_animation(self):
-        """Stop animation shown while the kernel is starting"""
+    def _show_loading_page(self):
+        """Show animation while the kernel is loading."""
+        self.shellwidget.hide()
+        self.infowidget.show()
+        self.infowidget.setHtml(self.loading_page,
+                                QUrl.fromLocalFile(CSS_PATH))
+
+    def _hide_loading_page(self):
+        """Hide animation shown while the kernel is loading."""
         self.infowidget.hide()
         self.shellwidget.show()
         self.infowidget.setHtml(BLANK)
 
         document = self.get_control().document()
-        document.contentsChange.disconnect(self._stop_loading_animation)
+        document.contentsChange.disconnect(self._hide_loading_page)

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -152,7 +152,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
             self.get_control().setFocus()
 
         # Set exit callback
-        self.shellwidget.set_exit_action()
+        self.shellwidget.set_exit_callback()
 
         # To save history
         self.shellwidget.executing.connect(self.add_to_history)
@@ -236,7 +236,6 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
     def get_options_menu(self):
         """Return options menu"""
-        # Main menu
         return self.menu_actions
 
     def get_toolbar_buttons(self):

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -358,6 +358,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                     before_prompt=True
                 )
 
+    @Slot(str)
     def kernel_restarted_message(self, msg):
         """Show kernel restarted/died messages."""
         stderr = codecs.open(self.stderr_file, 'r', encoding='utf-8').read()

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -30,6 +30,7 @@ from spyder.config.base import (_, get_conf_path, get_image_path,
                                 get_module_source_path)
 from spyder.config.gui import get_font, get_shortcut
 from spyder.utils import icon_manager as ima
+from spyder.utils.programs import TEMPDIR
 from spyder.utils.qthelpers import (add_actions, create_action,
                                     create_toolbutton)
 from spyder.widgets.browser import WebView
@@ -136,6 +137,14 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         document.contentsChange.connect(self._stop_loading_animation)
 
     #------ Public API --------------------------------------------------------
+    @property
+    def stderr_file(self):
+        """Filename to save kernel stderr output."""
+        json_file = osp.basename(self.connection_file)
+        stderr_file = json_file.split('json')[0] + 'stderr'
+        stderr_file = osp.join(TEMPDIR, stderr_file)
+        return stderr_file
+
     def configure_shellwidget(self, give_focus=True):
         """Configure shellwidget after kernel is started"""
         if give_focus:

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -68,8 +68,8 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget):
         self._kernel_reply = None
 
     #---- Public API ----------------------------------------------------------
-    def set_exit_action(self):
-        """Set exit action for this widget."""
+    def set_exit_callback(self):
+        """Set exit callback for this shell."""
         self.exit_requested.connect(self.ipyclient.exit_callback)
 
     def is_running(self):

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -164,6 +164,9 @@ the sympy module (e.g. plot)
                                   parent=self)
         clear_console = config_shortcut(self.clear_console, context='Console',
                                         name='Clear shell', parent=self)
+        restart_kernel = config_shortcut(self.ipyclient.restart_kernel,
+                                         context='ipython_console',
+                                         name='Restart kernel', parent=self)
         new_tab = config_shortcut(lambda: self.new_client.emit(),
                                   context='ipython_console', name='new tab', parent=self)
         reset_namespace = config_shortcut(lambda: self.reset_namespace(),
@@ -176,8 +179,8 @@ the sympy module (e.g. plot)
                                       context='array_builder',
                                       name='enter array table', parent=self)
 
-        return [inspect, clear_console, new_tab, reset_namespace,
-                array_inline, array_table]
+        return [inspect, clear_console, restart_kernel, new_tab,
+                reset_namespace, array_inline, array_table]
 
     # --- To communicate with the kernel
     def silent_execute(self, code):

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -45,6 +45,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget):
     focus_changed = Signal()
     new_client = Signal()
     sig_got_reply = Signal()
+    sig_kernel_restarted = Signal(str)
 
     def __init__(self, additional_options, interpreter_versions,
                  external_kernel, *args, **kw):
@@ -273,6 +274,10 @@ the sympy module (e.g. plot)
             return self.long_banner()
         else:
             return self.short_banner()
+
+    def _kernel_restarted_message(self, died=True):
+        msg = _("Kernel died, restarting") if died else _("Kernel restarting")
+        self.sig_kernel_restarted.emit(msg)
 
     #---- Qt methods ----------------------------------------------------------
     def focusInEvent(self, event):

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -47,20 +47,19 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget):
     sig_got_reply = Signal()
     sig_kernel_restarted = Signal(str)
 
-    def __init__(self, additional_options, interpreter_versions,
+    def __init__(self, ipyclient, additional_options, interpreter_versions,
                  external_kernel, *args, **kw):
         # To override the Qt widget used by RichJupyterWidget
         self.custom_control = ControlWidget
         self.custom_page_control = PageControlWidget
         super(ShellWidget, self).__init__(*args, **kw)
+
+        self.ipyclient = ipyclient
         self.additional_options = additional_options
         self.interpreter_versions = interpreter_versions
+        self.external_kernel = external_kernel
 
         self.set_background_color()
-
-        # Additional variables
-        self.ipyclient = None
-        self.external_kernel = external_kernel
 
         # Keyboard shortcuts
         self.shortcuts = self.create_shortcuts()
@@ -69,10 +68,9 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget):
         self._kernel_reply = None
 
     #---- Public API ----------------------------------------------------------
-    def set_ipyclient(self, ipyclient):
-        """Bind this shell widget to an IPython client one"""
-        self.ipyclient = ipyclient
-        self.exit_requested.connect(ipyclient.exit_callback)
+    def set_exit_action(self):
+        """Set exit action for this widget."""
+        self.exit_requested.connect(self.ipyclient.exit_callback)
 
     def is_running(self):
         if self.kernel_client is not None and \


### PR DESCRIPTION
Fixes #3458.

----

This PR does several things:

1. Redirects the kernel process stderr output to a file and shows it in case of failure in our consoles. With this I'm trying to avoid the infinite stream of *Kernel died, restarting* messages and give feedback to users of what's the cause of the error.
2. Introduces a shortcut to restart kernels, so that we can override the one defined in qtconsole and control this process ourselves.
3. Clears the console on restarts.