### PR TITLE
Fix "TypeError: got multiple values for argument" in Profiler

### DIFF
--- a/spyder_profiler/profiler.py
+++ b/spyder_profiler/profiler.py
@@ -151,5 +151,5 @@ class Profiler(SpyderPluginWidget):
                 wdir = runconf.wdir
             if runconf.args_enabled:
                 args = runconf.args
-        self.profiler.analyze(self, filename, wdir=wdir, args=args,
+        self.profiler.analyze(filename, wdir=wdir, args=args,
                               pythonpath=pythonpath)


### PR DESCRIPTION
Fixes #3923.

self.profiler.analyze should not take self as otherwise filename=self, wdir=filename and wdir=wdir