### PR TITLE
PR:  Save file with original encoding if possible

### DIFF
--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -171,6 +171,13 @@ def encode(text, orig_coding):
     if orig_coding == 'utf-8-bom':
         return BOM_UTF8 + text.encode("utf-8"), 'utf-8-bom'
     
+    # Try saving with original encoding
+    if orig_coding:
+        try:
+            return text.encode(orig_coding), orig_coding
+        except UnicodeError:
+            pass
+
     # Try declared coding spec
     coding = get_coding(text)
     if coding:


### PR DESCRIPTION
Fixes #3753

---------------

`encodings.write()` will try to save the file with the original encoding as first option.