### PR TITLE
PR: Use encoding.encode function in run_code_analysis.

### DIFF
--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -204,7 +204,7 @@ class FileInfo(QObject):
         self.pep8_results = []
         if self.editor.is_python():
             enc = self.encoding.replace('-guessed', '').replace('-bom', '')
-            source_code = self.get_source_code().encode(enc)
+            source_code, enc = encoding.encode(self.get_source_code(), enc)
             if run_pyflakes:
                 self.pyflakes_results = None
             if run_pep8:


### PR DESCRIPTION
Fixes #3322

---------------

Using `encoding.encode` function won't throw an error if the text can't be encoded with the current encoding, instead It will try to guess the text encoding.