### PR TITLE
PR: Catch LookupError when encoding in encode() function

### DIFF
--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -175,7 +175,7 @@ def encode(text, orig_coding):
     if orig_coding:
         try:
             return text.encode(orig_coding), orig_coding
-        except UnicodeError:
+        except (UnicodeError, LookupError):
             pass
 
     # Try declared coding spec


### PR DESCRIPTION
In #3929 I forget to catch LookUpError, when encoping text