### PR TITLE
PR: Change ScrollFlagArea panel to use panel API

### DIFF
--- a/spyder/widgets/panels/scrollflag.py
+++ b/spyder/widgets/panels/scrollflag.py
@@ -22,6 +22,7 @@ class ScrollFlagArea(Panel):
     def __init__(self, editor):
         Panel.__init__(self, editor)
         self.setAttribute(Qt.WA_OpaquePaintEvent)
+        self._enabled = None
         editor.verticalScrollBar().valueChanged.connect(
                                                   lambda value: self.repaint())
 
@@ -136,3 +137,8 @@ class ScrollFlagArea(Panel):
         """Set scroll flag area painter pen and brush colors"""
         painter.setPen(QColor(light_color).darker(120))
         painter.setBrush(QBrush(QColor(light_color)))
+
+    def set_enabled(self, state):
+        """Toggle scroll flag area visibility"""
+        self.enabled = state
+        self.setVisible(state)

--- a/spyder/widgets/panels/scrollflag.py
+++ b/spyder/widgets/panels/scrollflag.py
@@ -35,50 +35,50 @@ class ScrollFlagArea(Panel):
         Override Qt method.
         Painting the scroll flag area
         """
-        make_flag = self.scrollflagarea.make_flag_qrect
-        make_slider = self.scrollflagarea.make_slider_range
+        make_flag = self.make_flag_qrect
+        make_slider = self.make_slider_range
 
         # Filling the whole painting area
-        painter = QPainter(self.scrollflagarea)
-        painter.fillRect(event.rect(), self.sideareas_color)
-        block = self.document().firstBlock()
+        painter = QPainter(self)
+        painter.fillRect(event.rect(), self.editor.sideareas_color)
+        block = self.editor.document().firstBlock()
 
         # Painting warnings and todos
-        for line_number in range(1, self.document().blockCount()+1):
+        for line_number in range(1, self.editor.document().blockCount()+1):
             data = block.userData()
             if data:
-                position = self.scrollflagarea.value_to_position(line_number)
+                position = self.value_to_position(line_number)
                 if data.code_analysis:
                     # Warnings
-                    color = self.warning_color
+                    color = self.editor.warning_color
                     for _message, error in data.code_analysis:
                         if error:
-                            color = self.error_color
+                            color = self.editor.error_color
                             break
                     self.set_scrollflagarea_painter(painter, color)
                     painter.drawRect(make_flag(position))
                 if data.todo:
                     # TODOs
-                    self.set_scrollflagarea_painter(painter, self.todo_color)
+                    self.set_scrollflagarea_painter(painter, self.editor.todo_color)
                     painter.drawRect(make_flag(position))
                 if data.breakpoint:
                     # Breakpoints
-                    self.set_scrollflagarea_painter(painter, self.breakpoint_color)
+                    self.set_scrollflagarea_painter(painter, self.editor.breakpoint_color)
                     painter.drawRect(make_flag(position))
             block = block.next()
 
         # Occurrences
-        if self.occurrences:
-            self.set_scrollflagarea_painter(painter, self.occurrence_color)
-            for line_number in self.occurrences:
-                position = self.scrollflagarea.value_to_position(line_number)
+        if self.editor.occurrences:
+            self.set_scrollflagarea_painter(painter, self.editor.occurrence_color)
+            for line_number in self.editor.occurrences:
+                position = self.value_to_position(line_number)
                 painter.drawRect(make_flag(position))
 
         # Found results
-        if self.found_results:
-            self.set_scrollflagarea_painter(painter, self.found_results_color)
-            for line_number in self.found_results:
-                position = self.scrollflagarea.value_to_position(line_number)
+        if self.editor.found_results:
+            self.set_scrollflagarea_painter(painter, self.editor.found_results_color)
+            for line_number in self.editor.found_results:
+                position = self.value_to_position(line_number)
                 painter.drawRect(make_flag(position))
 
         # Painting the slider range
@@ -88,7 +88,7 @@ class ScrollFlagArea(Panel):
         brush_color = QColor(Qt.white)
         brush_color.setAlphaF(.5)
         painter.setBrush(QBrush(brush_color))
-        painter.drawRect(make_slider(self.firstVisibleBlock().blockNumber()))
+        painter.drawRect(make_slider(self.editor.firstVisibleBlock().blockNumber()))
 
     def mousePressEvent(self, event):
         """Override Qt method"""

--- a/spyder/widgets/panels/scrollflag.py
+++ b/spyder/widgets/panels/scrollflag.py
@@ -55,28 +55,28 @@ class ScrollFlagArea(Panel):
                         if error:
                             color = self.editor.error_color
                             break
-                    self.set_scrollflagarea_painter(painter, color)
+                    self.set_painter(painter, color)
                     painter.drawRect(make_flag(position))
                 if data.todo:
                     # TODOs
-                    self.set_scrollflagarea_painter(painter, self.editor.todo_color)
+                    self.set_painter(painter, self.editor.todo_color)
                     painter.drawRect(make_flag(position))
                 if data.breakpoint:
                     # Breakpoints
-                    self.set_scrollflagarea_painter(painter, self.editor.breakpoint_color)
+                    self.set_painter(painter, self.editor.breakpoint_color)
                     painter.drawRect(make_flag(position))
             block = block.next()
 
         # Occurrences
         if self.editor.occurrences:
-            self.set_scrollflagarea_painter(painter, self.editor.occurrence_color)
+            self.set_painter(painter, self.editor.occurrence_color)
             for line_number in self.editor.occurrences:
                 position = self.value_to_position(line_number)
                 painter.drawRect(make_flag(position))
 
         # Found results
         if self.editor.found_results:
-            self.set_scrollflagarea_painter(painter, self.editor.found_results_color)
+            self.set_painter(painter, self.editor.found_results_color)
             for line_number in self.editor.found_results:
                 position = self.value_to_position(line_number)
                 painter.drawRect(make_flag(position))
@@ -133,7 +133,7 @@ class ScrollFlagArea(Panel):
         """Override Qt method"""
         self.editor.wheelEvent(event)
 
-    def set_scrollflagarea_painter(painter, light_color):
+    def set_painter(self, painter, light_color):
         """Set scroll flag area painter pen and brush colors"""
         painter.setPen(QColor(light_color).darker(120))
         painter.setBrush(QBrush(QColor(light_color)))

--- a/spyder/widgets/panels/scrollflag.py
+++ b/spyder/widgets/panels/scrollflag.py
@@ -7,19 +7,20 @@
 This module contains the Scroll Flag panel
 """
 
-from qtpy.QtWidgets import QWidget
 from qtpy.QtCore import QSize, Qt, QRect
 
-class ScrollFlagArea(QWidget):
+from spyder.api.panel import Panel
+
+
+class ScrollFlagArea(Panel):
     """Source code editor's scroll flag area"""
     WIDTH = 12
     FLAGS_DX = 4
     FLAGS_DY = 2
 
     def __init__(self, editor):
-        QWidget.__init__(self, editor)
+        Panel.__init__(self, editor)
         self.setAttribute(Qt.WA_OpaquePaintEvent)
-        self.code_editor = editor
         editor.verticalScrollBar().valueChanged.connect(
                                                   lambda value: self.repaint())
 
@@ -29,11 +30,11 @@ class ScrollFlagArea(QWidget):
 
     def paintEvent(self, event):
         """Override Qt method"""
-        self.code_editor.scrollflagarea_paint_event(event)
+        self.editor.scrollflagarea_paint_event(event)
 
     def mousePressEvent(self, event):
         """Override Qt method"""
-        vsb = self.code_editor.verticalScrollBar()
+        vsb = self.editor.verticalScrollBar()
         value = self.position_to_value(event.pos().y()-1)
         vsb.setValue(value-.5*vsb.pageStep())
 
@@ -41,7 +42,7 @@ class ScrollFlagArea(QWidget):
         """Return scrollbar's scale factor:
         ratio between pixel span height and value span height"""
         delta = 0 if slider else 2
-        vsb = self.code_editor.verticalScrollBar()
+        vsb = self.editor.verticalScrollBar()
         position_height = vsb.height()-delta-1
         value_height = vsb.maximum()-vsb.minimum()+vsb.pageStep()
         return float(position_height)/value_height
@@ -49,13 +50,13 @@ class ScrollFlagArea(QWidget):
     def value_to_position(self, y, slider=False):
         """Convert value to position"""
         offset = 0 if slider else 1
-        vsb = self.code_editor.verticalScrollBar()
+        vsb = self.editor.verticalScrollBar()
         return (y-vsb.minimum())*self.get_scale_factor(slider)+offset
 
     def position_to_value(self, y, slider=False):
         """Convert position to value"""
         offset = 0 if slider else 1
-        vsb = self.code_editor.verticalScrollBar()
+        vsb = self.editor.verticalScrollBar()
         return vsb.minimum()+max([0, (y-offset)/self.get_scale_factor(slider)])
 
     def make_flag_qrect(self, position):
@@ -65,11 +66,11 @@ class ScrollFlagArea(QWidget):
 
     def make_slider_range(self, value):
         """Make slider range QRect"""
-        vsb = self.code_editor.verticalScrollBar()
+        vsb = self.editor.verticalScrollBar()
         pos1 = self.value_to_position(value, slider=True)
         pos2 = self.value_to_position(value + vsb.pageStep(), slider=True)
         return QRect(1, pos1, self.WIDTH-2, pos2-pos1+1)
 
     def wheelEvent(self, event):
         """Override Qt method"""
-        self.code_editor.wheelEvent(event)
+        self.editor.wheelEvent(event)

--- a/spyder/widgets/panels/scrollflag.py
+++ b/spyder/widgets/panels/scrollflag.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+"""
+This module contains the Scroll Flag panel
+"""
+
+from qtpy.QtWidgets import QWidget
+from qtpy.QtCore import QSize, Qt, QRect
+
+class ScrollFlagArea(QWidget):
+    """Source code editor's scroll flag area"""
+    WIDTH = 12
+    FLAGS_DX = 4
+    FLAGS_DY = 2
+
+    def __init__(self, editor):
+        QWidget.__init__(self, editor)
+        self.setAttribute(Qt.WA_OpaquePaintEvent)
+        self.code_editor = editor
+        editor.verticalScrollBar().valueChanged.connect(
+                                                  lambda value: self.repaint())
+
+    def sizeHint(self):
+        """Override Qt method"""
+        return QSize(self.WIDTH, 0)
+
+    def paintEvent(self, event):
+        """Override Qt method"""
+        self.code_editor.scrollflagarea_paint_event(event)
+
+    def mousePressEvent(self, event):
+        """Override Qt method"""
+        vsb = self.code_editor.verticalScrollBar()
+        value = self.position_to_value(event.pos().y()-1)
+        vsb.setValue(value-.5*vsb.pageStep())
+
+    def get_scale_factor(self, slider=False):
+        """Return scrollbar's scale factor:
+        ratio between pixel span height and value span height"""
+        delta = 0 if slider else 2
+        vsb = self.code_editor.verticalScrollBar()
+        position_height = vsb.height()-delta-1
+        value_height = vsb.maximum()-vsb.minimum()+vsb.pageStep()
+        return float(position_height)/value_height
+
+    def value_to_position(self, y, slider=False):
+        """Convert value to position"""
+        offset = 0 if slider else 1
+        vsb = self.code_editor.verticalScrollBar()
+        return (y-vsb.minimum())*self.get_scale_factor(slider)+offset
+
+    def position_to_value(self, y, slider=False):
+        """Convert position to value"""
+        offset = 0 if slider else 1
+        vsb = self.code_editor.verticalScrollBar()
+        return vsb.minimum()+max([0, (y-offset)/self.get_scale_factor(slider)])
+
+    def make_flag_qrect(self, position):
+        """Make flag QRect"""
+        return QRect(self.FLAGS_DX/2, position-self.FLAGS_DY/2,
+                     self.WIDTH-self.FLAGS_DX, self.FLAGS_DY)
+
+    def make_slider_range(self, value):
+        """Make slider range QRect"""
+        vsb = self.code_editor.verticalScrollBar()
+        pos1 = self.value_to_position(value, slider=True)
+        pos2 = self.value_to_position(value + vsb.pageStep(), slider=True)
+        return QRect(1, pos1, self.WIDTH-2, pos2-pos1+1)
+
+    def wheelEvent(self, event):
+        """Override Qt method"""
+        self.code_editor.wheelEvent(event)

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -29,8 +29,8 @@ import time
 # Third party imports
 from qtpy import is_pyqt46
 from qtpy.compat import to_qvariant
-from qtpy.QtCore import QRect, QRegExp, QSize, Qt, QTimer, Signal, Slot
-from qtpy.QtGui import (QBrush, QColor, QCursor, QFont, QIntValidator,
+from qtpy.QtCore import QRegExp, Qt, QTimer, Signal, Slot
+from qtpy.QtGui import (QColor, QCursor, QFont, QIntValidator,
                         QKeySequence, QPaintEvent, QPainter,
                         QTextBlockUserData, QTextCharFormat, QTextCursor,
                         QTextDocument, QTextFormat, QTextOption)
@@ -38,7 +38,7 @@ from qtpy.QtPrintSupport import QPrinter
 from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
                             QGridLayout, QHBoxLayout, QInputDialog, QLabel,
                             QLineEdit, QMenu, QMessageBox, QSplitter,
-                            QTextEdit, QToolTip, QVBoxLayout, QWidget)
+                            QTextEdit, QToolTip, QVBoxLayout)
 
 # %% This line is for cell execution testing
 

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -1116,8 +1116,6 @@ class CodeEditor(TextEditBaseWidget):
     def resizeEvent(self, event):
         """Reimplemented Qt method to handle p resizing"""
         TextEditBaseWidget.resizeEvent(self, event)
-        cr = self.contentsRect()
-        self.__set_scrollflagarea_geometry(cr)
         self.panels.resize()
 
     def showEvent(self, event):
@@ -1125,29 +1123,11 @@ class CodeEditor(TextEditBaseWidget):
         super(CodeEditor, self).showEvent(event)
         self.panels.refresh()
 
-    def __set_scrollflagarea_geometry(self, contentrect):
-        """Set scroll flag area geometry"""
-        cr = contentrect
-        if self.verticalScrollBar().isVisible():
-            vsbw = self.verticalScrollBar().contentsRect().width()
-        else:
-            vsbw = 0
-        _left, _top, right, _bottom = self.getContentsMargins()
-        if right > vsbw:
-            # Depending on the platform (e.g. on Ubuntu), the scrollbar sizes
-            # may be taken into account in the contents margins whereas it is
-            # not on Windows for example
-            vsbw = 0
-        self.scrollflagarea.setGeometry(\
-                        QRect(cr.right()-ScrollFlagArea.WIDTH-vsbw, cr.top(),
-                              self.scrollflagarea.WIDTH, cr.height()))
-
     #-----edgeline
     def viewportEvent(self, event):
         """Override Qt method"""
         cr = self.contentsRect()
         self.edge_line.set_geometry(cr)
-        self.__set_scrollflagarea_geometry(cr)
         return TextEditBaseWidget.viewportEvent(self, event)
 
     #-----Misc.

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -61,6 +61,7 @@ from spyder.widgets.panels.linenumber import LineNumberArea
 from spyder.widgets.panels.edgeline import EdgeLine
 from spyder.widgets.panels.scrollflag import ScrollFlagArea
 from spyder.widgets.panels.manager import PanelsManager
+from spyder.api.panel import Panel
 
 try:
     import nbformat as nbformat
@@ -301,7 +302,8 @@ class CodeEditor(TextEditBaseWidget):
         self.highlight_current_line_enabled = False
 
         # Scrollbar flag area
-        self.scrollflagarea = ScrollFlagArea(self)
+        self.scrollflagarea = self.panels.register(ScrollFlagArea(self),
+                                                   Panel.Position.RIGHT)
         self.scrollflagarea.hide()
         self.warning_color = "#FFAD07"
         self.error_color = "#EA2B0E"

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -1119,14 +1119,6 @@ class CodeEditor(TextEditBaseWidget):
         self.scrollflagarea.setVisible(state)
         self.panels.refresh()
 
-    def get_scrollflagarea_width(self):
-        """Return scroll flag area width"""
-        if self.scrollflagarea_enabled:
-            return ScrollFlagArea.WIDTH
-        else:
-            return 0
-
-
     def resizeEvent(self, event):
         """Reimplemented Qt method to handle p resizing"""
         TextEditBaseWidget.resizeEvent(self, event)

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -175,12 +175,6 @@ class BlockUserData(QTextBlockUserData):
         bud_list.pop(bud_list.index(self))
 
 
-def set_scrollflagarea_painter(painter, light_color):
-    """Set scroll flag area painter pen and brush colors"""
-    painter.setPen(QColor(light_color).darker(120))
-    painter.setBrush(QBrush(QColor(light_color)))
-
-
 def get_file_language(filename, text=None):
     """Get file language from filename"""
     ext = osp.splitext(filename)[1]
@@ -1132,62 +1126,6 @@ class CodeEditor(TextEditBaseWidget):
         else:
             return 0
 
-    def scrollflagarea_paint_event(self, event):
-        """Painting the scroll flag area"""
-        make_flag = self.scrollflagarea.make_flag_qrect
-        make_slider = self.scrollflagarea.make_slider_range
-
-        # Filling the whole painting area
-        painter = QPainter(self.scrollflagarea)
-        painter.fillRect(event.rect(), self.sideareas_color)
-        block = self.document().firstBlock()
-
-        # Painting warnings and todos
-        for line_number in range(1, self.document().blockCount()+1):
-            data = block.userData()
-            if data:
-                position = self.scrollflagarea.value_to_position(line_number)
-                if data.code_analysis:
-                    # Warnings
-                    color = self.warning_color
-                    for _message, error in data.code_analysis:
-                        if error:
-                            color = self.error_color
-                            break
-                    set_scrollflagarea_painter(painter, color)
-                    painter.drawRect(make_flag(position))
-                if data.todo:
-                    # TODOs
-                    set_scrollflagarea_painter(painter, self.todo_color)
-                    painter.drawRect(make_flag(position))
-                if data.breakpoint:
-                    # Breakpoints
-                    set_scrollflagarea_painter(painter, self.breakpoint_color)
-                    painter.drawRect(make_flag(position))
-            block = block.next()
-
-        # Occurrences
-        if self.occurrences:
-            set_scrollflagarea_painter(painter, self.occurrence_color)
-            for line_number in self.occurrences:
-                position = self.scrollflagarea.value_to_position(line_number)
-                painter.drawRect(make_flag(position))
-
-        # Found results
-        if self.found_results:
-            set_scrollflagarea_painter(painter, self.found_results_color)
-            for line_number in self.found_results:
-                position = self.scrollflagarea.value_to_position(line_number)
-                painter.drawRect(make_flag(position))
-
-        # Painting the slider range
-        pen_color = QColor(Qt.white)
-        pen_color.setAlphaF(.8)
-        painter.setPen(pen_color)
-        brush_color = QColor(Qt.white)
-        brush_color.setAlphaF(.5)
-        painter.setBrush(QBrush(brush_color))
-        painter.drawRect(make_slider(self.firstVisibleBlock().blockNumber()))
 
     def resizeEvent(self, event):
         """Reimplemented Qt method to handle p resizing"""

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -59,6 +59,7 @@ from spyder.widgets.sourcecode.base import TextEditBaseWidget
 from spyder.widgets.sourcecode.kill_ring import QtKillRing
 from spyder.widgets.panels.linenumber import LineNumberArea
 from spyder.widgets.panels.edgeline import EdgeLine
+from spyder.widgets.panels.scrollflag import ScrollFlagArea
 from spyder.widgets.panels.manager import PanelsManager
 
 try:
@@ -151,76 +152,6 @@ class GoToLineDialog(QDialog):
         # It is import to avoid accessing Qt C++ object as it has probably
         # already been destroyed, due to the Qt.WA_DeleteOnClose attribute
         return self.lineno
-
-
-#===============================================================================
-# Viewport widgets
-#===============================================================================
-
-
-class ScrollFlagArea(QWidget):
-    """Source code editor's scroll flag area"""
-    WIDTH = 12
-    FLAGS_DX = 4
-    FLAGS_DY = 2
-
-    def __init__(self, editor):
-        QWidget.__init__(self, editor)
-        self.setAttribute(Qt.WA_OpaquePaintEvent)
-        self.code_editor = editor
-        editor.verticalScrollBar().valueChanged.connect(
-                                                  lambda value: self.repaint())
-
-    def sizeHint(self):
-        """Override Qt method"""
-        return QSize(self.WIDTH, 0)
-
-    def paintEvent(self, event):
-        """Override Qt method"""
-        self.code_editor.scrollflagarea_paint_event(event)
-
-    def mousePressEvent(self, event):
-        """Override Qt method"""
-        vsb = self.code_editor.verticalScrollBar()
-        value = self.position_to_value(event.pos().y()-1)
-        vsb.setValue(value-.5*vsb.pageStep())
-
-    def get_scale_factor(self, slider=False):
-        """Return scrollbar's scale factor:
-        ratio between pixel span height and value span height"""
-        delta = 0 if slider else 2
-        vsb = self.code_editor.verticalScrollBar()
-        position_height = vsb.height()-delta-1
-        value_height = vsb.maximum()-vsb.minimum()+vsb.pageStep()
-        return float(position_height)/value_height
-
-    def value_to_position(self, y, slider=False):
-        """Convert value to position"""
-        offset = 0 if slider else 1
-        vsb = self.code_editor.verticalScrollBar()
-        return (y-vsb.minimum())*self.get_scale_factor(slider)+offset
-
-    def position_to_value(self, y, slider=False):
-        """Convert position to value"""
-        offset = 0 if slider else 1
-        vsb = self.code_editor.verticalScrollBar()
-        return vsb.minimum()+max([0, (y-offset)/self.get_scale_factor(slider)])
-
-    def make_flag_qrect(self, position):
-        """Make flag QRect"""
-        return QRect(self.FLAGS_DX/2, position-self.FLAGS_DY/2,
-                     self.WIDTH-self.FLAGS_DX, self.FLAGS_DY)
-
-    def make_slider_range(self, value):
-        """Make slider range QRect"""
-        vsb = self.code_editor.verticalScrollBar()
-        pos1 = self.value_to_position(value, slider=True)
-        pos2 = self.value_to_position(value + vsb.pageStep(), slider=True)
-        return QRect(1, pos1, self.WIDTH-2, pos2-pos1+1)
-
-    def wheelEvent(self, event):
-        """Override Qt method"""
-        self.code_editor.wheelEvent(event)
 
 
 #===============================================================================

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -301,7 +301,6 @@ class CodeEditor(TextEditBaseWidget):
         self.highlight_current_line_enabled = False
 
         # Scrollbar flag area
-        self.scrollflagarea_enabled = None
         self.scrollflagarea = ScrollFlagArea(self)
         self.scrollflagarea.hide()
         self.warning_color = "#FFAD07"
@@ -558,7 +557,7 @@ class CodeEditor(TextEditBaseWidget):
         self.set_tab_stop_width_spaces(tab_stop_width_spaces)
 
         # Scrollbar flag area
-        self.set_scrollflagarea_enabled(scrollflagarea)
+        self.scrollflagarea.set_enabled(scrollflagarea)
 
         # Edge line
         self.edge_line.set_enabled(edge_line)
@@ -1111,13 +1110,6 @@ class CodeEditor(TextEditBaseWidget):
         self.document().setDefaultTextOption(option)
         # Rehighlight to make the spaces less apparent.
         self.rehighlight()
-
-    #-----scrollflagarea
-    def set_scrollflagarea_enabled(self, state):
-        """Toggle scroll flag area visibility"""
-        self.scrollflagarea_enabled = state
-        self.scrollflagarea.setVisible(state)
-        self.panels.refresh()
 
     def resizeEvent(self, event):
         """Reimplemented Qt method to handle p resizing"""


### PR DESCRIPTION
- Migration of ScrollFlagArea to panels folder.
- Use panel API.
- Move some functions from the CodeEditor to ScrollFlagArea class.

This is a continuation of the decoupling of code editor panels.