### PR TITLE
PR: Fix error when running cells because previous_focused_widget is not initialized in main window

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -486,6 +486,7 @@ class MainWindow(QMainWindow):
 
         # To keep track of the last focused widget
         self.last_focused_widget = None
+        self.previous_focused_widget = None
 
         # Server to open external files on a single instance
         self.open_files_server = socket.socket(socket.AF_INET,


### PR DESCRIPTION
Fixes #4025 

Sorry I introduced this error, I forget to add that variable to the `MainWindow.__init__` I think was the hurry fixing #4022.