### PR TITLE
PR: Show internal errors in a QMessageBox

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2296,7 +2296,7 @@ class MainWindow(QMainWindow):
         dlg.exec_()
 
     @Slot()
-    def report_issue(self):
+    def report_issue(self, traceback=""):
         if PY3:
             from urllib.parse import quote
         else:
@@ -2320,6 +2320,7 @@ class MainWindow(QMainWindow):
 
 **Please provide any additional information below**
 
+%s
 
 ## Version and main components
 
@@ -2331,7 +2332,8 @@ class MainWindow(QMainWindow):
 ```
 %s
 ```
-""" % (versions['spyder'],
+""" % (traceback,
+       versions['spyder'],
        revision,
        versions['python'],
        versions['qt'],

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -428,6 +428,11 @@ class MainWindow(QMainWindow):
         if options.window_title is not None:
             title += ' -- ' + options.window_title
 
+        if DEV or DEBUG or PYTEST:
+            # Show errors in internal console when developing or testing.
+            CONF.set('main', 'show_internal_console_if_traceback', True)
+
+
         self.base_title = title
         self.update_window_title()
         resample = os.name != 'nt'

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -93,7 +93,7 @@ DEFAULTS = [
               'cpu_usage/timeout': 2000,
               'use_custom_margin': True,
               'custom_margin': 0,
-              'show_internal_console_if_traceback': True,
+              'show_internal_console_if_traceback': False,
               'check_updates_on_startup': True,
               'toolbars_visible': True,
               # Global Spyder fonts
@@ -655,7 +655,7 @@ DEFAULTS = [
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '37.1.0'
+CONF_VERSION = '37.2.0'
 
 # Main configuration instance
 try:

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -213,16 +213,17 @@ class Console(SpyderPluginWidget):
                 self.msgbox_traceback = QMessageBox(
                     QMessageBox.Critical,
                     _('Error'),
-                    _("<b>Spyder-IDE has encountered a problem.</b>"
+                    _("<b>Spyder has encountered a problem.</b><br>"
                       "Sorry for the inconvenience."
-                      "<b>Please tell us about this problem.</b>"
                       "<br><br>"
-                      "You can submit this error to the github issue tracker"),
-                      QMessageBox.Ok,
+                      "You can automatically submit this error to our Github "
+                      "issues tracker.<br><br>"
+                      "<i>Note:</i> You need a Github account for that."),
+                    QMessageBox.Ok,
                     parent=self)
 
                 self.submit_btn = self.msgbox_traceback.addButton(
-                        _('Submit to github'), QMessageBox.YesRole)
+                        _('Submit to Github'), QMessageBox.YesRole)
                 self.submit_btn.pressed.connect(self.press_submit_btn)
 
                 self.msgbox_traceback.setWindowModality(Qt.NonModal)

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -228,9 +228,13 @@ class Console(SpyderPluginWidget):
                 self.msgbox_traceback.setWindowModality(Qt.NonModal)
                 self.error_traceback = ""
                 self.msgbox_traceback.show()
+                self.msgbox_traceback.finished.connect(self.close_msg)
 
             self.error_traceback += text
             self.msgbox_traceback.setDetailedText(self.error_traceback)
+
+    def close_msg(self):
+        self.msgbox_traceback = None
 
     def press_submit_btn(self):
         self.main.report_issue(self.error_traceback)

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -218,8 +218,12 @@ class Console(SpyderPluginWidget):
                       "<b>Please tell us about this problem.</b>"
                       "<br><br>"
                       "You can submit this error to the github issue tracker"),
-                    QMessageBox.Cancel | QMessageBox.Ok,
+                      QMessageBox.Ok,
                     parent=self)
+
+                self.submit_btn = self.msgbox_traceback.addButton(
+                        _('Submit to github'), QMessageBox.YesRole)
+                self.submit_btn.pressed.connect(self.press_submit_btn)
 
                 self.msgbox_traceback.setWindowModality(Qt.NonModal)
                 self.error_traceback = ""
@@ -228,6 +232,9 @@ class Console(SpyderPluginWidget):
             self.error_traceback += text
             self.msgbox_traceback.setDetailedText(self.error_traceback)
 
+    def press_submit_btn(self):
+        self.main.report_issue(self.error_traceback)
+        self.msgbox_traceback = None
 
     #------ Public API ---------------------------------------------------------
     @Slot()

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -1276,7 +1276,7 @@ class ConsoleBaseWidget(TextEditBaseWidget):
     """Console base widget"""
     BRACE_MATCHING_SCOPE = ('sol', 'eol')
     COLOR_PATTERN = re.compile('\x01?\x1b\[(.*?)m\x02?')
-    traceback_available = Signal()
+    traceback_available = Signal(str)
     userListActivated = Signal(int, str)
     completion_widget_activated = Signal(str)
     
@@ -1398,7 +1398,7 @@ class ConsoleBaseWidget(TextEditBaseWidget):
                     # Show error/warning messages in red
                     cursor.insertText(text, self.error_style.format)
             if is_traceback:
-                self.traceback_available.emit()
+                self.traceback_available.emit(text)
         elif prompt:
             # Show prompt in green
             insert_text_to(cursor, text, self.prompt_style.format)


### PR DESCRIPTION
Fixes: #1525 

~~This isn't ready, I implemented but the behavior isn't the expected, the QMessageBox is shown but for every single line of the traceback (because `traceback_available` signal is emitted for every line).~~

~~any ideas of how I could fix this?~~

I implemented using a QMessageBox with non modal behavior

![traceback_box](https://cloud.githubusercontent.com/assets/2024217/22275240/32ca8e12-e279-11e6-887d-cf1a81792624.png)
