### PR TITLE
PR: Add "run selection" icon to run toolbar

### DIFF
--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -1051,8 +1051,8 @@ class Editor(SpyderPluginWidget):
                             configure_action, MENU_SEPARATOR]
         self.main.run_menu_actions += run_menu_actions
         run_toolbar_actions = [run_action, run_cell_action,
-                               run_cell_advance_action, re_run_action,
-                               configure_action]
+                               run_cell_advance_action, run_selected_action,
+                               re_run_action]
         self.main.run_toolbar_actions += run_toolbar_actions
 
         # ---- Debug menu/toolbar construction ----

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -819,7 +819,7 @@ class Editor(SpyderPluginWidget):
                                             triggered=self.run_selection,
                                             context=Qt.WidgetShortcut)
         self.register_shortcut(run_selected_action, context="Editor",
-                               name="Run selection")
+                               name="Run selection", add_sc_to_tip=True)
 
         run_cell_action = create_action(self,
                             _("Run cell"),


### PR DESCRIPTION
Fixes #4020 

This also removes the "Run settings" icon. The run toolbar looks like this now:

![image](https://cloud.githubusercontent.com/assets/3608776/22271959/60accd36-e265-11e6-9b8b-a2fb94c2cb6b.png)
