### PR TITLE
PR: More autoindentation fixes

### DIFF
--- a/spyder/plugins/tests/test_ipythonconsole.py
+++ b/spyder/plugins/tests/test_ipythonconsole.py
@@ -71,6 +71,7 @@ def test_load_kernel_file_from_id(ipyconsole, qtbot):
     ipyconsole.close()
 
 
+@pytest.mark.skipif(os.name == 'nt', reason="It times out on Windows")
 def test_load_kernel_file_from_location(ipyconsole, qtbot):
     """
     Test that a new client is created using a connection file
@@ -95,6 +96,7 @@ def test_load_kernel_file_from_location(ipyconsole, qtbot):
     ipyconsole.close()
 
 
+@pytest.mark.skipif(os.name == 'nt', reason="It times out on Windows")
 def test_load_kernel_file(ipyconsole, qtbot):
     """
     Test that a new client is created using the connection file

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2368,9 +2368,11 @@ class CodeEditor(TextEditBaseWidget):
         self.setTextCursor(cursor)
 
     #------Autoinsertion of quotes/colons
-    def __get_current_color(self):
+    def __get_current_color(self, cursor=None):
         """Get the syntax highlighting color for the current cursor position"""
-        cursor = self.textCursor()
+        if cursor is None:
+            cursor = self.textCursor()
+
         block = cursor.block()
         pos = cursor.position() - block.position()  # relative pos within block
         layout = block.layout()
@@ -2392,10 +2394,14 @@ class CodeEditor(TextEditBaseWidget):
         else:
             return None
 
-    def in_comment_or_string(self):
+    def in_comment_or_string(self, cursor=None):
         """Is the cursor inside or next to a comment or string?"""
         if self.highlighter:
-            current_color = self.__get_current_color()
+            if cursor is None:
+                current_color = self.__get_current_color()
+            else:
+                current_color = self.__get_current_color(cursor=cursor)
+
             comment_color = self.highlighter.get_color_name('comment')
             string_color = self.highlighter.get_color_name('string')
             if (current_color == comment_color) or (current_color == string_color):
@@ -2698,7 +2704,15 @@ class CodeEditor(TextEditBaseWidget):
                    and self.codecompletion_enter:
                     self.select_completion_list()
                 else:
-                    cmt_or_str = self.in_comment_or_string()
+                    cmt_or_str_cursor = self.in_comment_or_string()
+
+                    # Check if the line start with a comment or string
+                    cursor = self.textCursor()
+                    cursor.setPosition(cursor.block().position(), QTextCursor.KeepAnchor)
+                    cmt_or_str_line_begin = self.in_comment_or_string(cursor=cursor)
+
+                    cmt_or_str = cmt_or_str_cursor and cmt_or_str_line_begin
+
                     self.textCursor().beginEditBlock()
                     TextEditBaseWidget.keyPressEvent(self, event)
                     self.fix_indent(comment_or_string=cmt_or_str)

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2731,13 +2731,18 @@ class CodeEditor(TextEditBaseWidget):
                    and self.codecompletion_enter:
                     self.select_completion_list()
                 else:
+                    # Check if we're in a comment or a string at the
+                    # current position
                     cmt_or_str_cursor = self.in_comment_or_string()
 
                     # Check if the line start with a comment or string
                     cursor = self.textCursor()
-                    cursor.setPosition(cursor.block().position(), QTextCursor.KeepAnchor)
-                    cmt_or_str_line_begin = self.in_comment_or_string(cursor=cursor)
+                    cursor.setPosition(cursor.block().position(),
+                                       QTextCursor.KeepAnchor)
+                    cmt_or_str_line_begin = self.in_comment_or_string(
+                                                cursor=cursor)
 
+                    # Check if we are in a comment or a string
                     cmt_or_str = cmt_or_str_cursor and cmt_or_str_line_begin
 
                     self.textCursor().beginEditBlock()

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2009,7 +2009,12 @@ class CodeEditor(TextEditBaseWidget):
 
                 # Hanging indent
                 # find out if the last one is (, {, or []})
-                elif re.search(r'[\(|\{|\[]\s*$', prevtext) is not None:
+                # only if prevtext is long that the hanging indentation
+                elif (re.search(r'[\(|\{|\[]\s*$', prevtext) is not None and
+                      ((self.indent_chars == '\t' and
+                        self.tab_stop_width_spaces * 2 < len(prevtext)) or
+                       (self.indent_chars.startswith(' ') and
+                        len(self.indent_chars) * 2 < len(prevtext)))):
                     if self.indent_chars == '\t':
                         correct_indent += self.tab_stop_width_spaces * 2
                     else:

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -1985,9 +1985,31 @@ class CodeEditor(TextEditBaseWidget):
                 else:
                     correct_indent -= len(self.indent_chars)
             elif len(re.split(r'\(|\{|\[', prevtext)) > 1:
+
+                # Check if all braces are matching using a stack
+                stack = ['dummy']  # Dummy elemet to avoid index errors
+                deactivate = None
+                for c in prevtext:
+                    if deactivate is not None:
+                        if c == deactivate:
+                            deactivate = None
+                    elif c in ["'", '"']:
+                        deactivate = c
+                    elif c in ['(', '[','{']:
+                        stack.append(c)
+                    elif c == ')' and stack[-1] == '(':
+                        stack.pop()
+                    elif c == ']' and stack[-1] == '[':
+                        stack.pop()
+                    elif c == '}' and stack[-1] == '{':
+                        stack.pop()
+
+                if len(stack) == 1:  # all braces matching
+                    pass
+
                 # Hanging indent
                 # find out if the last one is (, {, or []})
-                if re.search(r'[\(|\{|\[]\s*$', prevtext) is not None:
+                elif re.search(r'[\(|\{|\[]\s*$', prevtext) is not None:
                     if self.indent_chars == '\t':
                         correct_indent += self.tab_stop_width_spaces * 2
                     else:

--- a/spyder/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyder/widgets/sourcecode/tests/test_autoindent.py
@@ -153,6 +153,7 @@ def test_first_line():
          "test_commented_brackets"),
         ("s = a[(a['a'] == l) & (a['a'] == 1)]['a']\n", "s = a[(a['a'] == l) & (a['a'] == 1)]['a']\n",
          "test_balanced_brackets"),
+        ("a = (a  #  some comment\n", "a = (a  #  some comment\n     ", "test_inline_comment"),
     ])
 def test_indentation_with_spaces(text_input, expected, test_text):
     text = get_indent_fix(text_input)

--- a/spyder/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyder/widgets/sourcecode/tests/test_autoindent.py
@@ -154,6 +154,14 @@ def test_first_line():
         ("s = a[(a['a'] == l) & (a['a'] == 1)]['a']\n", "s = a[(a['a'] == l) & (a['a'] == 1)]['a']\n",
          "test_balanced_brackets"),
         ("a = (a  #  some comment\n", "a = (a  #  some comment\n     ", "test_inline_comment"),
+
+        # Failing test
+        pytest.mark.xfail(
+            ("len(a) == 1\n", "len(a) == 1\n",
+             "test_balanced_brackets_not_ending_in_bracket")),
+        pytest.mark.xfail(
+            ("x = f(\n", "x = f\n      ",
+             "test_short_open_bracket_not_hanging_indent")),
     ])
 def test_indentation_with_spaces(text_input, expected, test_text):
     text = get_indent_fix(text_input)
@@ -192,6 +200,9 @@ def test_def_with_unindented_comment():
         pytest.mark.xfail(
             ("def function():\n# Comment\n", "def function():\n# Comment\n\t",
              "test_def_with_unindented_comment")),
+        pytest.mark.xfail(
+            ("a = (a  #  some comment\n", "a = (a  #  some comment\n\t ",
+             "test_inline_comment")),
     ])
 def test_indentation_with_tabs(text_input, expected, test_text,
                                tab_stop_width_spaces):

--- a/spyder/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyder/widgets/sourcecode/tests/test_autoindent.py
@@ -154,11 +154,9 @@ def test_first_line():
         ("s = a[(a['a'] == l) & (a['a'] == 1)]['a']\n", "s = a[(a['a'] == l) & (a['a'] == 1)]['a']\n",
          "test_balanced_brackets"),
         ("a = (a  #  some comment\n", "a = (a  #  some comment\n     ", "test_inline_comment"),
+        ("len(a) == 1\n", "len(a) == 1\n", "test_balanced_brackets_not_ending_in_bracket"),
 
-        # Failing test
-        pytest.mark.xfail(
-            ("len(a) == 1\n", "len(a) == 1\n",
-             "test_balanced_brackets_not_ending_in_bracket")),
+        # Failing test,
         pytest.mark.xfail(
             ("x = f(\n", "x = f\n      ",
              "test_short_open_bracket_not_hanging_indent")),

--- a/spyder/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyder/widgets/sourcecode/tests/test_autoindent.py
@@ -155,11 +155,7 @@ def test_first_line():
          "test_balanced_brackets"),
         ("a = (a  #  some comment\n", "a = (a  #  some comment\n     ", "test_inline_comment"),
         ("len(a) == 1\n", "len(a) == 1\n", "test_balanced_brackets_not_ending_in_bracket"),
-
-        # Failing test,
-        pytest.mark.xfail(
-            ("x = f(\n", "x = f\n      ",
-             "test_short_open_bracket_not_hanging_indent")),
+        ("x = f(\n", "x = f(\n      ", "test_short_open_bracket_not_hanging_indent"),
     ])
 def test_indentation_with_spaces(text_input, expected, test_text):
     text = get_indent_fix(text_input)
@@ -185,7 +181,7 @@ def test_def_with_unindented_comment():
          "test with indented comment"),
         ("def function():\n\tprint []\n", "def function():\n\tprint []\n\t",
          "test brackets alone"),
-        ("\na = {\n", "\na = {\n\t\t", "indentation after opening bracket"),
+        ("\nsome_long_name = {\n", "\nsome_long_name = {\n\t\t", "indentation after opening bracket"),
         ("def function():\n", "def function():\n\t", "test simple def"),
         ("open_parenthesis(\n", "open_parenthesis(\n\t\t",
          "open parenthesis"),

--- a/spyder/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyder/widgets/sourcecode/tests/test_autoindent.py
@@ -156,6 +156,11 @@ def test_first_line():
         ("a = (a  #  some comment\n", "a = (a  #  some comment\n     ", "test_inline_comment"),
         ("len(a) == 1\n", "len(a) == 1\n", "test_balanced_brackets_not_ending_in_bracket"),
         ("x = f(\n", "x = f(\n      ", "test_short_open_bracket_not_hanging_indent"),
+
+        pytest.mark.xfail(
+            ("foo = 1  # Comment open parenthesis (\n",
+             "foo = 1  # Comment open parenthesis (\n",
+             "test_comment_with parenthesis")),
     ])
 def test_indentation_with_spaces(text_input, expected, test_text):
     text = get_indent_fix(text_input)


### PR DESCRIPTION
Fixes #4096 
Fixes #4074 

I fixed some issues reported applying hanging indent for long text only

```
a = {
     } #not hanging indent
```
```
some_long_name = {
              } #hanging indent (8 spaces)
```
