### PR TITLE
Add AppStream metainfo file

### DIFF
--- a/scripts/spyder.desktop
+++ b/scripts/spyder.desktop
@@ -11,4 +11,4 @@ Icon=spyder
 Terminal=false
 StartupNotify=true
 MimeType=text/x-python;
-
+X-AppStream-Ignore=True

--- a/scripts/spyder3.appdata.xml
+++ b/scripts/spyder3.appdata.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component type="desktop-application">
+  <id>spyder3.desktop</id>
+  <name>Spyder</name>
+  <summary>Scientific Python Development Environment</summary>
+
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <developer_name>Spyder Project Contributors</developer_name>
+
+  <description>
+    <p>
+      Spyder is a free open-source Python development environment providing MATLAB-like features in a simple and light-weighted software.
+    </p>
+    <p>
+      It contains a powerful interactive development environment for the Python language with advanced editing, interactive testing, debugging and introspection features
+      and a numerical computing environment thanks to the support of IPython (enhanced interactive Python interpreter) and popular Python libraries such as NumPy
+      (linear algebra), SciPy (signal and image processing) or matplotlib (interactive 2D/3D plotting).
+    </p>
+    <p>
+      Spyder may also be used as a library providing powerful console-related widgets for your PyQt-based applications – for example, it may be used to integrate
+      a debugging console directly in the layout of your graphical user interface.
+    </p>
+  </description>
+
+  <screenshots>
+​    <screenshot type="default">
+​      <image>https://raw.githubusercontent.com/spyder-ide/spyder/master/img_src/screenshot.png</image>
+​    </screenshot>
+​  </screenshots>
+
+</component>

--- a/scripts/spyder3.desktop
+++ b/scripts/spyder3.desktop
@@ -11,4 +11,3 @@ Icon=spyder3
 Terminal=false
 StartupNotify=true
 MimeType=text/x-python;
-

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,8 @@ def get_data_files():
     if sys.platform.startswith('linux'):
         if PY3:
             data_files = [('share/applications', ['scripts/spyder3.desktop']),
-                          ('share/pixmaps', ['img_src/spyder3.png'])]
+                          ('share/pixmaps', ['img_src/spyder3.png']),
+                          ('share/metainfo', ['scripts/spyder3.appdata.xml'])]
         else:
             data_files = [('share/applications', ['scripts/spyder.desktop']),
                           ('share/pixmaps', ['img_src/spyder.png'])]


### PR DESCRIPTION
This patch adds an AppStream metainfo file to Spyder, providing metadata to make Spyder visible in the software centers of Linux distributions, like KDE Discover and GNOME Software (the default software center in Ubuntu and Fedora).

At time, we process the .desktop file in Debian/Ubuntu to make Spyder show up, but that's not ideal - with this patch, you gain control over the information that is shown and a screenshot gets displayed as well.

The metainfo XML file can be translated, so you can hook it up into your l10n system if you have one and want that.

More information on AppStream can be found [here](https://www.freedesktop.org/software/appstream/docs/), and there is a [quickstart guide](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps) for application maintainers too.

This patch makes the Python3 version of Spyder the only version to be shown in software centers - the other versions are not shown. I think that is a good and future-proof decision, but if you think otherwise, let me know and I will adjust the patch.

You can validate the metainfo file using the command `appstreamcli validate spyder3.appdata.xml`.

Additionally to adding this metadata, you might also consider the following:
  * Rename the .desktop files to follow the reverse-DNS scheme as recommended by the [specification](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s02.html). - This will kill warnings when AppStream validates the metainfo file.
  * Ship more icon sizes (or an SVG icon) in the canonical locations in `/usr/share/icons/hicolor/<size>/apps` to make icon handling easier (and save desktops from resizing stuff a lot).

Cheers,
    Matthias