### PR TITLE
PR: Use an older Miniconda version for Python 3

### DIFF
--- a/continuous_integration/appveyor/install.ps1
+++ b/continuous_integration/appveyor/install.ps1
@@ -8,7 +8,7 @@ $MINICONDA_URL = "http://repo.continuum.io/miniconda/"
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
     if ($python_version -match "3.5") {
-        $filename = "Miniconda3-latest-Windows-" + $platform_suffix + ".exe"
+        $filename = "Miniconda3-4.2.12-Windows-" + $platform_suffix + ".exe"
     } else {
         $filename = "Miniconda2-latest-Windows-" + $platform_suffix + ".exe"
     }

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -38,7 +38,7 @@ install_conda()
     if [ "$PY_VERSION" = "2.7" ]; then
         wget "http://repo.continuum.io/miniconda/Miniconda-$MINICONDA_VERSION-$MINICONDA_OS.sh" -O miniconda.sh;
     else
-        wget "http://repo.continuum.io/miniconda/Miniconda3-$MINICONDA_VERSION-$MINICONDA_OS.sh" -O miniconda.sh;
+        wget "http://repo.continuum.io/miniconda/Miniconda3-4.2.12-$MINICONDA_OS.sh" -O miniconda.sh;
     fi
 
     bash miniconda.sh -b -p "$HOME/miniconda";


### PR DESCRIPTION
Tests are failing with the latest Miniconda on Appveyor and Travis.