### PR TITLE
PR: Fix error edgeline offset, take codefolding panel width in account.

### DIFF
--- a/spyder/widgets/panels/edgeline.py
+++ b/spyder/widgets/panels/edgeline.py
@@ -13,6 +13,7 @@ from qtpy.QtCore import Qt, QRect
 from qtpy.QtGui import QPainter, QColor
 
 from spyder.py3compat import is_text_string
+from spyder.api.panel import Panel
 
 class EdgeLine(QWidget):
     """Source code editor's edge line (default: 79 columns, PEP8)"""
@@ -74,6 +75,6 @@ class EdgeLine(QWidget):
         offset = self.editor.contentOffset()
         x = self.editor.blockBoundingGeometry(self.editor.firstVisibleBlock()) \
             .translated(offset.x(), offset.y()).left() \
-            +self.editor.linenumberarea.get_width() \
+            +self.editor.panels.margin_size(Panel.Position.LEFT) \
             +self.editor.fontMetrics().width('9'*min(self.columns))+5
         self.setGeometry(QRect(x, cr.top(), width, cr.bottom()))


### PR DESCRIPTION
Fixes #4163

This was caused because the edge line doesn't take in account the width of the codefolding panel.

Although we need a way to define panels with arbitrary position