### PR TITLE
PR: Add testing requirements to setup.py

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -61,14 +61,10 @@ install_conda()
 install_pip()
 {
     # Install PyQt5
-    conda install 'pyqt>=5.6.0';
+    pip install pyqt5;
 
     # Install testing packages
-    pip install pytest pytest-cov pytest-qt mock
-
-    # Install extra packages
-    EXTRA_PACKAGES="matplotlib pandas sympy pyzmq pillow"
-    pip install $EXTRA_PACKAGES
+    pip install -e .[test]
 }
 
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -61,7 +61,7 @@ install_conda()
 install_pip()
 {
     # Install PyQt5
-    pip install pyqt5;
+    conda install 'pyqt>=5.6.0';
 }
 
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -62,9 +62,6 @@ install_pip()
 {
     # Install PyQt5
     pip install pyqt5;
-
-    # Install testing packages
-    pip install -e .[test]
 }
 
 

--- a/continuous_integration/travis/run_test.sh
+++ b/continuous_integration/travis/run_test.sh
@@ -26,6 +26,9 @@ if [ "$USE_CONDA" = true ] ; then
 else
     cd $FULL_SPYDER_CLONE
     pip install dist/spyder-*.whl
+
+    # Install testing packages
+    pip install -e .[test]
 fi
 
 

--- a/continuous_integration/travis/run_test.sh
+++ b/continuous_integration/travis/run_test.sh
@@ -25,10 +25,8 @@ if [ "$USE_CONDA" = true ] ; then
     conda install -q $EXTRA_PACKAGES
 else
     cd $FULL_SPYDER_CLONE
-    pip install dist/spyder-*.whl
-
-    # Install testing packages
-    pip install -e .[test]
+    export WHEEL=`ls dist/spyder-*.whl`
+    pip install $WHEEL[test]
 fi
 
 

--- a/continuous_integration/travis/run_test.sh
+++ b/continuous_integration/travis/run_test.sh
@@ -6,14 +6,14 @@ set -ex
 export TEST_CI_APP=True
 
 
-# Extra packages to install besides Spyder regular dependencies
-# We install them here and not in travis_install.sh to see if
-# Spyder is correctly pulling its deps (some of them are shared
-# with mpl)
-export EXTRA_PACKAGES="nomkl pandas sympy pillow scipy"
-
 # Install our builds of Spyder
 if [ "$USE_CONDA" = true ] ; then
+    # Extra packages to install besides Spyder regular dependencies
+    # We install them here and not in travis_install.sh to see if
+    # Spyder is correctly pulling its deps (some of them are shared
+    # with mpl)
+    export EXTRA_PACKAGES="nomkl pandas sympy pillow scipy"
+
     # Move to a tmp dir
     mkdir ~/tmp
     cd ~/tmp

--- a/setup.py
+++ b/setup.py
@@ -290,8 +290,16 @@ install_requires = [
 
 extras_require = {
     'test:python_version == "2.7"': ['mock'],
-    'test': ['pytest', 'pytest-qt', 'pytest-cov', 'mock', 'coveralls',
-             'flaky', 'pandas', 'scipy', 'sympy', 'pillow'],
+    'test': ['pytest',
+             'pytest-qt',
+             'pytest-cov',
+             'mock',
+             'flaky',
+             'pandas',
+             'scipy',
+             'sympy',
+             'pillow',
+             'matplotlib'],
 }
 
 if 'setuptools' in sys.modules:

--- a/setup.py
+++ b/setup.py
@@ -288,8 +288,15 @@ install_requires = [
     'numpydoc',
 ]
 
+extras_require = {
+    'test:python_version == "2.7"': ['mock'],
+    'test': ['pytest', 'pytest-qt', 'pytest-cov', 'mock', 'coveralls',
+             'ciocheck', 'flaky', 'pandas', 'scipy', 'sympy', 'pillow'],
+}
+
 if 'setuptools' in sys.modules:
     setup_args['install_requires'] = install_requires
+    setup_args['extras_require'] = extras_require
 
     setup_args['entry_points'] = {
         'gui_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -291,7 +291,7 @@ install_requires = [
 extras_require = {
     'test:python_version == "2.7"': ['mock'],
     'test': ['pytest', 'pytest-qt', 'pytest-cov', 'mock', 'coveralls',
-             'ciocheck', 'flaky', 'pandas', 'scipy', 'sympy', 'pillow'],
+             'flaky', 'pandas', 'scipy', 'sympy', 'pillow'],
 }
 
 if 'setuptools' in sys.modules:


### PR DESCRIPTION
Fixes: #4174

-------
I take the packages that I found in the continuum integration recipes.

I'm not sure if `numpy` should also be added (pandas will install it as a dependency), and if `pillow` if needed (circle-ci recipe doesn't install it)
