### PR TITLE
PR: Fixup MANIFEST.in to include the changelog

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,5 +12,5 @@ include img_src/spyder3.png
 include MANIFEST.in
 include README.md
 include LICENSE
-include CHANGELOG
+include CHANGELOG.md
 include bootstrap.py


### PR DESCRIPTION
The PyPI release is missing the change log due to a typo that this PR is rectifying.
