### PR TITLE
PR : Add Cython files import and run support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ a Python version greater than 2.7 (Python 3.2 is not supported anymore).
 * **Numpy**: View and edit two or three dimensional arrays in the Variable Explorer.
 * **SymPy**: Symbolic mathematics in the IPython console.
 * **SciPy**: Import Matlab workspace files in the Variable Explorer.
+* **Cython**: Run Cython files in the IPython console.
 
 
 ## More information

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ machine:
     CONDA_DEPENDENCIES_FLAGS: "--quiet"
     CONDA_DEPENDENCIES: >
       rope jedi pyflakes sphinx pygments pylint pep8 psutil nbconvert qtawesome pickleshare
-      qtpy pyzmq chardet mock nomkl pandas pytest pytest-cov numpydoc scipy
+      qtpy pyzmq chardet mock nomkl pandas pytest pytest-cov numpydoc scipy cython
     PIP_DEPENDENCIES: "coveralls pytest-qt flaky"
 
 dependencies:

--- a/continuous_integration/travis/modules_test.sh
+++ b/continuous_integration/travis/modules_test.sh
@@ -16,7 +16,7 @@ fi
 
 # Depth 1
 for f in spyder/*.py; do
-    if [[ $f == *test*/test_* ]]; then
+    if [[ $f == *test*/*.* ]]; then
         continue
     fi
     if [[ $f == spyder/pyplot.py ]]; then
@@ -31,7 +31,7 @@ done
 
 # Depth 2
 for f in spyder/*/*.py; do
-    if [[ $f == *test*/test_* ]]; then
+    if [[ $f == *test*/*.* ]]; then
         continue
     fi
     if [[ $f == spyder/app/*.py ]]; then
@@ -62,7 +62,7 @@ done
 
 # Depth 3
 for f in spyder/*/*/*.py; do
-    if [[ $f == *test*/test_* ]]; then
+    if [[ $f == *test*/*.* ]]; then
         continue
     fi
     if [[ $f == spyder/external/*/*.py ]]; then
@@ -101,7 +101,7 @@ done
 
 # Depth 4
 for f in spyder/*/*/*/*.py; do
-    if [[ $f == *test*/test_* ]]; then
+    if [[ $f == *test*/*.* ]]; then
         continue
     fi
     python "$f"
@@ -113,7 +113,7 @@ done
 
 # Spyderplugins
 for f in spyder_*/widgets/*.py; do
-    if [[ $f == *test*/test_* ]]; then
+    if [[ $f == *test*/*.* ]]; then
         continue
     fi
     python "$f"

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -218,6 +218,9 @@ Optional modules
 * `Scipy <http://www.scipy.org/>`_ -- for importing Matlab workspace files in
   the Variable Explorer.
 
+* `Cython <http://cython.org/>`_ >=0.21 -- Run Cython files or Python files that
+  depend on Cython libraries in the IPython console.
+
 
 Installation procedure
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/spyder/app/tests/pyx_lib.pyx
+++ b/spyder/app/tests/pyx_lib.pyx
@@ -1,0 +1,2 @@
+def f(double x):
+    return x*x

--- a/spyder/app/tests/pyx_lib.pyx
+++ b/spyder/app/tests/pyx_lib.pyx
@@ -1,2 +1,0 @@
-def f(double x):
-    return x*x

--- a/spyder/app/tests/pyx_lib_import.py
+++ b/spyder/app/tests/pyx_lib_import.py
@@ -1,0 +1,3 @@
+import pyx_lib
+
+a = pyx_lib.f(2.0)

--- a/spyder/app/tests/pyx_lib_import.py
+++ b/spyder/app/tests/pyx_lib_import.py
@@ -1,3 +1,3 @@
-import pyx_lib
+import pyx_script
 
-a = pyx_lib.f(2.0)
+b = pyx_script.factorial(10)

--- a/spyder/app/tests/pyx_script.pyx
+++ b/spyder/app/tests/pyx_script.pyx
@@ -1,0 +1,1 @@
+cdef int a = 10

--- a/spyder/app/tests/pyx_script.pyx
+++ b/spyder/app/tests/pyx_script.pyx
@@ -1,1 +1,15 @@
-cdef int a = 10
+cpdef int factorial(int x):
+    # Basic example of a cython function, which defines
+    # python-like operations and control flow on defined c types
+
+    cdef int m = x
+    cdef int i
+
+    if x <= 1:
+        return 1
+    else:
+        for i in range(1, x):
+            m = m * i
+    return m
+
+a = factorial(10)

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -203,6 +203,7 @@ def test_run_code(main_window, qtbot):
                     reason="It times out sometimes on Windows and Cython is needed")
 def test_run_cython_code(main_window, qtbot):
     """Test all the different ways we have to run code"""
+    print('Cython installed', is_module_installed('Cython'))
     # ---- Setup ----
     # Wait until the window is fully up
     shell = main_window.ipyconsole.get_current_shellwidget()
@@ -230,7 +231,7 @@ def test_run_cython_code(main_window, qtbot):
     qtbot.keyClick(code_editor, Qt.Key_F5)
 
     # Wait until all objects have appeared in the variable explorer
-    qtbot.waitUntil(lambda: nsb.editor.model.rowCount() == 3,
+    qtbot.waitUntil(lambda: nsb.editor.model.rowCount() == 1,
                     timeout=COMPILE_AND_EVAL_TIMEOUT)
 
     # Verify result
@@ -252,7 +253,7 @@ def test_run_cython_code(main_window, qtbot):
     qtbot.keyClick(code_editor, Qt.Key_F5)
 
     # Wait until all objects have appeared in the variable explorer
-    qtbot.waitUntil(lambda: nsb.editor.model.rowCount() == 3,
+    qtbot.waitUntil(lambda: nsb.editor.model.rowCount() == 1,
                     timeout=COMPILE_AND_EVAL_TIMEOUT)
 
     # Verify result

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -83,7 +83,7 @@ def main_window(request):
 #==============================================================================
 # Tests
 #==============================================================================
-#@flaky(max_runs=10)
+@flaky(max_runs=10)
 @pytest.mark.skipif(os.name == 'nt' or not is_module_installed('Cython'),
                     reason="It times out sometimes on Windows and Cython is needed")
 def test_run_cython_code(main_window, qtbot):

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -202,8 +202,7 @@ def test_run_code(main_window, qtbot):
 @pytest.mark.skipif(os.name == 'nt' or not is_module_installed('Cython'),
                     reason="It times out sometimes on Windows and Cython is needed")
 def test_run_cython_code(main_window, qtbot):
-    """Test all the different ways we have to run code"""
-    print('Cython installed', is_module_installed('Cython'))
+    """Test all the different ways we have to run Cython code"""
     # ---- Setup ----
     # Wait until the window is fully up
     shell = main_window.ipyconsole.get_current_shellwidget()

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -34,6 +34,10 @@ LOCATION = osp.realpath(osp.join(os.getcwd(), osp.dirname(__file__)))
 # (in miliseconds)
 SHELL_TIMEOUT = 20000
 
+# Need longer EVAL_TIMEOUT, because need to cythonize and C compile ".pyx" file
+# before import and eval it
+COMPILE_AND_EVAL_TIMEOUT=30000
+
 # Time to wait for the IPython console to evaluate something (in
 # miliseconds)
 EVAL_TIMEOUT = 3000
@@ -79,6 +83,56 @@ def main_window(request):
 #==============================================================================
 # Tests
 #==============================================================================
+#@flaky(max_runs=10)
+@pytest.mark.skipif(os.name == 'nt' or not is_module_installed('Cython'),
+                    reason="It times out sometimes on Windows and Cython is needed")
+def test_run_cython_code(main_window, qtbot):
+    """Test all the different ways we have to run Cython code"""
+    # ---- Setup ----
+    # Wait until the window is fully up
+    shell = main_window.ipyconsole.get_current_shellwidget()
+    qtbot.waitUntil(lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
+
+    # Get a reference to the namespace browser widget
+    nsb = main_window.variableexplorer.get_focus_widget()
+
+    # Get a reference to the code editor widget
+    code_editor = main_window.editor.get_focus_widget()
+
+    # ---- Run pyx file ----
+    # Load test file
+    main_window.editor.load(osp.join(LOCATION, 'pyx_script.pyx'))
+
+    # run file
+    qtbot.keyClick(code_editor, Qt.Key_F5)
+    qtbot.waitUntil(lambda: nsb.editor.model.rowCount() == 1,
+                    timeout=COMPILE_AND_EVAL_TIMEOUT)
+
+    # Verify result
+    assert shell.get_value('a') == 3628800
+
+    # Reset and close file
+    reset_run_code(qtbot, shell, code_editor, nsb)
+    main_window.editor.close_file()
+
+    # ---- Import pyx file ----
+    # Load test file
+    main_window.editor.load(osp.join(LOCATION, 'pyx_lib_import.py'))
+
+    # Run file
+    qtbot.keyClick(code_editor, Qt.Key_F5)
+
+    # Wait until all objects have appeared in the variable explorer
+    qtbot.waitUntil(lambda: nsb.editor.model.rowCount() == 1,
+                    timeout=COMPILE_AND_EVAL_TIMEOUT)
+
+    # Verify result
+    assert shell.get_value('b') == 3628800
+
+    # Close file
+    main_window.editor.close_file()
+
+
 @flaky(max_runs=10)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_set_new_breakpoints(main_window, qtbot):
@@ -196,70 +250,6 @@ def test_run_code(main_window, qtbot):
     qtbot.keyClick(code_editor, Qt.Key_Return, modifier=Qt.ControlModifier)
     assert nsb.editor.model.rowCount() == 1
 
-    main_window.editor.close_file()
-
-@flaky(max_runs=10)
-@pytest.mark.skipif(os.name == 'nt' or not is_module_installed('Cython'),
-                    reason="It times out sometimes on Windows and Cython is needed")
-def test_run_cython_code(main_window, qtbot):
-    """Test all the different ways we have to run Cython code"""
-    # ---- Setup ----
-    # Wait until the window is fully up
-    shell = main_window.ipyconsole.get_current_shellwidget()
-    qtbot.waitUntil(lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
-
-    # Get a reference to the namespace browser widget
-    nsb = main_window.variableexplorer.get_focus_widget()
-
-    # Get a reference to the code editor widget
-    code_editor = main_window.editor.get_focus_widget()
-    
-    # Need longer EVAL_TIMEOUT, because need to cythonize and C compile ".pyx" file
-    # before import and eval it
-    COMPILE_AND_EVAL_TIMEOUT=30000
-
-    # ---- Run pyx file ----
-    # Load test file
-    main_window.editor.load(osp.join(LOCATION, 'pyx_script.pyx'))
-
-    # Move to the editor's first line
-    code_editor.setFocus()
-    qtbot.keyClick(code_editor, Qt.Key_Home, modifier=Qt.ControlModifier)
-
-    # run file
-    qtbot.keyClick(code_editor, Qt.Key_F5)
-
-    # Wait until all objects have appeared in the variable explorer
-    qtbot.waitUntil(lambda: nsb.editor.model.rowCount() == 1,
-                    timeout=COMPILE_AND_EVAL_TIMEOUT)
-
-    # Verify result
-    assert shell.get_value('a') == 10
-
-    # reset
-    reset_run_code(qtbot, shell, code_editor, nsb)
-    main_window.editor.close_file()
-
-    # ---- Import pyx file ----
-    # Load test file
-    main_window.editor.load(osp.join(LOCATION, 'pyx_lib_import.py'))
-
-    # Move to the editor's first line
-    code_editor.setFocus()
-    qtbot.keyClick(code_editor, Qt.Key_Home, modifier=Qt.ControlModifier)
-
-    # run file
-    qtbot.keyClick(code_editor, Qt.Key_F5)
-
-    # Wait until all objects have appeared in the variable explorer
-    qtbot.waitUntil(lambda: nsb.editor.model.rowCount() == 1,
-                    timeout=COMPILE_AND_EVAL_TIMEOUT)
-
-    # Verify result
-    assert shell.get_value('a') == 4.0
-
-    # reset
-    reset_run_code(qtbot, shell, code_editor, nsb)
     main_window.editor.close_file()
     
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -251,7 +251,7 @@ def test_run_code(main_window, qtbot):
     assert nsb.editor.model.rowCount() == 1
 
     main_window.editor.close_file()
-    
+
 
 @flaky(max_runs=10)
 @pytest.mark.skipif(os.name == 'nt' or os.environ.get('CI', None) is None,

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -1120,6 +1120,7 @@ class Editor(SpyderPluginWidget):
                                              blockcomment_action,
                                              unblockcomment_action,
                                              self.winpdb_action]
+        self.cythonfile_compatible_actions = [run_action, configure_action]
         self.file_dependent_actions = self.pythonfile_dependent_actions + \
                 [self.save_action, save_as_action, print_preview_action,
                  self.print_action, self.save_all_action, gotoline_action,
@@ -1568,8 +1569,14 @@ class Editor(SpyderPluginWidget):
         # Refresh Python file dependent actions:
         editor = self.get_current_editor()
         if editor:
-            enable = editor.is_python()
+            python_enable = editor.is_python()
+            cython_enable = python_enable or (
+                programs.is_module_installed('Cython') and editor.is_cython())
             for action in self.pythonfile_dependent_actions:
+                if action in self.cythonfile_compatible_actions:
+                    enable = cython_enable
+                else:
+                    enable = python_enable
                 if action is self.winpdb_action:
                     action.setEnabled(enable and WINPDB_PATH is not None)
                 else:

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -65,6 +65,11 @@ dependencies.add("sympy", _("Symbolic mathematics in the IPython Console"),
                  required_version=SYMPY_REQVER, optional=True)
 
 
+CYTHON_REQVER = '>=0.21'
+dependencies.add("cython", _("Run Cython files in the IPython Console"),
+                 required_version=CYTHON_REQVER, optional=True)
+
+
 #------------------------------------------------------------------------------
 # Existing kernels
 #------------------------------------------------------------------------------

--- a/spyder/utils/ipython/start_kernel.py
+++ b/spyder/utils/ipython/start_kernel.py
@@ -133,6 +133,11 @@ def kernel_config():
            height_o = float(CONF.get('ipython_console', 'pylab/inline/height'))
            spy_cfg.InlineBackend.rc['figure.figsize'] = (width_o, height_o)
 
+
+    # Enable Cython magic
+    if is_module_installed('Cython'):
+        spy_cfg.IPKernelApp.exec_lines.append('%load_ext Cython')
+
     # Run a file at startup
     use_file_o = CONF.get('ipython_console', 'startup/use_run_file')
     run_file_o = CONF.get('ipython_console', 'startup/run_file')

--- a/spyder/utils/site/sitecustomize.py
+++ b/spyder/utils/site/sitecustomize.py
@@ -9,14 +9,15 @@
 # Spyder consoles sitecustomize
 #
 
-import sys
+import bdb
+import io
 import os
 import os.path as osp
 import pdb
-import bdb
+import shlex
+import sys
 import time
 import traceback
-import shlex
 
 
 PY2 = sys.version[0] == '2'
@@ -898,7 +899,7 @@ def runfile(filename, args=None, wdir=None, namespace=None, post_mortem=False):
         set_post_mortem()
     if HAS_CYTHON and os.path.splitext(filename)[1].lower() == '.pyx':
         # Cython files
-        with open(filename, 'rt') as f:
+        with io.open(filename, encoding='utf-8') as f:
             if IS_IPYKERNEL:
                 from IPython.core.getipython import get_ipython
                 ipython_shell = get_ipython()

--- a/spyder/utils/site/sitecustomize.py
+++ b/spyder/utils/site/sitecustomize.py
@@ -899,7 +899,10 @@ def runfile(filename, args=None, wdir=None, namespace=None, post_mortem=False):
     if HAS_CYTHON and os.path.splitext(filename)[1].lower() == '.pyx':
         # Cython files
         with open(filename, 'rt') as f:
-            cython_inline(f.read(), globals=namespace, quiet=True)
+            if IS_IPYKERNEL:
+                from IPython.core.getipython import get_ipython
+                ipython_shell = get_ipython()
+                ipython_shell.run_cell_magic('cython', '', f.read())
     else:
         execfile(filename, namespace)
 

--- a/spyder/widgets/dependencies.py
+++ b/spyder/widgets/dependencies.py
@@ -137,7 +137,7 @@ class DependenciesDialog(QDialog):
 
         self.view = DependenciesTableView(self, [])
 
-        opt_mods = ['NumPy', 'Matplotlib', 'Pandas', 'SymPy']
+        opt_mods = ['NumPy', 'Matplotlib', 'Pandas', 'SymPy', 'Cython']
         self.label = QLabel(_("Spyder depends on several Python modules to "
                               "provide the right functionality for all its "
                               "panes. The table below shows the required "


### PR DESCRIPTION
This PR improve Cython support by adding ".pyx" importing and running abilities to consoles.
- Automatically compile ".pyx" files when importing them with `import` (Enable `pyximport` with file reload option and NumPy support).
- Allow to run ".pyx" file with the "Run" button and the `runfile ` function (Using `cython_inline` function).
- Automatically enable IPython Cython magic.