### PR TITLE
PR: Remove u function from py3compat

### DIFF
--- a/spyder/py3compat.py
+++ b/spyder/py3compat.py
@@ -82,18 +82,6 @@ else:
 #==============================================================================
 # Strings
 #==============================================================================
-if PY2:
-    # Python 2
-    import codecs
-    def u(obj):
-        """Make unicode object"""
-        return codecs.unicode_escape_decode(obj)[0]
-else:
-    # Python 3
-    def u(obj):
-        """Return string as it is"""
-        return obj
-
 def is_text_string(obj):
     """Return True if `obj` is a text string, False if it is anything else,
     like binary data (Python 3) or QString (Python 2, PyQt API #1)"""

--- a/spyder/utils/help/conf.py
+++ b/spyder/utils/help/conf.py
@@ -11,7 +11,6 @@ from sphinx import __version__ as sphinx_version
 
 # Local imports
 from spyder.config.main import CONF
-from spyder.py3compat import u
 
 #==============================================================================
 # General configuration
@@ -53,8 +52,8 @@ source_suffix = '.rst'
 master_doc = 'docstring'
 
 # General information about the project.
-project = u("Spyder Help plugin")
-copyright = u('The Spyder Project Contributors')
+project = u"Spyder Help plugin"
+copyright = u'The Spyder Project Contributors'
 
 # List of directories, relative to source directory, that shouldn't be searched
 # for source files.

--- a/spyder/utils/iofuncs.py
+++ b/spyder/utils/iofuncs.py
@@ -467,12 +467,12 @@ def save_auto(data, filename):
 
 
 if __name__ == "__main__":
-    from spyder.py3compat import u, io
+    from spyder.py3compat import io
     import datetime
     testdict = {'d': 1, 'a': np.random.rand(10, 10), 'b': [1, 2]}
     testdate = datetime.date(1945, 5, 8)
     example = {'str': 'kjkj kj k j j kj k jkj',
-               'unicode': u('éù'),
+               'unicode': u'éù',
                'list': [1, 3, [4, 5, 6], 'kjkj', None],
                'tuple': ([1, testdate, testdict], 'kjkj', None),
                'dict': testdict,

--- a/spyder/utils/iofuncs.py
+++ b/spyder/utils/iofuncs.py
@@ -467,7 +467,7 @@ def save_auto(data, filename):
 
 
 if __name__ == "__main__":
-    from spyder.py3compat import io
+    import io
     import datetime
     testdict = {'d': 1, 'a': np.random.rand(10, 10), 'b': [1, 2]}
     testdate = datetime.date(1945, 5, 8)

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -32,7 +32,7 @@ from spyder.config.base import _, DEBUG, STDERR, STDOUT
 from spyder.config.gui import config_shortcut
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
                                  get_filter)
-from spyder.py3compat import qbytearray_to_str, to_text_string, u
+from spyder.py3compat import qbytearray_to_str, to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils import (codeanalysis, encoding, sourcecode,
                           syntaxhighlighters)
@@ -989,7 +989,7 @@ class EditorStack(QWidget):
         if self.fullpath_sorting_enabled:
             text = filename
         else:
-            text = u("%s — %s")
+            text = u"%s — %s"
         text = self.__modified_readonly_title(text,
                                               is_modified, is_readonly)
         if self.tempfile_path is not None\

--- a/spyder/widgets/internalshell.py
+++ b/spyder/widgets/internalshell.py
@@ -26,7 +26,7 @@ from qtpy.QtWidgets import QMessageBox
 from spyder import get_versions
 from spyder.interpreter import Interpreter
 from spyder.py3compat import (builtins, getcwd, to_binary_string,
-                              to_text_string, u)
+                              to_text_string)
 from spyder.utils import icon_manager as ima
 from spyder.utils import programs
 from spyder.utils.dochelpers import getargtxt, getdoc, getobjdir, getsource
@@ -335,7 +335,7 @@ class InternalShell(PythonShellWidget):
             t0 = time()
             for _ in range(10):
                 self.execute_command(command)
-            self.insert_text(u("\n<Δt>=%dms\n") % (1e2*(time()-t0)))
+            self.insert_text(u"\n<Δt>=%dms\n" % (1e2*(time()-t0)))
             self.new_prompt(self.interpreter.p1)
         else:
             self.execute_command(command)

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -26,7 +26,7 @@ from qtpy import QT_VERSION
 
 # Local imports
 from spyder.config.base import _
-from spyder.py3compat import is_text_string, to_text_string, u
+from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils import encoding, sourcecode, programs
 from spyder.utils.dochelpers import (getargspecfromtext, getobj,
                                      getsignaturefromtext)
@@ -298,7 +298,7 @@ class BaseEditMixin(object):
         if text and not all_text:
             while text.endswith("\n"):
                 text = text[:-1]
-            while text.endswith(u("\u2029")):
+            while text.endswith(u"\u2029"):
                 text = text[:-1]
         return text
     
@@ -381,7 +381,7 @@ class BaseEditMixin(object):
         """Return line at *coordinates* (QPoint)"""
         cursor = self.cursorForPosition(coordinates)
         cursor.select(QTextCursor.BlockUnderCursor)
-        return to_text_string(cursor.selectedText()).replace(u('\u2029'), '')
+        return to_text_string(cursor.selectedText()).replace(u'\u2029', '')
     
     def get_word_at(self, coordinates):
         """Return word at *coordinates* (QPoint)"""
@@ -416,7 +416,7 @@ class BaseEditMixin(object):
         Replace the unicode line separator character \u2029 by 
         the line separator characters returned by get_line_separator
         """
-        return to_text_string(self.textCursor().selectedText()).replace(u("\u2029"),
+        return to_text_string(self.textCursor().selectedText()).replace(u"\u2029",
                                                      self.get_line_separator())
     
     def remove_selected_text(self):


### PR DESCRIPTION
- That function was needed for Python 3.2 compatibility only.
- This PR also fixes a failing test.