### PR TITLE
PR: Add a new panel to show/explore class and methods/functions present in the current file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,3 @@ spyder_crash.log
 
 # git .orig files
 *.orig
-
-.venv*

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ spyder_crash.log
 
 # git .orig files
 *.orig
+
+.venv*

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -234,6 +234,7 @@ DEFAULTS = [
               'occurrence_highlighting/timeout': 1500,
               'always_remove_trailing_spaces': False,
               'show_tab_bar': True,
+              'show_class_func_dropdown': True,
               'max_recent_files': 20,
               'save_all_before_run': True,
               'focus_to_editor': True,

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -106,9 +106,13 @@ class EditorConfigPage(PluginConfigPage):
         interface_group = QGroupBox(_("Interface"))
         newcb = self.create_checkbox
         showtabbar_box = newcb(_("Show tab bar"), 'show_tab_bar')
+        showclassfuncdropdown_box = newcb(_("Show Class/Function Dropdown"),
+                                          'show_class_func_dropdown')
+        
 
         interface_layout = QVBoxLayout()
         interface_layout.addWidget(showtabbar_box)
+        interface_layout.addWidget(showclassfuncdropdown_box)
         interface_group.setLayout(interface_layout)
         
         display_group = QGroupBox(_("Source code"))
@@ -1262,6 +1266,7 @@ class Editor(SpyderPluginWidget):
             ('set_checkeolchars_enabled',           'check_eol_chars'),
             ('set_fullpath_sorting_enabled',        'fullpath_sorting'),
             ('set_tabbar_visible',                  'show_tab_bar'),
+            ('set_classfunc_dropdown_visible',      'show_class_func_dropdown'),
             ('set_always_remove_trailing_spaces',   'always_remove_trailing_spaces'),
                     )
         for method, setting in settings:
@@ -2507,6 +2512,8 @@ class Editor(SpyderPluginWidget):
             fpsorting_o = self.get_option(fpsorting_n)
             tabbar_n = 'show_tab_bar'
             tabbar_o = self.get_option(tabbar_n)
+            classfuncdropdown_n = 'show_class_func_dropdown'
+            classfuncdropdown_o = self.get_option(classfuncdropdown_n)
             linenb_n = 'line_numbers'
             linenb_o = self.get_option(linenb_n)
             blanks_n = 'blank_spaces'
@@ -2570,6 +2577,8 @@ class Editor(SpyderPluginWidget):
                     editorstack.set_fullpath_sorting_enabled(fpsorting_o)
                 if tabbar_n in options:
                     editorstack.set_tabbar_visible(tabbar_o)
+                if classfuncdropdown_n in options:
+                    editorstack.set_classfunc_dropdown_visible(classfuncdropdown_o)
                 if linenb_n in options:
                     editorstack.set_linenumbers_enabled(linenb_o,
                                                         current_finfo=finfo)

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -515,6 +515,7 @@ class EditorStack(QWidget):
         self.auto_unindent_enabled = True
         self.indent_chars = " "*4
         self.tab_stop_width_spaces = 4
+        self.show_class_func_dropdown = True
         self.help_enabled = False
         self.default_font = None
         self.wrap_enabled = False
@@ -841,6 +842,7 @@ class EditorStack(QWidget):
         self.title = text
 
     def set_classfunc_dropdown_visible(self, state):
+        self.show_class_func_dropdown = state
         if self.data:
             for finfo in self.data:
                 if finfo.editor.is_python_like():
@@ -1899,7 +1901,8 @@ class EditorStack(QWidget):
                 indent_chars=self.indent_chars,
                 tab_stop_width_spaces=self.tab_stop_width_spaces,
                 cloned_from=cloned_from,
-                filename=fname)
+                filename=fname,
+                show_class_func_dropdown=self.show_class_func_dropdown)
         if cloned_from is None:
             editor.set_text(txt)
             editor.document().setModified(False)

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -840,6 +840,12 @@ class EditorStack(QWidget):
     def set_title(self, text):
         self.title = text
 
+    def set_classfunc_dropdown_visible(self, state):
+        if self.data:
+            for finfo in self.data:
+                if finfo.editor.is_python_like():
+                    finfo.editor.classfuncdropdown.setVisible(state)
+
     def __update_editor_margins(self, editor):
         editor.linenumberarea.setup_margins(linenumbers=self.linenumbers_enabled,
                              markers=self.has_markers())

--- a/spyder/widgets/panels/classfunctiondropdown.py
+++ b/spyder/widgets/panels/classfunctiondropdown.py
@@ -236,11 +236,26 @@ def update_selected_cb(parents, combobox):
 
 class FoldScopeHelper(object):
     """
+    This is a helper class to make using FoldScope easier.
+
+    It is a wrapper around a FoldScope object and an OutlineExplorerData
+    object, raises certain attributes to this level, and gives them more
+    descriptive names.
+
+    It defines some nicely-formatted ``str`` and ``repr`` and allows
+    for easy tracking of the parents of a given FoldScope.
 
     Parameters
     ----------
     fold_scope : :class:`spyder.widgets.sourcecode.folding.FoldScope`
     oed : :class:`spyder.utils.syntaxhighlighters.OutlineExplorerData`
+
+    Properties
+    ----------
+    parents : list of :class:`FoldScopeHelper`
+        The parents of this ``FoldScopeHelper`` object. The 1st index will
+        be the top-level parent defined at the module level while the
+        last index will be the class or funtion that contains this object.
     """
 
     def __init__(self, fold_scope, oed):

--- a/spyder/widgets/panels/classfunctiondropdown.py
+++ b/spyder/widgets/panels/classfunctiondropdown.py
@@ -141,6 +141,33 @@ def _adjust_parent_stack(fsh, prev, parents):
         pass
 
 
+def _split_classes_and_methods(folds):
+    """
+    Split out classes and methods into two separate lists.
+
+    Parameters
+    ----------
+    folds : list of :class:`FoldScopeHelper`
+        The result of :func:`_get_fold_levels`.
+
+    Returns
+    -------
+    classes, functions: list of :class:`FoldScopeHelper`
+        Two separate lists of :class:`FoldScopeHelper` objects. The former
+        contains only class definitions while the latter contains only
+        function/method definitions.
+    """
+    classes = []
+    functions = []
+    for fold in folds:
+        if fold.def_type == OED.FUNCTION_TOKEN:
+            functions.append(fold)
+        elif fold.def_type == OED.CLASS_TOKEN:
+            classes.append(fold)
+
+    return classes, functions
+
+
 class FoldScopeHelper(object):
     """
 

--- a/spyder/widgets/panels/classfunctiondropdown.py
+++ b/spyder/widgets/panels/classfunctiondropdown.py
@@ -397,8 +397,8 @@ class ClassFunctionDropdown(Panel):
         sender = self.sender()
         data = sender.itemData(sender.currentIndex())
 
-        # TODO: don't trigger a _handle_cursor_position_change_event
-        self.editor.go_to_line(data.line + 1)
+        if isinstance(data, FoldScopeHelper):
+            self.editor.go_to_line(data.line + 1)
 
     def update_selected(self, linenum):
         """Updates the dropdowns to reflect the current class and function."""

--- a/spyder/widgets/panels/classfunctiondropdown.py
+++ b/spyder/widgets/panels/classfunctiondropdown.py
@@ -5,7 +5,9 @@
 # (see spyder/__init__.py for details)
 
 """
-Editor widget based on QtGui.QPlainTextEdit
+A Class and Function Dropdown Panel for Spyder.
+
+To demo this panel, run spyder/widgets/sourcecode/codeeditor.py
 """
 import operator
 import copy
@@ -412,10 +414,3 @@ class ClassFunctionDropdown(Panel):
     def _handle_cursor_position_change_event(self, linenum, column):
         self._update_data()
         self.update_selected(linenum)
-
-
-# ##########################################################################
-# Classes and Functions for Testing.
-# ##########################################################################
-if __name__ == "__main__":
-    print("To demo this panel, run spyder/widgets/sourcecode/codeeditor.py")

--- a/spyder/widgets/panels/classfunctiondropdown.py
+++ b/spyder/widgets/panels/classfunctiondropdown.py
@@ -168,6 +168,40 @@ def _split_classes_and_methods(folds):
     return classes, functions
 
 
+def _get_parents(folds, linenum):
+    """
+    Get the parents at a given linenum.
+
+    If parents is empty, then the linenum belongs to the module.
+
+    Parameters
+    ----------
+    folds : list of :class:`FoldScopeHelper`
+    linenum : int
+        The line number to get parents for. Typically this would be the
+        cursor position.
+
+    Returns
+    -------
+    parents : list of :class:`FoldScopeHelper`
+        A list of :class:`FoldScopeHelper` objects that describe the defintion
+        heirarcy for the given ``linenum``. The 1st index will be the
+        top-level parent defined at the module level while the last index
+        will be the class or funtion that contains ``linenum``.
+    """
+    # Note: this might be able to be sped up by finding some kind of
+    # abort-early condition.
+    parents = []
+    for fold in folds:
+        start, end = fold.range
+        if linenum >= start and linenum <= end:
+            parents.append(fold)
+        else:
+            continue
+
+    return parents
+
+
 class FoldScopeHelper(object):
     """
 

--- a/spyder/widgets/panels/classfunctiondropdown.py
+++ b/spyder/widgets/panels/classfunctiondropdown.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Editor widget based on QtGui.QPlainTextEdit
+"""

--- a/spyder/widgets/panels/classfunctiondropdown.py
+++ b/spyder/widgets/panels/classfunctiondropdown.py
@@ -7,3 +7,85 @@
 """
 Editor widget based on QtGui.QPlainTextEdit
 """
+from spyder.utils.syntaxhighlighters import OutlineExplorerData as OED
+
+
+DUMMY_OED = OED()
+DUMMY_OED.fold_level = 0
+DUMMY_OED.text = "<None>"
+
+
+class FoldScopeHelper(object):
+    """
+
+    Parameters
+    ----------
+    fold_scope : :class:`spyder.widgets.sourcecode.folding.FoldScope`
+    oed : :class:`spyder.utils.syntaxhighlighters.OutlineExplorerData`
+    """
+
+    def __init__(self, fold_scope, oed):
+        self._fold_scope = fold_scope
+        self._oed = oed
+        self.parents = []
+
+    def __str__(self):
+        fmt = "<{}: {} {} at line {}>"
+        if self.parents:        # is not None or is not empty list.
+            fmt = "<{}: {} {} at line {}, parents: {}>"
+            return fmt.format(self.__class__.__name__,
+                              self.def_type.upper(),
+                              self.name,
+                              self.line,
+                              self.parents,
+                              )
+        return fmt.format(self.__class__.__name__,
+                          self.def_type.upper(),
+                          self.name,
+                          self.line,
+                          )
+
+    def __repr__(self):
+        fmt = "<{} object {} '{}', line {} (at {:#x})>"
+        return fmt.format(self.__class__.__name__,
+                          self.def_type.upper(),
+                          self.name,
+                          self.line,
+                          id(self))
+
+    @property
+    def fold_scope(self):
+        return self._fold_scope
+
+    @property
+    def range(self):
+        return self.fold_scope.get_range()
+
+    @property
+    def start_line(self):
+        return self.range[0]
+
+    @property
+    def end_line(self):
+        return self.range[1]
+
+    @property
+    def oed(self):
+        return self._oed
+
+    @property
+    def name(self):
+        return self.oed.def_name
+
+    @property
+    def line(self):
+        return self.start_line
+
+    @property
+    def def_type(self):
+        if self.oed.def_type == OED.FUNCTION:
+            return OED.FUNCTION_TOKEN
+        elif self.oed.def_type == OED.CLASS:
+            return OED.CLASS_TOKEN
+        else:
+            return "Unknown"

--- a/spyder/widgets/panels/classfunctiondropdown.py
+++ b/spyder/widgets/panels/classfunctiondropdown.py
@@ -202,6 +202,30 @@ def _get_parents(folds, linenum):
     return parents
 
 
+def update_selected_cb(parents, combobox):
+    """
+    Update the combobox with the selected item based on the parents.
+
+    Parameters
+    ----------
+    parents : list of :class:`FoldScopeHelper`
+    combobox : :class:`qtpy.QtWidets.QComboBox`
+        The combobox to populate
+
+    Returns
+    -------
+    None
+    """
+    if parents is not None and len(parents) == 0:
+        combobox.setCurrentIndex(0)
+    else:
+        item = parents[-1]
+        for i in range(combobox.count()):
+            if combobox.itemData(i) == item:
+                combobox.setCurrentIndex(i)
+                break
+
+
 class FoldScopeHelper(object):
     """
 

--- a/spyder/widgets/panels/classfunctiondropdown.py
+++ b/spyder/widgets/panels/classfunctiondropdown.py
@@ -12,9 +12,7 @@ To demo this panel, run spyder/widgets/sourcecode/codeeditor.py
 import operator
 import copy
 
-from qtpy.QtWidgets import (QComboBox,
-                            QHBoxLayout,
-                            )
+from qtpy.QtWidgets import QComboBox, QHBoxLayout
 
 from qtpy.QtCore import Slot
 from qtpy.QtCore import QSize
@@ -85,7 +83,7 @@ def _get_fold_levels(editor):
 
     Parameters
     ----------
-    editor :
+    editor : :class:`spyder.widgets.sourcecode.codeeditor.CodeEditor`
 
     Returns
     -------
@@ -333,7 +331,7 @@ class ClassFunctionDropdown(Panel):
 
     Parameters
     ----------
-    editor :
+    editor : :class:`spyder.widgets.sourcecode.codeeditor.CodeEditor`
         The editor to act on.
     """
 

--- a/spyder/widgets/panels/classfunctiondropdown.py
+++ b/spyder/widgets/panels/classfunctiondropdown.py
@@ -397,3 +397,10 @@ class ClassFunctionDropdown(Panel):
     def _handle_cursor_position_change_event(self, linenum, column):
         self._update_data()
         self.update_selected(linenum)
+
+
+# ##########################################################################
+# Classes and Functions for Testing.
+# ##########################################################################
+if __name__ == "__main__":
+    print("To demo this panel, run spyder/widgets/sourcecode/codeeditor.py")

--- a/spyder/widgets/panels/classfunctiondropdown.py
+++ b/spyder/widgets/panels/classfunctiondropdown.py
@@ -66,6 +66,35 @@ def populate(combobox, data):
             combobox.addItem(fqn, item)
 
 
+def _adjust_parent_stack(fsh, prev, parents):
+    """
+    Adjust the parent stack in-place as the trigger level changes.
+
+    Parameters
+    ----------
+    fsh : :class:`FoldScopeHelper`
+        The :class:`FoldScopeHelper` object to act on.
+    prev : :class:`FoldScopeHelper`
+        The previous :class:`FoldScopeHelper` object.
+    parents : list of :class:`FoldScopeHelper`
+        The current list of parent objects.
+
+    Returns
+    -------
+    None
+    """
+    if prev is None:
+        return
+
+    if fsh.fold_scope.trigger_level < prev.fold_scope.trigger_level:
+        diff = prev.fold_scope.trigger_level - fsh.fold_scope.trigger_level
+        del parents[-diff:]
+    elif fsh.fold_scope.trigger_level > prev.fold_scope.trigger_level:
+        parents.append(prev)
+    elif fsh.fold_scope.trigger_level == prev.fold_scope.trigger_level:
+        pass
+
+
 class FoldScopeHelper(object):
     """
 

--- a/spyder/widgets/panels/tests/test_classfunctiondropdown.py
+++ b/spyder/widgets/panels/tests/test_classfunctiondropdown.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+
+
+# Standard library imports
+import io
+import tokenize
+
+# Third party imports
+from qtpy.QtGui import QTextDocument
+from qtpy.QtGui import QTextCursor
+from qtpy.QtWidgets import QComboBox
+
+import pytest
+from pytestqt import qtbot
+
+# Local imports
+from spyder.widgets.panels import classfunctiondropdown as cfd
+from spyder.utils.syntaxhighlighters import OutlineExplorerData as OED
+from spyder.utils.syntaxhighlighters import PythonSH
+from spyder.widgets.sourcecode.folding import FoldScope
+from spyder.utils.editor import TextBlockHelper
+from spyder.widgets.sourcecode.folding import IndentFoldDetector
+
+
+# ---------------------------------------------------------------------------
+# Helper Functions
+# ---------------------------------------------------------------------------
+def create_editor(editor_bot, text):
+    _, editor = editor_bot
+    editor.set_text(text)
+    return editor
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def qcombobox_bot(qtbot):
+    widget = QComboBox()
+    qtbot.addWidget(widget)
+    return qtbot, widget
+
+@pytest.fixture
+def editor_bot(qtbot):
+    from spyder.widgets.editor import codeeditor
+    widget = codeeditor.CodeEditor(None)
+    widget.setup_editor(linenumbers=True,
+                        markers=True,
+                        tab_mode=False,
+                        show_blanks=True,
+                        color_scheme='Zenburn')
+    widget.setup_editor(language='Python')
+    qtbot.addWidget(widget)
+    widget.show()
+    return qtbot, widget
+
+
+# ---------------------------------------------------------------------------
+# Examples to Test Against
+# ---------------------------------------------------------------------------
+complicated = """# -*- coding: utf-8 -*-            # Line 0
+def func1():                                        # Line 1
+    pass                                            # Line 2
+
+print("0")                                          # Line 4
+
+def func2():                                        # Line 6
+    print("a")                                      # Line 7
+
+    def func3():                                    # Line 9
+                    print("b")                      # Line 10
+                    print("c")                      # Line 11
+
+                    def func4():                    # Line 13
+                        print("d")                  # Line 14
+    print("aaa")                                    # Line 15
+print("e")                                          # Line 16
+
+print("d")                                          # Line 18
+
+def _goodbye():                                     # Line 20
+    print(a)                                        # Line 21
+    print(a)                                        # Line 22
+"""
+
+simple = """# -*- coding: utf-8 -*-
+def my_add():
+    a = 1
+    b = 2
+    return a + b
+
+print("b")
+
+class MyClass():
+    def __init__(self):
+        a = 1
+        b = 2
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+def test_get_fold_levels(editor_bot):
+
+    editor = create_editor(editor_bot, complicated)
+
+    folds = cfd._get_fold_levels(editor)
+
+    expected = [
+        (1, 2),
+        (6, 15),
+        (9, 14),
+        (13, 14),
+        (20, 22),
+    ]
+
+    for fold, expected_range in zip(folds, expected):
+        assert fold.range == expected_range
+
+
+def test_split_classes_and_methods(editor_bot):
+    editor = create_editor(editor_bot, simple)
+    folds = cfd._get_fold_levels(editor)
+    classes, functions = cfd._split_classes_and_methods(folds)
+    assert len(classes) == 1
+    assert len(functions) == 2
+
+
+def test_get_parents(editor_bot):
+    editor = create_editor(editor_bot, simple)
+    folds = cfd._get_fold_levels(editor)
+    assert len(cfd._get_parents(folds, 1)) == 1
+    assert len(cfd._get_parents(folds, 2)) == 1
+    assert len(cfd._get_parents(folds, 6)) == 0
+    assert len(cfd._get_parents(folds, 10)) == 2
+
+
+class TestFoldScopeHelper(object):
+
+    test_case = """# -*- coding: utf-8 -*-
+def my_add():
+    a = 1
+    b = 2
+    return a + b
+"""
+
+    doc = QTextDocument(test_case)
+    sh = PythonSH(doc, color_scheme='Spyder')
+    sh.fold_detector = IndentFoldDetector()
+    sh.rehighlightBlock(doc.firstBlock())
+    block = doc.firstBlock()
+    block = block.next()
+    TextBlockHelper.set_fold_trigger(block, True)
+    fold_scope = FoldScope(block)
+    oed = sh.get_outlineexplorer_data()[1]
+
+    def test_fold_scope_helper(self):
+        fsh = cfd.FoldScopeHelper(None, None)
+        assert isinstance(fsh, cfd.FoldScopeHelper)
+
+    def test_fold_scope_helper_str(self):
+        fsh = cfd.FoldScopeHelper(self.fold_scope, self.oed)
+        assert "my_add" in str(fsh)
+
+    def test_fold_scope_helper_str_with_parents(self):
+        fsh = cfd.FoldScopeHelper(self.fold_scope, self.oed)
+        fsh.parents = ["fake parent list!"]
+        assert "parents:" in str(fsh)
+
+    def test_fold_scope_helper_repr(self):
+        fsh = cfd.FoldScopeHelper(self.fold_scope, self.oed)
+        assert "(at 0x" in repr(fsh)
+
+    def test_fold_scope_helper_properties(self):
+        fsh = cfd.FoldScopeHelper(self.fold_scope, self.oed)
+        assert fsh.range == (1, 4)
+        assert fsh.start_line == 1
+        assert fsh.end_line == 4
+        assert fsh.name == "my_add"
+        assert fsh.line == 1
+        assert fsh.def_type == OED.FUNCTION_TOKEN

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -39,6 +39,7 @@ from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
                             QGridLayout, QHBoxLayout, QInputDialog, QLabel,
                             QLineEdit, QMenu, QMessageBox, QSplitter,
                             QTextEdit, QToolTip, QVBoxLayout)
+from spyder.widgets.panels.classfunctiondropdown import ClassFunctionDropdown
 
 # %% This line is for cell execution testing
 
@@ -286,7 +287,13 @@ class CodeEditor(TextEditBaseWidget):
         # Line number area management
         self.linenumberarea = self.panels.register(LineNumberArea(self))
         self.updateRequest.connect(self.linenumberarea.update_)
-
+        
+        # Class and Method/Function Dropdowns
+        self.classfuncdropdown = self.panels.register(
+            ClassFunctionDropdown(self),
+            Panel.Position.TOP,
+        )
+        
         # Colors to be defined in _apply_highlighter_color_scheme()
         # Currentcell color and current line color are defined in base.py
         self.occurrence_color = None
@@ -1352,6 +1359,7 @@ class CodeEditor(TextEditBaseWidget):
         self.update_extra_selections()
         self.setUpdatesEnabled(True)
         self.linenumberarea.update()
+        self.classfuncdropdown.update()
 
     def show_code_analysis_results(self, line_number, code_analysis):
         """Show warning/error messages"""

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -625,6 +625,10 @@ class CodeEditor(TextEditBaseWidget):
             self.set_color_scheme(color_scheme)
 
         self.toggle_wrap_mode(wrap)
+        
+        # Disable the Class/Function dropdown if we're not in a Python file.
+        if not self.is_python_like():
+            self.classfuncdropdown.setVisible(False)
 
     def set_tab_mode(self, enable):
         """

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -567,7 +567,7 @@ class CodeEditor(TextEditBaseWidget):
                      close_parentheses=True, close_quotes=False,
                      add_colons=True, auto_unindent=True, indent_chars=" "*4,
                      tab_stop_width_spaces=4, cloned_from=None, filename=None,
-                     occurrence_timeout=1500):
+                     occurrence_timeout=1500, show_class_func_dropdown=True):
         
         # Code completion and calltips
         self.set_codecompletion_auto(codecompletion_auto)
@@ -625,10 +625,10 @@ class CodeEditor(TextEditBaseWidget):
             self.set_color_scheme(color_scheme)
 
         self.toggle_wrap_mode(wrap)
-        
-        # Disable the Class/Function dropdown if we're not in a Python file.
-        if not self.is_python_like():
-            self.classfuncdropdown.setVisible(False)
+
+        # Class/Function dropdown will be disabled if we're not in a Python file.
+        self.classfuncdropdown.setVisible(show_class_func_dropdown
+                                          and self.is_python_like())
 
     def set_tab_mode(self, enable):
         """


### PR DESCRIPTION
### Summary
This PR adds a class and function dropdown to the top of the editor and below the tabs. This implements #2627.
![image](https://cloud.githubusercontent.com/assets/5386897/23570609/cdd216d8-0019-11e7-8a47-397cde0e72a3.png)


The idea is to mimic Visual Studio's feature:
![image](https://cloud.githubusercontent.com/assets/5386897/23568825/44d0800c-0011-11e7-9076-4b8bb3c48e6a.png)

**This PR is still a WIP**. I have the very basics of the widget done, but I'm having trouble with:
1. how to integrate it with the editor
2. how to connect the signal to the cursor_move event.

> Note: This PR is currently based against the `v3.1.3` tag. Let me know if this should be changed.

### (Planned) Features
+ Displayed class and method names update as the cursor moves. It will always display the current class and method that the cursor is in.
  + If not in a class or method, "\<None\>" will be displayed.
  + Optionally show line number and part of the call signature
+ Class dropdown is populated with all classes in the file
  + **To discuss:** sorted by line number or by class name?
+ Method dropdown is populated with all methods belonging to the class that the cursor resides in
  + **To discuss:** also show module-level functions?
  + **To discuss:** show all functions and methods, not just those belonging to the class? (I vote no on this)
+ User can click on a dropdown and select a class or method/function. Cursor jumps to definition

### Issues
#### 1: How to integrate it with the editor?
I'm having a hard time figuring out how to insert the dropdown widget between the Tabs and the Editor itself. I'm currently just putting it below the editor for testing purposes.

It looks like I should be adding it to the `spyder/widgets/sourcecode/CodeEditor` class, but that inherits from `TextEditBaseWidget` and in order to set a layout, it needs to be a `QWidget`.

I could potentially make a wrapper around CodeEditor... would that be the best way to go?

The discussion long ago on #2627 was to overlay the class/method display and a borderless Widget was discussed - should I look into that more?

#### 2: How to connect the signals?
I think this will depend pretty significantly on how it's integrated into the editor. Would the best thing to do be to piggyback on the `spyder/widgets/sourcecode/CodeEditor.sig_cursor_position_changed` signal?


### Other Comments
+ I'll be squashing things into a reasonable number of commits before removing WIP.
+ I'll revert the changes to `.gitignore` before removing WIP.