### PR TITLE
PR: Improvements to visual style of code-folding

### DIFF
--- a/spyder/api/panel.py
+++ b/spyder/api/panel.py
@@ -100,7 +100,7 @@ class Panel(QWidget, Mode):
         if self.isVisible():
             # fill background
             self._background_brush = QBrush(QColor(
-                self.palette().window().color()))
+                self.editor.sideareas_color))
             self._foreground_pen = QPen(QColor(
                 self.palette().windowText().color()))
             painter = QPainter(self)


### PR DESCRIPTION
Fixes: #4147

------

Now It looks like this:
![code_folding_style](https://cloud.githubusercontent.com/assets/2024217/24008796/bd457572-0a40-11e7-952b-99bd3a8bd14b.png)

And in darker themes:

![spectacle b10214](https://cloud.githubusercontent.com/assets/2024217/24008925/45230ca2-0a41-11e7-831c-00df6c26030e.png)
