### PR TITLE
PR: Avoid tab scrolling when changing current tab.

### DIFF
--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -457,6 +457,7 @@ class Editor(SpyderPluginWidget):
         self.splitter.setStretchFactor(1, 1)
         layout.addWidget(self.splitter)
         self.setLayout(layout)
+        self.setFocusPolicy(Qt.ClickFocus)
         
         # Editor's splitter state
         state = self.get_option('splitter_state', None)


### PR DESCRIPTION
The issue is described in #1170 and reappear after removing `StrongFocus` from the `MainWindow` (#4109)

I added `ClickFocus` to the `Editor` plugin.