### PR TITLE
PR: More robust username query

### DIFF
--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -30,7 +30,8 @@ class ProgramError(Exception):
 if os.name == 'nt':
     TEMPDIR = tempfile.gettempdir() + osp.sep + 'spyder'
 else:
-    username = encoding.to_unicode_from_fs(os.environ.get('USER'))
+    from getpass import getuser
+    username = encoding.to_unicode_from_fs(getuser())
     TEMPDIR = tempfile.gettempdir() + osp.sep + 'spyder-' + username
 
 

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -9,6 +9,7 @@
 from __future__ import print_function
 
 from distutils.version import LooseVersion
+from getpass import getuser
 import imp
 import inspect
 import os
@@ -30,7 +31,6 @@ class ProgramError(Exception):
 if os.name == 'nt':
     TEMPDIR = tempfile.gettempdir() + osp.sep + 'spyder'
 else:
-    from getpass import getuser
     username = encoding.to_unicode_from_fs(getuser())
     TEMPDIR = tempfile.gettempdir() + osp.sep + 'spyder-' + username
 


### PR DESCRIPTION
The current method for querying the username via the `USER` envvar is fragile and may yield to [problems](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=859080). This PR proposes to use the `getpass` module from the stdlib instead, which should be more robust according to the [docs](https://docs.python.org/3/library/getpass.html#getpass.getuser).