### PR TITLE
PR: Remove misplaced flags from re.sub() call

### DIFF
--- a/spyder/widgets/ipythonconsole/help.py
+++ b/spyder/widgets/ipythonconsole/help.py
@@ -35,10 +35,7 @@ class HelpWidget(RichJupyterWidget):
 
         Taken from http://stackoverflow.com/a/3305731/438386
         """
-        if PY3:
-            return re.sub('\W|^(?=\d)', '_', var, re.UNICODE)
-        else:
-            return re.sub('\W|^(?=\d)', '_', var)
+        return re.sub('\W|^(?=\d)', '_', var)
 
     def get_signature(self, content):
         """Get signature from inspect reply content"""


### PR DESCRIPTION
The 4th argument of `re.sub()` is maximum number of substitutions, not flags.
`re.UNICODE` is the default in Python 3, so it doesn't have to be passed explicitly to re.sub().

Found using [pydiatra](https://github.com/jwilk/pydiatra).