### PR TITLE
PR: Add icon earlier when running application

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -78,7 +78,7 @@ from qtpy import API, PYQT5
 from qtpy.compat import from_qvariant
 from qtpy.QtCore import (QByteArray, QCoreApplication, QPoint, QSize, Qt,
                          QThread, QTimer, QUrl, Signal, Slot)
-from qtpy.QtGui import QColor, QDesktopServices, QKeySequence, QPixmap
+from qtpy.QtGui import QColor, QDesktopServices, QIcon, QKeySequence, QPixmap
 from qtpy.QtWidgets import (QAction, QApplication, QDockWidget, QMainWindow,
                             QMenu, QMessageBox, QShortcut, QSplashScreen,
                             QStyleFactory)
@@ -113,13 +113,21 @@ if hasattr(Qt, 'AA_EnableHighDpiScaling'):
 # splash screen created below
 #==============================================================================
 from spyder.utils.qthelpers import qapplication, MENU_SEPARATOR
+from spyder.config.base import get_image_path
 MAIN_APP = qapplication()
 
+if PYQT5:
+    APP_ICON = QIcon(get_image_path("spyder.svg"))
+else:
+    APP_ICON = QIcon(get_image_path("spyder.png"))
+
+MAIN_APP.setWindowIcon(APP_ICON)
 
 #==============================================================================
 # Create splash screen out of MainWindow to reduce perceived startup time. 
 #==============================================================================
 from spyder.config.base import _, get_image_path, DEV, PYTEST
+
 if not PYTEST:
     SPLASH = QSplashScreen(QPixmap(get_image_path('splash.svg')))
     SPLASH_FONT = SPLASH.font()
@@ -131,7 +139,6 @@ if not PYTEST:
     QApplication.processEvents()
 else:
     SPLASH = None
-
 
 #==============================================================================
 # Local utility imports
@@ -434,10 +441,7 @@ class MainWindow(QMainWindow):
 
         self.base_title = title
         self.update_window_title()
-        resample = os.name != 'nt'
-        icon = ima.icon('spyder', resample=resample)
-        # Resampling SVG icon only on non-Windows platforms (see Issue 1314):
-        self.setWindowIcon(icon)
+
         if set_windows_appusermodelid != None:
             res = set_windows_appusermodelid()
             debug_print("appusermodelid: " + str(res))
@@ -2858,6 +2862,9 @@ def initialize():
     # MAIN_APP, created above to show our splash screen as early as
     # possible
     app = qapplication()
+
+    # --- Set application icon
+    app.setWindowIcon(APP_ICON)
 
     #----Monkey patching QApplication
     class FakeQApplication(QApplication):

--- a/spyder/app/restart.py
+++ b/spyder/app/restart.py
@@ -21,14 +21,14 @@ import sys
 import time
 
 # Third party imports
+from qtpy import PYQT5
 from qtpy.QtCore import Qt, QTimer
-from qtpy.QtGui import QColor, QPixmap
+from qtpy.QtGui import QColor, QPixmap, QIcon
 from qtpy.QtWidgets import QApplication, QMessageBox, QSplashScreen, QWidget
 
 # Local imports
 from spyder.config.base import _, get_image_path
 from spyder.py3compat import to_text_string
-from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import qapplication
 
 
@@ -158,10 +158,12 @@ def main():
     # Start Qt Splash to inform the user of the current status
     app = qapplication()
     restarter = Restarter()
-    resample = not IS_WINDOWS
-    # Resampling SVG icon only on non-Windows platforms (see Issue 1314):
-    icon = ima.icon('spyder', resample=resample)
-    app.setWindowIcon(icon)
+
+    if PYQT5:
+        APP_ICON = QIcon(get_image_path("spyder.svg"))
+    else:
+        APP_ICON = QIcon(get_image_path("spyder.png"))
+    app.setWindowIcon(APP_ICON)
     restarter.set_splash_message(_('Closing Spyder'))
 
     # Get variables


### PR DESCRIPTION
Fixes #4444

This adds the spyder icon to the mac dock when running from bootstrap.

<img width="1254" alt="screen shot 2017-05-08 at 1 53 35 pm" src="https://cloud.githubusercontent.com/assets/3627835/25820092/c65fc124-33f5-11e7-9f16-dbc1f3c6e832.png">
