### PR TITLE
PR: Add more regular code annotation types

### DIFF
--- a/spyder/utils/codeanalysis.py
+++ b/spyder/utils/codeanalysis.py
@@ -24,7 +24,8 @@ DEBUG_EDITOR = DEBUG >= 3
 #==============================================================================
 # Pyflakes/pep8 code analysis
 #==============================================================================
-TASKS_PATTERN = r"(^|#)[ ]*(TODO|FIXME|XXX|HINT|TIP|@todo)([^#]*)"
+TASKS_PATTERN = r"(^|#)[ ]*(TODO|FIXME|XXX|HINT|TIP|@todo|" \
+                r"HACK|BUG|OPTIMIZE|!!!|\?\?\?)([^#]*)"
 
 #TODO: this is a test for the following function
 def find_tasks(source_code):


### PR DESCRIPTION
Fixes #4452 

----

The PR corresponds to the #4452 issue. It adds code tags HACK, BUG, OPTIMIZE, !!!, ??? to the common TODO and FIXME.

To keep the most common ones, I did a compromise according to the pep8-350 and many forums/websites relating to this topic.

hopefully I PR-ed pushed pulled all correctly :)