### PR TITLE
Fixup rope dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,7 @@ if any(arg == 'bdist_wheel' for arg in sys.argv):
     import setuptools     # analysis:ignore
 
 install_requires = [
-    'rope_py3k' if PY3 else 'rope>=0.9.4',
+    'rope>=0.10.5' if PY3 else 'rope>=0.9.4',
     'jedi>=0.9.0',
     'pyflakes',
     'pygments>=2.0',


### PR DESCRIPTION
Starting from version 0.10.5, rope is compatible with Python 3.

It is still worth keeping the lower versioned dependency for Python 2 to ease potential backports.