### PR TITLE
PR: Disable tab with setting when indent chars are spaces.

### DIFF
--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -204,6 +204,16 @@ class EditorConfigPage(PluginConfigPage):
                                          (_("Tabulations"), '*\t*')), 'indent_chars')
         tabwidth_spin = self.create_spinbox(_("Tab stop width:"), _("spaces"),
                                             'tab_stop_width_spaces', 4, 1, 8, 1)
+        def enable_tabwidth_spin(index):
+            if index == 7:  # Tabulations
+                tabwidth_spin.plabel.setEnabled(True)
+                tabwidth_spin.spinbox.setEnabled(True)
+            else:
+                tabwidth_spin.plabel.setEnabled(False)
+                tabwidth_spin.spinbox.setEnabled(False)
+
+        indent_chars_box.combobox.currentIndexChanged.connect(enable_tabwidth_spin)
+
         tab_mode_box = newcb(_("Tab always indent"),
                       'tab_always_indent', default=False,
                       tip=_("If enabled, pressing Tab will always indent,\n"


### PR DESCRIPTION
A little usability change, tab stop width is only used when indenting with tabs, and the GUI should reflect that.

![spectacle n14293](https://cloud.githubusercontent.com/assets/2024217/26073194/b55bb1f2-3973-11e7-9339-8067a6bdeec4.png)
