### PR TITLE
PR: Fold improvements

### DIFF
--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -218,7 +218,7 @@ class BaseSH(QSyntaxHighlighter):
         """
         Highlights a block of text. Please do not override, this method.
         Instead you should implement
-        :func:`pyqode.core.api.SyntaxHighlighter.highlight_block`.
+        :func:`spyder.utils.syntaxhighplighters.SyntaxHighlighter.highlight_block`.
 
         :param text: text to highlight.
         """

--- a/spyder/widgets/sourcecode/api/folding.py
+++ b/spyder/widgets/sourcecode/api/folding.py
@@ -47,7 +47,8 @@ def print_tree(editor, file=sys.stdout, print_blocks=False, return_list=False):
                       (block.blockNumber() + 1, lvl, visible), file=file)
         block = block.next()
 
-    if return_list: return output_list
+    if return_list:
+        return output_list
 
 class FoldDetector(object):
     """

--- a/spyder/widgets/sourcecode/api/folding.py
+++ b/spyder/widgets/sourcecode/api/folding.py
@@ -14,7 +14,7 @@ import sys
 from spyder.utils.editor import TextBlockHelper
 
 
-def print_tree(editor, file=sys.stdout, print_blocks=False):
+def print_tree(editor, file=sys.stdout, print_blocks=False, return_list=False):
     """
     Prints the editor fold tree to stdout, for debugging purpose.
 
@@ -23,6 +23,8 @@ def print_tree(editor, file=sys.stdout, print_blocks=False):
     :param print_blocks: True to print all blocks, False to only print blocks
         that are fold triggers
     """
+    output_list = []
+
     block = editor.document().firstBlock()
     while block.isValid():
         trigger = TextBlockHelper().is_fold_trigger(block)
@@ -31,14 +33,21 @@ def print_tree(editor, file=sys.stdout, print_blocks=False):
         visible = 'V' if block.isVisible() else 'I'
         if trigger:
             trigger = '+' if trigger_state else '-'
-            print('l%d:%s%s%s' %
-                  (block.blockNumber() + 1, lvl, trigger, visible),
-                  file=file)
+            if return_list:
+                output_list.append([block.blockNumber() + 1, lvl, visible])
+            else:
+                print('l%d:%s%s%s' %
+                      (block.blockNumber() + 1, lvl, trigger, visible),
+                      file=file)
         elif print_blocks:
-            print('l%d:%s%s' %
-                  (block.blockNumber() + 1, lvl, visible), file=file)
+            if return_list:
+                output_list.append([block.blockNumber() + 1, lvl, visible])
+            else:
+                print('l%d:%s%s' %
+                      (block.blockNumber() + 1, lvl, visible), file=file)
         block = block.next()
 
+    if return_list: return output_list
 
 class FoldDetector(object):
     """

--- a/spyder/widgets/sourcecode/folding.py
+++ b/spyder/widgets/sourcecode/folding.py
@@ -212,9 +212,17 @@ class IndentFoldDetector(FoldDetector):
         :param block: current block to highlight
         """
         text = block.text()
+        prev_lvl = TextBlockHelper().get_fold_lvl(prev_block)
         # round down to previous indentation guide to ensure contiguous block
         # fold level evolution.
-        return (len(text) - len(text.lstrip())) // len(self.editor.indent_chars)
+
+        if prev_lvl and prev_block is not None:
+            prev_text = prev_block.text()
+            indent_len = (len(prev_text) - len(prev_text.lstrip())) // prev_lvl
+        else:
+            indent_len = len(self.editor.indent_chars)
+
+        return (len(text) - len(text.lstrip())) // indent_len
 
 
 class CharBasedFoldDetector(FoldDetector):

--- a/spyder/widgets/sourcecode/folding.py
+++ b/spyder/widgets/sourcecode/folding.py
@@ -241,3 +241,23 @@ class CharBasedFoldDetector(FoldDetector):
         if self.close_chars in prev_text:
             return TextBlockHelper.get_fold_lvl(prev_block) - 1
         return TextBlockHelper.get_fold_lvl(prev_block)
+
+
+if __name__ == '__main__':
+    """Print folding blocks of this file for debugging"""
+    from spyder.widgets.sourcecode.api.folding import print_tree
+    from spyder.utils.qthelpers import qapplication
+    from spyder.widgets.sourcecode.codeeditor import CodeEditor
+
+    if len(sys.argv) > 1:
+        fname = sys.argv[1]
+    else:
+        fname = __file__
+
+    app = qapplication()
+    editor = CodeEditor(parent=None)
+    editor.setup_editor(language='Python')
+
+    editor.set_text_from_file(fname)
+
+    print_tree(editor)

--- a/spyder/widgets/sourcecode/tests/test_folding.py
+++ b/spyder/widgets/sourcecode/tests/test_folding.py
@@ -23,36 +23,31 @@ from spyder.widgets.sourcecode.api.folding import print_tree
 @pytest.fixture()
 def get_fold_levels():
     """setup editor and return fold levels."""
+    app = qapplication()
+    editor = CodeEditor(parent=None)
+    editor.setup_editor(language='Python')
 
-    def get_fold_levels():
-        app = qapplication()
-        editor = CodeEditor(parent=None)
-        editor.setup_editor(language='Python')
-    
-        text = ('# dummy test file\n'
-                'class a():\n'  # fold-block level-0
-                '    self.b = 1\n'
-                '    print(self.b)\n'
-                '    \n'
-                '    def some_method(self):\n'  # fold-block level-1
-                '        self.b = 3\n'
-                '\n'
-                '    def other_method(self):\n'  # fold-block level-1
-                '         a = (1,\n'  # fold-block level-2
-                '              2,\n'
-                '              3)\n'
-                )
-    
-        editor.set_text(text)
-        return print_tree(editor, return_list=True)
-        
-    return get_fold_levels
+    text = ('# dummy test file\n'
+            'class a():\n'  # fold-block level-0
+            '    self.b = 1\n'
+            '    print(self.b)\n'
+            '    \n'
+            '    def some_method(self):\n'  # fold-block level-1
+            '        self.b = 3\n'
+            '\n'
+            '    def other_method(self):\n'  # fold-block level-1
+            '         a = (1,\n'  # fold-block level-2
+            '              2,\n'
+            '              3)\n'
+            )
 
+    editor.set_text(text)
+    return print_tree(editor, return_list=True)
 
 # --- Tests
 # -----------------------------------------------------------------------------
 def test_simple_folding(get_fold_levels):
-    assert get_fold_levels() == [[2, 0, 'V'], 
+    assert get_fold_levels == [[2, 0, 'V'], 
                                  [6, 1, 'V'],
                                  [9, 1, 'V'],
                                  [10, 2, 'V']]

--- a/spyder/widgets/sourcecode/tests/test_folding.py
+++ b/spyder/widgets/sourcecode/tests/test_folding.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+#
+
+"""
+Tests for the autoindent features
+"""
+
+# Third party imports
+from qtpy.QtGui import QTextCursor
+import pytest
+
+# Local imports
+from spyder.utils.qthelpers import qapplication
+from spyder.widgets.sourcecode.codeeditor import CodeEditor
+from spyder.widgets.sourcecode.api.folding import print_tree
+
+
+# --- Fixtures
+# -----------------------------------------------------------------------------
+@pytest.fixture()
+def get_fold_levels():
+    """setup editor and return fold levels."""
+
+    def get_fold_levels():
+        app = qapplication()
+        editor = CodeEditor(parent=None)
+        editor.setup_editor(language='Python')
+    
+        text = ('# dummy test file\n'
+                'class a():\n'  # fold-block level-0
+                '    self.b = 1\n'
+                '    print(self.b)\n'
+                '    \n'
+                '    def some_method(self):\n'  # fold-block level-1
+                '        self.b = 3\n'
+                '\n'
+                '    def other_method(self):\n'  # fold-block level-1
+                '         a = (1,\n'  # fold-block level-2
+                '              2,\n'
+                '              3)\n'
+                )
+    
+        editor.set_text(text)
+        return print_tree(editor, return_list=True)
+        
+    return get_fold_levels
+
+
+# --- Tests
+# -----------------------------------------------------------------------------
+def test_simple_folding(get_fold_levels):
+    assert get_fold_levels() == [[2, 0, 'V'], 
+                                 [6, 1, 'V'],
+                                 [9, 1, 'V'],
+                                 [10, 2, 'V']]
+
+


### PR DESCRIPTION
Fixes: #4463

Now `IndentFoldDetector` will take in account previous fold indentation before using `CodeEditor.indent_chars`

I tried the solution that I propose in https://github.com/spyder-ide/spyder/issues/4463#issuecomment-301543920 but didn't work very well, the solution that I implemented is partially based in https://github.com/spyder-ide/spyder/issues/4463#issuecomment-301705657

