### PR TITLE
PR: Add manpage for Spyder

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -192,3 +192,16 @@ latex_documents = [
 
 # If false, no module index is generated.
 #latex_use_modindex = True
+
+
+# -- Options for manual page output ---------------------------------------
+
+# One entry per manual page. List of tuples
+# (source start file, name, description, authors, manual section).
+man_pages = [
+        ('manpage', 'spyder', 'Scientific PYthon Development EnviRonment',
+            ['Ghislain Antony Vaillant <ghisvail@gmail.com>'], 1)
+        ]
+
+# If true, show URL addresses after external links.
+#man_show_urls = False

--- a/doc/manpage.rst
+++ b/doc/manpage.rst
@@ -53,6 +53,9 @@ Options
 --window-title=WINDOW_TITLE
                         show this string in the main window title
 
+-p OPEN_PROJECT, --project=OPEN_PROJECT
+                        open a Spyder project (directory with a .spyproject
+                        folder)
 
 Bugs
 ----

--- a/doc/manpage.rst
+++ b/doc/manpage.rst
@@ -1,0 +1,61 @@
+:orphan:
+
+spyder manual
+=============
+
+
+Synopsis
+--------
+
+**spyder** [*options*] [*filenames*]
+
+
+Description
+-----------
+
+Spyder provides:
+
+* a powerful interactive development environment for the Python language with
+  advanced editing, interactive testing, debugging and introspection features,
+
+* and a numerical computing environment thanks to the support of `IPython`
+  (enhanced interactive Python interpreter) and popular Python libraries such
+  as `NumPy` (linear algebra), `SciPy` (signal and image processing) or
+  `matplotlib` (interactive 2D/3D plotting).
+
+
+Options
+-------
+
+-h, --help              show this help message and exit
+
+--new-instance          run a new instance of Spyder, even if the single
+                        instance mode has been turned on (default)
+
+--defaults              reset configuration settings to defaults
+
+--reset                 remove all configuration files
+
+--optimize              optimize the Spyder bytecode (may require
+                        administrative privileges)
+
+-w WORKING_DIRECTORY, --workdir=WORKING_DIRECTORY
+                        set the default working directory
+
+--show-console          do not hide parent console window (Windows)
+
+--multithread           execute the internal console in a separate thread
+                        (from the main application thread)
+
+--profile               run spyder in profile mode (for internal testing, not
+                        related with Python profiling)
+
+--window-title=WINDOW_TITLE
+                        show this string in the main window title
+
+
+Bugs
+----
+
+If you find a bug, please consider reporting it to the Spyder issue tracker at
+<https://github.com/spyder-ide/spyder/issues>.


### PR DESCRIPTION
The first commit adds the manpage configuration for Sphinx. The second commit adds the source of the manpage. The manpage can be generated from the root of the source tree via `sphinx-build -b man doc/manpage.rst build/man`, which will output the manpage under `build/man/spyder.1`.

Closes #4423.