### PR TITLE
PR: Add Shift+Del shortcut to delete lines in the Editor 

### DIFF
--- a/spyder/plugins/shortcuts.py
+++ b/spyder/plugins/shortcuts.py
@@ -65,6 +65,13 @@ BLACKLIST = {
     'Shift+Del': _('Currently used to delete lines on editor')
 }
 
+if os.name == 'nt':
+    BLACKLIST['Alt+Backspace'] = _('We cannot support this '
+                                   'shortcut on Windows')
+
+BLACKLIST['Shift'] = _('Shortcuts that use Shift and another key'
+                       ' are unsupported')
+
 
 class CustomLineEdit(QLineEdit):
     """QLineEdit that filters its key press and release events."""
@@ -117,7 +124,7 @@ class ShortcutFinder(QLineEdit):
 
 # Error codes for the shortcut editor dialog
 (NO_WARNING, SEQUENCE_LENGTH, SEQUENCE_CONFLICT,
- INVALID_KEY, IN_BLACKLIST) = [0, 1, 2, 3, 4]
+ INVALID_KEY, IN_BLACKLIST, SHIFT_BLACKLIST) = [0, 1, 2, 3, 4, 5]
 
 
 class ShortcutEditor(QDialog):
@@ -331,6 +338,15 @@ class ShortcutEditor(QDialog):
                 tip_body = use
             tip = template.format(tip_title, tip_body)
             warn = True
+        elif warning_type == SHIFT_BLACKLIST:
+            template = '<i>{0}<b>{1}</b></i>'
+            tip_title = _('Forbidden key sequence!') + '<br>'
+            tip_body = ''
+            use = BLACKLIST['Shift']
+            if use is not None:
+                tip_body = use
+            tip = template.format(tip_title, tip_body)
+            warn = True
         elif warning_type == SEQUENCE_LENGTH:
             # Sequences with 5 keysequences (i.e. Ctrl+1, Ctrl+2, Ctrl+3,
             # Ctrl+4, Ctrl+5) are invalid
@@ -380,10 +396,13 @@ class ShortcutEditor(QDialog):
 
         conflicts = self.check_conflicts()
         blacklist = self.new_sequence in BLACKLIST
+        individual_keys = self.new_sequence.split('+')
         if conflicts and different_sequence:
             warning_type = SEQUENCE_CONFLICT
         elif blacklist:
             warning_type = IN_BLACKLIST
+        elif len(individual_keys) == 2 and individual_keys[0] == 'Shift':
+            warning_type = SHIFT_BLACKLIST
         else:
             warning_type = NO_WARNING
 

--- a/spyder/plugins/shortcuts.py
+++ b/spyder/plugins/shortcuts.py
@@ -61,6 +61,10 @@ VALID_KEYS = [getattr(Qt, 'Key_{0}'.format(k)) for k in KEYSTRINGS+SINGLE_KEYS]
 VALID_ACCENT_CHARS = "ÁÉÍOÚáéíúóàèìòùÀÈÌÒÙâêîôûÂÊÎÔÛäëïöüÄËÏÖÜñÑ"
 VALID_FINDER_CHARS = "[A-Za-z\s{0}]".format(VALID_ACCENT_CHARS)
 
+BLACKLIST = {
+    'Shift+Del': _('Currently used to delete lines on editor')
+}
+
 
 class CustomLineEdit(QLineEdit):
     """QLineEdit that filters its key press and release events."""
@@ -112,7 +116,8 @@ class ShortcutFinder(QLineEdit):
 
 
 # Error codes for the shortcut editor dialog
-NO_WARNING, SEQUENCE_LENGTH, SEQUENCE_CONFLICT, INVALID_KEY = [0, 1, 2, 3]
+(NO_WARNING, SEQUENCE_LENGTH, SEQUENCE_CONFLICT,
+ INVALID_KEY, IN_BLACKLIST) = [0, 1, 2, 3, 4]
 
 
 class ShortcutEditor(QDialog):
@@ -317,6 +322,15 @@ class ShortcutEditor(QDialog):
             tip_body = tip_body[:-4]  # Removing last <br>
             tip = template.format(tip_title, tip_body)
             warn = True
+        elif warning_type == IN_BLACKLIST:
+            template = '<i>{0}<b>{1}</b></i>'
+            tip_title = _('Forbidden key sequence!') + '<br>'
+            tip_body = ''
+            use = BLACKLIST[self.new_sequence]
+            if use is not None:
+                tip_body = use
+            tip = template.format(tip_title, tip_body)
+            warn = True
         elif warning_type == SEQUENCE_LENGTH:
             # Sequences with 5 keysequences (i.e. Ctrl+1, Ctrl+2, Ctrl+3,
             # Ctrl+4, Ctrl+5) are invalid
@@ -365,8 +379,11 @@ class ShortcutEditor(QDialog):
         self.new_sequence = sequence
 
         conflicts = self.check_conflicts()
+        blacklist = self.new_sequence in BLACKLIST
         if conflicts and different_sequence:
             warning_type = SEQUENCE_CONFLICT
+        elif blacklist:
+            warning_type = IN_BLACKLIST
         else:
             warning_type = NO_WARNING
 

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2764,6 +2764,10 @@ class CodeEditor(TextEditBaseWidget):
                 self.run_cell_and_advance.emit()
             elif ctrl:
                 self.run_cell.emit()
+        elif shift and key == Qt.Key_Delete:
+            # Shift + Del is a Key sequence reserved by most OSes
+            # https://github.com/spyder-ide/spyder/issues/3405
+            self.delete_line()
         elif key == Qt.Key_Insert and not shift and not ctrl:
             self.setOverwriteMode(not self.overwriteMode())
         elif key == Qt.Key_Backspace and not shift and not ctrl:


### PR DESCRIPTION
Fixes #4496 
Fixes #3405 

----

This also prevents using shortcuts of the form `Shift+<key>`, where `<key>` is a single key (e.g. `Shift+Space`).