### PR TITLE
PR: Fix font size for the Help plugin

### DIFF
--- a/spyder/config/fonts.py
+++ b/spyder/config/fonts.py
@@ -36,16 +36,14 @@ if sys.platform == 'darwin':
     MONOSPACE = ['Menlo'] + MONOSPACE
     BIG = MEDIUM = SMALL = 12
 elif os.name == 'nt':
-    BIG = 12
-    MEDIUM = 10
+    BIG = MEDIUM = 10
     SMALL = 9
 elif is_ubuntu():
     SANS_SERIF = ['Ubuntu'] + SANS_SERIF
     MONOSPACE = ['Ubuntu Mono'] + MONOSPACE
-    BIG = 13
-    MEDIUM = SMALL = 11
+    BIG = MEDIUM = SMALL = 11
 else:
-    BIG = 12
+    BIG = 10
     MEDIUM = SMALL = 9
 
 DEFAULT_SMALL_DELTA = SMALL - MEDIUM

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -655,7 +655,7 @@ DEFAULTS = [
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '37.0.0'
+CONF_VERSION = '37.1.0'
 
 # Main configuration instance
 try:


### PR DESCRIPTION
After PR #4454 there's no need to have a bigger font size for the Help plugin. This PR addresses that.