### PR TITLE
PR: Use Python module to launch pylint

### DIFF
--- a/spyder_pylint/pylint.py
+++ b/spyder_pylint/pylint.py
@@ -23,8 +23,9 @@ from spyder.config.base import get_translation
 from spyder.plugins import SpyderPluginMixin
 from spyder.plugins.configdialog import PluginConfigPage
 from spyder.utils import icon_manager as ima
+from spyder.utils.programs import is_module_installed
 from spyder.utils.qthelpers import create_action, MENU_SEPARATOR
-from .widgets.pylintgui import (PYLINT_PATH, PylintWidget)
+from .widgets.pylintgui import PylintWidget
 
 
 _ = get_translation("pylint", "spyder_pylint")
@@ -132,7 +133,7 @@ class Pylint(PylintWidget, SpyderPluginMixin):
         
         pylint_act = create_action(self, _("Run static code analysis"),
                                    triggered=self.run_pylint)
-        pylint_act.setEnabled(PYLINT_PATH is not None)
+        pylint_act.setEnabled(is_module_installed('pylint'))
         self.register_shortcut(pylint_act, context="Pylint",
                                name="Run analysis")
         

--- a/spyder_pylint/widgets/pylintgui.py
+++ b/spyder_pylint/widgets/pylintgui.py
@@ -294,7 +294,7 @@ class PylintWidget(QWidget):
         
         plver = PYLINT_VER
         if plver is not None:
-            p_args = ['-m', 'pylint']
+            p_args = ['-m', 'pylint', '--output-format=text']
             if plver.split('.')[0] == '0':
                 p_args += ['-i', 'yes']
             else:

--- a/spyder_pylint/widgets/pylintgui.py
+++ b/spyder_pylint/widgets/pylintgui.py
@@ -13,13 +13,13 @@
 
 # Standard library imports
 from __future__ import print_function, with_statement
-import os
 import os.path as osp
 import re
 import sys
 import time
 
 # Third party imports
+import pylint
 from qtpy.compat import getopenfilename
 from qtpy.QtCore import QByteArray, QProcess, QTextCodec, Signal, Slot
 from qtpy.QtWidgets import (QHBoxLayout, QLabel, QMessageBox, QTreeWidgetItem,
@@ -28,9 +28,8 @@ from qtpy.QtWidgets import (QHBoxLayout, QLabel, QMessageBox, QTreeWidgetItem,
 # Local imports
 from spyder import dependencies
 from spyder.config.base import get_conf_path, get_translation
-from spyder.py3compat import getcwd, pickle, PY3, to_text_string
+from spyder.py3compat import getcwd, pickle, to_text_string
 from spyder.utils import icon_manager as ima
-from spyder.utils import programs
 from spyder.utils.encoding import to_unicode_from_fs
 from spyder.utils.qthelpers import create_toolbutton
 from spyder.widgets.comboboxes import (is_module_or_package,
@@ -46,40 +45,9 @@ except KeyError as error:
     import gettext
     _ = gettext.gettext
 
-
-PYLINT = 'pylint'
-if PY3:
-    if programs.find_program('pylint3'):
-        PYLINT = 'pylint3'
-    elif programs.find_program('python3-pylint'):
-        PYLINT = 'python3-pylint'
-
-
 locale_codec = QTextCodec.codecForLocale()
-PYLINT_PATH = programs.find_program(PYLINT)
-
-
-def get_pylint_version():
-    """Return pylint version"""
-    if PYLINT_PATH is None:
-        return
-    cwd = osp.dirname(PYLINT_PATH)
-    args = ['--version']
-    if os.name == 'nt':
-        cmd = ' '.join([PYLINT] + args)
-        process = programs.run_shell_command(cmd, cwd=cwd)
-    else:
-        process = programs.run_program(PYLINT, args, cwd=cwd)
-    lines = to_unicode_from_fs(process.stdout.read()).splitlines()
-    if lines:
-        regex = '({0}*|pylint-script.py) ([0-9\.]*)'.format(PYLINT)
-        match = re.match(regex, lines[0])
-        if match is not None:
-            return match.groups()[1]
-
-
 PYLINT_REQVER = '>=0.25'
-PYLINT_VER = get_pylint_version()
+PYLINT_VER = pylint.__version__
 dependencies.add("pylint", _("Static code analysis"),
                  required_version=PYLINT_REQVER, installed_version=PYLINT_VER)
 
@@ -248,28 +216,9 @@ class PylintWidget(QWidget):
         
         self.process = None
         self.set_running_state(False)
-        
-        if PYLINT_PATH is None:
-            for widget in (self.treewidget, self.filecombo,
-                           self.start_button, self.stop_button):
-                widget.setDisabled(True)
-            if os.name == 'nt' \
-               and programs.is_module_installed("pylint"):
-                # Pylint is installed but pylint script is not in PATH
-                # (AFAIK, could happen only on Windows)
-                text = _('Pylint script was not found. Please add "%s" to PATH.')
-                text = to_text_string(text) % osp.join(sys.prefix, "Scripts")
-            else:
-                text = _('Please install <b>pylint</b>:')
-                url = 'http://www.logilab.fr'
-                text += ' <a href=%s>%s</a>' % (url, url)
-            self.ratelabel.setText(text)
-        else:
-            self.show_data()
+        self.show_data()
         
     def analyze(self, filename):
-        if PYLINT_PATH is None:
-            return
         filename = to_text_string(filename) # filename is a QString instance
         self.kill_if_running()
         index, _data = self.get_data(filename)
@@ -345,17 +294,18 @@ class PylintWidget(QWidget):
         
         plver = PYLINT_VER
         if plver is not None:
+            p_args = ['-m', 'pylint']
             if plver.split('.')[0] == '0':
-                p_args = ['-i', 'yes']
+                p_args += ['-i', 'yes']
             else:
                 # Option '-i' (alias for '--include-ids') was removed in pylint
                 # 1.0
-                p_args = ["--msg-template='{msg_id}:{line:3d},"\
-                          "{column}: {obj}: {msg}"]
+                p_args += ["--msg-template='{msg_id}:{line:3d},"\
+                           "{column}: {obj}: {msg}"]
             p_args += [osp.basename(filename)]
         else:
             p_args = [osp.basename(filename)]
-        self.process.start(PYLINT_PATH, p_args)
+        self.process.start(sys.executable, p_args)
         
         running = self.process.waitForStarted()
         self.set_running_state(running)


### PR DESCRIPTION
I ran into a problem getting the right version of pylint to launch within the plugin since it's not configurable and expects 'pylint' to used for Python 2 and 'pylint3' or 'python3-pylint' to be used for Python 3.

In my configuration (Fedora 25) the system-installed pylint is 'pylint' and 'python3-pylint', however in order to use a newer version, I've installed pylint using pip3 and the --user option to install it under ~/.local. This creates a 'pylint' executable for Python3 in ~/.local/bin.

In order to use the newer version within Spyder, I have to modify my system PATH as well as rename or symlink ~/.local/bin/pylint to 'pylint3' or 'python3-pylint'.

My proposal is to avoid all this by using the pylint module which is already a requirement for Spyder. The module can be imported to determine the version and can be executed using '-m' for both cpython and pypy.

Here's my attempt to do this. It works well, but I'm not sure of there is a better way to do parts of it.