### PR TITLE
PR: Add indentation shortcuts and simple indentation for non-Python files

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -367,6 +367,8 @@ DEFAULTS = [
               'editor/delete line': 'Ctrl+D',
               'editor/transform to uppercase': 'Ctrl+Shift+U',
               'editor/transform to lowercase': 'Ctrl+U',
+              'editor/indent': 'Ctrl+[',
+              'editor/unindent': 'Ctrl+]',
               'editor/move line up': "Alt+Up",
               'editor/move line down': "Alt+Down",
               'editor/go to definition': "Ctrl+G",

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -1909,7 +1909,33 @@ class CodeEditor(TextEditBaseWidget):
                                     QTextCursor.KeepAnchor, len(prefix))
                 cursor.removeSelectedText()
 
-    def fix_indent(self, forward=True, comment_or_string=False):
+
+    def fix_indent(self, *args, **kwargs):
+        """Indent line according to the preferences"""
+        if self.is_python_like():
+            self.fix_indent_smart(*args, **kwargs)
+        else:
+            self.simple_indentation(*args, **kwargs)
+
+
+    def simple_indentation(self, forward=True, **kwargs):
+        """
+        Simply preserve the indentation-level of the previous line.
+        """
+        cursor = self.textCursor()
+        block_nb = cursor.blockNumber()
+        prev_block = self.document().findBlockByLineNumber(block_nb-1)
+        prevline = to_text_string(prev_block.text())
+
+        indentation = re.match(r"\s*", prevline).group()
+        # Unident
+        if not forward:
+            indentation = indentation[len(self.indent_chars):]
+
+        cursor.insertText(indentation)
+
+
+    def fix_indent_smart(self, forward=True, comment_or_string=False):
         """
         Fix indentation (Python only, no text selection)
         forward=True: fix indent only if text is not enough indented

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -549,6 +549,12 @@ class CodeEditor(TextEditBaseWidget):
                                               name='Transform to lowercase',
                                               parent=self)
 
+        indent = config_shortcut(lambda: self.indent(force=True),
+                                 context='Editor', name='Indent', parent=self)
+        unindent = config_shortcut(lambda: self.unindent(force=True),
+                                   context='Editor', name='Unindent',
+                                   parent=self)
+
         def cb_maker(attr):
             """Make a callback for cursor move event type, (e.g. "Start")
             """
@@ -632,7 +638,8 @@ class CodeEditor(TextEditBaseWidget):
                 prev_char, next_char, prev_word, next_word, kill_line_end,
                 kill_line_start, yank, kill_ring_rotate, kill_prev_word,
                 kill_next_word, start_doc, end_doc, undo, redo, cut, copy,
-                paste, delete, select_all, array_inline, array_table]
+                paste, delete, select_all, array_inline, array_table, indent,
+                unindent]
 
     def get_shortcut_data(self):
         """

--- a/spyder/widgets/sourcecode/tests/test_autoindent.py
+++ b/spyder/widgets/sourcecode/tests/test_autoindent.py
@@ -21,11 +21,11 @@ from spyder.widgets.sourcecode.codeeditor import CodeEditor
 # --- Fixtures
 # -----------------------------------------------------------------------------
 def get_indent_fix(text, indent_chars=" " * 4, tab_stop_width_spaces=4,
-                   sol=False, forward=True):
+                   sol=False, forward=True, language='Python'):
     """Return text with last line's indentation fixed."""
     app = qapplication()
     editor = CodeEditor(parent=None)
-    editor.setup_editor(language='Python', indent_chars=indent_chars,
+    editor.setup_editor(language=language, indent_chars=indent_chars,
                         tab_stop_width_spaces=tab_stop_width_spaces)
 
     editor.set_text(text)
@@ -240,6 +240,24 @@ def test_unindentation_with_tabs(text_input, expected, test_text,
                           tab_stop_width_spaces=tab_stop_width_spaces, 
                           forward=False)
     assert text == expected, test_text
+
+
+# --- Simple indentation tests
+# -----------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "text_input, expected, test_text",
+    [
+        ("hola\n", "hola\n", "witout indentation"),
+        ("  hola\n", "  hola\n  ", "some indentation"),
+        ("\thola\n", "\thola\n\t", "tab indentation"),
+        ("  hola(\n", "  hola(\n  ", "line with parenthesis"),
+    ])
+def test_simple_indentation(text_input, expected, test_text,):
+    # language None deactivate smart indentation
+    text = get_indent_fix(text_input, language=None)
+    assert text == expected, test_text
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes: #3406
Fixes: #4157

I added configurable shortcuts for indent/unindent, with `Ctrl+[`/`Ctrl+]` as defaults, I didn't change `Tab`/`Shift+Tab` logic because Tab can't be a shortcut (so I leave it hardcoded), also it could interfere with autocompletion 

I didn't add new preferences for simple indentation, It's activated in non-Python files. as discussed in #4157