### PR TITLE
PR: Add indentation guidelines

### DIFF
--- a/spyder/api/panel.py
+++ b/spyder/api/panel.py
@@ -11,6 +11,7 @@ Adapted from https://github.com/pyQode/pyqode.core/blob/master/pyqode/core/api/p
 """
 from qtpy.QtWidgets import QWidget, QApplication
 from qtpy.QtGui import QBrush, QColor, QPen, QPainter
+from qtpy.QtCore import Qt
 
 from spyder.api.mode import Mode
 from spyder.config.base import debug_print
@@ -35,6 +36,8 @@ class Panel(QWidget, Mode):
         RIGHT = 2
         # Bottom margin
         BOTTOM = 3
+        # Floating panel
+        FLOATING = 4
 
         @classmethod
         def iterable(cls):
@@ -95,9 +98,12 @@ class Panel(QWidget, Mode):
         self._foreground_pen = QPen(QColor(
             self.palette().windowText().color()))
 
+        if self.position == self.Position.FLOATING:
+            self.setAttribute(Qt.WA_TransparentForMouseEvents)
+
     def paintEvent(self, event):
         """Fills the panel background using QPalette."""
-        if self.isVisible():
+        if self.isVisible() and self.position != self.Position.FLOATING:
             # fill background
             self._background_brush = QBrush(QColor(
                 self.editor.sideareas_color))

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -215,6 +215,7 @@ DEFAULTS = [
               'blank_spaces': False,
               'edge_line': True,
               'edge_line_columns': '79',
+              'indent_guides': False,
               'toolbox_panel': True,
               'calltips': True,
               'go_to_definition': True,

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -1000,6 +1000,8 @@ class Editor(SpyderPluginWidget):
                                       triggered=self.remove_trailing_spaces)
         self.showblanks_action = create_action(self, _("Show blank spaces"),
                                                toggled=self.toggle_show_blanks)
+        showindentguides_action = create_action(self, _("Show indent guides."),
+                                               toggled=self.toggle_show_indent_guides)
         fixindentation_action = create_action(self, _("Fix indentation"),
                       tip=_("Replace tab characters by space characters"),
                       triggered=self.fix_indentation)
@@ -1121,6 +1123,7 @@ class Editor(SpyderPluginWidget):
         # ---- Source menu/toolbar construction ----
         source_menu_actions = [eol_menu,
                                self.showblanks_action,
+                               showindentguides_action,
                                trailingspaces_action,
                                fixindentation_action,
                                MENU_SEPARATOR,
@@ -2201,6 +2204,11 @@ class Editor(SpyderPluginWidget):
     def toggle_show_blanks(self, checked):
         editor = self.get_current_editor()
         editor.set_blanks_enabled(checked)
+
+    @Slot(bool)
+    def toggle_show_indent_guides(self, checked):
+        for editorstack in self.editorstacks:
+            editorstack.set_indent_guides(checked)
 
     @Slot()
     def remove_trailing_spaces(self):

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -1000,8 +1000,11 @@ class Editor(SpyderPluginWidget):
                                       triggered=self.remove_trailing_spaces)
         self.showblanks_action = create_action(self, _("Show blank spaces"),
                                                toggled=self.toggle_show_blanks)
+        self.showblanks_action.setChecked(CONF.get('editor', 'blank_spaces'))
+
         showindentguides_action = create_action(self, _("Show indent guides."),
                                                toggled=self.toggle_show_indent_guides)
+        showindentguides_action.setChecked(CONF.get('editor', 'indent_guides'))
         fixindentation_action = create_action(self, _("Fix indentation"),
                       tip=_("Replace tab characters by space characters"),
                       triggered=self.fix_indentation)

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -115,11 +115,13 @@ class EditorConfigPage(PluginConfigPage):
         showtabbar_box = newcb(_("Show tab bar"), 'show_tab_bar')
         showclassfuncdropdown_box = newcb(_("Show Class/Function Dropdown"),
                                           'show_class_func_dropdown')
-        
+        showindentguides_box = newcb(_("Show Indent Guides"),
+                                      'indent_guides')
 
         interface_layout = QVBoxLayout()
         interface_layout.addWidget(showtabbar_box)
         interface_layout.addWidget(showclassfuncdropdown_box)
+        interface_layout.addWidget(showindentguides_box)
         interface_group.setLayout(interface_layout)
         
         display_group = QGroupBox(_("Source code"))
@@ -1269,6 +1271,7 @@ class Editor(SpyderPluginWidget):
             ('set_linenumbers_enabled',             'line_numbers'),
             ('set_edgeline_enabled',                'edge_line'),
             ('set_edgeline_columns',                'edge_line_columns'),
+            ('set_indent_guides',                   'indent_guides'),
             ('set_codecompletion_auto_enabled',     'codecompletion/auto'),
             ('set_codecompletion_case_enabled',     'codecompletion/case_sensitive'),
             ('set_codecompletion_enter_enabled',    'codecompletion/enter_key'),
@@ -2543,6 +2546,8 @@ class Editor(SpyderPluginWidget):
             edgelinecols_o = self.get_option(edgelinecols_n)
             wrap_n = 'wrap'
             wrap_o = self.get_option(wrap_n)
+            indentguides_n = 'indent_guides'
+            indentguides_o = self.get_option(indentguides_n)
             tabindent_n = 'tab_always_indent'
             tabindent_o = self.get_option(tabindent_n)
             ibackspace_n = 'intelligent_backspace'
@@ -2608,6 +2613,8 @@ class Editor(SpyderPluginWidget):
                     editorstack.set_edgeline_enabled(edgeline_o)
                 if edgelinecols_n in options:
                     editorstack.set_edgeline_columns(edgelinecols_o)
+                if indentguides_n in options:
+                    editorstack.set_indent_guides(indentguides_o)
                 if wrap_n in options:
                     editorstack.set_wrap_enabled(wrap_o)
                 if tabindent_n in options:

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -2202,8 +2202,8 @@ class Editor(SpyderPluginWidget):
 
     @Slot(bool)
     def toggle_show_blanks(self, checked):
-        editor = self.get_current_editor()
-        editor.set_blanks_enabled(checked)
+        for editorstack in self.editorstacks:
+            editorstack.set_blanks_enabled(checked)
 
     @Slot(bool)
     def toggle_show_indent_guides(self, checked):

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -541,6 +541,7 @@ class EditorStack(QWidget):
         self.focus_to_editor = True
         self.set_fullpath_sorting_enabled(False)
         self.create_new_file_if_empty = True
+        self.indent_guides = False
         ccs = 'Spyder'
         if ccs not in syntaxhighlighters.COLOR_SCHEME_NAMES:
             ccs = syntaxhighlighters.COLOR_SCHEME_NAMES[0]
@@ -938,6 +939,12 @@ class EditorStack(QWidget):
         if self.data:
             for finfo in self.data:
                 finfo.editor.edge_line.set_columns(columns)
+
+    def set_indent_guides(self, state):
+        self.indent_guides = state
+        if self.data:
+            for finfo in self.data:
+                finfo.editor.indent_guides.set_enabled(state)
 
     def set_codecompletion_auto_enabled(self, state):
         # CONF.get(self.CONF_SECTION, 'codecompletion_auto')
@@ -1951,7 +1958,8 @@ class EditorStack(QWidget):
                 tab_stop_width_spaces=self.tab_stop_width_spaces,
                 cloned_from=cloned_from,
                 filename=fname,
-                show_class_func_dropdown=self.show_class_func_dropdown)
+                show_class_func_dropdown=self.show_class_func_dropdown,
+                indent_guides=self.indent_guides)
         if cloned_from is None:
             editor.set_text(txt)
             editor.document().setModified(False)

--- a/spyder/widgets/panels/edgeline.py
+++ b/spyder/widgets/panels/edgeline.py
@@ -24,8 +24,6 @@ class EdgeLine(Panel):
         self.columns = (79,)
         self.color = Qt.darkGray
 
-        self._enabled = True
-
     def paintEvent(self, event):
         """Override Qt method"""
         painter = QPainter(self)

--- a/spyder/widgets/panels/edgeline.py
+++ b/spyder/widgets/panels/edgeline.py
@@ -23,7 +23,7 @@ class EdgeLine(Panel):
         Panel.__init__(self, editor)
         self.columns = (79,)
         self.color = Qt.darkGray
-        self.setAttribute(Qt.WA_TransparentForMouseEvents)
+
         self._enabled = True
 
     def paintEvent(self, event):

--- a/spyder/widgets/panels/edgeline.py
+++ b/spyder/widgets/panels/edgeline.py
@@ -8,24 +8,22 @@
 This module contains the edge line panel
 """
 
-from qtpy.QtWidgets import QWidget
 from qtpy.QtCore import Qt, QRect, QPoint
 from qtpy.QtGui import QPainter, QColor
 
 from spyder.py3compat import is_text_string
+from spyder.api.panel import Panel
 
-class EdgeLine(QWidget):
+class EdgeLine(Panel):
     """Source code editor's edge line (default: 79 columns, PEP8)"""
 
     # --- Qt Overrides
     # -----------------------------------------------------------------
-    def __init__(self, editor, color=Qt.darkGray, columns=(79,)):
-        QWidget.__init__(self, editor)
-        self.editor = editor
-        self.columns = columns
-        self.color = color
+    def __init__(self, editor):
+        Panel.__init__(self, editor)
+        self.columns = (79,)
+        self.color = Qt.darkGray
         self.setAttribute(Qt.WA_TransparentForMouseEvents)
-
         self._enabled = True
 
     def paintEvent(self, event):

--- a/spyder/widgets/panels/indentationguides.py
+++ b/spyder/widgets/panels/indentationguides.py
@@ -27,7 +27,6 @@ class IndentationGuide(Panel):
         self.color = Qt.darkGray
         self.i_width = 4
 
-        self.setAttribute(Qt.WA_TransparentForMouseEvents)
         self._enabled = True
 
     def paintEvent(self, event):

--- a/spyder/widgets/panels/indentationguides.py
+++ b/spyder/widgets/panels/indentationguides.py
@@ -28,8 +28,6 @@ class IndentationGuide(Panel):
         self.color = Qt.darkGray
         self.i_width = 4
 
-        self._enabled = True
-
     def paintEvent(self, event):
         """Override Qt method."""
         painter = QPainter(self)

--- a/spyder/widgets/panels/indentationguides.py
+++ b/spyder/widgets/panels/indentationguides.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+This module contains the indentation guide panel
+"""
+
+from qtpy.QtWidgets import QWidget
+from qtpy.QtCore import Qt, QRect, QPoint
+from qtpy.QtGui import QPainter, QColor
+
+
+class IndentationGuide(QWidget):
+    """Source code editor's edge line (default: 79 columns, PEP8)"""
+
+    # --- Qt Overrides
+    # -----------------------------------------------------------------
+    def __init__(self, editor, color=Qt.darkGray, indentation_width=4):
+        QWidget.__init__(self, editor)
+        self.editor = editor
+        self.color = color
+        self.i_width = indentation_width
+
+        self.setAttribute(Qt.WA_TransparentForMouseEvents)
+        self._enabled = True
+
+    def paintEvent(self, event):
+        """Override Qt method"""
+        painter = QPainter(self)
+
+        color = QColor(self.color)
+        color.setAlphaF(.5)
+        painter.setPen(color)
+
+        for top, line_number, block in self.editor.visible_blocks:
+            bottom = top + int(self.editor.blockBoundingRect(block).height())
+
+            # replace tabs for spaces
+            text = block.text().replace('\t', ' ' * self.i_width)
+
+            indentation = len(text) -len(text.lstrip())
+            for i in range(self.i_width, indentation, self.i_width):
+                x = self.editor.fontMetrics().width(i * '9')
+                painter.drawLine(x, top, x, bottom)
+
+    # --- Other methods
+    # -----------------------------------------------------------------
+
+    def set_enabled(self, state):
+        """Toggle edge line visibility"""
+        self._enabled = state
+        self.setVisible(state)
+
+    def update_color(self):
+        """
+        Set edgeline color using syntax highlighter color for comments
+        """
+        self.color = self.editor.highlighter.get_color_name('comment')
+
+    def set_indentation_width(self, indentation_width):
+        """Set indentation width to be used to draw indent guides."""
+        self.i_width = indentation_width
+
+    def set_geometry(self, cr):
+        """Calculate and set geometry of edge line panel.
+            start --> fist line position
+            width --> max position - min position
+        """
+        offset = self.editor.contentOffset()
+        x = self.editor.blockBoundingGeometry(self.editor.firstVisibleBlock()) \
+            .translated(offset.x(), offset.y()).left() + 5
+
+        top_left = QPoint(x, cr.top())
+        top_left = self.editor.calculate_real_position(top_left)
+        bottom_right = QPoint(top_left.x() + cr.width(), cr.bottom())
+
+        self.setGeometry(QRect(top_left, bottom_right))

--- a/spyder/widgets/panels/indentationguides.py
+++ b/spyder/widgets/panels/indentationguides.py
@@ -11,6 +11,7 @@ This module contains the indentation guide panel.
 from qtpy.QtCore import Qt, QRect, QPoint
 from qtpy.QtGui import QPainter, QColor
 
+from spyder.utils.editor import TextBlockHelper
 from spyder.api.panel import Panel
 
 class IndentationGuide(Panel):
@@ -37,21 +38,13 @@ class IndentationGuide(Panel):
         color.setAlphaF(.5)
         painter.setPen(color)
 
-        prev_indentation = 0
         for top, line_number, block in self.editor.visible_blocks:
             bottom = top + int(self.editor.blockBoundingRect(block).height())
 
-            # replace tabs for spaces
-            text = block.text().replace('\t', ' ' * self.i_width)
+            indentation = TextBlockHelper.get_fold_lvl(block)
 
-            indentation = len(text) -len(text.lstrip())
-
-            if text.strip() == "":
-                indentation = max(indentation, prev_indentation)
-            prev_indentation = indentation
-
-            for i in range(self.i_width, indentation, self.i_width):
-                x = self.editor.fontMetrics().width(i * '9')
+            for i in range(1, indentation):
+                x = self.editor.fontMetrics().width(i * self.i_width * '9')
                 painter.drawLine(x, top, x, bottom)
 
     # --- Other methods

--- a/spyder/widgets/panels/indentationguides.py
+++ b/spyder/widgets/panels/indentationguides.py
@@ -8,21 +8,20 @@
 This module contains the indentation guide panel
 """
 
-from qtpy.QtWidgets import QWidget
 from qtpy.QtCore import Qt, QRect, QPoint
 from qtpy.QtGui import QPainter, QColor
 
+from spyder.api.panel import Panel
 
-class IndentationGuide(QWidget):
+class IndentationGuide(Panel):
     """Source code editor's edge line (default: 79 columns, PEP8)"""
 
     # --- Qt Overrides
     # -----------------------------------------------------------------
-    def __init__(self, editor, color=Qt.darkGray, indentation_width=4):
-        QWidget.__init__(self, editor)
-        self.editor = editor
-        self.color = color
-        self.i_width = indentation_width
+    def __init__(self, editor):
+        Panel.__init__(self, editor)
+        self.color = Qt.darkGray
+        self.i_width = 4
 
         self.setAttribute(Qt.WA_TransparentForMouseEvents)
         self._enabled = True

--- a/spyder/widgets/panels/indentationguides.py
+++ b/spyder/widgets/panels/indentationguides.py
@@ -37,6 +37,7 @@ class IndentationGuide(Panel):
         color.setAlphaF(.5)
         painter.setPen(color)
 
+        prev_indentation = 0
         for top, line_number, block in self.editor.visible_blocks:
             bottom = top + int(self.editor.blockBoundingRect(block).height())
 
@@ -44,6 +45,11 @@ class IndentationGuide(Panel):
             text = block.text().replace('\t', ' ' * self.i_width)
 
             indentation = len(text) -len(text.lstrip())
+
+            if text.strip() == "":
+                indentation = max(indentation, prev_indentation)
+            prev_indentation = indentation
+
             for i in range(self.i_width, indentation, self.i_width):
                 x = self.editor.fontMetrics().width(i * '9')
                 painter.drawLine(x, top, x, bottom)

--- a/spyder/widgets/panels/indentationguides.py
+++ b/spyder/widgets/panels/indentationguides.py
@@ -5,7 +5,7 @@
 # (see spyder/__init__.py for details)
 
 """
-This module contains the indentation guide panel
+This module contains the indentation guide panel.
 """
 
 from qtpy.QtCore import Qt, QRect, QPoint
@@ -14,11 +14,15 @@ from qtpy.QtGui import QPainter, QColor
 from spyder.api.panel import Panel
 
 class IndentationGuide(Panel):
-    """Source code editor's edge line (default: 79 columns, PEP8)"""
+    """Indentation guides to easy identify nested blocks."""
 
     # --- Qt Overrides
     # -----------------------------------------------------------------
     def __init__(self, editor):
+        """Initialize IndentationGuide panel.
+
+        i_width(int): identation width in characters.
+        """
         Panel.__init__(self, editor)
         self.color = Qt.darkGray
         self.i_width = 4
@@ -27,7 +31,7 @@ class IndentationGuide(Panel):
         self._enabled = True
 
     def paintEvent(self, event):
-        """Override Qt method"""
+        """Override Qt method."""
         painter = QPainter(self)
 
         color = QColor(self.color)
@@ -49,14 +53,12 @@ class IndentationGuide(Panel):
     # -----------------------------------------------------------------
 
     def set_enabled(self, state):
-        """Toggle edge line visibility"""
+        """Toggle edge line visibility."""
         self._enabled = state
         self.setVisible(state)
 
     def update_color(self):
-        """
-        Set edgeline color using syntax highlighter color for comments
-        """
+        """Set color using syntax highlighter color for comments."""
         self.color = self.editor.highlighter.get_color_name('comment')
 
     def set_indentation_width(self, indentation_width):
@@ -64,10 +66,7 @@ class IndentationGuide(Panel):
         self.i_width = indentation_width
 
     def set_geometry(self, cr):
-        """Calculate and set geometry of edge line panel.
-            start --> fist line position
-            width --> max position - min position
-        """
+        """Calculate and set geometry of indentation guides panel."""
         offset = self.editor.contentOffset()
         x = self.editor.blockBoundingGeometry(self.editor.firstVisibleBlock()) \
             .translated(offset.x(), offset.y()).left() + 5

--- a/spyder/widgets/panels/linenumber.py
+++ b/spyder/widgets/panels/linenumber.py
@@ -25,7 +25,7 @@ class LineNumberArea(Panel):
         Panel.__init__(self, editor)
 
         self.setMouseTracking(True)
-
+        self.scrollable = True
         self.linenumbers_color = QColor(Qt.darkGray)
 
         # Markers
@@ -178,14 +178,6 @@ class LineNumberArea(Panel):
         else:
             return 0
 
-    def update_(self, qrect, dy):
-        """Update line number area"""
-        if dy:
-            self.scroll(0, dy)
-        else:
-            self.update(0, qrect.y(),
-                        self.width(),
-                        qrect.height())
 
     def setup_margins(self, linenumbers=True, markers=True):
         """

--- a/spyder/widgets/panels/linenumber.py
+++ b/spyder/widgets/panels/linenumber.py
@@ -39,7 +39,6 @@ class LineNumberArea(Panel):
 
         # Line number area management
         self._margin = True
-        self._enabled = None
         self._pressed = -1
         self._released = -1
 

--- a/spyder/widgets/panels/manager.py
+++ b/spyder/widgets/panels/manager.py
@@ -30,7 +30,8 @@ class PanelsManager(Manager):
             Panel.Position.TOP: {},
             Panel.Position.LEFT: {},
             Panel.Position.RIGHT: {},
-            Panel.Position.BOTTOM: {}
+            Panel.Position.BOTTOM: {},
+            Panel.Position.FLOATING: {}
         }
         try:
             editor.blockCountChanged.connect(self._update_viewport_margins)
@@ -53,7 +54,8 @@ class PanelsManager(Manager):
             Panel.Position.BOTTOM: 'bottom',
             Panel.Position.LEFT: 'left',
             Panel.Position.RIGHT: 'right',
-            Panel.Position.TOP: 'top'
+            Panel.Position.TOP: 'top',
+            Panel.Position.FLOATING: 'floating'
         }
         debug_print('adding panel {} at {}'.format(panel.name,
                                                    pos_to_string[position]))
@@ -205,6 +207,15 @@ class PanelsManager(Manager):
                 size_hint.height())
             bottom += size_hint.height()
 
+    def update_floating_panels(self):
+        """Update foating panels."""
+        crect = self.editor.contentsRect()
+        panels = self.panels_for_zone(Panel.Position.FLOATING)
+        for panel in panels:
+            if not panel.isVisible():
+                continue
+            panel.set_geometry(crect)
+
     def _update(self, rect, delta_y, force_update_margins=False):
         """Updates panels."""
         if not self:
@@ -225,6 +236,7 @@ class PanelsManager(Manager):
         if (rect.contains(self.editor.viewport().rect()) or
                 force_update_margins):
             self._update_viewport_margins()
+        self.update_floating_panels()
 
     def _update_viewport_margins(self):
         """Update viewport margins."""

--- a/spyder/widgets/panels/scrollflag.py
+++ b/spyder/widgets/panels/scrollflag.py
@@ -22,8 +22,7 @@ class ScrollFlagArea(Panel):
     def __init__(self, editor):
         Panel.__init__(self, editor)
         self.setAttribute(Qt.WA_OpaquePaintEvent)
-        editor.verticalScrollBar().valueChanged.connect(
-                                                  lambda value: self.repaint())
+        self.scrollable = True
 
     def sizeHint(self):
         """Override Qt method"""

--- a/spyder/widgets/panels/scrollflag.py
+++ b/spyder/widgets/panels/scrollflag.py
@@ -22,7 +22,6 @@ class ScrollFlagArea(Panel):
     def __init__(self, editor):
         Panel.__init__(self, editor)
         self.setAttribute(Qt.WA_OpaquePaintEvent)
-        self._enabled = None
         editor.verticalScrollBar().valueChanged.connect(
                                                   lambda value: self.repaint())
 

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -284,8 +284,8 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
 
     def set_tab_stop_width_spaces(self, tab_stop_width_spaces):
         self.tab_stop_width_spaces = tab_stop_width_spaces
-        self.setTabStopWidth(tab_stop_width_spaces
-                             * self.fontMetrics().width('9'))
+        self.setTabStopWidth(self.fontMetrics().width(
+                '9'* tab_stop_width_spaces))
 
     def set_palette(self, background, foreground):
         """

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -60,6 +60,7 @@ from spyder.widgets.sourcecode.base import TextEditBaseWidget
 from spyder.widgets.sourcecode.kill_ring import QtKillRing
 from spyder.widgets.panels.linenumber import LineNumberArea
 from spyder.widgets.panels.edgeline import EdgeLine
+from spyder.widgets.panels.indentationguides import IndentationGuide
 from spyder.widgets.panels.scrollflag import ScrollFlagArea
 from spyder.widgets.panels.manager import PanelsManager
 from spyder.widgets.panels.codefolding import FoldingPanel
@@ -227,6 +228,7 @@ class CodeEditor(TextEditBaseWidget):
 
     # To have these attrs when early viewportEvent's are triggered
     edge_line = None
+    indent_guides = None
 
     breakpoints_changed = Signal()
     get_completions = Signal(bool)
@@ -274,6 +276,9 @@ class CodeEditor(TextEditBaseWidget):
 
         # 79-col edge line
         self.edge_line = EdgeLine(self)
+
+        # indent guides
+        self.indent_guides = IndentationGuide(self)
 
         # Blanks enabled
         self.blanks_enabled = False
@@ -595,6 +600,13 @@ class CodeEditor(TextEditBaseWidget):
         # Edge line
         self.edge_line.set_enabled(edge_line)
         self.edge_line.set_columns(edge_line_columns)
+
+        # Indent guides
+        self.indent_guides.set_enabled(True)
+        if self.indent_chars == '\t':
+            self.indent_guides.set_indentation_width(self.tab_stop_width_spaces)
+        else:
+            self.indent_guides.set_indentation_width(len(self.indent_chars))
 
         # Blanks
         self.set_blanks_enabled(show_blanks)
@@ -1172,6 +1184,7 @@ class CodeEditor(TextEditBaseWidget):
         """Override Qt method"""
         cr = self.contentsRect()
         self.edge_line.set_geometry(cr)
+        self.indent_guides.set_geometry(cr)
         return TextEditBaseWidget.viewportEvent(self, event)
 
     #-----Misc.
@@ -1192,6 +1205,7 @@ class CodeEditor(TextEditBaseWidget):
             self.unmatched_p_color = hl.get_unmatched_p_color()
 
             self.edge_line.update_color()
+            self.indent_guides.update_color()
 
     def apply_highlighter_settings(self, color_scheme=None):
         """Apply syntax highlighter settings"""

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -275,10 +275,12 @@ class CodeEditor(TextEditBaseWidget):
         self._panels = PanelsManager(self)
 
         # 79-col edge line
-        self.edge_line = EdgeLine(self)
+        self.edge_line = self.panels.register(EdgeLine(self),
+                                              Panel.Position.FLOATING)
 
         # indent guides
-        self.indent_guides = IndentationGuide(self)
+        self.indent_guides = self.panels.register(IndentationGuide(self),
+                                                  Panel.Position.FLOATING)
 
         # Blanks enabled
         self.blanks_enabled = False
@@ -1180,13 +1182,6 @@ class CodeEditor(TextEditBaseWidget):
         super(CodeEditor, self).showEvent(event)
         self.panels.refresh()
 
-    #-----edgeline
-    def viewportEvent(self, event):
-        """Override Qt method"""
-        cr = self.contentsRect()
-        self.edge_line.set_geometry(cr)
-        self.indent_guides.set_geometry(cr)
-        return TextEditBaseWidget.viewportEvent(self, event)
 
     #-----Misc.
     def _apply_highlighter_color_scheme(self):

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -579,7 +579,8 @@ class CodeEditor(TextEditBaseWidget):
                      close_parentheses=True, close_quotes=False,
                      add_colons=True, auto_unindent=True, indent_chars=" "*4,
                      tab_stop_width_spaces=4, cloned_from=None, filename=None,
-                     occurrence_timeout=1500, show_class_func_dropdown=True):
+                     occurrence_timeout=1500, show_class_func_dropdown=True,
+                     indent_guides=False):
         
         # Code completion and calltips
         self.set_codecompletion_auto(codecompletion_auto)
@@ -602,7 +603,7 @@ class CodeEditor(TextEditBaseWidget):
         self.edge_line.set_columns(edge_line_columns)
 
         # Indent guides
-        self.indent_guides.set_enabled(True)
+        self.indent_guides.set_enabled(indent_guides)
         if self.indent_chars == '\t':
             self.indent_guides.set_indentation_width(self.tab_stop_width_spaces)
         else:

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -293,7 +293,6 @@ class CodeEditor(TextEditBaseWidget):
 
         # Line number area management
         self.linenumberarea = self.panels.register(LineNumberArea(self))
-        self.updateRequest.connect(self.linenumberarea.update_)
         
         # Class and Method/Function Dropdowns
         self.classfuncdropdown = self.panels.register(

--- a/spyder/widgets/sourcecode/tests/test_panels.py
+++ b/spyder/widgets/sourcecode/tests/test_panels.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+#
+'''
+Tests for editor panels.
+'''
+
+# Third party imports
+from qtpy.QtGui import QTextCursor
+import pytest
+
+# Local imports
+from spyder.utils.qthelpers import qapplication
+from spyder.widgets.sourcecode.codeeditor import CodeEditor
+from spyder.widgets.panels.linenumber import LineNumberArea
+from spyder.widgets.panels.edgeline import EdgeLine
+from spyder.widgets.panels.scrollflag import ScrollFlagArea
+from spyder.widgets.panels.indentationguides import IndentationGuide
+
+
+# --- Fixtures
+# -----------------------------------------------------------------------------
+def construct_editor(*args, **kwargs):
+    app = qapplication()
+    editor = CodeEditor(parent=None)
+    kwargs['language'] = 'Python'
+    editor.setup_editor(*args, **kwargs)
+    return editor
+
+
+# --- Tests
+# -----------------------------------------------------------------------------
+@pytest.mark.parametrize('state', [True, False])
+@pytest.mark.parametrize('setting, panelclass', [
+    ('linenumbers', LineNumberArea),
+    ('edge_line', EdgeLine),
+    ('scrollflagarea', ScrollFlagArea),
+    ('indent_guides', IndentationGuide),
+])
+def test_activate_panels(setting, panelclass, state):
+    """Test activate/deactivate of editors Panels.
+
+    Also test that the panel is added to the editor.
+    """
+    kwargs = {}
+    kwargs[setting] = state
+    editor = construct_editor(**kwargs)
+
+    found = False
+    for panel in editor.panels:
+        if isinstance(panel, panelclass):
+            assert panel.enabled == state
+            found = True
+    assert found
+
+
+if __name__ == '__main__':
+    pytest.main()


### PR DESCRIPTION
Fixes: #2987 

I added a floating type panel, and move `edgeline` and `indentguides` to use it.

I didn't find a way to abstract all the logic in the `PanelManager`, and floatings Panels need to have a `set_geometry` method

This is how it looks like, It uses the comments color (same as edgeline)
![spectacle j13255](https://user-images.githubusercontent.com/2024217/26898032-3204d548-4b90-11e7-91cd-6e0f61642ed3.png)