### PR TITLE
PR: Add Whitespace option in the import wizard

### DIFF
--- a/spyder/widgets/variableexplorer/importwizard.py
+++ b/spyder/widgets/variableexplorer/importwizard.py
@@ -142,6 +142,9 @@ class ContentsWidget(QWidget):
         self.tab_btn = QRadioButton(_("Tab"))
         self.tab_btn.setChecked(False)
         col_btn_layout.addWidget(self.tab_btn)
+        self.ws_btn = QRadioButton(_("Whitespace"))
+        self.ws_btn.setChecked(False)
+        col_btn_layout.addWidget(self.ws_btn)
         other_btn_col = QRadioButton(_("other"))
         other_btn_col.setChecked(True)
         col_btn_layout.addWidget(other_btn_col)
@@ -231,6 +234,8 @@ class ContentsWidget(QWidget):
         """Return the column separator"""
         if self.tab_btn.isChecked():
             return u"\t"
+        elif self.ws_btn.isChecked():
+            return None
         return to_text_string(self.line_edt.text())
 
     def get_row_sep(self):
@@ -462,7 +467,10 @@ class PreviewWidget(QWidget):
         if pd:
             self.pd_text = text
             self.pd_info = dict(sep=colsep, lineterminator=rowsep,
-                skiprows=skiprows,comment=comments)
+                skiprows=skiprows, comment=comments)
+            if colsep is None:
+                self.pd_info = dict(lineterminator=rowsep, skiprows=skiprows,
+                    comment=comments, delim_whitespace=True)
         self._table_view.process_data(text, colsep, rowsep, transpose,
                                       skiprows, comments)
 


### PR DESCRIPTION
This PR fixes #4581 by adding continuous whitespace as an option to the column separator section of the import wizard.

Let me know if this needs a test, and I'll write one.

Currently the data import wizard doesn't play nicely with text data with multiple spaces as delimiters(or maybe I don't play nicely with the data importer ;-). This is common in fixed width data sets like this:
```
FIRST  LAST           STATE     TELEPHONE      AGE   WEIGHT
John   Smith          WA        418-Y11-4111    26    3.0456
Mary   Hartford       CA        319-Z19-4341     5   13.5687
Evan   Nolan          IL        219-532-c301   145   45.7890
```
Putting a `' '` (a space) in a the 'other' text box gives this:

![screenshot from 2017-06-09 22-54-23](https://user-images.githubusercontent.com/10513354/27000139-d82be01e-4d67-11e7-8744-60a5ccf6eaf8.png)

When it could give this:

![screenshot from 2017-06-09 22-59-21](https://user-images.githubusercontent.com/10513354/27000146-f6d744e0-4d67-11e7-8119-212dbf0b212f.png)

It looks like this:

![image](https://user-images.githubusercontent.com/10513354/27006211-92650a18-4deb-11e7-8812-11f877270537.png)