### PR TITLE
PR: Fix unwanted scrolling when selecting tabs

### DIFF
--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -1210,7 +1210,11 @@ class EditorStack(QWidget):
         is_readonly = finfo.editor.isReadOnly()
         tab_text = self.get_tab_text(index, is_modified, is_readonly)
         tab_tip = self.get_tab_tip(fname, is_modified, is_readonly)
-        self.tabs.setTabText(index, tab_text)
+
+        # Only update tab text if have changed, otherwise an unwanted scrolling
+        # will happen when changing tabs. See Issue #1170.
+        if tab_text != self.tabs.tabText(index):
+            self.tabs.setTabText(index, tab_text)
         self.tabs.setTabToolTip(index, tab_tip)
 
 

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -717,7 +717,7 @@ class EditorStack(QWidget):
             # a crash when the editor is detached from the main window
             # Fixes Issue 561
             self.tabs.setDocumentMode(True)
-        self.tabs.currentChanged.connect(self.current_changed_tabs)
+        self.tabs.currentChanged.connect(self.current_changed)
 
         if sys.platform == 'darwin':
             tab_container = QWidget()
@@ -1621,17 +1621,14 @@ class EditorStack(QWidget):
         if self.data:
             return self.data[self.get_stack_index()].todo_results
 
-    def  current_changed_tabs(self, index):
-        self.current_changed(index, set_focus=False)
-
-    def current_changed(self, index, set_focus=True):
+    def current_changed(self, index):
         """Stack index has changed"""
 #        count = self.get_stack_count()
 #        for btn in (self.filelist_btn, self.previous_btn, self.next_btn):
 #            btn.setEnabled(count > 1)
 
         editor = self.get_current_editor()
-        if index != -1 and set_focus:
+        if index != -1:
             editor.setFocus()
             if DEBUG_EDITOR:
                 print("setfocusto:", editor, file=STDOUT)


### PR DESCRIPTION
Fixes #4597 
Original bug was #1170

The solution implemented in 2228e83b656a476683f27e9ddd5e234a08135be6 wasn't the best, focus should be give to the Editor when changing tabs.

I reverted 2228e83b656a476683f27e9ddd5e234a08135be6, and traced the error until `self.tabs.setTabText(index, tab_text)` I'm not sure why this line was causing that error, maybe it raises again the `currentChanged` signal.