### PR TITLE
PR: Add pyopengl to Linux wheels only

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,9 +12,11 @@ To release a new version of Spyder you need to follow these steps:
 
 * python setup.py sdist upload
 
-* python2 setup.py bdist_wheel upload
+* python setup.py bdist_wheel --plat-name manylinux1_x86_64 upload
 
-* python3 setup.py bdist_wheel upload
+* python setup.py bdist_wheel --plat-name manylinux1_i686 upload
+
+* python setup.py bdist_wheel upload
 
 * git tag -a vX.X.X -m 'Release X.X.X'
 

--- a/setup.py
+++ b/setup.py
@@ -287,9 +287,13 @@ install_requires = [
     'pickleshare',
     'pyzmq',
     'chardet>=2.0.0',
-    'numpydoc',
-    'pyopengl',  # This is needed only in pip installations see issue #3332
+    'numpydoc'
 ]
+
+# This is needed only for pip installations on Linux.
+# See issue #3332
+if any([arg.startswith('manylinux1') for arg in sys.argv]):
+    install_requires = install_requires + ['pyopengl']
 
 extras_require = {
     'test:python_version == "2.7"': ['mock'],


### PR DESCRIPTION
The problem is there are no wheels for `pyopengl` on Windows or macOS, so people would need a compiler to pip-install Spyder in those platforms.