### PR TITLE
Fix to issue #1785 regarding comment function in the editor

### DIFF
--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2206,11 +2206,12 @@ class CodeEditor(TextEditBaseWidget):
 
     def comment(self):
         """Comment current line or selection."""
-        self.add_prefix(self.comment_string)
+        self.add_prefix(self.comment_string + " ")
 
     def uncomment(self):
         """Uncomment current line or selection."""
         self.remove_prefix(self.comment_string)
+        self.remove_prefix(" ")
 
     def __blockcomment_bar(self):
         return self.comment_string + '='*(79-len(self.comment_string))


### PR DESCRIPTION
Comment function : adds a space after the comment string (# for Python)
Uncomment function : removes the comment string and removes one space
if there is one