### PR TITLE
PR: Don't register external plugins if check_compatibility fails

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1066,13 +1066,12 @@ class MainWindow(QMainWindow):
         for mod in get_spyderplugins_mods():
             try:
                 plugin = mod.PLUGIN_CLASS(self)
-                check = True
                 try:
                     # Not all the plugins have the check_compatibility method
                     # i.e Breakpoints, Profiler, Pylint
-                    check, message = plugin.check_compatibility()
+                    check = plugin.check_compatibility()[0]
                 except AttributeError:
-                    pass
+                    check = True
                 if check:
                     self.thirdparty_plugins.append(plugin)
                     plugin.register_plugin()

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1066,8 +1066,16 @@ class MainWindow(QMainWindow):
         for mod in get_spyderplugins_mods():
             try:
                 plugin = mod.PLUGIN_CLASS(self)
-                self.thirdparty_plugins.append(plugin)
-                plugin.register_plugin()
+                check = True
+                try:
+                    # Not all the plugins have the check_compatibility method
+                    # i.e Breakpoints, Profiler, Pylint
+                    check, message = plugin.check_compatibility()
+                except AttributeError:
+                    pass
+                if check:
+                    self.thirdparty_plugins.append(plugin)
+                    plugin.register_plugin()
             except Exception as error:
                 print("%s: %s" % (mod, str(error)), file=STDERR)
                 traceback.print_exc(file=STDERR)


### PR DESCRIPTION
Fixes #4665 

It works with the Notebook plugin when running with PyQt4 (for example)