### PR TITLE
PR: Update ArrayEditor to correct deprecated Numpy operator

### DIFF
--- a/spyder/widgets/variableexplorer/arrayeditor.py
+++ b/spyder/widgets/variableexplorer/arrayeditor.py
@@ -267,7 +267,7 @@ class ArrayModel(QAbstractTableModel):
           and value is not np.ma.masked:
             hue = self.hue0+\
                   self.dhue*(float(self.vmax)-self.color_func(value)) \
-                  /(float(self.vmax)-self.vmin)
+                  /(float(self.vmax)-self.vmin) #float convert to handle bool arrays
             hue = float(np.abs(hue))
             color = QColor.fromHsvF(hue, self.sat, self.val, self.alp)
             return to_qvariant(color)

--- a/spyder/widgets/variableexplorer/arrayeditor.py
+++ b/spyder/widgets/variableexplorer/arrayeditor.py
@@ -266,7 +266,7 @@ class ArrayModel(QAbstractTableModel):
         elif role == Qt.BackgroundColorRole and self.bgcolor_enabled \
           and value is not np.ma.masked:
             hue = self.hue0+\
-                  self.dhue*(self.vmax-self.color_func(value)) \
+                  self.dhue*(np.logical_xor(self.vmax,self.color_func(value))) \
                   /(self.vmax-self.vmin)
             hue = float(np.abs(hue))
             color = QColor.fromHsvF(hue, self.sat, self.val, self.alp)

--- a/spyder/widgets/variableexplorer/arrayeditor.py
+++ b/spyder/widgets/variableexplorer/arrayeditor.py
@@ -266,8 +266,8 @@ class ArrayModel(QAbstractTableModel):
         elif role == Qt.BackgroundColorRole and self.bgcolor_enabled \
           and value is not np.ma.masked:
             hue = self.hue0+\
-                  self.dhue*(np.logical_xor(self.vmax,self.color_func(value))) \
-                  /(self.vmax-self.vmin)
+                  self.dhue*(float(self.vmax)-self.color_func(value)) \
+                  /(float(self.vmax)-self.vmin)
             hue = float(np.abs(hue))
             color = QColor.fromHsvF(hue, self.sat, self.val, self.alp)
             return to_qvariant(color)


### PR DESCRIPTION
Changed numpy boolean subract operator '-' to np.logical_xor. As suggested in the numpy deprec warning.
Tested locally with no error originally described in #4663

