### PR TITLE
PR: Revert PR #4651

### DIFF
--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2258,12 +2258,11 @@ class CodeEditor(TextEditBaseWidget):
 
     def comment(self):
         """Comment current line or selection."""
-        self.add_prefix(self.comment_string + " ")
+        self.add_prefix(self.comment_string)
 
     def uncomment(self):
         """Uncomment current line or selection."""
         self.remove_prefix(self.comment_string)
-        self.remove_prefix(" ")
 
     def __blockcomment_bar(self):
         return self.comment_string + ' ' + '=' * (78 - len(self.comment_string))


### PR DESCRIPTION
As discussed in PR #4651 

---------------------

This leaves the change in the block commenting functionality (a space between the `'#'` and the `'='`).