### PR TITLE
PR: Fix running in dedicated consoles and other UI fixes

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -432,7 +432,7 @@ class MainWindow(QMainWindow):
         if options.window_title is not None:
             title += ' -- ' + options.window_title
 
-        if DEV or DEBUG or PYTEST:
+        if DEBUG or PYTEST:
             # Show errors in internal console when developing or testing.
             CONF.set('main', 'show_internal_console_if_traceback', True)
 

--- a/spyder/plugins/configdialog.py
+++ b/spyder/plugins/configdialog.py
@@ -872,9 +872,6 @@ class MainConfigPage(GeneralConfigPage):
         tear_off_box = newcb(_("Tear off menus"), 'tear_off_menus',
                              tip=_("Set this to detach any<br> "
                                    "menu from the main window"))
-        high_dpi_scaling_box = newcb(_("Enable high DPI scaling"), 
-                                     'high_dpi_scaling',
-                                     tip=_("Set this for high DPI displays"))
         margin_box = newcb(_("Custom margin for panes:"),
                            'use_custom_margin')
         margin_spin = self.create_spinbox("", _("pixels"), 'custom_margin',
@@ -901,7 +898,6 @@ class MainConfigPage(GeneralConfigPage):
         interface_layout.addWidget(verttabs_box)
         interface_layout.addWidget(animated_box)
         interface_layout.addWidget(tear_off_box)
-        interface_layout.addWidget(high_dpi_scaling_box)
         interface_layout.addLayout(margins_layout)
         interface_group.setLayout(interface_layout)
 

--- a/spyder/plugins/configdialog.py
+++ b/spyder/plugins/configdialog.py
@@ -39,6 +39,9 @@ from spyder.widgets.colors import ColorLayout
 from spyder.widgets.sourcecode.codeeditor import CodeEditor
 
 
+HDPI_QT_PAGE = "http://doc.qt.io/qt-5/highdpi.html"
+
+
 class ConfigAccessMixin(object):
     """Namespace for methods that access config storage"""
     CONF_SECTION = None
@@ -949,9 +952,13 @@ class MainConfigPage(GeneralConfigPage):
         # --- Screen resolution Group (hidpi)
         screen_resolution_group = QGroupBox(_("Screen resolution"))
         screen_resolution_bg = QButtonGroup(screen_resolution_group)
-        screen_resolution_label = QLabel(_("Configurations for highdpi screens, "
-                                "See: <a href=\"http://doc.qt.io/qt-5/highdpi.html\">http://doc.qt.io/qt-5/highdpi.html</a><> "
-                                "for more information"))
+        screen_resolution_label = QLabel(_("Configuration for high DPI "
+                                           "screens<br><br>"
+                                           "Please see "
+                                           "<a href=\"{0}\">{0}</a><> "
+                                           "for more information about "
+                                           "these options (in "
+                                           "English).").format(HDPI_QT_PAGE))
         screen_resolution_label.setWordWrap(True)
 
         normal_radio = self.create_radiobutton(

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -1384,6 +1384,7 @@ class IPythonConsole(SpyderPluginWidget):
         client = self.clients.pop(index_from)
         self.filenames.insert(index_to, filename)
         self.clients.insert(index_to, client)
+        self.update_tabs_text()
         self.update_plugin_title.emit()
 
     def disambiguate_fname(self, fname):
@@ -1395,9 +1396,11 @@ class IPythonConsole(SpyderPluginWidget):
     def update_tabs_text(self):
         """Update the text from the tabs."""
         for index, fname in enumerate(self.filenames):
+            client = self.clients[index]
             if fname:
-                client = self.clients[index]
                 self.rename_client_tab(client, self.disambiguate_fname(fname))
+            else:
+                self.rename_client_tab(client, None)
 
     def rename_client_tab(self, client, given_name):
         """Rename client's tab"""

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -1285,8 +1285,9 @@ class IPythonConsole(SpyderPluginWidget):
     def get_client_for_file(self, filename):
         """Get client associated with a given file."""
         client = None
-        for cl in self.get_clients():
-            if cl.given_name == filename:
+        for idx, cl in enumerate(self.get_clients()):
+            if self.filenames[idx] == filename:
+                self.tabwidget.setCurrentIndex(idx)
                 client = cl
                 break
         return client

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -358,7 +358,7 @@ class TabSwitcherWidget(QListWidget):
         for index in reversed(self.stack_history):
             text = self.tabs.tabText(index)
             text = text.replace('&', '')
-            item = QListWidgetItem(ima.icon('FileIcon'), text)
+            item = QListWidgetItem(ima.icon('TextFileIcon'), text)
             self.addItem(item)
 
     def item_selected(self, item=None):


### PR DESCRIPTION
* There was a bug after PR #4694, which I fixed here.
* Make drag and drop of tabs in the IPython console to work.
* Use `TexFileIcon` in the Editor tab switcher.
* Fix wording of *Screen resolution* section in Preferences/General. Also remove a repeated option about that.