### PR TITLE
PR: Avoid visible_blocks to be empty when first visible block is wrapped

### DIFF
--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -3088,7 +3088,7 @@ class CodeEditor(TextEditBaseWidget):
         ebottom_bottom = self.height()
 
         while block.isValid():
-            visible = (top >= ebottom_top and bottom <= ebottom_bottom)
+            visible = bottom <= ebottom_bottom
             if not visible:
                 break
             if block.isVisible():


### PR DESCRIPTION
Fixes #3166

This was also causing the fold panel to be empty.