### PR TITLE
PR: Add mdw as markdown extension.

### DIFF
--- a/spyder/utils/sourcecode.py
+++ b/spyder/utils/sourcecode.py
@@ -33,7 +33,7 @@ ALL_LANGUAGES = {
                  'Cpp': ('c', 'cc', 'cpp', 'cxx', 'h', 'hh', 'hpp', 'hxx'),
                  'OpenCL': ('cl',),
                  'Yaml':('yaml','yml'),
-                 "Markdown": ('md', ),
+                 "Markdown": ('md', 'mdw'),
                  }
 
 PYTHON_LIKE_LANGUAGES = ('Python', 'Cython', 'Enaml')


### PR DESCRIPTION
In #4352 I only add `md` as supported extension for Markdown, this is causing `mdw` files to appear as plain text.

This is a quick fix, a more robust solution should be implemented in spyder reports (https://github.com/spyder-ide/spyder-reports/issues/6), using the languages API (to be developed in spyder4)