### PR TITLE
PR: Update pixmap height calculation

### DIFF
--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -1179,7 +1179,8 @@ class CodeEditor(TextEditBaseWidget):
         active_line_number = active_block.blockNumber() + 1
 
         def draw_pixmap(ytop, pixmap):
-            painter.drawPixmap(0, ytop + (font_height-pixmap.height()) / 2,
+            pixmap_height = pixmap.height() / pixmap.devicePixelRatio()
+            painter.drawPixmap(0, ytop + (font_height-pixmap_height) / 2,
                                pixmap)
 
         for top, line_number, block in self.visible_blocks:

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -27,7 +27,7 @@ import sys
 import time
 
 # Third party imports
-from qtpy import is_pyqt46
+from qtpy import is_pyqt46, QT_VERSION
 from qtpy.compat import to_qvariant
 from qtpy.QtCore import QRect, QRegExp, QSize, Qt, QTimer, Signal, Slot
 from qtpy.QtGui import (QBrush, QColor, QCursor, QFont, QIntValidator,
@@ -52,6 +52,7 @@ from spyder.utils import icon_manager as ima
 from spyder.utils import syntaxhighlighters as sh
 from spyder.utils import encoding, sourcecode
 from spyder.utils.dochelpers import getobj
+from spyder.utils.programs import check_version
 from spyder.utils.qthelpers import add_actions, create_action, mimedata2url
 from spyder.utils.sourcecode import ALL_LANGUAGES, CELL_LANGUAGES
 from spyder.widgets.editortools import PythonCFM
@@ -68,6 +69,7 @@ except:
 # For debugging purpose:
 LOG_FILENAME = get_conf_path('codeeditor.log')
 DEBUG_EDITOR = DEBUG >= 3
+QT55_VERSION = check_version(QT_VERSION, "5.5", ">=")
 
 
 def is_letter_or_number(char):
@@ -1179,7 +1181,7 @@ class CodeEditor(TextEditBaseWidget):
         active_line_number = active_block.blockNumber() + 1
 
         def draw_pixmap(ytop, pixmap):
-            if is_pyqt46:
+            if not QT55_VERSION:
                 pixmap_height = pixmap.height()
             else:
                 # scale pixmap height to device independent pixels

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -1179,7 +1179,11 @@ class CodeEditor(TextEditBaseWidget):
         active_line_number = active_block.blockNumber() + 1
 
         def draw_pixmap(ytop, pixmap):
-            pixmap_height = pixmap.height() / pixmap.devicePixelRatio()
+            if is_pyqt46:
+                pixmap_height = pixmap.height()
+            else:
+                # scale pixmap height to device independent pixels
+                pixmap_height = pixmap.height() / pixmap.devicePixelRatio()
             painter.drawPixmap(0, ytop + (font_height-pixmap_height) / 2,
                                pixmap)
 


### PR DESCRIPTION
Fixes #4734 

----

The font height and pixmap height were in incompatible units when DPI scaling is on.  Dividing the qpixmap height by self.devicePixelRatio() converts it into device independent units.  See http://doc.qt.io/qt-5/qpixmap.html#devicePixelRatio