### PR TITLE
PR: Add icon to MessageCheckBox while avoiding unclickable  issue

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2811,14 +2811,12 @@ class MainWindow(QMainWindow):
         url_i = 'http://pythonhosted.org/spyder/installation.html'
 
         # Define the custom QMessageBox
-        box = MessageCheckBox()
+        box = MessageCheckBox(icon=QMessageBox.Information,
+                              parent=self)
         box.setWindowTitle(_("Spyder updates"))
         box.set_checkbox_text(_("Check for updates on startup"))
         box.setStandardButtons(QMessageBox.Ok)
         box.setDefaultButton(QMessageBox.Ok)
-        # The next line is commented because it freezes the dialog.
-        # For now there is then no info icon. This solves issue #3609.
-        # box.setIcon(QMessageBox.Information)
 
         # Adjust the checkbox depending on the stored configuration
         section, option = 'main', 'check_updates_on_startup'

--- a/spyder/utils/site/sitecustomize.py
+++ b/spyder/utils/site/sitecustomize.py
@@ -271,12 +271,7 @@ unittest.main = IPyTesProgram
 # Pandas adjustments
 #==============================================================================
 try:
-    # Make Pandas recognize our Jupyter consoles as proper qtconsoles
-    # Fixes Issue 2015
-    def in_qtconsole():
-        return True
     import pandas as pd
-    pd.core.common.in_qtconsole = in_qtconsole
 
     # Set Pandas output encoding
     pd.options.display.encoding = 'utf-8'

--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -71,8 +71,12 @@ class MessageCheckBox(QMessageBox):
         check_layout.addItem(QSpacerItem(size, size))
 
         # Access the Layout of the MessageBox to add the Checkbox
+        from qtpy import PYQT5
         layout = self.layout()
-        layout.addLayout(check_layout, 1, 1)
+        if PYQT5:
+            layout.addLayout(check_layout, 1, 2)
+        else:
+            layout.addLayout(check_layout, 1, 1)
 
     # --- Public API
     # Methods to access the checkbox

--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -9,6 +9,7 @@ Helper widgets.
 """
 
 # Third party imports
+from qtpy import PYQT5
 from qtpy.QtCore import QPoint, QSize, Qt
 from qtpy.QtGui import QAbstractTextDocumentLayout, QPainter, QTextDocument
 from qtpy.QtWidgets import (QApplication, QCheckBox, QLineEdit, QMessageBox,
@@ -71,7 +72,6 @@ class MessageCheckBox(QMessageBox):
         check_layout.addItem(QSpacerItem(size, size))
 
         # Access the Layout of the MessageBox to add the Checkbox
-        from qtpy import PYQT5
         layout = self.layout()
         if PYQT5:
             layout.addLayout(check_layout, 1, 2)


### PR DESCRIPTION
Fixes #3609

----

Add an icon to the MessageCheckBox while avoiding the unclickable update message issue in PyQt5 and preserving backward compatibility with PyQt4.

Please revised that this fix works correctly in PyQt5. I cannot install PyQt5 alongside PyQt4 without messing my installation on my current setup. Feel free to give me advice to improve the way I can contribute.