### PR TITLE
PR: Don't set pandas.core.common.in_qtconsole anymore

### DIFF
--- a/spyder/utils/site/sitecustomize.py
+++ b/spyder/utils/site/sitecustomize.py
@@ -271,12 +271,7 @@ unittest.main = IPyTesProgram
 # Pandas adjustments
 #==============================================================================
 try:
-    # Make Pandas recognize our Jupyter consoles as proper qtconsoles
-    # Fixes Issue 2015
-    def in_qtconsole():
-        return True
     import pandas as pd
-    pd.core.common.in_qtconsole = in_qtconsole
 
     # Set Pandas output encoding
     pd.options.display.encoding = 'utf-8'


### PR DESCRIPTION
Fixes spyder-ide/spyder-notebook#85

- This was only needed for IPython 2, but we don't support that version anymore.
- This was also breaking the display of Dataframes as html tables in spyder-notebook.