### PR TITLE
PR: Remove startup options of working directory plugin

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -281,7 +281,6 @@ DEFAULTS = [
              {
               'working_dir_adjusttocontents': False,
               'working_dir_history': 20,
-              'startup/use_project_or_home_directory': True,
               'console/use_project_or_home_directory': True,
               'console/use_cwd': False,
               'console/use_fixed_directory': False,
@@ -633,7 +632,7 @@ DEFAULTS = [
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '39.0.0'
+CONF_VERSION = '40.0.0'
 
 # Main configuration instance
 try:

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -281,8 +281,8 @@ DEFAULTS = [
              {
               'working_dir_adjusttocontents': False,
               'working_dir_history': 20,
-              'console/use_project_or_home_directory': True,
-              'console/use_cwd': False,
+              'console/use_project_or_home_directory': False,
+              'console/use_cwd': True,
               'console/use_fixed_directory': False,
               }),
             ('shortcuts',

--- a/spyder/plugins/workingdirectory.py
+++ b/spyder/plugins/workingdirectory.py
@@ -152,7 +152,7 @@ class WorkingDirectory(QToolBar, SpyderPluginMixin):
             if self.get_option('console/use_project_or_home_directory'):
                 workdir = get_home_dir()
             else:
-                workdir = self.get_option('console/fixed_directory')
+                workdir = self.get_option('console/fixed_directory', default='')
                 if not osp.isdir(workdir):
                     workdir = get_home_dir()
         self.chdir(workdir)

--- a/spyder/plugins/workingdirectory.py
+++ b/spyder/plugins/workingdirectory.py
@@ -40,41 +40,6 @@ class WorkingDirectoryConfigPage(PluginConfigPage):
                     "and the current directory for the File Explorer."))
         about_label.setWordWrap(True)
 
-        startup_group = QGroupBox(_("Startup"))
-        startup_bg = QButtonGroup(startup_group)
-        startup_label = QLabel(_("At startup, the current working "
-                                 "directory is:"))
-        startup_label.setWordWrap(True)
-        lastdir_radio = self.create_radiobutton(
-                                _("The current project directory "
-                                  "or user home directory "
-                                  "(if no project is active)"),
-                                'startup/use_project_or_home_directory',
-                                True,
-                                _("At startup,"),  # TODO
-                                button_group=startup_bg)
-        thisdir_radio = self.create_radiobutton(
-                                _("the following directory:"),
-                                'startup/use_fixed_directory', False,
-                                _("At startup, the current working "
-                                  "directory will be the specified path"),
-                                button_group=startup_bg)
-        thisdir_bd = self.create_browsedir("", 'startup/fixed_directory',
-                                           getcwd())
-        thisdir_radio.toggled.connect(thisdir_bd.setEnabled)
-        lastdir_radio.toggled.connect(thisdir_bd.setDisabled)
-        thisdir_layout = QHBoxLayout()
-        thisdir_layout.addWidget(thisdir_radio)
-        thisdir_layout.addWidget(thisdir_bd)
-
-        startup_layout = QVBoxLayout()
-        startup_layout.addWidget(startup_label)
-        startup_layout.addWidget(lastdir_radio)
-        startup_layout.addLayout(thisdir_layout)
-        startup_group.setLayout(startup_layout)
-
-        # Console Directory
-
         console_group = QGroupBox(_("Console directory"))
         console_label = QLabel(_("The working directory for new consoles is:"))
         console_label.setWordWrap(True)
@@ -117,7 +82,6 @@ class WorkingDirectoryConfigPage(PluginConfigPage):
         vlayout = QVBoxLayout()
         vlayout.addWidget(about_label)
         vlayout.addSpacing(10)
-        vlayout.addWidget(startup_group)
         vlayout.addWidget(console_group)
         vlayout.addStretch(1)
         self.setLayout(vlayout)
@@ -185,12 +149,12 @@ class WorkingDirectory(QToolBar, SpyderPluginMixin):
         self.pathedit.setMaxCount(self.get_option('working_dir_history'))
         wdhistory = self.load_wdhistory(workdir)
         if workdir is None:
-            if self.get_option('startup/use_project_or_home_directory'):
+            if self.get_option('console/use_project_or_home_directory'):
                 workdir = get_home_dir()
             else:
-                workdir = self.get_option('startup/fixed_directory', ".")
+                workdir = self.get_option('console/fixed_directory')
                 if not osp.isdir(workdir):
-                    workdir = "."
+                    workdir = get_home_dir()
         self.chdir(workdir)
         self.pathedit.addItems(wdhistory)
         self.pathedit.selected_text = self.pathedit.currentText()


### PR DESCRIPTION
Those options are conflicting with the console ones, so we have to remove them.

I discovered this during my SciPy talk.