### PR TITLE
PR: Fix enable/disable spinbox bug in Editor preferences panel

### DIFF
--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -124,8 +124,10 @@ class EditorConfigPage(PluginConfigPage):
         edgeline_box = newcb(_("Show vertical line after"), 'edge_line')
         edgeline_spin = self.create_spinbox("", _("characters"),
                                             'edge_line_column', 79, 1, 500)
-        edgeline_box.toggled.connect(edgeline_spin.setEnabled)
-        edgeline_spin.setEnabled(self.get_option('edge_line'))
+        edgeline_box.toggled.connect(edgeline_spin.spinbox.setEnabled)
+        edgeline_box.toggled.connect(edgeline_spin.slabel.setEnabled)
+        edgeline_spin.spinbox.setEnabled(self.get_option('edge_line'))
+        edgeline_spin.slabel.setEnabled(self.get_option('edge_line'))
 
         currentline_box = newcb(_("Highlight current line"),
                                 'highlight_current_line')
@@ -136,8 +138,12 @@ class EditorConfigPage(PluginConfigPage):
         occurrence_spin = self.create_spinbox("", _(" ms"),
                                              'occurrence_highlighting/timeout',
                                              min_=100, max_=1000000, step=100)
-        occurrence_box.toggled.connect(occurrence_spin.setEnabled)
-        occurrence_spin.setEnabled(self.get_option('occurrence_highlighting'))
+        occurrence_box.toggled.connect(occurrence_spin.spinbox.setEnabled)
+        occurrence_box.toggled.connect(occurrence_spin.slabel.setEnabled)
+        occurrence_spin.spinbox.setEnabled(
+                self.get_option('occurrence_highlighting'))
+        occurrence_spin.slabel.setEnabled(
+                self.get_option('occurrence_highlighting'))
 
         wrap_mode_box = newcb(_("Wrap lines"), 'wrap')
 


### PR DESCRIPTION
Both the spinbox and slabel of the `edgeline_spin` and `occurrence_spin`
widget were not disabled properly when their respective checkbox was
unchecked.