### PR TITLE
PR: Add missing QMessageBox import

### DIFF
--- a/spyder/api/plugins.py
+++ b/spyder/api/plugins.py
@@ -18,7 +18,7 @@ import os
 # Third party imports
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtGui import QCursor
-from qtpy.QtWidgets import QApplication, QMainWindow
+from qtpy.QtWidgets import QApplication, QMainWindow, QMessageBox
 
 # Local imports
 from spyder.config.gui import get_color_scheme


### PR DESCRIPTION
A missing import after the 3.x changes was merged in master
```
    def show_compatibility_message(self, message):
        """Show compatibility message."""
>       messageBox = QMessageBox(self)
E       NameError: name 'QMessageBox' is not defined
```