### PR TITLE
PR: Fix tab does not switch when ctrl is released issue

### DIFF
--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -2185,7 +2185,7 @@ class EditorStack(QWidget):
                         self.tabs_switcher = None
                         return
 
-        super(EditorStack, self).keyPressEvent(event)
+        super(EditorStack, self).keyReleaseEvent(event)
 
 
 class EditorSplitter(QSplitter):

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -22,7 +22,7 @@ from collections import MutableSequence
 from qtpy import is_pyqt46
 from qtpy.compat import getsavefilename
 from qtpy.QtCore import (QByteArray, QFileInfo, QObject, QPoint, QSize, Qt,
-                         QThread, QTimer, Signal, Slot)
+                         QThread, QTimer, Signal, Slot, QEvent)
 from qtpy.QtGui import QFont
 from qtpy.QtWidgets import (QAction, QApplication, QHBoxLayout, QMainWindow,
                             QMessageBox, QMenu, QSplitter, QVBoxLayout,
@@ -1896,6 +1896,7 @@ class EditorStack(QWidget):
         editor.get_completions.connect(introspector.get_completions)
         editor.sig_show_object_info.connect(introspector.show_object_info)
         editor.go_to_definition.connect(introspector.go_to_definition)
+        editor.installEventFilter(self)
 
         finfo = FileInfo(fname, enc, editor, new, self.threadmanager,
                          self.introspector)
@@ -2168,24 +2169,23 @@ class EditorStack(QWidget):
                 editor.insert_text( source.text() )
         event.acceptProposedAction()
 
-    def keyReleaseEvent(self, event):
-        """Reimplement Qt method.
-
+    def eventFilter(self, widget, event):   
+        """
         Handle "most recent used" tab behavior,
         When ctrl is released and tab_switcher is visible, tab will be changed.
-        """
-        if self.tabs_switcher is not None and self.tabs_switcher.isVisible():
-            qsc = get_shortcut(context='Editor', name='Go to next file')
-
-            for key in qsc.split('+'):
-                key = key.lower()
-                if ((key == 'ctrl' and event.key() == Qt.Key_Control) or
-                   (key == 'alt' and event.key() == Qt.Key_Alt)):
-                        self.tabs_switcher.item_selected()
-                        self.tabs_switcher = None
-                        return
-
-        super(EditorStack, self).keyPressEvent(event)
+        """              
+        if event.type() == QEvent.KeyRelease:
+            if (self.tabs_switcher is not None and 
+                self.tabs_switcher.isVisible()):
+                qsc = get_shortcut(context='Editor', name='Go to next file')
+                for key in qsc.split('+'):
+                    key = key.lower()
+                    if ((key == 'ctrl' and event.key() == Qt.Key_Control) or
+                       (key == 'alt' and event.key() == Qt.Key_Alt)):
+                            self.tabs_switcher.item_selected()
+                            self.tabs_switcher = None    
+                            
+        return super(EditorStack, self).eventFilter(widget, event)
 
 
 class EditorSplitter(QSplitter):

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2746,6 +2746,7 @@ class CodeEditor(TextEditBaseWidget):
         """Override Qt method."""
         self.timer_syntax_highlight.start()
         super(CodeEditor, self).keyReleaseEvent(event)
+        event.ignore()
 
     def keyPressEvent(self, event):
         """Reimplement Qt method"""


### PR DESCRIPTION
Fixes #4763

----

It seems like the ctrl key release event never reach the [EditorStack ](https://github.com/spyder-ide/spyder/blob/master/spyder/widgets/editor.py). It seems to be swallowed by the [CodeEditor](https://github.com/spyder-ide/spyder/blob/master/spyder/widgets/sourcecode/codeeditor.py).

The proposed solution to solve this issue it to install an eventFilter on each `editor` added to
the `EditorStack` and to move the code that is in the `keyReleaseEvent` in the `eventFilter` method.

There may be a more elegant way to solve this directly in the CodeEditor class. I can look into it if this approach is preferred.
