### PR TITLE
PR: Prevent potential problems when importing third-party modules

### DIFF
--- a/spyder/app/start.py
+++ b/spyder/app/start.py
@@ -76,6 +76,20 @@ def main():
     else:
         os.environ['QT_SCREEN_SCALE_FACTORS'] = ''
 
+    # Prevent Spyder from crashing in macOS if locale is not defined
+    if sys.platform == 'darwin':
+        LANG = os.environ.get('LANG')
+        LC_ALL = os.environ.get('LC_ALL')
+        if bool(LANG) and not bool(LC_ALL):
+            LC_ALL = LANG
+        elif not bool(LANG) and bool(LC_ALL):
+            LANG = LC_ALL
+        else:
+            LANG = LC_ALL = 'en_US.UTF-8'
+
+        os.environ['LANG'] = LANG
+        os.environ['LC_ALL'] = LC_ALL
+
     if CONF.get('main', 'single_instance') and not options.new_instance \
       and not options.reset_config_files and not running_in_mac_app():
         # Minimal delay (0.1-0.2 secs) to avoid that several

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -386,18 +386,18 @@ def get_supported_types():
     try:
         from numpy import ndarray, matrix, generic
         editable_types += [ndarray, matrix, generic]
-    except ImportError:
+    except:
         pass
     try:
         from pandas import DataFrame, Series, DatetimeIndex
         editable_types += [DataFrame, Series, DatetimeIndex]
-    except ImportError:
+    except:
         pass
     picklable_types = editable_types[:]
     try:
         from spyder.pil_patch import Image
         editable_types.append(Image.Image)
-    except ImportError:
+    except:
         pass
     return dict(picklable=picklable_types, editable=editable_types)
 

--- a/spyder/pyplot.py
+++ b/spyder/pyplot.py
@@ -5,5 +5,5 @@ Importing guiqwt's pyplot module or matplotlib's pyplot
 
 try:
     from guiqwt.pyplot import *
-except (ImportError, AssertionError):
+except:
     from matplotlib.pyplot import *

--- a/spyder/utils/ipython/spyder_kernel.py
+++ b/spyder/utils/ipython/spyder_kernel.py
@@ -328,7 +328,7 @@ class SpyderKernel(IPythonKernel):
         try:
             import numpy
             return isinstance(var, numpy.ndarray)
-        except ImportError:
+        except:
             return False
 
     def _is_image(self, var):
@@ -336,7 +336,7 @@ class SpyderKernel(IPythonKernel):
         try:
             from PIL import Image
             return isinstance(var, Image.Image)
-        except ImportError:
+        except:
             return False
 
     def _is_data_frame(self, var):

--- a/spyder/utils/site/sitecustomize.py
+++ b/spyder/utils/site/sitecustomize.py
@@ -133,7 +133,7 @@ if os.name == 'nt' and PY2:
         except (ValueError, TypeError):
             # Code page number in locale is not valid
             pass
-    except ImportError:
+    except:
         pass
 
 
@@ -173,7 +173,7 @@ try:
     import pyximport
     HAS_PYXIMPORT = True
     pyx_setup_args = {}
-except ImportError:
+except:
     HAS_PYXIMPORT = False
 
 if HAS_PYXIMPORT:
@@ -181,7 +181,7 @@ if HAS_PYXIMPORT:
     try:
         import numpy
         pyx_setup_args['include_dirs'] = numpy.get_include()
-    except ImportError:
+    except:
         pass
 
     # Setup pyximport and enable Cython files reload
@@ -191,7 +191,7 @@ try:
     # Import cython_inline for runfile function
     from Cython.Build.Inline import cython_inline
     HAS_CYTHON = True
-except ImportError:
+except:
     HAS_CYTHON = False
 
 
@@ -200,7 +200,7 @@ except ImportError:
 #==============================================================================
 try:
     import sitecustomize  #analysis:ignore
-except ImportError:
+except:
     pass
 
 
@@ -234,7 +234,7 @@ if os.environ["QT_API"] == 'pyqt':
 #==============================================================================
 try:
     import matplotlib
-except (ImportError, UnicodeDecodeError):
+except:
     matplotlib = None   # analysis:ignore
 
 
@@ -290,7 +290,7 @@ try:
     warnings.filterwarnings(action='ignore', category=RuntimeWarning,
                             module='pandas.formats.format',
                             message=".*invalid value encountered in.*")
-except (ImportError, AttributeError):
+except:
     pass
 
 

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1007,13 +1007,13 @@ class BaseTableView(QTableView):
         try:
             import guiqwt.pyplot   #analysis:ignore
             return True
-        except (ImportError, AssertionError):
+        except:
             try:
                 if 'matplotlib' not in sys.modules:
                     import matplotlib
                     matplotlib.use("Qt4Agg")
                 return True
-            except ImportError:
+            except:
                 QMessageBox.warning(self, _("Import error"),
                                     _("Please install <b>matplotlib</b>"
                                       " or <b>guiqwt</b>."))

--- a/spyder/widgets/variableexplorer/importwizard.py
+++ b/spyder/widgets/variableexplorer/importwizard.py
@@ -60,7 +60,7 @@ class FakeObject(object):
     pass
 try:
     from numpy import ndarray, array
-except ImportError:
+except:
     class ndarray(FakeObject):  # analysis:ignore
         """Fake ndarray"""
         pass
@@ -69,7 +69,7 @@ except ImportError:
 import datetime
 try:
     from dateutil.parser import parse as dateparse
-except ImportError:
+except:
     def dateparse(datestr, dayfirst=True):  # analysis:ignore
         """Just for 'day/month/year' strings"""
         _a, _b, _c = list(map(int, datestr.split('/')))

--- a/spyder/widgets/variableexplorer/importwizard.py
+++ b/spyder/widgets/variableexplorer/importwizard.py
@@ -22,9 +22,11 @@ from qtpy.QtWidgets import (QCheckBox, QDialog, QFrame, QGridLayout, QGroupBox,
                             QSizePolicy, QSpacerItem, QTableView, QTabWidget,
                             QTextEdit, QVBoxLayout, QWidget)
 
+# If pandas fails to import here (for any reason), Spyder
+# will crash at startup.
 try:
     import pandas as pd
-except ImportError:
+except:
     pd = None
 
 # Local import

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -53,7 +53,7 @@ try:
     from numpy.ma import MaskedArray
     from numpy import savetxt as np_savetxt
     from numpy import get_printoptions, set_printoptions
-except ImportError:
+except:
     ndarray = array = matrix = recarray = MaskedArray = np_savetxt = \
     int64 = int32 = float64 = float32 = complex64 = complex128 = FakeObject
 
@@ -81,7 +81,10 @@ def get_numpy_dtype(obj):
 # Pandas support
 #==============================================================================
 if programs.is_module_installed('pandas', PANDAS_REQVER):
-    from pandas import DataFrame, DatetimeIndex, Series
+    try:
+        from pandas import DataFrame, DatetimeIndex, Series
+    except:
+        DataFrame = DatetimeIndex = Series = FakeObject
 else:
     DataFrame = DatetimeIndex = Series = FakeObject      # analysis:ignore
 
@@ -92,7 +95,7 @@ else:
 try:
     from spyder import pil_patch
     Image = pil_patch.Image.Image
-except ImportError:
+except:
     Image = FakeObject  # analysis:ignore
 
 
@@ -102,7 +105,7 @@ except ImportError:
 try:
     import bs4
     NavigableString = bs4.element.NavigableString
-except (ImportError, AttributeError):
+except:
     NavigableString = FakeObject  # analysis:ignore
 
 
@@ -168,7 +171,7 @@ import datetime
 
 try:
     from dateutil.parser import parse as dateparse
-except ImportError:
+except:
     def dateparse(datestr):  # analysis:ignore
         """Just for 'year, month, day' strings"""
         return datetime.datetime( *list(map(int, datestr.split(','))) )


### PR DESCRIPTION
Fixes ContinuumIO/anaconda-issues#3287

----

This also prevents Spyder from crashing in macOS if locale is not defined correctly there.

TODO

- [x] Add locale environment variables to `start.py`