### PR TITLE
PR: Fix shifting code selection issues in the Editor

### DIFF
--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -886,61 +886,66 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         cursor = self.textCursor()
         cursor.beginEditBlock()
         start_pos, end_pos = self.__save_selection()
-        add_linesep = False
-        if to_text_string(cursor.selectedText()):
-            # Check if start_pos is at the start of a block
-            cursor.setPosition(start_pos)
-            cursor.movePosition(QTextCursor.StartOfBlock)
-            start_pos = cursor.position()
-
-            cursor.setPosition(end_pos)
-            # Check if end_pos is at the start of a block: if so, starting
-            # changes from the previous block
-            cursor.movePosition(QTextCursor.StartOfBlock,
-                                QTextCursor.KeepAnchor)
-            if to_text_string(cursor.selectedText()):
-                cursor.movePosition(QTextCursor.NextBlock)
-                end_pos = cursor.position()
-        else:
-            cursor.movePosition(QTextCursor.StartOfBlock)
-            start_pos = cursor.position()
-            cursor.movePosition(QTextCursor.NextBlock)
-            end_pos = cursor.position()
-            # check if on last line
-            if end_pos == start_pos:
-                cursor.movePosition(QTextCursor.End)
-                end_pos = cursor.position()
-                if start_pos == end_pos:
-                    cursor.endEditBlock()
-                    return
-                add_linesep = True
+        last_line = False
+        
+        # ------ Select text
+        
+        # get selection start location
         cursor.setPosition(start_pos)
-        cursor.setPosition(end_pos, QTextCursor.KeepAnchor)
-
-        sel_text = to_text_string(cursor.selectedText())
-        if add_linesep:
-            sel_text += os.linesep
-        cursor.removeSelectedText()
-
-        if after_current_line:
-            text = to_text_string(cursor.block().text())
-            if len(text) == 0:
-                #If the next line is blank
-                sel_text = sel_text[0:-1]
-                sel_text = os.linesep + sel_text
-            if not text:
-                cursor.insertText(sel_text)
-                cursor.endEditBlock()
-                return
-            start_pos += len(text)+1
-            end_pos += len(text)+1
+        cursor.movePosition(QTextCursor.StartOfBlock)
+        start_pos = cursor.position()
+        
+        # get selection end location
+        cursor.setPosition(end_pos)
+        if not cursor.atBlockStart() or end_pos == start_pos:
+            cursor.movePosition(QTextCursor.EndOfBlock)
             cursor.movePosition(QTextCursor.NextBlock)
-            if cursor.position() < start_pos:
-                cursor.movePosition(QTextCursor.End)
-                sel_text = os.linesep + sel_text
-                end_pos -= 1
-        else:
-            cursor.movePosition(QTextCursor.PreviousBlock)
+        end_pos = cursor.position()
+        
+        # check if selection ends on the last line of the document
+        if cursor.atEnd():
+            if not cursor.atBlockStart() or end_pos == start_pos:
+                last_line = True
+                
+        # ------ Stop if at document boundary
+        
+        cursor.setPosition(start_pos)
+        if cursor.atStart() and not after_current_line:
+            # Stop if selection is already at top of the file while moving up
+            cursor.endEditBlock()
+            self.setTextCursor(cursor)
+            self.__restore_selection(start_pos, end_pos)
+            return
+                
+        cursor.setPosition(end_pos, QTextCursor.KeepAnchor)
+        if last_line and after_current_line:
+            # Stop if selection is already at end of the file while moving down
+            cursor.endEditBlock()
+            self.setTextCursor(cursor)
+            self.__restore_selection(start_pos, end_pos)
+            return
+        
+        # ------ Move text
+        
+        sel_text = to_text_string(cursor.selectedText())
+        cursor.removeSelectedText()
+        
+        if after_current_line:  # shift selection down
+            text = to_text_string(cursor.block().text())  
+            sel_text = os.linesep + sel_text[0:-1]  # move linesep at the start
+            cursor.movePosition(QTextCursor.EndOfBlock)
+            start_pos += len(text)+1
+            end_pos += len(text)
+            if not cursor.atEnd():
+                end_pos += 1
+        else:  # shift selection up
+            if last_line:
+                cursor.deletePreviousChar()  # remove last linesep...
+                sel_text = sel_text + os.linesep  # ...and add it to sel_text
+                cursor.movePosition(QTextCursor.StartOfBlock)
+                end_pos += 1
+            else:
+                cursor.movePosition(QTextCursor.PreviousBlock)
             text = to_text_string(cursor.block().text())
             start_pos -= len(text)+1
             end_pos -= len(text)+1

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -890,19 +890,19 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         
         # ------ Select text
         
-        # get selection start location
+        # Get selection start location
         cursor.setPosition(start_pos)
         cursor.movePosition(QTextCursor.StartOfBlock)
         start_pos = cursor.position()
         
-        # get selection end location
+        # Get selection end location
         cursor.setPosition(end_pos)
         if not cursor.atBlockStart() or end_pos == start_pos:
             cursor.movePosition(QTextCursor.EndOfBlock)
             cursor.movePosition(QTextCursor.NextBlock)
         end_pos = cursor.position()
         
-        # check if selection ends on the last line of the document
+        # Check if selection ends on the last line of the document
         if cursor.atEnd():
             if not cursor.atBlockStart() or end_pos == start_pos:
                 last_line = True
@@ -930,18 +930,22 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         sel_text = to_text_string(cursor.selectedText())
         cursor.removeSelectedText()
         
-        if after_current_line:  # shift selection down
+        
+        if after_current_line:
+            # Shift selection down
             text = to_text_string(cursor.block().text())  
-            sel_text = os.linesep + sel_text[0:-1]  # move linesep at the start
+            sel_text = os.linesep + sel_text[0:-1]  # Move linesep at the start
             cursor.movePosition(QTextCursor.EndOfBlock)
             start_pos += len(text)+1
             end_pos += len(text)
             if not cursor.atEnd():
-                end_pos += 1
-        else:  # shift selection up
+                end_pos += 1        
+        else:
+            # Shift selection up
             if last_line:
-                cursor.deletePreviousChar()  # remove last linesep...
-                sel_text = sel_text + os.linesep  # ...and add it to sel_text
+                # Remove the last linesep and add it to the selected text
+                cursor.deletePreviousChar()
+                sel_text = sel_text + os.linesep
                 cursor.movePosition(QTextCursor.StartOfBlock)
                 end_pos += 1
             else:

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -17,6 +17,7 @@ except ImportError:
 # Third party imports
 import pytest
 from qtpy.QtCore import Qt
+from qtpy.QtGui import QTextCursor
 
 # Local imports
 from spyder.utils.fixtures import setup_editor
@@ -81,6 +82,107 @@ def editor_cells_bot(base_editor_bot):
 
 # Tests
 #-------------------------------
+def test_move_current_line_up(editor_bot):
+    editor_stack, editor, qtbot = editor_bot
+        
+    # Move second line up when nothing is selected.
+    editor.go_to_line(2)
+    editor.move_line_up()
+    expected_new_text = ('print(a)\n'
+                         'a = 1\n'
+                         '\n'
+                         'x = 2\n')
+    assert editor.toPlainText() == expected_new_text
+    
+    # Move line up when already at the top.
+    editor.move_line_up()
+    assert editor.toPlainText() == expected_new_text
+    
+    # Move fourth line up when part of the line is selected.
+    editor.go_to_line(4)    
+    editor.moveCursor(QTextCursor.Right, QTextCursor.MoveAnchor)
+    for i in range(2):
+        editor.moveCursor(QTextCursor.Right, QTextCursor.KeepAnchor)
+    editor.move_line_up()
+    expected_new_text = ('print(a)\n'
+                         'a = 1\n'                         
+                         'x = 2\n'
+                         '\n')
+    assert editor.toPlainText()[:] == expected_new_text
+    
+def test_move_current_line_down(editor_bot):
+    editor_stack, editor, qtbot = editor_bot
+        
+    # Move fourth line down when nothing is selected.
+    editor.go_to_line(4)
+    editor.move_line_down()
+    expected_new_text = ('a = 1\n'
+                         'print(a)\n'
+                         '\n'
+                         '\n'
+                         'x = 2')
+    assert editor.toPlainText() == expected_new_text
+    
+    # Move line down when already at the bottom.
+    editor.move_line_down()
+    assert editor.toPlainText() == expected_new_text
+        
+    # Move first line down when part of the line is selected.
+    editor.go_to_line(1)
+    editor.moveCursor(QTextCursor.Right, QTextCursor.MoveAnchor)
+    for i in range(2):
+        editor.moveCursor(QTextCursor.Right, QTextCursor.KeepAnchor)
+    editor.move_line_down()
+    expected_new_text = ('print(a)\n'
+                         'a = 1\n'
+                         '\n'
+                         '\n'
+                         'x = 2')
+    assert editor.toPlainText() == expected_new_text
+    
+def test_move_multiple_lines_up(editor_bot):
+    editor_stack, editor, qtbot = editor_bot
+    
+    # Move second and third lines up.
+    editor.go_to_line(2)
+    cursor = editor.textCursor()
+    cursor.movePosition(QTextCursor.Down, QTextCursor.KeepAnchor)
+    cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor)
+    editor.setTextCursor(cursor)
+    editor.move_line_up()
+    
+    expected_new_text = ('print(a)\n'
+                         '\n'
+                         'a = 1\n'
+                         'x = 2\n')
+    assert editor.toPlainText() == expected_new_text     
+ 
+    # Move first and second lines up (to test already at top condition).
+    editor.move_line_up()
+    assert editor.toPlainText() == expected_new_text
+
+def test_move_multiple_lines_down(editor_bot):
+    editor_stack, editor, qtbot = editor_bot
+    
+    # Move third and fourth lines down.
+    editor.go_to_line(3)
+    cursor = editor.textCursor()
+    cursor.movePosition(QTextCursor.Down, QTextCursor.KeepAnchor)
+    cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor)
+    editor.setTextCursor(cursor)
+    editor.move_line_down()
+    
+    expected_new_text = ('a = 1\n'
+                         'print(a)\n'
+                         '\n'
+                         '\n'
+                         'x = 2')
+    assert editor.toPlainText() == expected_new_text
+    
+    # Move fourht and fifth lines down (to test already at bottom condition).
+    editor.move_line_down()
+    assert editor.toPlainText() == expected_new_text
+    
 def test_run_top_line(editor_bot):
     editor_stack, editor, qtbot = editor_bot
     editor.go_to_line(1) # line number is one based


### PR DESCRIPTION
Fixes #4754

----

**Solves multiple issues with the code for shifting lines vertically in the editor:**
- Solve out of range error when trying to shift up a block of code that is already at the top of the file
- Code remains properly selected after shifting down multiples lines of code
- Code remains properly selected when shifting down a single line of code with an empty line
- Fix various issues when shifting up or down code at the end of the file:
  - when shifting penultimate line down, an extra empty line was added at the end of the file
  - when shifting last line down, an extra empty line was added above and below.
  - when shifting last line up, an extra empty line was added at the end of file