### PR TITLE
PR: Prevent Jedi and Rope to open two previously unopened files simultaneously

### DIFF
--- a/spyder/utils/introspection/manager.py
+++ b/spyder/utils/introspection/manager.py
@@ -143,8 +143,8 @@ class PluginManager(QObject):
                 % (self.info.name, response['name'],
                    str(response['result'])[:100], delta))
             response['info'] = self.info
-            self.introspection_complete.emit(response)
             self.info = None
+            self.introspection_complete.emit(response)            
         if self.pending_request:
             info = self.pending_request
             self.pending_request = None


### PR DESCRIPTION
Fixes #3940

After receiving first response from either rope or jedi,
`self.introspection_complete.emit(response)` caused a delay before
`self.info` was set to `None`. This _sometimes_ allowed the response
from the other plugin to pass through. If the command was to open a file, this resulted in a crash. 

Switching these two lines removes the delay in the attribution of `None` value to self.info, which allows to systematically block the second response from the other introspection plugin after the first one has passed through.