### PR TITLE
PR: Fix some code folding related errors

### DIFF
--- a/spyder/utils/editor.py
+++ b/spyder/utils/editor.py
@@ -18,6 +18,8 @@ from qtpy.QtGui import QColor, QTextCursor, QTextBlock, QTextDocument, QCursor
 
 from qtpy.QtWidgets import QApplication
 
+from spyder.py3compat import to_text_string
+
 
 def drift_color(base_color, factor=110):
     """
@@ -117,7 +119,7 @@ class TextHelper(object):
         except TypeError:
             self._editor_ref = editor
 
-    def goto_line(self, line, column=0, move=True):
+    def goto_line(self, line, column=0, move=True, word=''):
         """
         Moves the text cursor to the specified position.
 
@@ -125,6 +127,7 @@ class TextHelper(object):
         :param column: Optional column number. Default is 0 (start of line).
         :param move: True to move the cursor. False will return the cursor
                      without setting it on the editor.
+        :param word: Highlight the word, when moving to the line.
         :return: The new text cursor
         :rtype: QtGui.QTextCursor
         """
@@ -136,6 +139,15 @@ class TextHelper(object):
             block = text_cursor.block()
             self.unfold_if_colapsed(block)
             self._editor.setTextCursor(text_cursor)
+
+            if self._editor.isVisible():
+                self._editor.centerCursor()
+            else:
+                self._editor.focus_in.connect(
+                        self._editor.center_cursor_on_next_focus)
+
+            if word and to_text_string(word) in to_text_string(block.text()):
+                self._editor.find(word, QTextDocument.FindCaseSensitively)
         return text_cursor
 
     def unfold_if_colapsed(self, block):
@@ -395,7 +407,7 @@ class TextHelper(object):
 
     def _move_cursor_to(self, line):
         cursor = self._editor.textCursor()
-        block = self._editor.document().findBlockByNumber(line)
+        block = self._editor.document().findBlockByNumber(line-1)
         cursor.setPosition(block.position())
         return cursor
 

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -55,6 +55,7 @@ from spyder.utils import encoding, sourcecode
 from spyder.utils.dochelpers import getobj
 from spyder.utils.qthelpers import add_actions, create_action, mimedata2url
 from spyder.utils.sourcecode import ALL_LANGUAGES, CELL_LANGUAGES
+from spyder.utils.editor import TextHelper
 from spyder.widgets.editortools import PythonCFM
 from spyder.widgets.sourcecode.base import TextEditBaseWidget
 from spyder.widgets.sourcecode.kill_ring import QtKillRing
@@ -271,6 +272,8 @@ class CodeEditor(TextEditBaseWidget):
 
         # Caret (text cursor)
         self.setCursorWidth( CONF.get('main', 'cursor/width') )
+
+        self.text_helper = TextHelper(self)
 
         self._panels = PanelsManager(self)
 
@@ -1314,15 +1317,7 @@ class CodeEditor(TextEditBaseWidget):
 
     def go_to_line(self, line, word=''):
         """Go to line number *line* and eventually highlight it"""
-        block = self.document().findBlockByNumber(line-1)
-        self.setTextCursor(QTextCursor(block))
-        if self.isVisible():
-            self.centerCursor()
-        else:
-            self.focus_in.connect(self.center_cursor_on_next_focus)
-        self.horizontalScrollBar().setValue(0)
-        if word and to_text_string(word) in to_text_string(block.text()):
-            self.find(word, QTextDocument.FindCaseSensitively)
+        self.text_helper.goto_line(line, move=True, word=word)
 
     def exec_gotolinedialog(self):
         """Execute the GoToLineDialog dialog box"""

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -1043,9 +1043,10 @@ class CodeEditor(TextEditBaseWidget):
 
         while block.isValid() and top < event.pos().y():
             block = block.next()
-            top = bottom
-            bottom = top + self.blockBoundingRect(block).height()
-            line_number += 1
+            if block.isVisible():  # skip collapsed blocks
+                top = bottom
+                bottom = top + self.blockBoundingRect(block).height()
+                line_number += 1
 
         return line_number
 

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -79,6 +79,27 @@ def editor_cells_bot(base_editor_bot):
     qtbot.addWidget(editor_stack)
     return editor_stack, finfo.editor, qtbot
 
+
+@pytest.fixture
+def editor_folding_bot(base_editor_bot):
+    """
+    Setup CodeEditor with some text usepful for folding related tests.
+    """
+    editor_stack, qtbot = base_editor_bot
+    text = ('# dummy test file\n'
+            'class a():\n'  # fold-block level-0
+            '    self.b = 1\n'
+            '    print(self.b)\n'
+            '    \n'
+            )
+    finfo = editor_stack.new('foo.py', 'utf-8', text)
+
+    find_replace = FindReplace(None, enable_replace=True)
+    editor_stack.set_find_widget(find_replace)
+    find_replace.set_editor(finfo.editor)
+    qtbot.addWidget(editor_stack)
+    return editor_stack, finfo.editor, find_replace, qtbot
+
 # Tests
 #-------------------------------
 def test_run_top_line(editor_bot):
@@ -208,6 +229,44 @@ def test_advance_cell(editor_cells_bot):
     # advance to 3rd cell
     editor_stack.advance_cell()
     assert editor.get_cursor_line_column() == (6, 0)
+
+
+def test_unfold_when_searching(editor_folding_bot):
+    editor_stack, editor, finder, qtbot = editor_folding_bot
+
+    folding_panel = editor.panels.get('FoldingPanel')
+
+    line_search = editor.document().findBlockByLineNumber(3)
+
+    # fold region
+    block = editor.document().findBlockByLineNumber(1)
+    folding_panel.toggle_fold_trigger(block)
+
+    assert not line_search.isVisible()
+
+    # unfolded when searching
+    finder.show()
+    qtbot.keyClicks(finder.search_text, 'print')
+    qtbot.keyPress(finder.search_text, Qt.Key_Return)
+    assert line_search.isVisible()
+
+
+def test_unfold_goto(editor_folding_bot):
+    editor_stack, editor, finder, qtbot = editor_folding_bot
+
+    folding_panel = editor.panels.get('FoldingPanel')
+
+    line_goto = editor.document().findBlockByLineNumber(3)
+
+    # fold region
+    block = editor.document().findBlockByLineNumber(1)
+    folding_panel.toggle_fold_trigger(block)
+
+    assert not line_goto.isVisible()
+
+    # unfolded when goto
+    editor.go_to_line(4)
+    assert line_goto.isVisible()
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -83,7 +83,7 @@ def editor_cells_bot(base_editor_bot):
 @pytest.fixture
 def editor_folding_bot(base_editor_bot):
     """
-    Setup CodeEditor with some text usepful for folding related tests.
+    Setup CodeEditor with some text useful for folding related tests.
     """
     editor_stack, qtbot = base_editor_bot
     text = ('# dummy test file\n'
@@ -233,15 +233,12 @@ def test_advance_cell(editor_cells_bot):
 
 def test_unfold_when_searching(editor_folding_bot):
     editor_stack, editor, finder, qtbot = editor_folding_bot
-
     folding_panel = editor.panels.get('FoldingPanel')
-
     line_search = editor.document().findBlockByLineNumber(3)
 
     # fold region
     block = editor.document().findBlockByLineNumber(1)
     folding_panel.toggle_fold_trigger(block)
-
     assert not line_search.isVisible()
 
     # unfolded when searching
@@ -253,15 +250,12 @@ def test_unfold_when_searching(editor_folding_bot):
 
 def test_unfold_goto(editor_folding_bot):
     editor_stack, editor, finder, qtbot = editor_folding_bot
-
     folding_panel = editor.panels.get('FoldingPanel')
-
     line_goto = editor.document().findBlockByLineNumber(3)
 
     # fold region
     block = editor.document().findBlockByLineNumber(1)
     folding_panel.toggle_fold_trigger(block)
-
     assert not line_goto.isVisible()
 
     # unfolded when goto


### PR DESCRIPTION
Fixes:  #4778
Fixes: #4777 

Related to #4732 (I only unify goto_line, some functions missing)

Should I completely delete the `Codeeditor.go_to_line()` and change its callings by `TextHelper(editor).goto_line()`?

~I'm also planing to merge the remaining functions of `TextHelper` that are duplicated in the `CodeEditor`~ to be addressed after improving Editor coverage.