### PR TITLE
PR: Make highlighting colors in the IPython Console match those used in the Spyder Editor

### DIFF
--- a/spyder/utils/ipython/style.py
+++ b/spyder/utils/ipython/style.py
@@ -49,7 +49,6 @@ def create_qss_style(color_scheme):
         in_prompt_color = 'lime'
         out_prompt_color = 'red'
     background_color = color_scheme['background']
-    selection_background_color = '#ccc'
     error_color = 'red'
     in_prompt_number_font_weight = 'bold'
     out_prompt_number_font_weight = 'bold'

--- a/spyder/utils/ipython/style.py
+++ b/spyder/utils/ipython/style.py
@@ -59,7 +59,6 @@ def create_qss_style(color_scheme):
     sheet = """QPlainTextEdit, QTextEdit, ControlWidget {{
                                           color: {} ;
                                           background-color: {};
-                                          selection-background-color: {}
                                          }}
               .error {{ color: {}; }}
               .in-prompt {{ color: {}; }}
@@ -70,7 +69,6 @@ def create_qss_style(color_scheme):
               """
 
     sheet_formatted = sheet.format(font_color, background_color,
-                                   selection_background_color,
                                    error_color,
                                    in_prompt_color, in_prompt_color,
                                    in_prompt_number_font_weight,

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -12,11 +12,13 @@ import ast
 import uuid
 
 from qtpy.QtCore import Signal
+from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QMessageBox
 from spyder.config.base import _
 from spyder.config.gui import config_shortcut
 from spyder.py3compat import to_text_string
 from spyder.utils import programs
+from spyder.utils import syntaxhighlighters as sh
 from spyder.utils.ipython.style import create_qss_style, create_style_class
 from spyder.widgets.ipythonconsole import (ControlWidget, DebuggingWidget,
                                            HelpWidget, NamepaceBrowserWidget,
@@ -70,6 +72,9 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget):
         # To save kernel replies in silent execution
         self._kernel_reply = None
 
+        color_scheme = kw['config']['JupyterWidget']['syntax_style']
+        self.set_bracket_matcher_color_scheme(color_scheme)
+                
     #---- Public API ----------------------------------------------------------
     def set_exit_callback(self):
         """Set exit callback for this shell."""
@@ -110,9 +115,15 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget):
             return
         else:
             self.silent_exec_method(code)
+            
+    def set_bracket_matcher_color_scheme(self, color_scheme):
+        bsh = sh.BaseSH(parent=self, color_scheme=color_scheme)
+        mpcolor = bsh.get_matched_p_color()
+        self._bracket_matcher.format.setBackground(mpcolor)
 
     def set_color_scheme(self, color_scheme):
         """Set color scheme of the shell."""
+        self.set_bracket_matcher_color_scheme(color_scheme)
         self.style_sheet, dark_color = create_qss_style(color_scheme)
         self.syntax_style = color_scheme
         self._style_sheet_changed()

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -12,7 +12,6 @@ import ast
 import uuid
 
 from qtpy.QtCore import Signal
-from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QMessageBox
 from spyder.config.base import _
 from spyder.config.gui import config_shortcut

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -71,7 +71,9 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget):
         # To save kernel replies in silent execution
         self._kernel_reply = None
 
-        # To set the color of the matched parentheses
+        # Set the color of the matched parentheses here since the qtconsole
+        # uses a hard-coded value that is not modified when the color scheme is
+        # set in the qtconsole constructor. See issue #4806.   
         self.set_bracket_matcher_color_scheme(self.syntax_style)
                 
     #---- Public API ----------------------------------------------------------

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -71,8 +71,8 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget):
         # To save kernel replies in silent execution
         self._kernel_reply = None
 
-        color_scheme = kw['config']['JupyterWidget']['syntax_style']
-        self.set_bracket_matcher_color_scheme(color_scheme)
+        # To set the color of the matched parentheses
+        self.set_bracket_matcher_color_scheme(self.syntax_style)
                 
     #---- Public API ----------------------------------------------------------
     def set_exit_callback(self):
@@ -116,6 +116,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget):
             self.silent_exec_method(code)
             
     def set_bracket_matcher_color_scheme(self, color_scheme):
+        """Set color scheme for matched parentheses."""
         bsh = sh.BaseSH(parent=self, color_scheme=color_scheme)
         mpcolor = bsh.get_matched_p_color()
         self._bracket_matcher.format.setBackground(mpcolor)


### PR DESCRIPTION
Fixes #4806

----

- Changes in `style.py` is to let the text highlighting color in the IPython console to be the same as for the Spyder main application instead of using the light gray color that was hard-coded.
- Changes in `shell.py` is to set the _matched-bracket_ highlighting color to the color defined in Spyder
preferences instead of using the hard coded light gray color.