### PR TITLE
PR: Save a reference to messagebox in EditorStack to avoid memory to be freed.

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -672,6 +672,29 @@ def test_open_files_in_new_editor_window(main_window, qtbot):
 
 
 @flaky(max_runs=3)
+def test_close_when_file_is_changed(main_window, qtbot):
+    """Test closing spyder when there is a file with modifications open."""
+    # Wait until the window is fully up
+    shell = main_window.ipyconsole.get_current_shellwidget()
+    qtbot.waitUntil(lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
+
+    # Load test file
+    test_file = osp.join(LOCATION, 'script.py')
+    main_window.editor.load(test_file)
+    editorstack = main_window.editor.get_current_editorstack()
+    editor = editorstack.get_current_editor()
+    editor.document().setModified(True)
+
+    # Close.main-window
+    QTimer.singleShot(1000, lambda: close_save_message_box(qtbot))
+    main_window.close()
+
+    # Wait for the segfault
+    qtbot.wait(3000)
+
+
+
+@flaky(max_runs=3)
 def test_maximize_minimize_plugins(main_window, qtbot):
     """Test that the maximize button is working correctly."""
     # Set focus to the Editor

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -672,6 +672,8 @@ def test_open_files_in_new_editor_window(main_window, qtbot):
 
 
 @flaky(max_runs=3)
+@pytest.mark.skipif(PYQT_WHEEL,
+                    reason="It times out sometimes on PyQt wheels")
 def test_close_when_file_is_changed(main_window, qtbot):
     """Test closing spyder when there is a file with modifications open."""
     # Wait until the window is fully up

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -556,6 +556,9 @@ class EditorStack(QWidget):
         #For opening last closed tabs
         self.last_closed_files = []
 
+        # Reference to save msgbox and avoid memory to be freed.
+        self.msgbox = None
+
     @Slot()
     def show_in_external_file_explorer(self, fnames=None):
         """Show file in external file explorer"""
@@ -1424,11 +1427,17 @@ class EditorStack(QWidget):
                 if not self.save():
                     return False
             elif finfo.editor.document().isModified():
-                answer = QMessageBox.question(self, self.title,
-                            _("<b>%s</b> has been modified."
-                              "<br>Do you want to save changes?"
-                              ) % osp.basename(finfo.filename),
-                            buttons)
+
+                self.msgbox = QMessageBox(
+                        QMessageBox.Question,
+                        self.title,
+                        _("<b>%s</b> has been modified."
+                          "<br>Do you want to save changes?"
+                         ) % osp.basename(finfo.filename),
+                          buttons,
+                          parent=self)
+
+                answer = self.msgbox.exec_()
                 if answer == QMessageBox.Yes:
                     if not self.save():
                         return False
@@ -1488,11 +1497,15 @@ class EditorStack(QWidget):
             self._refresh_outlineexplorer(index)
             return True
         except EnvironmentError as error:
-            QMessageBox.critical(self, _("Save"),
-                                 _("<b>Unable to save file '%s'</b>"
-                                   "<br><br>Error message:<br>%s"
-                                   ) % (osp.basename(finfo.filename),
-                                        str(error)))
+            self.msgbox = QMessageBox(
+                    QMessageBox.Critical,
+                    _("Save"),
+                    _("<b>Unable to save file '%s'</b>"
+                      "<br><br>Error message:<br>%s"
+                      ) % (osp.basename(finfo.filename),
+                                        str(error)),
+                      self)
+            self.msgbox.exec_()
             return False
 
     def file_saved_in_other_editorstack(self, index, filename):
@@ -1577,11 +1590,15 @@ class EditorStack(QWidget):
                 self.plugin_load.emit(filename)
                 return True
             except EnvironmentError as error:
-                QMessageBox.critical(self, _("Save"),
-                                     _("<b>Unable to save file '%s'</b>"
-                                       "<br><br>Error message:<br>%s"
-                                       ) % (osp.basename(finfo.filename),
-                                            str(error)))
+                self.msgbox = QMessageBox(
+                    QMessageBox.Critical,
+                    _("Save"),
+                    _("<b>Unable to save file '%s'</b>"
+                      "<br><br>Error message:<br>%s"
+                      ) % (osp.basename(finfo.filename),
+                                        str(error)),
+                      self)
+                self.msgbox.exec_()
         else:
             return False
 
@@ -1750,12 +1767,16 @@ class EditorStack(QWidget):
 
         elif not osp.isfile(finfo.filename):
             # File doesn't exist (removed, moved or offline):
-            answer = QMessageBox.warning(self, self.title,
-                                _("<b>%s</b> is unavailable "
-                                  "(this file may have been removed, moved "
-                                  "or renamed outside Spyder)."
-                                  "<br>Do you want to close it?") % name,
-                                QMessageBox.Yes | QMessageBox.No)
+            self.msgbox = QMessageBox(
+                    QMessageBox.Warning,
+                    self.title,
+                    _("<b>%s</b> is unavailable "
+                      "(this file may have been removed, moved "
+                      "or renamed outside Spyder)."
+                      "<br>Do you want to close it?") % name,
+                    QMessageBox.Yes | QMessageBox.No,
+                    self)
+            answer = self.msgbox.exec_()
             if answer == QMessageBox.Yes:
                 self.close_file(index)
             else:
@@ -1769,12 +1790,15 @@ class EditorStack(QWidget):
             if to_text_string(lastm.toString()) \
                != to_text_string(finfo.lastmodified.toString()):
                 if finfo.editor.document().isModified():
-                    answer = QMessageBox.question(self,
-                                self.title,
-                                _("<b>%s</b> has been modified outside Spyder."
-                                  "<br>Do you want to reload it and lose all "
-                                  "your changes?") % name,
-                                QMessageBox.Yes | QMessageBox.No)
+                    self.msgbox = QMessageBox(
+                        QMessageBox.Question,
+                        self.title,
+                        _("<b>%s</b> has been modified outside Spyder."
+                          "<br>Do you want to reload it and lose all "
+                          "your changes?") % name,
+                        QMessageBox.Yes | QMessageBox.No,
+                        self)
+                    answer = self.msgbox.exec_()  
                     if answer == QMessageBox.Yes:
                         self.reload(index)
                     else:
@@ -1876,11 +1900,15 @@ class EditorStack(QWidget):
         finfo = self.data[index]
         filename = finfo.filename
         if finfo.editor.document().isModified():
-            answer = QMessageBox.warning(self, self.title,
-                                _("All changes to <b>%s</b> will be lost."
-                                  "<br>Do you want to revert file from disk?"
-                                  ) % osp.basename(filename),
-                                  QMessageBox.Yes|QMessageBox.No)
+            self.msgbox = QMessageBox(
+                    QMessageBox.Warning,
+                    self.title,
+                    _("All changes to <b>%s</b> will be lost."
+                      "<br>Do you want to revert file from disk?"
+                      ) % osp.basename(filename),
+                    QMessageBox.Yes | QMessageBox.No,
+                    self)
+            answer = self.msgbox.exec_()  
             if answer != QMessageBox.Yes:
                 return
         self.reload(index)
@@ -2032,11 +2060,15 @@ class EditorStack(QWidget):
         if self.isVisible() and self.checkeolchars_enabled \
            and sourcecode.has_mixed_eol_chars(text):
             name = osp.basename(filename)
-            QMessageBox.warning(self, self.title,
-                                _("<b>%s</b> contains mixed end-of-line "
-                                  "characters.<br>Spyder will fix this "
-                                  "automatically.") % name,
-                                QMessageBox.Ok)
+            self.msgbox = QMessageBox(
+                    QMessageBox.Warning,
+                    self.title,
+                    _("<b>%s</b> contains mixed end-of-line "
+                      "characters.<br>Spyder will fix this "
+                      "automatically.") % name,
+                    QMessageBox.Ok,
+                    self)
+            self.msgbox.exec_()
             self.set_os_eol_chars(index)
         self.is_analysis_done = False
         return finfo


### PR DESCRIPTION
Fixes: #4453 
Fixes: #4442 

I tried different solutions, like returning the focus, or checking if the widget is alive, but didn't work

This solution works better, and I think that's a cleaner solution (thanks @goanpeca for the idea)

Only two of the message box was related two the errors mentioned above, but I also change the others because they could raise the same error (but that use cases are less common)