### PR TITLE
PR: Preserve order when saving/loading files from a project.

### DIFF
--- a/spyder/widgets/projects/tests/test_project.py
+++ b/spyder/widgets/projects/tests/test_project.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+#
+"""
+Tests for __init__.py
+"""
+
+# Test library imports
+import pytest
+
+# Local imports
+from spyder.widgets.projects import EmptyProject
+
+
+@pytest.fixture(scope='session')
+def project_test(tmpdir_factory):
+    """
+    Fixture for create a temporary project (mdw).
+
+    Returns:
+        str: Path of temporary project dir.
+    """
+    p = tmpdir_factory.mktemp("test_project")
+    path = str(p)
+    project = EmptyProject(path)
+    return path, project
+
+
+def test_empty_project(project_test):
+    path, project = project_test
+    assert project.root_path == path
+
+if __name__ == "__main__":
+    pytest.main()

--- a/spyder/widgets/projects/tests/test_project.py
+++ b/spyder/widgets/projects/tests/test_project.py
@@ -4,7 +4,7 @@
 # Licensed under the terms of the MIT License
 #
 """
-Tests for __init__.py
+Tests for __init__.py.
 """
 
 # Test library imports
@@ -21,10 +21,11 @@ from spyder.widgets.projects.config import (CODESTYLE, WORKSPACE, ENCODING,
 @pytest.fixture(scope='session')
 def project_test(tmpdir_factory):
     """
-    Fixture for create a temporary project (mdw).
+    Fixture for create a temporary project.
 
     Returns:
-        str: Path of temporary project dir.
+        project_dir: fixture of temporary project dir.
+        project: EmptyProject object.
     """
     project_dir = tmpdir_factory.mktemp("test_project")
     project = EmptyProject(str(project_dir))
@@ -32,6 +33,7 @@ def project_test(tmpdir_factory):
 
 
 def test_empty_project(project_test):
+    """Test creation of anEmpy project, and its configuration files."""
     project_dir, project = project_test
     assert project.root_path == str(project_dir)
 
@@ -46,6 +48,10 @@ def test_empty_project(project_test):
 
 
 def test_set_load_recent_files(project_test):
+    """Test saving and loading files from the configuration.
+
+    Saving/loading should preserved the order, and remove duplicates.
+    """
     project_dir, project = project_test
 
     # Create some files for testing

--- a/spyder/widgets/projects/tests/test_project.py
+++ b/spyder/widgets/projects/tests/test_project.py
@@ -26,15 +26,14 @@ def project_test(tmpdir_factory):
     Returns:
         str: Path of temporary project dir.
     """
-    p = tmpdir_factory.mktemp("test_project")
-    path = str(p)
-    project = EmptyProject(path)
-    return path, project
+    project_dir = tmpdir_factory.mktemp("test_project")
+    project = EmptyProject(str(project_dir))
+    return project_dir, project
 
 
 def test_empty_project(project_test):
-    path, project = project_test
-    assert project.root_path == path
+    project_dir, project = project_test
+    assert project.root_path == str(project_dir)
 
     # Assert Project onfigs
     conf_files = project.get_conf_files()
@@ -44,6 +43,28 @@ def test_empty_project(project_test):
 
         # assert configurations files
         assert osp.exists(project_config.filename())
+
+
+def test_set_load_recent_files(project_test):
+    project_dir, project = project_test
+
+    # Create some files for testing
+    files_paths = []
+    for f in ['a.py', 'b.py', 'c.py']:
+        file_ = project_dir.join(f)
+        file_.write('# Some dummy content')
+        files_paths.append(str(file_))
+
+    # setting and loading
+    project.set_recent_files(files_paths[:])
+    assert project.get_recent_files() == files_paths
+
+    # adding a duplicate elemnent
+    files_paths_duplicate = files_paths + [files_paths[0]]
+    assert len(files_paths_duplicate) == len(files_paths) + 1
+
+    project.set_recent_files(files_paths_duplicate[:])
+    assert project.get_recent_files() == files_paths
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/projects/tests/test_project.py
+++ b/spyder/widgets/projects/tests/test_project.py
@@ -9,9 +9,13 @@ Tests for __init__.py
 
 # Test library imports
 import pytest
+import os.path as osp
 
 # Local imports
 from spyder.widgets.projects import EmptyProject
+
+from spyder.widgets.projects.config import (CODESTYLE, WORKSPACE, ENCODING,
+                                            VCS)
 
 
 @pytest.fixture(scope='session')
@@ -31,6 +35,16 @@ def project_test(tmpdir_factory):
 def test_empty_project(project_test):
     path, project = project_test
     assert project.root_path == path
+
+    # Assert Project onfigs
+    conf_files = project.get_conf_files()
+    for dir_ in [CODESTYLE, WORKSPACE, ENCODING, VCS]:
+        assert dir_ in conf_files
+        project_config = conf_files[dir_]
+
+        # assert configurations files
+        assert osp.exists(project_config.filename())
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/widgets/projects/type/__init__.py
+++ b/spyder/widgets/projects/type/__init__.py
@@ -9,6 +9,7 @@
 
 import os
 import os.path as osp
+from collections import OrderedDict
 
 from spyder.config.base import _
 from spyder.py3compat import to_text_string
@@ -70,7 +71,7 @@ class BaseProject(object):
             if not os.path.isfile(recent_file):
                 recent_files.remove(recent_file)
         self.CONF[WORKSPACE].set('main', 'recent_files',
-                                 list(set(recent_files)))
+                                 list(OrderedDict.fromkeys(recent_files)))
 
     def get_recent_files(self):
         """Return a list of files opened by the project."""
@@ -79,7 +80,7 @@ class BaseProject(object):
         for recent_file in recent_files[:]:
             if not os.path.isfile(recent_file):
                 recent_files.remove(recent_file)
-        return list(set(recent_files))
+        return list(OrderedDict.fromkeys(recent_files))
 
     def create_project_config_files(self):
         """ """


### PR DESCRIPTION
Fixes: #4839 

When saving loading files from project configuration the order wasn't preserved, `set` doesn't preserve the order (except in python3.6).

Searching I found that using `collections.OrderedDict` is maybe the best way to delete duplicates and preserve order regardless the python interpreter implementation.

