### PR TITLE
PR: Add a button in the Variable Explorer toolbar to reset namespace

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -144,6 +144,7 @@ DEFAULTS = [
               'use_pager': False,
               'show_calltips': True,
               'ask_before_closing': False,
+              'show_reset_namespace_warning': True,
               'buffer_size': 500,
               'pylab': True,
               'pylab/autoload': False,

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -301,11 +301,10 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         ask_box = newcb(_("Ask for confirmation before closing"),
                         'ask_before_closing')
         reset_namespace_box = newcb(
-                _("Ask for confirmation before reseting the IPython "
-                  "console namespace"), 'show_reset_namespace_warning',
+                _("Ask for confirmation before resetting the namespace."),
+                'show_reset_namespace_warning',
                 tip=_("This option lets you hide the warning message shown\n"
-                      "when reseting the IPython console namespace from\n"
-                      "the Spyder GUI"))
+                      "when resetting the namespace from Spyder."))
 
         interface_layout = QVBoxLayout()
         interface_layout.addWidget(banner_box)

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -303,8 +303,8 @@ class IPythonConsoleConfigPage(PluginConfigPage):
                 _("Ask for confirmation before reseting the IPython "
                   "console namespace"), 'show_reset_namespace_warning',
                 tip=_("This option lets you hide the warning message shown\n"
-                      "when reseting the IPython console namespace from the\n"
-                      "variable explorer 'reset namespace' button."))
+                      "when reseting the IPython console namespace from\n"
+                      "the Spyder GUI"))
 
         interface_layout = QVBoxLayout()
         interface_layout.addWidget(banner_box)

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -299,12 +299,19 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         calltips_box = newcb(_("Display balloon tips"), 'show_calltips')
         ask_box = newcb(_("Ask for confirmation before closing"),
                         'ask_before_closing')
+        reset_namespace_box = newcb(
+                _("Ask for confirmation before reseting the IPython "
+                  "console namespace"), 'show_reset_namespace_warning',
+                tip=_("This option lets you hide the warning message shown\n"
+                      "when reseting the IPython console namespace from the\n"
+                      "variable explorer 'reset namespace' button."))
 
         interface_layout = QVBoxLayout()
         interface_layout.addWidget(banner_box)
         interface_layout.addWidget(pager_box)
         interface_layout.addWidget(calltips_box)
         interface_layout.addWidget(ask_box)
+        interface_layout.addWidget(reset_namespace_box)
         interface_group.setLayout(interface_layout)
 
         comp_group = QGroupBox(_("Completion Type"))

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -919,9 +919,9 @@ class IPythonConsole(SpyderPluginWidget):
                     sw.silent_execute('%clear')
                     sw.silent_execute(
                         'get_ipython().kernel.close_all_mpl_figures()')
-                    sw.reset_namespace(force=True)
+                    sw.reset_namespace(warning=False, silent=True)
                 elif current_client and clear_variables:
-                    sw.reset_namespace(force=True)
+                    sw.reset_namespace(warning=False, silent=True)
                 sw.execute(to_text_string(to_text_string(lines)))
             self.activateWindow()
             self.get_current_client().get_control().setFocus()

--- a/spyder/plugins/tests/test_ipythonconsole.py
+++ b/spyder/plugins/tests/test_ipythonconsole.py
@@ -468,7 +468,7 @@ def test_clear_and_reset_magics_dbg(ipyconsole, qtbot):
     qtbot.wait(500)
     assert shell.get_value('bb') == 10
 
-    shell.reset_namespace(force=True)
+    shell.reset_namespace(warning=False, silent=True)
     qtbot.wait(1000)
 
     qtbot.keyClicks(control, '!bb')

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -262,7 +262,7 @@ the sympy module (e.g. plot)
                 # namespacebrowser table when the reset is done silently. When
                 # silent is False, something is written in the console,
                 # which trigger a refresh of the variable table automatically.
-                # See PR #4885 
+                # See PR #4885
             else:
                 self.execute("%reset -f")
 

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -42,7 +42,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget):
     sig_var_properties = Signal(object)
     sig_show_syspath = Signal(object)
     sig_show_env = Signal(object)
-    sig_namespace_reseted = Signal()
+    sig_namespace_reseted_silently = Signal()
 
     # For DebuggingWidget
     sig_pdb_step = Signal(str, int)
@@ -257,7 +257,12 @@ the sympy module (e.g. plot)
         else:
             if silent:
                 self.silent_execute("%reset -f")
-                self.sig_namespace_reseted.emit()
+                self.sig_namespace_reseted_silently.emit()
+                # This signal is needed to force a refresh of the
+                # namespacebrowser table when the reset is done silently. When
+                # silent is False, something is written in the console,
+                # which trigger a refresh of the variable table automatically.
+                # See PR #4885 
             else:
                 self.execute("%reset -f")
 

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -201,8 +201,12 @@ class NamespaceBrowser(QWidget):
                                            text=_("Save data as..."),
                                            icon=ima.icon('filesaveas'),
                                            triggered=self.save_data)
+        reset_namespace_button = create_toolbutton(
+                self, text=_("Reset the namespace"),
+                icon=ima.icon('editclear'), triggered=self.reset_namespace)
 
-        toolbar += [load_button, self.save_button, save_as_button]
+        toolbar += [load_button, self.save_button, save_as_button,
+                    reset_namespace_button]
         
         self.exclude_private_action = create_action(self,
                 _("Exclude private references"),
@@ -450,6 +454,11 @@ class NamespaceBrowser(QWidget):
                                        "<br><br>Error message:<br>%s"
                                        ) % (self.filename, error_message))
             self.refresh_table()
+            
+    @Slot()
+    def reset_namespace(self):
+        self.shellwidget.reset_namespace(force=True)
+        self.refresh_table()
             
     @Slot()
     def save_data(self, filename=None):

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -28,6 +28,7 @@ except ImportError:
     serialize_object = None
 
 # Local imports
+from spyder.config.main import CONF
 from spyder.config.base import _, get_supported_types
 from spyder.py3compat import is_text_string, getcwd, to_text_string
 from spyder.utils import encoding
@@ -41,6 +42,7 @@ from spyder.widgets.variableexplorer.collectionseditor import (
     RemoteCollectionsEditorTableView)
 from spyder.widgets.variableexplorer.importwizard import ImportWizard
 from spyder.widgets.variableexplorer.utils import REMOTE_SETTINGS
+from spyder.widgets.helperwidgets import MessageCheckBox
 
 
 SUPPORTED_TYPES = get_supported_types()
@@ -457,8 +459,30 @@ class NamespaceBrowser(QWidget):
             
     @Slot()
     def reset_namespace(self):
-        self.shellwidget.reset_namespace(force=True)
-        self.refresh_table()
+        section, option = 'ipython_console', 'show_reset_namespace_warning'
+        show_reset_namespace_warning = CONF.get(section, option)        
+        if show_reset_namespace_warning:
+            box = MessageCheckBox(icon=QMessageBox.Warning, parent=self)
+            box.setWindowTitle(_("Reset namespace"))
+            box.set_checkbox_text(_("Don't show again."))
+            box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+            box.setDefaultButton(QMessageBox.No)            
+            
+            box.set_checked(False)
+            box.set_check_visible(True)
+            box.setText(_("Once deleted, variables cannot be recovered. "
+                          "Proceed?"))
+            
+            answer = box.exec_()           
+            if answer == QMessageBox.Yes:
+                self.shellwidget.reset_namespace(force=True)
+                self.refresh_table()
+                
+            # Update checkbox based on user interaction
+            CONF.set(section, option, not box.is_checked())
+        else:
+            self.shellwidget.reset_namespace(force=True)
+            self.refresh_table()
             
     @Slot()
     def save_data(self, filename=None):

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -29,6 +29,7 @@ except ImportError:
 
 # Local imports
 from spyder.config.base import _, get_supported_types
+from spyder.config.main import CONF
 from spyder.py3compat import is_text_string, getcwd, to_text_string
 from spyder.utils import encoding
 from spyder.utils import icon_manager as ima
@@ -180,7 +181,6 @@ class NamespaceBrowser(QWidget):
         """Bind shellwidget instance to namespace browser"""
         self.shellwidget = shellwidget
         shellwidget.set_namespacebrowser(self)
-        shellwidget.sig_namespace_reseted_silently.connect(self.refresh_table)
 
     def setup_toolbar(self, exclude_private, exclude_uppercase,
                       exclude_capitalized, exclude_unsupported):
@@ -456,7 +456,8 @@ class NamespaceBrowser(QWidget):
 
     @Slot()
     def reset_namespace(self):
-        self.shellwidget.reset_namespace(silent=True)
+        warning = CONF.get('ipython_console', 'show_reset_namespace_warning')
+        self.shellwidget.reset_namespace(silent=True, warning=warning)
 
     @Slot()
     def save_data(self, filename=None):

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -182,7 +182,7 @@ class NamespaceBrowser(QWidget):
         """Bind shellwidget instance to namespace browser"""
         self.shellwidget = shellwidget
         shellwidget.set_namespacebrowser(self)
-        shellwidget.sig_namespace_reseted.connect(self.refresh_table)
+        shellwidget.sig_namespace_reseted_silently.connect(self.refresh_table)
 
     def setup_toolbar(self, exclude_private, exclude_uppercase,
                       exclude_capitalized, exclude_unsupported):


### PR DESCRIPTION
Fixes #313

----

When clicking on the button, %reset is called in the corresponding
IPython console with `force=True`, i.e. no confirmation is asked from
the user before doing it.

![reset_the_namespace](https://user-images.githubusercontent.com/10170372/28904801-7d87df7a-77db-11e7-9a85-4da1ecabfb24.png)