### PR TITLE
PR: Remove capture_dir_change method of IPython console shell widget

### DIFF
--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -206,8 +206,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         self.shellwidget.sig_show_syspath.connect(self.show_syspath)
         self.shellwidget.sig_show_env.connect(self.show_env)
 
-        #To sync global working directory
-        self.shellwidget.executing.connect(self.shellwidget.capture_dir_change)
+        # To sync with working directory toolbar
         self.shellwidget.executed.connect(self.shellwidget.get_cwd)
 
         if not create_qss_style(self.shellwidget.syntax_style)[1]:

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -402,16 +402,6 @@ the sympy module (e.g. plot)
             if not 'inline' in command:
                 self.silent_execute(command)
 
-    def capture_dir_change(self, command):
-        """
-        Capture dir change magic for synchronization with working directory.
-        """
-        try:
-            if command.startswith('%cd') or command.split()[0] == 'cd':
-                self.get_cwd()
-        except IndexError:
-            pass
-
     #---- Private methods (overrode by us) ---------------------------------
     def _context_menu_make(self, pos):
         """Reimplement the IPython context menu"""


### PR DESCRIPTION
This is no longer needed. It should have been removed in 3.2, but I forgot to do it.