### PR TITLE
PR: Do not full-restart plugins when changing pythonpath

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -110,7 +110,7 @@ def main_window(request):
     # (it's faster and less memory consuming not to use it!)
     marker = request.node.get_marker('use_introspection')
     if marker:
-        os.environ['SPY_TEST_USE_INTROSPECTION'] = 'True'
+        os.environ['SPY_TEST_USE_INTROSPECTION'] = 'USE_INTROSPECTION'
     else:
         try:
             os.environ.pop('SPY_TEST_USE_INTROSPECTION')
@@ -161,6 +161,52 @@ def test_calltip(main_window, qtbot):
     qtbot.keyPress(code_editor, Qt.Key_ParenRight, delay=1000)
     qtbot.keyPress(code_editor, Qt.Key_Enter, delay=1000)
 
+    QTimer.singleShot(1000, lambda: close_save_message_box(qtbot))
+    main_window.editor.close_file()
+
+
+@flaky(max_runs=3)
+@pytest.mark.skipif(os.name != 'nt' and PYQT5 or os.name == 'nt' and PY2,
+                    reason="It times out on Linux with PyQt5."
+                           "It makes to not finish the test run on Windows with Python 2.")
+@pytest.mark.timeout(timeout=60, method='thread')
+@pytest.mark.use_introspection
+def test_introspection(main_window, qtbot):
+    """Validate introspection after restart of the introspection plugin."""
+    # Load test file
+    main_window.editor.new(fname="test.py", text="")
+    code_editor = main_window.editor.get_focus_widget()
+
+    # Set cursor to start
+    text = 'fr\n'
+    code_editor.set_text(text)
+    code_editor.go_to_line(1)
+    code_editor.move_cursor(2)
+    completion = code_editor.completion_widget
+    qtbot.wait(5000)
+    assert not completion.isVisible()
+
+    # Try to get completion
+    qtbot.keyPress(code_editor, Qt.Key_Tab, delay=3000)
+    qtbot.waitUntil(lambda: completion.completion_list, timeout=2000)
+    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=1000)
+
+    # Assert the completion widget is not visible
+    qtbot.keyPress(code_editor, Qt.Key_Space)
+    assert not completion.isVisible()
+
+    # Modify PYTHONPATH
+    main_window.path_manager_callback(extra_path=LOCATION)
+    qtbot.wait(5000)
+
+    # Type 'n' and try to get completion
+    qtbot.keyPress(code_editor, Qt.Key_N, delay=1000)
+    qtbot.keyPress(code_editor, Qt.Key_Tab, delay=2000)
+    qtbot.waitUntil(lambda: len(completion.completion_list) > 0, timeout=2000)
+    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=1000)
+    assert not completion.isVisible()
+
+    # Close file
     QTimer.singleShot(1000, lambda: close_save_message_box(qtbot))
     main_window.editor.close_file()
 

--- a/spyder/utils/introspection/manager.py
+++ b/spyder/utils/introspection/manager.py
@@ -134,6 +134,12 @@ class PluginManager(QObject):
             plugin.close()
             debug_print("Introspection Plugin Closed: {}".format(name))
 
+    def change_extra_path(self, extra_path):
+        """Change python path in every plugin client."""
+        for name, plugin in self.plugins.items():
+            plugin.change_extra_path(extra_path)
+            debug_print("Introspection Plugin extra path changed: {}".format(name))
+
     def _finalize(self, response):
         self.waiting = False
         self.pending = None
@@ -180,7 +186,7 @@ class IntrospectionManager(QObject):
     def change_extra_path(self, extra_path):
         if extra_path != self.extra_path:
             self.extra_path = extra_path
-            self._restart_plugin()
+            self.plugin_manager.change_extra_path(self.extra_path)
 
     def _restart_plugin(self):
         self.plugin_manager.close()

--- a/spyder/utils/introspection/plugin_client.py
+++ b/spyder/utils/introspection/plugin_client.py
@@ -117,6 +117,26 @@ class AsyncClient(QObject):
         self.notifier = QSocketNotifier(fid, QSocketNotifier.Read, self)
         self.notifier.activated.connect(self._on_msg_received)
 
+    def change_extra_path(self, extra_path):
+        """Setting up a new extra path.
+
+        It requieres the plugin to be restarted.
+        """
+        self.extra_path = extra_path
+        if not self.is_initialized:
+            return
+        self.restart()
+
+    def restart(self):
+        """Restart plugin client.
+
+        Close process, reset socket and setup the plugin process again.
+        """
+        debug_print("Restarting plugin client, process and connection.")
+        self.close()
+        self.context = zmq.Context()
+        self.run()
+
     def request(self, func_name, *args, **kwargs):
         """Send a request to the server.
 
@@ -152,6 +172,7 @@ class AsyncClient(QObject):
             self.process.waitForFinished(1000)
             self.process.close()
         self.context.destroy()
+        self.socket = None
 
     def _on_finished(self):
         """Handle a finished signal from the process.


### PR DESCRIPTION
Tries to fix #4410
see https://github.com/spyder-ide/spyder/pull/4783#issuecomment-320978826

Only restart `PluginClient` internals (process, socket and notifier) when setting a new extra path. Previously changing extra_path delete and create again `PluginManager` and `PluginClient` objects.

Although this PR avoid the full restart of `PluginManager` and `PluginClientt`, the `QProcess` has to be restarted in order to set a new environment variable.

I also cherrypick a test from #4783