### PR TITLE
PR: Some File Explorer Enhancements

### DIFF
--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -346,7 +346,8 @@ class DirView(QTreeView):
         rename_action = create_action(self, _("Rename..."),
                                       icon=ima.icon('rename'),
                                       triggered=self.rename)
-        open_action = create_action(self, _("Open"), triggered=self.open)
+        open_external_action = create_action(self, _("Open With OS"), 
+                                             triggered=self.open_external)
         ipynb_convert_action = create_action(self, _("Convert to Python script"),
                                              icon=ima.icon('python'),
                                              triggered=self.convert_notebooks)
@@ -356,8 +357,8 @@ class DirView(QTreeView):
             actions.append(run_action)
         if only_valid and only_files:
             actions.append(edit_action)
-        else:
-            actions.append(open_action)
+        if only_files:
+            actions.append(open_external_action)
         if sys.platform == 'darwin':
             text=_("Show in Finder")
         else:
@@ -533,6 +534,14 @@ class DirView(QTreeView):
                 self.parent_widget.sig_open_file.emit(fname)
             else:
                 self.open_outside_spyder([fname])
+                
+    @Slot()
+    def open_external(self, fnames=None):
+        """Open files with default application"""
+        if fnames is None:
+            fnames = self.get_selected_filenames()
+        for fname in fnames:
+            self.open_outside_spyder([fname])
         
     def open_outside_spyder(self, fnames):
         """Open file outside Spyder with the appropriate application

--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -437,9 +437,6 @@ class DirView(QTreeView):
             actions.append(None)
         if fnames and all([osp.isdir(_fn) for _fn in fnames]):
             actions += self.create_folder_manage_actions(fnames)
-        if actions:
-            actions.append(None)
-        actions += self.common_actions
         return actions
 
     def update_menu(self):

--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -45,6 +45,7 @@ try:
 except:
     nbexporter = None    # analysis:ignore
 
+
 def open_file_in_external_explorer(filename):
     if sys.platform == "darwin":
         subprocess.call(["open", "-R", filename])
@@ -180,6 +181,7 @@ class DirView(QTreeView):
         self.fsmodel = None
         self.setup_fs_model()
         self._scrollbar_positions = None
+        self.setSelectionMode(self.ExtendedSelection)
                 
     #---- Model
     def setup_fs_model(self):
@@ -231,7 +233,8 @@ class DirView(QTreeView):
     def get_selected_filenames(self):
         """Return selected filenames"""
         if self.selectionMode() == self.ExtendedSelection:
-            return [self.get_filename(idx) for idx in self.selectedIndexes()]
+            return [self.get_filename(idx) for idx in 
+                    self.selectionModel().selectedRows()]
         else:
             return [self.get_filename(self.currentIndex())]
             

--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -49,12 +49,11 @@ except:
 def open_file_in_external_explorer(filename):
     if sys.platform == "darwin":
         subprocess.call(["open", "-R", filename])
+    if os.name == 'nt':
+        subprocess.call(["explorer", "/select,", filename])
     else:
         filename=os.path.dirname(filename)
-        if os.name == 'nt':
-            os.startfile(filename)
-        else:
-            subprocess.call(["xdg-open", filename])
+        subprocess.call(["xdg-open", filename])
 
 def show_in_external_file_explorer(fnames=None):
     """Show files in external file explorer

--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -357,20 +357,22 @@ class DirView(QTreeView):
             actions.append(run_action)
         if only_valid and only_files:
             actions.append(edit_action)
-        if only_files:
-            actions.append(open_external_action)
+        
         if sys.platform == 'darwin':
             text=_("Show in Finder")
         else:
-            text=_("Show in external file explorer")
+            text=_("Show in Folder")
         external_fileexp_action = create_action(self, text, 
                                 triggered=self.show_in_external_file_explorer)        
-        actions.append(external_fileexp_action)
         actions += [delete_action, rename_action]
         basedir = fixpath(osp.dirname(fnames[0]))
         if all([fixpath(osp.dirname(_fn)) == basedir for _fn in fnames]):
             actions.append(move_action)
         actions += [None]
+        if only_files:
+            actions.append(open_external_action)
+        actions.append(external_fileexp_action)
+        actions.append([None])
         if only_notebooks and nbexporter is not None:
             actions.append(ipynb_convert_action)
 

--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -49,7 +49,7 @@ except:
 def open_file_in_external_explorer(filename):
     if sys.platform == "darwin":
         subprocess.call(["open", "-R", filename])
-    if os.name == 'nt':
+    elif os.name == 'nt':
         subprocess.call(["explorer", "/select,", filename])
     else:
         filename=os.path.dirname(filename)


### PR DESCRIPTION
Fixes #2406 

This pull request fixes issues in #2406, plus a few minor improvements

Changes:
* Add "Open With OS" to all files, but not folders. This action opens the selected files with the default program.
* Remove "Open" from folders, because it was a duplicate functionality of "Open in external file browser"
* Add multi-select (ctrl / shift + click)
* Remove global options from context menu. These are not file related actions and are all present in the gear menu on the top right of the file explorer.
* Rename "Open in external file browser" to the more commonly used "Show in Folder" (MacOS remains "Show in Finder").
* Make "Show in Folder" action highlight the file in Windows Explorer. Previously it would open the folder but not highlight the file. MacOS already has this implemented, and in linux it is not implemented because xdg-open doesn't support highlighting files.
* Move "Open With OS" and "Show in Folder" out of the file editing section of the context menu into their own section.

The context menu will show different actions depending on which files are selected. Other than the changes mentioned above, the rules for what actions are shown remain the same. When multiple files are selected, the set of actions shown is the intersection of the actions for the individual files. Commit/Browse Repository are not shown for multiple selections because they don't operate on multiple files.

*.py file:
![py_only](https://user-images.githubusercontent.com/15150702/29200170-e5da9a40-7e07-11e7-8674-711f5ead9514.png)

folder:
![folder_only](https://user-images.githubusercontent.com/15150702/29200180-fadcd98a-7e07-11e7-9291-23f525e7888a.png)

Multi select: folder, *.py, binary file
![folder_py_bin](https://user-images.githubusercontent.com/15150702/29200347-6c1979ae-7e09-11e7-818f-624167250a1c.png)







