### PR TITLE
PR: Fix error when the selecting an unicode word

### DIFF
--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -357,7 +357,8 @@ class BaseEditMixin(object):
 
         cursor.select(QTextCursor.WordUnderCursor)
         text = to_text_string(cursor.selectedText())
-        match = re.findall(r'([a-zA-Z\_]+[0-9a-zA-Z\_]*)', text)
+        # find a valid python variable name
+        match = re.findall(r'([^\d\W]\w*)', text, re.UNICODE)
         if match:
             return match[0]
     

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -312,5 +312,48 @@ def test_advance_cell(editor_cells_bot):
     assert editor.get_cursor_line_column() == (6, 0)
 
 
+def test_get_current_word(base_editor_bot):
+    """Test getting selected valid python word."""
+    editor_stack, qtbot = base_editor_bot
+    text = ('some words with non-ascii  characters\n'
+            'niño\n'
+            'garçon\n'
+            'α alpha greek\n'
+            '123valid_python_word')
+    finfo = editor_stack.new('foo.py', 'utf-8', text)
+    qtbot.addWidget(editor_stack)
+    editor = finfo.editor
+    editor.go_to_line(1)
+
+    # Select some
+    editor.moveCursor(QTextCursor.EndOfWord, QTextCursor.KeepAnchor)
+    assert 'some' == editor.textCursor().selectedText()
+    assert editor.get_current_word() == 'some'
+
+    # Select niño
+    editor.go_to_line(2)
+    editor.moveCursor(QTextCursor.EndOfWord, QTextCursor.KeepAnchor)
+    assert 'niño' == editor.textCursor().selectedText()
+    assert editor.get_current_word() == 'niño'
+
+    # Select garçon
+    editor.go_to_line(3)
+    editor.moveCursor(QTextCursor.EndOfWord, QTextCursor.KeepAnchor)
+    assert 'garçon' == editor.textCursor().selectedText()
+    assert editor.get_current_word() == 'garçon'
+
+    # Select α
+    editor.go_to_line(4)
+    editor.moveCursor(QTextCursor.EndOfWord, QTextCursor.KeepAnchor)
+    assert 'α' == editor.textCursor().selectedText()
+    assert editor.get_current_word() == 'α'
+
+    # Select valid_python_word, should search first valid python word
+    editor.go_to_line(5)
+    editor.moveCursor(QTextCursor.EndOfWord, QTextCursor.KeepAnchor)
+    assert '123valid_python_word' == editor.textCursor().selectedText()
+    assert editor.get_current_word() == 'valid_python_word'
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -23,6 +23,7 @@ from qtpy.QtGui import QTextCursor
 from spyder.utils.fixtures import setup_editor
 from spyder.widgets.editor import EditorStack
 from spyder.widgets.findreplace import FindReplace
+from spyder.py3compat import PY2
 
 # Qt Test Fixtures
 #--------------------------------
@@ -312,6 +313,7 @@ def test_advance_cell(editor_cells_bot):
     assert editor.get_cursor_line_column() == (6, 0)
 
 
+@pytest.mark.skipif(PY2, reason="Python2 does not support unicode very well")
 def test_get_current_word(base_editor_bot):
     """Test getting selected valid python word."""
     editor_stack, qtbot = base_editor_bot


### PR DESCRIPTION
Fixes: #4943 

I tried to use @stonebig suggestion of `isidentifier()` but It was not possible because it was used in a regex expression, I instead improve the regex according in this answer https://stackoverflow.com/a/10134719/1335555