### PR TITLE
PR: Unify layout for panes and widgets

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2527,8 +2527,11 @@ class MainWindow(QMainWindow):
             except:
                 pass
         else:
-            qapp.setStyle(CONF.get('main', 'windows_style',
-                                   self.default_style))
+            style_name = CONF.get('main', 'windows_style',
+                                  self.default_style)
+            style = QStyleFactory.create(style_name)
+            style.setProperty('name', style_name)
+            qapp.setStyle(style)
         
         default = self.DOCKOPTIONS
         if CONF.get('main', 'vertical_tabs'):

--- a/spyder/plugins/help.py
+++ b/spyder/plugins/help.py
@@ -32,7 +32,7 @@ from spyder.utils import programs
 from spyder.utils.help.sphinxify import (CSS_PATH, generate_context,
                                          sphinxify, usage, warning)
 from spyder.utils.qthelpers import (add_actions, create_action,
-                                    create_toolbutton)
+                                    create_toolbutton, create_plugin_layout)
 from spyder.widgets.browser import FrameWebView
 from spyder.widgets.comboboxes import EditableComboBox
 from spyder.widgets.findreplace import FindReplace
@@ -448,9 +448,8 @@ class Help(SpyderPluginWidget):
         self.source_changed()
 
         # Main layout
-        layout = QVBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addLayout(layout_edit)
+        layout = create_plugin_layout(layout_edit, None)
+        # we have two main widgets, but only one of them is shown at a time
         layout.addWidget(self.plain_text)
         layout.addWidget(self.rich_text)
         self.setLayout(layout)

--- a/spyder/plugins/help.py
+++ b/spyder/plugins/help.py
@@ -32,7 +32,8 @@ from spyder.utils import programs
 from spyder.utils.help.sphinxify import (CSS_PATH, generate_context,
                                          sphinxify, usage, warning)
 from spyder.utils.qthelpers import (add_actions, create_action,
-                                    create_toolbutton)
+                                    create_toolbutton,
+                                    create_control_layout)
 from spyder.widgets.browser import FrameWebView
 from spyder.widgets.comboboxes import EditableComboBox
 from spyder.widgets.findreplace import FindReplace
@@ -448,9 +449,8 @@ class Help(SpyderPluginWidget):
         self.source_changed()
 
         # Main layout
-        layout = QVBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addLayout(layout_edit)
+        layout = create_control_layout(layout_edit, main_widget=None)
+        # we have two main widgets, but only one of them is shown at a time.
         layout.addWidget(self.plain_text)
         layout.addWidget(self.rich_text)
         self.setLayout(layout)

--- a/spyder/plugins/help.py
+++ b/spyder/plugins/help.py
@@ -32,8 +32,7 @@ from spyder.utils import programs
 from spyder.utils.help.sphinxify import (CSS_PATH, generate_context,
                                          sphinxify, usage, warning)
 from spyder.utils.qthelpers import (add_actions, create_action,
-                                    create_toolbutton,
-                                    create_control_layout)
+                                    create_toolbutton)
 from spyder.widgets.browser import FrameWebView
 from spyder.widgets.comboboxes import EditableComboBox
 from spyder.widgets.findreplace import FindReplace
@@ -449,8 +448,9 @@ class Help(SpyderPluginWidget):
         self.source_changed()
 
         # Main layout
-        layout = create_control_layout(layout_edit, main_widget=None)
-        # we have two main widgets, but only one of them is shown at a time.
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(layout_edit)
         layout.addWidget(self.plain_text)
         layout.addWidget(self.rich_text)
         self.setLayout(layout)

--- a/spyder/plugins/help.py
+++ b/spyder/plugins/help.py
@@ -448,7 +448,7 @@ class Help(SpyderPluginWidget):
         self.source_changed()
 
         # Main layout
-        layout = create_plugin_layout(layout_edit, None)
+        layout = create_plugin_layout(layout_edit)
         # we have two main widgets, but only one of them is shown at a time
         layout.addWidget(self.plain_text)
         layout.addWidget(self.rich_text)

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -17,9 +17,9 @@ from qtpy.compat import to_qvariant, from_qvariant
 from qtpy.QtCore import (QEvent, QLibraryInfo, QLocale, QObject, Qt, QTimer,
                          QTranslator, Signal, Slot)
 from qtpy.QtGui import QIcon, QKeyEvent, QKeySequence, QPixmap
-from qtpy.QtWidgets import (QAction, QApplication, QHBoxLayout,
-                            QLabel, QLayout, QLineEdit, QMenu, QStyle,
-                            QToolBar, QToolButton, QVBoxLayout, QWidget)
+from qtpy.QtWidgets import (QAction, QApplication, QHBoxLayout, QLabel,
+                            QLineEdit, QMenu, QStyle, QToolBar, QToolButton,
+                            QVBoxLayout, QWidget)
 
 # Local imports
 from spyder.config.base import get_image_path, running_in_mac_app
@@ -501,41 +501,6 @@ def show_std_icons():
     dialog = ShowStdIcons(None)
     dialog.show()
     sys.exit(app.exec_())
-
-
-def create_control_layout(controls, main_widget):
-    """
-    Returns a layout for a set of controls above a main widget. This is a
-    standard layout for many panes and some other widgets.
-
-    The use-case is currently limited to a single line of controls.
-
-    controls: a list of QWidgets to be placed in a HBoxLayout at the top.
-        You may use 'stretch' to add a stretch to the layout.
-        If a more complex control of the layout is needed, you can pass a
-        ready made layout instead.
-    main_widget: the main widget. Can be None, if you want to add this
-        manually later on.
-    """
-    layout = QVBoxLayout()
-    layout.setContentsMargins(0, 0, 0, 0)
-    layout.setSpacing(2)
-
-    if isinstance(controls, QLayout):
-        layout.addLayout(controls)
-    else:
-        clayout = QHBoxLayout()
-        clayout.setAlignment(Qt.AlignLeft)
-        for control in controls:
-            if control == 'stretch':
-                clayout.addStretch()
-            else:
-                clayout.addWidget(control)
-        layout.addLayout(clayout)
-
-    if main_widget is not None:
-        layout.addWidget(main_widget)
-    return layout
 
 
 MENU_SEPARATOR = None

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -523,7 +523,7 @@ def calc_tools_spacing(tools_layout):
     """
     metrics = {  # (tabbar_height, offset)
         'nt.fusion': (32, 0),
-        'nt.windowsvista': (21, 2),
+        'nt.windowsvista': (21, 3),
         'nt.windowsxp': (24, 0),
         'nt.windows': (21, 3),
         'posix.breeze': (28, -1),

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -13,6 +13,7 @@ import re
 import sys
 
 # Third party imports
+from PyQt5.QtWidgets import QStyleFactory
 from qtpy.compat import to_qvariant, from_qvariant
 from qtpy.QtCore import (QEvent, QLibraryInfo, QLocale, QObject, Qt, QTimer,
                          QTranslator, Signal, Slot)
@@ -516,6 +517,18 @@ def create_plugin_layout(tools_layout, main_widget):
     """
     layout = QVBoxLayout()
     layout.setContentsMargins(0, 0, 0, 0)
+
+    if os.name == 'nt':
+        # adapt spacing so that main_widget has the same vertical position as
+        # the editor widgets (which have tabs above)
+        # TODO: This is a hard coded workaround until we find a way to
+        #       calculate is from the metrics.
+        spacings = {'fusion': 9, 'windowsvista': 2, 'windowsxp': 2,
+                    'windows': 2}
+        style_name = qapplication().style().property('name')
+        if style_name in spacings:
+            layout.setSpacing(spacings[style_name])
+
     layout.addLayout(tools_layout)
     if main_widget is not None:
         layout.addWidget(main_widget)

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -13,7 +13,6 @@ import re
 import sys
 
 # Third party imports
-from PyQt5.QtWidgets import QStyleFactory
 from qtpy.compat import to_qvariant, from_qvariant
 from qtpy.QtCore import (QEvent, QLibraryInfo, QLocale, QObject, Qt, QTimer,
                          QTranslator, Signal, Slot)

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -503,6 +503,25 @@ def show_std_icons():
     sys.exit(app.exec_())
 
 
+def create_plugin_layout(tools_layout, main_widget):
+    """
+    Returns a layout for a set of controls above a main widget. This is a
+    standard layout for many plugin panes (even though, it's currently
+    more often applied not to the pane itself but with in the one widget
+    contained in the pane.
+
+    tools_layout: a layout containing the top toolbar
+    main_widget: the main widget. Can be None, if you want to add this
+        manually later on.
+    """
+    layout = QVBoxLayout()
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.addLayout(tools_layout)
+    if main_widget is not None:
+        layout.addWidget(main_widget)
+    return layout
+
+
 MENU_SEPARATOR = None
 
 

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -543,7 +543,7 @@ def calc_tools_spacing(tools_layout):
         return max(spacing, 0)
 
 
-def create_plugin_layout(tools_layout, main_widget):
+def create_plugin_layout(tools_layout, main_widget=None):
     """
     Returns a layout for a set of controls above a main widget. This is a
     standard layout for many plugin panes (even though, it's currently

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -17,9 +17,9 @@ from qtpy.compat import to_qvariant, from_qvariant
 from qtpy.QtCore import (QEvent, QLibraryInfo, QLocale, QObject, Qt, QTimer,
                          QTranslator, Signal, Slot)
 from qtpy.QtGui import QIcon, QKeyEvent, QKeySequence, QPixmap
-from qtpy.QtWidgets import (QAction, QApplication, QHBoxLayout, QLabel,
-                            QLineEdit, QMenu, QStyle, QToolBar, QToolButton,
-                            QVBoxLayout, QWidget)
+from qtpy.QtWidgets import (QAction, QApplication, QHBoxLayout,
+                            QLabel, QLayout, QLineEdit, QMenu, QStyle,
+                            QToolBar, QToolButton, QVBoxLayout, QWidget)
 
 # Local imports
 from spyder.config.base import get_image_path, running_in_mac_app
@@ -502,7 +502,42 @@ def show_std_icons():
     dialog.show()
     sys.exit(app.exec_())
 
-    
+
+def create_control_layout(controls, main_widget):
+    """
+    Returns a layout for a set of controls above a main widget. This is a
+    standard layout for many panes and some other widgets.
+
+    The use-case is currently limited to a single line of controls.
+
+    controls: a list of QWidgets to be placed in a HBoxLayout at the top.
+        You may use 'stretch' to add a stretch to the layout.
+        If a more complex control of the layout is needed, you can pass a
+        ready made layout instead.
+    main_widget: the main widget. Can be None, if you want to add this
+        manually later on.
+    """
+    layout = QVBoxLayout()
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.setSpacing(2)
+
+    if isinstance(controls, QLayout):
+        layout.addLayout(controls)
+    else:
+        clayout = QHBoxLayout()
+        clayout.setAlignment(Qt.AlignLeft)
+        for control in controls:
+            if control == 'stretch':
+                clayout.addStretch()
+            else:
+                clayout.addWidget(control)
+        layout.addLayout(clayout)
+
+    if main_widget is not None:
+        layout.addWidget(main_widget)
+    return layout
+
+
 MENU_SEPARATOR = None
 
 

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -21,8 +21,7 @@ from qtpy.QtGui import QFontInfo
 from spyder.config.base import _, DEV
 from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils.qthelpers import (action2button, add_actions,
-                                    create_action, create_toolbutton,
-                                    create_control_layout)
+                                    create_action, create_toolbutton)
 from spyder.utils import icon_manager as ima
 from spyder.widgets.comboboxes import UrlComboBox
 from spyder.widgets.findreplace import FindReplace
@@ -223,7 +222,8 @@ class WebBrowser(QWidget):
                        refresh_button, progressbar, stop_button):
             hlayout.addWidget(widget)
         
-        layout = create_control_layout(hlayout, main_widget=None)
+        layout = QVBoxLayout()
+        layout.addLayout(hlayout)
         layout.addWidget(self.webview)
         layout.addWidget(self.find_widget)
         self.setLayout(layout)

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -21,7 +21,8 @@ from qtpy.QtGui import QFontInfo
 from spyder.config.base import _, DEV
 from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils.qthelpers import (action2button, add_actions,
-                                    create_action, create_toolbutton)
+                                    create_action, create_toolbutton,
+                                    create_control_layout)
 from spyder.utils import icon_manager as ima
 from spyder.widgets.comboboxes import UrlComboBox
 from spyder.widgets.findreplace import FindReplace
@@ -222,8 +223,7 @@ class WebBrowser(QWidget):
                        refresh_button, progressbar, stop_button):
             hlayout.addWidget(widget)
         
-        layout = QVBoxLayout()
-        layout.addLayout(hlayout)
+        layout = create_control_layout(hlayout, main_widget=None)
         layout.addWidget(self.webview)
         layout.addWidget(self.find_widget)
         self.setLayout(layout)

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -223,7 +223,7 @@ class WebBrowser(QWidget):
                        refresh_button, progressbar, stop_button):
             hlayout.addWidget(widget)
         
-        layout = create_plugin_layout(hlayout, main_widget=None)
+        layout = create_plugin_layout(hlayout)
         layout.addWidget(self.webview)
         layout.addWidget(self.find_widget)
         self.setLayout(layout)

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -21,7 +21,8 @@ from qtpy.QtGui import QFontInfo
 from spyder.config.base import _, DEV
 from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils.qthelpers import (action2button, add_actions,
-                                    create_action, create_toolbutton)
+                                    create_action, create_toolbutton,
+                                    create_plugin_layout)
 from spyder.utils import icon_manager as ima
 from spyder.widgets.comboboxes import UrlComboBox
 from spyder.widgets.findreplace import FindReplace
@@ -222,8 +223,7 @@ class WebBrowser(QWidget):
                        refresh_button, progressbar, stop_button):
             hlayout.addWidget(widget)
         
-        layout = QVBoxLayout()
-        layout.addLayout(hlayout)
+        layout = create_plugin_layout(hlayout, main_widget=None)
         layout.addWidget(self.webview)
         layout.addWidget(self.find_widget)
         self.setLayout(layout)

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -21,7 +21,7 @@ from spyder.config.base import _, STDOUT
 from spyder.py3compat import to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import (create_action, create_toolbutton,
-                                    set_item_user_text)
+                                    set_item_user_text, create_plugin_layout)
 from spyder.widgets.onecolumntree import OneColumnTree
 
 
@@ -517,10 +517,7 @@ class OutlineExplorerWidget(QWidget):
         for btn in self.setup_buttons():
             btn_layout.addWidget(btn)
 
-        layout = QVBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addLayout(btn_layout)
-        layout.addWidget(self.treewidget)
+        layout = create_plugin_layout(btn_layout, self.treewidget)
         self.setLayout(layout)
 
     @Slot(bool)

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -21,8 +21,7 @@ from spyder.config.base import _, STDOUT
 from spyder.py3compat import to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import (create_action, create_toolbutton,
-                                    set_item_user_text,
-                                    create_control_layout)
+                                    set_item_user_text)
 from spyder.widgets.onecolumntree import OneColumnTree
 
 
@@ -513,7 +512,15 @@ class OutlineExplorerWidget(QWidget):
                                            toggled=self.toggle_visibility)
         self.visibility_action.setChecked(True)
         
-        layout = create_control_layout(self.setup_buttons(), self.treewidget)
+        btn_layout = QHBoxLayout()
+        btn_layout.setAlignment(Qt.AlignLeft)
+        for btn in self.setup_buttons():
+            btn_layout.addWidget(btn)
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(btn_layout)
+        layout.addWidget(self.treewidget)
         self.setLayout(layout)
 
     @Slot(bool)

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -21,7 +21,8 @@ from spyder.config.base import _, STDOUT
 from spyder.py3compat import to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import (create_action, create_toolbutton,
-                                    set_item_user_text)
+                                    set_item_user_text,
+                                    create_control_layout)
 from spyder.widgets.onecolumntree import OneColumnTree
 
 
@@ -512,15 +513,7 @@ class OutlineExplorerWidget(QWidget):
                                            toggled=self.toggle_visibility)
         self.visibility_action.setChecked(True)
         
-        btn_layout = QHBoxLayout()
-        btn_layout.setAlignment(Qt.AlignLeft)
-        for btn in self.setup_buttons():
-            btn_layout.addWidget(btn)
-
-        layout = QVBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addLayout(btn_layout)
-        layout.addWidget(self.treewidget)
+        layout = create_control_layout(self.setup_buttons(), self.treewidget)
         self.setLayout(layout)
 
     @Slot(bool)

--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -38,8 +38,7 @@ from spyder.py3compat import (getcwd, str_lower, to_binary_string,
                               to_text_string, PY2)
 from spyder.utils import icon_manager as ima
 from spyder.utils import encoding, misc, programs, vcs
-from spyder.utils.qthelpers import (add_actions, create_action, file_uri,
-                                    create_control_layout)
+from spyder.utils.qthelpers import add_actions, create_action, file_uri
 
 try:
     from nbconvert import PythonExporter as nbexporter
@@ -1202,9 +1201,16 @@ class ExplorerWidget(QWidget):
             widget.setIconSize(QSize(16, 16))
 
         # Layouts
-        controls = [button_previous, button_next, button_parent, 'stretch',
-                    self.button_menu]
-        layout = create_control_layout(controls, main_widget=self.treewidget)
+        blayout = QHBoxLayout()
+        blayout.addWidget(button_previous)
+        blayout.addWidget(button_next)
+        blayout.addWidget(button_parent)
+        blayout.addStretch()
+        blayout.addWidget(self.button_menu)
+
+        layout = QVBoxLayout()
+        layout.addLayout(blayout)
+        layout.addWidget(self.treewidget)
         self.setLayout(layout)
 
         # Signals and slots

--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -38,7 +38,7 @@ from spyder.py3compat import (getcwd, str_lower, to_binary_string,
                               to_text_string, PY2)
 from spyder.utils import icon_manager as ima
 from spyder.utils import encoding, misc, programs, vcs
-from spyder.utils.qthelpers import add_actions, create_action, file_uri
+from spyder.utils.qthelpers import add_actions, create_action, file_uri, create_control_layout
 
 try:
     from nbconvert import PythonExporter as nbexporter
@@ -1201,16 +1201,9 @@ class ExplorerWidget(QWidget):
             widget.setIconSize(QSize(16, 16))
 
         # Layouts
-        blayout = QHBoxLayout()
-        blayout.addWidget(button_previous)
-        blayout.addWidget(button_next)
-        blayout.addWidget(button_parent)
-        blayout.addStretch()
-        blayout.addWidget(self.button_menu)
-
-        layout = QVBoxLayout()
-        layout.addLayout(blayout)
-        layout.addWidget(self.treewidget)
+        controls = [button_previous, button_next, button_parent, 'stretch',
+             self.button_menu]
+        layout = create_control_layout(controls, main_widget=self.treewidget)
         self.setLayout(layout)
 
         # Signals and slots

--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -38,7 +38,8 @@ from spyder.py3compat import (getcwd, str_lower, to_binary_string,
                               to_text_string, PY2)
 from spyder.utils import icon_manager as ima
 from spyder.utils import encoding, misc, programs, vcs
-from spyder.utils.qthelpers import add_actions, create_action, file_uri, create_control_layout
+from spyder.utils.qthelpers import (add_actions, create_action, file_uri,
+                                    create_control_layout)
 
 try:
     from nbconvert import PythonExporter as nbexporter
@@ -1202,7 +1203,7 @@ class ExplorerWidget(QWidget):
 
         # Layouts
         controls = [button_previous, button_next, button_parent, 'stretch',
-             self.button_menu]
+                    self.button_menu]
         layout = create_control_layout(controls, main_widget=self.treewidget)
         self.setLayout(layout)
 

--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -38,7 +38,8 @@ from spyder.py3compat import (getcwd, str_lower, to_binary_string,
                               to_text_string, PY2)
 from spyder.utils import icon_manager as ima
 from spyder.utils import encoding, misc, programs, vcs
-from spyder.utils.qthelpers import add_actions, create_action, file_uri
+from spyder.utils.qthelpers import (add_actions, create_action, file_uri,
+                                    create_plugin_layout)
 
 try:
     from nbconvert import PythonExporter as nbexporter
@@ -1208,9 +1209,7 @@ class ExplorerWidget(QWidget):
         blayout.addStretch()
         blayout.addWidget(self.button_menu)
 
-        layout = QVBoxLayout()
-        layout.addLayout(blayout)
-        layout.addWidget(self.treewidget)
+        layout = create_plugin_layout(blayout, self.treewidget)
         self.setLayout(layout)
 
         # Signals and slots

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -36,7 +36,7 @@ from spyder.utils.iofuncs import iofunctions
 from spyder.utils.misc import fix_reference_name
 from spyder.utils.programs import is_module_installed
 from spyder.utils.qthelpers import (add_actions, create_action,
-                                    create_toolbutton)
+                                    create_toolbutton, create_plugin_layout)
 from spyder.widgets.variableexplorer.collectionseditor import (
     RemoteCollectionsEditorTableView)
 from spyder.widgets.variableexplorer.importwizard import ImportWizard
@@ -148,7 +148,6 @@ class NamespaceBrowser(QWidget):
         self.editor.sig_files_dropped.connect(self.import_data)
 
         # Setup layout
-        layout = QVBoxLayout()
         blayout = QHBoxLayout()
         toolbar = self.setup_toolbar(exclude_private, exclude_uppercase,
                                      exclude_capitalized, exclude_unsupported)
@@ -171,10 +170,9 @@ class NamespaceBrowser(QWidget):
 
         blayout.addStretch()
         blayout.addWidget(options_button)
-        layout.addLayout(blayout)
-        layout.addWidget(self.editor)
+
+        layout = create_plugin_layout(blayout, self.editor)
         self.setLayout(layout)
-        layout.setContentsMargins(0, 0, 0, 0)
 
         self.sig_option_changed.connect(self.option_changed)
         

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -36,8 +36,7 @@ from spyder.utils.iofuncs import iofunctions
 from spyder.utils.misc import fix_reference_name
 from spyder.utils.programs import is_module_installed
 from spyder.utils.qthelpers import (add_actions, create_action,
-                                    create_toolbutton,
-                                    create_control_layout)
+                                    create_toolbutton)
 from spyder.widgets.variableexplorer.collectionseditor import (
     RemoteCollectionsEditorTableView)
 from spyder.widgets.variableexplorer.importwizard import ImportWizard
@@ -148,6 +147,14 @@ class NamespaceBrowser(QWidget):
         self.editor.sig_option_changed.connect(self.sig_option_changed.emit)
         self.editor.sig_files_dropped.connect(self.import_data)
 
+        # Setup layout
+        layout = QVBoxLayout()
+        blayout = QHBoxLayout()
+        toolbar = self.setup_toolbar(exclude_private, exclude_uppercase,
+                                     exclude_capitalized, exclude_unsupported)
+        for widget in toolbar:
+            blayout.addWidget(widget)
+
         # Options menu
         options_button = create_toolbutton(self, text=_('Options'),
                                            icon=ima.icon('tooloptions'))
@@ -162,13 +169,12 @@ class NamespaceBrowser(QWidget):
         add_actions(menu, actions)
         options_button.setMenu(menu)
 
-        # Setup layout
-        toolbar = self.setup_toolbar(exclude_private, exclude_uppercase,
-                                     exclude_capitalized, exclude_unsupported)
-        toolbar.extend(['stretch', options_button])
-
-        layout = create_control_layout(toolbar, main_widget=self.editor)
+        blayout.addStretch()
+        blayout.addWidget(options_button)
+        layout.addLayout(blayout)
+        layout.addWidget(self.editor)
         self.setLayout(layout)
+        layout.setContentsMargins(0, 0, 0, 0)
 
         self.sig_option_changed.connect(self.option_changed)
         

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -36,7 +36,8 @@ from spyder.utils.iofuncs import iofunctions
 from spyder.utils.misc import fix_reference_name
 from spyder.utils.programs import is_module_installed
 from spyder.utils.qthelpers import (add_actions, create_action,
-                                    create_toolbutton)
+                                    create_toolbutton,
+                                    create_control_layout)
 from spyder.widgets.variableexplorer.collectionseditor import (
     RemoteCollectionsEditorTableView)
 from spyder.widgets.variableexplorer.importwizard import ImportWizard
@@ -147,14 +148,6 @@ class NamespaceBrowser(QWidget):
         self.editor.sig_option_changed.connect(self.sig_option_changed.emit)
         self.editor.sig_files_dropped.connect(self.import_data)
 
-        # Setup layout
-        layout = QVBoxLayout()
-        blayout = QHBoxLayout()
-        toolbar = self.setup_toolbar(exclude_private, exclude_uppercase,
-                                     exclude_capitalized, exclude_unsupported)
-        for widget in toolbar:
-            blayout.addWidget(widget)
-
         # Options menu
         options_button = create_toolbutton(self, text=_('Options'),
                                            icon=ima.icon('tooloptions'))
@@ -169,12 +162,13 @@ class NamespaceBrowser(QWidget):
         add_actions(menu, actions)
         options_button.setMenu(menu)
 
-        blayout.addStretch()
-        blayout.addWidget(options_button)
-        layout.addLayout(blayout)
-        layout.addWidget(self.editor)
+        # Setup layout
+        toolbar = self.setup_toolbar(exclude_private, exclude_uppercase,
+                                     exclude_capitalized, exclude_unsupported)
+        toolbar.extend(['stretch', options_button])
+
+        layout = create_control_layout(toolbar, main_widget=self.editor)
         self.setLayout(layout)
-        layout.setContentsMargins(0, 0, 0, 0)
 
         self.sig_option_changed.connect(self.option_changed)
         


### PR DESCRIPTION
fixes #4953 

`create_control_layout()` provides a unified way of creating the required layouts. Here's an example how it will look like:

![2017-08-13 22_19_53-spyder 3 2 1 dev0 python 3 6 debug mode 1](https://user-images.githubusercontent.com/2836374/29253109-9895b3b2-8075-11e7-977c-dade8b1b2593.png)

The panes with multiple lines of control widgets (bottom panes in the screenshot) can be addressed at a later time.
