### PR TITLE
PR: Reduce row height in shortcut dialog

### DIFF
--- a/spyder/plugins/shortcuts.py
+++ b/spyder/plugins/shortcuts.py
@@ -690,6 +690,7 @@ class ShortcutsTable(QTableView):
 
     def adjust_cells(self):
         """Adjust column size based on contents."""
+        self.resizeRowsToContents()
         self.resizeColumnsToContents()
         fm = self.horizontalHeader().fontMetrics()
         names = [fm.width(s.name + ' '*9) for s in self.source_model.shortcuts]


### PR DESCRIPTION
The rows of the shortcut table have unneccesarily large heights. This patch reduces the height to the minimal possible height, so that more entries are visible -> increased usability.

before:
![2017-08-14 20_52_48-preferences](https://user-images.githubusercontent.com/2836374/29286765-68e49cdc-8133-11e7-9401-5d59a077192d.png)

after:
![2017-08-14 20_53_54-preferences_new](https://user-images.githubusercontent.com/2836374/29286771-710070d0-8133-11e7-87bf-dab56a741e77.png)

