### PR TITLE
PR: Fix shortcut to make array builders appear in the IPython Console

### DIFF
--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -257,10 +257,10 @@ the sympy module (e.g. plot)
         reset_namespace = config_shortcut(lambda: self.reset_namespace(),
                                           context='ipython_console',
                                           name='reset namespace', parent=self)
-        array_inline = config_shortcut(lambda: self.enter_array_inline(),
+        array_inline = config_shortcut(self._control.enter_array_inline,
                                        context='array_builder',
                                        name='enter array inline', parent=self)
-        array_table = config_shortcut(lambda: self.enter_array_table(),
+        array_table = config_shortcut(self._control.enter_array_table,
                                       context='array_builder',
                                       name='enter array table', parent=self)
 


### PR DESCRIPTION
Fixes #4981 

## Preview
![peek 17-08-201716-06](https://user-images.githubusercontent.com/1878982/29433881-8c5aa82a-8366-11e7-8506-731b6b6b242c.gif)
