### PR TITLE
PR: Remove regex escape characters from replacement string on the Find/Replace widget

### DIFF
--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -29,6 +29,14 @@ from spyder.utils.qthelpers import create_toolbutton, get_icon
 from spyder.widgets.comboboxes import PatternComboBox
 
 
+CONTROL_CHARACTERS = {
+    '\\n': '\n',
+    '\\r': '\r',
+    '\\t': '\t',
+    '\\f': '\f'
+}
+
+
 def is_position_sup(pos1, pos2):
     """Return True is pos1 > pos2"""
     return pos1 > pos2
@@ -515,6 +523,10 @@ class FindReplace(QWidget):
                 replacement = re.sub(pattern, replace_text, seltxt, flags=re_flags)
             if replacement != seltxt:
                 cursor.removeSelectedText()
+                for plain_char in CONTROL_CHARACTERS:
+                    replacement = replacement.replace(
+                        plain_char, CONTROL_CHARACTERS[plain_char])
+                replacement = re.sub(r'\\(.)', r'\1', replacement)
                 cursor.insertText(replacement)
             cursor.endEditBlock()
             if focus_replace_text:

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -287,6 +287,20 @@ def test_replace_enter_press(editor_find_replace_bot):
     qtbot.keyPress(finder.search_text, Qt.Key_Return, modifier=Qt.ShiftModifier)
     assert editor.get_cursor_line_column() == (3,4)
 
+def test_selection_replace_plain_regex(editor_find_replace_bot):
+    """Test that regex reserved characters are displayed as plain text."""
+    editor_stack, editor, finder, qtbot = editor_find_replace_bot
+    expected_new_text = ('.\\[()]*test bacon\n'
+                         'spam sausage\n'
+                         'spam egg')
+    old_text = editor.toPlainText()
+    finder.show()
+    finder.show_replace()
+    qtbot.keyClicks(finder.search_text, 'spam')
+    qtbot.keyClicks(finder.replace_text, '.\[()]*test')
+    qtbot.keyPress(finder.replace_text, Qt.Key_Return)
+    text = editor.toPlainText()[0:-1]
+    assert editor.toPlainText()[0:-1] == expected_new_text
 
 def test_advance_cell(editor_cells_bot):
     editor_stack, editor, qtbot = editor_cells_bot

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -287,6 +287,7 @@ def test_replace_enter_press(editor_find_replace_bot):
     qtbot.keyPress(finder.search_text, Qt.Key_Return, modifier=Qt.ShiftModifier)
     assert editor.get_cursor_line_column() == (3,4)
 
+
 def test_selection_replace_plain_regex(editor_find_replace_bot):
     """Test that regex reserved characters are displayed as plain text."""
     editor_stack, editor, finder, qtbot = editor_find_replace_bot


### PR DESCRIPTION
Fixes #4934

## Preview
![peek 17-08-2017 16-37](https://user-images.githubusercontent.com/1878982/29434967-a3885f5c-836a-11e7-8ceb-d313004e6586.gif)
