### PR TITLE
PR: Fix setting SPYDER_DEBUG variable on Windows

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3037,10 +3037,10 @@ def main():
     options, args = get_options()
 
     if set_attached_console_visible is not None:
-        set_attached_console_visible(DEBUG or options.show_console \
+        set_attached_console_visible(options.show_console \
                                      or options.reset_config_files \
                                      or options.reset_to_defaults \
-                                     or options.optimize)
+                                     or options.optimize or bool(DEBUG))
 
     app = initialize()
     if options.reset_config_files:

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3037,9 +3037,9 @@ def main():
     options, args = get_options()
 
     if set_attached_console_visible is not None:
-        set_attached_console_visible(options.show_console \
-                                     or options.reset_config_files \
-                                     or options.reset_to_defaults \
+        set_attached_console_visible(options.show_console
+                                     or options.reset_config_files
+                                     or options.reset_to_defaults
                                      or options.optimize or bool(DEBUG))
 
     app = initialize()


### PR DESCRIPTION
Fixes #4829 

------------------------------------------------
In Windows running something like `3 or True` will return `3` however running something like `True or 3` will return `True`. Also running something like `False or 3` will return 3. As a reference:

![imagen](https://user-images.githubusercontent.com/16781833/29489909-6e092e0a-84f1-11e7-805e-e6905b017089.png)
