### PR TITLE
PR: Add all possible string prefixes for syntax highlighting

### DIFF
--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -14,7 +14,6 @@ from __future__ import print_function
 import keyword
 import os
 import re
-import sys
 import weakref
 
 # Third party imports
@@ -27,7 +26,7 @@ from qtpy.QtWidgets import QApplication
 from spyder import dependencies
 from spyder.config.base import _
 from spyder.config.main import CONF
-from spyder.py3compat import builtins, is_text_string, to_text_string
+from spyder.py3compat import builtins, is_text_string, to_text_string, PY3
 from spyder.utils.sourcecode import CELL_LANGUAGES
 from spyder.utils.editor import TextBlockHelper as tbh
 from spyder.utils.workers import WorkerManager
@@ -341,7 +340,7 @@ def make_python_patterns(additional_keywords=[], additional_builtins=[]):
                   r"\b[+-]?0[oO][0-7]+[lL]?\b",
                   r"\b[+-]?0[bB][01]+[lL]?\b",
                   r"\b[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?[jJ]?\b"])
-    if sys.version_info[0] == 3:
+    if PY3:
         prefix = "r|u|R|U|f|F|fr|Fr|fR|FR|rf|rF|Rf|RF|b|B|br|Br|bR|BR|rb|rB|Rb|RB"
     else:
         prefix = "r|u|ur|R|U|UR|Ur|uR|b|B|br|Br|bR|BR"

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 import keyword
 import os
 import re
+import sys
 import weakref
 
 # Third party imports
@@ -340,14 +341,20 @@ def make_python_patterns(additional_keywords=[], additional_builtins=[]):
                   r"\b[+-]?0[oO][0-7]+[lL]?\b",
                   r"\b[+-]?0[bB][01]+[lL]?\b",
                   r"\b[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?[jJ]?\b"])
-    sqstring =     r"(\b[rRuU])?'[^'\\\n]*(\\.[^'\\\n]*)*'?"
-    dqstring =     r'(\b[rRuU])?"[^"\\\n]*(\\.[^"\\\n]*)*"?'
-    uf_sqstring =  r"(\b[rRuU])?'[^'\\\n]*(\\.[^'\\\n]*)*(\\)$(?!')$"
-    uf_dqstring =  r'(\b[rRuU])?"[^"\\\n]*(\\.[^"\\\n]*)*(\\)$(?!")$'
-    sq3string =    r"(\b[rRuU])?'''[^'\\]*((\\.|'(?!''))[^'\\]*)*(''')?"
-    dq3string =    r'(\b[rRuU])?"""[^"\\]*((\\.|"(?!""))[^"\\]*)*(""")?'
-    uf_sq3string = r"(\b[rRuU])?'''[^'\\]*((\\.|'(?!''))[^'\\]*)*(\\)?(?!''')$"
-    uf_dq3string = r'(\b[rRuU])?"""[^"\\]*((\\.|"(?!""))[^"\\]*)*(\\)?(?!""")$'
+    if sys.version_info[0] == 3:
+        prefix = "r|u|R|U|f|F|fr|Fr|fR|FR|rf|rF|Rf|RF|b|B|br|Br|bR|BR|rb|rB|Rb|RB"
+    else:
+        prefix = "r|u|ur|R|U|UR|Ur|uR|b|B|br|Br|bR|BR"
+    sqstring =     r"(\b(%s))?'[^'\\\n]*(\\.[^'\\\n]*)*'?" % prefix
+    dqstring =     r'(\b(%s))?"[^"\\\n]*(\\.[^"\\\n]*)*"?' % prefix
+    uf_sqstring =  r"(\b(%s))?'[^'\\\n]*(\\.[^'\\\n]*)*(\\)$(?!')$" % prefix
+    uf_dqstring =  r'(\b(%s))?"[^"\\\n]*(\\.[^"\\\n]*)*(\\)$(?!")$' % prefix
+    sq3string =    r"(\b(%s))?'''[^'\\]*((\\.|'(?!''))[^'\\]*)*(''')?" % prefix
+    dq3string =    r'(\b(%s))?"""[^"\\]*((\\.|"(?!""))[^"\\]*)*(""")?' % prefix
+    uf_sq3string = r"(\b(%s))?'''[^'\\]*((\\.|'(?!''))[^'\\]*)*(\\)?(?!''')$" \
+                   % prefix
+    uf_dq3string = r'(\b(%s))?"""[^"\\]*((\\.|"(?!""))[^"\\]*)*(\\)?(?!""")$' \
+                   % prefix
     string = any("string", [sq3string, dq3string, sqstring, dqstring])
     ufstring1 = any("uf_sqstring", [uf_sqstring])
     ufstring2 = any("uf_dqstring", [uf_dqstring])

--- a/spyder/utils/tests/test_syntaxhighlighters.py
+++ b/spyder/utils/tests/test_syntaxhighlighters.py
@@ -50,24 +50,25 @@ def test_HtmlSH_unclosed_commend():
 
 def test_python_string_prefix():
     if PY3:
-        prefixes = ("r","u","R","U","f","F","fr","Fr","fR","FR","rf","rF","Rf",
-                    "RF","b","B","br","Br","bR","BR","rb","rB","Rb","RB")
+        prefixes = ("r", "u", "R", "U", "f", "F", "fr", "Fr", "fR", "FR", 
+                    "rf", "rF", "Rf", "RF", "b", "B", "br", "Br", "bR", "BR",
+                    "rb", "rB", "Rb", "RB")
     else:
-        prefixes = ("r","u","ur","R","U","UR","Ur","uR","b","B","br","Br","bR",
-                    "BR")
+        prefixes = ("r", "u", "ur", "R", "U", "UR", "Ur", "uR", "b", "B",
+                    "br", "Br", "bR", "BR")
     for prefix in prefixes:
         txt = "[%s'test', %s'''test''']" % (prefix, prefix)
 
         doc = QTextDocument(txt)
         sh = PythonSH(doc, color_scheme='Spyder')
         sh.rehighlightBlock(doc.firstBlock())
-        
+
         offset = len(prefix)
-        res = [(0, 1, 'normal'),                    # |[|
-               (1, 6 + offset, 'string'),           # |{prefix}'test'|
-               (7 + offset, 2, 'normal'),           # |, |
-               (9 + offset, 10 + offset, 'string'), # |{prefix}'''test'''|
-               (19 + 2*offset, 1, 'normal')]        # | |
+        res = [(0, 1, 'normal'),                     # |[|
+               (1, 6 + offset, 'string'),            # |{prefix}'test'|
+               (7 + offset, 2, 'normal'),            # |, |
+               (9 + offset, 10 + offset, 'string'),  # |{prefix}'''test'''|
+               (19 + 2*offset, 1, 'normal')]         # | |
 
         compare_formats(doc.firstBlock().layout().additionalFormats(), res, sh)
 

--- a/spyder/utils/tests/test_syntaxhighlighters.py
+++ b/spyder/utils/tests/test_syntaxhighlighters.py
@@ -47,6 +47,26 @@ def test_HtmlSH_unclosed_commend():
     compare_formats(doc.firstBlock().layout().additionalFormats(), res, sh)
 
 
+def test_python_string_prefix():
+    txt = "[r'test', b'test', f'test', u'test']"     
+
+    doc = QTextDocument(txt)
+    sh = PythonSH(doc, color_scheme='Spyder')
+    sh.rehighlightBlock(doc.firstBlock())
+
+    res = [(0, 1, 'normal'),   # |[|
+           (1, 7, 'string'),   # |r'test'|
+           (8, 2, 'normal'),   # |, |
+           (10, 7, 'string'),  # |b'test'|
+           (17, 2, 'normal'),  # |, |
+           (19, 7, 'string'),  # |f'test'|
+           (26, 2, 'normal'),  # |, |
+           (28, 7, 'string'),  # |u'test'|
+           (35, 1, 'normal')]  # |]|
+
+    compare_formats(doc.firstBlock().layout().additionalFormats(), res, sh)
+
+
 def test_Markdown_basic():
     txt = "Some __random__ **text** with ~~different~~ [styles](link_url)"
 

--- a/spyder/utils/tests/test_syntaxhighlighters.py
+++ b/spyder/utils/tests/test_syntaxhighlighters.py
@@ -50,7 +50,7 @@ def test_HtmlSH_unclosed_commend():
 
 def test_python_string_prefix():
     if PY3:
-        prefixes = ("r", "u", "R", "U", "f", "F", "fr", "Fr", "fR", "FR", 
+        prefixes = ("r", "u", "R", "U", "f", "F", "fr", "Fr", "fR", "FR",
                     "rf", "rF", "Rf", "RF", "b", "B", "br", "Br", "bR", "BR",
                     "rb", "rB", "Rb", "RB")
     else:


### PR DESCRIPTION
Fixes #4884 

----

As suggested in #4884 the string prefixes should be highlighted with the same color as the string itself. The list of all possible prefixes is given [here](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals) for Python 3 and [here](https://docs.python.org/2/reference/lexical_analysis.html#string-literals) for Python 2. 
![image](https://user-images.githubusercontent.com/20270441/29490573-c5d1884a-8540-11e7-9b8e-427cf412950a.png)

I have added a small test as well but not sure it is actually necessary. Is it? 