### PR TITLE
PR: Make value_to_display more robust

### DIFF
--- a/spyder/widgets/variableexplorer/tests/test_utils.py
+++ b/spyder/widgets/variableexplorer/tests/test_utils.py
@@ -7,12 +7,30 @@
 Tests for utils.py
 """
 
+from collections import defaultdict
+
 # Third party imports
+import numpy as np
+import pandas as pd
 import pytest
 
 # Local imports
 from spyder.config.base import get_supported_types
-from spyder.widgets.variableexplorer.utils import sort_against, is_supported
+from spyder.widgets.variableexplorer.utils import (sort_against,
+    is_supported, value_to_display)
+
+
+def generate_complex_object():
+    """Taken from issue #4221."""
+    bug = defaultdict(list)
+    for i in range(50000):
+        a = {j:np.random.rand(10) for j in range(10)}
+        bug[i] = a
+    return bug
+
+
+COMPLEX_OBJECT = generate_complex_object()
+PANEL = pd.Panel({0: pd.DataFrame([1,2]), 1:pd.DataFrame([3,4])})
 
 
 # --- Tests
@@ -32,7 +50,7 @@ def test_sort_against_is_stable():
 
 
 def test_none_values_are_supported():
-    # None values should be displayed by default
+    """Tests that None values are displayed by default"""
     supported_types = get_supported_types()
     mode = 'editable'
     none_var = None
@@ -43,6 +61,21 @@ def test_none_values_are_supported():
     assert is_supported(none_list, filters=tuple(supported_types[mode]))
     assert is_supported(none_dict, filters=tuple(supported_types[mode]))
     assert is_supported(none_tuple, filters=tuple(supported_types[mode]))
+
+
+def test_default_display():
+    """Tests for default_display."""
+    # Display of defaultdict
+    assert (value_to_display(COMPLEX_OBJECT) ==
+            'defaultdict object of collections module')
+
+    # Display of array of COMPLEX_OBJECT
+    assert (value_to_display(np.array(COMPLEX_OBJECT)) ==
+            'ndarray object of numpy module')
+
+    # Display of Panel
+    assert (value_to_display(PANEL) ==
+            'Panel object of pandas.core.panel module')
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/variableexplorer/tests/test_utils.py
+++ b/spyder/widgets/variableexplorer/tests/test_utils.py
@@ -113,5 +113,41 @@ def test_list_display():
     assert value_to_display(li) == result
 
 
+def test_dict_display():
+    """Tests for display of dicts."""
+    long_list = list(range(100))
+    long_dict = dict(zip(list(range(100)), list(range(100))))
+
+    # Simple dict
+    assert value_to_display({0:0, 'a':'b'}) == "{0:0, 'a':'b'}"
+
+    # Long dict
+    assert (value_to_display(long_dict) ==
+            '{0:0, 1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8, 9:9, ...}')
+
+    # Short list of lists
+    assert (value_to_display({1:long_dict, 2:long_dict}) ==
+            '{1:{0:0, 1:1, 2:2, 3:3, 4:4, ...}, 2:{0:0, 1:1, 2:2, 3:3, 4:4, ...}}')
+
+    # Long dict of dicts
+    result = ('{(0, 0, 0, 0, 0, ...):[0, 1, 2, 3, 4, ...], '
+               '(1, 1, 1, 1, 1, ...):[0, 1, 2, 3, 4, ...]}')
+    assert value_to_display({(0,)*100:long_list, (1,)*100:long_list}) == result[:70] + ' ...'
+
+    # Multiple level dicts
+    assert (value_to_display({0: {1:1, 2:2, 3:3, 4:{0:0}, 5:5}, 1:1}) ==
+            '{0:{1:1, 2:2, 3:3, 4:{...}, 5:5}, 1:1}')
+    assert value_to_display({0:0, 1:1, 2:2, 3:DF}) == '{0:0, 1:1, 2:2, 3:Dataframe}'
+    assert value_to_display({0:0, 1:1, 2:[[DF], PANEL]}) == '{0:0, 1:1, 2:[[...], Panel]}'
+
+    # Dict of complex object
+    assert value_to_display({0:COMPLEX_OBJECT}) == '{0:defaultdict}'
+
+    # Dict of composed objects
+    li = {0:COMPLEX_OBJECT, 1:PANEL, 2:2, 3:{0:0, 1:1}, 4:DF}
+    result = '{0:defaultdict, 1:Panel, 2:2, 3:{0:0, 1:1}, 4:Dataframe}'
+    assert value_to_display(li) == result
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/widgets/variableexplorer/tests/test_utils.py
+++ b/spyder/widgets/variableexplorer/tests/test_utils.py
@@ -30,6 +30,7 @@ def generate_complex_object():
 
 
 COMPLEX_OBJECT = generate_complex_object()
+DF = pd.DataFrame([1,2,3])
 PANEL = pd.Panel({0: pd.DataFrame([1,2]), 1:pd.DataFrame([3,4])})
 
 
@@ -76,6 +77,40 @@ def test_default_display():
     # Display of Panel
     assert (value_to_display(PANEL) ==
             'Panel object of pandas.core.panel module')
+
+
+def test_list_display():
+    """Tests for display of lists."""
+    long_list = list(range(100))
+
+    # Simple list
+    assert value_to_display([1, 2, 3]) == '[1, 2, 3]'
+
+    # Long list
+    assert (value_to_display(long_list) ==
+            '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...]')
+
+    # Short list of lists
+    assert (value_to_display([long_list] * 3) ==
+            '[[0, 1, 2, 3, 4, ...], [0, 1, 2, 3, 4, ...], [0, 1, 2, 3, 4, ...]]')
+
+    # Long list of lists
+    result = '[' + ''.join('[0, 1, 2, 3, 4, ...], '*10)[:-2] + ']'
+    assert value_to_display([long_list] * 10) == result[:70] + ' ...'
+
+    # Multiple level lists
+    assert (value_to_display([[1, 2, 3, [4], 5]] + long_list) ==
+            '[[1, 2, 3, [...], 5], 0, 1, 2, 3, 4, 5, 6, 7, 8, ...]')
+    assert value_to_display([1, 2, [DF]]) == '[1, 2, [Dataframe]]'
+    assert value_to_display([1, 2, [[DF], PANEL]]) == '[1, 2, [[...], Panel]]'
+
+    # List of complex object
+    assert value_to_display([COMPLEX_OBJECT]) == '[defaultdict]'
+
+    # List of composed objects
+    li = [COMPLEX_OBJECT, PANEL, 1, {1:2, 3:4}, DF]
+    result = '[defaultdict, Panel, 1, {1:2, 3:4}, Dataframe]'
+    assert value_to_display(li) == result
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -271,7 +271,36 @@ def default_display(value, with_module=True):
         return type_str[1:-1]
 
 
-def value_to_display(value, minmax=False):
+def collections_display(value, recursion):
+    """Display for collections (i.e list, tuple and dict)."""
+    if isinstance(value, (list, tuple)):
+        # Truncate values
+        truncate = False
+        elements = value
+        if recursion == 1 and len(value) > 10:
+            elements = value[:10]
+            truncate = True
+        elif recursion == 2 and len(value) > 5:
+            elements = value[:5]
+            truncate = True
+
+        if recursion <= 2:
+            displays = [value_to_display(e, recursion) for e in elements]
+            if truncate:
+                displays.append('...')
+            display = ', '.join(displays)
+        else:
+            display = '...'
+
+        if isinstance(value, list):
+            display = '[' + display + ']'
+        else:
+            display = '(' + display + ')'
+
+        return display
+
+
+def value_to_display(value, minmax=False, recursion=0):
     """Convert value for display purpose"""
     # To save current Numpy threshold
     np_threshold = FakeObject
@@ -303,8 +332,8 @@ def value_to_display(value, minmax=False):
                 display = repr(value)
             else:
                 display = default_display(value)
-        elif any([type(value) == t for t in [list, tuple, dict, set]]):
-            display = CollectionsRepr.repr(value)
+        elif any([type(value) == t for t in [list, tuple, dict]]):
+            display = collections_display(value, recursion+1)
         elif isinstance(value, Image):
             display = '%s  Mode: %s' % (address(value), value.mode)
         elif isinstance(value, DataFrame):

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -256,13 +256,16 @@ def unsorted_unique(lista):
 #==============================================================================
 # Display <--> Value
 #==============================================================================
-def default_display(value):
+def default_display(value, with_module=True):
     """Default display for unknown objects."""
     object_type = type(value)
     try:
         name = object_type.__name__
         module = object_type.__module__
-        return name + ' of ' + module + ' module'
+        if with_module:
+            return name + ' of ' + module + ' module'
+        else:
+            return name
     except:
         type_str = to_text_string(object_type)
         return type_str[1:-1]

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -256,10 +256,23 @@ def unsorted_unique(lista):
 #==============================================================================
 # Display <--> Value
 #==============================================================================
+def default_display(value):
+    """Default display for unknown objects."""
+    object_type = type(value)
+    try:
+        name = object_type.__name__
+        module = object_type.__module__
+        return name + ' of ' + module
+    except:
+        type_str = to_text_string(object_type)
+        return type_str[1:-1]
+
+
 def value_to_display(value, minmax=False):
     """Convert value for display purpose"""
     # To save current Numpy threshold
     np_threshold = FakeObject
+
     try:
         numeric_numpy_types = (int64, int32, float64, float32,
                                complex128, complex64)
@@ -321,12 +334,9 @@ def value_to_display(value, minmax=False):
         else:
             # Note: Don't trust on repr's. They can be inefficient and
             # so freeze Spyder quite easily
-            # display = repr(value)
-            type_str = to_text_string(type(value))
-            display = type_str[1:-1]
+            display = default_display(value)
     except:
-        type_str = to_text_string(type(value))
-        display = type_str[1:-1]
+        display = default_display(value)
 
     # Truncate display at 80 chars to avoid freezing Spyder
     # because of large displays

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -387,7 +387,7 @@ def value_to_display(value, minmax=False, level=0):
                 display = value
             if level > 0:
                 display = (to_binary_string("'") + display +
-                           to_binary_string('"'))
+                           to_binary_string("'"))
         elif is_text_string(value):
             display = value
             if level > 0:

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -282,7 +282,7 @@ def value_to_display(value, minmax=False):
                     display = repr(value)
             else:
                 display = repr(value)
-        elif isinstance(value, (list, tuple, dict, set)):
+        elif any([type(value) == t for t in [list, tuple, dict, set]]):
             display = CollectionsRepr.repr(value)
         elif isinstance(value, Image):
             display = '%s  Mode: %s' % (address(value), value.mode)

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -373,6 +373,8 @@ def value_to_display(value, minmax=False, level=0):
         elif isinstance(value, NavigableString):
             # Fixes Issue 2448
             display = to_text_string(value)
+            if level > 0:
+                display = u"'" + display + u"'"
         elif isinstance(value, DatetimeIndex):
             if level == 0:
                 display = value.summary()
@@ -383,8 +385,13 @@ def value_to_display(value, minmax=False, level=0):
                 display = to_text_string(value, 'utf8')
             except:
                 display = value
+            if level > 0:
+                display = (to_binary_string("'") + display +
+                           to_binary_string('"'))
         elif is_text_string(value):
             display = value
+            if level > 0:
+                display = u"'" + display + u"'"
         elif (isinstance(value, NUMERIC_TYPES) or isinstance(value, bool) or
               isinstance(value, datetime.date) or
               isinstance(value, numeric_numpy_types)):

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -15,8 +15,8 @@ import re
 # Local imports
 from spyder.config.base import get_supported_types
 from spyder.py3compat import (NUMERIC_TYPES, TEXT_TYPES, to_text_string,
-                              is_text_string, is_binary_string, reprlib,
-                              PY2, to_binary_string)
+                              is_text_string, is_binary_string, PY2,
+                              to_binary_string)
 from spyder.utils import programs
 from spyder import dependencies
 from spyder.config.base import _
@@ -150,17 +150,6 @@ def get_object_attrs(obj):
     if not attrs:
         attrs = dir(obj)
     return attrs
-
-
-# =============================================================================
-# Set limits for the amount of elements in the repr of collections (lists,
-# dicts, tuples and sets) and Numpy arrays
-# =============================================================================
-CollectionsRepr = reprlib.Repr()
-CollectionsRepr.maxlist = 10
-CollectionsRepr.maxdict = 10
-CollectionsRepr.maxtuple = 10
-CollectionsRepr.maxset = 10
 
 
 #==============================================================================

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -260,21 +260,21 @@ def default_display(value, with_module=True):
         return type_str[1:-1]
 
 
-def collections_display(value, recursion):
+def collections_display(value, level):
     """Display for collections (i.e list, tuple and dict)."""
     if isinstance(value, (list, tuple)):
         # Truncate values
         truncate = False
         elements = value
-        if recursion == 1 and len(value) > 10:
+        if level == 1 and len(value) > 10:
             elements = value[:10]
             truncate = True
-        elif recursion == 2 and len(value) > 5:
+        elif level == 2 and len(value) > 5:
             elements = value[:5]
             truncate = True
 
-        if recursion <= 2:
-            displays = [value_to_display(e, recursion=recursion)
+        if level <= 2:
+            displays = [value_to_display(e, level=level)
                         for e in elements]
             if truncate:
                 displays.append('...')
@@ -290,7 +290,7 @@ def collections_display(value, recursion):
         return display
 
 
-def value_to_display(value, minmax=False, recursion=0):
+def value_to_display(value, minmax=False, level=0):
     """Convert value for display purpose"""
     # To save current Numpy threshold
     np_threshold = FakeObject
@@ -305,7 +305,7 @@ def value_to_display(value, minmax=False, recursion=0):
             # in our display
             set_printoptions(threshold=10)
         if isinstance(value, recarray):
-            if recursion == 0:
+            if level == 0:
                 fields = value.names
                 display = 'Field names: ' + ', '.join(fields)
             else:
@@ -313,7 +313,7 @@ def value_to_display(value, minmax=False, recursion=0):
         elif isinstance(value, MaskedArray):
             display = 'Masked array'
         elif isinstance(value, ndarray):
-            if recursion == 0:
+            if level == 0:
                 if minmax:
                     try:
                         display = 'Min: %r\nMax: %r' % (value.min(), value.max())
@@ -329,14 +329,14 @@ def value_to_display(value, minmax=False, recursion=0):
             else:
                 display = 'Numpy array'
         elif any([type(value) == t for t in [list, tuple, dict]]):
-            display = collections_display(value, recursion+1)
+            display = collections_display(value, level+1)
         elif isinstance(value, Image):
-            if recursion == 0:
+            if level == 0:
                 display = '%s  Mode: %s' % (address(value), value.mode)
             else:
                 display = 'Image'
         elif isinstance(value, DataFrame):
-            if recursion == 0:
+            if level == 0:
                 cols = value.columns
                 if PY2 and len(cols) > 0:
                     # Get rid of possible BOM utf-8 data present at the
@@ -358,7 +358,7 @@ def value_to_display(value, minmax=False, recursion=0):
             # Fixes Issue 2448
             display = to_text_string(value)
         elif isinstance(value, DatetimeIndex):
-            if recursion == 0:
+            if level == 0:
                 display = value.summary()
             else:
                 display = 'DatetimeIndex'
@@ -374,7 +374,7 @@ def value_to_display(value, minmax=False, recursion=0):
               isinstance(value, numeric_numpy_types)):
             display = repr(value)
         else:
-            if recursion == 0:
+            if level == 0:
                 display = default_display(value)
             else:
                 display = default_display(value, with_module=False)

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -285,7 +285,8 @@ def collections_display(value, recursion):
             truncate = True
 
         if recursion <= 2:
-            displays = [value_to_display(e, recursion) for e in elements]
+            displays = [value_to_display(e, recursion=recursion)
+                        for e in elements]
             if truncate:
                 displays.append('...')
             display = ', '.join(displays)

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -253,7 +253,7 @@ def default_display(value, with_module=True):
         name = object_type.__name__
         module = object_type.__module__
         if with_module:
-            return name + ' of ' + module + ' module'
+            return name + ' object of ' + module + ' module'
         else:
             return name
     except:

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -262,7 +262,7 @@ def default_display(value):
     try:
         name = object_type.__name__
         module = object_type.__module__
-        return name + ' of ' + module
+        return name + ' of ' + module + ' module'
     except:
         type_str = to_text_string(object_type)
         return type_str[1:-1]
@@ -292,9 +292,14 @@ def value_to_display(value, minmax=False):
                 try:
                     display = 'Min: %r\nMax: %r' % (value.min(), value.max())
                 except (TypeError, ValueError):
-                    display = repr(value)
-            else:
+                    if value.dtype.type in numeric_numpy_types:
+                        display = repr(value)
+                    else:
+                        display = default_display(value)
+            elif value.dtype.type in numeric_numpy_types:
                 display = repr(value)
+            else:
+                display = default_display(value)
         elif any([type(value) == t for t in [list, tuple, dict, set]]):
             display = CollectionsRepr.repr(value)
         elif isinstance(value, Image):

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -397,10 +397,10 @@ def value_to_display(value, minmax=False, level=0):
     except:
         display = default_display(value)
 
-    # Truncate display at 80 chars to avoid freezing Spyder
+    # Truncate display at 70 chars to avoid freezing Spyder
     # because of large displays
-    if len(display) > 80:
-        display = display[:80].rstrip() + ' ...'
+    if len(display) > 70:
+        display = display[:70].rstrip() + ' ...'
 
     # Restore Numpy threshold
     if np_threshold is not FakeObject:


### PR DESCRIPTION
Fixes #4221 

----

This PR

1. Improves how any object is displayed in the Variable Explorer. Now objects will be shown as `foo object of bar module` (except for know objects, like Dataframes).
2. Doesn't try to display subclasses of list, dict and tuple, to avoid things like issue #4221 (which was using a generalization of a dict that doesn't have an optimized `repr`).
3. Applies `value_to_display` recursively to the elements of lists, dicts and tuples. This prevents freezes in the Variable Explorer when people add objects with huge `repr`'s as elements of those collection types.

Screenshots:

*Before*

![seleccion_001](https://user-images.githubusercontent.com/365293/29795680-db6882c0-8c12-11e7-979a-dd9e561dc72e.png)

*After*

![seleccion_002](https://user-images.githubusercontent.com/365293/29795775-5100aa1c-8c13-11e7-800d-5b80a90fb627.png)


----

TODO:

- [x] Tests

[skip pep8]