### PR TITLE
PR: Allow values with '%' in config system

### DIFF
--- a/spyder/config/tests/test_user.py
+++ b/spyder/config/tests/test_user.py
@@ -28,6 +28,13 @@ def userconfig(tmpdir, monkeypatch):
     return UserConfig('foo', defaults={}, subfolder=True,
                       version='1.0.0', raw_mode=True)
 
+
+def test_userconfig_set_percentage_string(userconfig):
+    """Test to set an option with a '%'."""
+    userconfig.set('section', 'option', '%value')
+    assert userconfig.get('section', 'option') == '%value'
+
+
 def test_userconfig_get_string_from_inifile(userconfig):
     assert userconfig.get('section', 'option') == 'value'
 

--- a/spyder/config/user.py
+++ b/spyder/config/user.py
@@ -48,7 +48,10 @@ class DefaultsConfig(cp.ConfigParser):
     UserConfig
     """
     def __init__(self, name, subfolder):
-        cp.ConfigParser.__init__(self)
+        if PY2:
+            cp.ConfigParser.__init__(self)
+        else:
+            cp.ConfigParser.__init__(self, interpolation=None)
         self.name = name
         self.subfolder = subfolder
 


### PR DESCRIPTION
Fixes #4921 