### PR TITLE
PR: Make inactive paths to be ignored when Spyder's path list is synchronized with PYTHONPATH on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
       rope pyflakes sphinx pygments pylint pycodestyle psutil nbconvert
       qtawesome pickleshare pyzmq chardet mock pandas pytest
       pytest-cov numpydoc scipy pillow qtconsole matplotlib jedi
-    PIP_DEPENDENCIES: "pytest-qt pytest-timeout flaky"
+    PIP_DEPENDENCIES: "pytest-qt pytest-mock pytest-timeout flaky"
 
   matrix:
     - PYTHON_VERSION: "2.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
     CONDA_DEPENDENCIES: >
       rope pyflakes sphinx pygments pylint pycodestyle psutil nbconvert
       qtawesome pickleshare pyzmq chardet mock pandas pytest
-      pytest-cov numpydoc scipy pillow qtconsole matplotlib jedi
+      pytest-cov numpydoc scipy pillow qtconsole matplotlib jedi pywin32
     PIP_DEPENDENCIES: "pytest-qt pytest-mock pytest-timeout flaky"
 
   matrix:

--- a/continuous_integration/circle/install.sh
+++ b/continuous_integration/circle/install.sh
@@ -4,7 +4,7 @@ export CONDA_DEPENDENCIES_FLAGS="--quiet"
 export CONDA_DEPENDENCIES="rope pyflakes sphinx pygments pylint psutil nbconvert \
                            qtawesome pickleshare qtpy pyzmq chardet mock nomkl pandas \
                            pytest pytest-cov numpydoc scipy cython pillow"
-export PIP_DEPENDENCIES="coveralls pytest-qt 'pytest-mock' pytest-xvfb flaky jedi pycodestyle"
+export PIP_DEPENDENCIES="coveralls pytest-qt pytest-mock pytest-xvfb flaky jedi pycodestyle"
 
 # Download and install miniconda and conda/pip dependencies
 # with astropy helpers

--- a/continuous_integration/circle/install.sh
+++ b/continuous_integration/circle/install.sh
@@ -4,7 +4,7 @@ export CONDA_DEPENDENCIES_FLAGS="--quiet"
 export CONDA_DEPENDENCIES="rope pyflakes sphinx pygments pylint psutil nbconvert \
                            qtawesome pickleshare qtpy pyzmq chardet mock nomkl pandas \
                            pytest pytest-cov numpydoc scipy cython pillow"
-export PIP_DEPENDENCIES="coveralls pytest-qt pytest-xvfb flaky jedi pycodestyle"
+export PIP_DEPENDENCIES="coveralls pytest-qt 'pytest-mock' pytest-xvfb flaky jedi pycodestyle"
 
 # Download and install miniconda and conda/pip dependencies
 # with astropy helpers

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -10,7 +10,7 @@ else
     export CONDA_DEPENDENCIES="rope pyflakes sphinx pygments pylint psutil nbconvert \
                                qtawesome pickleshare qtpy pyzmq chardet mock nomkl pandas \
                                pytest pytest-cov numpydoc scipy cython pillow jedi pycodestyle"
-    export PIP_DEPENDENCIES="coveralls pytest-qt pytest-timeout flaky"
+    export PIP_DEPENDENCIES="coveralls pytest-qt 'pytest-mock' pytest-timeout flaky"
 fi
 
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -10,7 +10,7 @@ else
     export CONDA_DEPENDENCIES="rope pyflakes sphinx pygments pylint psutil nbconvert \
                                qtawesome pickleshare qtpy pyzmq chardet mock nomkl pandas \
                                pytest pytest-cov numpydoc scipy cython pillow jedi pycodestyle"
-    export PIP_DEPENDENCIES="coveralls pytest-qt 'pytest-mock' pytest-timeout flaky"
+    export PIP_DEPENDENCIES="coveralls pytest-qt pytest-mock pytest-timeout flaky"
 fi
 
 

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,6 +1,7 @@
 mock
 pytest
 pytest-qt
+pytest-mock
 pytest-cov
 pytest-timeout
 pandas

--- a/setup.py
+++ b/setup.py
@@ -299,6 +299,7 @@ extras_require = {
     'test:python_version == "2.7"': ['mock'],
     'test': ['pytest',
              'pytest-qt',
+             'pytest-mock',
              'pytest-cov',
              'pytest-xvfb',
              'pytest-timeout',

--- a/spyder/widgets/pathmanager.py
+++ b/spyder/widgets/pathmanager.py
@@ -80,7 +80,12 @@ class PathManager(QDialog):
         
         self.update_list()
         self.refresh()
-        
+
+    @property
+    def active_pathlist(self):
+        return [path for path in self.pathlist
+                if path not in self.not_active_pathlist]
+
     def _add_widgets_to_layout(self, layout, widgets):
         layout.setAlignment(Qt.AlignLeft)
         for widget in widgets:
@@ -165,17 +170,17 @@ class PathManager(QDialog):
                                           listdict2envdict)
         env = get_user_env()
         if remove:
-            ppath = self.pathlist+self.ro_pathlist
+            ppath = self.active_pathlist+self.ro_pathlist
         else:
             ppath = env.get('PYTHONPATH', [])
             if not isinstance(ppath, list):
                 ppath = [ppath]
             ppath = [path for path in ppath
-                     if path not in (self.pathlist+self.ro_pathlist)]
-            ppath.extend(self.pathlist+self.ro_pathlist)
+                     if path not in (self.active_pathlist+self.ro_pathlist)]
+            ppath.extend(self.active_pathlist+self.ro_pathlist)
         env['PYTHONPATH'] = ppath
-        set_user_env( listdict2envdict(env), parent=self )
-        
+        set_user_env(listdict2envdict(env), parent=self)
+
     def get_path_list(self):
         """Return path list (does not include the read-only path list)"""
         return self.pathlist

--- a/spyder/widgets/tests/test_pathmanager.py
+++ b/spyder/widgets/tests/test_pathmanager.py
@@ -20,10 +20,10 @@ except ImportError:
 import pytest
 from qtpy import PYQT4
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QMessageBox
 
 # Local imports
 from spyder.py3compat import PY3
+from spyder.widgets import pathmanager as pathmanager_mod
 from spyder.widgets.pathmanager import PathManager
 
 
@@ -67,7 +67,8 @@ def test_check_uncheck_path(qtbot):
     assert pathmanager.not_active_pathlist == []
 
 
-@patch.object(QMessageBox, 'question', return_value=QMessageBox.Yes)
+@patch.object(pathmanager_mod.QMessageBox, 'question',
+              return_value=pathmanager_mod.QMessageBox.Yes)
 def test_synchronize_with_PYTHONPATH(qtbot):
     if os.name != 'nt':
         return
@@ -104,3 +105,4 @@ def test_synchronize_with_PYTHONPATH(qtbot):
 
 if __name__ == "__main__":
     pytest.main([os.path.basename(__file__)])
+    # pytest.main()

--- a/spyder/widgets/tests/test_pathmanager.py
+++ b/spyder/widgets/tests/test_pathmanager.py
@@ -68,7 +68,7 @@ def test_check_uncheck_path(qtbot):
 
 
 @patch.object(QMessageBox, 'question', return_value=QMessageBox.Yes)
-def test_synchronize_with_PYTHONPATH_clearIsTrue(qtbot):
+def test_synchronize_with_PYTHONPATH(qtbot):
     pathmanager = setup_pathmanager(qtbot, None,
                                     pathlist=['path1', 'path2', 'path3'],
                                     ro_pathlist=['path4', 'path5', 'path6'])

--- a/spyder/widgets/tests/test_pathmanager.py
+++ b/spyder/widgets/tests/test_pathmanager.py
@@ -76,7 +76,7 @@ def test_synchronize_with_PYTHONPATH(qtbot, mocker):
     # Store PYTHONPATH original state
     env = get_user_env()
     original_pathlist = env.get('PYTHONPATH', [])
-
+    return
     # Mock the dialog window and answer "Yes" to clear contents of PYTHONPATH
     # before adding Spyder's path list
     mocker.patch.object(pathmanager_mod.QMessageBox, 'question',

--- a/spyder/widgets/tests/test_pathmanager.py
+++ b/spyder/widgets/tests/test_pathmanager.py
@@ -62,14 +62,14 @@ def test_check_uncheck_path(qtbot):
     assert pathmanager.not_active_pathlist == []
 
 
+@pytest.mark.skipif(os.name != 'nt',
+                    reason="This feature is not applicable for Unix systems")
 def test_synchronize_with_PYTHONPATH(qtbot, mocker):
-    if os.name != 'nt':
-        return
-
     pathmanager = setup_pathmanager(qtbot, None,
                                     pathlist=['path1', 'path2', 'path3'],
                                     ro_pathlist=['path4', 'path5', 'path6'])
 
+    # Import here to prevent an ImportError when testing on unix systems
     from spyder.utils.environ import (get_user_env, set_user_env,
                                       listdict2envdict)
 
@@ -116,4 +116,3 @@ def test_synchronize_with_PYTHONPATH(qtbot, mocker):
 
 if __name__ == "__main__":
     pytest.main([os.path.basename(__file__)])
-    # pytest.main()

--- a/spyder/widgets/tests/test_pathmanager.py
+++ b/spyder/widgets/tests/test_pathmanager.py
@@ -81,7 +81,7 @@ def test_synchronize_with_PYTHONPATH(qtbot):
 
     # Store PYTHONPATH original state
     env = get_user_env()
-    original_pathlist = env['PYTHONPATH']
+    original_pathlist = env.get('PYTHONPATH', [])
 
     # Assert that PYTHONPATH is synchronized correctly with Spyder's path list
     pathmanager.synchronize()
@@ -103,5 +103,4 @@ def test_synchronize_with_PYTHONPATH(qtbot):
 
 
 if __name__ == "__main__":
-    import os
     pytest.main([os.path.basename(__file__)])

--- a/spyder/widgets/tests/test_pathmanager.py
+++ b/spyder/widgets/tests/test_pathmanager.py
@@ -19,6 +19,7 @@ from qtpy.QtCore import Qt
 # Local imports
 from spyder.py3compat import PY3
 from spyder.widgets import pathmanager as pathmanager_mod
+from spyder.utils.programs import is_module_installed
 
 
 @pytest.fixture
@@ -62,8 +63,9 @@ def test_check_uncheck_path(qtbot):
     assert pathmanager.not_active_pathlist == []
 
 
-@pytest.mark.skipif(os.name != 'nt',
-                    reason="This feature is not applicable for Unix systems")
+@pytest.mark.skipif(os.name != 'nt' or not is_module_installed('win32con'),
+                    reason=("This feature is not applicable for Unix "
+                            "systems and pywin32 is needed"))
 def test_synchronize_with_PYTHONPATH(qtbot, mocker):
     pathmanager = setup_pathmanager(qtbot, None,
                                     pathlist=['path1', 'path2', 'path3'],

--- a/spyder/widgets/tests/test_pathmanager.py
+++ b/spyder/widgets/tests/test_pathmanager.py
@@ -76,7 +76,7 @@ def test_synchronize_with_PYTHONPATH(qtbot, mocker):
     # Store PYTHONPATH original state
     env = get_user_env()
     original_pathlist = env.get('PYTHONPATH', [])
-    return
+
     # Mock the dialog window and answer "Yes" to clear contents of PYTHONPATH
     # before adding Spyder's path list
     mocker.patch.object(pathmanager_mod.QMessageBox, 'question',

--- a/spyder/widgets/tests/test_pathmanager.py
+++ b/spyder/widgets/tests/test_pathmanager.py
@@ -24,14 +24,14 @@ from qtpy.QtCore import Qt
 # Local imports
 from spyder.py3compat import PY3
 from spyder.widgets import pathmanager as pathmanager_mod
-from spyder.widgets.pathmanager import PathManager
 
 
 @pytest.fixture
 def setup_pathmanager(qtbot, parent=None, pathlist=None, ro_pathlist=None,
                       sync=True):
     """Set up PathManager."""
-    widget = PathManager(None, pathlist=pathlist, ro_pathlist=ro_pathlist)
+    widget = pathmanager_mod.PathManager(None, pathlist=pathlist,
+                                         ro_pathlist=ro_pathlist)
     qtbot.addWidget(widget)
     return widget
 

--- a/spyder/widgets/tests/test_pathmanager.py
+++ b/spyder/widgets/tests/test_pathmanager.py
@@ -69,12 +69,13 @@ def test_check_uncheck_path(qtbot):
 
 @patch.object(QMessageBox, 'question', return_value=QMessageBox.Yes)
 def test_synchronize_with_PYTHONPATH_clearIsTrue(qtbot):
-    env = get_user_env()
-    original_pathlist = env['PYTHONPATH']
-
     pathmanager = setup_pathmanager(qtbot, None,
                                     pathlist=['path1', 'path2', 'path3'],
                                     ro_pathlist=['path4', 'path5', 'path6'])
+
+    # Store PYTHONPATH original state
+    env = get_user_env()
+    original_pathlist = env['PYTHONPATH']
 
     # Assert that PYTHONPATH is synchronized correctly with Spyder's path list
     pathmanager.synchronize()
@@ -90,7 +91,7 @@ def test_synchronize_with_PYTHONPATH_clearIsTrue(qtbot):
     env = get_user_env()
     assert env['PYTHONPATH'] == expected_pathlist
 
-    # Restore 'PYTHONPATH' to its original state
+    # Restore PYTHONPATH to its original state
     env['PYTHONPATH'] = original_pathlist
     set_user_env(listdict2envdict(env))
 

--- a/spyder/widgets/tests/test_pathmanager.py
+++ b/spyder/widgets/tests/test_pathmanager.py
@@ -9,6 +9,7 @@ Tests for pathmanager.py
 """
 # Standard library imports
 import sys
+import os
 # Standard library imports
 try:
     from unittest.mock import patch
@@ -24,7 +25,6 @@ from qtpy.QtWidgets import QMessageBox
 # Local imports
 from spyder.py3compat import PY3
 from spyder.widgets.pathmanager import PathManager
-from spyder.utils.environ import (get_user_env, set_user_env, listdict2envdict)
 
 
 @pytest.fixture
@@ -69,9 +69,15 @@ def test_check_uncheck_path(qtbot):
 
 @patch.object(QMessageBox, 'question', return_value=QMessageBox.Yes)
 def test_synchronize_with_PYTHONPATH(qtbot):
+    if os.name != 'nt':
+        return
+
     pathmanager = setup_pathmanager(qtbot, None,
                                     pathlist=['path1', 'path2', 'path3'],
                                     ro_pathlist=['path4', 'path5', 'path6'])
+
+    from spyder.utils.environ import (get_user_env, set_user_env,
+                                      listdict2envdict)
 
     # Store PYTHONPATH original state
     env = get_user_env()


### PR DESCRIPTION
This PR is to expand the new feature (PR: https://github.com/spyder-ide/spyder/pull/4756) that allowed to check and uncheck paths in the pathmanager to quickly add or remove them from the Spyder's path list.

With this PR, paths that are unchecked won't be added to the PYTHONPATH environment variable when synchronizing with  Spyder's path list. Note that the "synchonize Spyder's PYTHONPATH with PYTHONPATH environment variable" feature is valid only for Windows environment.

Also, added a test for the synchonize feature.

![image](https://user-images.githubusercontent.com/10170372/29690610-aa92bbcc-88f5-11e7-8775-53a3323fb5a4.png)

