### PR TITLE
PR: Fix unable to split editor

### DIFF
--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -1238,7 +1238,7 @@ class Editor(SpyderPluginWidget):
             self.set_last_focus_editorstack(self, editorstack)
             editorstack.set_closable( len(self.editorstacks) > 1 )
             if self.outlineexplorer is not None:
-                editorstack.set_outlineexplorer(self.outlineexplorer)
+                editorstack.set_outlineexplorer(self.outlineexplorer.explorer)
             editorstack.set_find_widget(self.find_widget)
             editorstack.reset_statusbar.connect(self.readwrite_status.hide)
             editorstack.reset_statusbar.connect(self.encoding_status.hide)

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -1472,13 +1472,15 @@ class Editor(SpyderPluginWidget):
     def get_current_editorstack(self, editorwindow=None):
         if self.editorstacks is not None:
             if len(self.editorstacks) == 1:
-                return self.editorstacks[0]
+                editorstack = self.editorstacks[0]
             else:
                 editorstack = self.__get_focus_editorstack()
                 if editorstack is None or editorwindow is not None:
-                    return self.get_last_focus_editorstack(editorwindow)
-                return editorstack
-        
+                    editorstack = self.get_last_focus_editorstack(editorwindow)
+                    if editorstack is None:
+                        editorstack = self.editorstacks[0]
+            return editorstack
+
     def get_current_editor(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -746,6 +746,12 @@ class EditorStack(QWidget):
     def closeEvent(self, event):
         self.threadmanager.close_all_threads()
         self.analysis_timer.timeout.disconnect(self.analyze_script)
+
+        # Remove editor references from the outline explorer settings
+        if self.outlineexplorer is not None:
+            for finfo in self.data:
+                self.outlineexplorer.remove_editor(finfo.editor)
+
         QWidget.closeEvent(self, event)
         if is_pyqt46:
             self.destroyed.emit()
@@ -2012,10 +2018,6 @@ class EditorStack(QWidget):
         editor.zoom_out.connect(lambda: self.zoom_out.emit())
         editor.zoom_reset.connect(lambda: self.zoom_reset.emit())
         editor.sig_eol_chars_changed.connect(lambda eol_chars: self.refresh_eol_chars(eol_chars))
-        if self.outlineexplorer is not None:
-            # Removing editor reference from outline explorer settings:
-            editor.destroyed.connect(lambda obj=editor:
-                                     self.outlineexplorer.remove_editor(obj))
 
         self.find_widget.set_editor(editor)
 

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -479,9 +479,14 @@ class OutlineExplorerTreeWidget(OneColumnTree):
             if i_item is root_item:
                 #XXX: not working anymore!!!
                 for editor, _id in list(self.editor_ids.items()):
-                    if _id == editor_id and editor.parent() is parent:
-                        self.current_editor = editor
-                        break
+                    try:
+                        if _id == editor_id and editor.parent() is parent:
+                            self.current_editor = editor
+                            break
+                    except RuntimeError:
+                        # This editor has been deleted, continue to the next
+                        # one in the list.
+                        continue
                 break
 
     def clicked(self, item):

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -477,7 +477,6 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         parent = self.current_editor.parent()
         for editor_id, i_item in list(self.editor_items.items()):
             if i_item is root_item:
-                #XXX: not working anymore!!!
                 for editor, _id in list(self.editor_ids.items()):
                     if _id == editor_id and editor.parent() is parent:
                         self.current_editor = editor

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -479,14 +479,9 @@ class OutlineExplorerTreeWidget(OneColumnTree):
             if i_item is root_item:
                 #XXX: not working anymore!!!
                 for editor, _id in list(self.editor_ids.items()):
-                    try:
-                        if _id == editor_id and editor.parent() is parent:
-                            self.current_editor = editor
-                            break
-                    except RuntimeError:
-                        # This editor has been deleted, continue to the next
-                        # one in the list.
-                        continue
+                    if _id == editor_id and editor.parent() is parent:
+                        self.current_editor = editor
+                        break
                 break
 
     def clicked(self, item):


### PR DESCRIPTION
Fixes #4705

Fixes 3 issues related to splitting the Editor in master branch :
- [x] Fix Issue 1
- [x] Fix Issue 2
- [x] Fix Issue 3

First issue :
----

**Steps to reproduce the problem:**
- Open Spyder
- Split the Editor through the cog menu

**Traceback:**
_Traceback (most recent call last):
File "C:\Users\jsgosselin\spyder\spyder\widgets\editor.py", line 2274, in 
lambda: self.split(orientation=Qt.Vertical))
File "C:\Users\jsgosselin\spyder\spyder\widgets\editor.py", line 2335, in split
unregister_editorstack_cb=self.unregister_editorstack_cb)
File "C:\Users\jsgosselin\spyder\spyder\widgets\editor.py", line 2269, in init
self.register_editorstack_cb(self.editorstack)
File "C:\Users\jsgosselin\spyder\spyder\plugins\editor.py", line 1241, in register_editorstack
editorstack.set_outlineexplorer(self.outlineexplorer)
File "C:\Users\jsgosselin\spyder\spyder\widgets\editor.py", line 847, in set_outlineexplorer
self.outlineexplorer.is_visible.connect(self._refresh_outlineexplorer)
AttributeError: 'OutlineExplorer' object has no attribute 'is_visible'_

**Fix :**
Pass `self.outlineexplorer.explorer` to the `editorstack` instead of `self.outlineexplorer` because they
don't need the plugin

Second issue :
----
**Steps to reproduce the problem :**
- Open Spyder
- Split the Editor through the cog menu and close the newly created editor panel
- Split the Editor again
- Click on the Outline Explorer

**Traceback  :**
_Traceback (most recent call last):
File "C:\Users\jsgosselin\spyder\spyder\widgets\editortools.py", line 491, in clicked
self.activated(item)
File "C:\Users\jsgosselin\spyder\spyder\widgets\editortools.py", line 482, in activated
if _id == editor_id and editor.parent() is parent:
RuntimeError: wrapped C/C++ object of type CodeEditor has been deleted_

**Fix :**
This bug occurs because editors are not removed correctly when a panel is close. This was done by connecting the `destroyed` signal to the `remove_editor` method of the outline explorer by passing the editor as an argument. However, this was not working because once the `destroyed` signal is fired, the editor is already destroyed, and therefore the wrong id was passed to the outline editor and it was not able to removed its reference to it.

Instead, we do this within the `closeEvent` method of the StackEditor, before the editors are destroyed so we can pass the right id to the outline explorer.

Third issue :
----
**Steps to reproduce the problem :**
- Open Spyder
- Split the Editor through the cog menu [X2 times]
- Close the last panel created
- Click on the outline editor

**Traceback :**
Traceback (most recent call last):
  File "C:\Users\jsgosselin\spyder\spyder\plugins\editor.py", line 552, in <lambda>
    editorwindow=self))
  File "C:\Users\jsgosselin\spyder\spyder\plugins\editor.py", line 1923, in load
    focus=focus)
  File "C:\Users\jsgosselin\spyder\spyder\plugins\editor.py", line 1506, in set_current_filename
    return editorstack.set_current_filename(filename, focus)
AttributeError: 'NoneType' object has no attribute 'set_current_filename'
Traceback (most recent call last):
  File "C:\Users\jsgosselin\spyder\spyder\widgets\editortools.py", line 492, in clicked
    
  File "C:\Users\jsgosselin\spyder\spyder\widgets\editortools.py", line 477, in activated
    parent = self.current_editor.parent()
AttributeError: 'NoneType' object has no attribute 'parent'

**Fix :**
To fix the issue, the case when `self.get_last_focus_editorstack(editorwindow)` returns `None` had to be defined in method `get_current_editorstack` so that it returns `self.editorstacks[0]` instead of `None` to prevent the error when clicking on the outline editor.
