### PR TITLE
PR: Don't run continue when starting debug if there is a breakpoint in the first line with code.

### DIFF
--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -2403,8 +2403,13 @@ class Editor(SpyderPluginWidget):
         self.run_file(debug=True)
         # Fixes 2034
         editor = self.get_current_editor()
-        if editor.get_breakpoints():
+        breakpoints = editor.get_breakpoints()
+        if breakpoints:
             time.sleep(0.5)
+            if editor.get_cursor_line_number() == breakpoints[0][0]:
+                # Not need to execute any code because the first breakpoint
+                # is set in the first line with code
+                return
             self.debug_command('continue')
 
     @Slot()


### PR DESCRIPTION
Fixes #4681 

I implement another approach that could be less error prone than manually checking for the first line of code.

I take advantage that when ipdb stops, the editor goto the line being debugged.

This could be improved when addressing #528 and adding a variable (or method) that will return the current line being debugged.