### PR TITLE
PR: Deactivate editor actions when Tab Swither is shown

### DIFF
--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -333,7 +333,7 @@ class TabSwitcherWidget(QListWidget):
 
     def __init__(self, parent, stack_history, tabs):
         QListWidget.__init__(self, parent)
-        self.setWindowFlags(Qt.SubWindow | Qt.FramelessWindowHint)
+        self.setWindowFlags(Qt.SubWindow | Qt.FramelessWindowHint | Qt.Dialog)
 
         self.editor = parent
         self.stack_history = stack_history
@@ -383,11 +383,10 @@ class TabSwitcherWidget(QListWidget):
 
     def set_dialog_position(self):
         """Positions the tab switcher in the top-center of the editor."""
-        parent = self.parent()
-        left = parent.geometry().width()/2 - self.width()/2
-        top = 0
+        left = self.editor.geometry().width()/2 - self.width()/2
+        top = self.editor.tabs.tabBar().geometry().height()
 
-        self.move(left, top + self.tabs.tabBar().geometry().height())
+        self.move(self.editor.mapToGlobal(QPoint(left, top)))
 
 
 class EditorStack(QWidget):

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -408,6 +408,13 @@ class TabSwitcherWidget(QListWidget):
                         self.item_selected()
         event.accept()
 
+    def keyPressEvent(self, event):
+        """Reimplement Qt method to allow cyclic behavior."""
+        if event.key() == Qt.Key_Down:
+            self.select_row(1)
+        elif event.key() == Qt.Key_Up:
+            self.select_row(-1)
+
 
 class EditorStack(QWidget):
     reset_statusbar = Signal()

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -371,10 +371,13 @@ class TabSwitcherWidget(QListWidget):
             item = self.currentItem()
 
         # stack history is in inverse order
-        index = self.stack_history[-(self.currentRow()+1)]
-
-        self.editor.set_stack_index(index)
-        self.editor.current_changed(index)
+        try:
+            index = self.stack_history[-(self.currentRow()+1)]
+        except IndexError:
+            pass
+        else:
+            self.editor.set_stack_index(index)
+            self.editor.current_changed(index)
         self.hide()
 
     def select_row(self, steps):


### PR DESCRIPTION
Fixes: #4844 

I also move some logic out to the editor to the TabSwitcher widget