### PR TITLE
PR: Enable scrolling past the end of the document

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -195,6 +195,7 @@ DEFAULTS = [
               'edge_line': True,
               'edge_line_columns': '79',
               'indent_guides': False,
+              'scroll_past_end': False,
               'toolbox_panel': True,
               'calltips': True,
               'go_to_definition': True,

--- a/spyder/plugins/configdialog.py
+++ b/spyder/plugins/configdialog.py
@@ -1228,6 +1228,7 @@ class ColorSchemeConfigPage(GeneralConfigPage):
                 '        print(bar)\n'
                 )
         show_blanks = CONF.get('editor', 'blank_spaces')
+        update_scrollbar = CONF.get('editor', 'scroll_past_end')
         if scheme_name is None:
             scheme_name = self.current_scheme
         self.preview_editor.setup_editor(linenumbers=True,
@@ -1235,7 +1236,8 @@ class ColorSchemeConfigPage(GeneralConfigPage):
                                          tab_mode=False,
                                          font=get_font(),
                                          show_blanks=show_blanks,
-                                         color_scheme=scheme_name)
+                                         color_scheme=scheme_name,
+                                         scroll_past_end=update_scrollbar)
         self.preview_editor.set_text(text)
         self.preview_editor.set_language('Python')
 

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -102,14 +102,14 @@ WINPDB_PATH = programs.find_program('winpdb')
 class EditorConfigPage(PluginConfigPage):
     def get_name(self):
         return _("Editor")
-
+        
     def get_icon(self):
         return ima.icon('edit')
-
+    
     def setup_page(self):
         template_btn = self.create_button(_("Edit template for new modules"),
                                     self.plugin.edit_template)
-
+        
         interface_group = QGroupBox(_("Interface"))
         newcb = self.create_checkbox
         showtabbar_box = newcb(_("Show tab bar"), 'show_tab_bar')
@@ -123,7 +123,7 @@ class EditorConfigPage(PluginConfigPage):
         interface_layout.addWidget(showclassfuncdropdown_box)
         interface_layout.addWidget(showindentguides_box)
         interface_group.setLayout(interface_layout)
-
+        
         display_group = QGroupBox(_("Source code"))
         linenumbers_box = newcb(_("Show line numbers"), 'line_numbers')
         blanks_box = newcb(_("Show blank spaces"), 'blank_spaces')
@@ -206,7 +206,7 @@ class EditorConfigPage(PluginConfigPage):
                                   "code completion and go-to-definition "
                                   "features won't be available."))
             rope_label.setWordWrap(True)
-
+        
         sourcecode_group = QGroupBox(_("Source code"))
         closepar_box = newcb(_("Automatic insertion of parentheses, braces "
                                                                "and brackets"),
@@ -251,7 +251,7 @@ class EditorConfigPage(PluginConfigPage):
         removetrail_box = newcb(_("Automatically remove trailing spaces "
                                   "when saving files"),
                                'always_remove_trailing_spaces', default=False)
-
+        
         analysis_group = QGroupBox(_("Analysis"))
         pep_url = '<a href="http://www.python.org/dev/peps/pep-0008/">PEP8</a>'
         pep8_label = QLabel(_("<i>(Refer to the {} page)</i>").format(pep_url))
@@ -295,15 +295,15 @@ class EditorConfigPage(PluginConfigPage):
         af_layout = QHBoxLayout()
         af_layout.addWidget(realtime_radio)
         af_layout.addWidget(af_spin)
-
+        
         run_layout = QVBoxLayout()
         run_layout.addWidget(saveall_box)
         run_group.setLayout(run_layout)
-
+        
         run_selection_layout = QVBoxLayout()
         run_selection_layout.addWidget(focus_box)
         run_selection_group.setLayout(run_selection_layout)
-
+        
         introspection_layout = QVBoxLayout()
         if rope_is_installed:
             introspection_layout.addWidget(calltips_box)
@@ -314,10 +314,10 @@ class EditorConfigPage(PluginConfigPage):
         else:
             introspection_layout.addWidget(rope_label)
         introspection_group.setLayout(introspection_layout)
-
+        
         analysis_layout = QVBoxLayout()
         analysis_layout.addWidget(pyflakes_box)
-        analysis_pep_layout = QHBoxLayout()
+        analysis_pep_layout = QHBoxLayout() 
         analysis_pep_layout.addWidget(pep8_box)
         analysis_pep_layout.addWidget(pep8_label)
         analysis_layout.addLayout(analysis_pep_layout)
@@ -325,7 +325,7 @@ class EditorConfigPage(PluginConfigPage):
         analysis_layout.addLayout(af_layout)
         analysis_layout.addWidget(saveonly_radio)
         analysis_group.setLayout(analysis_layout)
-
+        
         sourcecode_layout = QVBoxLayout()
         sourcecode_layout.addWidget(closepar_box)
         sourcecode_layout.addWidget(autounindent_box)
@@ -361,7 +361,7 @@ class EditorConfigPage(PluginConfigPage):
         eol_layout.addWidget(eol_label)
         eol_layout.addWidget(check_eol_box)
         eol_group.setLayout(eol_layout)
-
+        
         tabs = QTabWidget()
         tabs.addTab(self.create_tab(interface_group, display_group),
                     _("Display"))
@@ -370,7 +370,7 @@ class EditorConfigPage(PluginConfigPage):
         tabs.addTab(self.create_tab(template_btn, run_group, run_selection_group,
                                     sourcecode_group, eol_group),
                     _("Advanced settings"))
-
+        
         vlayout = QVBoxLayout()
         vlayout.addWidget(tabs)
         self.setLayout(vlayout)
@@ -385,7 +385,7 @@ class Editor(SpyderPluginWidget):
     TEMPFILE_PATH = get_conf_path('temp.py')
     TEMPLATE_PATH = get_conf_path('template.py')
     DISABLE_ACTIONS_WHEN_HIDDEN = False # SpyderPluginWidget class attribute
-
+    
     # Signals
     run_in_current_ipyclient = Signal(str, str, str, bool, bool, bool, bool)
     exec_in_extconsole = Signal(str, bool)
@@ -427,19 +427,19 @@ class Editor(SpyderPluginWidget):
         # (see spyder.py: 'update_edit_menu' method)
         self.search_menu_actions = None #XXX: same thing ('update_search_menu')
         self.stack_menu_actions = None
-
+        
         # Initialize plugin
         self.initialize_plugin()
-
+        
         # Configuration dialog size
         self.dialog_size = None
-
+        
         statusbar = self.main.statusBar()
         self.readwrite_status = ReadWriteStatus(self, statusbar)
         self.eol_status = EOLStatus(self, statusbar)
         self.encoding_status = EncodingStatus(self, statusbar)
         self.cursorpos_status = CursorPositionStatus(self, statusbar)
-
+        
         layout = QVBoxLayout()
         self.dock_toolbar = QToolBar(self)
         add_actions(self.dock_toolbar, self.dock_toolbar_actions)
@@ -449,7 +449,7 @@ class Editor(SpyderPluginWidget):
         self.cursor_pos_history = []
         self.cursor_pos_index = None
         self.__ignore_cursor_position = True
-
+        
         self.editorstacks = []
         self.last_focus_editorstack = {}
         self.editorwindows = []
@@ -501,13 +501,13 @@ class Editor(SpyderPluginWidget):
         layout.addWidget(self.splitter)
         self.setLayout(layout)
         self.setFocusPolicy(Qt.ClickFocus)
-
+        
         # Editor's splitter state
         state = self.get_option('splitter_state', None)
         if state is not None:
             self.splitter.restoreState( QByteArray().fromHex(
                     str(state).encode('utf-8')) )
-
+        
         self.recent_files = self.get_option('recent_files', [])
         self.untitled_num = 0
 
@@ -527,7 +527,7 @@ class Editor(SpyderPluginWidget):
             self.add_cursor_position_to_history(filename, position)
         self.update_cursorpos_actions()
         self.set_path()
-
+        
     def set_projects(self, projects):
         self.projects = projects
 
@@ -541,7 +541,7 @@ class Editor(SpyderPluginWidget):
                 dw.show()
                 dw.raise_()
             self.switch_to_plugin()
-
+        
     def set_outlineexplorer(self, outlineexplorer):
         self.outlineexplorer = outlineexplorer
         for editorstack in self.editorstacks:
@@ -570,8 +570,8 @@ class Editor(SpyderPluginWidget):
             self.get_current_editor().centerCursor()
         except AttributeError:
             pass
-
-    #------ SpyderPluginWidget API ---------------------------------------------
+            
+    #------ SpyderPluginWidget API ---------------------------------------------    
     def get_plugin_title(self):
         """Return widget title"""
         title = _('Editor')
@@ -587,7 +587,7 @@ class Editor(SpyderPluginWidget):
     def get_plugin_icon(self):
         """Return widget icon."""
         return ima.icon('edit')
-
+    
     def get_focus_widget(self):
         """
         Return the widget to give focus to.
@@ -606,13 +606,13 @@ class Editor(SpyderPluginWidget):
         if enable:
             self.refresh_plugin()
         self.sig_update_plugin_title.emit()
-
+    
     def refresh_plugin(self):
         """Refresh editor plugin"""
         editorstack = self.get_current_editorstack()
         editorstack.refresh()
         self.refresh_save_all_action()
-
+        
     def closing_plugin(self, cancelable=False):
         """Perform actions before parent main window is closed"""
         state = self.splitter.saveState()
@@ -666,7 +666,7 @@ class Editor(SpyderPluginWidget):
         )
         self.register_shortcut(self.open_last_closed_action, context="Editor",
                                name="Open last closed")
-
+        
         self.open_action = create_action(self, _("&Open..."),
                 icon=ima.icon('fileopen'), tip=_("Open file"),
                 triggered=self.load,
@@ -878,7 +878,7 @@ class Editor(SpyderPluginWidget):
         self.todo_menu = QMenu(self)
         self.todo_list_action.setMenu(self.todo_menu)
         self.todo_menu.aboutToShow.connect(self.update_todo_menu)
-
+        
         self.warning_list_action = create_action(self,
                 _("Show warning/error list"), icon=ima.icon('wng_list'),
                 tip=_("Show code analysis warnings/errors"),
@@ -894,7 +894,7 @@ class Editor(SpyderPluginWidget):
                 _("Next warning/error"), icon=ima.icon('next_wng'),
                 tip=_("Go to next code analysis warning/error"),
                 triggered=self.go_to_next_warning)
-
+        
         self.previous_edit_cursor_action = create_action(self,
                 _("Last edit location"), icon=ima.icon('last_edit_location'),
                 tip=_("Go to last edit location"),
@@ -910,7 +910,7 @@ class Editor(SpyderPluginWidget):
                 triggered=self.go_to_previous_cursor_position,
                 context=Qt.WidgetShortcut)
         self.register_shortcut(self.previous_cursor_action,
-                               context="Editor",
+                               context="Editor", 
                                name="Previous cursor position",
                                add_sc_to_tip=True)
         self.next_cursor_action = create_action(self,
@@ -943,7 +943,7 @@ class Editor(SpyderPluginWidget):
                 triggered=self.unblockcomment, context=Qt.WidgetShortcut)
         self.register_shortcut(unblockcomment_action, context="Editor",
                                name="Unblockcomment")
-
+                
         # ----------------------------------------------------------------------
         # The following action shortcuts are hard-coded in CodeEditor
         # keyPressEvent handler (the shortcut is here only to inform user):
@@ -971,7 +971,7 @@ class Editor(SpyderPluginWidget):
         self.register_shortcut(self.text_lowercase_action, context="Editor",
                                name="transform to lowercase")
         # ----------------------------------------------------------------------
-
+        
         self.win_eol_action = create_action(self,
                            _("Carriage return and line feed (Windows)"),
                            toggled=lambda checked: self.toggle_eol_chars('nt', checked))
@@ -987,7 +987,7 @@ class Editor(SpyderPluginWidget):
         add_actions(eol_action_group, eol_actions)
         eol_menu = QMenu(_("Convert end-of-line characters"), self)
         add_actions(eol_menu, eol_actions)
-
+        
         trailingspaces_action = create_action(self,
                                       _("Remove trailing spaces"),
                                       triggered=self.remove_trailing_spaces)
@@ -999,7 +999,7 @@ class Editor(SpyderPluginWidget):
                                           _("Scroll past the end"),
                                           toggled=self.toggle_scroll_past_end)
         self.scrollpastend_action.setChecked(CONF.get('editor',
-                                                      'scroll_past_end'))
+                                             'scroll_past_end'))
 
         showindentguides_action = create_action(self, _("Show indent guides."),
                                                toggled=self.toggle_show_indent_guides)
@@ -1085,7 +1085,7 @@ class Editor(SpyderPluginWidget):
         self.search_menu_actions = [gotoline_action]
         self.main.search_menu_actions += self.search_menu_actions
         self.main.search_toolbar_actions += [gotoline_action]
-
+          
         # ---- Run menu/toolbar construction ----
         run_menu_actions = [run_action, run_cell_action,
                             run_cell_advance_action,
@@ -1099,7 +1099,7 @@ class Editor(SpyderPluginWidget):
         self.main.run_toolbar_actions += run_toolbar_actions
 
         # ---- Debug menu/toolbar construction ----
-        # NOTE: 'list_breakpoints' is used by the breakpoints
+        # NOTE: 'list_breakpoints' is used by the breakpoints 
         # plugin to add its "List breakpoints" action to this
         # menu
         debug_menu_actions = [debug_action,
@@ -1178,9 +1178,9 @@ class Editor(SpyderPluginWidget):
                  self.toggle_comment_action, self.revert_action,
                  self.indent_action, self.unindent_action]
         self.stack_menu_actions = [gotoline_action, workdir_action]
-
+        
         return self.file_dependent_actions
-
+    
     def register_plugin(self):
         """Register plugin in Spyder's main window"""
         self.main.restore_scrollbar_position.connect(
@@ -1209,7 +1209,7 @@ class Editor(SpyderPluginWidget):
             for finfo in editorstack.data:
                 comp_widget = finfo.editor.completion_widget
                 comp_widget.setup_appearance(completion_size, font)
-
+        
     #------ Focus tabwidget
     def __get_focus_editorstack(self):
         fwidget = QApplication.focusWidget()
@@ -1219,19 +1219,19 @@ class Editor(SpyderPluginWidget):
             for editorstack in self.editorstacks:
                 if editorstack.isAncestorOf(fwidget):
                     return editorstack
-
+        
     def set_last_focus_editorstack(self, editorwindow, editorstack):
         self.last_focus_editorstack[editorwindow] = editorstack
         self.last_focus_editorstack[None] = editorstack # very last editorstack
-
+        
     def get_last_focus_editorstack(self, editorwindow=None):
         return self.last_focus_editorstack[editorwindow]
-
+    
     def remove_last_focus_editorstack(self, editorstack):
         for editorwindow, widget in list(self.last_focus_editorstack.items()):
             if widget is editorstack:
                 self.last_focus_editorstack[editorwindow] = None
-
+        
     def save_focus_editorstack(self):
         editorstack = self.__get_focus_editorstack()
         if editorstack is not None:
@@ -1370,7 +1370,7 @@ class Editor(SpyderPluginWidget):
         else:
             # editorstack was not removed!
             return False
-
+        
     def clone_editorstack(self, editorstack):
         editorstack.clone_from(self.editorstacks[0])
         for finfo in editorstack.data:
@@ -1449,7 +1449,7 @@ class Editor(SpyderPluginWidget):
         for layout_settings in self.editorwindows_to_be_created:
             win = self.create_new_window()
             win.set_layout_settings(layout_settings)
-
+        
     def create_new_window(self):
         oe_options = self.outlineexplorer.explorer.get_options()
         fullpath_sorting=self.get_option('fullpath_sorting', True),
@@ -1466,14 +1466,14 @@ class Editor(SpyderPluginWidget):
         self.register_editorwindow(window)
         window.destroyed.connect(lambda: self.unregister_editorwindow(window))
         return window
-
+    
     def register_editorwindow(self, window):
         self.editorwindows.append(window)
-
+        
     def unregister_editorwindow(self, window):
         self.editorwindows.pop(self.editorwindows.index(window))
-
-
+    
+        
     #------ Accessors
     def get_filenames(self):
         return [finfo.filename for finfo in self.editorstacks[0].data]
@@ -1490,25 +1490,25 @@ class Editor(SpyderPluginWidget):
                 if editorstack is None or editorwindow is not None:
                     return self.get_last_focus_editorstack(editorwindow)
                 return editorstack
-
+        
     def get_current_editor(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:
             return editorstack.get_current_editor()
-
+        
     def get_current_finfo(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:
             return editorstack.get_current_finfo()
-
+        
     def get_current_filename(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:
             return editorstack.get_current_filename()
-
+        
     def is_file_opened(self, filename=None):
         return self.editorstacks[0].is_file_opened(filename)
-
+        
     def set_current_filename(self, filename, editorwindow=None, focus=True):
         """Set focus to *filename* if this file has been opened.
 
@@ -1523,7 +1523,7 @@ class Editor(SpyderPluginWidget):
         if self.introspector:
             self.introspector.change_extra_path(
                     self.main.get_spyder_pythonpath())
-
+    
     #------ FileSwitcher API
     def get_current_tab_manager(self):
         """Get the widget with the TabWidget attribute."""
@@ -1537,7 +1537,7 @@ class Editor(SpyderPluginWidget):
             enable = self.get_current_editor() is not None
             for action in self.file_dependent_actions:
                 action.setEnabled(enable)
-
+                
     def refresh_save_all_action(self):
         """Enable 'Save All' if there are files to be saved"""
         editorstack = self.get_current_editorstack()
@@ -1545,7 +1545,7 @@ class Editor(SpyderPluginWidget):
             state = any(finfo.editor.document().isModified() or finfo.newly_created
                         for finfo in editorstack.data)
             self.save_all_action.setEnabled(state)
-
+            
     def update_warning_menu(self):
         """Update warning list menu"""
         editorstack = self.get_current_editorstack()
@@ -1563,7 +1563,7 @@ class Editor(SpyderPluginWidget):
                 slot = lambda _l=line_number: self.load(filename, goto=_l)
             action = create_action(self, text=text, icon=icon, triggered=slot)
             self.warning_menu.addAction(action)
-
+            
     def analysis_results_changed(self):
         """
         Synchronize analysis results between editorstacks
@@ -1577,7 +1577,7 @@ class Editor(SpyderPluginWidget):
                 if other_editorstack is not editorstack:
                     other_editorstack.set_analysis_results(index, results)
         self.update_code_analysis_actions()
-
+            
     def update_todo_menu(self):
         """Update todo list menu"""
         editorstack = self.get_current_editorstack()
@@ -1594,7 +1594,7 @@ class Editor(SpyderPluginWidget):
             action = create_action(self, text=text, icon=icon, triggered=slot)
             self.todo_menu.addAction(action)
         self.update_todo_actions()
-
+            
     def todo_results_changed(self):
         """
         Synchronize todo results between editorstacks
@@ -1608,7 +1608,7 @@ class Editor(SpyderPluginWidget):
                 if other_editorstack is not editorstack:
                     other_editorstack.set_todo_results(index, results)
         self.update_todo_actions()
-
+            
     def refresh_eol_chars(self, os_name):
         os_name = to_text_string(os_name)
         self.__set_eol_chars = False
@@ -1619,8 +1619,8 @@ class Editor(SpyderPluginWidget):
         else:
             self.mac_eol_action.setChecked(True)
         self.__set_eol_chars = True
-
-
+    
+    
     #------ Slots
     def opened_files_list_changed(self):
         """
@@ -1649,7 +1649,7 @@ class Editor(SpyderPluginWidget):
     def update_code_analysis_actions(self):
         editorstack = self.get_current_editorstack()
         results = editorstack.get_analysis_results()
-
+        
         # Update code analysis buttons
         state = (self.get_option('code_analysis/pyflakes') \
                  or self.get_option('code_analysis/pep8')) \
@@ -1657,7 +1657,7 @@ class Editor(SpyderPluginWidget):
         for action in (self.warning_list_action, self.previous_warning_action,
                        self.next_warning_action):
             action.setEnabled(state)
-
+            
     def update_todo_actions(self):
         editorstack = self.get_current_editorstack()
         results = editorstack.get_todo_results()
@@ -1683,7 +1683,7 @@ class Editor(SpyderPluginWidget):
             breakpoints = []
         save_breakpoints(filename, breakpoints)
         self.breakpoints_saved.emit()
-
+        
     #------ File I/O
     def __load_temp_file(self):
         """Load temporary file from a text file in user home directory"""
@@ -1705,7 +1705,7 @@ class Editor(SpyderPluginWidget):
         if fname is not None:
             directory = osp.dirname(osp.abspath(fname))
             self.open_dir.emit(directory)
-
+                
     def __add_recent_file(self, fname):
         """Add to recent file list"""
         if fname is None:
@@ -1729,7 +1729,7 @@ class Editor(SpyderPluginWidget):
     def new(self, fname=None, editorstack=None, text=None):
         """
         Create a new file - Untitled
-
+        
         fname=None --> fname will be 'untitledXX.py' but do not create file
         fname=<basestring> --> create file
         """
@@ -1788,7 +1788,7 @@ class Editor(SpyderPluginWidget):
             index = current_es.has_filename(fname)
             if index and not current_es.close_file(index):
                 return
-
+        
         # Creating the editor widget in the first editorstack (the one that
         # can't be destroyed), then cloning this editor widget in all other
         # editorstacks:
@@ -1897,7 +1897,7 @@ class Editor(SpyderPluginWidget):
                 filenames = [osp.normpath(fname) for fname in filenames]
             else:
                 return
-
+            
         focus_widget = QApplication.focusWidget()
         if self.dockwidget and not self.ismaximized and\
            (not self.dockwidget.isAncestorOf(focus_widget)\
@@ -1905,7 +1905,7 @@ class Editor(SpyderPluginWidget):
             self.dockwidget.setVisible(True)
             self.dockwidget.setFocus()
             self.dockwidget.raise_()
-
+        
         def _convert(fname):
             fname = osp.abspath(encoding.to_unicode_from_fs(fname))
             if os.name == 'nt' and len(fname) >= 2 and fname[1] == ':':
@@ -2005,13 +2005,13 @@ class Editor(SpyderPluginWidget):
     def close_all_files(self):
         """Close all opened scripts"""
         self.editorstacks[0].close_all_files()
-
+    
     @Slot()
     def save(self, index=None, force=False):
         """Save file"""
         editorstack = self.get_current_editorstack()
         return editorstack.save(index=index, force=force)
-
+    
     @Slot()
     def save_as(self):
         """Save *as* the currently edited file"""
@@ -2030,7 +2030,7 @@ class Editor(SpyderPluginWidget):
     def save_all(self):
         """Save all opened files"""
         self.get_current_editorstack().save_all()
-
+    
     @Slot()
     def revert(self):
         """Revert the currently edited file from disk"""
@@ -2061,7 +2061,7 @@ class Editor(SpyderPluginWidget):
         """Replace slot"""
         editorstack = self.get_current_editorstack()
         editorstack.find_widget.show_replace()
-
+    
     def open_last_closed(self):
         """ Reopens the last closed tab."""
         editorstack = self.get_current_editorstack()
@@ -2071,7 +2071,7 @@ class Editor(SpyderPluginWidget):
             last_closed_files.remove(file_to_open)
             editorstack.set_last_closed_files(last_closed_files)
             self.load(file_to_open)
-
+    
     #------ Explorer widget
     def close_file_from_name(self, filename):
         """Close file from its name"""
@@ -2079,18 +2079,18 @@ class Editor(SpyderPluginWidget):
         index = self.editorstacks[0].has_filename(filename)
         if index is not None:
             self.editorstacks[0].close_file(index)
-
+                
     def removed(self, filename):
         """File was removed in file explorer widget or in project explorer"""
         self.close_file_from_name(filename)
-
+    
     def removed_tree(self, dirname):
         """Directory was removed in project explorer widget"""
         dirname = osp.abspath(to_text_string(dirname))
         for fname in self.get_filenames():
             if osp.abspath(fname).startswith(dirname):
                 self.close_file_from_name(fname)
-
+    
     def renamed(self, source, dest):
         """File was renamed in file explorer widget or in project explorer"""
         filename = osp.abspath(to_text_string(source))
@@ -2099,8 +2099,8 @@ class Editor(SpyderPluginWidget):
             for editorstack in self.editorstacks:
                 editorstack.rename_in_data(index,
                                            new_filename=to_text_string(dest))
-
-
+        
+    
     #------ Source code
     @Slot()
     def indent(self):
@@ -2188,7 +2188,7 @@ class Editor(SpyderPluginWidget):
             # (subprocess "cwd" default is None, so empty str
             # must be changed to None in this case.)
             programs.run_program(WINPDB_PATH, [fname] + args, cwd=wdir or None)
-
+        
     def toggle_eol_chars(self, os_name, checked):
         if checked:
             editor = self.get_current_editor()
@@ -2222,7 +2222,7 @@ class Editor(SpyderPluginWidget):
     def fix_indentation(self):
         editorstack = self.get_current_editorstack()
         editorstack.fix_indentation()
-
+                    
     #------ Cursor position history management
     def update_cursorpos_actions(self):
         self.previous_edit_cursor_action.setEnabled(
@@ -2231,7 +2231,7 @@ class Editor(SpyderPluginWidget):
                self.cursor_pos_index is not None and self.cursor_pos_index > 0)
         self.next_cursor_action.setEnabled(self.cursor_pos_index is not None \
                     and self.cursor_pos_index < len(self.cursor_pos_history)-1)
-
+        
     def add_cursor_position_to_history(self, filename, position, fc=False):
         if self.__ignore_cursor_position:
             return
@@ -2254,16 +2254,16 @@ class Editor(SpyderPluginWidget):
         self.cursor_pos_history.append((filename, position))
         self.cursor_pos_index = len(self.cursor_pos_history)-1
         self.update_cursorpos_actions()
-
+    
     def cursor_moved(self, filename0, position0, filename1, position1):
         """Cursor was just moved: 'go to'"""
         if position0 is not None:
             self.add_cursor_position_to_history(filename0, position0)
         self.add_cursor_position_to_history(filename1, position1)
-
+        
     def text_changed_at(self, filename, position):
         self.last_edit_cursor_pos = (to_text_string(filename), position)
-
+        
     def current_file_changed(self, filename, position):
         self.add_cursor_position_to_history(to_text_string(filename), position,
                                             fc=True)
@@ -2280,7 +2280,7 @@ class Editor(SpyderPluginWidget):
                 editor = self.get_current_editor()
                 if position < editor.document().characterCount():
                     editor.set_cursor_position(position)
-
+            
     def __move_cursor_position(self, index_move):
         if self.cursor_pos_index is None:
             return
@@ -2346,7 +2346,7 @@ class Editor(SpyderPluginWidget):
             for data in editorstack.data:
                 data.editor.clear_breakpoints()
         self.refresh_plugin()
-
+                
     def clear_breakpoint(self, filename, lineno):
         """Remove a single breakpoint"""
         clear_breakpoint(filename, lineno)
@@ -2356,7 +2356,7 @@ class Editor(SpyderPluginWidget):
             index = self.is_file_opened(filename)
             if index is not None:
                 editorstack.data[index].editor.add_remove_breakpoint(lineno)
-
+                
     def debug_command(self, command):
         """Debug actions"""
         self.main.ipyconsole.write_to_stdin(command)
@@ -2386,11 +2386,11 @@ class Editor(SpyderPluginWidget):
         if editorstack.save():
             editor = self.get_current_editor()
             fname = osp.abspath(self.get_current_filename())
-
+            
             # Escape single and double quotes in fname (Fixes Issue 2158)
             fname = fname.replace("'", r"\'")
             fname = fname.replace('"', r'\"')
-
+            
             runconf = get_run_configuration(fname)
             if runconf is None:
                 dialog = RunConfigOneDialog(self)
@@ -2399,13 +2399,13 @@ class Editor(SpyderPluginWidget):
                     dialog.resize(self.dialog_size)
                 dialog.setup(fname)
                 if CONF.get('run', 'open_at_least_once', not PYTEST):
-                    # Open Run Config dialog at least once: the first time
-                    # a script is ever run in Spyder, so that the user may
+                    # Open Run Config dialog at least once: the first time 
+                    # a script is ever run in Spyder, so that the user may 
                     # see it at least once and be conscious that it exists
                     show_dlg = True
                     CONF.set('run', 'open_at_least_once', False)
                 else:
-                    # Open Run Config dialog only
+                    # Open Run Config dialog only 
                     # if ALWAYS_OPEN_FIRST_RUN_OPTION option is enabled
                     show_dlg = CONF.get('run', ALWAYS_OPEN_FIRST_RUN_OPTION)
                 if show_dlg and not dialog.exec_():
@@ -2432,7 +2432,7 @@ class Editor(SpyderPluginWidget):
             python = True # Note: in the future, it may be useful to run
             # something in a terminal instead of a Python interp.
             self.__last_ec_exec = (fname, wdir, args, interact, debug,
-                                   python, python_args, current, systerm,
+                                   python, python_args, current, systerm, 
                                    post_mortem, clear_namespace)
             self.re_run_file()
             if not interact and not debug:
@@ -2441,7 +2441,7 @@ class Editor(SpyderPluginWidget):
                 # current external shell automatically
                 # (see SpyderPluginWidget.visibility_changed method)
                 editor.setFocus()
-
+                
     def set_dialog_size(self, size):
         self.dialog_size = size
 
@@ -2529,14 +2529,14 @@ class Editor(SpyderPluginWidget):
             currentline_n = 'highlight_current_line'
             currentline_o = self.get_option(currentline_n)
             currentcell_n = 'highlight_current_cell'
-            currentcell_o = self.get_option(currentcell_n)
+            currentcell_o = self.get_option(currentcell_n)            
             occurrence_n = 'occurrence_highlighting'
             occurrence_o = self.get_option(occurrence_n)
             occurrence_timeout_n = 'occurrence_highlighting/timeout'
             occurrence_timeout_o = self.get_option(occurrence_timeout_n)
             focus_to_editor_n = 'focus_to_editor'
             focus_to_editor_o = self.get_option(focus_to_editor_n)
-
+            
             for editorstack in self.editorstacks:
                 if color_scheme_n in options:
                     editorstack.set_color_scheme(color_scheme_o)
@@ -2545,7 +2545,7 @@ class Editor(SpyderPluginWidget):
                                                                 currentline_o)
                 if currentcell_n in options:
                     editorstack.set_highlight_current_cell_enabled(
-                                                                currentcell_o)
+                                                                currentcell_o)              
                 if occurrence_n in options:
                     editorstack.set_occurrence_highlighting_enabled(occurrence_o)
                 if occurrence_timeout_n in options:
@@ -2705,7 +2705,7 @@ class Editor(SpyderPluginWidget):
         filenames = []
         filenames += [finfo.filename for finfo in editorstack.data]
         return filenames
-
+        
     def set_open_filenames(self):
         """
         Set the recent opened files on editor based on active project.
@@ -2717,7 +2717,7 @@ class Editor(SpyderPluginWidget):
             if not self.projects.get_active_project():
                 filenames = self.get_open_filenames()
                 self.set_option('filenames', filenames)
-
+ 
     def setup_open_files(self):
         """Open the list of saved files per project"""
         self.set_create_new_file_if_empty(False)
@@ -2751,10 +2751,10 @@ class Editor(SpyderPluginWidget):
     def reorder_filenames(self, filenames):
         """Take the last session filenames and put the last open on first.
 
-        It takes a list of filenames and using the current filename from the
-        layout settings, sets the one that had focused last in the position 0.
-        It also reorders the current lines for each file (supposing that they
-        are in the same order as the filenames) and sets them back in the
+        It takes a list of filenames and using the current filename from the 
+        layout settings, sets the one that had focused last in the position 0. 
+        It also reorders the current lines for each file (supposing that they 
+        are in the same order as the filenames) and sets them back in the 
         layout settings.
         """
         layout = self.get_option('layout_settings', None)

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -155,6 +155,8 @@ class EditorConfigPage(PluginConfigPage):
                 self.get_option('occurrence_highlighting'))
 
         wrap_mode_box = newcb(_("Wrap lines"), 'wrap')
+        scroll_past_end_box = newcb(_("Scroll past the end"),
+                                     'scroll_past_end')
 
         display_layout = QGridLayout()
         display_layout.addWidget(linenumbers_box, 0, 0)
@@ -168,6 +170,7 @@ class EditorConfigPage(PluginConfigPage):
         display_layout.addWidget(occurrence_spin.spinbox, 5, 1)
         display_layout.addWidget(occurrence_spin.slabel, 5, 2)
         display_layout.addWidget(wrap_mode_box, 6, 0)
+        display_layout.addWidget(scroll_past_end_box, 7, 0)
         display_h_layout = QHBoxLayout()
         display_h_layout.addLayout(display_layout)
         display_h_layout.addStretch(1)
@@ -992,9 +995,14 @@ class Editor(SpyderPluginWidget):
                                                toggled=self.toggle_show_blanks)
         self.showblanks_action.setChecked(CONF.get('editor', 'blank_spaces'))
 
+        self.scrollpastend_action = create_action(self, _("Scroll past the end"),
+                                             toggled=self.toggle_scroll_past_end)
+        self.scrollpastend_action.setChecked(CONF.get('editor', 'scroll_past_end'))
+
         showindentguides_action = create_action(self, _("Show indent guides."),
                                                toggled=self.toggle_show_indent_guides)
         showindentguides_action.setChecked(CONF.get('editor', 'indent_guides'))
+
         fixindentation_action = create_action(self, _("Fix indentation"),
                       tip=_("Replace tab characters by space characters"),
                       triggered=self.fix_indentation)
@@ -1114,6 +1122,7 @@ class Editor(SpyderPluginWidget):
         # ---- Source menu/toolbar construction ----
         source_menu_actions = [eol_menu,
                                self.showblanks_action,
+                               self.scrollpastend_action,
                                showindentguides_action,
                                trailingspaces_action,
                                fixindentation_action,
@@ -1264,6 +1273,7 @@ class Editor(SpyderPluginWidget):
             ('set_realtime_analysis_enabled',       'realtime_analysis'),
             ('set_realtime_analysis_timeout',       'realtime_analysis/timeout'),
             ('set_blanks_enabled',                  'blank_spaces'),
+            ('set_scrollpastend_enabled',           'scroll_past_end'),
             ('set_linenumbers_enabled',             'line_numbers'),
             ('set_edgeline_enabled',                'edge_line'),
             ('set_edgeline_columns',                'edge_line_columns'),
@@ -1833,7 +1843,7 @@ class Editor(SpyderPluginWidget):
              processevents=True):
         """
         Load a text file
-        editorwindow: load in this editorwindow (useful when clicking on 
+        editorwindow: load in this editorwindow (useful when clicking on
         outline explorer with multiple editor windows)
         processevents: determines if processEvents() should be called at the
         end of this method (set to False to prevent keyboard events from
@@ -2190,6 +2200,12 @@ class Editor(SpyderPluginWidget):
                 editorstack.set_blanks_enabled(checked)
 
     @Slot(bool)
+    def toggle_scroll_past_end(self, checked):
+        if self.editorstacks:
+            for editorstack in self.editorstacks:
+                editorstack.set_scrollpastend_enabled(checked)
+
+    @Slot(bool)
     def toggle_show_indent_guides(self, checked):
         if self.editorstacks:
             for editorstack in self.editorstacks:
@@ -2542,6 +2558,8 @@ class Editor(SpyderPluginWidget):
             linenb_o = self.get_option(linenb_n)
             blanks_n = 'blank_spaces'
             blanks_o = self.get_option(blanks_n)
+            scrollpastend_n = 'scroll_past_end'
+            scrollpastend_o = self.get_option(scrollpastend_n)
             edgeline_n = 'edge_line'
             edgeline_o = self.get_option(edgeline_n)
             edgelinecols_n = 'edge_line_columns'
@@ -2611,6 +2629,9 @@ class Editor(SpyderPluginWidget):
                 if blanks_n in options:
                     editorstack.set_blanks_enabled(blanks_o)
                     self.showblanks_action.setChecked(blanks_o)
+                if scrollpastend_n in options:
+                    editorstack.set_scrollpastend_enabled(scrollpastend_o)
+                    self.scrollpastend_action.setChecked(scrollpastend_o)
                 if edgeline_n in options:
                     editorstack.set_edgeline_enabled(edgeline_o)
                 if edgelinecols_n in options:

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -102,14 +102,14 @@ WINPDB_PATH = programs.find_program('winpdb')
 class EditorConfigPage(PluginConfigPage):
     def get_name(self):
         return _("Editor")
-        
+
     def get_icon(self):
         return ima.icon('edit')
-    
+
     def setup_page(self):
         template_btn = self.create_button(_("Edit template for new modules"),
                                     self.plugin.edit_template)
-        
+
         interface_group = QGroupBox(_("Interface"))
         newcb = self.create_checkbox
         showtabbar_box = newcb(_("Show tab bar"), 'show_tab_bar')
@@ -123,7 +123,7 @@ class EditorConfigPage(PluginConfigPage):
         interface_layout.addWidget(showclassfuncdropdown_box)
         interface_layout.addWidget(showindentguides_box)
         interface_group.setLayout(interface_layout)
-        
+
         display_group = QGroupBox(_("Source code"))
         linenumbers_box = newcb(_("Show line numbers"), 'line_numbers')
         blanks_box = newcb(_("Show blank spaces"), 'blank_spaces')
@@ -156,7 +156,7 @@ class EditorConfigPage(PluginConfigPage):
 
         wrap_mode_box = newcb(_("Wrap lines"), 'wrap')
         scroll_past_end_box = newcb(_("Scroll past the end"),
-                                     'scroll_past_end')
+                                    'scroll_past_end')
 
         display_layout = QGridLayout()
         display_layout.addWidget(linenumbers_box, 0, 0)
@@ -206,7 +206,7 @@ class EditorConfigPage(PluginConfigPage):
                                   "code completion and go-to-definition "
                                   "features won't be available."))
             rope_label.setWordWrap(True)
-        
+
         sourcecode_group = QGroupBox(_("Source code"))
         closepar_box = newcb(_("Automatic insertion of parentheses, braces "
                                                                "and brackets"),
@@ -251,7 +251,7 @@ class EditorConfigPage(PluginConfigPage):
         removetrail_box = newcb(_("Automatically remove trailing spaces "
                                   "when saving files"),
                                'always_remove_trailing_spaces', default=False)
-        
+
         analysis_group = QGroupBox(_("Analysis"))
         pep_url = '<a href="http://www.python.org/dev/peps/pep-0008/">PEP8</a>'
         pep8_label = QLabel(_("<i>(Refer to the {} page)</i>").format(pep_url))
@@ -295,15 +295,15 @@ class EditorConfigPage(PluginConfigPage):
         af_layout = QHBoxLayout()
         af_layout.addWidget(realtime_radio)
         af_layout.addWidget(af_spin)
-        
+
         run_layout = QVBoxLayout()
         run_layout.addWidget(saveall_box)
         run_group.setLayout(run_layout)
-        
+
         run_selection_layout = QVBoxLayout()
         run_selection_layout.addWidget(focus_box)
         run_selection_group.setLayout(run_selection_layout)
-        
+
         introspection_layout = QVBoxLayout()
         if rope_is_installed:
             introspection_layout.addWidget(calltips_box)
@@ -314,10 +314,10 @@ class EditorConfigPage(PluginConfigPage):
         else:
             introspection_layout.addWidget(rope_label)
         introspection_group.setLayout(introspection_layout)
-        
+
         analysis_layout = QVBoxLayout()
         analysis_layout.addWidget(pyflakes_box)
-        analysis_pep_layout = QHBoxLayout() 
+        analysis_pep_layout = QHBoxLayout()
         analysis_pep_layout.addWidget(pep8_box)
         analysis_pep_layout.addWidget(pep8_label)
         analysis_layout.addLayout(analysis_pep_layout)
@@ -325,7 +325,7 @@ class EditorConfigPage(PluginConfigPage):
         analysis_layout.addLayout(af_layout)
         analysis_layout.addWidget(saveonly_radio)
         analysis_group.setLayout(analysis_layout)
-        
+
         sourcecode_layout = QVBoxLayout()
         sourcecode_layout.addWidget(closepar_box)
         sourcecode_layout.addWidget(autounindent_box)
@@ -361,7 +361,7 @@ class EditorConfigPage(PluginConfigPage):
         eol_layout.addWidget(eol_label)
         eol_layout.addWidget(check_eol_box)
         eol_group.setLayout(eol_layout)
-        
+
         tabs = QTabWidget()
         tabs.addTab(self.create_tab(interface_group, display_group),
                     _("Display"))
@@ -370,7 +370,7 @@ class EditorConfigPage(PluginConfigPage):
         tabs.addTab(self.create_tab(template_btn, run_group, run_selection_group,
                                     sourcecode_group, eol_group),
                     _("Advanced settings"))
-        
+
         vlayout = QVBoxLayout()
         vlayout.addWidget(tabs)
         self.setLayout(vlayout)
@@ -385,7 +385,7 @@ class Editor(SpyderPluginWidget):
     TEMPFILE_PATH = get_conf_path('temp.py')
     TEMPLATE_PATH = get_conf_path('template.py')
     DISABLE_ACTIONS_WHEN_HIDDEN = False # SpyderPluginWidget class attribute
-    
+
     # Signals
     run_in_current_ipyclient = Signal(str, str, str, bool, bool, bool, bool)
     exec_in_extconsole = Signal(str, bool)
@@ -427,19 +427,19 @@ class Editor(SpyderPluginWidget):
         # (see spyder.py: 'update_edit_menu' method)
         self.search_menu_actions = None #XXX: same thing ('update_search_menu')
         self.stack_menu_actions = None
-        
+
         # Initialize plugin
         self.initialize_plugin()
-        
+
         # Configuration dialog size
         self.dialog_size = None
-        
+
         statusbar = self.main.statusBar()
         self.readwrite_status = ReadWriteStatus(self, statusbar)
         self.eol_status = EOLStatus(self, statusbar)
         self.encoding_status = EncodingStatus(self, statusbar)
         self.cursorpos_status = CursorPositionStatus(self, statusbar)
-        
+
         layout = QVBoxLayout()
         self.dock_toolbar = QToolBar(self)
         add_actions(self.dock_toolbar, self.dock_toolbar_actions)
@@ -449,7 +449,7 @@ class Editor(SpyderPluginWidget):
         self.cursor_pos_history = []
         self.cursor_pos_index = None
         self.__ignore_cursor_position = True
-        
+
         self.editorstacks = []
         self.last_focus_editorstack = {}
         self.editorwindows = []
@@ -501,13 +501,13 @@ class Editor(SpyderPluginWidget):
         layout.addWidget(self.splitter)
         self.setLayout(layout)
         self.setFocusPolicy(Qt.ClickFocus)
-        
+
         # Editor's splitter state
         state = self.get_option('splitter_state', None)
         if state is not None:
             self.splitter.restoreState( QByteArray().fromHex(
                     str(state).encode('utf-8')) )
-        
+
         self.recent_files = self.get_option('recent_files', [])
         self.untitled_num = 0
 
@@ -527,7 +527,7 @@ class Editor(SpyderPluginWidget):
             self.add_cursor_position_to_history(filename, position)
         self.update_cursorpos_actions()
         self.set_path()
-        
+
     def set_projects(self, projects):
         self.projects = projects
 
@@ -541,7 +541,7 @@ class Editor(SpyderPluginWidget):
                 dw.show()
                 dw.raise_()
             self.switch_to_plugin()
-        
+
     def set_outlineexplorer(self, outlineexplorer):
         self.outlineexplorer = outlineexplorer
         for editorstack in self.editorstacks:
@@ -570,8 +570,8 @@ class Editor(SpyderPluginWidget):
             self.get_current_editor().centerCursor()
         except AttributeError:
             pass
-            
-    #------ SpyderPluginWidget API ---------------------------------------------    
+
+    #------ SpyderPluginWidget API ---------------------------------------------
     def get_plugin_title(self):
         """Return widget title"""
         title = _('Editor')
@@ -587,7 +587,7 @@ class Editor(SpyderPluginWidget):
     def get_plugin_icon(self):
         """Return widget icon."""
         return ima.icon('edit')
-    
+
     def get_focus_widget(self):
         """
         Return the widget to give focus to.
@@ -606,13 +606,13 @@ class Editor(SpyderPluginWidget):
         if enable:
             self.refresh_plugin()
         self.sig_update_plugin_title.emit()
-    
+
     def refresh_plugin(self):
         """Refresh editor plugin"""
         editorstack = self.get_current_editorstack()
         editorstack.refresh()
         self.refresh_save_all_action()
-        
+
     def closing_plugin(self, cancelable=False):
         """Perform actions before parent main window is closed"""
         state = self.splitter.saveState()
@@ -666,7 +666,7 @@ class Editor(SpyderPluginWidget):
         )
         self.register_shortcut(self.open_last_closed_action, context="Editor",
                                name="Open last closed")
-        
+
         self.open_action = create_action(self, _("&Open..."),
                 icon=ima.icon('fileopen'), tip=_("Open file"),
                 triggered=self.load,
@@ -878,7 +878,7 @@ class Editor(SpyderPluginWidget):
         self.todo_menu = QMenu(self)
         self.todo_list_action.setMenu(self.todo_menu)
         self.todo_menu.aboutToShow.connect(self.update_todo_menu)
-        
+
         self.warning_list_action = create_action(self,
                 _("Show warning/error list"), icon=ima.icon('wng_list'),
                 tip=_("Show code analysis warnings/errors"),
@@ -894,7 +894,7 @@ class Editor(SpyderPluginWidget):
                 _("Next warning/error"), icon=ima.icon('next_wng'),
                 tip=_("Go to next code analysis warning/error"),
                 triggered=self.go_to_next_warning)
-        
+
         self.previous_edit_cursor_action = create_action(self,
                 _("Last edit location"), icon=ima.icon('last_edit_location'),
                 tip=_("Go to last edit location"),
@@ -910,7 +910,7 @@ class Editor(SpyderPluginWidget):
                 triggered=self.go_to_previous_cursor_position,
                 context=Qt.WidgetShortcut)
         self.register_shortcut(self.previous_cursor_action,
-                               context="Editor", 
+                               context="Editor",
                                name="Previous cursor position",
                                add_sc_to_tip=True)
         self.next_cursor_action = create_action(self,
@@ -943,7 +943,7 @@ class Editor(SpyderPluginWidget):
                 triggered=self.unblockcomment, context=Qt.WidgetShortcut)
         self.register_shortcut(unblockcomment_action, context="Editor",
                                name="Unblockcomment")
-                
+
         # ----------------------------------------------------------------------
         # The following action shortcuts are hard-coded in CodeEditor
         # keyPressEvent handler (the shortcut is here only to inform user):
@@ -971,7 +971,7 @@ class Editor(SpyderPluginWidget):
         self.register_shortcut(self.text_lowercase_action, context="Editor",
                                name="transform to lowercase")
         # ----------------------------------------------------------------------
-        
+
         self.win_eol_action = create_action(self,
                            _("Carriage return and line feed (Windows)"),
                            toggled=lambda checked: self.toggle_eol_chars('nt', checked))
@@ -987,7 +987,7 @@ class Editor(SpyderPluginWidget):
         add_actions(eol_action_group, eol_actions)
         eol_menu = QMenu(_("Convert end-of-line characters"), self)
         add_actions(eol_menu, eol_actions)
-        
+
         trailingspaces_action = create_action(self,
                                       _("Remove trailing spaces"),
                                       triggered=self.remove_trailing_spaces)
@@ -995,9 +995,11 @@ class Editor(SpyderPluginWidget):
                                                toggled=self.toggle_show_blanks)
         self.showblanks_action.setChecked(CONF.get('editor', 'blank_spaces'))
 
-        self.scrollpastend_action = create_action(self, _("Scroll past the end"),
-                                             toggled=self.toggle_scroll_past_end)
-        self.scrollpastend_action.setChecked(CONF.get('editor', 'scroll_past_end'))
+        self.scrollpastend_action = create_action(self,
+                                          _("Scroll past the end"),
+                                          toggled=self.toggle_scroll_past_end)
+        self.scrollpastend_action.setChecked(CONF.get('editor',
+                                                      'scroll_past_end'))
 
         showindentguides_action = create_action(self, _("Show indent guides."),
                                                toggled=self.toggle_show_indent_guides)
@@ -1083,7 +1085,7 @@ class Editor(SpyderPluginWidget):
         self.search_menu_actions = [gotoline_action]
         self.main.search_menu_actions += self.search_menu_actions
         self.main.search_toolbar_actions += [gotoline_action]
-          
+
         # ---- Run menu/toolbar construction ----
         run_menu_actions = [run_action, run_cell_action,
                             run_cell_advance_action,
@@ -1097,7 +1099,7 @@ class Editor(SpyderPluginWidget):
         self.main.run_toolbar_actions += run_toolbar_actions
 
         # ---- Debug menu/toolbar construction ----
-        # NOTE: 'list_breakpoints' is used by the breakpoints 
+        # NOTE: 'list_breakpoints' is used by the breakpoints
         # plugin to add its "List breakpoints" action to this
         # menu
         debug_menu_actions = [debug_action,
@@ -1176,9 +1178,9 @@ class Editor(SpyderPluginWidget):
                  self.toggle_comment_action, self.revert_action,
                  self.indent_action, self.unindent_action]
         self.stack_menu_actions = [gotoline_action, workdir_action]
-        
+
         return self.file_dependent_actions
-    
+
     def register_plugin(self):
         """Register plugin in Spyder's main window"""
         self.main.restore_scrollbar_position.connect(
@@ -1207,7 +1209,7 @@ class Editor(SpyderPluginWidget):
             for finfo in editorstack.data:
                 comp_widget = finfo.editor.completion_widget
                 comp_widget.setup_appearance(completion_size, font)
-        
+
     #------ Focus tabwidget
     def __get_focus_editorstack(self):
         fwidget = QApplication.focusWidget()
@@ -1217,19 +1219,19 @@ class Editor(SpyderPluginWidget):
             for editorstack in self.editorstacks:
                 if editorstack.isAncestorOf(fwidget):
                     return editorstack
-        
+
     def set_last_focus_editorstack(self, editorwindow, editorstack):
         self.last_focus_editorstack[editorwindow] = editorstack
         self.last_focus_editorstack[None] = editorstack # very last editorstack
-        
+
     def get_last_focus_editorstack(self, editorwindow=None):
         return self.last_focus_editorstack[editorwindow]
-    
+
     def remove_last_focus_editorstack(self, editorstack):
         for editorwindow, widget in list(self.last_focus_editorstack.items()):
             if widget is editorstack:
                 self.last_focus_editorstack[editorwindow] = None
-        
+
     def save_focus_editorstack(self):
         editorstack = self.__get_focus_editorstack()
         if editorstack is not None:
@@ -1368,7 +1370,7 @@ class Editor(SpyderPluginWidget):
         else:
             # editorstack was not removed!
             return False
-        
+
     def clone_editorstack(self, editorstack):
         editorstack.clone_from(self.editorstacks[0])
         for finfo in editorstack.data:
@@ -1447,7 +1449,7 @@ class Editor(SpyderPluginWidget):
         for layout_settings in self.editorwindows_to_be_created:
             win = self.create_new_window()
             win.set_layout_settings(layout_settings)
-        
+
     def create_new_window(self):
         oe_options = self.outlineexplorer.explorer.get_options()
         fullpath_sorting=self.get_option('fullpath_sorting', True),
@@ -1464,14 +1466,14 @@ class Editor(SpyderPluginWidget):
         self.register_editorwindow(window)
         window.destroyed.connect(lambda: self.unregister_editorwindow(window))
         return window
-    
+
     def register_editorwindow(self, window):
         self.editorwindows.append(window)
-        
+
     def unregister_editorwindow(self, window):
         self.editorwindows.pop(self.editorwindows.index(window))
-    
-        
+
+
     #------ Accessors
     def get_filenames(self):
         return [finfo.filename for finfo in self.editorstacks[0].data]
@@ -1488,25 +1490,25 @@ class Editor(SpyderPluginWidget):
                 if editorstack is None or editorwindow is not None:
                     return self.get_last_focus_editorstack(editorwindow)
                 return editorstack
-        
+
     def get_current_editor(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:
             return editorstack.get_current_editor()
-        
+
     def get_current_finfo(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:
             return editorstack.get_current_finfo()
-        
+
     def get_current_filename(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:
             return editorstack.get_current_filename()
-        
+
     def is_file_opened(self, filename=None):
         return self.editorstacks[0].is_file_opened(filename)
-        
+
     def set_current_filename(self, filename, editorwindow=None, focus=True):
         """Set focus to *filename* if this file has been opened.
 
@@ -1521,7 +1523,7 @@ class Editor(SpyderPluginWidget):
         if self.introspector:
             self.introspector.change_extra_path(
                     self.main.get_spyder_pythonpath())
-    
+
     #------ FileSwitcher API
     def get_current_tab_manager(self):
         """Get the widget with the TabWidget attribute."""
@@ -1535,7 +1537,7 @@ class Editor(SpyderPluginWidget):
             enable = self.get_current_editor() is not None
             for action in self.file_dependent_actions:
                 action.setEnabled(enable)
-                
+
     def refresh_save_all_action(self):
         """Enable 'Save All' if there are files to be saved"""
         editorstack = self.get_current_editorstack()
@@ -1543,7 +1545,7 @@ class Editor(SpyderPluginWidget):
             state = any(finfo.editor.document().isModified() or finfo.newly_created
                         for finfo in editorstack.data)
             self.save_all_action.setEnabled(state)
-            
+
     def update_warning_menu(self):
         """Update warning list menu"""
         editorstack = self.get_current_editorstack()
@@ -1561,7 +1563,7 @@ class Editor(SpyderPluginWidget):
                 slot = lambda _l=line_number: self.load(filename, goto=_l)
             action = create_action(self, text=text, icon=icon, triggered=slot)
             self.warning_menu.addAction(action)
-            
+
     def analysis_results_changed(self):
         """
         Synchronize analysis results between editorstacks
@@ -1575,7 +1577,7 @@ class Editor(SpyderPluginWidget):
                 if other_editorstack is not editorstack:
                     other_editorstack.set_analysis_results(index, results)
         self.update_code_analysis_actions()
-            
+
     def update_todo_menu(self):
         """Update todo list menu"""
         editorstack = self.get_current_editorstack()
@@ -1592,7 +1594,7 @@ class Editor(SpyderPluginWidget):
             action = create_action(self, text=text, icon=icon, triggered=slot)
             self.todo_menu.addAction(action)
         self.update_todo_actions()
-            
+
     def todo_results_changed(self):
         """
         Synchronize todo results between editorstacks
@@ -1606,7 +1608,7 @@ class Editor(SpyderPluginWidget):
                 if other_editorstack is not editorstack:
                     other_editorstack.set_todo_results(index, results)
         self.update_todo_actions()
-            
+
     def refresh_eol_chars(self, os_name):
         os_name = to_text_string(os_name)
         self.__set_eol_chars = False
@@ -1617,8 +1619,8 @@ class Editor(SpyderPluginWidget):
         else:
             self.mac_eol_action.setChecked(True)
         self.__set_eol_chars = True
-    
-    
+
+
     #------ Slots
     def opened_files_list_changed(self):
         """
@@ -1647,7 +1649,7 @@ class Editor(SpyderPluginWidget):
     def update_code_analysis_actions(self):
         editorstack = self.get_current_editorstack()
         results = editorstack.get_analysis_results()
-        
+
         # Update code analysis buttons
         state = (self.get_option('code_analysis/pyflakes') \
                  or self.get_option('code_analysis/pep8')) \
@@ -1655,7 +1657,7 @@ class Editor(SpyderPluginWidget):
         for action in (self.warning_list_action, self.previous_warning_action,
                        self.next_warning_action):
             action.setEnabled(state)
-            
+
     def update_todo_actions(self):
         editorstack = self.get_current_editorstack()
         results = editorstack.get_todo_results()
@@ -1681,7 +1683,7 @@ class Editor(SpyderPluginWidget):
             breakpoints = []
         save_breakpoints(filename, breakpoints)
         self.breakpoints_saved.emit()
-        
+
     #------ File I/O
     def __load_temp_file(self):
         """Load temporary file from a text file in user home directory"""
@@ -1703,7 +1705,7 @@ class Editor(SpyderPluginWidget):
         if fname is not None:
             directory = osp.dirname(osp.abspath(fname))
             self.open_dir.emit(directory)
-                
+
     def __add_recent_file(self, fname):
         """Add to recent file list"""
         if fname is None:
@@ -1727,7 +1729,7 @@ class Editor(SpyderPluginWidget):
     def new(self, fname=None, editorstack=None, text=None):
         """
         Create a new file - Untitled
-        
+
         fname=None --> fname will be 'untitledXX.py' but do not create file
         fname=<basestring> --> create file
         """
@@ -1786,7 +1788,7 @@ class Editor(SpyderPluginWidget):
             index = current_es.has_filename(fname)
             if index and not current_es.close_file(index):
                 return
-        
+
         # Creating the editor widget in the first editorstack (the one that
         # can't be destroyed), then cloning this editor widget in all other
         # editorstacks:
@@ -1895,7 +1897,7 @@ class Editor(SpyderPluginWidget):
                 filenames = [osp.normpath(fname) for fname in filenames]
             else:
                 return
-            
+
         focus_widget = QApplication.focusWidget()
         if self.dockwidget and not self.ismaximized and\
            (not self.dockwidget.isAncestorOf(focus_widget)\
@@ -1903,7 +1905,7 @@ class Editor(SpyderPluginWidget):
             self.dockwidget.setVisible(True)
             self.dockwidget.setFocus()
             self.dockwidget.raise_()
-        
+
         def _convert(fname):
             fname = osp.abspath(encoding.to_unicode_from_fs(fname))
             if os.name == 'nt' and len(fname) >= 2 and fname[1] == ':':
@@ -2003,13 +2005,13 @@ class Editor(SpyderPluginWidget):
     def close_all_files(self):
         """Close all opened scripts"""
         self.editorstacks[0].close_all_files()
-    
+
     @Slot()
     def save(self, index=None, force=False):
         """Save file"""
         editorstack = self.get_current_editorstack()
         return editorstack.save(index=index, force=force)
-    
+
     @Slot()
     def save_as(self):
         """Save *as* the currently edited file"""
@@ -2028,7 +2030,7 @@ class Editor(SpyderPluginWidget):
     def save_all(self):
         """Save all opened files"""
         self.get_current_editorstack().save_all()
-    
+
     @Slot()
     def revert(self):
         """Revert the currently edited file from disk"""
@@ -2059,7 +2061,7 @@ class Editor(SpyderPluginWidget):
         """Replace slot"""
         editorstack = self.get_current_editorstack()
         editorstack.find_widget.show_replace()
-    
+
     def open_last_closed(self):
         """ Reopens the last closed tab."""
         editorstack = self.get_current_editorstack()
@@ -2069,7 +2071,7 @@ class Editor(SpyderPluginWidget):
             last_closed_files.remove(file_to_open)
             editorstack.set_last_closed_files(last_closed_files)
             self.load(file_to_open)
-    
+
     #------ Explorer widget
     def close_file_from_name(self, filename):
         """Close file from its name"""
@@ -2077,18 +2079,18 @@ class Editor(SpyderPluginWidget):
         index = self.editorstacks[0].has_filename(filename)
         if index is not None:
             self.editorstacks[0].close_file(index)
-                
+
     def removed(self, filename):
         """File was removed in file explorer widget or in project explorer"""
         self.close_file_from_name(filename)
-    
+
     def removed_tree(self, dirname):
         """Directory was removed in project explorer widget"""
         dirname = osp.abspath(to_text_string(dirname))
         for fname in self.get_filenames():
             if osp.abspath(fname).startswith(dirname):
                 self.close_file_from_name(fname)
-    
+
     def renamed(self, source, dest):
         """File was renamed in file explorer widget or in project explorer"""
         filename = osp.abspath(to_text_string(source))
@@ -2097,8 +2099,8 @@ class Editor(SpyderPluginWidget):
             for editorstack in self.editorstacks:
                 editorstack.rename_in_data(index,
                                            new_filename=to_text_string(dest))
-        
-    
+
+
     #------ Source code
     @Slot()
     def indent(self):
@@ -2186,7 +2188,7 @@ class Editor(SpyderPluginWidget):
             # (subprocess "cwd" default is None, so empty str
             # must be changed to None in this case.)
             programs.run_program(WINPDB_PATH, [fname] + args, cwd=wdir or None)
-        
+
     def toggle_eol_chars(self, os_name, checked):
         if checked:
             editor = self.get_current_editor()
@@ -2220,7 +2222,7 @@ class Editor(SpyderPluginWidget):
     def fix_indentation(self):
         editorstack = self.get_current_editorstack()
         editorstack.fix_indentation()
-                    
+
     #------ Cursor position history management
     def update_cursorpos_actions(self):
         self.previous_edit_cursor_action.setEnabled(
@@ -2229,7 +2231,7 @@ class Editor(SpyderPluginWidget):
                self.cursor_pos_index is not None and self.cursor_pos_index > 0)
         self.next_cursor_action.setEnabled(self.cursor_pos_index is not None \
                     and self.cursor_pos_index < len(self.cursor_pos_history)-1)
-        
+
     def add_cursor_position_to_history(self, filename, position, fc=False):
         if self.__ignore_cursor_position:
             return
@@ -2252,16 +2254,16 @@ class Editor(SpyderPluginWidget):
         self.cursor_pos_history.append((filename, position))
         self.cursor_pos_index = len(self.cursor_pos_history)-1
         self.update_cursorpos_actions()
-    
+
     def cursor_moved(self, filename0, position0, filename1, position1):
         """Cursor was just moved: 'go to'"""
         if position0 is not None:
             self.add_cursor_position_to_history(filename0, position0)
         self.add_cursor_position_to_history(filename1, position1)
-        
+
     def text_changed_at(self, filename, position):
         self.last_edit_cursor_pos = (to_text_string(filename), position)
-        
+
     def current_file_changed(self, filename, position):
         self.add_cursor_position_to_history(to_text_string(filename), position,
                                             fc=True)
@@ -2278,7 +2280,7 @@ class Editor(SpyderPluginWidget):
                 editor = self.get_current_editor()
                 if position < editor.document().characterCount():
                     editor.set_cursor_position(position)
-            
+
     def __move_cursor_position(self, index_move):
         if self.cursor_pos_index is None:
             return
@@ -2344,7 +2346,7 @@ class Editor(SpyderPluginWidget):
             for data in editorstack.data:
                 data.editor.clear_breakpoints()
         self.refresh_plugin()
-                
+
     def clear_breakpoint(self, filename, lineno):
         """Remove a single breakpoint"""
         clear_breakpoint(filename, lineno)
@@ -2354,7 +2356,7 @@ class Editor(SpyderPluginWidget):
             index = self.is_file_opened(filename)
             if index is not None:
                 editorstack.data[index].editor.add_remove_breakpoint(lineno)
-                
+
     def debug_command(self, command):
         """Debug actions"""
         self.main.ipyconsole.write_to_stdin(command)
@@ -2384,11 +2386,11 @@ class Editor(SpyderPluginWidget):
         if editorstack.save():
             editor = self.get_current_editor()
             fname = osp.abspath(self.get_current_filename())
-            
+
             # Escape single and double quotes in fname (Fixes Issue 2158)
             fname = fname.replace("'", r"\'")
             fname = fname.replace('"', r'\"')
-            
+
             runconf = get_run_configuration(fname)
             if runconf is None:
                 dialog = RunConfigOneDialog(self)
@@ -2397,13 +2399,13 @@ class Editor(SpyderPluginWidget):
                     dialog.resize(self.dialog_size)
                 dialog.setup(fname)
                 if CONF.get('run', 'open_at_least_once', not PYTEST):
-                    # Open Run Config dialog at least once: the first time 
-                    # a script is ever run in Spyder, so that the user may 
+                    # Open Run Config dialog at least once: the first time
+                    # a script is ever run in Spyder, so that the user may
                     # see it at least once and be conscious that it exists
                     show_dlg = True
                     CONF.set('run', 'open_at_least_once', False)
                 else:
-                    # Open Run Config dialog only 
+                    # Open Run Config dialog only
                     # if ALWAYS_OPEN_FIRST_RUN_OPTION option is enabled
                     show_dlg = CONF.get('run', ALWAYS_OPEN_FIRST_RUN_OPTION)
                 if show_dlg and not dialog.exec_():
@@ -2430,7 +2432,7 @@ class Editor(SpyderPluginWidget):
             python = True # Note: in the future, it may be useful to run
             # something in a terminal instead of a Python interp.
             self.__last_ec_exec = (fname, wdir, args, interact, debug,
-                                   python, python_args, current, systerm, 
+                                   python, python_args, current, systerm,
                                    post_mortem, clear_namespace)
             self.re_run_file()
             if not interact and not debug:
@@ -2439,7 +2441,7 @@ class Editor(SpyderPluginWidget):
                 # current external shell automatically
                 # (see SpyderPluginWidget.visibility_changed method)
                 editor.setFocus()
-                
+
     def set_dialog_size(self, size):
         self.dialog_size = size
 
@@ -2527,14 +2529,14 @@ class Editor(SpyderPluginWidget):
             currentline_n = 'highlight_current_line'
             currentline_o = self.get_option(currentline_n)
             currentcell_n = 'highlight_current_cell'
-            currentcell_o = self.get_option(currentcell_n)            
+            currentcell_o = self.get_option(currentcell_n)
             occurrence_n = 'occurrence_highlighting'
             occurrence_o = self.get_option(occurrence_n)
             occurrence_timeout_n = 'occurrence_highlighting/timeout'
             occurrence_timeout_o = self.get_option(occurrence_timeout_n)
             focus_to_editor_n = 'focus_to_editor'
             focus_to_editor_o = self.get_option(focus_to_editor_n)
-            
+
             for editorstack in self.editorstacks:
                 if color_scheme_n in options:
                     editorstack.set_color_scheme(color_scheme_o)
@@ -2543,7 +2545,7 @@ class Editor(SpyderPluginWidget):
                                                                 currentline_o)
                 if currentcell_n in options:
                     editorstack.set_highlight_current_cell_enabled(
-                                                                currentcell_o)              
+                                                                currentcell_o)
                 if occurrence_n in options:
                     editorstack.set_occurrence_highlighting_enabled(occurrence_o)
                 if occurrence_timeout_n in options:
@@ -2703,7 +2705,7 @@ class Editor(SpyderPluginWidget):
         filenames = []
         filenames += [finfo.filename for finfo in editorstack.data]
         return filenames
-        
+
     def set_open_filenames(self):
         """
         Set the recent opened files on editor based on active project.
@@ -2715,7 +2717,7 @@ class Editor(SpyderPluginWidget):
             if not self.projects.get_active_project():
                 filenames = self.get_open_filenames()
                 self.set_option('filenames', filenames)
- 
+
     def setup_open_files(self):
         """Open the list of saved files per project"""
         self.set_create_new_file_if_empty(False)
@@ -2749,10 +2751,10 @@ class Editor(SpyderPluginWidget):
     def reorder_filenames(self, filenames):
         """Take the last session filenames and put the last open on first.
 
-        It takes a list of filenames and using the current filename from the 
-        layout settings, sets the one that had focused last in the position 0. 
-        It also reorders the current lines for each file (supposing that they 
-        are in the same order as the filenames) and sets them back in the 
+        It takes a list of filenames and using the current filename from the
+        layout settings, sets the one that had focused last in the position 0.
+        It also reorders the current lines for each file (supposing that they
+        are in the same order as the filenames) and sets them back in the
         layout settings.
         """
         layout = self.get_option('layout_settings', None)

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -996,9 +996,10 @@ class Editor(SpyderPluginWidget):
                                                toggled=self.toggle_show_blanks)
         self.showblanks_action.setChecked(CONF.get('editor', 'blank_spaces'))
 
-        self.scrollpastend_action = create_action(self,
-                                          _("Scroll past the end"),
-                                          toggled=self.toggle_scroll_past_end)
+        self.scrollpastend_action = create_action(
+                                        self,
+                                        _("Scroll past the end"),
+                                        toggled=self.toggle_scroll_past_end)
         self.scrollpastend_action.setChecked(CONF.get('editor',
                                              'scroll_past_end'))
 

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -512,6 +512,7 @@ class EditorStack(QWidget):
         self.is_analysis_done = False
         self.linenumbers_enabled = True
         self.blanks_enabled = False
+        self.scrollpastend_enabled = False
         self.edgeline_enabled = True
         self.edgeline_columns = (79,)
         self.codecompletion_auto_enabled = True
@@ -933,6 +934,12 @@ class EditorStack(QWidget):
         if self.data:
             for finfo in self.data:
                 finfo.editor.set_blanks_enabled(state)
+
+    def set_scrollpastend_enabled(self, state):
+        self.scrollpastend_enabled = state
+        if self.data:
+            for finfo in self.data:
+                finfo.editor.set_scrollpastend_enabled(state)
 
     def set_edgeline_enabled(self, state):
         # CONF.get(self.CONF_SECTION, 'edge_line')
@@ -1970,6 +1977,7 @@ class EditorStack(QWidget):
         editor.setup_editor(
                 linenumbers=self.linenumbers_enabled,
                 show_blanks=self.blanks_enabled,
+                scroll_past_end=self.scrollpastend_enabled,
                 edge_line=self.edgeline_enabled,
                 edge_line_columns=self.edgeline_columns, language=language,
                 markers=self.has_markers(), font=self.default_font,

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -1214,7 +1214,7 @@ class CodeEditor(TextEditBaseWidget):
         """
         self.scrollpastend_enabled = state
         self.setCenterOnScroll(state)
-        self.update()
+        self.setDocument(self.document())
 
     def resizeEvent(self, event):
         """Reimplemented Qt method to handle p resizing"""

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -288,6 +288,9 @@ class CodeEditor(TextEditBaseWidget):
         # Blanks enabled
         self.blanks_enabled = False
 
+        # Scrolling past the end of the document
+        self.scrollpastend_enabled = False
+
         self.background = QColor('white')
         self.decorations = TextDecorationsManager(self)
 
@@ -597,8 +600,8 @@ class CodeEditor(TextEditBaseWidget):
                      add_colons=True, auto_unindent=True, indent_chars=" "*4,
                      tab_stop_width_spaces=4, cloned_from=None, filename=None,
                      occurrence_timeout=1500, show_class_func_dropdown=True,
-                     indent_guides=False):
-        
+                     indent_guides=False, scroll_past_end=False):
+
         # Code completion and calltips
         self.set_codecompletion_auto(codecompletion_auto)
         self.set_codecompletion_case(codecompletion_case)
@@ -628,6 +631,9 @@ class CodeEditor(TextEditBaseWidget):
 
         # Blanks
         self.set_blanks_enabled(show_blanks)
+
+        # Scrolling past the end
+        self.set_scrollpastend_enabled(scroll_past_end)
 
         # Line number area
         if cloned_from:
@@ -1187,6 +1193,15 @@ class CodeEditor(TextEditBaseWidget):
         self.document().setDefaultTextOption(option)
         # Rehighlight to make the spaces less apparent.
         self.rehighlight()
+
+    def set_scrollpastend_enabled(self, state):
+        """
+        Allow user to scroll past the end of the document to have the last
+        line on top of the screen
+        """
+        self.scrollpastend_enabled = state
+        self.setCenterOnScroll(state)
+        self.update()
 
     def resizeEvent(self, event):
         """Reimplemented Qt method to handle p resizing"""

--- a/spyder/widgets/tests/test_codeeditor.py
+++ b/spyder/widgets/tests/test_codeeditor.py
@@ -21,8 +21,9 @@ from spyder.widgets.editor import codeeditor
 def editorbot(qtbot):
     widget = codeeditor.CodeEditor(None)
     widget.setup_editor(linenumbers=True, markers=True, tab_mode=False,
-                         font=QFont("Courier New", 10),
-                         show_blanks=True, color_scheme='Zenburn')
+                        font=QFont("Courier New", 10),
+                        show_blanks=True, color_scheme='Zenburn',
+                        scroll_past_end=True)
     widget.setup_editor(language='Python')
     qtbot.addWidget(widget)
     widget.show()


### PR DESCRIPTION
Fixes #3345

Hi team, 
This is an attempt to solve #3345 and #2063: I added an option (default to `False`) to enable the user to scroll past the end of the document in order to have the last line of code on top of the screen (without having to added unnecessary blank lines). 
I don't know if this is an option you are willing to add to Spyder. I find it very useful but that is not my call :-)
The option is already available in QtPlainTextEdit (`setCenterOnScroll(True)`) so it did not add a lot of complexity to the editor code. The `scrollflagarea` does not need to be modified.

![scrollpastend](https://user-images.githubusercontent.com/20270441/30020471-329c778a-9164-11e7-9f0a-fedc2bac8681.gif)

For some reason however I can't find a way to update the editor immediatly after adding the option. The tab that has focus is not updated while the others are updated. As soon as I add a new line (or remove one) it gets updated. Could you point me to what I am missing? 
- [x] Update editor after adding the option 