### PR TITLE
PR: Add keyboard shortcuts for Next|Previous Warning/Error

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -395,6 +395,8 @@ DEFAULTS = [
               'editor/last edit location': "Ctrl+Alt+Shift+Left",
               'editor/previous cursor position': "Ctrl+Alt+Left",
               'editor/next cursor position': "Ctrl+Alt+Right",
+              'editor/previous warning': "Ctrl+Alt+Shift+,",
+              'editor/next warning': "Ctrl+Alt+Shift+.",
               'editor/zoom in 1': "Ctrl++",
               'editor/zoom in 2': "Ctrl+=",
               'editor/zoom out': "Ctrl+-",

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -102,14 +102,14 @@ WINPDB_PATH = programs.find_program('winpdb')
 class EditorConfigPage(PluginConfigPage):
     def get_name(self):
         return _("Editor")
-
+        
     def get_icon(self):
         return ima.icon('edit')
-
+    
     def setup_page(self):
         template_btn = self.create_button(_("Edit template for new modules"),
                                     self.plugin.edit_template)
-
+        
         interface_group = QGroupBox(_("Interface"))
         newcb = self.create_checkbox
         showtabbar_box = newcb(_("Show tab bar"), 'show_tab_bar')
@@ -123,7 +123,7 @@ class EditorConfigPage(PluginConfigPage):
         interface_layout.addWidget(showclassfuncdropdown_box)
         interface_layout.addWidget(showindentguides_box)
         interface_group.setLayout(interface_layout)
-
+        
         display_group = QGroupBox(_("Source code"))
         linenumbers_box = newcb(_("Show line numbers"), 'line_numbers')
         blanks_box = newcb(_("Show blank spaces"), 'blank_spaces')
@@ -203,7 +203,7 @@ class EditorConfigPage(PluginConfigPage):
                                   "code completion and go-to-definition "
                                   "features won't be available."))
             rope_label.setWordWrap(True)
-
+        
         sourcecode_group = QGroupBox(_("Source code"))
         closepar_box = newcb(_("Automatic insertion of parentheses, braces "
                                                                "and brackets"),
@@ -248,7 +248,7 @@ class EditorConfigPage(PluginConfigPage):
         removetrail_box = newcb(_("Automatically remove trailing spaces "
                                   "when saving files"),
                                'always_remove_trailing_spaces', default=False)
-
+        
         analysis_group = QGroupBox(_("Analysis"))
         pep_url = '<a href="http://www.python.org/dev/peps/pep-0008/">PEP8</a>'
         pep8_label = QLabel(_("<i>(Refer to the {} page)</i>").format(pep_url))
@@ -292,15 +292,15 @@ class EditorConfigPage(PluginConfigPage):
         af_layout = QHBoxLayout()
         af_layout.addWidget(realtime_radio)
         af_layout.addWidget(af_spin)
-
+        
         run_layout = QVBoxLayout()
         run_layout.addWidget(saveall_box)
         run_group.setLayout(run_layout)
-
+        
         run_selection_layout = QVBoxLayout()
         run_selection_layout.addWidget(focus_box)
         run_selection_group.setLayout(run_selection_layout)
-
+        
         introspection_layout = QVBoxLayout()
         if rope_is_installed:
             introspection_layout.addWidget(calltips_box)
@@ -311,10 +311,10 @@ class EditorConfigPage(PluginConfigPage):
         else:
             introspection_layout.addWidget(rope_label)
         introspection_group.setLayout(introspection_layout)
-
+        
         analysis_layout = QVBoxLayout()
         analysis_layout.addWidget(pyflakes_box)
-        analysis_pep_layout = QHBoxLayout()
+        analysis_pep_layout = QHBoxLayout() 
         analysis_pep_layout.addWidget(pep8_box)
         analysis_pep_layout.addWidget(pep8_label)
         analysis_layout.addLayout(analysis_pep_layout)
@@ -322,7 +322,7 @@ class EditorConfigPage(PluginConfigPage):
         analysis_layout.addLayout(af_layout)
         analysis_layout.addWidget(saveonly_radio)
         analysis_group.setLayout(analysis_layout)
-
+        
         sourcecode_layout = QVBoxLayout()
         sourcecode_layout.addWidget(closepar_box)
         sourcecode_layout.addWidget(autounindent_box)
@@ -358,7 +358,7 @@ class EditorConfigPage(PluginConfigPage):
         eol_layout.addWidget(eol_label)
         eol_layout.addWidget(check_eol_box)
         eol_group.setLayout(eol_layout)
-
+        
         tabs = QTabWidget()
         tabs.addTab(self.create_tab(interface_group, display_group),
                     _("Display"))
@@ -367,7 +367,7 @@ class EditorConfigPage(PluginConfigPage):
         tabs.addTab(self.create_tab(template_btn, run_group, run_selection_group,
                                     sourcecode_group, eol_group),
                     _("Advanced settings"))
-
+        
         vlayout = QVBoxLayout()
         vlayout.addWidget(tabs)
         self.setLayout(vlayout)
@@ -382,7 +382,7 @@ class Editor(SpyderPluginWidget):
     TEMPFILE_PATH = get_conf_path('temp.py')
     TEMPLATE_PATH = get_conf_path('template.py')
     DISABLE_ACTIONS_WHEN_HIDDEN = False # SpyderPluginWidget class attribute
-
+    
     # Signals
     run_in_current_ipyclient = Signal(str, str, str, bool, bool, bool, bool)
     exec_in_extconsole = Signal(str, bool)
@@ -424,19 +424,19 @@ class Editor(SpyderPluginWidget):
         # (see spyder.py: 'update_edit_menu' method)
         self.search_menu_actions = None #XXX: same thing ('update_search_menu')
         self.stack_menu_actions = None
-
+        
         # Initialize plugin
         self.initialize_plugin()
-
+        
         # Configuration dialog size
         self.dialog_size = None
-
+        
         statusbar = self.main.statusBar()
         self.readwrite_status = ReadWriteStatus(self, statusbar)
         self.eol_status = EOLStatus(self, statusbar)
         self.encoding_status = EncodingStatus(self, statusbar)
         self.cursorpos_status = CursorPositionStatus(self, statusbar)
-
+        
         layout = QVBoxLayout()
         self.dock_toolbar = QToolBar(self)
         add_actions(self.dock_toolbar, self.dock_toolbar_actions)
@@ -446,7 +446,7 @@ class Editor(SpyderPluginWidget):
         self.cursor_pos_history = []
         self.cursor_pos_index = None
         self.__ignore_cursor_position = True
-
+        
         self.editorstacks = []
         self.last_focus_editorstack = {}
         self.editorwindows = []
@@ -498,13 +498,13 @@ class Editor(SpyderPluginWidget):
         layout.addWidget(self.splitter)
         self.setLayout(layout)
         self.setFocusPolicy(Qt.ClickFocus)
-
+        
         # Editor's splitter state
         state = self.get_option('splitter_state', None)
         if state is not None:
             self.splitter.restoreState( QByteArray().fromHex(
                     str(state).encode('utf-8')) )
-
+        
         self.recent_files = self.get_option('recent_files', [])
         self.untitled_num = 0
 
@@ -524,7 +524,7 @@ class Editor(SpyderPluginWidget):
             self.add_cursor_position_to_history(filename, position)
         self.update_cursorpos_actions()
         self.set_path()
-
+        
     def set_projects(self, projects):
         self.projects = projects
 
@@ -538,7 +538,7 @@ class Editor(SpyderPluginWidget):
                 dw.show()
                 dw.raise_()
             self.switch_to_plugin()
-
+        
     def set_outlineexplorer(self, outlineexplorer):
         self.outlineexplorer = outlineexplorer
         for editorstack in self.editorstacks:
@@ -567,8 +567,8 @@ class Editor(SpyderPluginWidget):
             self.get_current_editor().centerCursor()
         except AttributeError:
             pass
-
-    #------ SpyderPluginWidget API ---------------------------------------------
+            
+    #------ SpyderPluginWidget API ---------------------------------------------    
     def get_plugin_title(self):
         """Return widget title"""
         title = _('Editor')
@@ -584,7 +584,7 @@ class Editor(SpyderPluginWidget):
     def get_plugin_icon(self):
         """Return widget icon."""
         return ima.icon('edit')
-
+    
     def get_focus_widget(self):
         """
         Return the widget to give focus to.
@@ -603,13 +603,13 @@ class Editor(SpyderPluginWidget):
         if enable:
             self.refresh_plugin()
         self.sig_update_plugin_title.emit()
-
+    
     def refresh_plugin(self):
         """Refresh editor plugin"""
         editorstack = self.get_current_editorstack()
         editorstack.refresh()
         self.refresh_save_all_action()
-
+        
     def closing_plugin(self, cancelable=False):
         """Perform actions before parent main window is closed"""
         state = self.splitter.saveState()
@@ -663,7 +663,7 @@ class Editor(SpyderPluginWidget):
         )
         self.register_shortcut(self.open_last_closed_action, context="Editor",
                                name="Open last closed")
-
+        
         self.open_action = create_action(self, _("&Open..."),
                 icon=ima.icon('fileopen'), tip=_("Open file"),
                 triggered=self.load,
@@ -875,7 +875,7 @@ class Editor(SpyderPluginWidget):
         self.todo_menu = QMenu(self)
         self.todo_list_action.setMenu(self.todo_menu)
         self.todo_menu.aboutToShow.connect(self.update_todo_menu)
-
+        
         self.warning_list_action = create_action(self,
                 _("Show warning/error list"), icon=ima.icon('wng_list'),
                 tip=_("Show code analysis warnings/errors"),
@@ -901,7 +901,7 @@ class Editor(SpyderPluginWidget):
                                context="Editor",
                                name="Next warning",
                                add_sc_to_tip=True)
-
+        
         self.previous_edit_cursor_action = create_action(self,
                 _("Last edit location"), icon=ima.icon('last_edit_location'),
                 tip=_("Go to last edit location"),
@@ -917,7 +917,7 @@ class Editor(SpyderPluginWidget):
                 triggered=self.go_to_previous_cursor_position,
                 context=Qt.WidgetShortcut)
         self.register_shortcut(self.previous_cursor_action,
-                               context="Editor",
+                               context="Editor", 
                                name="Previous cursor position",
                                add_sc_to_tip=True)
         self.next_cursor_action = create_action(self,
@@ -950,7 +950,7 @@ class Editor(SpyderPluginWidget):
                 triggered=self.unblockcomment, context=Qt.WidgetShortcut)
         self.register_shortcut(unblockcomment_action, context="Editor",
                                name="Unblockcomment")
-
+                
         # ----------------------------------------------------------------------
         # The following action shortcuts are hard-coded in CodeEditor
         # keyPressEvent handler (the shortcut is here only to inform user):
@@ -978,7 +978,7 @@ class Editor(SpyderPluginWidget):
         self.register_shortcut(self.text_lowercase_action, context="Editor",
                                name="transform to lowercase")
         # ----------------------------------------------------------------------
-
+        
         self.win_eol_action = create_action(self,
                            _("Carriage return and line feed (Windows)"),
                            toggled=lambda checked: self.toggle_eol_chars('nt', checked))
@@ -994,7 +994,7 @@ class Editor(SpyderPluginWidget):
         add_actions(eol_action_group, eol_actions)
         eol_menu = QMenu(_("Convert end-of-line characters"), self)
         add_actions(eol_menu, eol_actions)
-
+        
         trailingspaces_action = create_action(self,
                                       _("Remove trailing spaces"),
                                       triggered=self.remove_trailing_spaces)
@@ -1085,7 +1085,7 @@ class Editor(SpyderPluginWidget):
         self.search_menu_actions = [gotoline_action]
         self.main.search_menu_actions += self.search_menu_actions
         self.main.search_toolbar_actions += [gotoline_action]
-
+          
         # ---- Run menu/toolbar construction ----
         run_menu_actions = [run_action, run_cell_action,
                             run_cell_advance_action,
@@ -1099,7 +1099,7 @@ class Editor(SpyderPluginWidget):
         self.main.run_toolbar_actions += run_toolbar_actions
 
         # ---- Debug menu/toolbar construction ----
-        # NOTE: 'list_breakpoints' is used by the breakpoints
+        # NOTE: 'list_breakpoints' is used by the breakpoints 
         # plugin to add its "List breakpoints" action to this
         # menu
         debug_menu_actions = [debug_action,
@@ -1177,9 +1177,9 @@ class Editor(SpyderPluginWidget):
                  self.toggle_comment_action, self.revert_action,
                  self.indent_action, self.unindent_action]
         self.stack_menu_actions = [gotoline_action, workdir_action]
-
+        
         return self.file_dependent_actions
-
+    
     def register_plugin(self):
         """Register plugin in Spyder's main window"""
         self.main.restore_scrollbar_position.connect(
@@ -1208,7 +1208,7 @@ class Editor(SpyderPluginWidget):
             for finfo in editorstack.data:
                 comp_widget = finfo.editor.completion_widget
                 comp_widget.setup_appearance(completion_size, font)
-
+        
     #------ Focus tabwidget
     def __get_focus_editorstack(self):
         fwidget = QApplication.focusWidget()
@@ -1218,19 +1218,19 @@ class Editor(SpyderPluginWidget):
             for editorstack in self.editorstacks:
                 if editorstack.isAncestorOf(fwidget):
                     return editorstack
-
+        
     def set_last_focus_editorstack(self, editorwindow, editorstack):
         self.last_focus_editorstack[editorwindow] = editorstack
         self.last_focus_editorstack[None] = editorstack # very last editorstack
-
+        
     def get_last_focus_editorstack(self, editorwindow=None):
         return self.last_focus_editorstack[editorwindow]
-
+    
     def remove_last_focus_editorstack(self, editorstack):
         for editorwindow, widget in list(self.last_focus_editorstack.items()):
             if widget is editorstack:
                 self.last_focus_editorstack[editorwindow] = None
-
+        
     def save_focus_editorstack(self):
         editorstack = self.__get_focus_editorstack()
         if editorstack is not None:
@@ -1370,7 +1370,7 @@ class Editor(SpyderPluginWidget):
         else:
             # editorstack was not removed!
             return False
-
+        
     def clone_editorstack(self, editorstack):
         editorstack.clone_from(self.editorstacks[0])
         for finfo in editorstack.data:
@@ -1449,7 +1449,7 @@ class Editor(SpyderPluginWidget):
         for layout_settings in self.editorwindows_to_be_created:
             win = self.create_new_window()
             win.set_layout_settings(layout_settings)
-
+        
     def create_new_window(self):
         oe_options = self.outlineexplorer.explorer.get_options()
         fullpath_sorting=self.get_option('fullpath_sorting', True),
@@ -1466,14 +1466,14 @@ class Editor(SpyderPluginWidget):
         self.register_editorwindow(window)
         window.destroyed.connect(lambda: self.unregister_editorwindow(window))
         return window
-
+    
     def register_editorwindow(self, window):
         self.editorwindows.append(window)
-
+        
     def unregister_editorwindow(self, window):
         self.editorwindows.pop(self.editorwindows.index(window))
-
-
+    
+        
     #------ Accessors
     def get_filenames(self):
         return [finfo.filename for finfo in self.editorstacks[0].data]
@@ -1490,25 +1490,25 @@ class Editor(SpyderPluginWidget):
                 if editorstack is None or editorwindow is not None:
                     return self.get_last_focus_editorstack(editorwindow)
                 return editorstack
-
+        
     def get_current_editor(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:
             return editorstack.get_current_editor()
-
+        
     def get_current_finfo(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:
             return editorstack.get_current_finfo()
-
+        
     def get_current_filename(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:
             return editorstack.get_current_filename()
-
+        
     def is_file_opened(self, filename=None):
         return self.editorstacks[0].is_file_opened(filename)
-
+        
     def set_current_filename(self, filename, editorwindow=None, focus=True):
         """Set focus to *filename* if this file has been opened.
 
@@ -1523,7 +1523,7 @@ class Editor(SpyderPluginWidget):
         if self.introspector:
             self.introspector.change_extra_path(
                     self.main.get_spyder_pythonpath())
-
+    
     #------ FileSwitcher API
     def get_current_tab_manager(self):
         """Get the widget with the TabWidget attribute."""
@@ -1537,7 +1537,7 @@ class Editor(SpyderPluginWidget):
             enable = self.get_current_editor() is not None
             for action in self.file_dependent_actions:
                 action.setEnabled(enable)
-
+                
     def refresh_save_all_action(self):
         """Enable 'Save All' if there are files to be saved"""
         editorstack = self.get_current_editorstack()
@@ -1545,7 +1545,7 @@ class Editor(SpyderPluginWidget):
             state = any(finfo.editor.document().isModified() or finfo.newly_created
                         for finfo in editorstack.data)
             self.save_all_action.setEnabled(state)
-
+            
     def update_warning_menu(self):
         """Update warning list menu"""
         editorstack = self.get_current_editorstack()
@@ -1563,7 +1563,7 @@ class Editor(SpyderPluginWidget):
                 slot = lambda _l=line_number: self.load(filename, goto=_l)
             action = create_action(self, text=text, icon=icon, triggered=slot)
             self.warning_menu.addAction(action)
-
+            
     def analysis_results_changed(self):
         """
         Synchronize analysis results between editorstacks
@@ -1577,7 +1577,7 @@ class Editor(SpyderPluginWidget):
                 if other_editorstack is not editorstack:
                     other_editorstack.set_analysis_results(index, results)
         self.update_code_analysis_actions()
-
+            
     def update_todo_menu(self):
         """Update todo list menu"""
         editorstack = self.get_current_editorstack()
@@ -1594,7 +1594,7 @@ class Editor(SpyderPluginWidget):
             action = create_action(self, text=text, icon=icon, triggered=slot)
             self.todo_menu.addAction(action)
         self.update_todo_actions()
-
+            
     def todo_results_changed(self):
         """
         Synchronize todo results between editorstacks
@@ -1608,7 +1608,7 @@ class Editor(SpyderPluginWidget):
                 if other_editorstack is not editorstack:
                     other_editorstack.set_todo_results(index, results)
         self.update_todo_actions()
-
+            
     def refresh_eol_chars(self, os_name):
         os_name = to_text_string(os_name)
         self.__set_eol_chars = False
@@ -1619,8 +1619,8 @@ class Editor(SpyderPluginWidget):
         else:
             self.mac_eol_action.setChecked(True)
         self.__set_eol_chars = True
-
-
+    
+    
     #------ Slots
     def opened_files_list_changed(self):
         """
@@ -1649,7 +1649,7 @@ class Editor(SpyderPluginWidget):
     def update_code_analysis_actions(self):
         editorstack = self.get_current_editorstack()
         results = editorstack.get_analysis_results()
-
+        
         # Update code analysis buttons
         state = (self.get_option('code_analysis/pyflakes') \
                  or self.get_option('code_analysis/pep8')) \
@@ -1657,7 +1657,7 @@ class Editor(SpyderPluginWidget):
         for action in (self.warning_list_action, self.previous_warning_action,
                        self.next_warning_action):
             action.setEnabled(state)
-
+            
     def update_todo_actions(self):
         editorstack = self.get_current_editorstack()
         results = editorstack.get_todo_results()
@@ -1683,7 +1683,7 @@ class Editor(SpyderPluginWidget):
             breakpoints = []
         save_breakpoints(filename, breakpoints)
         self.breakpoints_saved.emit()
-
+        
     #------ File I/O
     def __load_temp_file(self):
         """Load temporary file from a text file in user home directory"""
@@ -1705,7 +1705,7 @@ class Editor(SpyderPluginWidget):
         if fname is not None:
             directory = osp.dirname(osp.abspath(fname))
             self.open_dir.emit(directory)
-
+                
     def __add_recent_file(self, fname):
         """Add to recent file list"""
         if fname is None:
@@ -1729,7 +1729,7 @@ class Editor(SpyderPluginWidget):
     def new(self, fname=None, editorstack=None, text=None):
         """
         Create a new file - Untitled
-
+        
         fname=None --> fname will be 'untitledXX.py' but do not create file
         fname=<basestring> --> create file
         """
@@ -1788,7 +1788,7 @@ class Editor(SpyderPluginWidget):
             index = current_es.has_filename(fname)
             if index and not current_es.close_file(index):
                 return
-
+        
         # Creating the editor widget in the first editorstack (the one that
         # can't be destroyed), then cloning this editor widget in all other
         # editorstacks:
@@ -1845,7 +1845,7 @@ class Editor(SpyderPluginWidget):
              processevents=True):
         """
         Load a text file
-        editorwindow: load in this editorwindow (useful when clicking on
+        editorwindow: load in this editorwindow (useful when clicking on 
         outline explorer with multiple editor windows)
         processevents: determines if processEvents() should be called at the
         end of this method (set to False to prevent keyboard events from
@@ -1897,7 +1897,7 @@ class Editor(SpyderPluginWidget):
                 filenames = [osp.normpath(fname) for fname in filenames]
             else:
                 return
-
+            
         focus_widget = QApplication.focusWidget()
         if self.dockwidget and not self.ismaximized and\
            (not self.dockwidget.isAncestorOf(focus_widget)\
@@ -1905,7 +1905,7 @@ class Editor(SpyderPluginWidget):
             self.dockwidget.setVisible(True)
             self.dockwidget.setFocus()
             self.dockwidget.raise_()
-
+        
         def _convert(fname):
             fname = osp.abspath(encoding.to_unicode_from_fs(fname))
             if os.name == 'nt' and len(fname) >= 2 and fname[1] == ':':
@@ -2005,13 +2005,13 @@ class Editor(SpyderPluginWidget):
     def close_all_files(self):
         """Close all opened scripts"""
         self.editorstacks[0].close_all_files()
-
+    
     @Slot()
     def save(self, index=None, force=False):
         """Save file"""
         editorstack = self.get_current_editorstack()
         return editorstack.save(index=index, force=force)
-
+    
     @Slot()
     def save_as(self):
         """Save *as* the currently edited file"""
@@ -2030,7 +2030,7 @@ class Editor(SpyderPluginWidget):
     def save_all(self):
         """Save all opened files"""
         self.get_current_editorstack().save_all()
-
+    
     @Slot()
     def revert(self):
         """Revert the currently edited file from disk"""
@@ -2061,7 +2061,7 @@ class Editor(SpyderPluginWidget):
         """Replace slot"""
         editorstack = self.get_current_editorstack()
         editorstack.find_widget.show_replace()
-
+    
     def open_last_closed(self):
         """ Reopens the last closed tab."""
         editorstack = self.get_current_editorstack()
@@ -2071,7 +2071,7 @@ class Editor(SpyderPluginWidget):
             last_closed_files.remove(file_to_open)
             editorstack.set_last_closed_files(last_closed_files)
             self.load(file_to_open)
-
+    
     #------ Explorer widget
     def close_file_from_name(self, filename):
         """Close file from its name"""
@@ -2079,18 +2079,18 @@ class Editor(SpyderPluginWidget):
         index = self.editorstacks[0].has_filename(filename)
         if index is not None:
             self.editorstacks[0].close_file(index)
-
+                
     def removed(self, filename):
         """File was removed in file explorer widget or in project explorer"""
         self.close_file_from_name(filename)
-
+    
     def removed_tree(self, dirname):
         """Directory was removed in project explorer widget"""
         dirname = osp.abspath(to_text_string(dirname))
         for fname in self.get_filenames():
             if osp.abspath(fname).startswith(dirname):
                 self.close_file_from_name(fname)
-
+    
     def renamed(self, source, dest):
         """File was renamed in file explorer widget or in project explorer"""
         filename = osp.abspath(to_text_string(source))
@@ -2099,8 +2099,8 @@ class Editor(SpyderPluginWidget):
             for editorstack in self.editorstacks:
                 editorstack.rename_in_data(index,
                                            new_filename=to_text_string(dest))
-
-
+        
+    
     #------ Source code
     @Slot()
     def indent(self):
@@ -2188,7 +2188,7 @@ class Editor(SpyderPluginWidget):
             # (subprocess "cwd" default is None, so empty str
             # must be changed to None in this case.)
             programs.run_program(WINPDB_PATH, [fname] + args, cwd=wdir or None)
-
+        
     def toggle_eol_chars(self, os_name, checked):
         if checked:
             editor = self.get_current_editor()
@@ -2216,7 +2216,7 @@ class Editor(SpyderPluginWidget):
     def fix_indentation(self):
         editorstack = self.get_current_editorstack()
         editorstack.fix_indentation()
-
+                    
     #------ Cursor position history management
     def update_cursorpos_actions(self):
         self.previous_edit_cursor_action.setEnabled(
@@ -2225,7 +2225,7 @@ class Editor(SpyderPluginWidget):
                self.cursor_pos_index is not None and self.cursor_pos_index > 0)
         self.next_cursor_action.setEnabled(self.cursor_pos_index is not None \
                     and self.cursor_pos_index < len(self.cursor_pos_history)-1)
-
+        
     def add_cursor_position_to_history(self, filename, position, fc=False):
         if self.__ignore_cursor_position:
             return
@@ -2248,16 +2248,16 @@ class Editor(SpyderPluginWidget):
         self.cursor_pos_history.append((filename, position))
         self.cursor_pos_index = len(self.cursor_pos_history)-1
         self.update_cursorpos_actions()
-
+    
     def cursor_moved(self, filename0, position0, filename1, position1):
         """Cursor was just moved: 'go to'"""
         if position0 is not None:
             self.add_cursor_position_to_history(filename0, position0)
         self.add_cursor_position_to_history(filename1, position1)
-
+        
     def text_changed_at(self, filename, position):
         self.last_edit_cursor_pos = (to_text_string(filename), position)
-
+        
     def current_file_changed(self, filename, position):
         self.add_cursor_position_to_history(to_text_string(filename), position,
                                             fc=True)
@@ -2274,7 +2274,7 @@ class Editor(SpyderPluginWidget):
                 editor = self.get_current_editor()
                 if position < editor.document().characterCount():
                     editor.set_cursor_position(position)
-
+            
     def __move_cursor_position(self, index_move):
         if self.cursor_pos_index is None:
             return
@@ -2340,7 +2340,7 @@ class Editor(SpyderPluginWidget):
             for data in editorstack.data:
                 data.editor.clear_breakpoints()
         self.refresh_plugin()
-
+                
     def clear_breakpoint(self, filename, lineno):
         """Remove a single breakpoint"""
         clear_breakpoint(filename, lineno)
@@ -2350,7 +2350,7 @@ class Editor(SpyderPluginWidget):
             index = self.is_file_opened(filename)
             if index is not None:
                 editorstack.data[index].editor.add_remove_breakpoint(lineno)
-
+                
     def debug_command(self, command):
         """Debug actions"""
         self.main.ipyconsole.write_to_stdin(command)
@@ -2380,11 +2380,11 @@ class Editor(SpyderPluginWidget):
         if editorstack.save():
             editor = self.get_current_editor()
             fname = osp.abspath(self.get_current_filename())
-
+            
             # Escape single and double quotes in fname (Fixes Issue 2158)
             fname = fname.replace("'", r"\'")
             fname = fname.replace('"', r'\"')
-
+            
             runconf = get_run_configuration(fname)
             if runconf is None:
                 dialog = RunConfigOneDialog(self)
@@ -2393,13 +2393,13 @@ class Editor(SpyderPluginWidget):
                     dialog.resize(self.dialog_size)
                 dialog.setup(fname)
                 if CONF.get('run', 'open_at_least_once', not PYTEST):
-                    # Open Run Config dialog at least once: the first time
-                    # a script is ever run in Spyder, so that the user may
+                    # Open Run Config dialog at least once: the first time 
+                    # a script is ever run in Spyder, so that the user may 
                     # see it at least once and be conscious that it exists
                     show_dlg = True
                     CONF.set('run', 'open_at_least_once', False)
                 else:
-                    # Open Run Config dialog only
+                    # Open Run Config dialog only 
                     # if ALWAYS_OPEN_FIRST_RUN_OPTION option is enabled
                     show_dlg = CONF.get('run', ALWAYS_OPEN_FIRST_RUN_OPTION)
                 if show_dlg and not dialog.exec_():
@@ -2426,7 +2426,7 @@ class Editor(SpyderPluginWidget):
             python = True # Note: in the future, it may be useful to run
             # something in a terminal instead of a Python interp.
             self.__last_ec_exec = (fname, wdir, args, interact, debug,
-                                   python, python_args, current, systerm,
+                                   python, python_args, current, systerm, 
                                    post_mortem, clear_namespace)
             self.re_run_file()
             if not interact and not debug:
@@ -2435,7 +2435,7 @@ class Editor(SpyderPluginWidget):
                 # current external shell automatically
                 # (see SpyderPluginWidget.visibility_changed method)
                 editor.setFocus()
-
+                
     def set_dialog_size(self, size):
         self.dialog_size = size
 
@@ -2513,14 +2513,14 @@ class Editor(SpyderPluginWidget):
             currentline_n = 'highlight_current_line'
             currentline_o = self.get_option(currentline_n)
             currentcell_n = 'highlight_current_cell'
-            currentcell_o = self.get_option(currentcell_n)
+            currentcell_o = self.get_option(currentcell_n)            
             occurrence_n = 'occurrence_highlighting'
             occurrence_o = self.get_option(occurrence_n)
             occurrence_timeout_n = 'occurrence_highlighting/timeout'
             occurrence_timeout_o = self.get_option(occurrence_timeout_n)
             focus_to_editor_n = 'focus_to_editor'
             focus_to_editor_o = self.get_option(focus_to_editor_n)
-
+            
             for editorstack in self.editorstacks:
                 if color_scheme_n in options:
                     editorstack.set_color_scheme(color_scheme_o)
@@ -2529,7 +2529,7 @@ class Editor(SpyderPluginWidget):
                                                                 currentline_o)
                 if currentcell_n in options:
                     editorstack.set_highlight_current_cell_enabled(
-                                                                currentcell_o)
+                                                                currentcell_o)              
                 if occurrence_n in options:
                     editorstack.set_occurrence_highlighting_enabled(occurrence_o)
                 if occurrence_timeout_n in options:
@@ -2684,7 +2684,7 @@ class Editor(SpyderPluginWidget):
         filenames = []
         filenames += [finfo.filename for finfo in editorstack.data]
         return filenames
-
+        
     def set_open_filenames(self):
         """
         Set the recent opened files on editor based on active project.
@@ -2696,7 +2696,7 @@ class Editor(SpyderPluginWidget):
             if not self.projects.get_active_project():
                 filenames = self.get_open_filenames()
                 self.set_option('filenames', filenames)
-
+ 
     def setup_open_files(self):
         """Open the list of saved files per project"""
         self.set_create_new_file_if_empty(False)
@@ -2730,10 +2730,10 @@ class Editor(SpyderPluginWidget):
     def reorder_filenames(self, filenames):
         """Take the last session filenames and put the last open on first.
 
-        It takes a list of filenames and using the current filename from the
-        layout settings, sets the one that had focused last in the position 0.
-        It also reorders the current lines for each file (supposing that they
-        are in the same order as the filenames) and sets them back in the
+        It takes a list of filenames and using the current filename from the 
+        layout settings, sets the one that had focused last in the position 0. 
+        It also reorders the current lines for each file (supposing that they 
+        are in the same order as the filenames) and sets them back in the 
         layout settings.
         """
         layout = self.get_option('layout_settings', None)

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -102,14 +102,14 @@ WINPDB_PATH = programs.find_program('winpdb')
 class EditorConfigPage(PluginConfigPage):
     def get_name(self):
         return _("Editor")
-        
+
     def get_icon(self):
         return ima.icon('edit')
-    
+
     def setup_page(self):
         template_btn = self.create_button(_("Edit template for new modules"),
                                     self.plugin.edit_template)
-        
+
         interface_group = QGroupBox(_("Interface"))
         newcb = self.create_checkbox
         showtabbar_box = newcb(_("Show tab bar"), 'show_tab_bar')
@@ -123,7 +123,7 @@ class EditorConfigPage(PluginConfigPage):
         interface_layout.addWidget(showclassfuncdropdown_box)
         interface_layout.addWidget(showindentguides_box)
         interface_group.setLayout(interface_layout)
-        
+
         display_group = QGroupBox(_("Source code"))
         linenumbers_box = newcb(_("Show line numbers"), 'line_numbers')
         blanks_box = newcb(_("Show blank spaces"), 'blank_spaces')
@@ -203,7 +203,7 @@ class EditorConfigPage(PluginConfigPage):
                                   "code completion and go-to-definition "
                                   "features won't be available."))
             rope_label.setWordWrap(True)
-        
+
         sourcecode_group = QGroupBox(_("Source code"))
         closepar_box = newcb(_("Automatic insertion of parentheses, braces "
                                                                "and brackets"),
@@ -248,7 +248,7 @@ class EditorConfigPage(PluginConfigPage):
         removetrail_box = newcb(_("Automatically remove trailing spaces "
                                   "when saving files"),
                                'always_remove_trailing_spaces', default=False)
-        
+
         analysis_group = QGroupBox(_("Analysis"))
         pep_url = '<a href="http://www.python.org/dev/peps/pep-0008/">PEP8</a>'
         pep8_label = QLabel(_("<i>(Refer to the {} page)</i>").format(pep_url))
@@ -292,15 +292,15 @@ class EditorConfigPage(PluginConfigPage):
         af_layout = QHBoxLayout()
         af_layout.addWidget(realtime_radio)
         af_layout.addWidget(af_spin)
-        
+
         run_layout = QVBoxLayout()
         run_layout.addWidget(saveall_box)
         run_group.setLayout(run_layout)
-        
+
         run_selection_layout = QVBoxLayout()
         run_selection_layout.addWidget(focus_box)
         run_selection_group.setLayout(run_selection_layout)
-        
+
         introspection_layout = QVBoxLayout()
         if rope_is_installed:
             introspection_layout.addWidget(calltips_box)
@@ -311,10 +311,10 @@ class EditorConfigPage(PluginConfigPage):
         else:
             introspection_layout.addWidget(rope_label)
         introspection_group.setLayout(introspection_layout)
-        
+
         analysis_layout = QVBoxLayout()
         analysis_layout.addWidget(pyflakes_box)
-        analysis_pep_layout = QHBoxLayout() 
+        analysis_pep_layout = QHBoxLayout()
         analysis_pep_layout.addWidget(pep8_box)
         analysis_pep_layout.addWidget(pep8_label)
         analysis_layout.addLayout(analysis_pep_layout)
@@ -322,7 +322,7 @@ class EditorConfigPage(PluginConfigPage):
         analysis_layout.addLayout(af_layout)
         analysis_layout.addWidget(saveonly_radio)
         analysis_group.setLayout(analysis_layout)
-        
+
         sourcecode_layout = QVBoxLayout()
         sourcecode_layout.addWidget(closepar_box)
         sourcecode_layout.addWidget(autounindent_box)
@@ -358,7 +358,7 @@ class EditorConfigPage(PluginConfigPage):
         eol_layout.addWidget(eol_label)
         eol_layout.addWidget(check_eol_box)
         eol_group.setLayout(eol_layout)
-        
+
         tabs = QTabWidget()
         tabs.addTab(self.create_tab(interface_group, display_group),
                     _("Display"))
@@ -367,7 +367,7 @@ class EditorConfigPage(PluginConfigPage):
         tabs.addTab(self.create_tab(template_btn, run_group, run_selection_group,
                                     sourcecode_group, eol_group),
                     _("Advanced settings"))
-        
+
         vlayout = QVBoxLayout()
         vlayout.addWidget(tabs)
         self.setLayout(vlayout)
@@ -382,7 +382,7 @@ class Editor(SpyderPluginWidget):
     TEMPFILE_PATH = get_conf_path('temp.py')
     TEMPLATE_PATH = get_conf_path('template.py')
     DISABLE_ACTIONS_WHEN_HIDDEN = False # SpyderPluginWidget class attribute
-    
+
     # Signals
     run_in_current_ipyclient = Signal(str, str, str, bool, bool, bool, bool)
     exec_in_extconsole = Signal(str, bool)
@@ -424,19 +424,19 @@ class Editor(SpyderPluginWidget):
         # (see spyder.py: 'update_edit_menu' method)
         self.search_menu_actions = None #XXX: same thing ('update_search_menu')
         self.stack_menu_actions = None
-        
+
         # Initialize plugin
         self.initialize_plugin()
-        
+
         # Configuration dialog size
         self.dialog_size = None
-        
+
         statusbar = self.main.statusBar()
         self.readwrite_status = ReadWriteStatus(self, statusbar)
         self.eol_status = EOLStatus(self, statusbar)
         self.encoding_status = EncodingStatus(self, statusbar)
         self.cursorpos_status = CursorPositionStatus(self, statusbar)
-        
+
         layout = QVBoxLayout()
         self.dock_toolbar = QToolBar(self)
         add_actions(self.dock_toolbar, self.dock_toolbar_actions)
@@ -446,7 +446,7 @@ class Editor(SpyderPluginWidget):
         self.cursor_pos_history = []
         self.cursor_pos_index = None
         self.__ignore_cursor_position = True
-        
+
         self.editorstacks = []
         self.last_focus_editorstack = {}
         self.editorwindows = []
@@ -498,13 +498,13 @@ class Editor(SpyderPluginWidget):
         layout.addWidget(self.splitter)
         self.setLayout(layout)
         self.setFocusPolicy(Qt.ClickFocus)
-        
+
         # Editor's splitter state
         state = self.get_option('splitter_state', None)
         if state is not None:
             self.splitter.restoreState( QByteArray().fromHex(
                     str(state).encode('utf-8')) )
-        
+
         self.recent_files = self.get_option('recent_files', [])
         self.untitled_num = 0
 
@@ -524,7 +524,7 @@ class Editor(SpyderPluginWidget):
             self.add_cursor_position_to_history(filename, position)
         self.update_cursorpos_actions()
         self.set_path()
-        
+
     def set_projects(self, projects):
         self.projects = projects
 
@@ -538,7 +538,7 @@ class Editor(SpyderPluginWidget):
                 dw.show()
                 dw.raise_()
             self.switch_to_plugin()
-        
+
     def set_outlineexplorer(self, outlineexplorer):
         self.outlineexplorer = outlineexplorer
         for editorstack in self.editorstacks:
@@ -567,8 +567,8 @@ class Editor(SpyderPluginWidget):
             self.get_current_editor().centerCursor()
         except AttributeError:
             pass
-            
-    #------ SpyderPluginWidget API ---------------------------------------------    
+
+    #------ SpyderPluginWidget API ---------------------------------------------
     def get_plugin_title(self):
         """Return widget title"""
         title = _('Editor')
@@ -584,7 +584,7 @@ class Editor(SpyderPluginWidget):
     def get_plugin_icon(self):
         """Return widget icon."""
         return ima.icon('edit')
-    
+
     def get_focus_widget(self):
         """
         Return the widget to give focus to.
@@ -603,13 +603,13 @@ class Editor(SpyderPluginWidget):
         if enable:
             self.refresh_plugin()
         self.sig_update_plugin_title.emit()
-    
+
     def refresh_plugin(self):
         """Refresh editor plugin"""
         editorstack = self.get_current_editorstack()
         editorstack.refresh()
         self.refresh_save_all_action()
-        
+
     def closing_plugin(self, cancelable=False):
         """Perform actions before parent main window is closed"""
         state = self.splitter.saveState()
@@ -663,7 +663,7 @@ class Editor(SpyderPluginWidget):
         )
         self.register_shortcut(self.open_last_closed_action, context="Editor",
                                name="Open last closed")
-        
+
         self.open_action = create_action(self, _("&Open..."),
                 icon=ima.icon('fileopen'), tip=_("Open file"),
                 triggered=self.load,
@@ -875,7 +875,7 @@ class Editor(SpyderPluginWidget):
         self.todo_menu = QMenu(self)
         self.todo_list_action.setMenu(self.todo_menu)
         self.todo_menu.aboutToShow.connect(self.update_todo_menu)
-        
+
         self.warning_list_action = create_action(self,
                 _("Show warning/error list"), icon=ima.icon('wng_list'),
                 tip=_("Show code analysis warnings/errors"),
@@ -886,12 +886,22 @@ class Editor(SpyderPluginWidget):
         self.previous_warning_action = create_action(self,
                 _("Previous warning/error"), icon=ima.icon('prev_wng'),
                 tip=_("Go to previous code analysis warning/error"),
-                triggered=self.go_to_previous_warning)
+                triggered=self.go_to_previous_warning,
+                context=Qt.WidgetShortcut)
+        self.register_shortcut(self.previous_warning_action,
+                               context="Editor",
+                               name="Previous warning",
+                               add_sc_to_tip=True)
         self.next_warning_action = create_action(self,
                 _("Next warning/error"), icon=ima.icon('next_wng'),
                 tip=_("Go to next code analysis warning/error"),
-                triggered=self.go_to_next_warning)
-        
+                triggered=self.go_to_next_warning,
+                context=Qt.WidgetShortcut)
+        self.register_shortcut(self.next_warning_action,
+                               context="Editor",
+                               name="Next warning",
+                               add_sc_to_tip=True)
+
         self.previous_edit_cursor_action = create_action(self,
                 _("Last edit location"), icon=ima.icon('last_edit_location'),
                 tip=_("Go to last edit location"),
@@ -907,7 +917,7 @@ class Editor(SpyderPluginWidget):
                 triggered=self.go_to_previous_cursor_position,
                 context=Qt.WidgetShortcut)
         self.register_shortcut(self.previous_cursor_action,
-                               context="Editor", 
+                               context="Editor",
                                name="Previous cursor position",
                                add_sc_to_tip=True)
         self.next_cursor_action = create_action(self,
@@ -940,7 +950,7 @@ class Editor(SpyderPluginWidget):
                 triggered=self.unblockcomment, context=Qt.WidgetShortcut)
         self.register_shortcut(unblockcomment_action, context="Editor",
                                name="Unblockcomment")
-                
+
         # ----------------------------------------------------------------------
         # The following action shortcuts are hard-coded in CodeEditor
         # keyPressEvent handler (the shortcut is here only to inform user):
@@ -968,7 +978,7 @@ class Editor(SpyderPluginWidget):
         self.register_shortcut(self.text_lowercase_action, context="Editor",
                                name="transform to lowercase")
         # ----------------------------------------------------------------------
-        
+
         self.win_eol_action = create_action(self,
                            _("Carriage return and line feed (Windows)"),
                            toggled=lambda checked: self.toggle_eol_chars('nt', checked))
@@ -984,7 +994,7 @@ class Editor(SpyderPluginWidget):
         add_actions(eol_action_group, eol_actions)
         eol_menu = QMenu(_("Convert end-of-line characters"), self)
         add_actions(eol_menu, eol_actions)
-        
+
         trailingspaces_action = create_action(self,
                                       _("Remove trailing spaces"),
                                       triggered=self.remove_trailing_spaces)
@@ -1075,7 +1085,7 @@ class Editor(SpyderPluginWidget):
         self.search_menu_actions = [gotoline_action]
         self.main.search_menu_actions += self.search_menu_actions
         self.main.search_toolbar_actions += [gotoline_action]
-          
+
         # ---- Run menu/toolbar construction ----
         run_menu_actions = [run_action, run_cell_action,
                             run_cell_advance_action,
@@ -1089,7 +1099,7 @@ class Editor(SpyderPluginWidget):
         self.main.run_toolbar_actions += run_toolbar_actions
 
         # ---- Debug menu/toolbar construction ----
-        # NOTE: 'list_breakpoints' is used by the breakpoints 
+        # NOTE: 'list_breakpoints' is used by the breakpoints
         # plugin to add its "List breakpoints" action to this
         # menu
         debug_menu_actions = [debug_action,
@@ -1167,9 +1177,9 @@ class Editor(SpyderPluginWidget):
                  self.toggle_comment_action, self.revert_action,
                  self.indent_action, self.unindent_action]
         self.stack_menu_actions = [gotoline_action, workdir_action]
-        
+
         return self.file_dependent_actions
-    
+
     def register_plugin(self):
         """Register plugin in Spyder's main window"""
         self.main.restore_scrollbar_position.connect(
@@ -1198,7 +1208,7 @@ class Editor(SpyderPluginWidget):
             for finfo in editorstack.data:
                 comp_widget = finfo.editor.completion_widget
                 comp_widget.setup_appearance(completion_size, font)
-        
+
     #------ Focus tabwidget
     def __get_focus_editorstack(self):
         fwidget = QApplication.focusWidget()
@@ -1208,19 +1218,19 @@ class Editor(SpyderPluginWidget):
             for editorstack in self.editorstacks:
                 if editorstack.isAncestorOf(fwidget):
                     return editorstack
-        
+
     def set_last_focus_editorstack(self, editorwindow, editorstack):
         self.last_focus_editorstack[editorwindow] = editorstack
         self.last_focus_editorstack[None] = editorstack # very last editorstack
-        
+
     def get_last_focus_editorstack(self, editorwindow=None):
         return self.last_focus_editorstack[editorwindow]
-    
+
     def remove_last_focus_editorstack(self, editorstack):
         for editorwindow, widget in list(self.last_focus_editorstack.items()):
             if widget is editorstack:
                 self.last_focus_editorstack[editorwindow] = None
-        
+
     def save_focus_editorstack(self):
         editorstack = self.__get_focus_editorstack()
         if editorstack is not None:
@@ -1347,6 +1357,8 @@ class Editor(SpyderPluginWidget):
         editorstack.sig_prev_cursor.connect(self.go_to_previous_cursor_position)
         editorstack.sig_next_cursor.connect(self.go_to_next_cursor_position)
         editorstack.tabs.tabBar().tabMoved.connect(self.move_editorstack_data)
+        editorstack.sig_prev_warning.connect(self.go_to_previous_warning)
+        editorstack.sig_next_warning.connect(self.go_to_next_warning)
 
     def unregister_editorstack(self, editorstack):
         """Removing editorstack only if it's not the last remaining"""
@@ -1358,7 +1370,7 @@ class Editor(SpyderPluginWidget):
         else:
             # editorstack was not removed!
             return False
-        
+
     def clone_editorstack(self, editorstack):
         editorstack.clone_from(self.editorstacks[0])
         for finfo in editorstack.data:
@@ -1437,7 +1449,7 @@ class Editor(SpyderPluginWidget):
         for layout_settings in self.editorwindows_to_be_created:
             win = self.create_new_window()
             win.set_layout_settings(layout_settings)
-        
+
     def create_new_window(self):
         oe_options = self.outlineexplorer.explorer.get_options()
         fullpath_sorting=self.get_option('fullpath_sorting', True),
@@ -1454,14 +1466,14 @@ class Editor(SpyderPluginWidget):
         self.register_editorwindow(window)
         window.destroyed.connect(lambda: self.unregister_editorwindow(window))
         return window
-    
+
     def register_editorwindow(self, window):
         self.editorwindows.append(window)
-        
+
     def unregister_editorwindow(self, window):
         self.editorwindows.pop(self.editorwindows.index(window))
-    
-        
+
+
     #------ Accessors
     def get_filenames(self):
         return [finfo.filename for finfo in self.editorstacks[0].data]
@@ -1478,25 +1490,25 @@ class Editor(SpyderPluginWidget):
                 if editorstack is None or editorwindow is not None:
                     return self.get_last_focus_editorstack(editorwindow)
                 return editorstack
-        
+
     def get_current_editor(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:
             return editorstack.get_current_editor()
-        
+
     def get_current_finfo(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:
             return editorstack.get_current_finfo()
-        
+
     def get_current_filename(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:
             return editorstack.get_current_filename()
-        
+
     def is_file_opened(self, filename=None):
         return self.editorstacks[0].is_file_opened(filename)
-        
+
     def set_current_filename(self, filename, editorwindow=None, focus=True):
         """Set focus to *filename* if this file has been opened.
 
@@ -1511,7 +1523,7 @@ class Editor(SpyderPluginWidget):
         if self.introspector:
             self.introspector.change_extra_path(
                     self.main.get_spyder_pythonpath())
-    
+
     #------ FileSwitcher API
     def get_current_tab_manager(self):
         """Get the widget with the TabWidget attribute."""
@@ -1525,7 +1537,7 @@ class Editor(SpyderPluginWidget):
             enable = self.get_current_editor() is not None
             for action in self.file_dependent_actions:
                 action.setEnabled(enable)
-                
+
     def refresh_save_all_action(self):
         """Enable 'Save All' if there are files to be saved"""
         editorstack = self.get_current_editorstack()
@@ -1533,7 +1545,7 @@ class Editor(SpyderPluginWidget):
             state = any(finfo.editor.document().isModified() or finfo.newly_created
                         for finfo in editorstack.data)
             self.save_all_action.setEnabled(state)
-            
+
     def update_warning_menu(self):
         """Update warning list menu"""
         editorstack = self.get_current_editorstack()
@@ -1551,7 +1563,7 @@ class Editor(SpyderPluginWidget):
                 slot = lambda _l=line_number: self.load(filename, goto=_l)
             action = create_action(self, text=text, icon=icon, triggered=slot)
             self.warning_menu.addAction(action)
-            
+
     def analysis_results_changed(self):
         """
         Synchronize analysis results between editorstacks
@@ -1565,7 +1577,7 @@ class Editor(SpyderPluginWidget):
                 if other_editorstack is not editorstack:
                     other_editorstack.set_analysis_results(index, results)
         self.update_code_analysis_actions()
-            
+
     def update_todo_menu(self):
         """Update todo list menu"""
         editorstack = self.get_current_editorstack()
@@ -1582,7 +1594,7 @@ class Editor(SpyderPluginWidget):
             action = create_action(self, text=text, icon=icon, triggered=slot)
             self.todo_menu.addAction(action)
         self.update_todo_actions()
-            
+
     def todo_results_changed(self):
         """
         Synchronize todo results between editorstacks
@@ -1596,7 +1608,7 @@ class Editor(SpyderPluginWidget):
                 if other_editorstack is not editorstack:
                     other_editorstack.set_todo_results(index, results)
         self.update_todo_actions()
-            
+
     def refresh_eol_chars(self, os_name):
         os_name = to_text_string(os_name)
         self.__set_eol_chars = False
@@ -1607,8 +1619,8 @@ class Editor(SpyderPluginWidget):
         else:
             self.mac_eol_action.setChecked(True)
         self.__set_eol_chars = True
-    
-    
+
+
     #------ Slots
     def opened_files_list_changed(self):
         """
@@ -1637,7 +1649,7 @@ class Editor(SpyderPluginWidget):
     def update_code_analysis_actions(self):
         editorstack = self.get_current_editorstack()
         results = editorstack.get_analysis_results()
-        
+
         # Update code analysis buttons
         state = (self.get_option('code_analysis/pyflakes') \
                  or self.get_option('code_analysis/pep8')) \
@@ -1645,7 +1657,7 @@ class Editor(SpyderPluginWidget):
         for action in (self.warning_list_action, self.previous_warning_action,
                        self.next_warning_action):
             action.setEnabled(state)
-            
+
     def update_todo_actions(self):
         editorstack = self.get_current_editorstack()
         results = editorstack.get_todo_results()
@@ -1671,7 +1683,7 @@ class Editor(SpyderPluginWidget):
             breakpoints = []
         save_breakpoints(filename, breakpoints)
         self.breakpoints_saved.emit()
-        
+
     #------ File I/O
     def __load_temp_file(self):
         """Load temporary file from a text file in user home directory"""
@@ -1693,7 +1705,7 @@ class Editor(SpyderPluginWidget):
         if fname is not None:
             directory = osp.dirname(osp.abspath(fname))
             self.open_dir.emit(directory)
-                
+
     def __add_recent_file(self, fname):
         """Add to recent file list"""
         if fname is None:
@@ -1717,7 +1729,7 @@ class Editor(SpyderPluginWidget):
     def new(self, fname=None, editorstack=None, text=None):
         """
         Create a new file - Untitled
-        
+
         fname=None --> fname will be 'untitledXX.py' but do not create file
         fname=<basestring> --> create file
         """
@@ -1776,7 +1788,7 @@ class Editor(SpyderPluginWidget):
             index = current_es.has_filename(fname)
             if index and not current_es.close_file(index):
                 return
-        
+
         # Creating the editor widget in the first editorstack (the one that
         # can't be destroyed), then cloning this editor widget in all other
         # editorstacks:
@@ -1833,7 +1845,7 @@ class Editor(SpyderPluginWidget):
              processevents=True):
         """
         Load a text file
-        editorwindow: load in this editorwindow (useful when clicking on 
+        editorwindow: load in this editorwindow (useful when clicking on
         outline explorer with multiple editor windows)
         processevents: determines if processEvents() should be called at the
         end of this method (set to False to prevent keyboard events from
@@ -1885,7 +1897,7 @@ class Editor(SpyderPluginWidget):
                 filenames = [osp.normpath(fname) for fname in filenames]
             else:
                 return
-            
+
         focus_widget = QApplication.focusWidget()
         if self.dockwidget and not self.ismaximized and\
            (not self.dockwidget.isAncestorOf(focus_widget)\
@@ -1893,7 +1905,7 @@ class Editor(SpyderPluginWidget):
             self.dockwidget.setVisible(True)
             self.dockwidget.setFocus()
             self.dockwidget.raise_()
-        
+
         def _convert(fname):
             fname = osp.abspath(encoding.to_unicode_from_fs(fname))
             if os.name == 'nt' and len(fname) >= 2 and fname[1] == ':':
@@ -1993,13 +2005,13 @@ class Editor(SpyderPluginWidget):
     def close_all_files(self):
         """Close all opened scripts"""
         self.editorstacks[0].close_all_files()
-    
+
     @Slot()
     def save(self, index=None, force=False):
         """Save file"""
         editorstack = self.get_current_editorstack()
         return editorstack.save(index=index, force=force)
-    
+
     @Slot()
     def save_as(self):
         """Save *as* the currently edited file"""
@@ -2018,7 +2030,7 @@ class Editor(SpyderPluginWidget):
     def save_all(self):
         """Save all opened files"""
         self.get_current_editorstack().save_all()
-    
+
     @Slot()
     def revert(self):
         """Revert the currently edited file from disk"""
@@ -2049,7 +2061,7 @@ class Editor(SpyderPluginWidget):
         """Replace slot"""
         editorstack = self.get_current_editorstack()
         editorstack.find_widget.show_replace()
-    
+
     def open_last_closed(self):
         """ Reopens the last closed tab."""
         editorstack = self.get_current_editorstack()
@@ -2059,7 +2071,7 @@ class Editor(SpyderPluginWidget):
             last_closed_files.remove(file_to_open)
             editorstack.set_last_closed_files(last_closed_files)
             self.load(file_to_open)
-    
+
     #------ Explorer widget
     def close_file_from_name(self, filename):
         """Close file from its name"""
@@ -2067,18 +2079,18 @@ class Editor(SpyderPluginWidget):
         index = self.editorstacks[0].has_filename(filename)
         if index is not None:
             self.editorstacks[0].close_file(index)
-                
+
     def removed(self, filename):
         """File was removed in file explorer widget or in project explorer"""
         self.close_file_from_name(filename)
-    
+
     def removed_tree(self, dirname):
         """Directory was removed in project explorer widget"""
         dirname = osp.abspath(to_text_string(dirname))
         for fname in self.get_filenames():
             if osp.abspath(fname).startswith(dirname):
                 self.close_file_from_name(fname)
-    
+
     def renamed(self, source, dest):
         """File was renamed in file explorer widget or in project explorer"""
         filename = osp.abspath(to_text_string(source))
@@ -2087,8 +2099,8 @@ class Editor(SpyderPluginWidget):
             for editorstack in self.editorstacks:
                 editorstack.rename_in_data(index,
                                            new_filename=to_text_string(dest))
-        
-    
+
+
     #------ Source code
     @Slot()
     def indent(self):
@@ -2176,7 +2188,7 @@ class Editor(SpyderPluginWidget):
             # (subprocess "cwd" default is None, so empty str
             # must be changed to None in this case.)
             programs.run_program(WINPDB_PATH, [fname] + args, cwd=wdir or None)
-        
+
     def toggle_eol_chars(self, os_name, checked):
         if checked:
             editor = self.get_current_editor()
@@ -2204,7 +2216,7 @@ class Editor(SpyderPluginWidget):
     def fix_indentation(self):
         editorstack = self.get_current_editorstack()
         editorstack.fix_indentation()
-                    
+
     #------ Cursor position history management
     def update_cursorpos_actions(self):
         self.previous_edit_cursor_action.setEnabled(
@@ -2213,7 +2225,7 @@ class Editor(SpyderPluginWidget):
                self.cursor_pos_index is not None and self.cursor_pos_index > 0)
         self.next_cursor_action.setEnabled(self.cursor_pos_index is not None \
                     and self.cursor_pos_index < len(self.cursor_pos_history)-1)
-        
+
     def add_cursor_position_to_history(self, filename, position, fc=False):
         if self.__ignore_cursor_position:
             return
@@ -2236,16 +2248,16 @@ class Editor(SpyderPluginWidget):
         self.cursor_pos_history.append((filename, position))
         self.cursor_pos_index = len(self.cursor_pos_history)-1
         self.update_cursorpos_actions()
-    
+
     def cursor_moved(self, filename0, position0, filename1, position1):
         """Cursor was just moved: 'go to'"""
         if position0 is not None:
             self.add_cursor_position_to_history(filename0, position0)
         self.add_cursor_position_to_history(filename1, position1)
-        
+
     def text_changed_at(self, filename, position):
         self.last_edit_cursor_pos = (to_text_string(filename), position)
-        
+
     def current_file_changed(self, filename, position):
         self.add_cursor_position_to_history(to_text_string(filename), position,
                                             fc=True)
@@ -2262,7 +2274,7 @@ class Editor(SpyderPluginWidget):
                 editor = self.get_current_editor()
                 if position < editor.document().characterCount():
                     editor.set_cursor_position(position)
-            
+
     def __move_cursor_position(self, index_move):
         if self.cursor_pos_index is None:
             return
@@ -2328,7 +2340,7 @@ class Editor(SpyderPluginWidget):
             for data in editorstack.data:
                 data.editor.clear_breakpoints()
         self.refresh_plugin()
-                
+
     def clear_breakpoint(self, filename, lineno):
         """Remove a single breakpoint"""
         clear_breakpoint(filename, lineno)
@@ -2338,7 +2350,7 @@ class Editor(SpyderPluginWidget):
             index = self.is_file_opened(filename)
             if index is not None:
                 editorstack.data[index].editor.add_remove_breakpoint(lineno)
-                
+
     def debug_command(self, command):
         """Debug actions"""
         self.main.ipyconsole.write_to_stdin(command)
@@ -2368,11 +2380,11 @@ class Editor(SpyderPluginWidget):
         if editorstack.save():
             editor = self.get_current_editor()
             fname = osp.abspath(self.get_current_filename())
-            
+
             # Escape single and double quotes in fname (Fixes Issue 2158)
             fname = fname.replace("'", r"\'")
             fname = fname.replace('"', r'\"')
-            
+
             runconf = get_run_configuration(fname)
             if runconf is None:
                 dialog = RunConfigOneDialog(self)
@@ -2381,13 +2393,13 @@ class Editor(SpyderPluginWidget):
                     dialog.resize(self.dialog_size)
                 dialog.setup(fname)
                 if CONF.get('run', 'open_at_least_once', not PYTEST):
-                    # Open Run Config dialog at least once: the first time 
-                    # a script is ever run in Spyder, so that the user may 
+                    # Open Run Config dialog at least once: the first time
+                    # a script is ever run in Spyder, so that the user may
                     # see it at least once and be conscious that it exists
                     show_dlg = True
                     CONF.set('run', 'open_at_least_once', False)
                 else:
-                    # Open Run Config dialog only 
+                    # Open Run Config dialog only
                     # if ALWAYS_OPEN_FIRST_RUN_OPTION option is enabled
                     show_dlg = CONF.get('run', ALWAYS_OPEN_FIRST_RUN_OPTION)
                 if show_dlg and not dialog.exec_():
@@ -2414,7 +2426,7 @@ class Editor(SpyderPluginWidget):
             python = True # Note: in the future, it may be useful to run
             # something in a terminal instead of a Python interp.
             self.__last_ec_exec = (fname, wdir, args, interact, debug,
-                                   python, python_args, current, systerm, 
+                                   python, python_args, current, systerm,
                                    post_mortem, clear_namespace)
             self.re_run_file()
             if not interact and not debug:
@@ -2423,7 +2435,7 @@ class Editor(SpyderPluginWidget):
                 # current external shell automatically
                 # (see SpyderPluginWidget.visibility_changed method)
                 editor.setFocus()
-                
+
     def set_dialog_size(self, size):
         self.dialog_size = size
 
@@ -2501,14 +2513,14 @@ class Editor(SpyderPluginWidget):
             currentline_n = 'highlight_current_line'
             currentline_o = self.get_option(currentline_n)
             currentcell_n = 'highlight_current_cell'
-            currentcell_o = self.get_option(currentcell_n)            
+            currentcell_o = self.get_option(currentcell_n)
             occurrence_n = 'occurrence_highlighting'
             occurrence_o = self.get_option(occurrence_n)
             occurrence_timeout_n = 'occurrence_highlighting/timeout'
             occurrence_timeout_o = self.get_option(occurrence_timeout_n)
             focus_to_editor_n = 'focus_to_editor'
             focus_to_editor_o = self.get_option(focus_to_editor_n)
-            
+
             for editorstack in self.editorstacks:
                 if color_scheme_n in options:
                     editorstack.set_color_scheme(color_scheme_o)
@@ -2517,7 +2529,7 @@ class Editor(SpyderPluginWidget):
                                                                 currentline_o)
                 if currentcell_n in options:
                     editorstack.set_highlight_current_cell_enabled(
-                                                                currentcell_o)              
+                                                                currentcell_o)
                 if occurrence_n in options:
                     editorstack.set_occurrence_highlighting_enabled(occurrence_o)
                 if occurrence_timeout_n in options:
@@ -2672,7 +2684,7 @@ class Editor(SpyderPluginWidget):
         filenames = []
         filenames += [finfo.filename for finfo in editorstack.data]
         return filenames
-        
+
     def set_open_filenames(self):
         """
         Set the recent opened files on editor based on active project.
@@ -2684,7 +2696,7 @@ class Editor(SpyderPluginWidget):
             if not self.projects.get_active_project():
                 filenames = self.get_open_filenames()
                 self.set_option('filenames', filenames)
- 
+
     def setup_open_files(self):
         """Open the list of saved files per project"""
         self.set_create_new_file_if_empty(False)
@@ -2718,10 +2730,10 @@ class Editor(SpyderPluginWidget):
     def reorder_filenames(self, filenames):
         """Take the last session filenames and put the last open on first.
 
-        It takes a list of filenames and using the current filename from the 
-        layout settings, sets the one that had focused last in the position 0. 
-        It also reorders the current lines for each file (supposing that they 
-        are in the same order as the filenames) and sets them back in the 
+        It takes a list of filenames and using the current filename from the
+        layout settings, sets the one that had focused last in the position 0.
+        It also reorders the current lines for each file (supposing that they
+        are in the same order as the filenames) and sets them back in the
         layout settings.
         """
         layout = self.get_option('layout_settings', None)

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -512,16 +512,16 @@ class EditorStack(QWidget):
                                     triggered=self.close_all_right)
         close_all_but_this = create_action(self, _("Close all but this"),
                                            triggered=self.close_all_but_this)
-
+        
         if sys.platform == 'darwin':
            text=_("Show in Finder")
         else:
            text= _("Show in external file explorer")
         external_fileexp_action = create_action(self, text,
                                 triggered=self.show_in_external_file_explorer)
-
+                
         actions.append(external_fileexp_action)
-
+        
         self.menu_actions = actions + [None, fileswitcher_action,
                                        symbolfinder_action,
                                        copy_to_cb_action, None, close_right,
@@ -825,10 +825,10 @@ class EditorStack(QWidget):
         self.fileswitcher_dlg.is_visible = True
 
     @Slot()
-    def open_symbolfinder_dlg(self):
+    def open_symbolfinder_dlg(self): 
         self.open_fileswitcher_dlg()
         self.fileswitcher_dlg.set_search_text('@')
-
+        
     def update_fileswitcher_dlg(self):
         """Synchronize file list dialog box with editor widget tabs"""
         if self.fileswitcher_dlg:
@@ -1357,7 +1357,7 @@ class EditorStack(QWidget):
             else:
                 self.stack_history.remove_and_append(index)
 
-            return editor
+            return editor  
 
     def is_file_opened(self, filename=None):
         if filename is None:
@@ -1444,19 +1444,19 @@ class EditorStack(QWidget):
         n = self.get_stack_count()
         for i in range(num, n-1):
             self.close_file(num+1)
-
+    
     def close_all_but_this(self):
         """Close all files but the current one"""
         self.close_all_right()
         for i in range(0, self.get_stack_count()-1  ):
             self.close_file(0)
-
+            
     def add_last_closed_file(self, fname):
         """Add to last closed file list."""
         if fname in self.last_closed_files:
             self.last_closed_files.remove(fname)
         self.last_closed_files.insert(0, fname)
-        if len(self.last_closed_files) > 10:
+        if len(self.last_closed_files) > 10: 
             self.last_closed_files.pop(-1)
 
     def get_last_closed_files(self):
@@ -1860,7 +1860,7 @@ class EditorStack(QWidget):
                           "your changes?") % name,
                         QMessageBox.Yes | QMessageBox.No,
                         self)
-                    answer = self.msgbox.exec_()
+                    answer = self.msgbox.exec_()  
                     if answer == QMessageBox.Yes:
                         self.reload(index)
                     else:
@@ -1970,7 +1970,7 @@ class EditorStack(QWidget):
                       ) % osp.basename(filename),
                     QMessageBox.Yes | QMessageBox.No,
                     self)
-            answer = self.msgbox.exec_()
+            answer = self.msgbox.exec_()  
             if answer != QMessageBox.Yes:
                 return
         self.reload(index)
@@ -2162,7 +2162,7 @@ class EditorStack(QWidget):
     #------ Run
     def run_selection(self):
         """
-        Run selected text or current line in console.
+        Run selected text or current line in console. 
 
         If some text is selected, then execute that text in console.
 
@@ -2559,7 +2559,7 @@ class EditorMainWindow(QMainWindow):
     def add_toolbars_to_menu(self, menu_title, actions):
         """Add toolbars to a menu."""
         # Six is the position of the view menu in menus list
-        # that you can find in plugins/editor.py setup_other_windows.
+        # that you can find in plugins/editor.py setup_other_windows. 
         view_menu = self.menus[6]
         if actions == self.toolbars and view_menu:
             toolbars = []
@@ -2571,7 +2571,7 @@ class EditorMainWindow(QMainWindow):
     def load_toolbars(self):
         """Loads the last visible toolbars from the .ini file."""
         toolbars_names = CONF.get('main', 'last_visible_toolbars', default=[])
-        if toolbars_names:
+        if toolbars_names:            
             dic = {}
             for toolbar in self.toolbars:
                 dic[toolbar.objectName()] = toolbar


### PR DESCRIPTION
Fixes #4081 

----

Sorry about the diff.  I'm not sure why so many lines showed up?

I used `Ctrl+Alt+Shift+,`  (<) and `Ctrl+Alt+Shift+.` (>) for the Previous and Next based on shortcuts in Eclipse to move to the previous/next error in compiled source.  When I used the `<` and `>` in the definition, it didn't work, thus the `,` and `.`.  I also didn't know if I needed tests to specifically test the shortcut action since the actual functionality already existed.  I couldn't find existing tests for other shortcuts, although I did find some for menu options.

Thanks!