### PR TITLE
PR: Fix error Editor loosing focus

### DIFF
--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2551,9 +2551,10 @@ class CodeEditor(TextEditBaseWidget):
                 self.unindent()
         elif not event.isAccepted():
             TextEditBaseWidget.keyPressEvent(self, event)
-            event.accept()
             if self.is_completion_widget_visible() and text:
                 self.completion_text += text
+        # Accept event to avoid it being handled by the parent
+        event.accept()
 
     def run_pygments_highlighter(self):
         """Run pygments highlighter."""


### PR DESCRIPTION
Accept keyboard event in CodeEditor to avoid it being handled by the parent.

Not accepting the event cause that the editor will lose the focus when pressing <Tab>, maybe other malfunctions could be caused too.

I introduced this error in #5002 sorry 😞 