### PR TITLE
PR: Support for all Pandas indexes in Variable Explorer

### DIFF
--- a/doc/variableexplorer.rst
+++ b/doc/variableexplorer.rst
@@ -54,7 +54,7 @@ Supported types
 The variable explorer can't show all types of objects. The ones currently
 supported are:
 
-#. `Pandas` DataFrame, TimeSeries and DatetimeIndex objects
+#. `Pandas` DataFrame, TimeSeries and Index objects
 #. `NumPy` arrays and matrices
 #. `PIL/Pillow` images
 #. `datetime` dates

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -388,8 +388,8 @@ def get_supported_types():
     except:
         pass
     try:
-        from pandas import DataFrame, Series, DatetimeIndex
-        editable_types += [DataFrame, Series, DatetimeIndex]
+        from pandas import DataFrame, Series, Index
+        editable_types += [DataFrame, Series, Index]
     except:
         pass
     picklable_types = editable_types[:]

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -47,11 +47,10 @@ from spyder.utils.qthelpers import (add_actions, create_action,
 from spyder.widgets.variableexplorer.importwizard import ImportWizard
 from spyder.widgets.variableexplorer.texteditor import TextEditor
 from spyder.widgets.variableexplorer.utils import (
-    array, DataFrame, DatetimeIndex, display_to_value, FakeObject,
-    get_color_name, get_human_readable_type, get_size, Image, is_editable_type,
-    is_known_type, MaskedArray, ndarray, np_savetxt, Series, sort_against,
-    try_to_eval, unsorted_unique, value_to_display, get_object_attrs,
-    get_type_string)
+    array, DataFrame, Index, display_to_value, FakeObject, get_color_name,
+    get_human_readable_type, get_size, Image, is_editable_type, is_known_type,
+    MaskedArray, ndarray, np_savetxt, Series, sort_against, try_to_eval,
+    unsorted_unique, value_to_display, get_object_attrs, get_type_string)
 
 if ndarray is not FakeObject:
     from spyder.widgets.variableexplorer.arrayeditor import ArrayEditor
@@ -481,7 +480,7 @@ class CollectionsDelegate(QItemDelegate):
                                             conv=conv_func))
             return None
         #--editor = DataFrameEditor
-        elif isinstance(value, (DataFrame, DatetimeIndex, Series)) \
+        elif isinstance(value, (DataFrame, Index, Series)) \
           and DataFrame is not FakeObject:
             editor = DataFrameEditor()
             if not editor.setup_and_check(value, title=key):

--- a/spyder/widgets/variableexplorer/dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/dataframeeditor.py
@@ -23,7 +23,7 @@ from qtpy.QtWidgets import (QApplication, QCheckBox, QDialogButtonBox, QDialog,
                             QMenu, QMessageBox, QPushButton, QTableView,
                             QHeaderView)
 
-from pandas import DataFrame, DatetimeIndex, Series
+from pandas import DataFrame, Index, Series
 import numpy as np
 
 # Local imports
@@ -658,7 +658,7 @@ class DataFrameEditor(QDialog):
         """
         Setup DataFrameEditor:
         return False if data is not supported, True otherwise.
-        Supported types for data are DataFrame, Series and DatetimeIndex.
+        Supported types for data are DataFrame, Series and Index.
         """
         self.layout = QGridLayout()
         self.setLayout(self.layout)
@@ -670,7 +670,7 @@ class DataFrameEditor(QDialog):
         if isinstance(data, Series):
             self.is_series = True
             data = data.to_frame()
-        elif isinstance(data, DatetimeIndex):
+        elif isinstance(data, Index):
             data = DataFrame(data)
 
         self.setWindowTitle(title)

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -20,6 +20,8 @@ import pytest
 # Local imports
 from spyder.widgets.variableexplorer.collectionseditor import (
     CollectionsEditorTableView, CollectionsModel)
+from spyder.widgets.variableexplorer.tests.test_dataframeeditor import \
+    generate_pandas_indexes
 
 # Helper functions
 def data(cm, i, j):
@@ -73,27 +75,27 @@ def test_collectionsmodel_with_two_ints():
     assert data(cm, row_with_y, 2) == '1'
     assert data(cm, row_with_y, 3) == '2'
 
-def test_collectionsmodel_with_datetimeindex():
-    # Regression test for issue #3380
-    rng = pandas.date_range('10/1/2016', periods=25, freq='bq')
-    coll = {'rng': rng}
-    cm = CollectionsModel(None, coll)
-    assert data(cm, 0, 0) == 'rng'
-    assert data(cm, 0, 1) == 'DatetimeIndex'
-    assert data(cm, 0, 2) == '(25,)' or data(cm, 0, 2) == '(25L,)'
-    assert data(cm, 0, 3) == rng.summary()
+def test_collectionsmodel_with_index():
+    # Regression test for issue #3380, modified for #3758
+    for rng_name, rng in generate_pandas_indexes().items():
+        coll = {'rng': rng}
+        cm = CollectionsModel(None, coll)
+        assert data(cm, 0, 0) == 'rng'
+        assert data(cm, 0, 1) == rng_name
+        assert data(cm, 0, 2) == '(20,)' or data(cm, 0, 2) == '(20L,)'
+        assert data(cm, 0, 3) == rng.summary()
 
-def test_shows_dataframeeditor_when_editing_datetimeindex(qtbot, monkeypatch):
-    MockDataFrameEditor = Mock()
-    mockDataFrameEditor_instance = MockDataFrameEditor()
-    monkeypatch.setattr('spyder.widgets.variableexplorer.collectionseditor.DataFrameEditor',
-                        MockDataFrameEditor)
-    rng = pandas.date_range('10/1/2016', periods=25, freq='bq')
-    coll = {'rng': rng}
-    editor = CollectionsEditorTableView(None, coll)
-    editor.delegate.createEditor(None, None, editor.model.createIndex(0, 3))
-    mockDataFrameEditor_instance.show.assert_called_once_with()
-
+def test_shows_dataframeeditor_when_editing_index(qtbot, monkeypatch):
+    for rng_name, rng in generate_pandas_indexes().items():
+        MockDataFrameEditor = Mock()
+        mockDataFrameEditor_instance = MockDataFrameEditor()
+        monkeypatch.setattr('spyder.widgets.variableexplorer.collectionseditor.DataFrameEditor',
+                            MockDataFrameEditor)
+        coll = {'rng': rng}
+        editor = CollectionsEditorTableView(None, coll)
+        editor.delegate.createEditor(None, None,
+                                     editor.model.createIndex(0, 3))
+        mockDataFrameEditor_instance.show.assert_called_once_with()
 
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/widgets/variableexplorer/tests/test_dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_dataframeeditor.py
@@ -17,8 +17,8 @@ except ImportError:
 import os
 
 # Third party imports
-import pandas
-from pandas import DataFrame, date_range, read_csv
+from pandas import (DataFrame, date_range, read_csv, Index, RangeIndex,
+                    DatetimeIndex, MultiIndex, CategoricalIndex)
 from qtpy.QtGui import QColor
 from qtpy.QtCore import Qt
 import numpy
@@ -50,15 +50,15 @@ def bgcolor(dfm, i, j):
 def generate_pandas_indexes():
     """ Creates a dictionnary of many possible pandas indexes """
     return {
-        'Index': pandas.Index(list('ABCDEFGHIJKLMNOPQRST')),
-        'RangeIndex': pandas.RangeIndex(0, 20),
-        'Float64Index': pandas.Index([i/10 for i in range(20)]),
-        'DatetimeIndex': pandas.DatetimeIndex(start='2017-01-01', periods=20,
-                                               freq='D'),
-        'MultiIndex': pandas.MultiIndex.from_product(
+        'Index': Index(list('ABCDEFGHIJKLMNOPQRST')),
+        'RangeIndex': RangeIndex(0, 20),
+        'Float64Index': Index([i/10 for i in range(20)]),
+        'DatetimeIndex': DatetimeIndex(start='2017-01-01', periods=20,
+                                       freq='D'),
+        'MultiIndex': MultiIndex.from_product(
             [list('ABCDEFGHIJ'), ('foo', 'bar')], names=['first', 'second']),
-        'CategoricalIndex': pandas.CategoricalIndex(
-            list('abcaadaccbbacabacccb'), categories=['a','b','c']),
+        'CategoricalIndex': CategoricalIndex(list('abcaadaccbbacabacccb'),
+                                             categories=['a', 'b', 'c']),
         }
 
 # --- Tests
@@ -233,39 +233,45 @@ def test_header_encoding():
 
 def test_dataframeeditor_with_various_indexes():
     for rng_name, rng in generate_pandas_indexes().items():
-        rng = rng[:3]
         editor = DataFrameEditor(None)
         editor.setup_and_check(rng)
         dfm = editor.dataModel
-        assert dfm.rowCount() == 3
+        assert dfm.rowCount() == 20
         assert dfm.columnCount() == 2
         assert data(dfm, 0, 0) == '0'
         assert data(dfm, 1, 0) == '1'
         assert data(dfm, 2, 0) == '2'
+        assert data(dfm, 19, 0) == '19'
         if rng_name == "Index":
             assert data(dfm, 0, 1) == 'A'
             assert data(dfm, 1, 1) == 'B'
             assert data(dfm, 2, 1) == 'C'
+            assert data(dfm, 19, 1) == 'T'
         elif rng_name == "RangeIndex":
             assert data(dfm, 0, 1) == '0'
             assert data(dfm, 1, 1) == '1'
             assert data(dfm, 2, 1) == '2'
+            assert data(dfm, 19, 1) == '19'
         elif rng_name == "Float64Index":
             assert data(dfm, 0, 1) == '0'
             assert data(dfm, 1, 1) == '0.1'
             assert data(dfm, 2, 1) == '0.2'
+            assert data(dfm, 19, 1) == '1.9'
         elif rng_name == "DatetimeIndex":
             assert data(dfm, 0, 1) == '2017-01-01 00:00:00'
             assert data(dfm, 1, 1) == '2017-01-02 00:00:00'
             assert data(dfm, 2, 1) == '2017-01-03 00:00:00'
+            assert data(dfm, 19, 1) == '2017-01-20 00:00:00'
         elif rng_name == "MultiIndex":
             assert data(dfm, 0, 1) == "('A', 'foo')"
             assert data(dfm, 1, 1) == "('A', 'bar')"
             assert data(dfm, 2, 1) == "('B', 'foo')"
+            assert data(dfm, 19, 1) == "('J', 'bar')"
         elif rng_name == "CategoricalIndex":
             assert data(dfm, 0, 1) == 'a'
             assert data(dfm, 1, 1) == 'b'
             assert data(dfm, 2, 1) == 'c'
+            assert data(dfm, 19, 1) == 'b'
 
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -470,8 +470,8 @@ def get_type_string(item):
     """Return type string of an object."""
     if isinstance(item, DataFrame):
         return "DataFrame"
-    if isinstance(item, DatetimeIndex):
-        return "Index"
+    if isinstance(item, Index):
+        return type(item).__name__
     if isinstance(item, Series):
         return "Series"
     found = re.findall(r"<(?:type|class) '(\S*)'>",

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -83,11 +83,11 @@ def get_numpy_dtype(obj):
 #==============================================================================
 if programs.is_module_installed('pandas', PANDAS_REQVER):
     try:
-        from pandas import DataFrame, DatetimeIndex, Series
+        from pandas import DataFrame, Index, Series
     except:
-        DataFrame = DatetimeIndex = Series = FakeObject
+        DataFrame = Index = Series = FakeObject
 else:
-    DataFrame = DatetimeIndex = Series = FakeObject      # analysis:ignore
+    DataFrame = Index = Series = FakeObject      # analysis:ignore
 
 
 #==============================================================================
@@ -135,7 +135,7 @@ def get_size(item):
         return item.shape
     elif isinstance(item, Image):
         return item.size
-    if isinstance(item, (DataFrame, DatetimeIndex, Series)):
+    if isinstance(item, (DataFrame, Index, Series)):
         return item.shape
     else:
         return 1
@@ -191,7 +191,7 @@ COLORS = {
            matrix,
            DataFrame,
            Series,
-           DatetimeIndex):    ARRAY_COLOR,
+           Index):            ARRAY_COLOR,
           Image:              "#008000",
           datetime.date:      "#808000",
           }
@@ -375,11 +375,11 @@ def value_to_display(value, minmax=False, level=0):
             display = to_text_string(value)
             if level > 0:
                 display = u"'" + display + u"'"
-        elif isinstance(value, DatetimeIndex):
+        elif isinstance(value, Index):
             if level == 0:
                 display = value.summary()
             else:
-                display = 'DatetimeIndex'
+                display = 'Index'
         elif is_binary_string(value):
             try:
                 display = to_text_string(value, 'utf8')
@@ -471,7 +471,7 @@ def get_type_string(item):
     if isinstance(item, DataFrame):
         return "DataFrame"
     if isinstance(item, DatetimeIndex):
-        return "DatetimeIndex"
+        return "Index"
     if isinstance(item, Series):
         return "Series"
     found = re.findall(r"<(?:type|class) '(\S*)'>",


### PR DESCRIPTION
Fixes #3758 

----

Hi team, 

This is a proposal in order to solve #3758. 
In addition to the support of pandas `DatetimeIndex` (#3849) in the Variable Explorer it is possible to support all pandas `Indexes`. 
Results are exactly the same as before for `DatetimeIndex` and very similar for all other types (`RangeIndex`, `MultiIndex`, `CategoricalIndex`, etc.).
![capture1](https://user-images.githubusercontent.com/20270441/30133497-63f26ae6-9354-11e7-940f-37cdc2688b7b.PNG)
![capture2](https://user-images.githubusercontent.com/20270441/30133498-67fb2e98-9354-11e7-8caf-17f46836843e.PNG)
