### PR TITLE
PR: Don't use super in _handle_error method of IPython console

### DIFF
--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -410,11 +410,7 @@ the sympy module (e.g. plot)
         """
         Reimplemented to reset the prompt if the error comes after the reply
         """
-        # In pyqt4, if super does not has _handle_error, disregard the error
-        if PYQT4:
-            if not hasattr(super(ShellWidget, self), '_handle_error'):
-                return
-        super(ShellWidget, self)._handle_error(msg)
+        self._process_execute_error(msg)
         self._show_interpreter_prompt()
 
     def _context_menu_make(self, pos):


### PR DESCRIPTION
Fixes #5158 

I don't know why but using `super` was failing completely in PyQt4 and now some Windows users report that it also fails in PyQt5.

Overriding completely `_handle_error` (by taking the code it uses in `qtconsole`) fixes the issue completely.