### PR TITLE
PR: Fix RuntimeError and AttributeError when using outline and split code editor

### DIFF
--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -1456,13 +1456,15 @@ class Editor(SpyderPluginWidget):
     def get_current_editorstack(self, editorwindow=None):
         if self.editorstacks is not None:
             if len(self.editorstacks) == 1:
-                return self.editorstacks[0]
+                editorstack = self.editorstacks[0]
             else:
                 editorstack = self.__get_focus_editorstack()
                 if editorstack is None or editorwindow is not None:
-                    return self.get_last_focus_editorstack(editorwindow)
-                return editorstack
-        
+                    editorstack = self.get_last_focus_editorstack(editorwindow)
+                    if editorstack is None:
+                        editorstack = self.editorstacks[0]
+            return editorstack
+
     def get_current_editor(self):
         editorstack = self.get_current_editorstack()
         if editorstack is not None:

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -767,6 +767,12 @@ class EditorStack(QWidget):
     def closeEvent(self, event):
         self.threadmanager.close_all_threads()
         self.analysis_timer.timeout.disconnect(self.analyze_script)
+
+        # Remove editor references from the outline explorer settings
+        if self.outlineexplorer is not None:
+            for finfo in self.data:
+                self.outlineexplorer.remove_editor(finfo.editor)
+
         QWidget.closeEvent(self, event)
         if is_pyqt46:
             self.destroyed.emit()
@@ -2015,10 +2021,6 @@ class EditorStack(QWidget):
         editor.zoom_out.connect(lambda: self.zoom_out.emit())
         editor.zoom_reset.connect(lambda: self.zoom_reset.emit())
         editor.sig_eol_chars_changed.connect(lambda eol_chars: self.refresh_eol_chars(eol_chars))
-        if self.outlineexplorer is not None:
-            # Removing editor reference from outline explorer settings:
-            editor.destroyed.connect(lambda obj=editor:
-                                     self.outlineexplorer.remove_editor(obj))
 
         self.find_widget.set_editor(editor)
 

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -476,7 +476,6 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         parent = self.current_editor.parent()
         for editor_id, i_item in list(self.editor_items.items()):
             if i_item is root_item:
-                #XXX: not working anymore!!!
                 for editor, _id in list(self.editor_ids.items()):
                     if _id == editor_id and editor.parent() is parent:
                         self.current_editor = editor


### PR DESCRIPTION
Fixes 2 issues related to splitting the Editor in 3.x branch.

- [x] Fix Issue 1 (Fixes #3390)
- [x] Fix Issue 2 (Fixes #5167)

**Important:** These issues were fixed in the master branch with PR #5083