### PR TITLE
PR: Use get_python_executable to run in external terminals

### DIFF
--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -21,6 +21,7 @@ import tempfile
 
 # Local imports
 from spyder.utils import encoding
+from spyder.utils.misc import get_python_executable
 from spyder.py3compat import PY2, is_text_string, to_text_string
 
 
@@ -265,7 +266,7 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
         fname = '"' + fname + '"'
         wdir = wdir.replace('/', '\\')
     
-    p_args = ['python']
+    p_args = [get_python_executable()]
     p_args += get_python_args(fname, python_args, interact, debug, args)
     
     if os.name == 'nt':


### PR DESCRIPTION
Fixes #5165.

Attempt to fix #5165 based on the suggestion to use `get_python_executable()` from @jitseniesen 

I tried to run the tests but got errors which seem unrelated to my changes (they also occur in clean 3.x branch.)
