### PR TITLE
PR: Unify how extra selections are added to the Editor

### DIFF
--- a/spyder/widgets/panels/codefolding.py
+++ b/spyder/widgets/panels/codefolding.py
@@ -348,6 +348,15 @@ class FoldingPanel(Panel):
         return color
 
     def _decorate_block(self, start, end):
+        """
+        Create a decoration and addedit to the editor.
+
+        NOTE: codefolding decorations will have draw_order=1
+
+        Args:
+            start (int) start line of the decoration
+            end (int) end line of the decoration
+        """
         color = self._get_scope_highlight_color()
         d = TextDecoration(self.editor.document(),
                            start_line=start, end_line=end+1, draw_order=1)

--- a/spyder/widgets/panels/codefolding.py
+++ b/spyder/widgets/panels/codefolding.py
@@ -16,7 +16,8 @@ from qtpy.QtGui import (QTextBlock, QColor, QFontMetricsF, QPainter,
                         QLinearGradient, QPen, QPalette, QResizeEvent,
                         QCursor)
 
-from spyder.widgets.sourcecode.api.decoration import TextDecoration
+from spyder.widgets.sourcecode.api.decoration import (TextDecoration,
+                                                      DRAW_ORDERS)
 from spyder.widgets.sourcecode.folding import FoldScope
 from spyder.api.panel import Panel
 from spyder.utils.editor import (TextBlockHelper, TextHelper, DelayJobRunner,
@@ -351,15 +352,14 @@ class FoldingPanel(Panel):
         """
         Create a decoration and add it to the editor.
 
-        NOTE: codefolding decorations will have draw_order=1
-
         Args:
             start (int) start line of the decoration
             end (int) end line of the decoration
         """
         color = self._get_scope_highlight_color()
-        d = TextDecoration(self.editor.document(),
-                           start_line=start, end_line=end+1, draw_order=1)
+        draw_order = DRAW_ORDERS.get('codefolding')
+        d = TextDecoration(self.editor.document(), start_line=start,
+                           end_line=end+1, draw_order=draw_order)
         d.set_background(color)
         d.set_full_width(True, clear=False)
         self.editor.decorations.add(d)
@@ -442,10 +442,10 @@ class FoldingPanel(Panel):
         Add fold decorations (boxes arround a folded block in the editor
         widget).
         """
-        deco = TextDecoration(block, draw_order=1)
+        draw_order = DRAW_ORDERS.get('codefolding')
+        deco = TextDecoration(block, draw_order=draw_order)
         deco.signals.clicked.connect(self._on_fold_deco_clicked)
         deco.tooltip = region.text(max_lines=25)
-        deco.draw_order = 1
         deco.block = block
         deco.select_line()
         deco.set_outline(drift_color(

--- a/spyder/widgets/panels/codefolding.py
+++ b/spyder/widgets/panels/codefolding.py
@@ -353,7 +353,7 @@ class FoldingPanel(Panel):
                            start_line=start, end_line=end+1, draw_order=1)
         d.set_background(color)
         d.set_full_width(True, clear=False)
-        self.editor.decorations.append(d)
+        self.editor.decorations.add(d)
         self._scope_decos.append(d)
 
     def _highlight_block(self, block):
@@ -444,7 +444,7 @@ class FoldingPanel(Panel):
         deco.set_background(self._get_scope_highlight_color())
         deco.set_foreground(QColor('#808080'))
         self._block_decos.append(deco)
-        self.editor.decorations.append(deco)
+        self.editor.decorations.add(deco)
 
     def toggle_fold_trigger(self, block):
         """
@@ -556,7 +556,7 @@ class FoldingPanel(Panel):
                 deco.set_outline(drift_color(
                     self._get_scope_highlight_color(), 110))
                 deco.set_background(self._get_scope_highlight_color())
-                self.editor.decorations.append(deco)
+                self.editor.decorations.add(deco)
         self._prev_cursor = cursor
 
     def _refresh_editor_and_scrollbars(self):

--- a/spyder/widgets/panels/codefolding.py
+++ b/spyder/widgets/panels/codefolding.py
@@ -349,7 +349,7 @@ class FoldingPanel(Panel):
 
     def _decorate_block(self, start, end):
         """
-        Create a decoration and addedit to the editor.
+        Create a decoration and add it to the editor.
 
         NOTE: codefolding decorations will have draw_order=1
 

--- a/spyder/widgets/panels/codefolding.py
+++ b/spyder/widgets/panels/codefolding.py
@@ -350,7 +350,7 @@ class FoldingPanel(Panel):
     def _decorate_block(self, start, end):
         color = self._get_scope_highlight_color()
         d = TextDecoration(self.editor.document(),
-                           start_line=start, end_line=end+1)
+                           start_line=start, end_line=end+1, draw_order=1)
         d.set_background(color)
         d.set_full_width(True, clear=False)
         self.editor.decorations.append(d)
@@ -433,7 +433,7 @@ class FoldingPanel(Panel):
         Add fold decorations (boxes arround a folded block in the editor
         widget).
         """
-        deco = TextDecoration(block)
+        deco = TextDecoration(block, draw_order=1)
         deco.signals.clicked.connect(self._on_fold_deco_clicked)
         deco.tooltip = region.text(max_lines=25)
         deco.draw_order = 1

--- a/spyder/widgets/sourcecode/api/decoration.py
+++ b/spyder/widgets/sourcecode/api/decoration.py
@@ -15,6 +15,22 @@ from qtpy.QtGui import (QTextCursor, QFont, QPen, QColor, QTextFormat,
                         QTextCharFormat)
 
 
+# DRAW_ORDERS are used for make some decorations appear in top of others,
+# and avoid a decoration from overlapping/hiding other decorations.
+#
+# For example, codefolding will appear in front of current cell but behind
+# other decorations.
+#
+# NOTE: If two decorations have the same draw_order smaller decoration will
+# appear in front of the other.
+
+DRAW_ORDERS = {'on_bottom': 0,
+               'current_cell': 1,
+               'codefolding': 2,
+               'current_line': 3,
+               'on_top': 4}
+
+
 class TextDecoration(QTextEdit.ExtraSelection):
     """
     Helper class to quickly create a text decoration.

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -329,9 +329,28 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
             return 0
 
     def get_extra_selections(self, key):
+        """Return editor extra selections.
+
+        Args:
+            key (str) name of the extra selections group
+
+        Returns:
+            list of sourcecode.api.TextDecoration.
+        """
         return self.extra_selections_dict.get(key, [])
 
     def set_extra_selections(self, key, extra_selections):
+        """Set extra selections for a key.
+
+        Also assign draw orders to leave current_cell and current_line
+        in the backgrund (and avoid them to cover other decorations)
+
+        NOTE: This will remove previous decorations added to  the same key.
+
+        Args:
+            key (str) name of the extra selections group.
+            extra_selections (list of sourcecode.api.TextDecoration).
+        """
         # current line has to be highlighted first
         draw_orders = {'current_cell': 0,
                        # draw order = 1 is used in codefolding
@@ -344,6 +363,11 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         self.extra_selections_dict[key] = extra_selections
 
     def update_extra_selections(self):
+        """Add extra selections to DecorationsManager.
+
+        TODO: This method could be remove it and decorations could be
+        added/removed in set_extra_selections/clear_extra_selections.
+        """
         extra_selections = []
 
         for key, extra in list(self.extra_selections_dict.items()):
@@ -351,6 +375,11 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         self.decorations.add(extra_selections)
 
     def clear_extra_selections(self, key):
+        """Remove decorations added through set_extra_selections.
+
+        Args:
+            key (str) name of the extra selections group.
+        """
         for decoration in self.extra_selections_dict.get(key, []):
             self.decorations.remove(decoration)
         self.extra_selections_dict[key] = []

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -34,7 +34,7 @@ from spyder.widgets.calltip import CallTipWidget
 from spyder.widgets.mixins import BaseEditMixin
 from spyder.widgets.sourcecode.terminal import ANSIEscapeCodeHandler
 from spyder.widgets.sourcecode.api.decoration import TextDecoration
-
+from spyder.widgets.sourcecode.utils.decoration import TextDecorationsManager
 
 def insert_text_to(cursor, text, fmt):
     """Helper to print text, taking into account backspaces"""
@@ -280,6 +280,8 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
 
         self.last_cursor_cell = None
 
+        self.decorations = TextDecorationsManager(self)
+
     def setup_completion(self):
         size = CONF.get('main', 'completion/size')
         font = get_font()
@@ -346,19 +348,12 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
 
         for key, extra in list(self.extra_selections_dict.items()):
             extra_selections.extend(extra)
-        try:
-            self.decorations.extend(extra_selections)
-        except AttributeError:
-            self.setExtraSelections(extra_selections)
+        self.decorations.extend(extra_selections)
 
     def clear_extra_selections(self, key):
-        try:
-            for decoration in self.extra_selections_dict.get(key, []):
-                self.decorations.remove(decoration)
-            self.extra_selections_dict[key] = []
-        except AttributeError:
-            self.extra_selections_dict[key] = []
-            self.update_extra_selections()
+        for decoration in self.extra_selections_dict.get(key, []):
+            self.decorations.remove(decoration)
+        self.extra_selections_dict[key] = []
 
     def changed(self):
         """Emit changed signal"""

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -15,7 +15,6 @@
 import os
 import re
 import sys
-from collections import OrderedDict
 
 # Third party imports
 from qtpy.compat import to_qvariant
@@ -237,7 +236,7 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         BaseEditMixin.__init__(self)
         self.setAttribute(Qt.WA_DeleteOnClose)
         
-        self.extra_selections_dict = OrderedDict()
+        self.extra_selections_dict = {}
         
         self.textChanged.connect(self.changed)
         self.cursorPositionChanged.connect(self.cursor_position_changed)
@@ -332,10 +331,6 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
 
     def set_extra_selections(self, key, extra_selections):
         self.extra_selections_dict[key] = extra_selections
-        self.extra_selections_dict = \
-            OrderedDict(sorted(self.extra_selections_dict.items(),
-                               key=lambda s: self.extra_selection_length(s[0]),
-                               reverse=True))
 
     def update_extra_selections(self):
         extra_selections = []

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -319,15 +319,6 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
 
 
     #------Extra selections
-    def extra_selection_length(self, key):
-        selection = self.get_extra_selections(key)
-        if selection:
-            cursor = self.extra_selections_dict[key][0].cursor
-            selection_length = cursor.selectionEnd() - cursor.selectionStart()
-            return selection_length
-        else:
-            return 0
-
     def get_extra_selections(self, key):
         """Return editor extra selections.
 

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -348,7 +348,7 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
 
         for key, extra in list(self.extra_selections_dict.items()):
             extra_selections.extend(extra)
-        self.decorations.extend(extra_selections)
+        self.decorations.add(extra_selections)
 
     def clear_extra_selections(self, key):
         for decoration in self.extra_selections_dict.get(key, []):

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -33,8 +33,10 @@ from spyder.utils import icon_manager as ima
 from spyder.widgets.calltip import CallTipWidget
 from spyder.widgets.mixins import BaseEditMixin
 from spyder.widgets.sourcecode.terminal import ANSIEscapeCodeHandler
-from spyder.widgets.sourcecode.api.decoration import TextDecoration
+from spyder.widgets.sourcecode.api.decoration import (TextDecoration,
+                                                      DRAW_ORDERS)
 from spyder.widgets.sourcecode.utils.decoration import TextDecorationsManager
+
 
 def insert_text_to(cursor, text, fmt):
     """Helper to print text, taking into account backspaces"""
@@ -342,11 +344,11 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
             key (str) name of the extra selections group.
             extra_selections (list of sourcecode.api.TextDecoration).
         """
-        # current line has to be highlighted first
-        draw_orders = {'current_cell': 0,
-                       # draw order = 1 is used in codefolding
-                       'current_line': 2}
-        draw_order = draw_orders.get(key,  5)
+        # use draw orders to highlight current_cell and current_line first
+        draw_order = DRAW_ORDERS.get(key)
+        if draw_order is None:
+            draw_order = DRAW_ORDERS.get('on_top')
+
         for selection in extra_selections:
             selection.draw_order = draw_order
 

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -330,21 +330,20 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         return self.extra_selections_dict.get(key, [])
 
     def set_extra_selections(self, key, extra_selections):
+        # current line has to be highlighted first
+        draw_orders = {'current_cell': 0,
+                       # draw order = 1 is used in codefolding
+                       'current_line': 2}
+        draw_order = draw_orders.get(key,  5)
+        for selection in extra_selections:
+            selection.draw_order = draw_order
         self.extra_selections_dict[key] = extra_selections
 
     def update_extra_selections(self):
         extra_selections = []
 
-        # Python 3 compatibility (weird): current line has to be
-        # highlighted first
-        if 'current_cell' in self.extra_selections_dict:
-            extra_selections.extend(self.extra_selections_dict['current_cell'])
-        if 'current_line' in self.extra_selections_dict:
-            extra_selections.extend(self.extra_selections_dict['current_line'])
-
         for key, extra in list(self.extra_selections_dict.items()):
-            if not (key == 'current_line' or key == 'current_cell'):
-                extra_selections.extend(extra)
+            extra_selections.extend(extra)
         try:
             self.decorations.extend(extra_selections)
         except AttributeError:

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -337,6 +337,8 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         draw_order = draw_orders.get(key,  5)
         for selection in extra_selections:
             selection.draw_order = draw_order
+
+        self.clear_extra_selections(key)
         self.extra_selections_dict[key] = extra_selections
 
     def update_extra_selections(self):

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -38,7 +38,7 @@ from qtpy.QtPrintSupport import QPrinter
 from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
                             QGridLayout, QHBoxLayout, QInputDialog, QLabel,
                             QLineEdit, QMenu, QMessageBox, QSplitter,
-                            QTextEdit, QToolTip, QVBoxLayout)
+                            QToolTip, QVBoxLayout)
 from spyder.widgets.panels.classfunctiondropdown import ClassFunctionDropdown
 
 # %% This line is for cell execution testing
@@ -71,7 +71,7 @@ from spyder.widgets.sourcecode.extensions.manager import (
         EditorExtensionsManager)
 from spyder.widgets.sourcecode.extensions.closequotes import (
         CloseQuotesExtension)
-
+from spyder.widgets.sourcecode.api.decoration import TextDecoration
 from spyder.api.panel import Panel
 
 try:
@@ -941,7 +941,7 @@ class CodeEditor(TextEditBaseWidget):
                         underline_style=QTextCharFormat.SpellCheckUnderline,
                         update=False):
         extra_selections = self.get_extra_selections(key)
-        selection = QTextEdit.ExtraSelection()
+        selection = TextDecoration(cursor)
         if foreground_color is not None:
             selection.format.setForeground(foreground_color)
         if background_color is not None:
@@ -953,7 +953,6 @@ class CodeEditor(TextEditBaseWidget):
                                          to_qvariant(underline_color))
         selection.format.setProperty(QTextFormat.FullWidthSelection,
                                      to_qvariant(True))
-        selection.cursor = cursor
         extra_selections.append(selection)
         self.set_extra_selections(key, extra_selections)
         if update:
@@ -1011,9 +1010,8 @@ class CodeEditor(TextEditBaseWidget):
         self.found_results = []
         for match in regobj.finditer(text):
             pos1, pos2 = match.span()
-            selection = QTextEdit.ExtraSelection()
+            selection = TextDecoration(self.textCursor())
             selection.format.setBackground(self.found_results_color)
-            selection.cursor = self.textCursor()
             selection.cursor.setPosition(pos1)
             self.found_results.append(selection.cursor.blockNumber())
             selection.cursor.setPosition(pos2, QTextCursor.KeepAnchor)

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -66,7 +66,6 @@ from spyder.widgets.panels.scrollflag import ScrollFlagArea
 from spyder.widgets.panels.manager import PanelsManager
 from spyder.widgets.panels.codefolding import FoldingPanel
 from spyder.widgets.sourcecode.folding import IndentFoldDetector
-from spyder.widgets.sourcecode.utils.decoration import TextDecorationsManager
 from spyder.widgets.sourcecode.extensions.manager import (
         EditorExtensionsManager)
 from spyder.widgets.sourcecode.extensions.closequotes import (
@@ -294,7 +293,6 @@ class CodeEditor(TextEditBaseWidget):
         self.blanks_enabled = False
 
         self.background = QColor('white')
-        self.decorations = TextDecorationsManager(self)
 
         # Folding
         self.panels.register(FoldingPanel())

--- a/spyder/widgets/sourcecode/tests/test_extra_selections.py
+++ b/spyder/widgets/sourcecode/tests/test_extra_selections.py
@@ -43,7 +43,6 @@ def test_extra_selections(qtbot):
     editor.setTextCursor(cursor)
 
     qtbot.waitUntil(lambda: len(editor.extraSelections()) >= 6, timeout=2000)
-    print(len(editor.extraSelections()))
     selections = editor.extraSelections()
     selected_texts = [sel.cursor.selectedText() for sel in selections]
 

--- a/spyder/widgets/sourcecode/tests/test_extra_selections.py
+++ b/spyder/widgets/sourcecode/tests/test_extra_selections.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+#
+"""Tests for editor extra selections (decorations)."""
+
+# Third party imports
+import pytest
+from qtpy.QtGui import QTextCursor, QTextFormat
+
+# Local imports
+from spyder.utils.qthelpers import qapplication
+from spyder.widgets.sourcecode.codeeditor import CodeEditor
+
+
+# --- Fixtures
+# -----------------------------------------------------------------------------
+def construct_editor(*args, **kwargs):
+    """Construct editor with some text for testing extra selections."""
+    app = qapplication()
+    editor = CodeEditor(parent=None)
+    kwargs['language'] = 'Python'
+    editor.setup_editor(*args, **kwargs)
+
+    text = ("def some_function():\n"
+            "    some_variable = 1\n"
+            "    some_variable += 2\n"
+            "    return some_variable\n"
+            "# %%")
+    editor.set_text(text)
+    return editor
+
+
+def test_extra_selections(qtbot):
+    """Test extra selections."""
+    editor = construct_editor()
+
+    # Move cursor over 'some_variable'
+    editor.go_to_line(2)
+    cursor = editor.textCursor()
+    cursor.movePosition(QTextCursor.Right, n=5)
+    editor.setTextCursor(cursor)
+
+    qtbot.waitUntil(lambda: len(editor.extraSelections()) >= 6, timeout=2000)
+    print(len(editor.extraSelections()))
+    selections = editor.extraSelections()
+    selected_texts = [sel.cursor.selectedText() for sel in selections]
+
+    # Assert that selection 0 is current cell
+    assert selections[0].format.background() == editor.currentcell_color
+
+    # Assert that selection 1 is current_line
+    assert selections[1].format.property(QTextFormat.FullWidthSelection)
+    assert selections[1].format.background() == editor.currentline_color
+
+    # Assert that selections 2, 3, 4 are some_variable
+    assert set(selected_texts[2:5]) == set(['some_variable'])
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/spyder/widgets/sourcecode/utils/decoration.py
+++ b/spyder/widgets/sourcecode/utils/decoration.py
@@ -30,16 +30,7 @@ class TextDecorationsManager(Manager):
         """
         if decoration not in self._decorations:
             self._decorations.append(decoration)
-
-            # order decorations acording draw_order, and selection lenght
-            # highest draw_orde will appear on top of the lowest values.
-            # if draw_order is equal,smaller selections are draw in top of
-            # bigger selections
-            self._decorations = sorted(
-                self._decorations,
-                key=lambda sel: (sel.draw_order,
-                                 -(sel.cursor.selectionEnd()
-                                   - sel.cursor.selectionStart())))
+            self._order_decorations()
             self.editor.setExtraSelections(self._decorations)
             return True
         return False
@@ -86,3 +77,19 @@ class TextDecorationsManager(Manager):
 
     def __len__(self):
         return len(self._decorations)
+
+    def _order_decorations(self):
+        """Order decorations according draw_order and size of selection.
+
+        Highest draw_order will appear on top of the lowest values.
+
+        If draw_order is equal,smaller selections are draw in top of
+        bigger selections.
+        """
+        def order_function(sel):
+            end = sel.cursor.selectionEnd()
+            start = sel.cursor.selectionStart()
+            return sel.draw_order, -(end - start)
+
+        self._decorations = sorted(self._decorations,
+                                   key=order_function)

--- a/spyder/widgets/sourcecode/utils/decoration.py
+++ b/spyder/widgets/sourcecode/utils/decoration.py
@@ -58,11 +58,11 @@ class TextDecorationsManager(Manager):
         Returns:
             int: Amount of decorations added.
         """
-        decorations_added = 0
-        for decoration in decorations:
-            if self.append(decoration):
-                decorations_added += 1
-        return decorations_added
+        not_repeated = set(decorations) - set(self._decorations)
+        self._decorations.extend(list(not_repeated))
+        self._order_decorations()
+        self.editor.setExtraSelections(self._decorations)
+        return len(not_repeated)
 
     def clear(self):
         """Removes all text decoration from the editor."""

--- a/spyder/widgets/sourcecode/utils/decoration.py
+++ b/spyder/widgets/sourcecode/utils/decoration.py
@@ -21,19 +21,31 @@ class TextDecorationsManager(Manager):
         super(TextDecorationsManager, self).__init__(editor)
         self._decorations = []
 
-    def append(self, decoration):
+    def add(self, decorations):
         """
-        Adds a text decoration on a CodeEditor instance
+        Add text decorations on a CodeEditor instance.
 
-        :param decoration: Text decoration to add
-        :type decoration: spyder.api.TextDecoration
+        Don't add duplicated decorations, and order decorations according
+        draw_order and the size of the selection.
+
+        Args:
+            decorations (sourcecode.api.TextDecoration) (could be a list)
+        Returns:
+            int: Amount of decorations added.
         """
-        if decoration not in self._decorations:
-            self._decorations.append(decoration)
+        added = 0
+        if isinstance(decorations, list):
+            not_repeated = set(decorations) - set(self._decorations)
+            self._decorations.extend(list(not_repeated))
+            added = len(not_repeated)
+        elif decorations not in self._decorations:
+            self._decorations.append(decorations)
+            added = 1
+
+        if added > 0:
             self._order_decorations()
             self.editor.setExtraSelections(self._decorations)
-            return True
-        return False
+        return added
 
     def remove(self, decoration):
         """
@@ -48,21 +60,6 @@ class TextDecorationsManager(Manager):
             return True
         except ValueError:
             return False
-
-    def extend(self, decorations):
-        """
-        Adds several text decorations on a CodeEditor instance.
-
-        Args:
-            decorations (list of spyder.api.TextDecoration)
-        Returns:
-            int: Amount of decorations added.
-        """
-        not_repeated = set(decorations) - set(self._decorations)
-        self._decorations.extend(list(not_repeated))
-        self._order_decorations()
-        self.editor.setExtraSelections(self._decorations)
-        return len(not_repeated)
 
     def clear(self):
         """Removes all text decoration from the editor."""

--- a/spyder/widgets/sourcecode/utils/decoration.py
+++ b/spyder/widgets/sourcecode/utils/decoration.py
@@ -30,8 +30,16 @@ class TextDecorationsManager(Manager):
         """
         if decoration not in self._decorations:
             self._decorations.append(decoration)
+
+            # order decorations acording draw_order, and selection lenght
+            # highest draw_orde will appear on top of the lowest values.
+            # if draw_order is equal,smaller selections are draw in top of
+            # bigger selections
             self._decorations = sorted(
-                self._decorations, key=lambda sel: sel.draw_order)
+                self._decorations,
+                key=lambda sel: (sel.draw_order,
+                                 -(sel.cursor.selectionEnd()
+                                   - sel.cursor.selectionStart())))
             self.editor.setExtraSelections(self._decorations)
             return True
         return False

--- a/spyder/widgets/sourcecode/utils/decoration.py
+++ b/spyder/widgets/sourcecode/utils/decoration.py
@@ -50,6 +50,21 @@ class TextDecorationsManager(Manager):
         except ValueError:
             return False
 
+    def extend(self, decorations):
+        """
+        Adds several text decorations on a CodeEditor instance.
+
+        Args:
+            decorations (list of spyder.api.TextDecoration)
+        Returns:
+            int: Amount of decorations added.
+        """
+        decorations_added = 0
+        for decoration in decorations:
+            if self.append(decoration):
+                decorations_added += 1
+        return decorations_added
+
     def clear(self):
         """Removes all text decoration from the editor."""
         self._decorations[:] = []


### PR DESCRIPTION
Fixes: #5176 

I'm not sure if adding `DecorationManager` to the `TextEditBaseWidget` is ok (commit f408110), or should `DecorationManager` belong to `CodeEditor` and use `try..  except` in `TextEditBaseWidget` methods
