### PR TITLE
PR: Make the fileswitcher aware of split editorstacks

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2807,14 +2807,11 @@ class MainWindow(QMainWindow):
         """Add a plugin to the File Switcher."""
         if self.fileswitcher is None:
             self.fileswitcher = FileSwitcher(self, plugin, tabs, data, icon)
-            self.fileswitcher.sig_goto_file.connect(
-                    plugin.get_current_tab_manager().set_stack_index
-                )
         else:
             self.fileswitcher.add_plugin(plugin, tabs, data, icon)
-            self.fileswitcher.sig_goto_file.connect(
-                    plugin.get_current_tab_manager().set_stack_index
-                )
+
+        self.fileswitcher.sig_goto_file.connect(
+                plugin.get_current_tab_manager().set_stack_index)
 
     # ---- Check for Spyder Updates
     def _check_updates_ready(self):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2792,6 +2792,7 @@ class MainWindow(QMainWindow):
             return
         if symbol:
             self.fileswitcher.plugin = self.editor
+            self.fileswitcher.set_search_text('@')
         else:
             self.fileswitcher.set_search_text('')
         self.fileswitcher.setup()
@@ -2801,8 +2802,6 @@ class MainWindow(QMainWindow):
     def open_symbolfinder(self):
         """Open symbol list management dialog box."""
         self.open_fileswitcher(symbol=True)
-        self.fileswitcher.set_search_text('@')
-        self.fileswitcher.setup()
 
     def add_to_fileswitcher(self, plugin, tabs, data, icon):
         """Add a plugin to the File Switcher."""

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -1214,10 +1214,17 @@ class Editor(SpyderPluginWidget):
                 if win.isAncestorOf(editorstack):
                     self.set_last_focus_editorstack(win, editorstack)
 
-    #------ Handling editorstacks
+    # ------ Handling editorstacks
     def register_editorstack(self, editorstack):
         self.editorstacks.append(editorstack)
         self.register_widget_shortcuts(editorstack)
+        if len(self.editorstacks) > 1 and self.main is not None:
+            # The first editostack is registered automatically with Spyder's
+            # main window through the `register_plugin` method. Only additional
+            # editors added by splitting need to be registered.
+            # See Issue #5057.
+            self.main.fileswitcher.sig_goto_file.connect(
+                      editorstack.set_stack_index)
 
         if self.isAncestorOf(editorstack):
             # editorstack is a child of the Editor plugin

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -2277,11 +2277,12 @@ class Editor(SpyderPluginWidget):
         self.__move_cursor_position(1)
 
     @Slot()
-    def go_to_line(self):
+    def go_to_line(self, line=None):
         """Open 'go to line' dialog"""
         editorstack = self.get_current_editorstack()
+        print(editorstack)
         if editorstack is not None:
-            editorstack.go_to_line()
+            editorstack.go_to_line(line)
 
     @Slot()
     def set_or_clear_breakpoint(self):

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -835,10 +835,15 @@ class EditorStack(QWidget):
         """Get the widget with the TabWidget attribute."""
         return self
 
-    def go_to_line(self):
+    def go_to_line(self, line=None):
         """Go to line dialog"""
-        if self.data:
-            self.get_current_editor().exec_gotolinedialog()
+        if line is not None:
+            # When this method is called from the flileswitcher, a line
+            # number is specified, so there is no need for the dialog.
+            self.get_current_editor().go_to_line(line)
+        else:
+            if self.data:
+                self.get_current_editor().exec_gotolinedialog()
 
     def set_or_clear_breakpoint(self):
         """Set/clear breakpoint"""

--- a/spyder/widgets/fileswitcher.py
+++ b/spyder/widgets/fileswitcher.py
@@ -541,7 +541,7 @@ class FileSwitcher(QDialog):
         return data
 
     def get_plugin_tabwidget(self, plugin):
-        """Get the data object of the plugin's current tab manager."""
+        """Get the tabwidget of the plugin's current tab manager."""
         # The tab widget is named "tabs" in the editor plugin while it is
         # named "tabwidget" in the notebook plugin.
         try:

--- a/spyder/widgets/fileswitcher.py
+++ b/spyder/widgets/fileswitcher.py
@@ -558,9 +558,8 @@ class FileSwitcher(QDialog):
         """Go to specified line number in current active editor."""
         if line_number:
             line_number = int(line_number)
-            editor = self.get_widget()
             try:
-                editor.go_to_line(min(line_number, editor.get_line_count()))
+                self.plugin.go_to_line(line_number)
             except AttributeError:
                 pass
 
@@ -616,6 +615,8 @@ class FileSwitcher(QDialog):
         # Get optional line number
         if trying_for_line_number:
             filter_text, line_number = filter_text.split(':')
+            if line_number == '':
+                line_number = None
             # Get all the available filenames
             scores = get_search_scores('', self.filenames,
                                        template="<b>{0}</b>")
@@ -625,7 +626,6 @@ class FileSwitcher(QDialog):
             # "fuzzy" matching
             scores = get_search_scores(filter_text, self.filenames,
                                        template="<b>{0}</b>")
-
 
         # Get max width to determine if shortpaths should be used
         max_width = self.get_item_size(paths)[0]

--- a/spyder/widgets/fileswitcher.py
+++ b/spyder/widgets/fileswitcher.py
@@ -530,6 +530,7 @@ class FileSwitcher(QDialog):
 
     # --- Helper methods: Widget
     def get_plugin_data(self, plugin):
+        """Get the data object of the plugin's current tab manager."""
         # The data object is named "data" in the editor plugin while it is
         # named "clients" in the notebook plugin.
         try:
@@ -540,6 +541,7 @@ class FileSwitcher(QDialog):
         return data
 
     def get_plugin_tabwidget(self, plugin):
+        """Get the data object of the plugin's current tab manager."""
         # The tab widget is named "tabs" in the editor plugin while it is
         # named "tabwidget" in the notebook plugin.
         try:

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -1649,6 +1649,7 @@ class CodeEditor(TextEditBaseWidget):
 
     def go_to_line(self, line, word=''):
         """Go to line number *line* and eventually highlight it"""
+        line = min(line, self.get_line_count())
         block = self.document().findBlockByNumber(line-1)
         self.setTextCursor(QTextCursor(block))
         if self.isVisible():


### PR DESCRIPTION
Fixes #5057

- [x] Connect split editor to fileswitcher for file switching
- [x] Connect split editor to fileswitcher for symbol search
- [x] Make things work when the file order is not synchronised across split editorstacks

![ctrl_p_fileswitcher](https://user-images.githubusercontent.com/10170372/30356135-5d6b5100-9805-11e7-92f9-e1297b588b98.gif)
