### PR TITLE
PR: Editor historystack improvements

### DIFF
--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -1723,12 +1723,11 @@ class EditorStack(QWidget):
                 pass
 
     def _get_previous_file_index(self):
-        if len(self.stack_history) > 1:
-            last = len(self.stack_history)-1
-            w_id = self.stack_history.pop(last)
-            self.stack_history.insert(0, w_id)
-
-            return self.stack_history[last]
+        """Return the penultimate element of the stack history."""
+        try:
+            return self.stack_history[-2]
+        except IndexError:
+            return None
 
     def tab_navigation_mru(self, forward=True):
         """

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -304,7 +304,12 @@ class StackHistory(MutableSequence):
         return len(self.history)
 
     def __getitem__(self, i):
-        return self.id_list.index(self.history[i])
+        self._update_id_list()
+        try:
+            return self.id_list.index(self.history[i])
+        except ValueError:
+            self.refresh
+            raise IndexError
 
     def __delitem__(self, i):
         del self.history[i]

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -308,7 +308,7 @@ class StackHistory(MutableSequence):
         try:
             return self.id_list.index(self.history[i])
         except ValueError:
-            self.refresh
+            self.refresh()
             raise IndexError
 
     def __delitem__(self, i):


### PR DESCRIPTION
Fixes: #5226 

I think the error was the unnecessary side effect of `_get_previous_file_index`, although I wasn't able to reproduce #5226 