### PR TITLE
PR: Support for sets in the Variable Explorer

### DIFF
--- a/doc/variableexplorer.rst
+++ b/doc/variableexplorer.rst
@@ -62,6 +62,7 @@ supported are:
 #. Floats
 #. Complex numbers
 #. Lists
+#. Sets
 #. Dictionaries
 #. Tuples
 #. Strings

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -380,7 +380,7 @@ def get_supported_types():
     If you update this list, don't forget to update doc/variablexplorer.rst
     """
     from datetime import date
-    editable_types = [int, float, complex, list, dict, tuple, date
+    editable_types = [int, float, complex, list, set, dict, tuple, date
                       ] + list(TEXT_TYPES) + list(INT_TYPES)
     try:
         from numpy import ndarray, matrix, generic

--- a/spyder/utils/ipython/spyder_kernel.py
+++ b/spyder/utils/ipython/spyder_kernel.py
@@ -131,6 +131,7 @@ class SpyderKernel(IPythonKernel):
                 properties[name] = {
                     'is_list':  isinstance(value, (tuple, list)),
                     'is_dict':  isinstance(value, dict),
+                    'is_set': isinstance(value, set),
                     'len': self._get_len(value),
                     'is_array': self._is_array(value),
                     'is_image': self._is_image(value),

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1525,6 +1525,7 @@ def get_test_data():
             'str': 'kjkj kj k j j kj k jkj',
             'unicode': to_text_string('éù', 'utf-8'),
             'list': [1, 3, [sorted, 5, 6], 'kjkj', None],
+            'set': {1, 2, 1, 3, None, 'A', 'B', 'C', True, False},
             'tuple': ([1, testdate, testdict], 'kjkj', None),
             'dict': testdict,
             'float': 1.2233,

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -130,7 +130,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
         data_type = get_type_string(data)
 
         if coll_filter is not None and not self.remote and \
-          isinstance(data, (tuple, list, dict)):
+          isinstance(data, (tuple, list, dict, set)):
             data = coll_filter(data)
         self.showndata = data
 
@@ -1170,7 +1170,10 @@ class CollectionsEditorTableView(BaseTableView):
 
         self.setup_table()
         self.menu = self.setup_menu(minmax)
-    
+
+        if isinstance(data, set):
+            self.horizontalHeader().hideSection(0)
+
     #------ Remote/local API --------------------------------------------------
     def remove_values(self, keys):
         """Remove values from data"""
@@ -1192,10 +1195,15 @@ class CollectionsEditorTableView(BaseTableView):
         self.set_data(data)
         
     def is_list(self, key):
-        """Return True if variable is a list, a set or a tuple"""
+        """Return True if variable is a list or a tuple"""
         data = self.model.get_data()
-        return isinstance(data[key], (tuple, list, set))
-        
+        return isinstance(data[key], (tuple, list))
+
+    def is_set(self, key):
+        """Return True if variable is a set"""
+        data = self.model.get_data()
+        return isinstance(data[key], set)
+
     def get_len(self, key):
         """Return sequence length"""
         data = self.model.get_data()
@@ -1309,16 +1317,13 @@ class CollectionsEditor(QDialog):
     def setup(self, data, title='', readonly=False, width=650, remote=False,
               icon=None, parent=None):
         """Setup editor."""
-        if isinstance(data, dict):
-            # dictionnary
+        if isinstance(data, (dict, set)):
+            # dictionnary, set
             self.data_copy = data.copy()
             datalen = len(data)
         elif isinstance(data, (tuple, list)):
             # list, tuple
             self.data_copy = data[:]
-            datalen = len(data)
-        elif isinstance(data, set):
-            self.data_copy = list(data)
             datalen = len(data)
         else:
             # unknown object

--- a/spyder/widgets/variableexplorer/importwizard.py
+++ b/spyder/widgets/variableexplorer/importwizard.py
@@ -85,6 +85,7 @@ COLORS = {
           bool: Qt.magenta,
           tuple([float] + list(INT_TYPES)): Qt.blue,
           list: Qt.yellow,
+          set: Qt.darkGreen,
           dict: Qt.cyan,
           tuple: Qt.lightGray,
           TEXT_TYPES: Qt.darkRed,

--- a/spyder/widgets/variableexplorer/objecteditor.py
+++ b/spyder/widgets/variableexplorer/objecteditor.py
@@ -107,7 +107,7 @@ def oedit(obj, modal=True, namespace=None):
     The object 'obj' is a container
     
     Supported container types:
-    dict, list, tuple, str/unicode or numpy.array
+    dict, list, set, tuple, str/unicode or numpy.array
     
     (instantiate a new QApplication if necessary,
     so it can be called directly from the interpreter)

--- a/spyder/widgets/variableexplorer/objecteditor.py
+++ b/spyder/widgets/variableexplorer/objecteditor.py
@@ -154,6 +154,7 @@ def test():
     image = Image.fromarray(data)
     example = {'str': 'kjkj kj k j j kj k jkj',
                'list': [1, 3, 4, 'kjkj', None],
+               'set': {1, 2, 1, 3, None, 'A', 'B', 'C', True, False},
                'dict': {'d': 1, 'a': np.random.rand(10, 10), 'b': [1, 2]},
                'float': 1.2233,
                'array': np.random.rand(10, 10),

--- a/spyder/widgets/variableexplorer/tests/test_utils.py
+++ b/spyder/widgets/variableexplorer/tests/test_utils.py
@@ -148,6 +148,28 @@ def test_dict_display():
     result = '{0:defaultdict, 1:Panel, 2:2, 3:{0:0, 1:1}, 4:Dataframe}'
     assert value_to_display(li) == result
 
+def test_set_display():
+    """Tests for display of sets."""
+    long_set = {i for i in range(100)}
+
+    # Simple set
+    assert value_to_display({1, 2, 3}) == '{1, 2, 3}'
+
+    # Long set
+    disp = '{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...}'
+    assert value_to_display(long_set) == disp
+
+    # Short list of sets
+    disp = '[{0, 1, 2, 3, 4, ...}, {0, 1, 2, 3, 4, ...}, {0, 1, 2, 3, 4, ...}]'
+    assert value_to_display([long_set] * 3) == disp
+
+    # Long list of sets
+    disp = '[' + ''.join('{0, 1, 2, 3, 4, ...}, '*10)[:-2] + ']'
+    assert value_to_display([long_set] * 10) == disp[:70] + ' ...'
+
+    # Sets of various objects
+    disp = "{NoneType, 2, True, 'a', builtin_function_or_method}"
+    assert value_to_display({'a', None, 2, True, len}) == disp
 
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/widgets/variableexplorer/tests/test_utils.py
+++ b/spyder/widgets/variableexplorer/tests/test_utils.py
@@ -148,6 +148,7 @@ def test_dict_display():
     result = '{0:defaultdict, 1:Panel, 2:2, 3:{0:0, 1:1}, 4:Dataframe}'
     assert value_to_display(li) == result
 
+
 def test_set_display():
     """Tests for display of sets."""
     long_set = {i for i in range(100)}
@@ -166,10 +167,6 @@ def test_set_display():
     # Long list of sets
     disp = '[' + ''.join('{0, 1, 2, 3, 4, ...}, '*10)[:-2] + ']'
     assert value_to_display([long_set] * 10) == disp[:70] + ' ...'
-
-    # Sets of various objects
-    disp = "{NoneType, 2, True, 'a', builtin_function_or_method}"
-    assert value_to_display({'a', None, 2, True, len}) == disp
 
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -129,7 +129,7 @@ def try_to_eval(value):
     
 def get_size(item):
     """Return size of an item of arbitrary type"""
-    if isinstance(item, (list, tuple, dict)):
+    if isinstance(item, (list, set, tuple, dict)):
         return len(item)
     elif isinstance(item, (ndarray, MaskedArray)):
         return item.shape
@@ -183,6 +183,7 @@ COLORS = {
           bool:               "#ff00ff",
           NUMERIC_TYPES:      SCALAR_COLOR,
           list:               "#ffff00",
+          set:                "#008000",
           dict:               "#00ffff",
           tuple:              "#c0c0c0",
           TEXT_TYPES:         "#800000",
@@ -262,8 +263,9 @@ def default_display(value, with_module=True):
 
 
 def collections_display(value, level):
-    """Display for collections (i.e. list, tuple and dict)."""
+    """Display for collections (i.e. list, set, tuple and dict)."""
     is_dict = isinstance(value, dict)
+    is_set = isinstance(value, set)
 
     # Get elements
     if is_dict:
@@ -274,10 +276,10 @@ def collections_display(value, level):
     # Truncate values
     truncate = False
     if level == 1 and len(value) > 10:
-        elements = islice(elements, 10) if is_dict else value[:10]
+        elements = islice(elements, 10) if is_dict or is_set else value[:10]
         truncate = True
     elif level == 2 and len(value) > 5:
-        elements = islice(elements, 5) if is_dict else value[:5]
+        elements = islice(elements, 5) if is_dict or is_set else value[:5]
         truncate = True
 
     # Get display of each element
@@ -300,6 +302,8 @@ def collections_display(value, level):
         display = '{' + display + '}'
     elif isinstance(value, list):
         display = '[' + display + ']'
+    elif isinstance(value, set):
+        display = '{' + display + '}'
     else:
         display = '(' + display + ')'
 
@@ -344,7 +348,7 @@ def value_to_display(value, minmax=False, level=0):
                     display = default_display(value)
             else:
                 display = 'Numpy array'
-        elif any([type(value) == t for t in [list, tuple, dict]]):
+        elif any([type(value) == t for t in [list, set, tuple, dict]]):
             display = collections_display(value, level+1)
         elif isinstance(value, Image):
             if level == 0:


### PR DESCRIPTION
Fixes #2355

----

`set` is now a supported type in the variable explorer. Now I chose the `Qt.darkGreen` color as it was not already used for other objects: if that is not ok there are some other colors left :smile: 
![capture3](https://user-images.githubusercontent.com/20270441/30395458-87a6fe1c-98c6-11e7-86ed-9e23b1b51e22.PNG)
![capture4](https://user-images.githubusercontent.com/20270441/30395457-87a054a4-98c6-11e7-8427-6cec0847df56.PNG)
