### PR TITLE
PR: Apply window style only if it's not None

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2545,9 +2545,10 @@ class MainWindow(QMainWindow):
             style_name = CONF.get('main', 'windows_style',
                                   self.default_style)
             style = QStyleFactory.create(style_name)
-            style.setProperty('name', style_name)
-            qapp.setStyle(style)
-        
+            if style is not None:
+                style.setProperty('name', style_name)
+                qapp.setStyle(style)
+
         default = self.DOCKOPTIONS
         if CONF.get('main', 'vertical_tabs'):
             default = default|QMainWindow.VerticalTabs


### PR DESCRIPTION
This error happens when moving from Anaconda envs to virtualenvs on KDE because Anaconda doesn't recognize `breeze` as a Qt theme, and so Spyder crashes at startup.