### PR TITLE
PR: Don't show errors when kernel_client is None

### DIFF
--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -936,7 +936,7 @@ class IPythonConsole(SpyderPluginWidget):
                     sw.reset_namespace(warning=False, silent=True)
                 elif current_client and clear_variables:
                     sw.reset_namespace(warning=False, silent=True)
-                sw.execute(to_text_string(to_text_string(lines)))
+                sw.execute(to_text_string(lines))
             self.activateWindow()
             self.get_current_client().get_control().setFocus()
 

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -887,7 +887,10 @@ class IPythonConsole(SpyderPluginWidget):
                 line += "\"%s\"" % to_text_string(filename)
                 if args:
                     line += " %s" % norm(args)
-            self.execute_code(line, current_client, clear_variables)
+            try:
+                self.execute_code(line, current_client, clear_variables)
+            except AttributeError:
+                pass
             self.visibility_changed(True)
             self.raise_()
         else:

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -290,7 +290,10 @@ the sympy module (e.g. plot)
     # --- To communicate with the kernel
     def silent_execute(self, code):
         """Execute code in the kernel without increasing the prompt"""
-        self.kernel_client.execute(to_text_string(code), silent=True)
+        try:
+            self.kernel_client.execute(to_text_string(code), silent=True)
+        except AttributeError:
+            pass
 
     def silent_exec_method(self, code):
         """Silently execute a kernel method and save its reply


### PR DESCRIPTION
Fixes #5053.

`kernel_client` can be None if the console failed to started for whatever reason.