### PR TITLE
PR: Prevent unchecked paths in the pathmanager to be added to the IPython console sys.path

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2486,22 +2486,23 @@ class MainWindow(QMainWindow):
         elif osp.isfile(osp.join(CWD, fname)):
             self.open_file(osp.join(CWD, fname), external=True)
 
-    #---- PYTHONPATH management, etc.
+    # ---- PYTHONPATH management, etc.
     def get_spyder_pythonpath(self):
         """Return Spyder PYTHONPATH"""
-        return self.path+self.project_path
+        active_path = [p for p in self.path if p not in self.not_active_path]
+        return active_path+self.project_path
 
     def add_path_to_sys_path(self):
         """Add Spyder path to sys.path"""
         for path in reversed(self.get_spyder_pythonpath()):
-            if path not in self.not_active_path:
-                sys.path.insert(1, path)
+            sys.path.insert(1, path)
 
     def remove_path_from_sys_path(self):
         """Remove Spyder path from sys.path"""
         sys_path = sys.path
-        while sys_path[1] in self.get_spyder_pythonpath():
-            sys_path.pop(1)
+        for path in self.path:
+            while path in sys_path:
+                sys_path.remove(path)
 
     @Slot()
     def path_manager_callback(self):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2490,7 +2490,7 @@ class MainWindow(QMainWindow):
     def get_spyder_pythonpath(self):
         """Return Spyder PYTHONPATH"""
         active_path = [p for p in self.path if p not in self.not_active_path]
-        return active_path+self.project_path
+        return active_path + self.project_path
 
     def add_path_to_sys_path(self):
         """Add Spyder path to sys.path"""


### PR DESCRIPTION
Fixes #5289
Related to Issue #1105 and PR #4756

----
### Changes summary

- Made the [remove_path_from_sys_path ](https://github.com/spyder-ide/spyder/blob/master/spyder/app/mainwindow.py#L2496) method more robust

- Made the [get_spyder_pythonpath ](https://github.com/spyder-ide/spyder/blob/master/spyder/app/mainwindow.py#L2486)  method return  only the active spyderpaths.

----

![make_uncheck_path_work](https://user-images.githubusercontent.com/10170372/30648802-e3b5b7b8-9dec-11e7-9199-a9071e64bf34.gif)
