### PR TITLE
PR: Wait until console is ready before executing code for dedicated consoles

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -295,6 +295,7 @@ def test_dedicated_consoles(main_window, qtbot):
     qtbot.keyClick(code_editor, Qt.Key_F5)
     qtbot.wait(500)
     shell = main_window.ipyconsole.get_current_shellwidget()
+    control = shell._control
     qtbot.waitUntil(lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
     nsb = main_window.variableexplorer.get_focus_widget()
 
@@ -304,12 +305,20 @@ def test_dedicated_consoles(main_window, qtbot):
     qtbot.wait(500)
     assert nsb.editor.model.rowCount() == 3
 
+    # --- Assert only runfile text is present and there's no banner text ---
+    # See PR #5301
+    text = control.toPlainText()
+    assert ('runfile' in text) and not ('Python' in text or 'IPython' in text)
+
     # --- Clean namespace after re-execution ---
     with qtbot.waitSignal(shell.executed):
         shell.execute('zz = -1')
     qtbot.keyClick(code_editor, Qt.Key_F5)
     qtbot.wait(500)
     assert not shell.is_defined('zz')
+
+    # --- Assert runfile text is present after reruns ---
+    assert 'runfile' in control.toPlainText()
 
     # ---- Closing test file and resetting config ----
     main_window.editor.close_file()

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -898,8 +898,8 @@ class IPythonConsole(SpyderPluginWidget):
                     else:
                         client.shellwidget.execute('%clear')
                     client.shellwidget.sig_prompt_ready.connect(
-                            lambda : self.execute_code(line, current_client,
-                                                       clear_variables))
+                            lambda: self.execute_code(line, current_client,
+                                                      clear_variables))
             except AttributeError:
                 pass
             self.visibility_changed(True)

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -52,7 +52,7 @@ from spyder.utils.ipython.kernelspec import SpyderKernelSpec
 from spyder.utils.ipython.style import create_qss_style
 from spyder.utils.qthelpers import create_action, MENU_SEPARATOR
 from spyder.utils import icon_manager as ima
-from spyder.utils import encoding, programs, sourcecode
+from spyder.utils import programs, sourcecode
 from spyder.utils.programs import TEMPDIR
 from spyder.utils.misc import get_error_match, remove_backslashes
 from spyder.widgets.findreplace import FindReplace

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -1438,7 +1438,7 @@ class IPythonConsole(SpyderPluginWidget):
 
         # Increase time to detect if a kernel is alive
         # See Issue 3444
-        kernel_client.hb_channel.time_to_dead = 6.0
+        kernel_client.hb_channel.time_to_dead = 18.0
 
         return kernel_manager, kernel_client
 

--- a/spyder/utils/ipython/start_kernel.py
+++ b/spyder/utils/ipython/start_kernel.py
@@ -64,6 +64,8 @@ def kernel_config():
     # Until we implement Issue 1052
     spy_cfg.InteractiveShell.xmode = 'Plain'
 
+    # Using Jedi slow completions a lot for objects
+    # with big repr's
     spy_cfg.IPCompleter.use_jedi = False
 
     # Run lines of code at startup

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -514,7 +514,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         self.infowidget.hide()
         self.shellwidget.show()
         self.infowidget.setHtml(BLANK)
-        self.shellwidget.sig_prompt_ready.connect(self._hide_loading_page)
+        self.shellwidget.sig_prompt_ready.disconnect(self._hide_loading_page)
 
     def _read_stderr(self):
         """Read the stderr file of the kernel."""

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -142,12 +142,6 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         # --- Exit function
         self.exit_callback = lambda: plugin.close_client(client=self)
 
-        # --- Signals
-        # As soon as some content is printed in the console, stop
-        # our loading animation
-        document = self.get_control().document()
-        document.contentsChange.connect(self._hide_loading_page)
-
         # --- Dialog manager
         self.dialog_manager = DialogManager()
 
@@ -215,10 +209,14 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         # To sync with working directory toolbar
         self.shellwidget.executed.connect(self.shellwidget.get_cwd)
 
+        # To apply style
         if not create_qss_style(self.shellwidget.syntax_style)[1]:
             self.shellwidget.silent_execute("%colors linux")
         else:
             self.shellwidget.silent_execute("%colors lightbg")
+
+        # To hide the loading page
+        self.shellwidget.sig_prompt_ready.connect(self._hide_loading_page)
 
     def enable_stop_button(self):
         self.stop_button.setEnabled(True)
@@ -516,9 +514,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         self.infowidget.hide()
         self.shellwidget.show()
         self.infowidget.setHtml(BLANK)
-
-        document = self.get_control().document()
-        document.contentsChange.disconnect(self._hide_loading_page)
+        self.shellwidget.sig_prompt_ready.connect(self._hide_loading_page)
 
     def _read_stderr(self):
         """Read the stderr file of the kernel."""

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -52,6 +52,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget):
     sig_got_reply = Signal()
     sig_is_spykernel = Signal(object)
     sig_kernel_restarted = Signal(str)
+    sig_prompt_ready = Signal()
 
     # For global working directory
     sig_change_cwd = Signal(str)
@@ -467,6 +468,12 @@ the sympy module (e.g. plot)
             self._highlighter._clear_caches()
         else:
             self._highlighter.set_style_sheet(self.style_sheet)
+
+    def _prompt_started_hook(self):
+        """Emit a signal when the prompt is ready."""
+        if not self._reading:
+            self._highlighter.highlighting_on = True
+            self.sig_prompt_ready.emit()
 
     #---- Qt methods ----------------------------------------------------------
     def focusInEvent(self, event):


### PR DESCRIPTION
Fixes #5296 
Fixes #4856 

This also:
* Waits until the prompt is ready before hiding the loading animation.
* Increases time_to_dead check to avoid spurious prompts.

TODO:

- [x] Tests