### PR TITLE
PR: Sync correctly the closing of files in multiple editorstacks.

### DIFF
--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -1344,7 +1344,7 @@ class EditorStack(QWidget):
             return len(self.data) > 0
         else:
             return self.has_filename(filename)
-        
+
     def get_index_from_filename(self, filename):
         filenames = [d.filename for d in self.data]
         return filenames.index(filename)

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -439,7 +439,7 @@ class EditorStack(QWidget):
     zoom_in = Signal()
     zoom_out = Signal()
     zoom_reset = Signal()
-    sig_close_file = Signal(str, int)
+    sig_close_file = Signal(str, str)
     file_saved = Signal(str, int, str)
     file_renamed_in_data = Signal(str, int, str)
     create_new_window = Signal()
@@ -748,6 +748,7 @@ class EditorStack(QWidget):
                              corner_widgets=corner_widgets)
         self.tabs.tabBar().setObjectName('plugin-tab')
         self.tabs.set_close_function(self.close_file)
+        self.tabs.tabBar().tabMoved.connect(self.move_editorstack_data)
         self.tabs.setMovable(True)
 
         self.stack_history.refresh()
@@ -1317,8 +1318,7 @@ class EditorStack(QWidget):
         self.horsplit_action.setEnabled(state)
         self.versplit_action.setEnabled(state)
 
-
-    #------ Accessors
+    # ------ Accessors
     def get_current_filename(self):
         if self.data:
             return self.data[self.get_stack_index()].filename
@@ -1344,6 +1344,30 @@ class EditorStack(QWidget):
             return len(self.data) > 0
         else:
             return self.has_filename(filename)
+        
+    def get_index_from_filename(self, filename):
+        filenames = [self.data[i].filename for i in self.data]
+        return filenames.index(filename)
+
+    @Slot(int, int)
+    def move_editorstack_data(self, start, end):
+        """Reorder editorstack.data so it is synchronized with the tab bar when
+        tabs are moved."""
+        print(self)
+        if start < 0 or end < 0:
+            return
+        else:
+            steps = abs(end - start)
+            direction = (end-start) // steps  # +1 for right, -1 for left
+
+        data = self.data
+        self.blockSignals(True)
+
+        for i in range(start, end, direction):
+            data[i], data[i+direction] = data[i+direction], data[i]
+
+        self.blockSignals(False)
+        self.refresh()
 
 
     #------ Close file, tabwidget...
@@ -1382,7 +1406,7 @@ class EditorStack(QWidget):
             # depend on the platform: long for 64bit, int for 32bit. Replacing
             # by long all the time is not working on some 32bit platforms
             # (see Issue 1094, Issue 1098)
-            self.sig_close_file.emit(str(id(self)), index)
+            self.sig_close_file.emit(str(id(self)), self.data[index].filename)
 
             if not self.data and self.is_closable:
                 # editortabwidget is empty: removing it
@@ -2741,11 +2765,12 @@ class EditorPluginExample(QSplitter):
     def get_focus_widget(self):
         pass
 
-    @Slot(str, int)
-    def close_file_in_all_editorstacks(self, editorstack_id_str, index):
+    @Slot(str, str)
+    def close_file_in_all_editorstacks(self, editorstack_id_str, filename):
         for editorstack in self.editorstacks:
             if str(id(editorstack)) != editorstack_id_str:
                 editorstack.blockSignals(True)
+                index = editorstack.get_index_from_filename(filename)
                 editorstack.close_file(index, force=True)
                 editorstack.blockSignals(False)
 

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -1346,6 +1346,10 @@ class EditorStack(QWidget):
             return self.has_filename(filename)
 
     def get_index_from_filename(self, filename):
+        """
+        Return the position index of a file in the tab bar of the editorstack
+        from its name.
+        """
         filenames = [d.filename for d in self.data]
         return filenames.index(filename)
 

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -1346,7 +1346,7 @@ class EditorStack(QWidget):
             return self.has_filename(filename)
         
     def get_index_from_filename(self, filename):
-        filenames = [self.data[i].filename for i in self.data]
+        filenames = [d.filename for d in self.data]
         return filenames.index(filename)
 
     @Slot(int, int)
@@ -1400,13 +1400,14 @@ class EditorStack(QWidget):
             if self.outlineexplorer is not None:
                 self.outlineexplorer.remove_editor(finfo.editor)
 
+            filename = self.data[index].filename
             self.remove_from_data(index)
 
             # We pass self object ID as a QString, because otherwise it would
             # depend on the platform: long for 64bit, int for 32bit. Replacing
             # by long all the time is not working on some 32bit platforms
             # (see Issue 1094, Issue 1098)
-            self.sig_close_file.emit(str(id(self)), self.data[index].filename)
+            self.sig_close_file.emit(str(id(self)), filename)
 
             if not self.data and self.is_closable:
                 # editortabwidget is empty: removing it

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -1353,7 +1353,6 @@ class EditorStack(QWidget):
     def move_editorstack_data(self, start, end):
         """Reorder editorstack.data so it is synchronized with the tab bar when
         tabs are moved."""
-        print(self)
         if start < 0 or end < 0:
             return
         else:


### PR DESCRIPTION
Fixes #5271

----
### Cause of the issue:
- When closing a file in a given Editorstack, a signal is emitted with the index of the file relative to its position in the tab bar of this Editorstack.
- Files are then closed in every other Editorstack using this index.
- Problem arises when files are ordered differently across Editorstack tab bars.

### Summary of what was done to fix the issue:
- Editorstacks data order are sync with the tab order of their respective tab bar in the `move_editorstack_data` method.
- Instead of emitting an index from the Editorstack from which the file is closed, we emit the name of the file instead.
- The good index corresponding to this filename is then retrieved in each Editorstack using its data.
- The file is then closed using this index instead.

### Proposed additional refactoring:
After the changes made in PR #4850, I propose that we move the `move_editorstack_data` method to the EditorStack widget. Currently, we send the signal all the way around from the sender editorstack widget, to the plugin, to finally, only acting on the sender editorstack widget with the `if editorstack.isAncestorOf(self.sender()):` condition. I think that would make the code simpler and easier to understand that way.

![fix_close_file_multiple](https://user-images.githubusercontent.com/10170372/30735979-fd915b5c-9f4e-11e7-9d24-17a80dced962.gif)
