### PR TITLE
PR: Only apply gtk style if pygtk isn't installed

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2538,9 +2538,13 @@ class MainWindow(QMainWindow):
         # Fixes Issue 2036
         if is_gtk_desktop() and ('GTK+' in QStyleFactory.keys()):
             try:
-                qapp.setStyle('gtk+')
-            except:
-                pass
+                import gtk
+            except ImportError:
+                # only apply gtk style if pygtk isn't installed
+                try:
+                    qapp.setStyle('gtk+')
+                except:
+                    pass
         else:
             style_name = CONF.get('main', 'windows_style',
                                   self.default_style)


### PR DESCRIPTION
Tries to fix #5212