### PR TITLE
PR: Add a safe getcwd function to handle errors when the current working was deleted

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -150,13 +150,13 @@ from spyder.config.main import OPEN_FILES_PORT
 from spyder.config.utils import IMPORT_EXT, is_gtk_desktop
 from spyder.app.cli_options import get_options
 from spyder import dependencies
-from spyder.py3compat import (getcwd, is_text_string, to_text_string,
+from spyder.py3compat import (is_text_string, to_text_string,
                               PY3, qbytearray_to_str, configparser as cp)
 from spyder.utils import encoding, programs
 from spyder.utils import icon_manager as ima
 from spyder.utils.introspection import module_completion
 from spyder.utils.programs import is_module_installed
-from spyder.utils.misc import select_port
+from spyder.utils.misc import select_port, getcwd_or_home
 from spyder.widgets.fileswitcher import FileSwitcher
 
 #==============================================================================
@@ -184,7 +184,7 @@ from spyder.app import tour
 # Get the cwd before initializing WorkingDirectory, which sets it to the one
 # used in the last session
 #==============================================================================
-CWD = getcwd()
+CWD = getcwd_or_home()
 
 
 #==============================================================================

--- a/spyder/interpreter.py
+++ b/spyder/interpreter.py
@@ -21,8 +21,8 @@ from code import InteractiveConsole
 # Local imports:
 from spyder.utils.dochelpers import isdefined
 from spyder.utils import encoding, programs
-from spyder.py3compat import is_text_string, getcwd
-from spyder.utils.misc import remove_backslashes
+from spyder.py3compat import is_text_string
+from spyder.utils.misc import remove_backslashes, getcwd_or_home
 
 # Force Python to search modules in the current directory first:
 sys.path.insert(0, '')
@@ -34,7 +34,7 @@ def guess_filename(filename):
         return filename
     if not filename.endswith('.py'):
         filename += '.py'
-    for path in [getcwd()] + sys.path:
+    for path in [getcwd_or_home()] + sys.path:
         fname = osp.join(path, filename)
         if osp.isfile(fname):
             return fname

--- a/spyder/plugins/configdialog.py
+++ b/spyder/plugins/configdialog.py
@@ -33,9 +33,10 @@ from spyder.config.gui import get_font, set_font
 from spyder.config.main import CONF
 from spyder.config.user import NoDefault
 from spyder.config.utils import is_gtk_desktop
-from spyder.py3compat import to_text_string, is_text_string, getcwd
+from spyder.py3compat import to_text_string, is_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils import syntaxhighlighters
+from spyder.utils.misc import getcwd_or_home
 from spyder.widgets.colors import ColorLayout
 from spyder.widgets.sourcecode.codeeditor import CodeEditor
 
@@ -521,7 +522,7 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
         """Select directory"""
         basedir = to_text_string(edit.text())
         if not osp.isdir(basedir):
-            basedir = getcwd()
+            basedir = getcwd_or_home()
         title = _("Select directory")
         directory = getexistingdirectory(self, title, basedir)
         if directory:
@@ -551,7 +552,7 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
         """Select File"""
         basedir = osp.dirname(to_text_string(edit.text()))
         if not osp.isdir(basedir):
-            basedir = getcwd()
+            basedir = getcwd_or_home()
         if filters is None:
             filters = _("All files (*)")
         title = _("Select file")

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -28,14 +28,15 @@ from spyder.config.base import _, debug_print
 from spyder.config.main import CONF
 from spyder.utils import icon_manager as ima
 from spyder.utils.environ import EnvDialog
-from spyder.utils.misc import get_error_match, remove_backslashes
+from spyder.utils.misc import (get_error_match, remove_backslashes,
+                               getcwd_or_home)
 from spyder.utils.qthelpers import (add_actions, create_action,
                                     DialogManager, mimedata2url)
 from spyder.widgets.internalshell import InternalShell
 from spyder.widgets.findreplace import FindReplace
 from spyder.widgets.variableexplorer.collectionseditor import CollectionsEditor
 from spyder.plugins import SpyderPluginWidget
-from spyder.py3compat import getcwd, to_text_string
+from spyder.py3compat import to_text_string
 
 
 class Console(SpyderPluginWidget):
@@ -278,8 +279,9 @@ class Console(SpyderPluginWidget):
         """Run a Python script"""
         if filename is None:
             self.shell.interpreter.restore_stds()
-            filename, _selfilter = getopenfilename(self, _("Run Python script"),
-                   getcwd(), _("Python scripts")+" (*.py ; *.pyw ; *.ipy)")
+            filename, _selfilter = getopenfilename(
+                    self, _("Run Python script"), getcwd_or_home(),
+                    _("Python scripts")+" (*.py ; *.pyw ; *.ipy)")
             self.shell.interpreter.redirect_stds()
             if filename:
                 os.chdir( osp.dirname(filename) )

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -35,11 +35,12 @@ from spyder.config.main import (CONF, RUN_CELL_SHORTCUT,
                                 RUN_CELL_AND_ADVANCE_SHORTCUT)
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
                                  get_filter)
-from spyder.py3compat import getcwd, PY2, qbytearray_to_str, to_text_string
+from spyder.py3compat import PY2, qbytearray_to_str, to_text_string
 from spyder.utils import codeanalysis, encoding, programs, sourcecode
 from spyder.utils import icon_manager as ima
 from spyder.utils.introspection.manager import IntrospectionManager
 from spyder.utils.qthelpers import create_action, add_actions, MENU_SEPARATOR
+from spyder.utils.misc import getcwd_or_home
 from spyder.widgets.findreplace import FindReplace
 from spyder.widgets.editor import (EditorMainWindow, EditorSplitter,
                                    EditorStack, Printer)
@@ -1745,7 +1746,7 @@ class Editor(SpyderPluginWidget):
                 self.untitled_num += 1
                 if not osp.isfile(fname):
                     break
-            basedir = getcwd()
+            basedir = getcwd_or_home()
 
             if self.main.projects.get_active_project() is not None:
                 basedir = self.main.projects.get_active_project_path()
@@ -1835,7 +1836,7 @@ class Editor(SpyderPluginWidget):
             if isinstance(action, QAction):
                 filenames = from_qvariant(action.data(), to_text_string)
         if not filenames:
-            basedir = getcwd()
+            basedir = getcwd_or_home()
             if self.edit_filetypes is None:
                 self.edit_filetypes = get_edit_filetypes()
             if self.edit_filters is None:

--- a/spyder/plugins/findinfiles.py
+++ b/spyder/plugins/findinfiles.py
@@ -21,7 +21,7 @@ from qtpy.QtCore import Signal, Slot
 # Local imports
 from spyder.config.base import _
 from spyder.config.utils import get_edit_extensions
-from spyder.py3compat import getcwd
+from spyder.utils.misc import getcwd_or_home
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import create_action, MENU_SEPARATOR
 from spyder.widgets.findinfiles import FindInFilesWidget
@@ -74,7 +74,7 @@ class FindInFiles(FindInFilesWidget, SpyderPluginMixin):
     
     def refreshdir(self):
         """Refresh search directory"""
-        self.find_options.set_directory(getcwd())
+        self.find_options.set_directory(getcwd_or_home())
 
     def set_project_path(self, path):
         """Refresh current project path"""

--- a/spyder/plugins/projects.py
+++ b/spyder/plugins/projects.py
@@ -22,9 +22,10 @@ from qtpy.QtWidgets import QMenu, QMessageBox
 # Local imports
 from spyder.config.base import _, get_home_dir
 from spyder.plugins import SpyderPluginMixin
-from spyder.py3compat import is_text_string, getcwd
+from spyder.py3compat import is_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import add_actions, create_action, MENU_SEPARATOR
+from spyder.utils.misc import getcwd_or_home
 from spyder.widgets.projects.explorer import ProjectExplorerWidget
 from spyder.widgets.projects.projectdialog import ProjectDialog
 from spyder.widgets.projects import EmptyProject
@@ -254,7 +255,7 @@ class Projects(ProjectExplorerWidget, SpyderPluginMixin):
         if self.current_active_project is None:
             if save_previous_files:
                 self.editor.save_open_files()
-            self.editor.set_option('last_working_dir', getcwd())
+            self.editor.set_option('last_working_dir', getcwd_or_home())
             self.show_explorer()
         else: # we are switching projects
             self.set_project_filenames(self.editor.get_open_filenames())
@@ -344,7 +345,8 @@ class Projects(ProjectExplorerWidget, SpyderPluginMixin):
 
     def get_last_working_dir(self):
         """Get the path of the last working directory"""
-        return self.editor.get_option('last_working_dir', default=getcwd())
+        return self.editor.get_option('last_working_dir',
+                                      default=getcwd_or_home())
 
     def save_config(self):
         """Save configuration: opened projects & tree widget state"""

--- a/spyder/plugins/runconfig.py
+++ b/spyder/plugins/runconfig.py
@@ -22,9 +22,9 @@ from qtpy.QtWidgets import (QButtonGroup, QCheckBox, QComboBox, QDialog,
 from spyder.config.base import _
 from spyder.config.main import CONF
 from spyder.plugins.configdialog import GeneralConfigPage
-from spyder.py3compat import getcwd, to_text_string
+from spyder.py3compat import to_text_string
 from spyder.utils import icon_manager as ima
-
+from spyder.utils.misc import getcwd_or_home
 
 CURRENT_INTERPRETER = _("Execute in current console")
 DEDICATED_INTERPRETER = _("Execute in a dedicated console")
@@ -264,7 +264,7 @@ class RunConfigOptions(QWidget):
         """Select directory"""
         basedir = to_text_string(self.wd_edit.text())
         if not osp.isdir(basedir):
-            basedir = getcwd()
+            basedir = getcwd_or_home()
         directory = getexistingdirectory(self, _("Select directory"), basedir)
         if directory:
             self.wd_edit.setText(directory)
@@ -528,7 +528,8 @@ class RunConfigPage(GeneralConfigPage):
                 FIXED_DIR,
                 WDIR_USE_FIXED_DIR_OPTION, False,
                 button_group=wdir_bg)
-        thisdir_bd = self.create_browsedir("", WDIR_FIXED_DIR_OPTION, getcwd())
+        thisdir_bd = self.create_browsedir("", WDIR_FIXED_DIR_OPTION,
+                                           getcwd_or_home())
         thisdir_radio.toggled.connect(thisdir_bd.setEnabled)
         dirname_radio.toggled.connect(thisdir_bd.setDisabled)
         cwd_radio.toggled.connect(thisdir_bd.setDisabled)

--- a/spyder/plugins/workingdirectory.py
+++ b/spyder/plugins/workingdirectory.py
@@ -26,7 +26,8 @@ from qtpy.QtWidgets import (QButtonGroup, QGroupBox, QHBoxLayout, QLabel,
 from spyder.config.base import _, get_conf_path, get_home_dir
 from spyder.plugins import SpyderPluginMixin
 from spyder.plugins.configdialog import PluginConfigPage
-from spyder.py3compat import to_text_string, getcwd
+from spyder.py3compat import to_text_string
+from spyder.utils.misc import getcwd_or_home
 from spyder.utils import encoding
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import create_action
@@ -64,7 +65,7 @@ class WorkingDirectoryConfigPage(PluginConfigPage):
                                   "is open will be the specified path"),
                                 button_group=console_bg)
         console_dir_bd = self.create_browsedir("", 'console/fixed_directory',
-                                               getcwd())
+                                               getcwd_or_home())
         console_dir_radio.toggled.connect(console_dir_bd.setEnabled)
         console_project_radio.toggled.connect(console_dir_bd.setDisabled)
         console_cwd_radio.toggled.connect(console_dir_bd.setDisabled)
@@ -198,7 +199,7 @@ class WorkingDirectory(QToolBar, SpyderPluginMixin):
         
     def refresh_plugin(self):
         """Refresh widget"""
-        curdir = getcwd()
+        curdir = getcwd_or_home()
         self.pathedit.add_text(curdir)
         self.save_wdhistory()
         self.set_previous_enabled.emit(
@@ -237,7 +238,7 @@ class WorkingDirectory(QToolBar, SpyderPluginMixin):
         """Select directory"""
         self.redirect_stdio.emit(False)
         directory = getexistingdirectory(self.main, _("Select directory"),
-                                         getcwd())
+                                         getcwd_or_home())
         if directory:
             self.chdir(directory)
         self.redirect_stdio.emit(True)
@@ -257,7 +258,7 @@ class WorkingDirectory(QToolBar, SpyderPluginMixin):
     @Slot()
     def parent_directory(self):
         """Change working directory to parent directory"""
-        self.chdir(os.path.join(getcwd(), os.path.pardir))
+        self.chdir(os.path.join(getcwd_or_home(), os.path.pardir))
 
     @Slot(str)
     @Slot(str, bool)

--- a/spyder/utils/iofuncs.py
+++ b/spyder/utils/iofuncs.py
@@ -35,7 +35,8 @@ except:
 
 # Local imports
 from spyder.config.base import _, get_conf_path
-from spyder.py3compat import pickle, to_text_string, getcwd, PY2
+from spyder.py3compat import pickle, to_text_string, PY2
+from spyder.utils.misc import getcwd_or_home
 
 
 class MatlabStruct(dict):
@@ -281,7 +282,7 @@ def load_json(filename):
 def save_dictionary(data, filename):
     """Save dictionary in a single file .spydata file"""
     filename = osp.abspath(filename)
-    old_cwd = getcwd()
+    old_cwd = getcwd_or_home()
     os.chdir(osp.dirname(filename))
     error_message = None
     try:
@@ -332,7 +333,7 @@ def save_dictionary(data, filename):
 def load_dictionary(filename):
     """Load dictionary from .spydata file"""
     filename = osp.abspath(filename)
-    old_cwd = getcwd()
+    old_cwd = getcwd_or_home()
     tmp_folder = tempfile.mkdtemp()
     os.chdir(tmp_folder)
     data = None

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -13,7 +13,7 @@ import sys
 import stat
 
 from spyder.py3compat import is_text_string, getcwd
-from spyder.config.base import get_home_dir
+from spyder.config.base import get_home_dir, debug_print
 
 
 def __remove_pyc_pyo(fname):
@@ -295,4 +295,6 @@ def getcwd_or_home():
     try:
         return getcwd()
     except OSError:
+        debug_print("WARNING: Current working directory was deleted, "
+                    "falling back to home dirertory")
         return get_home_dir()

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -12,7 +12,8 @@ import os.path as osp
 import sys
 import stat
 
-from spyder.py3compat import is_text_string
+from spyder.py3compat import is_text_string, getcwd
+from spyder.config.base import get_home_dir
 
 
 def __remove_pyc_pyo(fname):
@@ -283,3 +284,15 @@ def memoize(obj):
             cache.popitem(last=False)
         return cache[key]
     return memoizer
+
+
+def getcwd_or_home():
+    """Safe version of getcwd that will fallback to home user dir.
+
+    This will catch the error raised when the current working directory
+    was removed for an external program.
+    """
+    try:
+        return getcwd()
+    except OSError:
+        return get_home_dir()

--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -34,12 +34,13 @@ from qtpy.QtWidgets import (QFileSystemModel, QHBoxLayout, QFileIconProvider,
                             QWidget)
 # Local imports
 from spyder.config.base import _
-from spyder.py3compat import (getcwd, str_lower, to_binary_string,
+from spyder.py3compat import (str_lower, to_binary_string,
                               to_text_string)
 from spyder.utils import icon_manager as ima
 from spyder.utils import encoding, misc, programs, vcs
 from spyder.utils.qthelpers import (add_actions, create_action, file_uri,
                                     create_plugin_layout)
+from spyder.utils.misc import getcwd_or_home
 
 try:
     from nbconvert import PythonExporter as nbexporter
@@ -1067,7 +1068,7 @@ class ExplorerTreeWidget(DirView):
         """Refresh widget
         force=False: won't refresh widget if path has not changed"""
         if new_path is None:
-            new_path = getcwd()
+            new_path = getcwd_or_home()
         if force_current:
             index = self.set_current_folder(new_path)
             self.expand(index)
@@ -1088,7 +1089,7 @@ class ExplorerTreeWidget(DirView):
     @Slot()
     def go_to_parent_directory(self):
         """Go to parent directory"""
-        self.chdir( osp.abspath(osp.join(getcwd(), os.pardir)) )
+        self.chdir(osp.abspath(osp.join(getcwd_or_home(), os.pardir)))
 
     @Slot()
     def go_to_previous_directory(self):
@@ -1187,7 +1188,7 @@ class ExplorerWidget(QWidget):
 
         # Setup widgets
         self.treewidget.setup(name_filters=name_filters, show_all=show_all)
-        self.treewidget.chdir(getcwd())
+        self.treewidget.chdir(getcwd_or_home())
         self.treewidget.common_actions += [None, icontext_action]
 
         button_previous.setDefaultAction(previous_action)

--- a/spyder/widgets/findinfiles.py
+++ b/spyder/widgets/findinfiles.py
@@ -32,9 +32,10 @@ from qtpy.QtWidgets import (QHBoxLayout, QLabel, QListWidget, QSizePolicy,
 
 # Local imports
 from spyder.config.base import _
-from spyder.py3compat import getcwd, to_text_string
+from spyder.py3compat import to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.encoding import is_text_file
+from spyder.utils.misc import getcwd_or_home
 from spyder.widgets.comboboxes import PatternComboBox
 from spyder.widgets.onecolumntree import OneColumnTree
 from spyder.utils.qthelpers import create_toolbutton, get_icon
@@ -232,7 +233,7 @@ class FindOptions(QWidget):
         QWidget.__init__(self, parent)
 
         if search_path is None:
-            search_path = getcwd()
+            search_path = getcwd_or_home()
 
         self.path = ''
         self.project_path = None

--- a/spyder/widgets/internalshell.py
+++ b/spyder/widgets/internalshell.py
@@ -25,12 +25,12 @@ from qtpy.QtWidgets import QMessageBox
 # Local imports
 from spyder import get_versions
 from spyder.interpreter import Interpreter
-from spyder.py3compat import (builtins, getcwd, to_binary_string,
+from spyder.py3compat import (builtins, to_binary_string,
                               to_text_string)
 from spyder.utils import icon_manager as ima
 from spyder.utils import programs
 from spyder.utils.dochelpers import getargtxt, getdoc, getobjdir, getsource
-from spyder.utils.misc import get_error_match
+from spyder.utils.misc import get_error_match, getcwd_or_home
 from spyder.utils.qthelpers import create_action
 from spyder.widgets.shell import PythonShellWidget
 from spyder.widgets.variableexplorer.objecteditor import oedit
@@ -430,7 +430,7 @@ class InternalShell(PythonShellWidget):
         
     def get_cdlistdir(self):
         """Return shell current directory list dir"""
-        return os.listdir(getcwd())
+        return os.listdir(getcwd_or_home())
                 
     def iscallable(self, objtxt):
         """Is object callable?"""

--- a/spyder/widgets/pathmanager.py
+++ b/spyder/widgets/pathmanager.py
@@ -21,7 +21,7 @@ from qtpy.QtWidgets import (QDialog, QDialogButtonBox, QHBoxLayout,
 
 # Local imports
 from spyder.config.base import _
-from spyder.py3compat import getcwd
+from spyder.utils.misc import getcwd_or_home
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import create_toolbutton
 
@@ -48,7 +48,7 @@ class PathManager(QDialog):
             ro_pathlist = []
         self.ro_pathlist = ro_pathlist
         
-        self.last_path = getcwd()
+        self.last_path = getcwd_or_home()
         
         self.setWindowTitle(_("PYTHONPATH manager"))
         self.setWindowIcon(ima.icon('pythonpath'))

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -38,9 +38,9 @@ from spyder.config.base import _
 from spyder.config.fonts import DEFAULT_SMALL_DELTA
 from spyder.config.gui import get_font
 from spyder.py3compat import (io, is_binary_string, is_text_string,
-                              getcwd, PY3, to_text_string)
+                              PY3, to_text_string)
 from spyder.utils import icon_manager as ima
-from spyder.utils.misc import fix_reference_name
+from spyder.utils.misc import fix_reference_name, getcwd_or_home
 from spyder.utils.qthelpers import (add_actions, create_action,
                                     mimedata2url)
 from spyder.widgets.variableexplorer.importwizard import ImportWizard
@@ -1047,7 +1047,7 @@ class BaseTableView(QTableView):
         """Save array"""
         title = _( "Save array")
         if self.array_filename is None:
-            self.array_filename = getcwd()
+            self.array_filename = getcwd_or_home()
         self.redirect_stdio.emit(False)
         filename, _selfilter = getsavefilename(self, title,
                                                self.array_filename,

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -30,11 +30,11 @@ except ImportError:
 # Local imports
 from spyder.config.base import _, get_supported_types
 from spyder.config.main import CONF
-from spyder.py3compat import is_text_string, getcwd, to_text_string
+from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils import encoding
 from spyder.utils import icon_manager as ima
 from spyder.utils.iofuncs import iofunctions
-from spyder.utils.misc import fix_reference_name
+from spyder.utils.misc import fix_reference_name, getcwd_or_home
 from spyder.utils.programs import is_module_installed
 from spyder.utils.qthelpers import (add_actions, create_action,
                                     create_toolbutton, create_plugin_layout)
@@ -390,7 +390,7 @@ class NamespaceBrowser(QWidget):
         title = _("Import data")
         if filenames is None:
             if self.filename is None:
-                basedir = getcwd()
+                basedir = getcwd_or_home()
             else:
                 basedir = osp.dirname(self.filename)
             filenames, _selfilter = getopenfilenames(self, title, basedir,
@@ -465,7 +465,7 @@ class NamespaceBrowser(QWidget):
         if filename is None:
             filename = self.filename
             if filename is None:
-                filename = getcwd()
+                filename = getcwd_or_home()
             filename, _selfilter = getsavefilename(self, _("Save data"),
                                                    filename,
                                                    iofunctions.save_filters)

--- a/spyder_profiler/widgets/profilergui.py
+++ b/spyder_profiler/widgets/profilergui.py
@@ -31,13 +31,13 @@ from qtpy.QtWidgets import (QApplication, QHBoxLayout, QLabel, QMessageBox,
 
 # Local imports
 from spyder.config.base import get_conf_path, get_translation
-from spyder.py3compat import getcwd, to_text_string
+from spyder.py3compat import to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import (create_toolbutton, get_item_user_text,
                                     set_item_user_text)
 from spyder.utils.programs import shell_split
 from spyder.widgets.comboboxes import PythonModulesComboBox
-from spyder.utils.misc import add_pathlist_to_PYTHONPATH
+from spyder.utils.misc import add_pathlist_to_PYTHONPATH, getcwd_or_home
 from spyder.widgets.variableexplorer.texteditor import TextEditor
 
 # This is needed for testing this module as a stand alone script
@@ -178,15 +178,16 @@ class ProfilerWidget(QWidget):
     def save_data(self):
         """Save data"""
         title = _( "Save profiler result")
-        filename, _selfilter = getsavefilename(self, title,
-                                               getcwd(),
-                                               _("Profiler result")+" (*.Result)")
+        filename, _selfilter = getsavefilename(
+                self, title, getcwd_or_home(),
+                _("Profiler result")+" (*.Result)")
         if filename:
             self.datatree.save_data(filename)
             
     def compare(self):
-        filename, _selfilter = getopenfilename(self, _("Select script to compare"),
-                                               getcwd(), _("Profiler result")+" (*.Result)")
+        filename, _selfilter = getopenfilename(
+                self, _("Select script to compare"),
+                getcwd_or_home(), _("Profiler result")+" (*.Result)")
         if filename:
             self.datatree.compare(filename)
             self.show_data()
@@ -217,8 +218,9 @@ class ProfilerWidget(QWidget):
             
     def select_file(self):
         self.redirect_stdio.emit(False)
-        filename, _selfilter = getopenfilename(self, _("Select Python script"),
-                           getcwd(), _("Python scripts")+" (*.py ; *.pyw)")
+        filename, _selfilter = getopenfilename(
+                self, _("Select Python script"),
+                getcwd_or_home(), _("Python scripts")+" (*.py ; *.pyw)")
         self.redirect_stdio.emit(True)
         if filename:
             self.analyze(filename)

--- a/spyder_pylint/widgets/pylintgui.py
+++ b/spyder_pylint/widgets/pylintgui.py
@@ -28,10 +28,11 @@ from qtpy.QtWidgets import (QHBoxLayout, QLabel, QMessageBox, QTreeWidgetItem,
 # Local imports
 from spyder import dependencies
 from spyder.config.base import get_conf_path, get_translation
-from spyder.py3compat import getcwd, pickle, to_text_string
+from spyder.py3compat import pickle, to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.encoding import to_unicode_from_fs
 from spyder.utils.qthelpers import create_toolbutton
+from spyder.utils.misc import getcwd_or_home
 from spyder.widgets.comboboxes import (is_module_or_package,
                                        PythonModulesComboBox)
 from spyder.widgets.onecolumntree import OneColumnTree
@@ -234,8 +235,9 @@ class PylintWidget(QWidget):
     @Slot()
     def select_file(self):
         self.redirect_stdio.emit(False)
-        filename, _selfilter = getopenfilename(self, _("Select Python file"),
-                           getcwd(), _("Python files")+" (*.py ; *.pyw)")
+        filename, _selfilter = getopenfilename(
+                self, _("Select Python file"),
+                getcwd_or_home(), _("Python files")+" (*.py ; *.pyw)")
         self.redirect_stdio.emit(True)
         if filename:
             self.analyze(filename)


### PR DESCRIPTION
Fixes: #5099

I think that returning home directory is better than returning None, because the calls of getcwd expect a directory, and returning None will cause other errors

Maybe a warning should be printed when falling back to home directory

I change it everywhere, except the tests and ipykernel file
