### PR TITLE
PR: Display all lists in the variable explorer

### DIFF
--- a/spyder/widgets/variableexplorer/tests/test_utils.py
+++ b/spyder/widgets/variableexplorer/tests/test_utils.py
@@ -114,9 +114,9 @@ def test_list_display():
 
     # List starting with a non-supported object (#5313)
     supported_types = tuple(get_supported_types()['editable'])
-    l = [len, 1]
-    assert value_to_display(l) == '[builtin_function_or_method, 1]'
-    assert is_supported(l, filters=supported_types)
+    li = [len, 1]
+    assert value_to_display(li) == '[builtin_function_or_method, 1]'
+    assert is_supported(li, filters=supported_types)
 
 def test_dict_display():
     """Tests for display of dicts."""
@@ -155,10 +155,11 @@ def test_dict_display():
 
     # Dict starting with a non-supported object (#5313)
     supported_types = tuple(get_supported_types()['editable'])
-    d = {max: len, 1: 1}
-    assert (value_to_display(d) ==
-            '{builtin_function_or_method:builtin_function_or_method, 1:1}')
-    assert is_supported(d, filters=supported_types)
+    di = {max: len, 1: 1}
+    assert value_to_display(di) in (
+            '{builtin_function_or_method:builtin_function_or_method, 1:1}',
+            '{1:1, builtin_function_or_method:builtin_function_or_method}')
+    assert is_supported(di, filters=supported_types)
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/variableexplorer/tests/test_utils.py
+++ b/spyder/widgets/variableexplorer/tests/test_utils.py
@@ -112,6 +112,11 @@ def test_list_display():
     result = '[defaultdict, Panel, 1, {1:2, 3:4}, Dataframe]'
     assert value_to_display(li) == result
 
+    # List starting with a non-supported object (#5313)
+    supported_types = tuple(get_supported_types()['editable'])
+    l = [len, 1]
+    assert value_to_display(l) == '[builtin_function_or_method, 1]'
+    assert is_supported(l, filters=supported_types)
 
 def test_dict_display():
     """Tests for display of dicts."""
@@ -147,6 +152,13 @@ def test_dict_display():
     li = {0:COMPLEX_OBJECT, 1:PANEL, 2:2, 3:{0:0, 1:1}, 4:DF}
     result = '{0:defaultdict, 1:Panel, 2:2, 3:{0:0, 1:1}, 4:Dataframe}'
     assert value_to_display(li) == result
+
+    # Dict starting with a non-supported object (#5313)
+    supported_types = tuple(get_supported_types()['editable'])
+    d = {max: len, 1: 1}
+    assert (value_to_display(d) ==
+            '{builtin_function_or_method:builtin_function_or_method, 1:1}')
+    assert is_supported(d, filters=supported_types)
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -504,7 +504,7 @@ def get_human_readable_type(item):
 # Globals filter: filter namespace dictionaries (to be edited in
 # CollectionsEditor)
 #==============================================================================
-def is_supported(value, check_all=False, filters=None, iterate=True):
+def is_supported(value, check_all=False, filters=None, iterate=False):
     """Return True if the value is supported, False otherwise"""
     assert filters is not None
     if value is None:


### PR DESCRIPTION
Fixes #5313

---------
To fix this issue we can remove the chunk of code that is under `elif iterate:` (in [`is_supported`](https://github.com/spyder-ide/spyder/blob/master/spyder/widgets/variableexplorer/utils.py#L511) function) but I did not feel confortable about it. There may be a reason for this piece of code that I am not able to see right now. 
As a compromise I just turned it off by default but it is still there in case we figure out why it was here in the first place.
Does it seem acceptable?