### PR TITLE
PR: Change error report dialog to enter issue description before submitting it

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2380,7 +2380,7 @@ class MainWindow(QMainWindow):
         dlg.set_data(dependencies.DEPENDENCIES)
         dlg.exec_()
 
-    def render_issue(self, traceback=""):
+    def render_issue(self, description, traceback):
         versions = get_versions()
         # Get git revision for development version
         revision = ''
@@ -2389,38 +2389,35 @@ class MainWindow(QMainWindow):
         issue_template = """\
 ## Description
 
-**What steps will reproduce the problem?**
+{description}
 
-1. 
-2. 
-3. 
+## Traceback
 
-**What is the expected output? What do you see instead?**
-
-
-**Please provide any additional information below**
-
-%s
+```python-traceback
+{traceback}
+```
 
 ## Version and main components
 
-* Spyder Version: %s %s
-* Python Version: %s
-* Qt Versions: %s, %s %s on %s
+* Spyder Version: {spyder_version} {commit}
+* Python Version: {python_version}
+* Qt Versions: {qt_version}, {qt_api} {qt_api_ver} on {system_version}
 
 ## Dependencies
+
 ```
-%s
+{dependencies}
 ```
-""" % (traceback,
-       versions['spyder'],
-       revision,
-       versions['python'],
-       versions['qt'],
-       versions['qt_api'],
-       versions['qt_api_ver'],
-       versions['system'],
-       dependencies.status())
+""".format(description=description,
+           traceback=traceback,
+           spyder_version=versions['spyder'],
+           commit=revision,
+           python_version=versions['python'],
+           qt_version=versions['qt'],
+           qt_api=versions['qt_api'],
+           qt_api_ver=versions['qt_api_ver'],
+           system_version=versions['system'],
+           dependencies=dependencies.status())
 
         return issue_template
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2381,7 +2381,7 @@ class MainWindow(QMainWindow):
         dlg.exec_()
 
     @Slot()
-    def report_issue(self, traceback="", description="1. \n2. \n3. ", expected=""):
+    def report_issue(self, traceback=""):
         if PY3:
             from urllib.parse import quote
         else:
@@ -2396,11 +2396,12 @@ class MainWindow(QMainWindow):
 
 **What steps will reproduce the problem?**
 
-%s
+1. 
+2. 
+3. 
 
 **What is the expected output? What do you see instead?**
 
-%s
 
 **Please provide any additional information below**
 
@@ -2416,9 +2417,7 @@ class MainWindow(QMainWindow):
 ```
 %s
 ```
-""" % (description,
-       expected,
-       traceback,
+""" % (traceback,
        versions['spyder'],
        revision,
        versions['python'],

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2380,22 +2380,35 @@ class MainWindow(QMainWindow):
         dlg.set_data(dependencies.DEPENDENCIES)
         dlg.exec_()
 
-    def render_issue(self, description, traceback):
+    def render_issue(self, description='', traceback=''):
+        """Render issue before sending it to Github"""
+        # Get component versions
         versions = get_versions()
+
         # Get git revision for development version
         revision = ''
         if versions['revision']:
             revision = versions['revision']
+
+        # Make a description header in case no description
+        # is supplied
+        if not description:
+            description = "**What steps will reproduce your problem?**"
+
+        # Make error section from traceback
+        if traceback:
+            error_section = ("## Traceback\n"
+                             "```python-traceback\n"
+                             "{}\n"
+                             "```".format(traceback))
+        else:
+            error_section = ''
         issue_template = """\
 ## Description
 
 {description}
 
-## Traceback
-
-```python-traceback
-{traceback}
-```
+{error_section}
 
 ## Version and main components
 
@@ -2409,7 +2422,7 @@ class MainWindow(QMainWindow):
 {dependencies}
 ```
 """.format(description=description,
-           traceback=traceback,
+           error_section=error_section,
            spyder_version=versions['spyder'],
            commit=revision,
            python_version=versions['python'],

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2381,7 +2381,7 @@ class MainWindow(QMainWindow):
         dlg.exec_()
 
     @Slot()
-    def report_issue(self, traceback=""):
+    def report_issue(self, traceback="", description="1. \n2. \n3. ", expected=""):
         if PY3:
             from urllib.parse import quote
         else:
@@ -2396,12 +2396,11 @@ class MainWindow(QMainWindow):
 
 **What steps will reproduce the problem?**
 
-1. 
-2. 
-3. 
+%s
 
 **What is the expected output? What do you see instead?**
 
+%s
 
 **Please provide any additional information below**
 
@@ -2417,7 +2416,9 @@ class MainWindow(QMainWindow):
 ```
 %s
 ```
-""" % (traceback,
+""" % (description,
+       expected,
+       traceback,
        versions['spyder'],
        revision,
        versions['python'],

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2380,12 +2380,7 @@ class MainWindow(QMainWindow):
         dlg.set_data(dependencies.DEPENDENCIES)
         dlg.exec_()
 
-    @Slot()
-    def report_issue(self, traceback=""):
-        if PY3:
-            from urllib.parse import quote
-        else:
-            from urllib import quote     # analysis:ignore
+    def render_issue(self, traceback=""):
         versions = get_versions()
         # Get git revision for development version
         revision = ''
@@ -2427,15 +2422,31 @@ class MainWindow(QMainWindow):
        versions['system'],
        dependencies.status())
 
+        return issue_template
+
+    @Slot()
+    def report_issue(self, body=None, title=None):
+        if PY3:
+            from urllib.parse import quote
+        else:
+            from urllib import quote     # analysis:ignore
+
+        if body is None:
+            body = self.render_issue()
+
         url = QUrl("https://github.com/spyder-ide/spyder/issues/new")
         if PYQT5:
             from qtpy.QtCore import QUrlQuery
             query = QUrlQuery()
-            query.addQueryItem("body", quote(issue_template))
+            query.addQueryItem("body", quote(body))
+            if title:
+                query.addQueryItem("title", quote(title))
             url.setQuery(query)
         else:
-            url.addEncodedQueryItem("body", quote(issue_template))
-            
+            url.addEncodedQueryItem("body", quote(body))
+            if title:
+                url.addEncodedQueryItem("title", quote(title))
+
         QDesktopServices.openUrl(url)
 
     @Slot()

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -98,7 +98,7 @@ def status(deps=DEPENDENCIES, linesep=os.linesep):
     text = ""
     for index in range(len(deps)):
         text += col1[index].ljust(maxwidth) + ':  ' + col2[index] + linesep
-    return text
+    return text[:-1]
 
 
 def missing_dependencies():

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -210,7 +210,7 @@ class Console(SpyderPluginWidget):
 
         Show a QDialog or the internal console to warn the user.
         """
-        # Skip errors without traceback
+        # Skip errors without traceback or dismiss
         if (not is_traceback and self.error_dlg is None) or self.dimiss_error:
             return
 
@@ -220,9 +220,12 @@ class Console(SpyderPluginWidget):
         else:
             if self.error_dlg is None:
                 self.error_dlg = SpyderErrorDlg(self)
+
                 self.error_dlg.dimiss_btn.clicked.connect(
                     self.dismiss_error_dlg)
+                self.error_dlg.rejected.connect(self.remove_error_dlg)
                 self.error_dlg.details.go_to_error.connect(self.go_to_error)
+
                 self.error_dlg.show()
 
             self.error_dlg.append_traceback(text)
@@ -231,6 +234,9 @@ class Console(SpyderPluginWidget):
         """Dismiss error dialog."""
         self.dimiss_error = True
         self.error_dlg.reject()
+
+    def remove_error_dlg(self):
+        """Remove error dialog."""
         self.error_dlg = None
 
     #------ Public API ---------------------------------------------------------

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -97,6 +97,7 @@ class Console(SpyderPluginWidget):
         # Traceback MessageBox
         self.msgbox_error= None
         self.error_traceback = ""
+        self.dimiss_error = False
 
     #------ Private API --------------------------------------------------------
     def set_historylog(self, historylog):
@@ -207,7 +208,7 @@ class Console(SpyderPluginWidget):
         """Exception ocurred in the internal console.
         Show a QMessageBox or the internal console to warn the user"""
         # Skip errors without traceback
-        if not is_traceback and self.msgbox_error is None:
+        if (not is_traceback and self.msgbox_error is None) or self.dimiss_error:
             return
 
         if CONF.get('main', 'show_internal_console_if_traceback', False):
@@ -220,7 +221,9 @@ class Console(SpyderPluginWidget):
 
             self.msgbox_error.append_traceback(text)
 
-    def close_msg(self):
+    def close_msg(self, result):
+        if result == 1:  # submited to github or dialog dismissed
+            self.dimiss_error = True
         self.msgbox_error = None
 
     #------ Public API ---------------------------------------------------------

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -220,10 +220,11 @@ class Console(SpyderPluginWidget):
         else:
             if self.error_dlg is None:
                 self.error_dlg = SpyderErrorDlg(self)
-                self.error_dlg.append_traceback(text)
                 self.error_dlg.dimiss_btn.clicked.connect(
                     self.dismiss_error_dlg)
-                self.error_dlg.exec_()
+                self.error_dlg.show()
+
+            self.error_dlg.append_traceback(text)
 
     def dismiss_error_dlg(self):
         """Dismiss error dialog."""

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -19,9 +19,8 @@ import sys
 # Third party imports
 from qtpy import PYQT5
 from qtpy.compat import getopenfilename
-from qtpy.QtCore import Signal, Slot, Qt
-from qtpy.QtWidgets import (QInputDialog, QLineEdit, QMenu, QVBoxLayout,
-                            QMessageBox)
+from qtpy.QtCore import Signal, Slot
+from qtpy.QtWidgets import QInputDialog, QLineEdit, QMenu, QVBoxLayout
 
 # Local imports
 from spyder.config.base import _, debug_print
@@ -35,6 +34,7 @@ from spyder.utils.qthelpers import (add_actions, create_action,
 from spyder.widgets.internalshell import InternalShell
 from spyder.widgets.findreplace import FindReplace
 from spyder.widgets.variableexplorer.collectionseditor import CollectionsEditor
+from spyder.widgets.reporterror import SpyderErrorMsgBox
 from spyder.plugins import SpyderPluginWidget
 from spyder.py3compat import to_text_string
 
@@ -95,7 +95,7 @@ class Console(SpyderPluginWidget):
         self.setAcceptDrops(True)
 
         # Traceback MessageBox
-        self.msgbox_traceback= None
+        self.msgbox_error= None
         self.error_traceback = ""
 
     #------ Private API --------------------------------------------------------
@@ -207,52 +207,21 @@ class Console(SpyderPluginWidget):
         """Exception ocurred in the internal console.
         Show a QMessageBox or the internal console to warn the user"""
         # Skip errors without traceback
-        if not is_traceback and self.msgbox_traceback is None:
+        if not is_traceback and self.msgbox_error is None:
             return
 
         if CONF.get('main', 'show_internal_console_if_traceback', False):
             self.dockwidget.show()
             self.dockwidget.raise_()
         else:
-            if self.msgbox_traceback is None:
-                self.msgbox_traceback = QMessageBox(
-                    QMessageBox.Critical,
-                    _('Error'),
-                    _("<b>Spyder has encountered a problem.</b><br>"
-                      "Sorry for the inconvenience."
-                      "<br><br>"
-                      "You can automatically submit this error to our Github "
-                      "issues tracker.<br><br>"
-                      "<i>Note:</i> You need a Github account for that."),
-                    QMessageBox.Ok,
-                    parent=self)
+            if self.msgbox_error is None:
+                self.msgbox_error = SpyderErrorMsgBox(self)
+                self.msgbox_error.finished.connect(self.close_msg)
 
-                self.submit_btn = self.msgbox_traceback.addButton(
-                        _('Submit to Github'), QMessageBox.YesRole)
-                self.submit_btn.pressed.connect(self.press_submit_btn)
-
-                self.msgbox_traceback.setWindowModality(Qt.NonModal)
-                self.error_traceback = ""
-                self.msgbox_traceback.show()
-                self.msgbox_traceback.finished.connect(self.close_msg)
-                self.msgbox_traceback.setDetailedText(' ')
-
-                # open show details (iterate over all buttons and click it)
-                for button in self.msgbox_traceback.buttons():
-                    if (self.msgbox_traceback.buttonRole(button)
-                       == QMessageBox.ActionRole):
-                        button.click()
-                        break
-
-            self.error_traceback += text
-            self.msgbox_traceback.setDetailedText(self.error_traceback)
+            self.msgbox_error.append_traceback(text)
 
     def close_msg(self):
-        self.msgbox_traceback = None
-
-    def press_submit_btn(self):
-        self.main.report_issue(self.error_traceback)
-        self.msgbox_traceback = None
+        self.msgbox_error = None
 
     #------ Public API ---------------------------------------------------------
     @Slot()

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -222,6 +222,7 @@ class Console(SpyderPluginWidget):
                 self.error_dlg = SpyderErrorDlg(self)
                 self.error_dlg.dimiss_btn.clicked.connect(
                     self.dismiss_error_dlg)
+                self.error_dlg.details.go_to_error.connect(self.go_to_error)
                 self.error_dlg.show()
 
             self.error_dlg.append_traceback(text)

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -34,7 +34,7 @@ from spyder.utils.qthelpers import (add_actions, create_action,
 from spyder.widgets.internalshell import InternalShell
 from spyder.widgets.findreplace import FindReplace
 from spyder.widgets.variableexplorer.collectionseditor import CollectionsEditor
-from spyder.widgets.reporterror import SpyderErrorDlg
+from spyder.widgets.reporterror import SpyderErrorDialog
 from spyder.plugins import SpyderPluginWidget
 from spyder.py3compat import to_text_string
 
@@ -214,12 +214,12 @@ class Console(SpyderPluginWidget):
         if (not is_traceback and self.error_dlg is None) or self.dimiss_error:
             return
 
-        if False: #CONF.get('main', 'show_internal_console_if_traceback'):
+        if CONF.get('main', 'show_internal_console_if_traceback'):
             self.dockwidget.show()
             self.dockwidget.raise_()
         else:
             if self.error_dlg is None:
-                self.error_dlg = SpyderErrorDlg(self)
+                self.error_dlg = SpyderErrorDialog(self)
 
                 self.error_dlg.dimiss_btn.clicked.connect(
                     self.dismiss_error_dlg)

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -205,8 +205,11 @@ class Console(SpyderPluginWidget):
         self.shell.exception_occurred.connect(self.exception_occurred)
     
     def exception_occurred(self, text, is_traceback):
-        """Exception ocurred in the internal console.
-        Show a QMessageBox or the internal console to warn the user"""
+        """
+        Exception ocurred in the internal console.
+
+        Show a QDialog or the internal console to warn the user.
+        """
         # Skip errors without traceback
         if (not is_traceback and self.error_dlg is None) or self.dimiss_error:
             return
@@ -217,15 +220,15 @@ class Console(SpyderPluginWidget):
         else:
             if self.error_dlg is None:
                 self.error_dlg = SpyderErrorDlg(self)
+                self.error_dlg.append_traceback(text)
                 self.error_dlg.dimiss_btn.clicked.connect(
                     self.dismiss_error_dlg)
                 self.error_dlg.exec_()
 
-            self.error_dlg.append_traceback(text)
-
     def dismiss_error_dlg(self):
         """Dismiss error dialog."""
         self.dimiss_error = True
+        self.error_dlg.reject()
         self.error_dlg = None
 
     #------ Public API ---------------------------------------------------------

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -34,7 +34,7 @@ from spyder.utils.qthelpers import (add_actions, create_action,
 from spyder.widgets.internalshell import InternalShell
 from spyder.widgets.findreplace import FindReplace
 from spyder.widgets.variableexplorer.collectionseditor import CollectionsEditor
-from spyder.widgets.reporterror import SpyderErrorMsgBox
+from spyder.widgets.reporterror import SpyderErrorDlg
 from spyder.plugins import SpyderPluginWidget
 from spyder.py3compat import to_text_string
 
@@ -95,7 +95,7 @@ class Console(SpyderPluginWidget):
         self.setAcceptDrops(True)
 
         # Traceback MessageBox
-        self.msgbox_error= None
+        self.error_dlg = None
         self.error_traceback = ""
         self.dimiss_error = False
 
@@ -208,23 +208,25 @@ class Console(SpyderPluginWidget):
         """Exception ocurred in the internal console.
         Show a QMessageBox or the internal console to warn the user"""
         # Skip errors without traceback
-        if (not is_traceback and self.msgbox_error is None) or self.dimiss_error:
+        if (not is_traceback and self.error_dlg is None) or self.dimiss_error:
             return
 
-        if CONF.get('main', 'show_internal_console_if_traceback', False):
+        if False: #CONF.get('main', 'show_internal_console_if_traceback'):
             self.dockwidget.show()
             self.dockwidget.raise_()
         else:
-            if self.msgbox_error is None:
-                self.msgbox_error = SpyderErrorMsgBox(self)
-                self.msgbox_error.finished.connect(self.close_msg)
+            if self.error_dlg is None:
+                self.error_dlg = SpyderErrorDlg(self)
+                self.error_dlg.dimiss_btn.clicked.connect(
+                    self.dismiss_error_dlg)
+                self.error_dlg.exec_()
 
-            self.msgbox_error.append_traceback(text)
+            self.error_dlg.append_traceback(text)
 
-    def close_msg(self, result):
-        if result == 1:  # submited to github or dialog dismissed
-            self.dimiss_error = True
-        self.msgbox_error = None
+    def dismiss_error_dlg(self):
+        """Dismiss error dialog."""
+        self.dimiss_error = True
+        self.error_dlg = None
 
     #------ Public API ---------------------------------------------------------
     @Slot()

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -54,7 +54,7 @@ class DescriptionWidget(CodeEditor):
         self.header_end_pos = self.get_position('eof')
 
     def remove_text(self):
-        """Remove selected text."""
+        """Remove text."""
         self.truncate_selection(self.header_end_pos)
         self.remove_selected_text()
 
@@ -87,6 +87,10 @@ class DescriptionWidget(CodeEditor):
             self.cut()
         else:
             CodeEditor.keyPressEvent(self, event)
+
+    def contextMenuEvent(self, event):
+        """Reimplemented Qt Method to not show the context menu."""
+        pass
 
 
 class ShowErrorWidget(TracebackLinksMixin, ConsoleBaseWidget, BaseEditMixin):

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -98,6 +98,9 @@ class SpyderErrorDialog(QDialog):
         self.setWindowTitle(_("Spyder internal error"))
         self.setModal(True)
 
+        # To save the traceback sent to the internal console
+        self.error_traceback = ""
+
         # Dialog main label
         self.main_label = QLabel(
             _("""<b>Spyder has encountered a problem!!</b><hr>
@@ -111,7 +114,7 @@ class SpyderErrorDialog(QDialog):
         self.main_label.setAlignment(Qt.AlignJustify)
 
         # Field to input the description of the problem
-        self.input_description = DescriptionWidget()
+        self.input_description = DescriptionWidget(self)
 
         # Only allow to submit to Github if we have a long enough description
         self.input_description.textChanged.connect(self._description_changed)
@@ -135,22 +138,23 @@ class SpyderErrorDialog(QDialog):
         self.initial_chars = len(self.input_description.toPlainText())
         self.chars_label = QLabel(_("Enter at least 15 characters"))
 
+        # Buttons layout
         hlayout = QHBoxLayout()
         hlayout.addWidget(self.submit_btn)
         hlayout.addWidget(self.details_btn)
         hlayout.addWidget(self.dimiss_btn)
 
+        # Main layout
         vlayout = QVBoxLayout()
         vlayout.addWidget(self.main_label)
         vlayout.addWidget(self.input_description)
         vlayout.addWidget(self.details)
         vlayout.addWidget(self.chars_label)
         vlayout.addLayout(hlayout)
-        self.resize(500, 420)
-
         self.setLayout(vlayout)
 
-        self.error_traceback = ""
+        self.resize(500, 420)
+        self.input_description.setFocus()
 
     def _submit_to_github(self):
         """Action to take when pressing the submit button."""

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -25,12 +25,10 @@ class SpyderErrorMsgBox(QMessageBox):
             _("<b>Spyder has encountered a problem.</b><br>"
               "Sorry for the inconvenience."
               "<br><br>"
-              "You can create a new issue in our Github "
-              "issues tracker.<br><br>"
-              "The issue dependencies and traceback "
-              "will be  copied  in the clipboard, "
-              "paste them when submiting the issue.<br><br>"
-              "<i>Note: You need a Github account for that.</i>"),
+              "All the information about this error "
+              "will be copied to the clipboard. Please "
+              "paste it when submiting the issue to Github.<br><br>"
+              "<b>Note</b>: You need a Github account for that."),
             parent=parent)
 
         self.submit_btn = self.addButton(

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -4,7 +4,7 @@
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
 
-"""Repport Error Dialog"""
+"""Report Error Dialog"""
 
 # Stdlib imports
 import sys

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -53,9 +53,8 @@ class SpyderErrorMsgBox(QMessageBox):
         if filldescription.exec_():
             self.accept()
 
-    def report_issue(self, description, expected):
-        self.parent().main.report_issue(self.error_traceback, description,
-                                        expected)
+    def report_issue(self, description):
+        self.parent().main.report_issue(self.error_traceback, description)
 
     def append_traceback(self, text):
         """Append text to the traceback, to be displayed in show details."""
@@ -65,7 +64,7 @@ class SpyderErrorMsgBox(QMessageBox):
 
 class FillDescription(QDialog):
 
-    sig_accepted = Signal(str, str)
+    sig_accepted = Signal(str)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -75,11 +74,6 @@ class FillDescription(QDialog):
             "What steps will reproduce the problem")
         self.input_description = QPlainTextEdit()
         self.input_description.textChanged.connect(self.text_changed)
-
-        self.label_expected = QLabel(
-            "What is the expected output? What do you see instead?")
-        self.input_expected = QPlainTextEdit()
-        self.input_expected.textChanged.connect(self.text_changed)
 
         self.ok_button = QPushButton("Ok")
         self.cancel_button = QPushButton("Cancel")
@@ -94,20 +88,14 @@ class FillDescription(QDialog):
         layout = QVBoxLayout()
         layout.addWidget(self.label_description)
         layout.addWidget(self.input_description)
-        layout.addWidget(self.label_expected)
-        layout.addWidget(self.input_expected)
         layout.addLayout(buttons_layout)
         self.setLayout(layout)
 
     def text_changed(self):
         words_description = len(self.input_description.toPlainText().split())
-        words_expected = len(self.input_expected.toPlainText().split())
-
-        state = words_description > 10 and words_expected > 10
-        self.ok_button.setEnabled(state)
+        self.ok_button.setEnabled(words_description > 10)
 
     def accept(self):
         text_description = self.input_description.toPlainText()
-        text_expected = self.input_expected.toPlainText()
-        self.sig_accepted.emit(text_description, text_expected)
+        self.sig_accepted.emit(text_description)
         super().accept()

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -30,7 +30,7 @@ class SpyderErrorMsgBox(QMessageBox):
               "The issue dependencies and traceback "
               "will be  copied  in the clipboard, "
               "paste them when submiting the issue.<br><br>"
-              "<i>Note:</i> You need a Github account for that."),
+              "<i>Note: You need a Github account for that.</i>"),
             parent=parent)
 
         self.submit_btn = self.addButton(

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -13,8 +13,6 @@ from qtpy.QtCore import Qt, Signal
 
 # Local Imports
 from spyder.config.base import _
-from spyder.widgets.sourcecode.codeeditor import CodeEditor
-from spyder.config.main import CONF
 
 
 class SpyderErrorMsgBox(QMessageBox):
@@ -72,19 +70,11 @@ class FillDescription(QDialog):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-
-        color_scheme = CONF.get('color_schemes', 'selected')
-
         self.setWindowTitle(_("Error Description"))
 
         self.label_description = QLabel(
             "What steps will reproduce the problem")
-        self.input_description = CodeEditor()
-        self.input_description.setup_editor(
-            language='md', linenumbers=False, scrollflagarea=False,
-            color_scheme=color_scheme)
-        self.input_description.set_text("1. \n2. \n3. ")
-        self.input_description.move_cursor(3)
+        self.input_description = QPlainTextEdit()
         self.input_description.textChanged.connect(self.text_changed)
 
         self.ok_button = QPushButton("Ok")

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -64,7 +64,7 @@ class SpyderErrorDlg(QDialog):
         # Dialog buttons
         self.submit_btn = QPushButton(_('Submit to Github'))
         self.submit_btn.setEnabled(False)
-        self.submit_btn.clicked.connect(self._press_submit_btn)
+        self.submit_btn.clicked.connect(self._submit_to_github)
 
         self.details_btn = QPushButton(_('Show details'))
         self.details_btn.clicked.connect(self._show_details)
@@ -86,12 +86,22 @@ class SpyderErrorDlg(QDialog):
 
         self.error_traceback = ""
 
-    def _press_submit_btn(self):
+    def _submit_to_github(self):
+        """Action to take when pressing the submit button."""
         main = self.parent().main
+
+        # Getting description and traceback
         description = self.input_description.toPlainText()
+        traceback = self.error_traceback[:-1] # Remove last eol
+
+        # Render issue
         issue_text  = main.render_issue(description=description,
-                                        traceback=self.error_traceback)
+                                        traceback=traceback)
+
+        # Copy issue to clipboard
         QApplication.clipboard().setText(issue_text)
+
+        # Submit issue to Github
         main.report_issue(body="", title="Automatic error report")
 
     def append_traceback(self, text):

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -67,7 +67,11 @@ class SpyderErrorDlg(QDialog):
             scrollflagarea=False,
             wrap=True,
             edge_line=False,
-            highlight_current_line=False)
+            highlight_current_line=False,
+            highlight_current_cell=False,
+            occurrence_highlighting=False,
+            auto_unindent=False)
+        self.input_description.set_font(get_font())
 
         # Set default text for description
         self.input_description.set_text(

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -37,6 +37,8 @@ class SpyderErrorMsgBox(QMessageBox):
         self.submit_btn = self.addButton(
             _('Submit to Github'), QMessageBox.YesRole)
         self.submit_btn.pressed.connect(self._press_submit_btn)
+        self.dimiss_btn = self.addButton(
+            _('Dimiss'), QMessageBox.RejectRole)
 
         self.setWindowModality(Qt.NonModal)
         self.error_traceback = ""

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -62,7 +62,7 @@ class SpyderErrorDialog(QDialog):
         self.input_description = CodeEditor()
         self.input_description.setup_editor(
             language='md',
-            color_scheme='IDLE',
+            color_scheme='Scintilla',
             linenumbers=False,
             scrollflagarea=False,
             wrap=True,

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -7,9 +7,8 @@
 """Repport Error Dialog"""
 
 # Third party imports
-from qtpy.QtWidgets import (QMessageBox, QVBoxLayout, QHBoxLayout, QDialog,
-                            QPlainTextEdit, QLabel, QPushButton)
-from qtpy.QtCore import Qt, Signal
+from qtpy.QtWidgets import QMessageBox
+from qtpy.QtCore import Qt
 
 # Local Imports
 from spyder.config.base import _
@@ -50,66 +49,9 @@ class SpyderErrorMsgBox(QMessageBox):
         self.show()
 
     def _press_submit_btn(self):
-        filldescription = FillDescription()
-        filldescription.sig_accepted.connect(self.report_issue)
-        if filldescription.exec_():
-            self.accept()
-
-    def report_issue(self, description, expected):
-        self.parent().main.report_issue(self.error_traceback, description,
-                                        expected)
+        self.parent().main.report_issue(self.error_traceback)
 
     def append_traceback(self, text):
         """Append text to the traceback, to be displayed in show details."""
         self.error_traceback += text
         self.setDetailedText(self.error_traceback)
-
-
-class FillDescription(QDialog):
-
-    sig_accepted = Signal(str, str)
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self.setWindowTitle(_("Error Description"))
-
-        self.label_description = QLabel(
-            "What steps will reproduce the problem")
-        self.input_description = QPlainTextEdit()
-        self.input_description.textChanged.connect(self.text_changed)
-
-        self.label_expected = QLabel(
-            "What is the expected output? What do you see instead?")
-        self.input_expected = QPlainTextEdit()
-        self.input_expected.textChanged.connect(self.text_changed)
-
-        self.ok_button = QPushButton("Ok")
-        self.cancel_button = QPushButton("Cancel")
-        self.ok_button.clicked.connect(self.accept)
-        self.ok_button.setEnabled(False)
-        self.cancel_button.clicked.connect(self.close)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(self.cancel_button)
-        buttons_layout.addWidget(self.ok_button)
-
-        layout = QVBoxLayout()
-        layout.addWidget(self.label_description)
-        layout.addWidget(self.input_description)
-        layout.addWidget(self.label_expected)
-        layout.addWidget(self.input_expected)
-        layout.addLayout(buttons_layout)
-        self.setLayout(layout)
-
-    def text_changed(self):
-        words_description = len(self.input_description.toPlainText().split())
-        words_expected = len(self.input_expected.toPlainText().split())
-
-        state = words_description > 10 and words_expected > 10
-        self.ok_button.setEnabled(state)
-
-    def accept(self):
-        text_description = self.input_description.toPlainText()
-        text_expected = self.input_expected.toPlainText()
-        self.sig_accepted.emit(text_description, text_expected)
-        super().accept()

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -6,47 +6,85 @@
 
 """Repport Error Dialog"""
 
+# Stdlib imports
+import sys
+
 # Third party imports
-from qtpy.QtWidgets import QMessageBox, QApplication
+from qtpy.QtWidgets import (QApplication, QDialog, QHBoxLayout, QLabel,
+                            QPushButton, QVBoxLayout)
 from qtpy.QtCore import Qt
 
 # Local Imports
 from spyder.config.base import _
+from spyder.widgets.sourcecode.codeeditor import CodeEditor
 
 
-class SpyderErrorMsgBox(QMessageBox):
+class SpyderErrorDlg(QDialog):
     """Custom message box for error reporting"""
 
     def __init__(self, parent=None):
-        QMessageBox.__init__(
-            self,
-            QMessageBox.Critical,
-            _('Error'),
-            _("<b>Spyder has encountered a problem.</b><br>"
-              "Sorry for the inconvenience."
-              "<br><br>"
-              "All the information about this error "
-              "will be copied to the clipboard. Please "
-              "paste it when submiting the issue to Github.<br><br>"
-              "<b>Note</b>: You need a Github account for that."),
-            parent=parent)
+        QDialog.__init__(self, parent)
+        self.setWindowTitle(_("Spyder internal error"))
+        self.setModal(True)
 
-        self.submit_btn = self.addButton(
-            _('Submit to Github'), QMessageBox.YesRole)
-        self.submit_btn.pressed.connect(self._press_submit_btn)
-        self.dimiss_btn = self.addButton(
-            _('Dimiss'), QMessageBox.RejectRole)
+        # Dialog main label
+        self.label = QLabel(
+            _("""<b>Spyder has encountered a problem!!</b><hr>
+              Please enter below a step-by-step description 
+              of your problem (in English). If you fail to 
+              do it, you won't be able to send your report.
+              <br><br>
+              <b>Note</b>: You need a Github account for this.
+              """))
+        self.label.setWordWrap(True)
+        self.label.setAlignment(Qt.AlignJustify)
 
-        self.setWindowModality(Qt.NonModal)
+        # Field to input the description of the problem
+        self.description_header = (
+            "**What steps will reproduce your problem?**\n\n"
+            "You can use Markdown here\n\n")
+        self.input_description = CodeEditor()
+        self.input_description.setup_editor(
+            language='md',
+            color_scheme='IDLE',
+            linenumbers=False,
+            scrollflagarea=False,
+            wrap=True,
+            edge_line=False,
+            highlight_current_line=False)
+
+        # Set default text for description
+        self.input_description.set_text(
+            "{0}1. \n2. \n3. ".format(self.description_header))
+        self.input_description.move_cursor(len(self.description_header) + 3)
+
+        # Only allow to submit to Github if we have a long enough description
+        self.input_description.textChanged.connect(self._description_changed)
+
+        # Dialog buttons
+        self.submit_btn = QPushButton(_('Submit to Github'))
+        self.submit_btn.setEnabled(False)
+        self.submit_btn.clicked.connect(self._press_submit_btn)
+
+        self.details_btn = QPushButton(_('Show details'))
+        self.details_btn.clicked.connect(self._show_details)
+
+        self.dimiss_btn = QPushButton(_('Dimiss'))
+
+        hlayout = QHBoxLayout()
+        hlayout.addWidget(self.submit_btn)
+        hlayout.addWidget(self.details_btn)
+        hlayout.addWidget(self.dimiss_btn)
+
+        vlayout = QVBoxLayout()
+        vlayout.addWidget(self.label)
+        vlayout.addWidget(self.input_description)
+        vlayout.addLayout(hlayout)
+        self.resize(500, 420)
+
+        self.setLayout(vlayout)
+
         self.error_traceback = ""
-        self.setDetailedText(' ')
-
-        # Open show details (iterate over all buttons and click it)
-        for button in self.buttons():
-            if self.buttonRole(button) == QMessageBox.ActionRole:
-                button.click()
-                break
-        self.show()
 
     def _press_submit_btn(self):
         main = self.parent().main
@@ -56,17 +94,26 @@ class SpyderErrorMsgBox(QMessageBox):
         self.accept()
 
     def append_traceback(self, text):
-        """Append text to the traceback, to be displayed in show details."""
+        """Append text to the traceback, to be displayed in details."""
         self.error_traceback += text
-        self.setDetailedText(self.error_traceback)
+
+    def _show_details(self):
+        """Show traceback on its own dialog"""
+        pass
+
+    def _description_changed(self):
+        """Activate submit_btn if we have a long enough description."""
+        ini_words = len(self.description_header.split())
+        words_in_description = len(self.input_description.toPlainText().split())
+        self.submit_btn.setEnabled(words_in_description - ini_words > 10)
 
 
 def test():
     from spyder.utils.qthelpers import qapplication
     app = qapplication()
-    report_dialog = SpyderErrorMsgBox()
-    report_dialog.show()
-    app.exec_()
+    dlg = SpyderErrorDlg()
+    dlg.show()
+    sys.exit(dlg.exec_())
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -7,8 +7,9 @@
 """Repport Error Dialog"""
 
 # Third party imports
-from qtpy.QtWidgets import QMessageBox
-from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (QMessageBox, QVBoxLayout, QHBoxLayout, QDialog,
+                            QPlainTextEdit, QLabel, QPushButton)
+from qtpy.QtCore import Qt, Signal
 
 # Local Imports
 from spyder.config.base import _
@@ -47,9 +48,66 @@ class SpyderErrorMsgBox(QMessageBox):
         self.show()
 
     def _press_submit_btn(self):
-        self.parent().main.report_issue(self.error_traceback)
+        filldescription = FillDescription()
+        filldescription.sig_accepted.connect(self.report_issue)
+        if filldescription.exec_():
+            self.accept()
+
+    def report_issue(self, description, expected):
+        self.parent().main.report_issue(self.error_traceback, description,
+                                        expected)
 
     def append_traceback(self, text):
         """Append text to the traceback, to be displayed in show details."""
         self.error_traceback += text
         self.setDetailedText(self.error_traceback)
+
+
+class FillDescription(QDialog):
+
+    sig_accepted = Signal(str, str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(_("Error Description"))
+
+        self.label_description = QLabel(
+            "What steps will reproduce the problem")
+        self.input_description = QPlainTextEdit()
+        self.input_description.textChanged.connect(self.text_changed)
+
+        self.label_expected = QLabel(
+            "What is the expected output? What do you see instead?")
+        self.input_expected = QPlainTextEdit()
+        self.input_expected.textChanged.connect(self.text_changed)
+
+        self.ok_button = QPushButton("Ok")
+        self.cancel_button = QPushButton("Cancel")
+        self.ok_button.clicked.connect(self.accept)
+        self.ok_button.setEnabled(False)
+        self.cancel_button.clicked.connect(self.close)
+
+        buttons_layout = QHBoxLayout()
+        buttons_layout.addWidget(self.cancel_button)
+        buttons_layout.addWidget(self.ok_button)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.label_description)
+        layout.addWidget(self.input_description)
+        layout.addWidget(self.label_expected)
+        layout.addWidget(self.input_expected)
+        layout.addLayout(buttons_layout)
+        self.setLayout(layout)
+
+    def text_changed(self):
+        words_description = len(self.input_description.toPlainText().split())
+        words_expected = len(self.input_expected.toPlainText().split())
+
+        state = words_description > 10 and words_expected > 10
+        self.ok_button.setEnabled(state)
+
+    def accept(self):
+        text_description = self.input_description.toPlainText()
+        text_expected = self.input_expected.toPlainText()
+        self.sig_accepted.emit(text_description, text_expected)
+        super().accept()

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -102,7 +102,12 @@ class SpyderErrorDlg(QDialog):
         QApplication.clipboard().setText(issue_text)
 
         # Submit issue to Github
-        main.report_issue(body="", title="Automatic error report")
+        issue_body=("<!--- "
+                    "Please paste the contents of your clipboard "
+                    "below to complete reporting your problem. "
+                    "--->\n\n")
+        main.report_issue(body=issue_body,
+                          title="Automatic error report")
 
     def append_traceback(self, text):
         """Append text to the traceback, to be displayed in details."""

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -23,7 +23,7 @@ from spyder.widgets.sourcecode.base import ConsoleBaseWidget
 
 
 class ShowErrorWidget(TracebackLinksMixin, ConsoleBaseWidget, BaseEditMixin):
-    """"""
+    """Widget to show errors as they appear in the Internal console."""
     QT_CLASS = QPlainTextEdit
     go_to_error = Signal(str)
 

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -44,7 +44,7 @@ class SpyderErrorDlg(QDialog):
         self.setModal(True)
 
         # Dialog main label
-        self.label = QLabel(
+        self.main_label = QLabel(
             _("""<b>Spyder has encountered a problem!!</b><hr>
               Please enter below a step-by-step description 
               of your problem (in English). If you fail to 
@@ -52,8 +52,8 @@ class SpyderErrorDlg(QDialog):
               <br><br>
               <b>Note</b>: You need a Github account for this.
               """))
-        self.label.setWordWrap(True)
-        self.label.setAlignment(Qt.AlignJustify)
+        self.main_label.setWordWrap(True)
+        self.main_label.setAlignment(Qt.AlignJustify)
 
         # Field to input the description of the problem
         self.description_header = (
@@ -92,15 +92,20 @@ class SpyderErrorDlg(QDialog):
 
         self.dimiss_btn = QPushButton(_('Dimiss'))
 
+        # Label to show missing chars
+        self.initial_chars = len(self.input_description.toPlainText())
+        self.chars_label = QLabel(_("Enter at least 15 characters"))
+
         hlayout = QHBoxLayout()
         hlayout.addWidget(self.submit_btn)
         hlayout.addWidget(self.details_btn)
         hlayout.addWidget(self.dimiss_btn)
 
         vlayout = QVBoxLayout()
-        vlayout.addWidget(self.label)
+        vlayout.addWidget(self.main_label)
         vlayout.addWidget(self.input_description)
         vlayout.addWidget(self.details)
+        vlayout.addWidget(self.chars_label)
         vlayout.addLayout(hlayout)
         self.resize(500, 420)
 
@@ -151,9 +156,13 @@ class SpyderErrorDlg(QDialog):
 
     def _description_changed(self):
         """Activate submit_btn if we have a long enough description."""
-        ini_words = len(self.description_header.split())
-        words_in_description = len(self.input_description.toPlainText().split())
-        self.submit_btn.setEnabled(words_in_description - ini_words > 10)
+        chars = len(self.input_description.toPlainText()) - self.initial_chars
+        if chars < 15:
+            self.chars_label.setText(
+                u"{} {}".format(15 - chars, _("more characters to go...")))
+        else:
+            self.chars_label.setText(_("Ready to submit"))
+        self.submit_btn.setEnabled(chars > 15)
 
 
 def test():

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -25,8 +25,11 @@ class SpyderErrorMsgBox(QMessageBox):
             _("<b>Spyder has encountered a problem.</b><br>"
               "Sorry for the inconvenience."
               "<br><br>"
-              "You can automatically submit this error to our Github "
+              "You can create a new issue in our Github "
               "issues tracker.<br><br>"
+              "The issue dependencies and traceback "
+              "will be  copied  in the clipboard, "
+              "paste them when submiting the issue.<br><br>"
               "<i>Note:</i> You need a Github account for that."),
             parent=parent)
 

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -55,8 +55,9 @@ class SpyderErrorMsgBox(QMessageBox):
         if filldescription.exec_():
             self.accept()
 
-    def report_issue(self, description):
-        self.parent().main.report_issue(self.error_traceback, description)
+    def report_issue(self, description, expected):
+        self.parent().main.report_issue(self.error_traceback, description,
+                                        expected)
 
     def append_traceback(self, text):
         """Append text to the traceback, to be displayed in show details."""
@@ -66,7 +67,7 @@ class SpyderErrorMsgBox(QMessageBox):
 
 class FillDescription(QDialog):
 
-    sig_accepted = Signal(str)
+    sig_accepted = Signal(str, str)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -76,6 +77,11 @@ class FillDescription(QDialog):
             "What steps will reproduce the problem")
         self.input_description = QPlainTextEdit()
         self.input_description.textChanged.connect(self.text_changed)
+
+        self.label_expected = QLabel(
+            "What is the expected output? What do you see instead?")
+        self.input_expected = QPlainTextEdit()
+        self.input_expected.textChanged.connect(self.text_changed)
 
         self.ok_button = QPushButton("Ok")
         self.cancel_button = QPushButton("Cancel")
@@ -90,14 +96,20 @@ class FillDescription(QDialog):
         layout = QVBoxLayout()
         layout.addWidget(self.label_description)
         layout.addWidget(self.input_description)
+        layout.addWidget(self.label_expected)
+        layout.addWidget(self.input_expected)
         layout.addLayout(buttons_layout)
         self.setLayout(layout)
 
     def text_changed(self):
         words_description = len(self.input_description.toPlainText().split())
-        self.ok_button.setEnabled(words_description > 10)
+        words_expected = len(self.input_expected.toPlainText().split())
+
+        state = words_description > 10 and words_expected > 10
+        self.ok_button.setEnabled(state)
 
     def accept(self):
         text_description = self.input_description.toPlainText()
-        self.sig_accepted.emit(text_description)
+        text_expected = self.input_expected.toPlainText()
+        self.sig_accepted.emit(text_description, text_expected)
         super().accept()

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -42,7 +42,7 @@ class SpyderErrorDlg(QDialog):
         # Field to input the description of the problem
         self.description_header = (
             "**What steps will reproduce your problem?**\n\n"
-            "You can use Markdown here\n\n")
+            "<!--- You can use Markdown here --->\n\n")
         self.input_description = CodeEditor()
         self.input_description.setup_editor(
             language='md',

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -35,8 +35,8 @@ class ShowErrorWidget(TracebackLinksMixin, ConsoleBaseWidget, BaseEditMixin):
         self.setReadOnly(True)
 
 
-class SpyderErrorDlg(QDialog):
-    """Custom message box for error reporting"""
+class SpyderErrorDialog(QDialog):
+    """Custom error dialog for error reporting."""
 
     def __init__(self, parent=None):
         QDialog.__init__(self, parent)
@@ -172,7 +172,7 @@ class SpyderErrorDlg(QDialog):
 def test():
     from spyder.utils.qthelpers import qapplication
     app = qapplication()
-    dlg = SpyderErrorDlg()
+    dlg = SpyderErrorDialog()
     dlg.show()
     sys.exit(dlg.exec_())
 

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -13,6 +13,8 @@ from qtpy.QtCore import Qt, Signal
 
 # Local Imports
 from spyder.config.base import _
+from spyder.widgets.sourcecode.codeeditor import CodeEditor
+from spyder.config.main import CONF
 
 
 class SpyderErrorMsgBox(QMessageBox):
@@ -68,11 +70,19 @@ class FillDescription(QDialog):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+
+        color_scheme = CONF.get('color_schemes', 'selected')
+
         self.setWindowTitle(_("Error Description"))
 
         self.label_description = QLabel(
             "What steps will reproduce the problem")
-        self.input_description = QPlainTextEdit()
+        self.input_description = CodeEditor()
+        self.input_description.setup_editor(
+            language='md', linenumbers=False, scrollflagarea=False,
+            color_scheme=color_scheme)
+        self.input_description.set_text("1. \n2. \n3. ")
+        self.input_description.move_cursor(3)
         self.input_description.textChanged.connect(self.text_changed)
 
         self.ok_button = QPushButton("Ok")

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -7,7 +7,7 @@
 """Repport Error Dialog"""
 
 # Third party imports
-from qtpy.QtWidgets import QMessageBox
+from qtpy.QtWidgets import QMessageBox, QApplication
 from qtpy.QtCore import Qt
 
 # Local Imports
@@ -49,7 +49,11 @@ class SpyderErrorMsgBox(QMessageBox):
         self.show()
 
     def _press_submit_btn(self):
-        self.parent().main.report_issue(self.error_traceback)
+        main = self.parent().main
+        issue_text  = main.render_issue(traceback=self.error_traceback)
+        QApplication.clipboard().setText(issue_text)
+        main.report_issue(body="", title="Spyder Error Report")
+        self.accept()
 
     def append_traceback(self, text):
         """Append text to the traceback, to be displayed in show details."""

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -28,7 +28,6 @@ class SpyderErrorMsgBox(QMessageBox):
               "You can automatically submit this error to our Github "
               "issues tracker.<br><br>"
               "<i>Note:</i> You need a Github account for that."),
-            QMessageBox.Ok,
             parent=parent)
 
         self.submit_btn = self.addButton(

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -46,9 +46,9 @@ class SpyderErrorDlg(QDialog):
         # Dialog main label
         self.main_label = QLabel(
             _("""<b>Spyder has encountered a problem!!</b><hr>
-              Please enter below a step-by-step description 
-              of your problem (in English). If you fail to 
-              do it, you won't be able to send your report.
+              Please enter below a step-by-step description of 
+              your problem (in English). Issue reports without 
+              a clear way to reproduce them will be closed.
               <br><br>
               <b>Note</b>: You need a Github account for this.
               """))
@@ -161,8 +161,8 @@ class SpyderErrorDlg(QDialog):
             self.chars_label.setText(
                 u"{} {}".format(15 - chars, _("more characters to go...")))
         else:
-            self.chars_label.setText(_("Ready to submit"))
-        self.submit_btn.setEnabled(chars > 15)
+            self.chars_label.setText(_("Ready to submit! Thanks!"))
+        self.submit_btn.setEnabled(chars >= 15)
 
 
 def test():

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -41,7 +41,7 @@ class SpyderErrorMsgBox(QMessageBox):
         self.error_traceback = ""
         self.setDetailedText(' ')
 
-        # open show details (iterate over all buttons and click it)
+        # Open show details (iterate over all buttons and click it)
         for button in self.buttons():
             if self.buttonRole(button) == QMessageBox.ActionRole:
                 button.click()
@@ -59,3 +59,15 @@ class SpyderErrorMsgBox(QMessageBox):
         """Append text to the traceback, to be displayed in show details."""
         self.error_traceback += text
         self.setDetailedText(self.error_traceback)
+
+
+def test():
+    from spyder.utils.qthelpers import qapplication
+    app = qapplication()
+    report_dialog = SpyderErrorMsgBox()
+    report_dialog.show()
+    app.exec_()
+
+
+if __name__ == "__main__":
+    test()

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -132,7 +132,7 @@ class SpyderErrorDialog(QDialog):
         self.details_btn = QPushButton(_('Show details'))
         self.details_btn.clicked.connect(self._show_details)
 
-        self.dimiss_btn = QPushButton(_('Dimiss'))
+        self.dimiss_btn = QPushButton(_('Dismiss'))
 
         # Label to show missing chars
         self.initial_chars = len(self.input_description.toPlainText())

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -142,6 +142,7 @@ class SpyderErrorDlg(QDialog):
             self.details_btn.setText(_('Show details'))
         else:
             self.resize(500, 550)
+            self.details.document().setPlainText('')
             self.details.append_text_to_shell(self.error_traceback,
                                               error=True,
                                               prompt=False)

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""Repport Error Dialog"""
+
+# Third party imports
+from qtpy.QtWidgets import QMessageBox
+from qtpy.QtCore import Qt
+
+# Local Imports
+from spyder.config.base import _
+
+
+class SpyderErrorMsgBox(QMessageBox):
+    """Custom message box for error reporting"""
+
+    def __init__(self, parent=None):
+        QMessageBox.__init__(
+            self,
+            QMessageBox.Critical,
+            _('Error'),
+            _("<b>Spyder has encountered a problem.</b><br>"
+              "Sorry for the inconvenience."
+              "<br><br>"
+              "You can automatically submit this error to our Github "
+              "issues tracker.<br><br>"
+              "<i>Note:</i> You need a Github account for that."),
+            QMessageBox.Ok,
+            parent=parent)
+
+        self.submit_btn = self.addButton(
+            _('Submit to Github'), QMessageBox.YesRole)
+        self.submit_btn.pressed.connect(self._press_submit_btn)
+
+        self.setWindowModality(Qt.NonModal)
+        self.error_traceback = ""
+        self.setDetailedText(' ')
+
+        # open show details (iterate over all buttons and click it)
+        for button in self.buttons():
+            if self.buttonRole(button) == QMessageBox.ActionRole:
+                button.click()
+                break
+        self.show()
+
+    def _press_submit_btn(self):
+        self.parent().main.report_issue(self.error_traceback)
+
+    def append_traceback(self, text):
+        """Append text to the traceback, to be displayed in show details."""
+        self.error_traceback += text
+        self.setDetailedText(self.error_traceback)

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -53,6 +53,17 @@ class DescriptionWidget(CodeEditor):
         self.move_cursor(len(self.header))
         self.header_end_pos = self.get_position('eof')
 
+    def remove_text(self):
+        """Remove selected text."""
+        self.truncate_selection(self.header_end_pos)
+        self.remove_selected_text()
+
+    def cut(self):
+        """Cut text"""
+        self.truncate_selection(self.header_end_pos)
+        if self.has_selected_text():
+            CodeEditor.cut(self)
+
     def keyPressEvent(self, event):
         """Reimplemented Qt Method to avoid removing the header."""
         event, text, key, ctrl, shift = restore_keyevent(event)
@@ -62,18 +73,18 @@ class DescriptionWidget(CodeEditor):
             self.restrict_cursor_position(self.header_end_pos, 'eof')
         elif key == Qt.Key_Delete:
             if self.has_selected_text():
-                self.truncate_selection(self.header_end_pos)
-                self.remove_selected_text()
+                self.remove_text()
             else:
                 self.stdkey_clear()
         elif key == Qt.Key_Backspace:
             if self.has_selected_text():
-                self.truncate_selection(self.header_end_pos)
-                self.remove_selected_text()
+                self.remove_text()
             elif self.header_end_pos == cursor_position:
                 return
             else:
                 self.stdkey_backspace()
+        elif key == Qt.Key_X and ctrl:
+            self.cut()
         else:
             CodeEditor.keyPressEvent(self, event)
 

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -88,10 +88,11 @@ class SpyderErrorDlg(QDialog):
 
     def _press_submit_btn(self):
         main = self.parent().main
-        issue_text  = main.render_issue(traceback=self.error_traceback)
+        description = self.input_description.toPlainText()
+        issue_text  = main.render_issue(description=description,
+                                        traceback=self.error_traceback)
         QApplication.clipboard().setText(issue_text)
-        main.report_issue(body="", title="Spyder Error Report")
-        self.accept()
+        main.report_issue(body="", title="Automatic error report")
 
     def append_traceback(self, text):
         """Append text to the traceback, to be displayed in details."""

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -1008,6 +1008,31 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         cursor.endEditBlock()
         self.ensureCursorVisible()
 
+    def set_selection(self, start, end):
+        cursor = self.textCursor()
+        cursor.setPosition(start)
+        cursor.setPosition(end, QTextCursor.KeepAnchor)
+        self.setTextCursor(cursor)
+
+    def truncate_selection(self, position_from):
+        """Unselect read-only parts in shell, like prompt"""
+        position_from = self.get_position(position_from)
+        cursor = self.textCursor()
+        start, end = cursor.selectionStart(), cursor.selectionEnd()
+        if start < end:
+            start = max([position_from, start])
+        else:
+            end = max([position_from, end])
+        self.set_selection(start, end)
+
+    def restrict_cursor_position(self, position_from, position_to):
+        """In shell, avoid editing text except between prompt and EOF"""
+        position_from = self.get_position(position_from)
+        position_to = self.get_position(position_to)
+        cursor = self.textCursor()
+        cursor_position = cursor.position()
+        if cursor_position < position_from or cursor_position > position_to:
+            self.set_cursor_position(position_to)
 
     #------Code completion / Calltips
     def hide_tooltip_if_necessary(self, key):
@@ -1335,32 +1360,6 @@ class ConsoleBaseWidget(TextEditBaseWidget):
                              foreground=QColor(Qt.lightGray))
         self.ansi_handler.set_light_background(state)
         self.set_pythonshell_font()
-        
-    def set_selection(self, start, end):
-        cursor = self.textCursor()
-        cursor.setPosition(start)
-        cursor.setPosition(end, QTextCursor.KeepAnchor)
-        self.setTextCursor(cursor)
-
-    def truncate_selection(self, position_from):
-        """Unselect read-only parts in shell, like prompt"""
-        position_from = self.get_position(position_from)
-        cursor = self.textCursor()
-        start, end = cursor.selectionStart(), cursor.selectionEnd()
-        if start < end:
-            start = max([position_from, start])
-        else:
-            end = max([position_from, end])
-        self.set_selection(start, end)
-
-    def restrict_cursor_position(self, position_from, position_to):
-        """In shell, avoid editing text except between prompt and EOF"""
-        position_from = self.get_position(position_from)
-        position_to = self.get_position(position_to)
-        cursor = self.textCursor()
-        cursor_position = cursor.position()
-        if cursor_position < position_from or cursor_position > position_to:
-            self.set_cursor_position(position_to)
 
     #------Python shell
     def insert_text(self, text):

--- a/spyder/widgets/tests/test_reporterror.py
+++ b/spyder/widgets/tests/test_reporterror.py
@@ -4,9 +4,7 @@
 # Licensed under the terms of the MIT License
 #
 
-"""
-Tests for error dialog
-"""
+"""Tests for report error dialog."""
 
 # 3rd party imports
 import pytest
@@ -18,14 +16,14 @@ from spyder.widgets.reporterror import SpyderErrorDialog
 
 @pytest.fixture
 def setup_dialog(qtbot):
-    """Set up dependency widget test."""
+    """Set up dialog."""
     widget = SpyderErrorDialog(None)
     qtbot.addWidget(widget)
     return widget
 
 
 def test_dialog(qtbot):
-    """Run dependency widget test."""
+    """Run dialog tests."""
     dlg = setup_dialog(qtbot)
     text = "123456789123456"
 

--- a/spyder/widgets/tests/test_reporterror.py
+++ b/spyder/widgets/tests/test_reporterror.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+#
+
+"""
+Tests for error dialog
+"""
+
+# 3rd party imports
+import pytest
+from qtpy.QtCore import Qt
+
+# Local imports
+from spyder.widgets.reporterror import SpyderErrorDialog
+
+
+@pytest.fixture
+def setup_dialog(qtbot):
+    """Set up dependency widget test."""
+    widget = SpyderErrorDialog(None)
+    qtbot.addWidget(widget)
+    return widget
+
+
+def test_dialog(qtbot):
+    """Run dependency widget test."""
+    dlg = setup_dialog(qtbot)
+    text = "123456789123456"
+
+    # Assert Submit button is disabled at first
+    assert not dlg.submit_btn.isEnabled()
+
+    # Introduce 15 chars to input_description
+    qtbot.keyClicks(dlg.input_description, text)
+
+    # Assert Submit button is now enabled
+    assert dlg.submit_btn.isEnabled()
+
+    # Assert cut leaves the header
+    dlg.input_description.selectAll()
+    dlg.input_description.cut()
+    assert dlg.input_description.toPlainText() == dlg.input_description.header
+
+    # Assert delete leaves the header
+    qtbot.keyClicks(dlg.input_description, text)
+    dlg.input_description.selectAll()
+    qtbot.keyPress(dlg.input_description, Qt.Key_Delete)
+    assert dlg.input_description.toPlainText() == dlg.input_description.header
+
+    # Assert backspace works as expected
+    qtbot.keyClicks(dlg.input_description, text)
+    qtbot.keyPress(dlg.input_description, Qt.Key_Backspace)
+    assert not dlg.submit_btn.isEnabled()
+
+    dlg.input_description.selectAll()
+    qtbot.keyPress(dlg.input_description, Qt.Key_Backspace)
+    assert dlg.input_description.toPlainText() == dlg.input_description.header
+
+    # Assert chars label works as expected
+    assert dlg.chars_label.text() == '15 more characters to go...'
+    qtbot.keyClicks(dlg.input_description, text)
+    assert dlg.chars_label.text() == 'Ready to submit! Thanks!'
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
Fixes #5247.

----

It looks like this, the ok button is activated when each text has more than 10 words, this has to be improved because it isn't obvious how the ok button will be activated

Also a button to dismiss and don't show the dialog again should be added 

![spectacle p15381](https://user-images.githubusercontent.com/2024217/30935134-59352f8e-a395-11e7-813c-bb30dfb5c573.png)

