### PR TITLE
PR: Add an error message when failing to serialize an object

### DIFF
--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -301,8 +301,12 @@ class NamespaceBrowser(QWidget):
 
     def set_value(self, name, value):
         """Set value for a variable."""
-        value = serialize_object(value)
-        self.shellwidget.set_value(name, value)
+        try:
+            value = serialize_object(value)
+            self.shellwidget.set_value(name, value)
+        except TypeError as e:
+            QMessageBox.critical(self, _("Error"),
+                                 "TypeError: %s" % to_text_string(e))
         self.refresh_table()
         
     def remove_values(self, names):


### PR DESCRIPTION
Fixes #5330

-------
This is a temporary fix waiting for #5341 (in Spyder 4). 
@ccordoba12 I was not really sure what you meant so the patch is very simple: just catch the error and display an error message to the user. 