### PR TITLE
PR: Add an option to the Editor to convert EOL characters on save

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -211,6 +211,8 @@ DEFAULTS = [
               'codecompletion/enter_key': True,
               'codecompletion/case_sensitive': True,
               'check_eol_chars': True,
+              'convert_eol_on_save': False,
+              'convert_eol_on_save_to': 'LF',
               'tab_always_indent': False,
               'intelligent_backspace': True,
               'highlight_current_line': True,

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -357,10 +357,29 @@ class EditorConfigPage(PluginConfigPage):
         check_eol_box = newcb(_("Fix automatically and show warning "
                                 "message box"),
                               'check_eol_chars', default=True)
+        convert_eol_on_save_box = newcb(_("On Save: convert EOL characters"
+                                          " to"),
+                                        'convert_eol_on_save', default=False)
+        eol_combo_choices = ((_("LF (UNIX)"), 'LF'),
+                             (_("CRLF (Windows)"), 'CRLF'),
+                             (_("CR (Mac)"), 'CR'),
+                             )
+        convert_eol_on_save_combo = self.create_combobox(_(""),
+                                                         eol_combo_choices,
+                                                         'convert_eol_on_save_to',
+                                                         )
+        convert_eol_on_save_box.toggled.connect(convert_eol_on_save_combo.setEnabled)
+        convert_eol_on_save_combo.setEnabled(
+                self.get_option('convert_eol_on_save'))
+
+        eol_on_save_layout = QHBoxLayout()
+        eol_on_save_layout.addWidget(convert_eol_on_save_box)
+        eol_on_save_layout.addWidget(convert_eol_on_save_combo)
 
         eol_layout = QVBoxLayout()
         eol_layout.addWidget(eol_label)
         eol_layout.addWidget(check_eol_box)
+        eol_layout.addLayout(eol_on_save_layout)
         eol_group.setLayout(eol_layout)
         
         tabs = QTabWidget()
@@ -1361,6 +1380,8 @@ class Editor(SpyderPluginWidget):
             ('set_tabbar_visible',                  'show_tab_bar'),
             ('set_classfunc_dropdown_visible',      'show_class_func_dropdown'),
             ('set_always_remove_trailing_spaces',   'always_remove_trailing_spaces'),
+            ('set_convert_eol_on_save',             'convert_eol_on_save'),
+            ('set_convert_eol_on_save_to',          'convert_eol_on_save_to'),
                     )
         for method, setting in settings:
             getattr(editorstack, method)(self.get_option(setting))
@@ -2614,6 +2635,10 @@ class Editor(SpyderPluginWidget):
             ibackspace_o = self.get_option(ibackspace_n)
             removetrail_n = 'always_remove_trailing_spaces'
             removetrail_o = self.get_option(removetrail_n)
+            converteol_n = 'convert_eol_on_save'
+            converteol_o = self.get_option(converteol_n)
+            converteolto_n = 'convert_eol_on_save_to'
+            converteolto_o = self.get_option(converteolto_n)
             autocomp_n = 'codecompletion/auto'
             autocomp_o = self.get_option(autocomp_n)
             case_comp_n = 'codecompletion/case_sensitive'
@@ -2676,6 +2701,10 @@ class Editor(SpyderPluginWidget):
                     editorstack.set_intelligent_backspace_enabled(ibackspace_o)
                 if removetrail_n in options:
                     editorstack.set_always_remove_trailing_spaces(removetrail_o)
+                if converteol_n in options:
+                    editorstack.set_convert_eol_on_save(converteol_o)
+                if converteolto_n in options:
+                    editorstack.set_convert_eol_on_save_to(converteolto_o)
                 if autocomp_n in options:
                     editorstack.set_codecompletion_auto_enabled(autocomp_o)
                 if case_comp_n in options:

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -364,7 +364,7 @@ class EditorConfigPage(PluginConfigPage):
                              (_("CRLF (Windows)"), 'CRLF'),
                              (_("CR (Mac)"), 'CR'),
                              )
-        convert_eol_on_save_combo = self.create_combobox(_(""),
+        convert_eol_on_save_combo = self.create_combobox("",
                                                          eol_combo_choices,
                                                          'convert_eol_on_save_to',
                                                          )

--- a/spyder/utils/sourcecode.py
+++ b/spyder/utils/sourcecode.py
@@ -56,8 +56,11 @@ def get_os_name_from_eol_chars(eol_chars):
 
 
 def get_eol_chars_from_os_name(os_name):
-    """Return EOL characters from OS name"""
-    for eol_chars, name in EOL_CHARS:
+    """Return EOL characters from OS name.
+
+    `os_name` can also be 'CR', 'CRLF', or 'LF'"""
+    extra_eol_chars = ("\r\n", 'CRLF'), ("\n", 'LF'), ("\r", 'CR')
+    for eol_chars, name in EOL_CHARS + extra_eol_chars:
         if name == os_name:
             return eol_chars
 

--- a/spyder/utils/sourcecode.py
+++ b/spyder/utils/sourcecode.py
@@ -56,11 +56,8 @@ def get_os_name_from_eol_chars(eol_chars):
 
 
 def get_eol_chars_from_os_name(os_name):
-    """Return EOL characters from OS name.
-
-    `os_name` can also be 'CR', 'CRLF', or 'LF'"""
-    extra_eol_chars = ("\r\n", 'CRLF'), ("\n", 'LF'), ("\r", 'CR')
-    for eol_chars, name in EOL_CHARS + extra_eol_chars:
+    """Return EOL characters from OS name"""
+    for eol_chars, name in EOL_CHARS:
         if name == os_name:
             return eol_chars
 

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -1596,10 +1596,7 @@ class EditorStack(QWidget):
         if self.always_remove_trailing_spaces:
             self.remove_trailing_spaces(index)
         if self.convert_eol_on_save:
-            # hack to account for the fact that the config file saves
-            # CR/LF/CRLF while set_os_eol_chars wants the os.name value.
-            osname_lookup = {'LF': 'posix', 'CRLF': 'nt', 'CR': 'mac'}
-            osname = osname_lookup[self.convert_eol_on_save_to]
+            osname = self.convert_eol_on_save_to
             self.set_os_eol_chars(osname=osname)
         txt = to_text_string(finfo.editor.get_text_with_eol())
         try:
@@ -2225,12 +2222,12 @@ class EditorStack(QWidget):
 
     def set_os_eol_chars(self, index=None, osname=None):
         """Sets the EOL character(s) based on the operating system.
-        
+
         If `osname` is None, then the default line endings for the current
         operating system (`os.name` value) will be used.
-        
+
         `osname` can be one of:
-            ('posix', 'nt', 'java')
+            ('posix', 'nt', 'java', 'CR', 'LF', 'CRFL')
         """
         if osname is None:
             osname = os.name

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -574,6 +574,8 @@ class EditorStack(QWidget):
         self.occurrence_highlighting_timeout=1500
         self.checkeolchars_enabled = True
         self.always_remove_trailing_spaces = False
+        self.convert_eol_on_save = False
+        self.convert_eol_on_save_to = 'LF'
         self.fullpath_sorting_enabled = None
         self.focus_to_editor = True
         self.set_fullpath_sorting_enabled(False)
@@ -1175,6 +1177,12 @@ class EditorStack(QWidget):
         # CONF.get(self.CONF_SECTION, 'always_remove_trailing_spaces')
         self.always_remove_trailing_spaces = state
 
+    def set_convert_eol_on_save(self, state):
+        self.convert_eol_on_save = state
+
+    def set_convert_eol_on_save_to(self, state):
+        self.convert_eol_on_save_to = state
+
     def set_focus_to_editor(self, state):
         self.focus_to_editor = state
 
@@ -1583,6 +1591,12 @@ class EditorStack(QWidget):
             return self.save_as(index=index)
         if self.always_remove_trailing_spaces:
             self.remove_trailing_spaces(index)
+        if self.convert_eol_on_save:
+            # hack to account for the fact that the config file saves
+            # CR/LF/CRLF while set_os_eol_chars wants the os.name value.
+            osname_lookup = {'LF': 'posix', 'CRLF': 'nt', 'CR': 'mac'}
+            osname = osname_lookup[self.convert_eol_on_save_to]
+            self.set_os_eol_chars(osname=osname)
         txt = to_text_string(finfo.editor.get_text_with_eol())
         try:
             finfo.encoding = encoding.write(txt, finfo.filename,

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -1596,7 +1596,10 @@ class EditorStack(QWidget):
         if self.always_remove_trailing_spaces:
             self.remove_trailing_spaces(index)
         if self.convert_eol_on_save:
-            osname = self.convert_eol_on_save_to
+            # hack to account for the fact that the config file saves
+            # CR/LF/CRLF while set_os_eol_chars wants the os.name value.
+            osname_lookup = {'LF': 'posix', 'CRLF': 'nt', 'CR': 'mac'}
+            osname = osname_lookup[self.convert_eol_on_save_to]
             self.set_os_eol_chars(osname=osname)
         txt = to_text_string(finfo.editor.get_text_with_eol())
         try:
@@ -2222,12 +2225,12 @@ class EditorStack(QWidget):
 
     def set_os_eol_chars(self, index=None, osname=None):
         """Sets the EOL character(s) based on the operating system.
-
+        
         If `osname` is None, then the default line endings for the current
         operating system (`os.name` value) will be used.
-
+        
         `osname` can be one of:
-            ('posix', 'nt', 'java', 'CR', 'LF', 'CRFL')
+            ('posix', 'nt', 'java')
         """
         if osname is None:
             osname = os.name

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -2205,11 +2205,13 @@ class EditorStack(QWidget):
         self.is_analysis_done = False
         return finfo
 
-    def set_os_eol_chars(self, index=None):
+    def set_os_eol_chars(self, index=None, osname=None):
+        if osname is None:
+            osname = os.name
         if index is None:
             index = self.get_stack_index()
         finfo = self.data[index]
-        eol_chars = sourcecode.get_eol_chars_from_os_name(os.name)
+        eol_chars = sourcecode.get_eol_chars_from_os_name(osname)
         finfo.editor.set_eol_chars(eol_chars)
         finfo.editor.document().setModified(True)
 

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -1178,9 +1178,13 @@ class EditorStack(QWidget):
         self.always_remove_trailing_spaces = state
 
     def set_convert_eol_on_save(self, state):
+        """If `state` is `True`, saving files will convert line endings."""
+        # CONF.get(self.CONF_SECTION, 'convert_eol_on_save')
         self.convert_eol_on_save = state
 
     def set_convert_eol_on_save_to(self, state):
+        """`state` can be one of ('LF', 'CRLF', 'CR')"""
+        # CONF.get(self.CONF_SECTION, 'convert_eol_on_save_to')
         self.convert_eol_on_save_to = state
 
     def set_focus_to_editor(self, state):
@@ -2220,6 +2224,14 @@ class EditorStack(QWidget):
         return finfo
 
     def set_os_eol_chars(self, index=None, osname=None):
+        """Sets the EOL character(s) based on the operating system.
+        
+        If `osname` is None, then the default line endings for the current
+        operating system (`os.name` value) will be used.
+        
+        `osname` can be one of:
+            ('posix', 'nt', 'java')
+        """
         if osname is None:
             osname = os.name
         if index is None:


### PR DESCRIPTION
This PR adds an option to the editor to convert EoL characters on save.

It simply adds another check to the `widgets.editor.EditorStack.save()` method, right after the remove_trailing_whitespace action.

The configuration was added to the `Editor -> Advanced settings` tab in the preferences and looks like so:

![image](https://user-images.githubusercontent.com/5386897/31040242-b9fddd66-a539-11e7-9f09-a90a40628c95.png)
![image](https://user-images.githubusercontent.com/5386897/31040245-c15f487e-a539-11e7-819c-3fcd8169ca07.png)

**Note:** At the time of submitting this PR, no unit tests are included - I might need some help with that if it's something I need to add. (e.g.: where are tests located? What's the procedure for testing something like this?)

This fixes #5365.