### PR TITLE
PR: Change spyderproject for spyproject in some missing places.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ Thumbs.db
 .DS_Store/
 spyder_crash.log
 .DS_Store
-.spyderproject
+.spyproject
 .idea/
 .cache
 .coverage

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -430,7 +430,7 @@ def running_in_mac_app():
 SAVED_CONFIG_FILES = ('help', 'onlinehelp', 'path', 'pylint.results',
                       'spyder.ini', 'temp.py', 'temp.spydata', 'template.py',
                       'history.py', 'history_internal.py', 'workingdir',
-                      '.projects', '.spyderproject', '.ropeproject',
+                      '.projects', '.spyproject', '.ropeproject',
                       'monitor.log', 'monitor_debug.log', 'rope.log',
                       'langconfig', 'spyder.lock')
 

--- a/spyder/widgets/projects/type/__init__.py
+++ b/spyder/widgets/projects/type/__init__.py
@@ -29,7 +29,7 @@ class BaseProject(object):
     This base class must not be used directly, but inherited from. It does not
     assume that python is specific to this project.
     """
-    PROJECT_FOLDER = '.spyderproject'
+    PROJECT_FOLDER = '.spyproject'
     PROJECT_TYPE_NAME = None
     IGNORE_FILE = ""
     CONFIG_SETUP = {WORKSPACE: {'filename': '{0}.ini'.format(WORKSPACE),


### PR DESCRIPTION
After the projects rewrite  #3377 `.spyderproject` was still in some places, e.g. `.spyproject` wasn't ignored because the `.gitignore` wasn't updated