### PR TITLE
PR: Fix crashing of the fileswitcher after closing the last file of the Editor.

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2794,7 +2794,6 @@ class MainWindow(QMainWindow):
             self.fileswitcher.plugin = self.editor
         else:
             self.fileswitcher.set_search_text('')
-        self.fileswitcher.setup()
         self.fileswitcher.show()
         self.fileswitcher.is_visible = True
 

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -817,7 +817,6 @@ class EditorStack(QWidget):
         self.fileswitcher_dlg = FileSwitcher(self, self, self.tabs, self.data,
                                              ima.icon('TextFileIcon'))
         self.fileswitcher_dlg.sig_goto_file.connect(self.set_stack_index)
-        self.fileswitcher_dlg.setup()
         self.fileswitcher_dlg.show()
         self.fileswitcher_dlg.is_visible = True
 

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -826,11 +826,6 @@ class EditorStack(QWidget):
         self.open_fileswitcher_dlg()
         self.fileswitcher_dlg.set_search_text('@')
         
-    def update_fileswitcher_dlg(self):
-        """Synchronize file list dialog box with editor widget tabs"""
-        if self.fileswitcher_dlg:
-            self.fileswitcher_dlg.setup()
-
     def get_current_tab_manager(self):
         """Get the widget with the TabWidget attribute."""
         return self
@@ -1170,7 +1165,6 @@ class EditorStack(QWidget):
         self.data.pop(index)
         self.tabs.blockSignals(False)
         self.update_actions()
-        self.update_fileswitcher_dlg()
 
     def __modified_readonly_title(self, title, is_modified, is_readonly):
         if is_modified is not None and is_modified:
@@ -1218,7 +1212,6 @@ class EditorStack(QWidget):
             self.set_stack_index(index)
             self.current_changed(index)
         self.update_actions()
-        self.update_fileswitcher_dlg()
 
     def __repopulate_stack(self):
         self.tabs.blockSignals(True)
@@ -1234,7 +1227,6 @@ class EditorStack(QWidget):
             index = self.tabs.addTab(finfo.editor, tab_text)
             self.tabs.setTabToolTip(index, tab_tip)
         self.tabs.blockSignals(False)
-        self.update_fileswitcher_dlg()
 
     def rename_in_data(self, index, new_filename):
         finfo = self.data[index]

--- a/spyder/widgets/fileswitcher.py
+++ b/spyder/widgets/fileswitcher.py
@@ -771,7 +771,10 @@ class FileSwitcher(QDialog):
         self.set_dialog_position()
 
     def show(self):
-        """Override Qt method."""
+        """
+        Override Qt method to force an update of the fileswitcher before
+        showing it. See Issue #5317 and PR #5389.
+        """
         self.setup()
         super(FileSwitcher, self).show()
 

--- a/spyder/widgets/fileswitcher.py
+++ b/spyder/widgets/fileswitcher.py
@@ -770,6 +770,11 @@ class FileSwitcher(QDialog):
         # Set position according to size
         self.set_dialog_position()
 
+    def show(self):
+        """Override Qt method."""
+        self.setup()
+        super(FileSwitcher, self).show()
+
     def add_plugin(self, plugin, tabs, data, icon):
         """Add a plugin to display its files."""
         self.plugins_tabs.append((tabs, plugin))


### PR DESCRIPTION
Fixes #5317 

Issues #5317 occurs when  `self.update_fileswitcher_dlg()` is called in the method [remove_from_data](https://github.com/spyder-ide/spyder/blob/master/spyder/widgets/editor.py#L1205) right after the last file has been closed in the Editor.

To fix this issue, I propose that we remove all calls to update the fileswitcher from the [Editor](https://github.com/spyder-ide/spyder/blob/master/spyder/widgets/editor.py) and the [MainWindow](https://github.com/spyder-ide/spyder/blob/master/spyder/app/mainwindow.py) and move it to the `show` method of the [FileSwitcher](https://github.com/spyder-ide/spyder/blob/master/spyder/widgets/fileswitcher.py).