### PR TITLE
PR: Fix PyQt4 compatibility issue with the QHeaderView class in findinfiles module

### DIFF
--- a/spyder/widgets/findinfiles.py
+++ b/spyder/widgets/findinfiles.py
@@ -22,6 +22,7 @@ import math
 import traceback
 
 # Third party imports
+from qtpy import PYQT5
 from qtpy.compat import getexistingdirectory
 from qtpy.QtGui import QAbstractTextDocumentLayout, QTextDocument
 from qtpy.QtCore import QMutex, QMutexLocker, Qt, QThread, Signal, Slot, QSize
@@ -653,7 +654,10 @@ class ResultsBrowser(OneColumnTree):
     def set_sorting(self, flag):
         """Enable result sorting after search is complete."""
         self.sorting['status'] = flag
-        self.header().setSectionsClickable(flag == ON)
+        if PYQT5:
+            self.header().setSectionsClickable(flag == ON)
+        else:
+            self.header().setClickable(flag == ON)
 
     @Slot(int)
     def sort_section(self, idx):


### PR DESCRIPTION
I've realised while looking at the tests that this PR is not the good way to solve Issue #5416. The problem should be already patch in `qtpy` and it should not be addressed in spyder directly.

----

The [setClickable](http://doc.qt.io/qt-4.8/qheaderview.html#setClickable) method in `QHeaderView` has been replaced in Qt4 by [setSectionsClickable ](http://doc.qt.io/qt-/qheaderview.html#setSectionsClickable) in Qt5.

I added a `if PYQT5` condition in the `findinfiles` module that will uses `setSectionsClickable` if PyQt5 is used and `setClickable` otherwise.

```python
if PYQT5:
    self.header().setSectionsClickable(flag == ON)
else:
    self.header().setClickable(flag == ON)
```
