### PR TITLE
PR: Add an error message when sorting a dataframe on categorical dtypes 

### DIFF
--- a/spyder/widgets/variableexplorer/dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/dataframeeditor.py
@@ -319,6 +319,10 @@ class DataFrameModel(QAbstractTableModel):
                     # Not possible to sort on duplicate columns #5225
                     QMessageBox.critical(self.dialog, "Error",
                                          "ValueError: %s" % to_text_string(e))
+                except SystemError as e:
+                    # Not possible to sort on category dtypes #5361
+                    QMessageBox.critical(self.dialog, "Error",
+                                         "SystemError: %s" % to_text_string(e))
                 self.update_df_index()
             else:
                 self.df.sort_index(inplace=True, ascending=ascending)

--- a/spyder/widgets/variableexplorer/tests/test_dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_dataframeeditor.py
@@ -246,5 +246,19 @@ def test_sort_dataframe_with_duplicate_column(qtbot):
     assert [data(dfm, row, 2) for row in range(len(df))] == ['4', '5', '6']
 
 
+def test_sort_dataframe_with_category_dtypes(qtbot):  # cf. issue 5361
+    df = DataFrame({'A': [1, 2, 3, 4],
+                    'B': ['a', 'b', 'c', 'd']})
+    df = df.astype(dtype={'B': 'category'})
+    df_cols = df.dtypes
+    editor = DataFrameEditor(None)
+    editor.setup_and_check(df_cols)
+    dfm = editor.dataModel
+    QTimer.singleShot(1000, lambda: close_message_box(qtbot))
+    editor.dataModel.sort(1)
+    assert data(dfm, 0, 1) == 'int64'
+    assert data(dfm, 1, 1) == 'category'
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Fixes #5361

-----
The error is caused by a bug in pandas. This PR just displays an error message to the user.
