### PR TITLE
PR: Don't rely on process name when detecting a previous instance

### DIFF
--- a/spyder/utils/external/lockfile.py
+++ b/spyder/utils/external/lockfile.py
@@ -182,10 +182,12 @@ class FilesystemLock:
                             conditions = ['spyder' in c.lower()
                                           for c in p.cmdline()]
                         else:
-                            conditions = [p.name() == 'spyder',
-                                          p.name() == 'spyder3']
-                        # For DEV
-                        conditions += ['bootstrap.py' in p.cmdline()]
+                            # Valid names for main script
+                            names = set(['spyder', 'spyder3', 'bootstrap.py'])
+                            # Check the first three command line arguments
+                            arguments = set(os.path.basename(arg)
+                                            for arg in p.cmdline()[:3])
+                            conditions = [names & arguments]
                         if not any(conditions):
                             raise(OSError(errno.ESRCH, 'No such process'))
                     except OSError as e:


### PR DESCRIPTION
Fixes #4186 

----

Instead of relying on the process name, up to the first three command line arguments are reduced to their basenames and compared against 'spyder', 'spyder3', and 'bootstrap.py'.

This should mimic the existing behavior and address cases where the process name does not show spyder.

When submitting this pull request, I found another option, using setproctitle. Will mention in #4186.