### PR TITLE
PR: Fix EditorSplitter menu_actions and add test.

### DIFF
--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -516,10 +516,9 @@ class EditorStack(QWidget):
            text= _("Show in external file explorer")
         external_fileexp_action = create_action(self, text,
                                 triggered=self.show_in_external_file_explorer)
-                
-        actions.append(external_fileexp_action)
-        
-        self.menu_actions = actions + [None, fileswitcher_action,
+
+        self.menu_actions = actions + [external_fileexp_action,
+                                       None, fileswitcher_action,
                                        symbolfinder_action,
                                        copy_to_cb_action, None, close_right,
                                        close_all_but_this]


### PR DESCRIPTION
Fixes #5475.  

In the editor menu, the option for 'Show in external file explorer' was shown multiple times, once for each time the editor panel was split.  This fix removes the code that changed a list parameter.

