### PR TITLE
PR: Reduce row height in dependencies dialog

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2351,7 +2351,6 @@ class MainWindow(QMainWindow):
         from spyder.widgets.dependencies import DependenciesDialog
         dlg = DependenciesDialog(None)
         dlg.set_data(dependencies.DEPENDENCIES)
-        dlg.show()
         dlg.exec_()
 
     @Slot()

--- a/spyder/widgets/dependencies.py
+++ b/spyder/widgets/dependencies.py
@@ -170,7 +170,15 @@ class DependenciesDialog(QDialog):
 
         self.setLayout(vlayout)
         self.resize(630, 420)
-        
+
+    def exec_(self):
+        self.show()
+        # we need an explicit show() because resizeRowsToContents() does only
+        # work correctly after the widget has been drawn. Without this the
+        # dimensions are not known yet.
+        self.view.resizeRowsToContents()
+        super(DependenciesDialog, self).exec_()
+
     def set_data(self, dependencies):
         self.view.model.set_data(dependencies)
         self.view.adjust_columns()


### PR DESCRIPTION
By default, Qt uses an unnecessarily large row height for tables. This results in not many rows being visible in the dependency dialog.

This patch reduces the row height of the dependency table.

Before:
![grafik](https://user-images.githubusercontent.com/2836374/31862415-bb51a588-b73d-11e7-80f5-dd6ac5b0829a.png)

After:
![grafik](https://user-images.githubusercontent.com/2836374/31862391-82beffae-b73d-11e7-9639-bcabd1a9b1cb.png)
