### PR TITLE
PR: Don't unescape control characteres in replace in selection

### DIFF
--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -29,14 +29,6 @@ from spyder.utils.qthelpers import create_toolbutton, get_icon
 from spyder.widgets.comboboxes import PatternComboBox
 
 
-CONTROL_CHARACTERS = {
-    '\\n': '\n',
-    '\\r': '\r',
-    '\\t': '\t',
-    '\\f': '\f'
-}
-
-
 def is_position_sup(pos1, pos2):
     """Return True is pos1 > pos2"""
     return pos1 > pos2
@@ -565,10 +557,8 @@ class FindReplace(QWidget):
                 cursor = self.editor.textCursor()
                 cursor.beginEditBlock()
                 cursor.removeSelectedText()
-                for plain_char in CONTROL_CHARACTERS:
-                    replacement = replacement.replace(
-                        plain_char, CONTROL_CHARACTERS[plain_char])
-                replacement = re.sub(r'\\(.)', r'\1', replacement)
+                if not self.re_button.isChecked():
+                    replacement = re.sub(r'\\(?![nrtf])(.)', r'\1', replacement)
                 cursor.insertText(replacement)
                 cursor.endEditBlock()
             if focus_replace_text:

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -320,19 +320,17 @@ def test_replace_enter_press(editor_find_replace_bot):
     qtbot.keyPress(finder.search_text, Qt.Key_Return, modifier=Qt.ShiftModifier)
     assert editor.get_cursor_line_column() == (3,4)
 
-def test_selection_replace_plain_regex(editor_find_replace_bot):
+def test_replace_plain_regex(editor_find_replace_bot):
     """Test that regex reserved characters are displayed as plain text."""
     editor_stack, editor, finder, qtbot = editor_find_replace_bot
     expected_new_text = ('.\\[()]*test bacon\n'
                          'spam sausage\n'
                          'spam egg')
-    old_text = editor.toPlainText()
     finder.show()
     finder.show_replace()
     qtbot.keyClicks(finder.search_text, 'spam')
     qtbot.keyClicks(finder.replace_text, '.\[()]*test')
     qtbot.keyPress(finder.replace_text, Qt.Key_Return)
-    text = editor.toPlainText()[0:-1]
     assert editor.toPlainText()[0:-1] == expected_new_text
 
 def test_replace_invalid_regex(editor_find_replace_bot):

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -350,6 +350,30 @@ def test_replace_invalid_regex(editor_find_replace_bot):
     qtbot.mouseClick(finder.replace_all_button, Qt.LeftButton)
     assert editor.toPlainText() == old_text
 
+
+def test_selection_escape_characters(editor_find_replace_bot):
+    editor_stack, editor, finder, qtbot = editor_find_replace_bot
+    expected_new_text = ('spam bacon\n'
+                         'spam sausage\n'
+                         'spam egg\n'
+                         '\\n \\t some escape characters')
+    qtbot.keyClicks(editor, '\\n \\t escape characters')
+
+    finder.show()
+    finder.show_replace()
+    qtbot.keyClicks(finder.search_text, 'escape')
+    qtbot.keyClicks(finder.replace_text, 'some escape')
+
+    # Select last line
+    cursor = editor.textCursor()
+    cursor.select(QTextCursor.LineUnderCursor)
+    assert cursor.selection().toPlainText() == "\\n \\t escape characters"
+
+    #replace
+    finder.replace_find_selection()
+    assert editor.toPlainText() == expected_new_text
+
+
 def test_advance_cell(editor_cells_bot):
     editor_stack, editor, qtbot = editor_cells_bot
 


### PR DESCRIPTION
Fixes #5494

the regex `\\(?![nrtf])(.)` will replace escaped characters like `\$`, `\#` for `$`, `#`; but won't replace `\n`, `\r`, `\t`, `\f`, for `n`, `r`, `t`, `f`