### PR TITLE
PR: Make clear line shortcut configurable in the IPython console

### DIFF
--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -349,12 +349,16 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                                     icon=ima.icon('MessageBoxInformation'),
                                     triggered=self.inspect_object)
         clear_line_action = create_action(self, _("Clear line or block"),
-                                          QKeySequence("Shift+Escape"),
+                                          QKeySequence(get_shortcut(
+                                                  'console',
+                                                  'clear line')),
                                           icon=ima.icon('editdelete'),
                                           triggered=self.clear_line)
         reset_namespace_action = create_action(self, _("Reset namespace"),
-                                          QKeySequence("Ctrl+Alt+R"),
-                                          triggered=self.reset_namespace)
+                                               QKeySequence(get_shortcut(
+                                                       'ipython_console',
+                                                       'reset namespace')),
+                                               triggered=self.reset_namespace)
         clear_console_action = create_action(self, _("Clear console"),
                                              QKeySequence(get_shortcut('console',
                                                                'clear shell')),

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -283,9 +283,12 @@ the sympy module (e.g. plot)
         array_table = config_shortcut(self._control.enter_array_table,
                                       context='array_builder',
                                       name='enter array table', parent=self)
+        clear_line = config_shortcut(self.ipyclient.clear_line,
+                                     context='console', name='clear line',
+                                     parent=self)
 
         return [inspect, clear_console, restart_kernel, new_tab,
-                reset_namespace, array_inline, array_table]
+                reset_namespace, array_inline, array_table, clear_line]
 
     # --- To communicate with the kernel
     def silent_execute(self, code):


### PR DESCRIPTION
Fixes: #5558

I'm not sure if it's the best solution because the `Shift+Esc` shortcut isn't replaced, instead a new shortcut is added for the same action