### PR TITLE
PR: Fix crash on empty project explorer context menu

### DIFF
--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -244,6 +244,8 @@ class DirView(QTreeView):
     def get_selected_filenames(self):
         """Return selected filenames"""
         if self.selectionMode() == self.ExtendedSelection:
+            if self.selectionModel() is None:
+                return []
             return [self.get_filename(idx) for idx in 
                     self.selectionModel().selectedRows()]
         else:

--- a/spyder/widgets/projects/explorer.py
+++ b/spyder/widgets/projects/explorer.py
@@ -187,7 +187,6 @@ class ProjectExplorerWidget(QWidget):
         self.treewidget.hide()
 
         self.emptywidget = ExplorerTreeWidget(self)
-        self.emptywidget.setup_view()
 
         if options_button:
             btn_layout = QHBoxLayout()

--- a/spyder/widgets/projects/explorer.py
+++ b/spyder/widgets/projects/explorer.py
@@ -187,6 +187,7 @@ class ProjectExplorerWidget(QWidget):
         self.treewidget.hide()
 
         self.emptywidget = ExplorerTreeWidget(self)
+        self.emptywidget.setup_view()
 
         if options_button:
             btn_layout = QHBoxLayout()


### PR DESCRIPTION
fixes #5594 

The fix works, even though, I'd recommend a change in the design. IMHO `setup_view()` should be part of the `__init__`, because it's necessary to obtain a fully functional (even if maybe emtpy) widget.