### PR TITLE
PR: Do not overwrite unmatched braces

### DIFF
--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2892,8 +2892,13 @@ class CodeEditor(TextEditBaseWidget):
             cursor.movePosition(QTextCursor.NextCharacter,
                                 QTextCursor.KeepAnchor)
             text = to_text_string(cursor.selectedText())
-            if text == {Qt.Key_ParenRight: ')', Qt.Key_BraceRight: '}',
-                        Qt.Key_BracketRight: ']'}[key]:
+            key_matches_next_char = (
+                text == {Qt.Key_ParenRight: ')', Qt.Key_BraceRight: '}',
+                         Qt.Key_BracketRight: ']'}[key]
+            )
+            if (key_matches_next_char
+              and not self.__unmatched_braces_in_line(cursor.block().text())):
+                # overwrite an existing brace if all braces in line are matched
                 cursor.clearSelection()
                 self.setTextCursor(cursor)
             else:

--- a/spyder/widgets/tests/test_codeeditor.py
+++ b/spyder/widgets/tests/test_codeeditor.py
@@ -55,3 +55,37 @@ def test_editor_lower_to_upper(editorbot):
     widget.transform_to_uppercase()
     new_text = widget.get_text('sof', 'eof')
     assert text != new_text
+
+def test_editor_complete_backet(editorbot):
+    qtbot, editor = editorbot
+    editor.textCursor().insertText('foo')
+    qtbot.keyClicks(editor, '(')
+    assert editor.toPlainText() == 'foo()'
+    assert editor.textCursor().columnNumber() == 4
+
+def test_editor_complete_bracket_nested(editorbot):
+    qtbot, editor = editorbot
+    editor.textCursor().insertText('foo(bar)')
+    editor.move_cursor(-1)
+    qtbot.keyClicks(editor, '(')
+    assert editor.toPlainText() == 'foo(bar())'
+    assert editor.textCursor().columnNumber() == 8
+
+def test_editor_bracket_closing(editorbot):
+    qtbot, editor = editorbot
+    editor.textCursor().insertText('foo(bar(x')
+    qtbot.keyClicks(editor, ')')
+    assert editor.toPlainText() == 'foo(bar(x)'
+    assert editor.textCursor().columnNumber() == 10
+    qtbot.keyClicks(editor, ')')
+    assert editor.toPlainText() == 'foo(bar(x))'
+    assert editor.textCursor().columnNumber() == 11
+    # same ')' closing with existing brackets starting at 'foo(bar(x|))'
+    editor.move_cursor(-2)
+    qtbot.keyClicks(editor, ')')
+    assert editor.toPlainText() == 'foo(bar(x))'
+    assert editor.textCursor().columnNumber() == 10
+    qtbot.keyClicks(editor, ')')
+    assert editor.toPlainText() == 'foo(bar(x))'
+    assert editor.textCursor().columnNumber() == 11
+


### PR DESCRIPTION
Fixes #5588

Sorry for the two char indentation, but the strict 80 char line limit give me really a hard time here. I don't see how one could format this reasonably otherwise without changing functionality (i.e. pre-evaluating `cursor.block().text()` and/or `__unmatched_braces_in_line()` even when that is not necessary because of `not key_matches_next_char`).