### PR TITLE
PR: Catch search regexp error while doing replace/find

### DIFF
--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -320,7 +320,6 @@ def test_replace_enter_press(editor_find_replace_bot):
     qtbot.keyPress(finder.search_text, Qt.Key_Return, modifier=Qt.ShiftModifier)
     assert editor.get_cursor_line_column() == (3,4)
 
-
 def test_selection_replace_plain_regex(editor_find_replace_bot):
     """Test that regex reserved characters are displayed as plain text."""
     editor_stack, editor, finder, qtbot = editor_find_replace_bot
@@ -335,6 +334,23 @@ def test_selection_replace_plain_regex(editor_find_replace_bot):
     qtbot.keyPress(finder.replace_text, Qt.Key_Return)
     text = editor.toPlainText()[0:-1]
     assert editor.toPlainText()[0:-1] == expected_new_text
+
+def test_replace_invalid_regex(editor_find_replace_bot):
+    """Assert that replacing an invalid regexp does nothing."""
+    editor_stack, editor, finder, qtbot = editor_find_replace_bot
+    old_text = editor.toPlainText()
+    finder.show()
+    finder.show_replace()
+    qtbot.keyClicks(finder.search_text, '\\')
+    qtbot.keyClicks(finder.replace_text, 'anything')
+    if not finder.re_button.isChecked():
+        qtbot.mouseClick(finder.re_button, Qt.LeftButton)
+    qtbot.mouseClick(finder.replace_button, Qt.LeftButton)
+    assert editor.toPlainText() == old_text
+    qtbot.mouseClick(finder.replace_sel_button, Qt.LeftButton)
+    assert editor.toPlainText() == old_text
+    qtbot.mouseClick(finder.replace_all_button, Qt.LeftButton)
+    assert editor.toPlainText() == old_text
 
 def test_advance_cell(editor_cells_bot):
     editor_stack, editor, qtbot = editor_cells_bot


### PR DESCRIPTION
fixes #5386

Perfroming `replace_find()` and `replace_find_selection()` with an invalid regexp used to raise an exception. After this patch, they will do nothing and silently return.