### PR TITLE
PR: Allow undo/redo on Source > Fix indentation

### DIFF
--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -907,12 +907,14 @@ class CodeEditor(TextEditBaseWidget):
         cursor.endEditBlock()
 
     def fix_indentation(self):
-        """Replace tabs by spaces"""
+        """Replace tabs by 4 spaces."""
         text_before = to_text_string(self.toPlainText())
         text_after = sourcecode.fix_indentation(text_before)
         if text_before != text_after:
-            self.setPlainText(text_after)
-            self.document().setModified(True)
+            # We do the following rather than using self.setPlainText
+            # to benefit from QTextEdit's undo/redo feature.
+            self.selectAll()
+            self.insertPlainText(text_after)
 
     def get_current_object(self):
         """Return current object (string) """

--- a/spyder/widgets/sourcecode/tests/test_indentation.py
+++ b/spyder/widgets/sourcecode/tests/test_indentation.py
@@ -67,7 +67,7 @@ def test_single_line_indent(code_editor_indent_bot):
 
 
 def test_selection_indent(code_editor_indent_bot):
-    """Test indentation with selection of more tha one line."""
+    """Test indentation with selection of more than one line."""
     editor, qtbot = code_editor_indent_bot
     text = ("class a():\n"
             "self.b = 1\n"
@@ -82,6 +82,36 @@ def test_selection_indent(code_editor_indent_bot):
                     "  print(self.b)\n"
                     "  \n"
                     )
+
+
+def test_fix_indentation(code_editor_indent_bot):
+    """Test fix_indentation() method."""
+    ed, qtbot = code_editor_indent_bot
+    # Contains tabs.
+    original = ("\t\n"
+                "class a():\t\n"
+                "\tself.b = 1\n"
+                "\tprint(self.b)\n"
+                "\n"
+                )
+    # Fix indentation replaces tabs with 4 spaces and not indent_chars spaces.
+    fixed = ("    \n"
+             "class a():    \n"
+             "    self.b = 1\n"
+             "    print(self.b)\n"
+             "\n"
+             )
+    ed.set_text(original)
+    ed.fix_indentation()
+    assert to_text_string(ed.toPlainText()) == fixed
+    assert ed.document().isModified()
+    # Test that undo/redo works - issue 1754.
+    ed.undo()
+    assert to_text_string(ed.toPlainText()) == original
+    assert not ed.document().isModified()
+    ed.redo()
+    assert to_text_string(ed.toPlainText()) == fixed
+    assert ed.document().isModified()
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/sourcecode/tests/test_indentation.py
+++ b/spyder/widgets/sourcecode/tests/test_indentation.py
@@ -86,7 +86,7 @@ def test_selection_indent(code_editor_indent_bot):
 
 def test_fix_indentation(code_editor_indent_bot):
     """Test fix_indentation() method."""
-    ed, qtbot = code_editor_indent_bot
+    editor, qtbot = code_editor_indent_bot
     # Contains tabs.
     original = ("\t\n"
                 "class a():\t\n"
@@ -101,17 +101,17 @@ def test_fix_indentation(code_editor_indent_bot):
              "    print(self.b)\n"
              "\n"
              )
-    ed.set_text(original)
-    ed.fix_indentation()
-    assert to_text_string(ed.toPlainText()) == fixed
-    assert ed.document().isModified()
+    editor.set_text(original)
+    editor.fix_indentation()
+    assert to_text_string(editor.toPlainText()) == fixed
+    assert editor.document().isModified()
     # Test that undo/redo works - issue 1754.
-    ed.undo()
-    assert to_text_string(ed.toPlainText()) == original
-    assert not ed.document().isModified()
-    ed.redo()
-    assert to_text_string(ed.toPlainText()) == fixed
-    assert ed.document().isModified()
+    editor.undo()
+    assert to_text_string(editor.toPlainText()) == original
+    assert not editor.document().isModified()
+    editor.redo()
+    assert to_text_string(editor.toPlainText()) == fixed
+    assert editor.document().isModified()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes issue #1754.

`Fix indentation` converts all the tabs in a document to 4 spaces.  Allow undo/redo on this operation.