### PR TITLE
PR: Convert command line options from optparse to argparse

### DIFF
--- a/spyder/app/cli_options.py
+++ b/spyder/app/cli_options.py
@@ -6,7 +6,7 @@
 
 import argparse
 
-def get_options():
+def get_options(argv=None):
     """
     Convert options into commands
     return commands, message
@@ -44,6 +44,6 @@ def get_options():
                       dest="open_project",
                       help="Path that contains an Spyder project")
     parser.add_argument('files', nargs='*')
-    options = parser.parse_args()
+    options = parser.parse_args(argv)
     args = options.files
     return options, args

--- a/spyder/app/cli_options.py
+++ b/spyder/app/cli_options.py
@@ -4,44 +4,46 @@
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
 
-import optparse
+import argparse
 
 def get_options():
     """
     Convert options into commands
     return commands, message
     """
-    parser = optparse.OptionParser(usage="spyder [options] files")
-    parser.add_option('--new-instance', action='store_true', default=False,
+    parser = argparse.ArgumentParser(usage="spyder [options] files")
+    parser.add_argument('--new-instance', action='store_true', default=False,
                       help="Run a new instance of Spyder, even if the single "
                            "instance mode has been turned on (default)")
-    parser.add_option('--defaults', dest="reset_to_defaults",
+    parser.add_argument('--defaults', dest="reset_to_defaults",
                       action='store_true', default=False,
                       help="Reset configuration settings to defaults")
-    parser.add_option('--reset', dest="reset_config_files",
+    parser.add_argument('--reset', dest="reset_config_files",
                       action='store_true', default=False,
                       help="Remove all configuration files!")
-    parser.add_option('--optimize', action='store_true', default=False,
+    parser.add_argument('--optimize', action='store_true', default=False,
                       help="Optimize Spyder bytecode (this may require "
                            "administrative privileges)")
-    parser.add_option('-w', '--workdir', dest="working_directory", default=None,
+    parser.add_argument('-w', '--workdir', dest="working_directory", default=None,
                       help="Default working directory")
-    parser.add_option('--hide-console', action='store_true', default=False,
+    parser.add_argument('--hide-console', action='store_true', default=False,
                       help="Hide parent console window (Windows)")
-    parser.add_option('--show-console', action='store_true', default=False,
+    parser.add_argument('--show-console', action='store_true', default=False,
                       help="(Deprecated) Does nothing, now the default behavior "
                       "is to show the console")
-    parser.add_option('--multithread', dest="multithreaded",
+    parser.add_argument('--multithread', dest="multithreaded",
                       action='store_true', default=False,
                       help="Internal console is executed in another thread "
                            "(separate from main application thread)")
-    parser.add_option('--profile', action='store_true', default=False,
+    parser.add_argument('--profile', action='store_true', default=False,
                       help="Profile mode (internal test, "
                            "not related with Python profiling)")
-    parser.add_option('--window-title', type=str, default=None,
+    parser.add_argument('--window-title', type=str, default=None,
                       help="String to show in the main window title")
-    parser.add_option('-p', '--project', default=None, type=str,
+    parser.add_argument('-p', '--project', default=None, type=str,
                       dest="open_project",
                       help="Path that contains an Spyder project")
-    options, args = parser.parse_args()
+    parser.add_argument('files', nargs='*')
+    options = parser.parse_args()
+    args = options.files
     return options, args

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3036,7 +3036,7 @@ def main():
     # **** Collect command line options ****
     # Note regarding Options:
     # It's important to collect options before monkey patching sys.exit,
-    # otherwise, optparse won't be able to exit if --help option is passed
+    # otherwise, argparse won't be able to exit if --help option is passed
     options, args = get_options()
 
     if options.show_console:

--- a/spyder/app/tests/test_cli_options.py
+++ b/spyder/app/tests/test_cli_options.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+#
+
+"""
+Tests for cli_options.py
+"""
+import pytest
+from spyder.app import cli_options
+
+
+def test_get_options():
+    getopt = cli_options.get_options
+
+    options, args = getopt([])
+    assert not options.new_instance
+    assert not options.reset_to_defaults
+    assert not options.reset_config_files
+    assert not options.optimize
+    assert options.working_directory is None
+    assert not options.hide_console
+    assert not options.show_console
+    assert not options.multithreaded
+    assert not options.profile
+    assert options.window_title is None
+    assert options.open_project is None
+    assert options.files == []
+    assert args == []
+
+    options, args = getopt(['--new-instance'])
+    assert options.new_instance
+
+    options, args = getopt(['--defaults', '--reset'])
+    assert options.reset_to_defaults
+    assert options.reset_config_files
+
+    options, args = getopt(['--optimize', '--workdir', 'test dir'])
+    assert options.optimize
+    assert options.working_directory == 'test dir'
+
+    options, args = getopt('--window-title MyWindow'.split())
+    assert options.window_title == 'MyWindow'
+
+    options, args = getopt('-p myproject test_file.py another_file.py'.split())
+    assert options.open_project == 'myproject'
+    assert options.files == ['test_file.py', 'another_file.py']
+    assert args == ['test_file.py', 'another_file.py']
+
+    with pytest.raises(SystemExit):
+        options, args = getopt(['--version'])
+
+    # Requires string.
+    with pytest.raises(SystemExit):
+        options, args = getopt(['-w'])
+
+    # Requires string.
+    with pytest.raises(SystemExit):
+        options, args = getopt(['-p'])
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
Fixes #5639.

I tried to minimize the changes by keeping the return value from `cli_options.py` the same as it was before, even though `parse_args` returns one value instead of two.