### PR TITLE
PR: Prevent Editor dockwidget to become visible when clicking on the outline explorer if the Editor is in a separate window

### DIFF
--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -1877,15 +1877,23 @@ class Editor(SpyderPluginWidget):
                 filenames = [osp.normpath(fname) for fname in filenames]
             else:
                 return
-            
+
         focus_widget = QApplication.focusWidget()
-        if self.dockwidget and not self.ismaximized and\
-           (not self.dockwidget.isAncestorOf(focus_widget)\
-            and not isinstance(focus_widget, CodeEditor)):
+        if self.editorwindows and not self.dockwidget.isVisible():
+            # We override the editorwindow variable to force a focus on
+            # the editor window instead of the hidden editor dockwidget.
+            # See PR #5742.
+            if editorwindow not in self.editorwindows:
+                editorwindow = self.editorwindows[0]
+            editorwindow.setFocus()
+            editorwindow.raise_()
+        elif (self.dockwidget and not self.ismaximized
+              and not self.dockwidget.isAncestorOf(focus_widget)
+              and not isinstance(focus_widget, CodeEditor)):
             self.dockwidget.setVisible(True)
             self.dockwidget.setFocus()
             self.dockwidget.raise_()
-        
+
         def _convert(fname):
             fname = osp.abspath(encoding.to_unicode_from_fs(fname))
             if os.name == 'nt' and len(fname) >= 2 and fname[1] == ':':


### PR DESCRIPTION
Fixes #2883 

Before PR #3824, Issue #2883 was hard to reproduce. But now that separate windows are created by default when undocking widgets, this issue has become easily reproducible and is much more annoying. One simply has to undock the editor and click on the outline explorer to trigger it (see animation below).

This is due to the fact that a `setVisible(True)`, `setFocus()` and `raise_()` is systematically called on the editor dockwidget in the [load](https://github.com/spyder-ide/spyder/blob/master/spyder/plugins/editor.py#L2033) method, which is the method that is connected to the action of clicking on the outline explorer. To fix Issue #2883, we simply have to prevent these calls when the editor is in a separate window and call `setFocus` and `raise_()` on this separate window instead.

![outline_focus_dockwidget](https://user-images.githubusercontent.com/10170372/32764375-1ddd672c-c8d3-11e7-8a44-384d88ac34e9.gif)