### PR TITLE
PR:  Simplify how pyopengl is declared in setup.py

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,14 +16,6 @@ To release a new version of Spyder you need to follow these steps:
 
 * python setup.py sdist upload
 
-* python2 setup.py bdist_wheel --plat-name manylinux1_x86_64 upload
-
-* python3 setup.py bdist_wheel --plat-name manylinux1_x86_64 upload
-
-* python2 setup.py bdist_wheel --plat-name manylinux1_i686 upload
-
-* python3 setup.py bdist_wheel --plat-name manylinux1_i686 upload
-
 * python2 setup.py bdist_wheel upload
 
 * python3 setup.py bdist_wheel upload

--- a/setup.py
+++ b/setup.py
@@ -287,13 +287,11 @@ install_requires = [
     'pickleshare',
     'pyzmq',
     'chardet>=2.0.0',
-    'numpydoc'
+    'numpydoc',
+    # This is only needed for our wheels on Linux.
+    # See issue #3332
+    'pyopengl;platform_system=="Linux"'
 ]
-
-# This is needed only for pip installations on Linux.
-# See issue #3332
-if any([arg.startswith('manylinux1') for arg in sys.argv]):
-    install_requires = install_requires + ['pyopengl']
 
 extras_require = {
     'test:python_version == "2.7"': ['mock'],


### PR DESCRIPTION
This will avoid us to build wheels for Linux.