### PR TITLE
PR: Disable smartpants quotes in Sphinx to prevent crash with MathJax

### DIFF
--- a/spyder/utils/help/conf.py
+++ b/spyder/utils/help/conf.py
@@ -99,7 +99,8 @@ html_context = {}
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# Spyder: Disabled to fix conflict with qtwebview and mathjax. See issue #5514
+html_use_smartypants = False
 
 # If false, no module index is generated.
 html_use_modindex = False


### PR DESCRIPTION
This fixes #5514 by disabling smartypants quotes in sphinx to fix the crash in the help widget.  See #5514 for more details 

This is a work around of course, but it is simple. Hopefully next time anaconda compiles Qt the problem will be fixed.