### PR TITLE
PR: Don't add extra newline when using new file template

### DIFF
--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -431,7 +431,7 @@ class Editor(SpyderPluginWidget):
             header = shebang + [
                 '# -*- coding: utf-8 -*-',
                 '"""', 'Created on %(date)s', '',
-                '@author: %(username)s', '"""', '']
+                '@author: %(username)s', '"""', '', '']
             encoding.write(os.linesep.join(header), self.TEMPLATE_PATH, 'utf-8')
 
         self.projects = None

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -2307,7 +2307,8 @@ class EditorStack(QWidget):
         finfo = self.create_new_editor(filename, encoding, text,
                                        set_current=False, new=True)
         finfo.editor.set_cursor_position('eof')
-        finfo.editor.insert_text(os.linesep)
+        if not default_content:
+            finfo.editor.insert_text(os.linesep)
         if default_content:
             finfo.default = True
             finfo.editor.document().setModified(False)


### PR DESCRIPTION
Fixes #1584.

When pulling in the default template for a new file, don't add a newline.
