### PR TITLE
PR: Remove `if/else/try/for` statements from the outline explorer tree

### DIFF
--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -394,8 +394,8 @@ class OutlineExplorerTreeWidget(OneColumnTree):
                 cname = to_text_string(citem.text(0))
 
             preceding = root_item if previous_item is None else previous_item
-            if not_class_nor_function:
-                if data.is_comment() and not self.show_comments:
+            if not_class_nor_function and data.is_comment():
+                if not self.show_comments:
                     if citem is not None:
                         remove_from_tree_cache(tree_cache, line=line_nb)
                     continue
@@ -406,15 +406,10 @@ class OutlineExplorerTreeWidget(OneColumnTree):
                         continue
                     else:
                         remove_from_tree_cache(tree_cache, line=line_nb)
-
-                if data.is_comment():
-                    if data.def_type == data.CELL:
-                        item = CellItem(data.text, line_nb, parent, preceding)
-                    else:
-                        item = CommentItem(
-                            data.text, line_nb, parent, preceding)
+                if data.def_type == data.CELL:
+                    item = CellItem(data.text, line_nb, parent, preceding)
                 else:
-                    item = TreeItem(data.text, line_nb, parent, preceding)
+                    item = CommentItem(data.text, line_nb, parent, preceding)
             elif class_name is not None:
                 if citem is not None:
                     if class_name == cname and level == clevel:

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -371,6 +371,12 @@ class OutlineExplorerTreeWidget(OneColumnTree):
                             remove_from_tree_cache(tree_cache, line=line_nb)
                         continue
 
+            # Skip iteration for if/else/try/for/etc foldable blocks.
+            if not_class_nor_function and not data.is_comment():
+                if citem is not None:
+                    remove_from_tree_cache(tree_cache, line=line_nb)
+                continue
+
             if previous_level is not None:
                 if level == previous_level:
                     pass

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -331,6 +331,10 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         self.sort_top_level_items(key=sort_func)
             
     def populate_branch(self, editor, root_item, tree_cache=None):
+        """
+        Generates an outline of the editor's content and stores the result
+        in a cache.
+        """
         if tree_cache is None:
             tree_cache = {}
         

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -329,23 +329,23 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         else:
             sort_func = lambda item: osp.basename(item.path.lower())
         self.sort_top_level_items(key=sort_func)
-
+            
     def populate_branch(self, editor, root_item, tree_cache=None):
         if tree_cache is None:
             tree_cache = {}
-
+        
         # Removing cached items for which line is > total line nb
         for _l in list(tree_cache.keys()):
             if _l >= editor.get_line_count():
-                # Checking if key is still in tree cache in case one of its
+                # Checking if key is still in tree cache in case one of its 
                 # ancestors was deleted in the meantime (deleting all children):
                 if _l in tree_cache:
                     remove_from_tree_cache(tree_cache, line=_l)
-
+                    
         ancestors = [(root_item, 0)]
         previous_item = None
         previous_level = None
-
+        
         oe_data = editor.highlighter.get_outlineexplorer_data()
         editor.has_cell_separators = oe_data.get('found_cell_separators', False)
         for block_nb in range(editor.get_line_count()):
@@ -353,13 +353,13 @@ class OutlineExplorerTreeWidget(OneColumnTree):
             data = oe_data.get(block_nb)
             level = None if data is None else data.fold_level
             citem, clevel, _d = tree_cache.get(line_nb, (None, None, ""))
-
+            
             # Skip iteration if line is not the first line of a foldable block
             if level is None:
                 if citem is not None:
                     remove_from_tree_cache(tree_cache, line=line_nb)
                 continue
-
+            
             # Searching for class/function statements
             not_class_nor_function = data.is_not_class_nor_function()
             if not not_class_nor_function:
@@ -380,7 +380,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
             if previous_level is not None:
                 if level == previous_level:
                     pass
-                elif level > previous_level+4:  # Invalid indentation
+                elif level > previous_level+4: # Invalid indentation
                     continue
                 elif level > previous_level:
                     ancestors.append((previous_item, previous_level))
@@ -389,7 +389,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
                         ancestors.pop(-1)
                         _item, previous_level = ancestors[-1]
             parent, _level = ancestors[-1]
-
+            
             if citem is not None:
                 cname = to_text_string(citem.text(0))
 
@@ -428,7 +428,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
                     else:
                         remove_from_tree_cache(tree_cache, line=line_nb)
                 item = FunctionItem(func_name, line_nb, parent, preceding)
-
+                
             item.setup()
             debug = "%s -- %s/%s" % (str(item.line).rjust(6),
                                      to_text_string(item.parent().text(0)),
@@ -436,7 +436,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
             tree_cache[line_nb] = (item, level, debug)
             previous_level = level
             previous_item = item
-
+            
         return tree_cache
 
     def root_item_selected(self, item):

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -329,19 +329,19 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         else:
             sort_func = lambda item: osp.basename(item.path.lower())
         self.sort_top_level_items(key=sort_func)
-            
+
     def populate_branch(self, editor, root_item, tree_cache=None):
         if tree_cache is None:
             tree_cache = {}
-        
+
         # Removing cached items for which line is > total line nb
         for _l in list(tree_cache.keys()):
             if _l >= editor.get_line_count():
-                # Checking if key is still in tree cache in case one of its 
+                # Checking if key is still in tree cache in case one of its
                 # ancestors was deleted in the meantime (deleting all children):
                 if _l in tree_cache:
                     remove_from_tree_cache(tree_cache, line=_l)
-                    
+
         ancestors = [(root_item, 0)]
         previous_item = None
         previous_level = None

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -392,7 +392,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
             
             if citem is not None:
                 cname = to_text_string(citem.text(0))
-
+                
             preceding = root_item if previous_item is None else previous_item
             if not_class_nor_function and data.is_comment():
                 if not self.show_comments:

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -351,10 +351,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         for block_nb in range(editor.get_line_count()):
             line_nb = block_nb+1
             data = oe_data.get(block_nb)
-            if data is None:
-                level = None
-            else:
-                level = data.fold_level
+            level = None if data is None else data.fold_level
             citem, clevel, _d = tree_cache.get(line_nb, (None, None, ""))
             
             # Skip iteration if line is not the first line of a foldable block

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -345,7 +345,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         ancestors = [(root_item, 0)]
         previous_item = None
         previous_level = None
-        
+
         oe_data = editor.highlighter.get_outlineexplorer_data()
         editor.has_cell_separators = oe_data.get('found_cell_separators', False)
         for block_nb in range(editor.get_line_count()):
@@ -353,13 +353,13 @@ class OutlineExplorerTreeWidget(OneColumnTree):
             data = oe_data.get(block_nb)
             level = None if data is None else data.fold_level
             citem, clevel, _d = tree_cache.get(line_nb, (None, None, ""))
-            
+
             # Skip iteration if line is not the first line of a foldable block
             if level is None:
                 if citem is not None:
                     remove_from_tree_cache(tree_cache, line=line_nb)
                 continue
-            
+
             # Searching for class/function statements
             not_class_nor_function = data.is_not_class_nor_function()
             if not not_class_nor_function:
@@ -370,11 +370,11 @@ class OutlineExplorerTreeWidget(OneColumnTree):
                         if citem is not None:
                             remove_from_tree_cache(tree_cache, line=line_nb)
                         continue
-                
+
             if previous_level is not None:
                 if level == previous_level:
                     pass
-                elif level > previous_level+4: # Invalid indentation
+                elif level > previous_level+4:  # Invalid indentation
                     continue
                 elif level > previous_level:
                     ancestors.append((previous_item, previous_level))
@@ -383,10 +383,10 @@ class OutlineExplorerTreeWidget(OneColumnTree):
                         ancestors.pop(-1)
                         _item, previous_level = ancestors[-1]
             parent, _level = ancestors[-1]
-            
+
             if citem is not None:
                 cname = to_text_string(citem.text(0))
-                
+
             preceding = root_item if previous_item is None else previous_item
             if not_class_nor_function:
                 if data.is_comment() and not self.show_comments:
@@ -400,6 +400,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
                         continue
                     else:
                         remove_from_tree_cache(tree_cache, line=line_nb)
+
                 if data.is_comment():
                     if data.def_type == data.CELL:
                         item = CellItem(data.text, line_nb, parent, preceding)
@@ -426,7 +427,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
                     else:
                         remove_from_tree_cache(tree_cache, line=line_nb)
                 item = FunctionItem(func_name, line_nb, parent, preceding)
-                
+
             item.setup()
             debug = "%s -- %s/%s" % (str(item.line).rjust(6),
                                      to_text_string(item.parent().text(0)),
@@ -434,7 +435,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
             tree_cache[line_nb] = (item, level, debug)
             previous_level = level
             previous_item = item
-            
+
         return tree_cache
 
     def root_item_selected(self, item):

--- a/spyder/widgets/tests/test_editortools.py
+++ b/spyder/widgets/tests/test_editortools.py
@@ -5,7 +5,7 @@
 #
 
 """
-Tests for editor.py
+Tests for editortool.py
 """
 
 # Third party imports
@@ -71,10 +71,16 @@ def outline_explorer_bot(qtbot):
     outline_explorer.set_current_editor(
             editor, 'test_outline_explorer.py', False, False)
 
+    qtbot.addWidget(outline_explorer)
+
     return outline_explorer, qtbot
 
 
+# Test OutlineExplorerWidget
+# -------------------------------
+
 def test_outline_explorer(outline_explorer_bot):
+    """Basic test to asser the outline explorer is initializing correctly."""
     outline_explorer, qtbot = outline_explorer_bot
     outline_explorer.show()
     outline_explorer.setFixedSize(400, 350)

--- a/spyder/widgets/tests/test_editortools.py
+++ b/spyder/widgets/tests/test_editortools.py
@@ -12,7 +12,9 @@ Tests for editortool.py
 import pytest
 
 # Local imports
-from spyder.widgets.editortools import OutlineExplorerWidget
+from spyder.widgets.editortools import (OutlineExplorerWidget, FileRootItem,
+                                        FunctionItem, CommentItem, CellItem,
+                                        ClassItem)
 from spyder.widgets.sourcecode.codeeditor import CodeEditor
 
 
@@ -28,7 +30,7 @@ text = ("# -*- coding: utf-8 -*-\n"
         "        print(i)\n"
         "\n"
         "\n"
-        "def func3():\n"
+        "def func2():\n"
         "    if True:\n"
         "        pass\n"
         "\n"
@@ -80,11 +82,41 @@ def outline_explorer_bot(qtbot):
 # -------------------------------
 
 def test_outline_explorer(outline_explorer_bot):
-    """Basic test to asser the outline explorer is initializing correctly."""
+    """
+    Test to assert the outline explorer is initializing correctly and
+    is showing the expected number of items, the expected type of items, and
+    the expected text for each item.
+    """
     outline_explorer, qtbot = outline_explorer_bot
     outline_explorer.show()
     outline_explorer.setFixedSize(400, 350)
     assert outline_explorer
+
+    outline_explorer.treewidget.expandAll()
+    tree_widget = outline_explorer.treewidget
+    all_items = tree_widget.get_top_level_items() + tree_widget.get_items()
+
+    # Assert that the expected number, text and type of items is displayed in
+    # the tree.
+    expected_results = [('test_outline_explorer.py', FileRootItem),
+                        ('functions', CellItem),
+                        ('---- func 1 and 2', CommentItem),
+                        ('func1', FunctionItem, False),
+                        ('func2', FunctionItem, False),
+                        ('---- func 3', CommentItem),
+                        ('func3', FunctionItem, False),
+                        ('classes', CellItem),
+                        ('class1', ClassItem),
+                        ('__ini__', FunctionItem, True),
+                        ('method1', FunctionItem, True),
+                        ('method2', FunctionItem, True)]
+
+    assert len(all_items) == len(expected_results)
+    for item, expected_result in zip(all_items, expected_results):
+        assert item.text(0) == expected_result[0]
+        assert type(item) == expected_result[1]
+        if type(item) == FunctionItem:
+            assert item.is_method() == expected_result[2]
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/tests/test_outline_explorer.py
+++ b/spyder/widgets/tests/test_outline_explorer.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+#
+
+"""
+Tests for editor.py
+"""
+
+# Third party imports
+import pytest
+
+# Local imports
+from spyder.widgets.editortools import OutlineExplorerWidget
+from spyder.widgets.sourcecode.codeeditor import CodeEditor
+
+
+text = ("# -*- coding: utf-8 -*-\n"
+        "\n"
+        "# %% functions\n"
+        "\n"
+        "\n"
+        "# ---- func 1 and 2\n"
+        "\n"
+        "def func1():\n"
+        "    for i in range(3):\n"
+        "        print(i)\n"
+        "\n"
+        "\n"
+        "def func3():\n"
+        "    if True:\n"
+        "        pass\n"
+        "\n"
+        "\n"
+        "# ---- func 3\n"
+        "\n"
+        "def func3():\n"
+        "    pass\n"
+        "\n"
+        "\n"
+        "# %% classes\n"
+        "\n"
+        "class class1(object):\n"
+        "\n"
+        "    def __ini__(self):\n"
+        "        super(class1, self).__init__()\n"
+        "\n"
+        "    def method1(self):\n"
+        "        if False:\n"
+        "            pass\n"
+        "\n"
+        "    def method2(self):\n"
+        "        try:\n"
+        "            assert 2 == 3\n"
+        "        except AssertionError:\n"
+        "            pass")
+
+
+# Qt Test Fixtures
+# --------------------------------
+
+@pytest.fixture
+def outline_explorer_bot(qtbot):
+    editor = CodeEditor()
+    editor = CodeEditor(None)
+    editor.set_language('py', 'test_outline_explorer.py')
+    editor.set_text(text)
+
+    outline_explorer = OutlineExplorerWidget()
+    outline_explorer.set_current_editor(
+            editor, 'test_outline_explorer.py', False, False)
+
+    return outline_explorer, qtbot
+
+
+def test_outline_explorer(outline_explorer_bot):
+    outline_explorer, qtbot = outline_explorer_bot
+    outline_explorer.show()
+    outline_explorer.setFixedSize(400, 350)
+    assert outline_explorer
+
+
+if __name__ == "__main__":
+    import os
+    pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])


### PR DESCRIPTION
Fixes #5821

- [x] Fixes issue in the code
- [x] Write tests

The goal of this PR is to prevent `if/else/try/for` statements from showing in the outline explorer tree.

![image](https://user-images.githubusercontent.com/10170372/33271861-702a8b4e-d356-11e7-9498-0116ef3abf6b.png)