### PR TITLE
PR: Add PyQt5 as a new wheel dependency

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -15,3 +15,4 @@ pickleshare
 pyzmq
 chardet>=2.0.0
 numpydoc
+pyqt5

--- a/setup.py
+++ b/setup.py
@@ -289,6 +289,7 @@ install_requires = [
     'pyzmq',
     'chardet>=2.0.0',
     'numpydoc',
+    'pyqt5',
     # This is only needed for our wheels on Linux.
     # See issue #3332
     'pyopengl;platform_system=="Linux"'


### PR DESCRIPTION
Fixes #3242.

Just added PyQt5 as dependency; nothing else.
See issues #3242, #5736. 