### PR TITLE
PR: Several improvements to the IPython console

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -162,8 +162,7 @@ DEFAULTS = [
               'symbolic_math': False,
               'in_prompt': '',
               'out_prompt': '',
-              'light_color': True,
-              'dark_color': False
+              'show_elapsed_time': False
               }),
             ('variable_explorer',
              {
@@ -635,7 +634,7 @@ DEFAULTS = [
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '41.0.0'
+CONF_VERSION = '42.0.0'
 
 # Main configuration instance
 try:

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -305,6 +305,7 @@ class IPythonConsoleConfigPage(PluginConfigPage):
                 'show_reset_namespace_warning',
                 tip=_("This option lets you hide the warning message shown\n"
                       "when resetting the namespace from Spyder."))
+        show_time_box = newcb(_("Show elapsed time"), 'show_elapsed_time')
 
         interface_layout = QVBoxLayout()
         interface_layout.addWidget(banner_box)
@@ -312,6 +313,7 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         interface_layout.addWidget(calltips_box)
         interface_layout.addWidget(ask_box)
         interface_layout.addWidget(reset_namespace_box)
+        interface_layout.addWidget(show_time_box)
         interface_group.setLayout(interface_layout)
 
         comp_group = QGroupBox(_("Completion Type"))
@@ -693,6 +695,8 @@ class IPythonConsole(SpyderPluginWidget):
         help_o = CONF.get('help', 'connect/ipython_console')
         color_scheme_n = 'color_scheme_name'
         color_scheme_o = CONF.get('color_schemes', 'selected')
+        show_time_n = 'show_elapsed_time'
+        show_time_o = self.get_option(show_time_n)
         for client in self.clients:
             control = client.get_control()
             if font_n in options:
@@ -701,6 +705,9 @@ class IPythonConsole(SpyderPluginWidget):
                 control.set_help_enabled(help_o)
             if color_scheme_n in options:
                 client.set_color_scheme(color_scheme_o)
+            if show_time_n in options:
+                client.show_time_action.setChecked(show_time_o)
+                client.set_elapsed_time_visible(show_time_o)
 
     def toggle_view(self, checked):
         """Toggle view"""
@@ -975,13 +982,15 @@ class IPythonConsole(SpyderPluginWidget):
         client_id = dict(int_id=to_text_string(self.master_clients),
                          str_id='A')
         cf = self._new_connection_file()
+        show_elapsed_time = self.get_option('show_elapsed_time')
         client = ClientWidget(self, id_=client_id,
                               history_filename=get_conf_path('history.py'),
                               config_options=self.config_options(),
                               additional_options=self.additional_options(),
                               interpreter_versions=self.interpreter_versions(),
                               connection_file=cf,
-                              menu_actions=self.menu_actions)
+                              menu_actions=self.menu_actions,
+                              show_elapsed_time=show_elapsed_time)
         if self.testing:
             client.stderr_dir = self.test_dir
         self.add_tab(client, name=client.get_name(), filename=filename)

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -698,6 +698,8 @@ class IPythonConsole(SpyderPluginWidget):
         color_scheme_o = CONF.get('color_schemes', 'selected')
         show_time_n = 'show_elapsed_time'
         show_time_o = self.get_option(show_time_n)
+        reset_namespace_n = 'show_reset_namespace_warning'
+        reset_namespace_o = self.get_option(reset_namespace_n)
         for client in self.clients:
             control = client.get_control()
             if font_n in options:
@@ -709,6 +711,8 @@ class IPythonConsole(SpyderPluginWidget):
             if show_time_n in options:
                 client.show_time_action.setChecked(show_time_o)
                 client.set_elapsed_time_visible(show_time_o)
+            if reset_namespace_n in options:
+                client.reset_warning = reset_namespace_o
 
     def toggle_view(self, checked):
         """Toggle view"""
@@ -985,6 +989,7 @@ class IPythonConsole(SpyderPluginWidget):
                          str_id='A')
         cf = self._new_connection_file()
         show_elapsed_time = self.get_option('show_elapsed_time')
+        reset_warning = self.get_option('show_reset_namespace_warning')
         client = ClientWidget(self, id_=client_id,
                               history_filename=get_conf_path('history.py'),
                               config_options=self.config_options(),
@@ -992,7 +997,8 @@ class IPythonConsole(SpyderPluginWidget):
                               interpreter_versions=self.interpreter_versions(),
                               connection_file=cf,
                               menu_actions=self.menu_actions,
-                              show_elapsed_time=show_elapsed_time)
+                              show_elapsed_time=show_elapsed_time,
+                              reset_warning=reset_warning)
         if self.testing:
             client.stderr_dir = self.test_dir
         self.add_tab(client, name=client.get_name(), filename=filename)

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -750,7 +750,8 @@ class IPythonConsole(SpyderPluginWidget):
             client = self.tabwidget.currentWidget()
             control = client.get_control()
             control.setFocus()
-            widgets = client.get_toolbar_buttons()+[5]
+            widgets = [client.create_time_label(), 5
+                       ] + client.get_toolbar_buttons()+[5]
         else:
             control = None
             widgets = []

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -301,7 +301,8 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         ask_box = newcb(_("Ask for confirmation before closing"),
                         'ask_before_closing')
         reset_namespace_box = newcb(
-                _("Ask for confirmation before resetting the namespace."),
+                _("Ask for confirmation before removing all user-defined "
+                  "variables"),
                 'show_reset_namespace_warning',
                 tip=_("This option lets you hide the warning message shown\n"
                       "when resetting the namespace from Spyder."))

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -762,7 +762,7 @@ class IPythonConsole(SpyderPluginWidget):
             client = self.tabwidget.currentWidget()
             control = client.get_control()
             control.setFocus()
-            buttons = [[b, -8] for b in client.get_toolbar_buttons()]
+            buttons = [[b, -7] for b in client.get_toolbar_buttons()]
             buttons = sum(buttons, [])[:-1]
             widgets = [client.create_time_label()] + buttons
         else:

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -758,8 +758,9 @@ class IPythonConsole(SpyderPluginWidget):
             client = self.tabwidget.currentWidget()
             control = client.get_control()
             control.setFocus()
-            widgets = [client.create_time_label(), 5
-                       ] + client.get_toolbar_buttons()+[5]
+            buttons = [[b, -8] for b in client.get_toolbar_buttons()]
+            buttons = sum(buttons, [])[:-1]
+            widgets = [client.create_time_label()] + buttons
         else:
             control = None
             widgets = []

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -964,8 +964,6 @@ class IPythonConsole(SpyderPluginWidget):
                         sw.sig_prompt_ready.disconnect()
                     except TypeError:
                         pass
-                    sw.silent_execute(
-                        'get_ipython().kernel.close_all_mpl_figures()')
                     sw.reset_namespace(warning=False, silent=True)
                 elif current_client and clear_variables:
                     sw.reset_namespace(warning=False, silent=True)

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -1265,6 +1265,12 @@ class IPythonConsole(SpyderPluginWidget):
         except RuntimeError:
             pass
 
+        # Disconnect timer needed to update elapsed time
+        try:
+            client.timer.timeout.disconnect(client.show_time)
+        except (RuntimeError, TypeError):
+            pass
+
         # Check if related clients or kernels are opened
         # and eventually ask before closing them
         if not self.mainwindow_close and not force:

--- a/spyder/plugins/runconfig.py
+++ b/spyder/plugins/runconfig.py
@@ -42,7 +42,7 @@ WDIR_FIXED_DIR_OPTION = 'default/wdir/fixed_directory'
 ALWAYS_OPEN_FIRST_RUN = _("Always show %s on a first file run")
 ALWAYS_OPEN_FIRST_RUN_OPTION = 'open_on_firstrun'
 
-CLEAR_ALL_VARIABLES = _("Clear all variables before execution")
+CLEAR_ALL_VARIABLES = _("Remove all variables before execution")
 POST_MORTEM = _("Directly enter debugging when errors appear")
 INTERACT = _("Interact with the Python console after execution")
 

--- a/spyder/plugins/tests/test_ipythonconsole.py
+++ b/spyder/plugins/tests/test_ipythonconsole.py
@@ -103,6 +103,23 @@ def ipyconsole(request):
 #==============================================================================
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
+def test_conf_env_vars(ipyconsole, qtbot):
+    """Test that kernels have env vars set by our kernel spec."""
+    # Wait until the window is fully up
+    shell = ipyconsole.get_current_shellwidget()
+    qtbot.waitUntil(lambda: shell._prompt_html is not None,
+                    timeout=SHELL_TIMEOUT)
+
+    # Get a CONF env var
+    with qtbot.waitSignal(shell.executed):
+        shell.execute("import os; a = os.environ.get('SPY_SYMPY_O')")
+
+    # Assert we get the assigned value correctly
+    assert shell.get_value('a') == 'False'
+
+
+@flaky(max_runs=3)
+@pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 @pytest.mark.no_stderr_file
 def test_no_stderr_file(ipyconsole, qtbot):
     """Test that consoles can run without an stderr."""

--- a/spyder/utils/ipython/kernelspec.py
+++ b/spyder/utils/ipython/kernelspec.py
@@ -99,7 +99,22 @@ class SpyderKernelSpec(KernelSpec):
             'EXTERNAL_INTERPRETER': not default_interpreter,
             'UMR_ENABLED': CONF.get('main_interpreter', 'umr/enabled'),
             'UMR_VERBOSE': CONF.get('main_interpreter', 'umr/verbose'),
-            'UMR_NAMELIST': ','.join(umr_namelist)
+            'UMR_NAMELIST': ','.join(umr_namelist),
+            'RUN_LINES_O': CONF.get('ipython_console', 'startup/run_lines'),
+            'PYLAB_O': CONF.get('ipython_console', 'pylab'),
+            'BACKEND_O': CONF.get('ipython_console', 'pylab/backend'),
+            'AUTOLOAD_PYLAB_O': CONF.get('ipython_console', 'pylab/autoload'),
+            'FORMAT_O': CONF.get('ipython_console',
+                                 'pylab/inline/figure_format'),
+            'RESOLUTION_O': CONF.get('ipython_console',
+                                     'pylab/inline/resolution'),
+            'WIDTH_O': CONF.get('ipython_console', 'pylab/inline/width'),
+            'HEIGHT_O': CONF.get('ipython_console', 'pylab/inline/height'),
+            'USE_FILE_O': CONF.get('ipython_console', 'startup/use_run_file'),
+            'RUN_FILE_O': CONF.get('ipython_console', 'startup/run_file'),
+            'AUTOCALL_O': CONF.get('ipython_console', 'autocall'),
+            'GREEDY_O': CONF.get('ipython_console', 'greedy_completer'),
+            'SYMPY_O': CONF.get('ipython_console', 'symbolic_math')
         }
 
         # Add our PYTHONPATH to env_vars

--- a/spyder/utils/ipython/kernelspec.py
+++ b/spyder/utils/ipython/kernelspec.py
@@ -96,25 +96,27 @@ class SpyderKernelSpec(KernelSpec):
                 CONF.set('main_interpreter', 'umr/namelist', umr_namelist)
 
         env_vars = {
-            'EXTERNAL_INTERPRETER': not default_interpreter,
-            'UMR_ENABLED': CONF.get('main_interpreter', 'umr/enabled'),
-            'UMR_VERBOSE': CONF.get('main_interpreter', 'umr/verbose'),
-            'UMR_NAMELIST': ','.join(umr_namelist),
-            'RUN_LINES_O': CONF.get('ipython_console', 'startup/run_lines'),
-            'PYLAB_O': CONF.get('ipython_console', 'pylab'),
-            'BACKEND_O': CONF.get('ipython_console', 'pylab/backend'),
-            'AUTOLOAD_PYLAB_O': CONF.get('ipython_console', 'pylab/autoload'),
-            'FORMAT_O': CONF.get('ipython_console',
-                                 'pylab/inline/figure_format'),
-            'RESOLUTION_O': CONF.get('ipython_console',
-                                     'pylab/inline/resolution'),
-            'WIDTH_O': CONF.get('ipython_console', 'pylab/inline/width'),
-            'HEIGHT_O': CONF.get('ipython_console', 'pylab/inline/height'),
-            'USE_FILE_O': CONF.get('ipython_console', 'startup/use_run_file'),
-            'RUN_FILE_O': CONF.get('ipython_console', 'startup/run_file'),
-            'AUTOCALL_O': CONF.get('ipython_console', 'autocall'),
-            'GREEDY_O': CONF.get('ipython_console', 'greedy_completer'),
-            'SYMPY_O': CONF.get('ipython_console', 'symbolic_math')
+            'SPY_EXTERNAL_INTERPRETER': not default_interpreter,
+            'SPY_UMR_ENABLED': CONF.get('main_interpreter', 'umr/enabled'),
+            'SPY_UMR_VERBOSE': CONF.get('main_interpreter', 'umr/verbose'),
+            'SPY_UMR_NAMELIST': ','.join(umr_namelist),
+            'SPY_RUN_LINES_O': CONF.get('ipython_console', 'startup/run_lines'),
+            'SPY_PYLAB_O': CONF.get('ipython_console', 'pylab'),
+            'SPY_BACKEND_O': CONF.get('ipython_console', 'pylab/backend'),
+            'SPY_AUTOLOAD_PYLAB_O': CONF.get('ipython_console',
+                                             'pylab/autoload'),
+            'SPY_FORMAT_O': CONF.get('ipython_console',
+                                     'pylab/inline/figure_format'),
+            'SPY_RESOLUTION_O': CONF.get('ipython_console',
+                                         'pylab/inline/resolution'),
+            'SPY_WIDTH_O': CONF.get('ipython_console', 'pylab/inline/width'),
+            'SPY_HEIGHT_O': CONF.get('ipython_console', 'pylab/inline/height'),
+            'SPY_USE_FILE_O': CONF.get('ipython_console',
+                                       'startup/use_run_file'),
+            'SPY_RUN_FILE_O': CONF.get('ipython_console', 'startup/run_file'),
+            'SPY_AUTOCALL_O': CONF.get('ipython_console', 'autocall'),
+            'SPY_GREEDY_O': CONF.get('ipython_console', 'greedy_completer'),
+            'SPY_SYMPY_O': CONF.get('ipython_console', 'symbolic_math')
         }
 
         # Add our PYTHONPATH to env_vars

--- a/spyder/utils/ipython/spyder_kernel.py
+++ b/spyder/utils/ipython/spyder_kernel.py
@@ -22,7 +22,7 @@ PY2 = sys.version[0] == '2'
 # Check if we are running under an external interpreter
 # We add "spyder" to sys.path for external interpreters,
 # so relative imports work!
-IS_EXT_INTERPRETER = os.environ.get('EXTERNAL_INTERPRETER', '').lower() == "true"
+IS_EXT_INTERPRETER = os.environ.get('SPY_EXTERNAL_INTERPRETER') == "True"
 
 # Excluded variables from the Variable Explorer (i.e. they are not
 # shown at all there)

--- a/spyder/utils/ipython/spyder_kernel.py
+++ b/spyder/utils/ipython/spyder_kernel.py
@@ -12,36 +12,17 @@ Spyder kernel for Jupyter
 import os
 import os.path as osp
 import sys
-import traceback
 
 # Third-party imports
-import cloudpickle
 from ipykernel.ipkernel import IPythonKernel
-
-# Check if we are running under an external interpreter
-IS_EXT_INTERPRETER = os.environ.get('EXTERNAL_INTERPRETER', '').lower() == "true"
-
-# Local imports
-if not IS_EXT_INTERPRETER:
-    from spyder.py3compat import is_text_string
-    from spyder.utils.dochelpers import isdefined, getdoc, getsource
-    from spyder.utils.iofuncs import iofunctions
-    from spyder.utils.misc import fix_reference_name
-    from spyder.widgets.variableexplorer.utils import (get_remote_data,
-                                                       make_remote_view)
-else:
-    # We add "spyder" to sys.path for external interpreters, so this works!
-    # See create_kernel_spec of plugins/ipythonconsole
-    from py3compat import is_text_string
-    from utils.dochelpers import isdefined, getdoc, getsource
-    from utils.iofuncs import iofunctions
-    from utils.misc import fix_reference_name
-    from widgets.variableexplorer.utils import (get_remote_data,
-                                                make_remote_view)
 
 
 PY2 = sys.version[0] == '2'
 
+# Check if we are running under an external interpreter
+# We add "spyder" to sys.path for external interpreters,
+# so relative imports work!
+IS_EXT_INTERPRETER = os.environ.get('EXTERNAL_INTERPRETER', '').lower() == "true"
 
 # Excluded variables from the Variable Explorer (i.e. they are not
 # shown at all there)
@@ -105,6 +86,11 @@ class SpyderKernel(IPythonKernel):
         * 'size' and 'type' are self-evident
         * and'view' is its value or the text shown in the last column
         """
+        if not IS_EXT_INTERPRETER:
+            from spyder.widgets.variableexplorer.utils import make_remote_view
+        else:
+            from widgets.variableexplorer.utils import make_remote_view
+
         settings = self.namespace_view_settings
         if settings:
             ns = self._get_current_namespace()
@@ -118,6 +104,11 @@ class SpyderKernel(IPythonKernel):
         Get some properties of the variables in the current
         namespace
         """
+        if not IS_EXT_INTERPRETER:
+            from spyder.widgets.variableexplorer.utils import get_remote_data
+        else:
+            from widgets.variableexplorer.utils import get_remote_data
+
         settings = self.namespace_view_settings
         if settings:
             ns = self._get_current_namespace()
@@ -156,6 +147,8 @@ class SpyderKernel(IPythonKernel):
             Any object that is serializable by cloudpickle (should be most
             things). Will arrive as cloudpickled bytes in `.buffers[0]`.
         """
+        import cloudpickle
+
         if content is None:
             content = {}
         content['spyder_msg_type'] = spyder_msg_type
@@ -183,6 +176,7 @@ class SpyderKernel(IPythonKernel):
 
     def set_value(self, name, value, PY2_frontend):
         """Set the value of a variable"""
+        import cloudpickle
         ns = self._get_reference_namespace(name)
 
         # We send serialized values in a list of one element
@@ -211,6 +205,13 @@ class SpyderKernel(IPythonKernel):
 
     def load_data(self, filename, ext):
         """Load data from filename"""
+        if not IS_EXT_INTERPRETER:
+            from spyder.utils.iofuncs import iofunctions
+            from spyder.utils.misc import fix_reference_name
+        else:
+            from utils.iofuncs import iofunctions
+            from utils.misc import fix_reference_name
+
         glbs = self._mglobals()
 
         load_func = iofunctions.load_funcs[ext]
@@ -233,6 +234,13 @@ class SpyderKernel(IPythonKernel):
 
     def save_namespace(self, filename):
         """Save namespace into filename"""
+        if not IS_EXT_INTERPRETER:
+            from spyder.utils.iofuncs import iofunctions
+            from spyder.widgets.variableexplorer.utils import get_remote_data
+        else:
+            from utils.iofuncs import iofunctions
+            from widgets.variableexplorer.utils import get_remote_data
+
         ns = self._get_current_namespace()
         settings = self.namespace_view_settings
         data = get_remote_data(ns, settings, mode='picklable',
@@ -265,17 +273,32 @@ class SpyderKernel(IPythonKernel):
     # --- For the Help plugin
     def is_defined(self, obj, force_import=False):
         """Return True if object is defined in current namespace"""
+        if not IS_EXT_INTERPRETER:
+            from spyder.utils.dochelpers import isdefined
+        else:
+            from utils.dochelpers import isdefined
+
         ns = self._get_current_namespace(with_magics=True)
         return isdefined(obj, force_import=force_import, namespace=ns)
 
     def get_doc(self, objtxt):
         """Get object documentation dictionary"""
+        if not IS_EXT_INTERPRETER:
+            from spyder.utils.dochelpers import getdoc
+        else:
+            from utils.dochelpers import getdoc
+
         obj, valid = self._eval(objtxt)
         if valid:
             return getdoc(obj)
 
     def get_source(self, objtxt):
         """Get object source"""
+        if not IS_EXT_INTERPRETER:
+            from spyder.utils.dochelpers import getsource
+        else:
+            from utils.dochelpers import getsource
+
         obj, valid = self._eval(objtxt)
         if valid:
             return getsource(obj)
@@ -434,6 +457,11 @@ class SpyderKernel(IPythonKernel):
         where *obj* is the object represented by *text*
         and *valid* is True if object evaluation did not raise any exception
         """
+        if not IS_EXT_INTERPRETER:
+            from spyder.py3compat import is_text_string
+        else:
+            from py3compat import is_text_string
+
         assert is_text_string(text)
         ns = self._get_current_namespace(with_magics=True)
         try:
@@ -449,7 +477,9 @@ class SpyderKernel(IPythonKernel):
         backend: A parameter that can be passed to %matplotlib
                  (e.g. inline or tk).
         """
+        import traceback
         from IPython.core.getipython import get_ipython
+
         generic_error = ("\n"
                          "NOTE: The following error appeared when setting "
                          "your Matplotlib backend\n\n"

--- a/spyder/utils/ipython/spyder_kernel.py
+++ b/spyder/utils/ipython/spyder_kernel.py
@@ -283,6 +283,12 @@ class SpyderKernel(IPythonKernel):
 
     def get_doc(self, objtxt):
         """Get object documentation dictionary"""
+        try:
+            import matplotlib
+            matplotlib.rcParams['docstring.hardcopy'] = True
+        except:
+            pass
+
         if not IS_EXT_INTERPRETER:
             from spyder.utils.dochelpers import getdoc
         else:

--- a/spyder/utils/ipython/start_kernel.py
+++ b/spyder/utils/ipython/start_kernel.py
@@ -14,6 +14,9 @@ import os.path as osp
 import sys
 
 
+PY2 = sys.version[0] == '2'
+
+
 def is_module_installed(module_name):
     """
     Simpler version of spyder.utils.programs.is_module_installed
@@ -65,9 +68,10 @@ def kernel_config():
     # Until we implement Issue 1052
     spy_cfg.InteractiveShell.xmode = 'Plain'
 
-    # Using Jedi slow completions a lot for objects
-    # with big repr's
-    spy_cfg.IPCompleter.use_jedi = False
+    # - Using Jedi slow completions a lot for objects with big repr's.
+    # - Jedi completions are not available in Python 2.
+    if not PY2:
+        spy_cfg.IPCompleter.use_jedi = False
 
     # Run lines of code at startup
     run_lines_o = os.environ.get('SPY_RUN_LINES_O')

--- a/spyder/utils/ipython/start_kernel.py
+++ b/spyder/utils/ipython/start_kernel.py
@@ -14,10 +14,6 @@ import os.path as osp
 import sys
 
 
-# Check if we are running under an external interpreter
-IS_EXT_INTERPRETER = os.environ.get('EXTERNAL_INTERPRETER', '').lower() == "true"
-
-
 def is_module_installed(module_name):
     """
     Simpler version of spyder.utils.programs.is_module_installed
@@ -74,7 +70,7 @@ def kernel_config():
     spy_cfg.IPCompleter.use_jedi = False
 
     # Run lines of code at startup
-    run_lines_o = os.environ.get('RUN_LINES_O')
+    run_lines_o = os.environ.get('SPY_RUN_LINES_O')
     if run_lines_o:
         spy_cfg.IPKernelApp.exec_lines = [x.strip() for x in run_lines_o.split(',')]
     else:
@@ -103,11 +99,11 @@ def kernel_config():
 
     # Pylab configuration
     mpl_backend = None
-    pylab_o = os.environ.get('PYLAB_O')
+    pylab_o = os.environ.get('SPY_PYLAB_O')
 
     if pylab_o == 'True' and is_module_installed('matplotlib'):
         # Get matplotlib backend
-        backend_o = os.environ.get('BACKEND_O')
+        backend_o = os.environ.get('SPY_BACKEND_O')
         if backend_o == '1':
             if is_module_installed('PyQt5'):
                 auto_backend = 'qt5'
@@ -132,7 +128,7 @@ def kernel_config():
 
         # Automatically load Pylab and Numpy, or only set Matplotlib
         # backend
-        autoload_pylab_o = os.environ.get('AUTOLOAD_PYLAB_O') == 'True'
+        autoload_pylab_o = os.environ.get('SPY_AUTOLOAD_PYLAB_O') == 'True'
         command = "get_ipython().kernel._set_mpl_backend('{0}', {1})"
         spy_cfg.IPKernelApp.exec_lines.append(
             command.format(mpl_backend, autoload_pylab_o))
@@ -140,18 +136,18 @@ def kernel_config():
         # Inline backend configuration
         if mpl_backend == 'inline':
             # Figure format
-            format_o = os.environ.get('FORMAT_O')
+            format_o = os.environ.get('SPY_FORMAT_O')
             formats = {'0': 'png',
                        '1': 'svg'}
             spy_cfg.InlineBackend.figure_format = formats[format_o]
 
             # Resolution
-            resolution_o = os.environ.get('RESOLUTION_O')
+            resolution_o = os.environ.get('SPY_RESOLUTION_O')
             spy_cfg.InlineBackend.rc[dpi_option] = float(resolution_o)
 
             # Figure size
-            width_o = float(os.environ.get('WIDTH_O'))
-            height_o = float(os.environ.get('HEIGHT_O'))
+            width_o = float(os.environ.get('SPY_WIDTH_O'))
+            height_o = float(os.environ.get('SPY_HEIGHT_O'))
             spy_cfg.InlineBackend.rc['figure.figsize'] = (width_o, height_o)
 
 
@@ -160,24 +156,24 @@ def kernel_config():
         spy_cfg.IPKernelApp.exec_lines.append('%load_ext Cython')
 
     # Run a file at startup
-    use_file_o = os.environ.get('USE_FILE_O')
-    run_file_o = os.environ.get('RUN_FILE_O')
+    use_file_o = os.environ.get('SPY_USE_FILE_O')
+    run_file_o = os.environ.get('SPY_RUN_FILE_O')
     if use_file_o == 'True' and run_file_o:
         spy_cfg.IPKernelApp.file_to_run = run_file_o
 
     # Autocall
-    autocall_o = os.environ.get('AUTOCALL_O')
+    autocall_o = os.environ.get('SPY_AUTOCALL_O')
     spy_cfg.ZMQInteractiveShell.autocall = int(autocall_o)
 
     # To handle the banner by ourselves in IPython 3+
     spy_cfg.ZMQInteractiveShell.banner1 = ''
 
     # Greedy completer
-    greedy_o = os.environ.get('GREEDY_O') == 'True'
+    greedy_o = os.environ.get('SPY_GREEDY_O') == 'True'
     spy_cfg.IPCompleter.greedy = greedy_o
 
     # Sympy loading
-    sympy_o = os.environ.get('SYMPY_O') == 'True'
+    sympy_o = os.environ.get('SPY_SYMPY_O') == 'True'
     if sympy_o and is_module_installed('sympy'):
         lines = sympy_config(mpl_backend)
         spy_cfg.IPKernelApp.exec_lines.append(lines)
@@ -225,7 +221,7 @@ def main():
     # Fire up the kernel instance.
     from ipykernel.kernelapp import IPKernelApp
 
-    if not IS_EXT_INTERPRETER:
+    if not os.environ.get('SPY_EXTERNAL_INTERPRETER') == "True":
         from spyder.utils.ipython.spyder_kernel import SpyderKernel
     else:
         # We add "spyder" to sys.path for external interpreters,

--- a/spyder/utils/ipython/start_kernel.py
+++ b/spyder/utils/ipython/start_kernel.py
@@ -71,7 +71,7 @@ def kernel_config():
 
     # Run lines of code at startup
     run_lines_o = os.environ.get('SPY_RUN_LINES_O')
-    if run_lines_o:
+    if run_lines_o is not None:
         spy_cfg.IPKernelApp.exec_lines = [x.strip() for x in run_lines_o.split(',')]
     else:
         spy_cfg.IPKernelApp.exec_lines = []
@@ -102,54 +102,58 @@ def kernel_config():
     pylab_o = os.environ.get('SPY_PYLAB_O')
 
     if pylab_o == 'True' and is_module_installed('matplotlib'):
-        # Get matplotlib backend
+        # Set Matplotlib backend
         backend_o = os.environ.get('SPY_BACKEND_O')
-        if backend_o == '1':
-            if is_module_installed('PyQt5'):
-                auto_backend = 'qt5'
-            elif is_module_installed('PyQt4'):
-                auto_backend = 'qt4'
-            elif is_module_installed('_tkinter'):
-                auto_backend = 'tk'
+        if backend_o is not None:
+            if backend_o == '1':
+                if is_module_installed('PyQt5'):
+                    auto_backend = 'qt5'
+                elif is_module_installed('PyQt4'):
+                    auto_backend = 'qt4'
+                elif is_module_installed('_tkinter'):
+                    auto_backend = 'tk'
+                else:
+                    auto_backend = 'inline'
             else:
-                auto_backend = 'inline'
-        else:
-            auto_backend = ''
-        backends = {'0': 'inline',
-                    '1': auto_backend,
-                    '2': 'qt5',
-                    '3': 'qt4',
-                    '4': 'osx',
-                    '5': 'gtk3',
-                    '6': 'gtk',
-                    '7': 'wx',
-                    '8': 'tk'}
-        mpl_backend = backends[backend_o]
+                auto_backend = ''
+            backends = {'0': 'inline',
+                        '1': auto_backend,
+                        '2': 'qt5',
+                        '3': 'qt4',
+                        '4': 'osx',
+                        '5': 'gtk3',
+                        '6': 'gtk',
+                        '7': 'wx',
+                        '8': 'tk'}
+            mpl_backend = backends[backend_o]
 
-        # Automatically load Pylab and Numpy, or only set Matplotlib
-        # backend
-        autoload_pylab_o = os.environ.get('SPY_AUTOLOAD_PYLAB_O') == 'True'
-        command = "get_ipython().kernel._set_mpl_backend('{0}', {1})"
-        spy_cfg.IPKernelApp.exec_lines.append(
-            command.format(mpl_backend, autoload_pylab_o))
+            # Automatically load Pylab and Numpy, or only set Matplotlib
+            # backend
+            autoload_pylab_o = os.environ.get('SPY_AUTOLOAD_PYLAB_O') == 'True'
+            command = "get_ipython().kernel._set_mpl_backend('{0}', {1})"
+            spy_cfg.IPKernelApp.exec_lines.append(
+                command.format(mpl_backend, autoload_pylab_o))
 
-        # Inline backend configuration
-        if mpl_backend == 'inline':
-            # Figure format
-            format_o = os.environ.get('SPY_FORMAT_O')
-            formats = {'0': 'png',
-                       '1': 'svg'}
-            spy_cfg.InlineBackend.figure_format = formats[format_o]
+            # Inline backend configuration
+            if mpl_backend == 'inline':
+                # Figure format
+                format_o = os.environ.get('SPY_FORMAT_O')
+                formats = {'0': 'png',
+                           '1': 'svg'}
+                if format_o is not None:
+                    spy_cfg.InlineBackend.figure_format = formats[format_o]
 
-            # Resolution
-            resolution_o = os.environ.get('SPY_RESOLUTION_O')
-            spy_cfg.InlineBackend.rc[dpi_option] = float(resolution_o)
+                # Resolution
+                resolution_o = os.environ.get('SPY_RESOLUTION_O')
+                if resolution_o is not None:
+                    spy_cfg.InlineBackend.rc[dpi_option] = float(resolution_o)
 
-            # Figure size
-            width_o = float(os.environ.get('SPY_WIDTH_O'))
-            height_o = float(os.environ.get('SPY_HEIGHT_O'))
-            spy_cfg.InlineBackend.rc['figure.figsize'] = (width_o, height_o)
-
+                # Figure size
+                width_o = float(os.environ.get('SPY_WIDTH_O'))
+                height_o = float(os.environ.get('SPY_HEIGHT_O'))
+                if width_o is not None and height_o is not None:
+                    spy_cfg.InlineBackend.rc['figure.figsize'] = (width_o,
+                                                                  height_o)
 
     # Enable Cython magic
     if is_module_installed('Cython'):
@@ -158,12 +162,13 @@ def kernel_config():
     # Run a file at startup
     use_file_o = os.environ.get('SPY_USE_FILE_O')
     run_file_o = os.environ.get('SPY_RUN_FILE_O')
-    if use_file_o == 'True' and run_file_o:
+    if use_file_o == 'True' and run_file_o is not None:
         spy_cfg.IPKernelApp.file_to_run = run_file_o
 
     # Autocall
     autocall_o = os.environ.get('SPY_AUTOCALL_O')
-    spy_cfg.ZMQInteractiveShell.autocall = int(autocall_o)
+    if autocall_o is not None:
+        spy_cfg.ZMQInteractiveShell.autocall = int(autocall_o)
 
     # To handle the banner by ourselves in IPython 3+
     spy_cfg.ZMQInteractiveShell.banner1 = ''

--- a/spyder/utils/ipython/start_kernel.py
+++ b/spyder/utils/ipython/start_kernel.py
@@ -18,6 +18,19 @@ import sys
 IS_EXT_INTERPRETER = os.environ.get('EXTERNAL_INTERPRETER', '').lower() == "true"
 
 
+def is_module_installed(module_name):
+    """
+    Simpler version of spyder.utils.programs.is_module_installed
+    to improve startup time.
+    """
+    try:
+        __import__(module_name)
+        return True
+    except:
+        # Module is not installed
+        return False
+
+
 def sympy_config(mpl_backend):
     """Sympy configuration"""
     if mpl_backend is not None:
@@ -37,15 +50,9 @@ init_session()
 
 def kernel_config():
     """Create a config object with IPython kernel options."""
+    import ipykernel
     from IPython.core.application import get_ipython_dir
     from traitlets.config.loader import Config, load_pyconfig_files
-    if not IS_EXT_INTERPRETER:
-        from spyder.utils.programs import is_module_installed
-    else:
-        # We add "spyder" to sys.path for external interpreters,
-        # so this works!
-        # See create_kernel_spec of plugins/ipythonconsole
-        from utils.programs import is_module_installed
 
     # ---- IPython config ----
     try:
@@ -122,7 +129,7 @@ def kernel_config():
             spy_cfg.InlineBackend.figure_format = formats[format_o]
 
             # Resolution
-            if is_module_installed('ipykernel', '<4.5'):
+            if ipykernel.__version__ < '4.5':
                 dpi_option = 'savefig.dpi'
             else:
                 dpi_option = 'figure.dpi'

--- a/spyder/utils/ipython/start_kernel.py
+++ b/spyder/utils/ipython/start_kernel.py
@@ -84,6 +84,23 @@ def kernel_config():
     clear_argv = "import sys;sys.argv = [''];del sys"
     spy_cfg.IPKernelApp.exec_lines.append(clear_argv)
 
+    # Default inline backend configuration
+    # This is useful to have when people doesn't
+    # use our config system to configure the
+    # inline backend but want to use
+    # '%matplotlib inline' at runtime
+    if ipykernel.__version__ < '4.5':
+        dpi_option = 'savefig.dpi'
+    else:
+        dpi_option = 'figure.dpi'
+
+    spy_cfg.InlineBackend.rc = {'figure.figsize': (6.0, 4.0),
+                                dpi_option: 72,
+                                'font.size': 10,
+                                'figure.subplot.bottom': .125,
+                                'figure.facecolor': 'white',
+                                'figure.edgecolor': 'white'}
+
     # Pylab configuration
     mpl_backend = None
     pylab_o = os.environ.get('PYLAB_O')
@@ -129,17 +146,6 @@ def kernel_config():
             spy_cfg.InlineBackend.figure_format = formats[format_o]
 
             # Resolution
-            if ipykernel.__version__ < '4.5':
-                dpi_option = 'savefig.dpi'
-            else:
-                dpi_option = 'figure.dpi'
-
-            spy_cfg.InlineBackend.rc = {'figure.figsize': (6.0, 4.0),
-                                        dpi_option: 72,
-                                        'font.size': 10,
-                                        'figure.subplot.bottom': .125,
-                                        'figure.facecolor': 'white',
-                                        'figure.edgecolor': 'white'}
             resolution_o = os.environ.get('RESOLUTION_O')
             spy_cfg.InlineBackend.rc[dpi_option] = float(resolution_o)
 

--- a/spyder/utils/site/sitecustomize.py
+++ b/spyder/utils/site/sitecustomize.py
@@ -34,7 +34,7 @@ if not hasattr(sys, 'argv'):
 #==============================================================================
 # Main constants
 #==============================================================================
-IS_EXT_INTERPRETER = os.environ.get('EXTERNAL_INTERPRETER', '').lower() == "true"
+IS_EXT_INTERPRETER = os.environ.get('SPY_EXTERNAL_INTERPRETER') == "True"
 
 
 #==============================================================================
@@ -654,14 +654,14 @@ def runfile(filename, args=None, wdir=None, namespace=None, post_mortem=False):
         # AttributeError --> systematically raised in Python 3
         pass
     global __umr__
-    if os.environ.get("UMR_ENABLED", "").lower() == "true":
+    if os.environ.get("SPY_UMR_ENABLED", "").lower() == "true":
         if __umr__ is None:
-            namelist = os.environ.get("UMR_NAMELIST", None)
+            namelist = os.environ.get("SPY_UMR_NAMELIST", None)
             if namelist is not None:
                 namelist = namelist.split(',')
             __umr__ = UserModuleReloader(namelist=namelist)
         else:
-            verbose = os.environ.get("UMR_VERBOSE", "").lower() == "true"
+            verbose = os.environ.get("SPY_UMR_VERBOSE", "").lower() == "true"
             __umr__.run(verbose=verbose)
     if args is not None and not isinstance(args, basestring):
         raise TypeError("expected a character buffer object")

--- a/spyder/utils/site/sitecustomize.py
+++ b/spyder/utils/site/sitecustomize.py
@@ -242,23 +242,6 @@ if os.environ["QT_API"] == 'pyqt':
     except:
         pass
 
-#==============================================================================
-# This prevents a kernel crash with the inline backend in our IPython
-# consoles on Linux and Python 3 (Fixes Issue 2257)
-#==============================================================================
-try:
-    import matplotlib
-except:
-    matplotlib = None   # analysis:ignore
-
-
-#==============================================================================
-# Matplotlib settings
-#==============================================================================
-if matplotlib is not None:
-    # To have mpl docstrings as rst
-    matplotlib.rcParams['docstring.hardcopy'] = True
-
 
 #==============================================================================
 # IPython kernel adjustments

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -95,7 +95,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                  additional_options, interpreter_versions,
                  connection_file=None, hostname=None,
                  menu_actions=None, slave=False,
-                 external_kernel=False, given_name=None):
+                 external_kernel=False, given_name=None,
+                 show_elapsed_time=False):
         super(ClientWidget, self).__init__(plugin)
         SaveHistoryMixin.__init__(self, history_filename)
 
@@ -127,7 +128,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         self.loading_page = self._create_loading_page()
         self._show_loading_page()
 
-        # Time label
+        # Elapsed time
+        self.show_elapsed_time = show_elapsed_time
         self.time_label = None
         self.t0 = None
         self.timer = QTimer(self)
@@ -153,6 +155,9 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
         # --- Dialog manager
         self.dialog_manager = DialogManager()
+
+        # Show timer
+        self.update_time_label_visibility()
 
     #------ Public API --------------------------------------------------------
     @property
@@ -532,6 +537,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                "</b></span>" % (color, strftime(fmt, gmtime(elapsed_time)))
         self.time_label.setText(text)
 
+    def update_time_label_visibility(self):
+        self.time_label.setVisible(self.show_elapsed_time)
 
     #------ Private API -------------------------------------------------------
     def _create_loading_page(self):

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -374,17 +374,16 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                                           QKeySequence(get_shortcut(
                                                   'console',
                                                   'clear line')),
-                                          icon=ima.icon('editdelete'),
                                           triggered=self.clear_line)
-        reset_namespace_action = create_action(self, _("Reset namespace"),
+        reset_namespace_action = create_action(self, _("Remove all variables"),
                                                QKeySequence(get_shortcut(
                                                        'ipython_console',
                                                        'reset namespace')),
+                                               icon=ima.icon('editdelete'),
                                                triggered=self.reset_namespace)
         clear_console_action = create_action(self, _("Clear console"),
                                              QKeySequence(get_shortcut('console',
                                                                'clear shell')),
-                                             icon=ima.icon('editclear'),
                                              triggered=self.clear_console)
         quit_action = create_action(self, _("&Quit"), icon=ima.icon('exit'),
                                     triggered=self.exit_callback)

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -542,10 +542,12 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         self.time_label.setText(text)
 
     def update_time_label_visibility(self):
+        """Update elapsed time visibility."""
         self.time_label.setVisible(self.show_elapsed_time)
 
     @Slot(bool)
     def set_elapsed_time_visible(self, state):
+        """Slot to show/hide elapsed time label."""
         self.show_elapsed_time = state
         if self.time_label is not None:
             self.time_label.setVisible(state)

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -309,6 +309,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
     def get_options_menu(self):
         """Return options menu"""
+        show_time_action = create_action(self, _("Show elapsed time"),
+                                         toggled=self.set_elapsed_time_visible)
         env_action = create_action(
                         self,
                         _("Show environment variables"),
@@ -322,7 +324,9 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                             triggered=self.shellwidget.get_syspath
                          )
 
-        additional_actions = [MENU_SEPARATOR, env_action, syspath_action]
+        show_time_action.setChecked(self.show_elapsed_time)
+        additional_actions = [MENU_SEPARATOR, show_time_action, env_action,
+                              syspath_action]
 
         if self.menu_actions is not None:
             return self.menu_actions + additional_actions
@@ -539,6 +543,12 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
     def update_time_label_visibility(self):
         self.time_label.setVisible(self.show_elapsed_time)
+
+    @Slot(bool)
+    def set_elapsed_time_visible(self, state):
+        self.show_elapsed_time = state
+        if self.time_label is not None:
+            self.time_label.setVisible(state)
 
     #------ Private API -------------------------------------------------------
     def _create_loading_page(self):

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -111,6 +111,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         # --- Other attrs
         self.options_button = None
         self.stop_button = None
+        self.reset_button = None
         self.stop_icon = ima.icon('stop')
         self.history = []
         self.allow_rename = True
@@ -336,6 +337,19 @@ class ClientWidget(QWidget, SaveHistoryMixin):
     def get_toolbar_buttons(self):
         """Return toolbar buttons list."""
         buttons = []
+
+        # Reset namespace button
+        if self.reset_button is None:
+            reset_fn = lambda: self.shellwidget.reset_namespace(warning=True)
+            self.reset_button = create_toolbutton(
+                                    self,
+                                    text=_("Remove"),
+                                    icon=ima.icon('editdelete'),
+                                    tip=_("Remove all variables"),
+                                    triggered=reset_fn)
+        if self.reset_button is not None:
+            buttons.append(self.reset_button)
+
         # Code to add the stop button
         if self.stop_button is None:
             self.stop_button = create_toolbutton(

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -107,6 +107,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         self.hostname = hostname
         self.menu_actions = menu_actions
         self.slave = slave
+        self.external_kernel = external_kernel
         self.given_name = given_name
         self.show_elapsed_time = show_elapsed_time
         self.reset_warning = reset_warning
@@ -606,7 +607,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         """
         Show possible errors when setting the selected Matplotlib backend.
         """
-        self.shellwidget.silent_execute(
-            "get_ipython().kernel._show_mpl_backend_errors()")
+        if not self.external_kernel:
+            self.shellwidget.silent_execute(
+                    "get_ipython().kernel._show_mpl_backend_errors()")
         self.shellwidget.sig_prompt_ready.disconnect(
             self._show_mpl_backend_errors)

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -309,7 +309,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
     def get_options_menu(self):
         """Return options menu"""
-        show_time_action = create_action(self, _("Show elapsed time"),
+        self.show_time_action = create_action(self, _("Show elapsed time"),
                                          toggled=self.set_elapsed_time_visible)
         env_action = create_action(
                         self,
@@ -324,9 +324,9 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                             triggered=self.shellwidget.get_syspath
                          )
 
-        show_time_action.setChecked(self.show_elapsed_time)
-        additional_actions = [MENU_SEPARATOR, show_time_action, env_action,
-                              syspath_action]
+        self.show_time_action.setChecked(self.show_elapsed_time)
+        additional_actions = [MENU_SEPARATOR, self.show_time_action,
+                              env_action, syspath_action]
 
         if self.menu_actions is not None:
             return self.menu_actions + additional_actions

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -313,14 +313,20 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
     def get_options_menu(self):
         """Return options menu"""
+        reset_action = create_action(self, _("Remove all variables"),
+                                     icon=ima.icon('editdelete'),
+                                     triggered=self.reset_namespace)
+
         self.show_time_action = create_action(self, _("Show elapsed time"),
                                          toggled=self.set_elapsed_time_visible)
+
         env_action = create_action(
                         self,
                         _("Show environment variables"),
                         icon=ima.icon('environ'),
                         triggered=self.shellwidget.get_env
                      )
+
         syspath_action = create_action(
                             self,
                             _("Show sys.path contents"),
@@ -329,8 +335,11 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                          )
 
         self.show_time_action.setChecked(self.show_elapsed_time)
-        additional_actions = [MENU_SEPARATOR, self.show_time_action,
-                              env_action, syspath_action]
+        additional_actions = [reset_action,
+                              MENU_SEPARATOR,
+                              env_action,
+                              syspath_action,
+                              self.show_time_action]
 
         if self.menu_actions is not None:
             return self.menu_actions + additional_actions
@@ -340,7 +349,6 @@ class ClientWidget(QWidget, SaveHistoryMixin):
     def get_toolbar_buttons(self):
         """Return toolbar buttons list."""
         buttons = []
-        sw = self.shellwidget
 
         # Code to add the stop button
         if self.stop_button is None:
@@ -357,14 +365,12 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
         # Reset namespace button
         if self.reset_button is None:
-            reset_fn = lambda: sw.reset_namespace(warning=self.reset_warning,
-                                                  message=True)
             self.reset_button = create_toolbutton(
                                     self,
                                     text=_("Remove"),
                                     icon=ima.icon('editdelete'),
                                     tip=_("Remove all variables"),
-                                    triggered=reset_fn)
+                                    triggered=self.reset_namespace)
         if self.reset_button is not None:
             buttons.append(self.reset_button)
 
@@ -396,15 +402,12 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                                                   'clear line')),
                                           triggered=self.clear_line)
 
-        sw = self.shellwidget
-        reset_fn = lambda: sw.reset_namespace(warning=self.reset_warning,
-                                              message=True)
         reset_namespace_action = create_action(self, _("Remove all variables"),
                                                QKeySequence(get_shortcut(
                                                        'ipython_console',
                                                        'reset namespace')),
                                                icon=ima.icon('editdelete'),
-                                               triggered=reset_fn)
+                                               triggered=self.reset_namespace)
 
         clear_console_action = create_action(self, _("Clear console"),
                                              QKeySequence(get_shortcut('console',
@@ -519,6 +522,12 @@ class ClientWidget(QWidget, SaveHistoryMixin):
     def clear_console(self):
         """Clear the whole console"""
         self.shellwidget.clear_console()
+
+    @Slot()
+    def reset_namespace(self):
+        """Resets the namespace by removing all names defined by the user"""
+        self.shellwidget.reset_namespace(warning=self.reset_warning,
+                                         message=True)
 
     def update_history(self):
         self.history = self.shellwidget._history

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -96,7 +96,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                  connection_file=None, hostname=None,
                  menu_actions=None, slave=False,
                  external_kernel=False, given_name=None,
-                 show_elapsed_time=False):
+                 show_elapsed_time=False,
+                 reset_warning=True):
         super(ClientWidget, self).__init__(plugin)
         SaveHistoryMixin.__init__(self, history_filename)
 
@@ -107,6 +108,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         self.menu_actions = menu_actions
         self.slave = slave
         self.given_name = given_name
+        self.show_elapsed_time = show_elapsed_time
+        self.reset_warning = reset_warning
 
         # --- Other attrs
         self.options_button = None
@@ -130,7 +133,6 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         self._show_loading_page()
 
         # Elapsed time
-        self.show_elapsed_time = show_elapsed_time
         self.time_label = None
         self.t0 = None
         self.timer = QTimer(self)
@@ -340,7 +342,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
         # Reset namespace button
         if self.reset_button is None:
-            reset_fn = lambda: self.shellwidget.reset_namespace(warning=True)
+            reset_fn = lambda: self.shellwidget.reset_namespace(
+                                   warning=self.reset_warning)
             self.reset_button = create_toolbutton(
                                     self,
                                     text=_("Remove"),

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -341,19 +341,6 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         """Return toolbar buttons list."""
         buttons = []
 
-        # Reset namespace button
-        if self.reset_button is None:
-            reset_fn = lambda: self.shellwidget.reset_namespace(
-                                   warning=self.reset_warning)
-            self.reset_button = create_toolbutton(
-                                    self,
-                                    text=_("Remove"),
-                                    icon=ima.icon('editdelete'),
-                                    tip=_("Remove all variables"),
-                                    triggered=reset_fn)
-        if self.reset_button is not None:
-            buttons.append(self.reset_button)
-
         # Code to add the stop button
         if self.stop_button is None:
             self.stop_button = create_toolbutton(
@@ -366,6 +353,19 @@ class ClientWidget(QWidget, SaveHistoryMixin):
             self.stop_button.clicked.connect(self.stop_button_click_handler)
         if self.stop_button is not None:
             buttons.append(self.stop_button)
+
+        # Reset namespace button
+        if self.reset_button is None:
+            reset_fn = lambda: self.shellwidget.reset_namespace(
+                                   warning=self.reset_warning)
+            self.reset_button = create_toolbutton(
+                                    self,
+                                    text=_("Remove"),
+                                    icon=ima.icon('editdelete'),
+                                    tip=_("Remove all variables"),
+                                    triggered=reset_fn)
+        if self.reset_button is not None:
+            buttons.append(self.reset_button)
 
         if self.options_button is None:
             options = self.get_options_menu()

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -340,6 +340,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
     def get_toolbar_buttons(self):
         """Return toolbar buttons list."""
         buttons = []
+        sw = self.shellwidget
 
         # Code to add the stop button
         if self.stop_button is None:
@@ -356,8 +357,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
         # Reset namespace button
         if self.reset_button is None:
-            reset_fn = lambda: self.shellwidget.reset_namespace(
-                                   warning=self.reset_warning)
+            reset_fn = lambda: sw.reset_namespace(warning=self.reset_warning,
+                                                  message=True)
             self.reset_button = create_toolbutton(
                                     self,
                                     text=_("Remove"),
@@ -388,23 +389,31 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                                                     'inspect current object')),
                                     icon=ima.icon('MessageBoxInformation'),
                                     triggered=self.inspect_object)
+
         clear_line_action = create_action(self, _("Clear line or block"),
                                           QKeySequence(get_shortcut(
                                                   'console',
                                                   'clear line')),
                                           triggered=self.clear_line)
+
+        sw = self.shellwidget
+        reset_fn = lambda: sw.reset_namespace(warning=self.reset_warning,
+                                              message=True)
         reset_namespace_action = create_action(self, _("Remove all variables"),
                                                QKeySequence(get_shortcut(
                                                        'ipython_console',
                                                        'reset namespace')),
                                                icon=ima.icon('editdelete'),
-                                               triggered=self.reset_namespace)
+                                               triggered=reset_fn)
+
         clear_console_action = create_action(self, _("Clear console"),
                                              QKeySequence(get_shortcut('console',
                                                                'clear shell')),
                                              triggered=self.clear_console)
+
         quit_action = create_action(self, _("&Quit"), icon=ima.icon('exit'),
                                     triggered=self.exit_callback)
+
         add_actions(menu, (None, inspect_action, clear_line_action,
                            clear_console_action, reset_namespace_action,
                            None, quit_action))
@@ -510,11 +519,6 @@ class ClientWidget(QWidget, SaveHistoryMixin):
     def clear_console(self):
         """Clear the whole console"""
         self.shellwidget.clear_console()
-
-    @Slot()
-    def reset_namespace(self):
-        """Resets the namespace by removing all names defined by the user"""
-        self.shellwidget.reset_namespace()
 
     def update_history(self):
         self.history = self.shellwidget._history

--- a/spyder/widgets/ipythonconsole/namespacebrowser.py
+++ b/spyder/widgets/ipythonconsole/namespacebrowser.py
@@ -9,6 +9,8 @@ Widget that handle communications between the IPython Console and
 the Variable Explorer
 """
 
+from time import time
+
 from qtpy.QtCore import QEventLoop
 from qtpy.QtWidgets import QMessageBox
 
@@ -224,10 +226,15 @@ class NamepaceBrowserWidget(RichJupyterWidget):
         """
         state = msg['content'].get('execution_state', '')
         msg_type = msg['parent_header'].get('msg_type', '')
-        if state == 'starting' and not self._kernel_is_starting:
+        if state == 'starting':
+            self.ipyclient.t0 = time()
+            self.ipyclient.timer.timeout.connect(self.ipyclient.show_time)
+            self.ipyclient.timer.start(1000)
+
             # This handles restarts when the kernel dies
             # unexpectedly
-            self._kernel_is_starting = True
+            if not self._kernel_is_starting:
+                self._kernel_is_starting = True
         elif state == 'idle' and msg_type == 'shutdown_request':
             # This handles restarts asked by the user
             if self.namespacebrowser is not None:

--- a/spyder/widgets/ipythonconsole/namespacebrowser.py
+++ b/spyder/widgets/ipythonconsole/namespacebrowser.py
@@ -211,6 +211,7 @@ class NamepaceBrowserWidget(RichJupyterWidget):
                 self.set_namespace_view_settings()
                 self.refresh_namespacebrowser()
             self._kernel_is_starting = False
+            self.ipyclient.t0 = time()
 
         # Handle silent execution of kernel methods
         if info and info.kind == 'silent_exec_method' and not self._hidden:
@@ -227,6 +228,8 @@ class NamepaceBrowserWidget(RichJupyterWidget):
         state = msg['content'].get('execution_state', '')
         msg_type = msg['parent_header'].get('msg_type', '')
         if state == 'starting':
+            # This is needed to show the time a kernel
+            # has been alive in each console.
             self.ipyclient.t0 = time()
             self.ipyclient.timer.timeout.connect(self.ipyclient.show_time)
             self.ipyclient.timer.start(1000)
@@ -240,5 +243,6 @@ class NamepaceBrowserWidget(RichJupyterWidget):
             if self.namespacebrowser is not None:
                 self.set_namespace_view_settings()
                 self.refresh_namespacebrowser()
+            self.ipyclient.t0 = time()
         else:
             super(NamepaceBrowserWidget, self)._handle_status(msg)

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -228,16 +228,16 @@ the sympy module (e.g. plot)
 
     def reset_namespace(self, warning=False, silent=True):
         """Reset the namespace by removing all names defined by the user."""
-        reset_str = _("Reset IPython namespace")
-        warn_str = _("All user-defined variables will be removed."
-                     "<br>Are you sure you want to reset the namespace?")
+        reset_str = _("Remove all variables")
+        warn_str = _("All user-defined variables will be removed. "
+                     "Are you sure you want to proceed?")
 
         if warning:
             box = MessageCheckBox(icon=QMessageBox.Warning, parent=self)
             box.setWindowTitle(reset_str)
             box.set_checkbox_text(_("Don't show again."))
             box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
-            box.setDefaultButton(QMessageBox.No)
+            box.setDefaultButton(QMessageBox.Yes)
 
             box.set_checked(False)
             box.set_check_visible(True)

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -267,6 +267,10 @@ the sympy module (e.g. plot)
             else:
                 self.execute("%reset -f")
 
+            if not self.external_kernel:
+                self.silent_execute(
+                    'get_ipython().kernel.close_all_mpl_figures()')
+
     def create_shortcuts(self):
         """Create shortcuts for ipyconsole."""
         inspect = config_shortcut(self._control.inspect_current_object,

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -227,7 +227,7 @@ the sympy module (e.g. plot)
         warning = CONF.get('ipython_console', 'show_reset_namespace_warning')
         self.reset_namespace(silent=True, warning=warning)
 
-    def reset_namespace(self, warning=False, silent=True):
+    def reset_namespace(self, warning=False, silent=True, message=False):
         """Reset the namespace by removing all names defined by the user."""
         reset_str = _("Remove all variables")
         warn_str = _("All user-defined variables will be removed. "
@@ -257,9 +257,11 @@ the sympy module (e.g. plot)
             self.dbg_exec_magic('reset', '-f')
         else:
             if silent:
-                self.reset()
-                self._append_html(_("<br><br>Removing all variables...\n<hr><br>"),
-                                  before_prompt=False)
+                if message:
+                    self.reset()
+                    self._append_html(_("<br><br>Removing all variables..."
+                                        "\n<hr>"),
+                                      before_prompt=False)
                 self.silent_execute("%reset -f")
                 self.refresh_namespacebrowser()
             else:

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -256,6 +256,9 @@ the sympy module (e.g. plot)
             self.dbg_exec_magic('reset', '-f')
         else:
             if silent:
+                self.reset()
+                self._append_html(_("<br><br>Removing all variables...\n<hr><br>"),
+                                  before_prompt=False)
                 self.silent_execute("%reset -f")
                 self.refresh_namespacebrowser()
             else:

--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -107,12 +107,13 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget):
         if os.name == 'nt':
             dirname = dirname.replace(u"\\", u"\\\\")
 
-        code = u"get_ipython().kernel.set_cwd(u'{}')".format(dirname)
-        if self._reading:
-            self.kernel_client.input(u'!' + code)
-        else:
-            self.silent_execute(code)
-        self._cwd = dirname
+        if not self.external_kernel:
+            code = u"get_ipython().kernel.set_cwd(u'{}')".format(dirname)
+            if self._reading:
+                self.kernel_client.input(u'!' + code)
+            else:
+                self.silent_execute(code)
+            self._cwd = dirname
 
     def get_cwd(self):
         """Update current working directory.

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -452,7 +452,8 @@ class NamespaceBrowser(QWidget):
     @Slot()
     def reset_namespace(self):
         warning = CONF.get('ipython_console', 'show_reset_namespace_warning')
-        self.shellwidget.reset_namespace(silent=True, warning=warning)
+        self.shellwidget.reset_namespace(warning=warning, silent=True,
+                                         message=True)
 
     @Slot()
     def save_data(self, filename=None):

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -190,7 +190,7 @@ class NamespaceBrowser(QWidget):
                                            icon=ima.icon('filesaveas'),
                                            triggered=self.save_data)
         reset_namespace_button = create_toolbutton(
-                self, text=_("Reset the namespace"),
+                self, text=_("Remove all variables"),
                 icon=ima.icon('editdelete'), triggered=self.reset_namespace)
 
         toolbar += [load_button, self.save_button, save_as_button,

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -191,7 +191,7 @@ class NamespaceBrowser(QWidget):
                                            triggered=self.save_data)
         reset_namespace_button = create_toolbutton(
                 self, text=_("Reset the namespace"),
-                icon=ima.icon('editclear'), triggered=self.reset_namespace)
+                icon=ima.icon('editdelete'), triggered=self.reset_namespace)
 
         toolbar += [load_button, self.save_button, save_as_button,
                     reset_namespace_button]


### PR DESCRIPTION
Fixes #5944 
Fixes #5759 
Fixes #5360 

This PR seeks to fix several issues with our IPython consoles, discovered after we removed the old Python console. In particular, we want to

- [x] Improve kernel startup time
  - [x] Move all imports in `spyder_kernel.py` to the methods that use them.
  - [x] Stop using CONF in `start_kernel.py`
  - [x] Use a local, simpler version of `is_module_installed` in `start_kernel.py`
  - [x] Don't load Matplotlib in `sitecustomize.py`
- [x] Use a default configuration for the inline backend.
- [x] Show elapsed time.
- [x] Show button to reset kernel.
- [x] Check IPython version when trying to set `use_jedi` option.
- [x] Test elapsed time with external kernels.
- [x] Close Matplotlib windows when resetting namespace.
- [x] Add *Remove all variables* entry to the Options menu
- [x] Test what happens on dedicated consoles.