### PR TITLE
PR: Collect virtual environment name (also should work for conda envs)

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -222,6 +222,19 @@ def get_focus_python_shell():
     elif isinstance(widget, ExternalPythonShell):
         return widget.shell
 
+def get_environment_infostr():
+    """Find if running inside a conda and/or venv
+    Return None if not the case or anything fails"""
+    debug_print("Collecting environment information")
+    try:
+        try:
+            return "env: {}".format(os.path.basename(sys.prefix))
+        except AttributeError:
+            return ""
+    except Exception as e:
+        debug_print("Exception {} while trying to obtain environment information".format(e))
+
+    return ""
 
 #==============================================================================
 # Main Window
@@ -446,6 +459,10 @@ class MainWindow(QMainWindow):
         else:
             title = "Spyder (Python %s.%s)" % (sys.version_info[0],
                                                sys.version_info[1])
+        env_info = get_environment_infostr()
+        if env_info:
+            title += " [%s]" % env_info
+
         if DEBUG:
             title += " [DEBUG MODE %d]" % DEBUG
         if options.window_title is not None:

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -222,6 +222,7 @@ def get_focus_python_shell():
     elif isinstance(widget, ExternalPythonShell):
         return widget.shell
 
+
 def get_environment_infostr():
     """Find if running inside a conda and/or venv
     Return None if not the case or anything fails"""
@@ -232,7 +233,9 @@ def get_environment_infostr():
         except AttributeError:
             return ""
     except Exception as e:
-        debug_print("Exception {} while trying to obtain environment information".format(e))
+        debug_print(
+        "Exception {} while trying to obtain environment information".format(e)
+        )
 
     return ""
 


### PR DESCRIPTION
Fixes #5803

I had a go at this, I tried a few approaches for conda and virtual environments, for some reason os.environ['CONDA_PREFIX'] did not work reliably for me.

However [sys.prefix](https://stackoverflow.com/questions/1871549/python-determine-if-running-inside-virtualenv) provides a reasonable result both for venv and conda environments. Mind that the root conda environment is also detected, which for me is not a problem.

I only tested this with windows. In any case, the proposed changes should fail cleanly and leave the title as-is if something does not work. 

![image](https://user-images.githubusercontent.com/8244088/33804255-46e28b2e-dda1-11e7-9784-f0191dc3cf5f.png)
(Top: spyder running in conda root, bottom, running in a conda environment named "condaclone")

