### PR TITLE
PR: Disable renames for list, set and tuple in the Variable Explorer

### DIFF
--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -951,8 +951,12 @@ class BaseTableView(QTableView):
         else:
             title = _('Duplicate')
             field_text = _('Variable name:')
-        new_key, valid = QInputDialog.getText(self, title, field_text,
-                                              QLineEdit.Normal, orig_key)
+        data = self.model.get_data()
+        if isinstance(data, (list, set)):
+            new_key, valid = len(data), True
+        else:
+            new_key, valid = QInputDialog.getText(self, title, field_text,
+                                                  QLineEdit.Normal, orig_key)
         if valid and to_text_string(new_key):
             new_key = try_to_eval(to_text_string(new_key))
             if new_key == orig_key:
@@ -1161,7 +1165,12 @@ class CollectionsEditorTableView(BaseTableView):
     def copy_value(self, orig_key, new_key):
         """Copy value"""
         data = self.model.get_data()
-        data[new_key] = data[orig_key]
+        if isinstance(data, list):
+            data.append(data[orig_key])
+        if isinstance(data, set):
+            data.add(data[orig_key])
+        else:
+            data[new_key] = data[orig_key]
         self.set_data(data)
     
     def new_value(self, key, value):
@@ -1242,6 +1251,9 @@ class CollectionsEditorTableView(BaseTableView):
         self.edit_action.setEnabled( condition )
         self.remove_action.setEnabled( condition )
         self.insert_action.setEnabled( not self.readonly )
+        self.duplicate_action.setEnabled(condition)
+        condition_rename = not isinstance(data, (tuple, list, set))
+        self.rename_action.setEnabled(condition_rename)
         self.refresh_plot_entries(index)
         
     def set_filter(self, dictfilter=None):

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -8,6 +8,7 @@ Tests for collectionseditor.py
 """
 
 # Standard library imports
+import copy
 try:
     from unittest.mock import Mock
 except ImportError:
@@ -140,6 +141,24 @@ def test_sort_collectionsmodel_with_many_rows():
     for _ in range(3):
         cm.fetchMore()
     assert cm.rowCount() == len(coll)
+
+
+def test_rename_and_duplicate_item_in_collection_editor():
+    collections = {'list': ([1, 2, 3], False, True),
+                   'tuple': ((1, 2, 3), False, False),
+                   'dict': ({'a': 1, 'b': 2}, True, True)}
+    for coll, rename_enabled, duplicate_enabled in collections.values():
+        coll_copy = copy.copy(coll)
+        editor = CollectionsEditorTableView(None, coll)
+        assert editor.rename_action.isEnabled()
+        assert editor.duplicate_action.isEnabled()
+        editor.setCurrentIndex(editor.model.createIndex(0, 0))
+        editor.refresh_menu()
+        assert editor.rename_action.isEnabled() == rename_enabled
+        assert editor.duplicate_action.isEnabled() == duplicate_enabled
+        if isinstance(coll, list):
+            editor.duplicate_item()
+            assert editor.model.get_data() == coll_copy + [coll_copy[0]]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #5885

---
- `Rename` is disabled for `list`, `set` and `tuple` in the collection editor
- `Duplicate` is disabled for `tuple`
- `Duplicate` behavior is modified for `list` and `set` (it appends or adds a element at the end)

![rename_duplicate](https://user-images.githubusercontent.com/20270441/33808964-294159da-ddef-11e7-8c50-bd0c59d26aff.gif)
 