### PR TITLE
PR: Remove/update outdated refs to Mac OS X, Mac DMG installers and Continuum.io

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -60,18 +60,8 @@ Installing on MacOS X
 The easy way
 ~~~~~~~~~~~~
 
-Thanks to the Spyder team and `Continuum <http://www.continuum.io/>`_, you have
-two alternatives:
-
-#. Use the `Anaconda <http://continuum.io/downloads.html>`_ Python distribution.
-
-#. Use our DMG installers, which can be found
-   `here <https://github.com/spyder-ide/spyder/releases>`_.
-
-  .. note::
-     
-     The minimal version to run our DMG's is Mavericks (10.9) since
-     Spyder 2.3.5. Previous versions work on Lion (10.7) or higher.
++Thanks to the Spyder team and `Continuum <http://www.continuum.io/>`_, Spyder is included
++in the `Anaconda <http://continuum.io/downloads.html>`_ Python distribution.
 
 
 The hard way

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-Spyder is quite easy to install on Windows, Linux and MacOS X. Just the read the
+Spyder is quite easy to install on Windows, Linux and macOS. Just the read the
 following instructions with care.
 
 Installing on Windows Vista/7/8/10
@@ -54,8 +54,8 @@ You can update Spyder by:
 
 |
 
-Installing on MacOS X
-----------------------
+Installing on macOS
+-------------------
 
 The easy way
 ~~~~~~~~~~~~

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -12,7 +12,7 @@ The easy way
 
 Spyder is already included in these *Python Scientific Distributions*:
 
-#. `Anaconda <http://continuum.io/downloads.html>`_
+#. `Anaconda <https://www.anaconda.com/download/>`_
 #. `WinPython <https://winpython.github.io/>`_
 #. `Python(x,y) <https://code.google.com/p/pythonxy>`_
 
@@ -60,8 +60,8 @@ Installing on MacOS X
 The easy way
 ~~~~~~~~~~~~
 
-+Thanks to the Spyder team and `Continuum <http://www.continuum.io/>`_, Spyder is included
-+in the `Anaconda <http://continuum.io/downloads.html>`_ Python distribution.
++Thanks to the Spyder team and `Anaconda <https://www.anaconda.com/>`_, Spyder is included
++in the `Anaconda <https://www.anaconda.com/download/>`_ Python distribution.
 
 
 The hard way


### PR DESCRIPTION
Fixes #5978

First PR, but figured it was good to start small...hopefully I haven't messed too much stuff up. Removed the outdated references to the Mac DMG installers that are apparently no longer offered, to fix issue #5978 . 

Also, as a tangentially related general formatting note (I didn't modify anything to this effect here, of course), it might make more sense to replace the numbers with bullets or (perhaps better yet) just simple headings under the Linux section, as they don't represent a sequential list of steps nor an ordered list of preferable alternatives, as a numbered list would imply. If its important enough, I can make another PR to do so.
