### PR TITLE
PR: Display date/times in human readable format in Variable Explorer

### DIFF
--- a/spyder/widgets/variableexplorer/tests/test_utils.py
+++ b/spyder/widgets/variableexplorer/tests/test_utils.py
@@ -8,6 +8,7 @@ Tests for utils.py
 """
 
 from collections import defaultdict
+import datetime
 
 # Third party imports
 import numpy as np
@@ -118,6 +119,7 @@ def test_list_display():
     assert value_to_display(li) == '[builtin_function_or_method, 1]'
     assert is_supported(li, filters=supported_types)
 
+
 def test_dict_display():
     """Tests for display of dicts."""
     long_list = list(range(100))
@@ -162,5 +164,41 @@ def test_dict_display():
     assert is_supported(di, filters=supported_types)
 
 
-if __name__ == "__main__":
-    pytest.main()
+def test_datetime_display():
+    """Simple tests that dates, datetimes and timedeltas display correctly."""
+    test_date = datetime.date(2017, 12, 18)
+    test_date_2 = datetime.date(2017, 2, 2)
+
+    test_datetime = datetime.datetime(2017, 12, 18, 13, 43, 2)
+    test_datetime_2 = datetime.datetime(2017, 8, 18, 0, 41, 27)
+
+    test_timedelta = datetime.timedelta(-1, 2000)
+    test_timedelta_2 = datetime.timedelta(0, 3600)
+
+    # Simple dates/datetimes/timedeltas
+    assert value_to_display(test_date) == '2017-12-18'
+    assert value_to_display(test_datetime) == '2017-12-18 13:43:02'
+    assert value_to_display(test_timedelta) == '-1 day, 0:33:20'
+
+    # Lists of dates/datetimes/timedeltas
+    assert (value_to_display([test_date, test_date_2]) ==
+            '[2017-12-18, 2017-02-02]')
+    assert (value_to_display([test_datetime, test_datetime_2]) ==
+            '[2017-12-18 13:43:02, 2017-08-18 00:41:27]')
+    assert (value_to_display([test_timedelta, test_timedelta_2]) ==
+            '[-1 day, 0:33:20, 1:00:00]')
+
+    # Tuple of dates/datetimes/timedeltas
+    assert (value_to_display((test_date, test_datetime, test_timedelta)) ==
+            '(2017-12-18, 2017-12-18 13:43:02, -1 day, 0:33:20)')
+
+    # Dict of dates/datetimes/timedeltas
+    assert (value_to_display({"date": test_date,
+                              "time": test_datetime,
+                              "delta": test_timedelta_2}) ==
+            ("{'date':2017-12-18, 'time':2017-12-18 13:43:02," +
+             " 'delta':1:00:00}"))
+
+
+#if __name__ == "__main__":
+#    pytest.main()

--- a/spyder/widgets/variableexplorer/tests/test_utils.py
+++ b/spyder/widgets/variableexplorer/tests/test_utils.py
@@ -193,12 +193,11 @@ def test_datetime_display():
             '(2017-12-18, 2017-12-18 13:43:02, -1 day, 0:33:20)')
 
     # Dict of dates/datetimes/timedeltas
-    assert (value_to_display({"date": test_date,
-                              "time": test_datetime,
-                              "delta": test_timedelta_2}) ==
-            ("{'date':2017-12-18, 'time':2017-12-18 13:43:02," +
-             " 'delta':1:00:00}"))
+    assert (value_to_display({0: test_date,
+                              1: test_datetime,
+                              2: test_timedelta_2}) ==
+            ("{0:2017-12-18, 1:2017-12-18 13:43:02, 2:1:00:00}"))
 
 
-#if __name__ == "__main__":
-#    pytest.main()
+if __name__ == "__main__":
+    pytest.main()

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -421,9 +421,12 @@ def value_to_display(value, minmax=False, level=0):
             display = value
             if level > 0:
                 display = u"'" + display + u"'"
-        elif (isinstance(value, NUMERIC_TYPES) or isinstance(value, bool) or
-              isinstance(value, datetime.date) or
-              isinstance(value, datetime.timedelta) or
+        # TODO: Implement full timedelta support in variable explorer
+        elif (isinstance(value, datetime.date) or 
+              isinstance(value, datetime.date)):
+            display = str(value)
+        elif (isinstance(value, NUMERIC_TYPES) or 
+              isinstance(value, bool) or
               isinstance(value, numeric_numpy_types)):
             display = repr(value)
         else:

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -421,9 +421,8 @@ def value_to_display(value, minmax=False, level=0):
             display = value
             if level > 0:
                 display = u"'" + display + u"'"
-        # TODO: Implement full timedelta support in variable explorer
         elif (isinstance(value, datetime.date) or
-              isinstance(value, datetime.date)):
+              isinstance(value, datetime.timedelta)):
             display = str(value)
         elif (isinstance(value, NUMERIC_TYPES) or
               isinstance(value, bool) or

--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -422,10 +422,10 @@ def value_to_display(value, minmax=False, level=0):
             if level > 0:
                 display = u"'" + display + u"'"
         # TODO: Implement full timedelta support in variable explorer
-        elif (isinstance(value, datetime.date) or 
+        elif (isinstance(value, datetime.date) or
               isinstance(value, datetime.date)):
             display = str(value)
-        elif (isinstance(value, NUMERIC_TYPES) or 
+        elif (isinstance(value, NUMERIC_TYPES) or
               isinstance(value, bool) or
               isinstance(value, numeric_numpy_types)):
             display = repr(value)


### PR DESCRIPTION
Currently, dates, datetimes and timedeltas are displayed as "Datetime(yyyy, mm, dd, hour)...etc. in the variable explorer (while not being "edited"); here, we instead properly display them in the standard (ISO 8601) shorter and more human readable format produced by str(), and without the duplicative type name (as that is already shown in its own column). This currently also works for the supported Pandas timestamp, etc. types as well.