### PR TITLE
PR: Differenciate between ), }, and ] when closing brackets

### DIFF
--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2534,11 +2534,11 @@ class CodeEditor(TextEditBaseWidget):
         block = self.textCursor().block()
         line_pos = block.position()
         for pos, char in enumerate(text):
-            if char in ['(', '[', '{']:
+            if char in opening_braces:
                 match = self.find_brace_match(line_pos+pos, char, forward=True)
                 if (match is None) or (match > line_pos+len(text)):
                     return True
-            if char in [')', ']', '}']:
+            if char in closing_braces:
                 match = self.find_brace_match(line_pos+pos, char, forward=False)
                 if (match is None) or (match < line_pos):
                     return True

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2521,7 +2521,7 @@ class CodeEditor(TextEditBaseWidget):
     def __unmatched_braces_in_line(self, text, closing_braces_type=None):
         """
         Checks if there is an unmatched brace in the 'text'.
-        The brace type can be general or specified by closing_braces_type 
+        The brace type can be general or specified by closing_braces_type
         (')', ']', or '}')
         """
         if closing_braces_type is None:
@@ -2529,7 +2529,8 @@ class CodeEditor(TextEditBaseWidget):
             closing_braces = [')', ']', '}']
         else:
             closing_braces = [closing_braces_type]
-            opening_braces = [{')': '(', '}': '{', ']': '['}[closing_braces_type]]
+            opening_braces = [{')': '(', '}': '{',
+                               ']': '['}[closing_braces_type]]
         block = self.textCursor().block()
         line_pos = block.position()
         for pos, char in enumerate(text):
@@ -2909,7 +2910,8 @@ class CodeEditor(TextEditBaseWidget):
                          Qt.Key_BracketRight: ']'}[key]
             )
             if (key_matches_next_char
-              and not self.__unmatched_braces_in_line(cursor.block().text(), text)):
+                    and not self.__unmatched_braces_in_line(
+                        cursor.block().text(), text)):
                 # overwrite an existing brace if all braces in line are matched
                 cursor.clearSelection()
                 self.setTextCursor(cursor)

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2518,7 +2518,18 @@ class CodeEditor(TextEditBaseWidget):
         else:
             return False
 
-    def __unmatched_braces_in_line(self, text):
+    def __unmatched_braces_in_line(self, text, closing_braces_type=None):
+        """
+        Checks if there is an unmatched brace in the 'text'.
+        The brace type can be general or specified by closing_braces_type 
+        (')', ']', or '}')
+        """
+        if closing_braces_type is None:
+            opening_braces = ['(', '[', '{']
+            closing_braces = [')', ']', '}']
+        else:
+            closing_braces = [closing_braces_type]
+            opening_braces = [{')': '(', '}': '{', ']': '['}[closing_braces_type]]
         block = self.textCursor().block()
         line_pos = block.position()
         for pos, char in enumerate(text):
@@ -2898,7 +2909,7 @@ class CodeEditor(TextEditBaseWidget):
                          Qt.Key_BracketRight: ']'}[key]
             )
             if (key_matches_next_char
-              and not self.__unmatched_braces_in_line(cursor.block().text())):
+              and not self.__unmatched_braces_in_line(cursor.block().text(), text)):
                 # overwrite an existing brace if all braces in line are matched
                 cursor.clearSelection()
                 self.setTextCursor(cursor)


### PR DESCRIPTION
This is related to issue #5588. Eg:
my cursor is |. if I type ']', I would expect it to not be written. 
( [|]
)
But as the parenthesis is closed on the next line, this is not closed! even though my brackets are all closed.