### PR TITLE
PR: Skip several failing tests on Windows and one on a specific CI build

### DIFF
--- a/spyder/app/tests/script.py
+++ b/spyder/app/tests/script.py
@@ -1,4 +1,9 @@
 #%%
+
+# pylint: enable=C0111
+# pylint: enable=C0103
+# pylint: enable=C0413
+
 a = 10
 
 

--- a/spyder/app/tests/script_pylint.py
+++ b/spyder/app/tests/script_pylint.py
@@ -1,4 +1,9 @@
 #%%
+
+# pylint: enable=C0111
+# pylint: enable=C0103
+# pylint: enable=C0413
+
 a = 10
 
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -10,6 +10,7 @@ Tests for the main window
 
 import os
 import os.path as osp
+from sys import version_info
 import shutil
 import tempfile
 
@@ -138,9 +139,9 @@ def main_window(request):
 # IMPORTANT NOTE: Please leave this test to be the first one here to
 # avoid possible timeouts in Appveyor
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.environ.get('CI', None) is not None,
-                    reason="It times out in our CIs")
-@pytest.mark.timeout(timeout=60, method='thread')
+@pytest.mark.skipif(os.environ.get('CI', None) is not None or os.name == 'nt',
+                    reason="It times out in our CIs, and apparently Windows.")
+@pytest.mark.timeout(timeout=30, method='thread')
 @pytest.mark.use_introspection
 def test_calltip(main_window, qtbot):
     """Hide the calltip in the editor when a matching ')' is found."""
@@ -173,6 +174,9 @@ def test_calltip(main_window, qtbot):
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt' or PY2 or PYQT4,
                     reason="It fails sometimes")
+@pytest.mark.skipif(os.environ.get('CI', None) is not None and
+                    version_info[0:2] == (3, 5) and PYQT5,
+                    reason="It failed without cause at least once on Travis.")
 def test_move_to_first_breakpoint(main_window, qtbot):
     """Test that we move to the first breakpoint if there's one present."""
     # Wait until the window is fully up
@@ -283,7 +287,7 @@ def test_runconfig_workdir(main_window, qtbot, tmpdir):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.name == 'nt' and PY2, reason="It's failing there")
+@pytest.mark.skipif(os.name == 'nt', reason="It's failing on Windows.")
 def test_dedicated_consoles(main_window, qtbot):
     """Test running code in dedicated consoles."""
     # ---- Load test file ----
@@ -531,8 +535,8 @@ def test_run_cython_code(main_window, qtbot):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.environ.get('CI', None) is not None,
-                    reason="It times out in our CIs")
+@pytest.mark.skipif(os.environ.get('CI', None) is not None or os.name == 'nt',
+                    reason="It times out in our CIs and fails on Windows.")
 def test_open_notebooks_from_project_explorer(main_window, qtbot):
     """Test that notebooks are open from the Project explorer."""
     projects = main_window.projects
@@ -1097,7 +1101,7 @@ def test_fileswitcher(main_window, qtbot):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(not PYQT5, reason="It times out.")
+@pytest.mark.skipif(not PYQT5 or os.name == 'nt', reason="It times out.")
 def test_run_static_code_analysis(main_window, qtbot):
     """This tests that the Pylint plugin is working as expected."""
     # Wait until the window is fully up

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1110,7 +1110,7 @@ def test_run_static_code_analysis(main_window, qtbot):
     pylint = get_thirdparty_plugin(main_window, "Static code analysis")
 
     # Do an analysis
-    test_file = osp.join(LOCATION, 'script.py')
+    test_file = osp.join(LOCATION, 'script_pylint.py')
     main_window.editor.load(test_file)
     code_editor = main_window.editor.get_focus_widget()
     qtbot.keyClick(code_editor, Qt.Key_F8)

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -141,7 +141,7 @@ def main_window(request):
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.environ.get('CI', None) is not None or os.name == 'nt',
                     reason="It times out in our CIs, and apparently Windows.")
-@pytest.mark.timeout(timeout=30, method='thread')
+@pytest.mark.timeout(timeout=60, method='thread')
 @pytest.mark.use_introspection
 def test_calltip(main_window, qtbot):
     """Hide the calltip in the editor when a matching ')' is found."""
@@ -287,7 +287,7 @@ def test_runconfig_workdir(main_window, qtbot, tmpdir):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.name == 'nt', reason="It's failing on Windows.")
+@pytest.mark.skipif(os.name == 'nt' and PY2, reason="It's failing there")
 def test_dedicated_consoles(main_window, qtbot):
     """Test running code in dedicated consoles."""
     # ---- Load test file ----
@@ -1101,7 +1101,7 @@ def test_fileswitcher(main_window, qtbot):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(not PYQT5 or os.name == 'nt', reason="It times out.")
+@pytest.mark.skipif(not PYQT5, reason="It times out.")
 def test_run_static_code_analysis(main_window, qtbot):
     """This tests that the Pylint plugin is working as expected."""
     # Wait until the window is fully up
@@ -1117,7 +1117,7 @@ def test_run_static_code_analysis(main_window, qtbot):
     main_window.editor.load(test_file)
     code_editor = main_window.editor.get_focus_widget()
     qtbot.keyClick(code_editor, Qt.Key_F8)
-    qtbot.wait(500)
+    qtbot.wait(3000)
 
     # Perform the test
     # Check output of the analysis

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -174,9 +174,6 @@ def test_calltip(main_window, qtbot):
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt' or PY2 or PYQT4,
                     reason="It fails sometimes")
-@pytest.mark.skipif(os.environ.get('CI', None) is not None and
-                    version_info[0:2] == (3, 5) and PYQT5,
-                    reason="It failed without cause at least once on Travis.")
 def test_move_to_first_breakpoint(main_window, qtbot):
     """Test that we move to the first breakpoint if there's one present."""
     # Wait until the window is fully up

--- a/spyder/plugins/tests/test_editor_introspection.py
+++ b/spyder/plugins/tests/test_editor_introspection.py
@@ -58,9 +58,9 @@ def setup_editor(qtbot, monkeypatch):
     editor.introspector.plugin_manager.close()
 
 
+@flaky(max_runs=3)
 @pytest.mark.skipif(os.environ.get('CI', None) is not None,
                     reason="This test fails too much in the CI :(")
-@pytest.mark.skipif(os.name == 'nt', reason="This fails regularly on Windows.")
 @pytest.mark.skipif(not JEDI_010,
                     reason="This feature is only supported in jedy >= 0.10")
 def test_introspection(setup_editor):
@@ -74,11 +74,11 @@ def test_introspection(setup_editor):
 
     # Complete fr --> from
     qtbot.keyClicks(code_editor, 'fr')
-    qtbot.wait(5000)
+    qtbot.wait(20000)
 
     # press tab and get completions
     with qtbot.waitSignal(completion.sig_show_completions,
-                          timeout=5000) as sig:
+                          timeout=10000) as sig:
         qtbot.keyPress(code_editor, Qt.Key_Tab)
     assert "from" in sig.args[0]
 

--- a/spyder/plugins/tests/test_editor_introspection.py
+++ b/spyder/plugins/tests/test_editor_introspection.py
@@ -60,6 +60,7 @@ def setup_editor(qtbot, monkeypatch):
 
 @pytest.mark.skipif(os.environ.get('CI', None) is not None,
                     reason="This test fails too much in the CI :(")
+@pytest.mark.skipif(os.name == 'nt', reason="This fails regularly on Windows.")
 @pytest.mark.skipif(not JEDI_010,
                     reason="This feature is only supported in jedy >= 0.10")
 def test_introspection(setup_editor):


### PR DESCRIPTION
Per @ccordoba12 's request, I went through the tests and disabled the 4 that were currently consistently failing, at least for me on Windows. Also, I skipped a test that randomly failed on a specific Travis build for that build (Py3.5 with PyQT5, Py2 and PyQT4 were already skipped; it didn't fail on any of the other CIs or builds, had nothing to do with the code I added and succeeded when I merely changed some whitespace to my next otherwise identical commit so I was almost sure it was spurious; it already had flaky(3) but failed all three times). I ran them about 20 times in total over the course of my testing.

A few key points to look at for in reviewing:

* Did I choose the right left of specificity for my `skipif`s (skipping the test for Windows, but not drilling down into my specific Python or PyQT version, nor generalizing to all builds)? This was more or less consistent with the other `skipif`s, but wasn't sure exactly what @ccordoba12  wanted.
* Should we skip tests for the CIs that only fail all three `flaky` runs once out of many builds, as I did?
* Is there a better/cleaner way to get the Python version that I should have used?

Thanks!