### PR TITLE
Add coverage files and Notepad++ backups to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # gedit files
 *~
 
+# Notepad++ files
+nppBackup/
+
 # Special dirs and files
 build/
 dist/
@@ -16,7 +19,7 @@ spyder_crash.log
 .spyproject
 .idea/
 .cache
-.coverage
+.coverage*
 
 # git .orig files
 *.orig


### PR DESCRIPTION
Just as it says on the tin, a rather trivial pull request to add all code coverage files (`coverage.MACHINENAME.####.####`) to the `.gitignore` list, along with Notepad++ auto-backup directories, the former per consultation with @ccordoba12  and the latter mostly for convenience (if not desired, I'm fine with omitting it).