### PR TITLE
PR: Fix error when attempting to view module contents in CollectionsEditor

### DIFF
--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1318,7 +1318,7 @@ class CollectionsEditor(QDialog):
                 self.data_copy = copy.deepcopy(data)
             except NotImplementedError:
                 self.data_copy = copy.copy(data)
-            except TypeError:
+            except (TypeError, AttributeError):
                 readonly = True
                 self.data_copy = data
             datalen = len(get_object_attrs(data))

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1322,13 +1322,14 @@ class CollectionsEditor(QDialog):
                 readonly = True
                 self.data_copy = data
             datalen = len(get_object_attrs(data))
-        self.widget = CollectionsEditorWidget(self, self.data_copy, title=title,
-                                              readonly=readonly, remote=remote)
+        self.widget = CollectionsEditorWidget(self, self.data_copy,
+                                              title=title, readonly=readonly,
+                                              remote=remote)
 
         layout = QVBoxLayout()
         layout.addWidget(self.widget)
         self.setLayout(layout)
-        
+
         # Buttons configuration
         buttons = QDialogButtonBox.Ok
         if not readonly:

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1318,6 +1318,9 @@ class CollectionsEditor(QDialog):
                 self.data_copy = copy.deepcopy(data)
             except NotImplementedError:
                 self.data_copy = copy.copy(data)
+            except TypeError:
+                readonly = True
+                self.data_copy = data
             datalen = len(get_object_attrs(data))
         self.widget = CollectionsEditorWidget(self, self.data_copy, title=title,
                                               readonly=readonly, remote=remote)

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -8,6 +8,7 @@ Tests for collectionseditor.py
 """
 
 # Standard library imports
+import os  # Example module for testing display inside collecitoneditor
 import copy
 import datetime
 try:
@@ -21,7 +22,9 @@ import pytest
 
 # Local imports
 from spyder.widgets.variableexplorer.collectionseditor import (
-    CollectionsEditorTableView, CollectionsModel, LARGE_NROWS, ROWS_TO_LOAD)
+    CollectionsEditorTableView, CollectionsModel, CollectionsEditor,
+    LARGE_NROWS, ROWS_TO_LOAD)
+
 
 # Helper functions
 def data(cm, i, j):
@@ -163,8 +166,9 @@ def test_rename_and_duplicate_item_in_collection_editor():
 
 
 def test_edit_mutable_and_immutable_types(qtbot, monkeypatch):
-    # To ensure mutable types (lists, dicts) and individual values are editable
-    # But not immutable ones (tuples) or anything inside of them, per #5991
+    """Check to ensure mutable types (lists, dicts) and individual values are
+    editable, but not immutable ones (tuples) or anything inside of them,
+    per #5991"""
     MockQLineEdit = Mock()
     attr_to_patch_qlineedit = ('spyder.widgets.variableexplorer.' +
                                'collectionseditor.QLineEdit')
@@ -263,6 +267,15 @@ def test_edit_mutable_and_immutable_types(qtbot, monkeypatch):
     mockCollectionsEditor_instance.setup.assert_called_with(ANY, ANY,
                                                             icon=ANY,
                                                             readonly=True)
+
+
+def test_view_module_in_coledit(qtbot, monkeypatch):
+    """Checks that modules don't produce an error when trying to open them in
+    Variable Explorer, and are set as readonly. Regression test for #6080"""
+
+    editor = CollectionsEditor()
+    editor.setup(os, "module_test", readonly=False)
+    assert editor.widget.editor.readonly
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -19,6 +19,7 @@ except ImportError:
 # Third party imports
 import pandas
 import pytest
+from flaky import flaky
 
 # Local imports
 from spyder.widgets.variableexplorer.collectionseditor import (
@@ -165,7 +166,7 @@ def test_rename_and_duplicate_item_in_collection_editor():
             assert editor.model.get_data() == coll_copy + [coll_copy[0]]
 
 
-def test_edit_mutable_and_immutable_types(qtbot, monkeypatch):
+def test_edit_mutable_and_immutable_types(monkeypatch):
     """Check to ensure mutable types (lists, dicts) and individual values are
     editable, but not immutable ones (tuples) or anything inside of them,
     per #5991"""
@@ -269,10 +270,10 @@ def test_edit_mutable_and_immutable_types(qtbot, monkeypatch):
                                                             readonly=True)
 
 
+@flaky(max_runs=3)
 def test_view_module_in_coledit():
     """Check that modules don't produce an error when trying to open them in
     Variable Explorer, and are set as readonly. Regression test for #6080"""
-
     editor = CollectionsEditor()
     editor.setup(os, "module_test", readonly=False)
     assert editor.widget.editor.readonly

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -269,7 +269,7 @@ def test_edit_mutable_and_immutable_types(qtbot, monkeypatch):
                                                             readonly=True)
 
 
-def test_view_module_in_coledit(qtbot, monkeypatch):
+def test_view_module_in_coledit():
     """Check that modules don't produce an error when trying to open them in
     Variable Explorer, and are set as readonly. Regression test for #6080"""
 

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -270,7 +270,7 @@ def test_edit_mutable_and_immutable_types(qtbot, monkeypatch):
 
 
 def test_view_module_in_coledit(qtbot, monkeypatch):
-    """Checks that modules don't produce an error when trying to open them in
+    """Check that modules don't produce an error when trying to open them in
     Variable Explorer, and are set as readonly. Regression test for #6080"""
 
     editor = CollectionsEditor()


### PR DESCRIPTION
Fixes #6080 , where Spyder would produce an error instead of viewing module contents, likely related to the recent introduction of `cloudpickle`.

Also includes a regression test making sure the editor is created without error and is properly readonly.