### PR TITLE
PR: Major overhaul of Readme, contributing and install docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 :+1::tada: First off, thanks for taking the time to contribute to Spyder! :tada::+1:
 
+
 ## General Guidelines
 
 This page documents at a very high level how to contribute to Spyder.
@@ -37,14 +38,14 @@ closed after a week (7 days). Thanks!
 ### Creating a conda environment or virtualenv
 
 If you use Anaconda you can create a conda environment with
-these commands:
+the following commands:
 
 ```bash
   $ conda create -n spyder-dev python=3
   $ source activate spyder-dev
 ```
 
-On Windows, you'll want to run them under the Anaconda Prompt,
+On Windows, you'll want to run the commands with the Anaconda Prompt,
 and use just ```activate spyder-dev``` for the second command.
 
 You can also use `virtualenv` on Linux, but `conda` is strongly
@@ -58,7 +59,7 @@ recommended:
 ### Installing dependencies
 
 After you have created your development environment, you need to install
-Spyder's necessary dependencies. For that, the easiest way to do so is
+Spyder's necessary dependencies. The easiest way to do so (with Anaconda) is
 
 ```bash
   $ conda install spyder
@@ -75,7 +76,8 @@ the directory where your git clone is stored and run:
   $ pip install -r requirements/requirements.txt
 ```
 
-If you are using pip, you also need to install a Qt binding package.
+If you are using `pip` and Python 2, you also need to install a Qt binding
+package (PyQt4 or PyQt5, with the latter strongly recommended).
 This can be achieved by running:
 
 ```bash
@@ -92,43 +94,52 @@ your environment, you need to run
   $ python bootstrap.py
 ```
 
-**Important Note**: You need to restart Spyder after any change you do to its
-source code. This is the only way to test your new code.
+To start Spyder in debug mode, useful for tracking down an issue, you can run:
+
+```bash
+  $ python bootstrap.py --debug
+```
+
+**Important Note**: To test any changes you've made to the Spyder source code,
+you need to restart Spyder or start a fresh instance (you can run multiple
+copies simultaneously by unchecking the Preferences option
+<kbd>Use a single instance</kbd> under
+<kbd>General</kbd> > <kbd>Advanced Settings</kbd> .
+
 
 ## Spyder Branches
 
 When you start to work on a new pull request (PR), you need to be sure that your
-feature branch is a child of the right Spyder branch, and also that you make
-your PR on Github against it.
+work is done on top of the correct Spyder branch, and that you base your
+PR on Github against it.
 
-Besides, issues are marked with a milestone that indicates the correct branch
-to use, like this:
+To guide you, issues on Github are marked with a milestone that indicates
+the correct branch to use. If not, follow these guidelines:
 
-* Use the `3.x` branch for bugfixes only (milestones `v3.2.1`, `v3.2.2`, `v3.2.3`,
-  etc)
+* Use the `3.x` branch for bugfixes only (*e.g.* milestones `v3.2.1`, `v3.2.2`,
+  or `v3.2.3`)
+* Use `master` to introduce new features or break compatibility with previous
+  Spyder versions (*e.g.* milestones `v4.0beta1` or `v4.0beta2`).
 
-* Use `master` to introduce new features that break compatibility with previous
-  Spyder versions (Milestone `v4.0beta1`, `v4.0beta2`, etc).
+You should also submit bugfixes to `3.x` or `master` for errors that are
+only present in those respective branches.
 
-
-You can also submit bugfixes to `3.x` or `master` for errors that are
-only present in those branches.
-
-So to start working on a new PR, you need to follow these commands:
+To start working on a new PR, you need to execute these commands, filling in
+the branch names where appropriate:
 
 ```bash
-  $ git checkout <branch>
-  $ git pull upstream <branch>
-  $ git checkout -b name-new-branch
+  $ git checkout <SPYDER-BASE-BRANCH>
+  $ git pull upstream <SPYDER-BASE-BRANC>
+  $ git checkout -b NAME-NEW-BRANCH
 ```
 
-### Changing base branch
+### Changing the base branch
 
-If you started your work in the wrong branch, or want to backport it, you could
-change the base branch using `git rebase --onto`, like this:
+If you started your work in the wrong base branch, or want to backport it,
+you can change the base branch using `git rebase --onto`, like this:
 
 ```bash
-  $ git rebase --onto <new_base> <old_base> <branch>
+  $ git rebase --onto <NEW-BASE-BRANCH> <OLD-BASE-BRANCH> <YOUR-BRANCH>
 ```
 
 For example, backporting `my_branch` from `master` to `3.x`:
@@ -137,20 +148,22 @@ For example, backporting `my_branch` from `master` to `3.x`:
   $ git rebase --onto 3.x master my_branch
 ```
 
+
 ##  Running Tests
 
-Install our test dependencies:
+To install our test dependencies under Anaconda:
 
 ```bash
   $ conda install --file requirements/test_requirements.txt -c spyder-ide
 ```
 
-or using `pip` (not recommended):
+If using `pip` (for experts only), run the following from the directory
+where your git clone is stored:
 ```bash
   $ pip install -r requirements/test_requirements.txt
 ```
 
-To run the Spyder test suite, please use (from the root spyder directory):
+To run the Spyder test suite, please use (from the `spyder` root directory):
 ```bash
   $ python runtests.py
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,21 @@ Please check the
 for a more detailed guide on how to do so.
 
 
+## Submitting a Helpful Issue
+
+Submitting useful, effective and to-the-point issue reports can go a long
+way toward improving Spyder for everyone. Accordingly, please read the
+[relevant section](https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ#calling-for-help-still-have-a-problem)
+of the Spyder Troubleshooting Guide, which describes in detail how to do
+just that.
+
+Most importantly, aside from the error message/traceback and the requested
+environment/dependency information, *please* be sure you include a detailed,
+step by step description of exactly what triggered the problem. Otherwise,
+we likely won't be able to find and fix it, and your issue will have to be
+closed after a week (7 days). Thanks!
+
+
 ## Setting Up a Development Environment
 
 
@@ -139,3 +154,13 @@ To run the Spyder test suite, please use (from the root spyder directory):
 ```bash
   $ python runtests.py
 ```
+
+
+## Troubleshooting
+
+Before posting a report, *please* carefully read our
+**[Troubleshooting Guide](https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ)**
+and search the [issue tracker](https://github.com/spyder-ide/spyder/issues)
+for your error message and problem description, as the great majority of bugs
+are either duplicates, or can be fixed on the user side with a few easy steps.
+Thanks!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@
 ## General Guidelines
 
 This page documents at a very high level how to contribute to Spyder.
-Please Check the
+Please check the
 [Spyder IDE Contributor Documentation](https://github.com/spyder-ide/spyder/wiki/Contributing-to-Spyder)
-for a more detailed guide on how to contribute to the Spyder.
+for a more detailed guide on how to do so.
 
 
 ## Setting Up a Development Environment
@@ -22,14 +22,18 @@ for a more detailed guide on how to contribute to the Spyder.
 ### Creating a conda environment or virtualenv
 
 If you use Anaconda you can create a conda environment with
-these instructions
+these commands:
 
 ```bash
   $ conda create -n spyder-dev python=3
   $ source activate spyder-dev
 ```
 
-You can also use `virtualenv` on Linux, but `conda` is preferred:
+On Windows, you'll want to run them under the Anaconda Prompt,
+and use just ```activate spyder-dev``` for the second command.
+
+You can also use `virtualenv` on Linux, but `conda` is strongly
+recommended:
 
 ```bash
   $ mkvirtualenv spyder-dev
@@ -39,21 +43,25 @@ You can also use `virtualenv` on Linux, but `conda` is preferred:
 ### Installing dependencies
 
 After you have created your development environment, you need to install
-Spyder necessary dependencies. For that you need to go to the directory
-where your git clone is placed and run:
+Spyder's necessary dependencies. For that, the easiest way to do so is
 
 ```bash
-  $ conda install --file requirements/requirements.txt
+  $ conda install spyder
+  $ conda remove spyder
 ```
 
-or using pip and virtualenv:
+This installs all of Spyder's dependencies into the environment along with
+the stable/packaged version of Spyder itself, and then removes the latter.
+
+If using `pip` and `virtualenv` (not recommended), you need to `cd` to
+the directory where your git clone is stored and run:
 
 ```bash
   $ pip install -r requirements/requirements.txt
 ```
 
-*Note*: If you are using pip, you also need to install a Qt binding
-package. This can be achieved by running
+If you are using pip, you also need to install a Qt binding package.
+This can be achieved by running:
 
 ```bash
   $ pip install pyqt5
@@ -61,8 +69,9 @@ package. This can be achieved by running
 
 ### Running Spyder
 
-To start Spyder directly from your clone, i.e. without installing it to your
-environment, you need to run
+To start Spyder directly from your clone, i.e. without installing it into
+your environment, you need to run
+(from the directory you cloned it to e.g. `spyder`):
 
 ```bash
   $ python bootstrap.py
@@ -87,8 +96,8 @@ to use, like this:
   Spyder versions (Milestone `v4.0beta1`, `v4.0beta2`, etc).
 
 
-You can also submit bugfixes to `3.x` or `master` for errors that are only present in
-those branches.
+You can also submit bugfixes to `3.x` or `master` for errors that are
+only present in those branches.
 
 So to start working on a new PR, you need to follow these commands:
 
@@ -121,12 +130,12 @@ Install our test dependencies:
   $ conda install --file requirements/test_requirements.txt -c spyder-ide
 ```
 
-or using pip
+or using `pip` (not recommended):
 ```bash
   $ pip install -r requirements/test_requirements.txt
 ```
 
-To run Spyder test suite, please use:
+To run the Spyder test suite, please use (from the root spyder directory):
 ```bash
   $ python runtests.py
 ```

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ Spyder is a Python development environment with a lot of features:
 
 * **Find in files**
 
-    Supporting regular expressions and mercurial repositories
+    Supporting regular expressions and Mercurial repositories
 
 * **File explorer**
+
+    Interact with your filesystem from within the IDE.
 
 * **History log**
 
@@ -90,19 +92,19 @@ solve on your own, we recommend you use Anaconda instead, as we are
 generally unable to offer individual assistance for problems specific
 to installing via these alternative distributions.
 
-** Windows **
+**Windows**
 
 Spyder is included in these other scientific Python distributions:
 
 * [WinPython](https://winpython.github.io/)
 * [Python(x,y)](http://python-xy.github.io)
 
-** macOS **
+**macOS**
 
 Spyder can be obtained through through
 [MacPorts](http://www.macports.org/).
 
-** GNU/Linux **
+**GNU/Linux**
 
 * You can often get Spyder through your distribution's package
 manager (i.e. `apt-get`, `yum`, etc), or install from source

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Spyder is a Python development environment with a lot of features:
 
     Python or IPython consoles with workspace and debugging support to
     instantly evaluate the code written in the Editor. It also comes
-    with Matplotlib figures integration. 
+    with Matplotlib figures integration.
 
 * **Documentation viewer**
 
@@ -69,60 +69,98 @@ This section explains how to install the latest stable release of
 Spyder. If you prefer testing the development version, please use
 the `bootstrap` script (see next section).
 
-The easiest way to install Spyder is:
+### The Easy/Recommended Way: Anaconda
 
-### On Windows:
+The easiest way to install Spyder for any of our platform, and
+the way we recommend to avoid unexpected issues we aren't able to
+help you with, is to download it as part of the
+[Anaconda](https://www.anaconda.com/download/) distribution, and keep
+it updated and install other packages with the `conda` package
+and environment manager.
 
-Using one (and only one) of these scientific Python distributions:
+If in doubt, you should install via this method; it generally has the
+least likelihood of potential pitfalls for non-experts, and we may be
+able to provide limited assistance if you do run into trouble.
 
-1. [Anaconda](http://continuum.io/downloads)
-2. [WinPython](https://winpython.github.io/)
-3. [Python(x,y)](http://python-xy.github.io)
+### The Harder Way: Alternative Distributions
 
-### On Mac OSX:
+**Important Note:** While we offer alternative options for users who
+desire them, if you encounter installation issues you are unable to
+solve on your own, we recommend you use Anaconda instead, as we are
+generally unable to offer individual assistance for problems specific
+to installing via these alternative distributions.
 
-- Using the [Anaconda Distribution](http://continuum.io/downloads).
-- Through [MacPorts](http://www.macports.org/).
+** Windows **
 
-### On GNU/Linux
+Spyder is included in these other scientific Python distributions:
 
-- Through your distribution package manager (i.e. `apt-get`, `yum`,
-  etc).
-- Using the [Anaconda Distribution](http://continuum.io/downloads).
-- Installing from source (see below).
+* [WinPython](https://winpython.github.io/)
+* [Python(x,y)](http://python-xy.github.io)
 
-### Cross-platform way from source
+** macOS **
+
+Spyder can be obtained through through
+[MacPorts](http://www.macports.org/).
+
+** GNU/Linux **
+
+* You can often get Spyder through your distribution's package
+manager (i.e. `apt-get`, `yum`, etc), or install from source
+(see below).
+
+### The Expert/Cross-platform Way: Installing from source with pip
+
+**Warning:** While this installation method is a viable option for
+experienced users, installing Spyder (and other SciPy stack packages)
+with `pip` can encounter a number of tricky issues. While you are welcome
+to try this on your own if you're an expert, we are unable to help if you
+do run into problems, except to recommend using Anaconda instead.
 
 You can also install Spyder with the `pip` package manager, which comes by
-default with most Python installations. For that you need to use the
-command:
-
+default with most Python installations. To do so, you need to use the command:
+```
     pip install spyder
-
+```
 To upgrade Spyder to its latest version, if it was installed before, you need
-to run
-
+to run:
+```
     pip install --upgrade spyder
-
-For more details on supported platforms, please refer to our
-[installation instructions](http://pythonhosted.org/spyder/installation.html).
+```
 
 **Important note**: This does not install the graphical Python libraries (i.e.
 PyQt5 or PyQt4) that Spyder depends on. Those have to be installed separately
 after installing Python.
 
 
+For more details on supported platforms, please refer to our
+[installation instructions](http://pythonhosted.org/spyder/installation.html).
+
+
 ## Running from source
 
-The fastest way to run Spyder is to get the source code using git, install
-PyQt5 or PyQt4, and run these commands:
-
-1. Install our *runtime dependencies* (see below).
-2. `cd /your/spyder/git-clone`
-3. `python bootstrap.py`
-
+The fastest way to run Spyder is to run form source, hosted on the
+[Spyder github repo](https://github.com/spyder-ide/spyder).
 You may want to do this for fixing bugs in Spyder, adding new
 features, learning how Spyder works or just getting a taste of it.
+Make sure to copy the path listed under the "Clone or Download" button there,
+or just use https://github.com/spyder-ide/spyder.git .
+
+If using `conda` (strongly recommended), run the following from
+the command line (the Anaconda Prompt, if on Windows):
+```
+conda install spyder
+conda remove spyder
+git clone PATH_FROM_SPYDER_REPO
+cd DIR_YOU_CLONED_IT_TO
+python bootstrap.py
+```
+
+Alternatively, you can install PyQt5 (or PyQt4) separately and use `pip`
+to install the *runtime dependencies* discussed below, but this is
+for experts only and is not recommend, so you'll have to solve any
+problems on your own. See the
+[installation instructions](http://pythonhosted.org/spyder/installation.html)
+for more detail.
 
 
 ## Dependencies
@@ -174,7 +212,7 @@ a Python version greater than 2.7 (Python 3.2 is not supported anymore).
 
 Everyone is welcome to contribute. Please read our
 [contributing instructions](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md),
-then get started!
+to get started!
 
 
 ## More information

--- a/README.md
+++ b/README.md
@@ -217,6 +217,16 @@ Everyone is welcome to contribute. Please read our
 to get started!
 
 
+## Troubleshooting
+
+Before posting a report, *please* carefully read our
+**[Troubleshooting Guide](https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ)**
+and search the [issue tracker](https://github.com/spyder-ide/spyder/issues)
+for your error message and problem description, as the great majority of bugs
+are either duplicates, or can be fixed on the user side with a few easy steps.
+Thanks!
+
+
 ## More information
 
 * For code development please go to:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 Copyright © Spyder Project Contributors.
 
+
 ## Project details
 [![license](https://img.shields.io/pypi/l/spyder.svg)](./LICENSE)
 [![pypi version](https://img.shields.io/pypi/v/spyder.svg)](https://pypi.python.org/pypi/spyder)
 [![Join the chat at https://gitter.im/spyder-ide/public](https://badges.gitter.im/spyder-ide/spyder.svg)](https://gitter.im/spyder-ide/public)
+
 
 ## Build status
 [![Travis status](https://travis-ci.org/spyder-ide/spyder.svg?branch=master)](https://travis-ci.org/spyder-ide/spyder)
@@ -14,11 +16,13 @@ Copyright © Spyder Project Contributors.
 [![Coverage Status](https://coveralls.io/repos/github/spyder-ide/spyder/badge.svg?branch=master)](https://coveralls.io/github/spyder-ide/spyder?branch=master)
 [![codecov](https://codecov.io/gh/spyder-ide/spyder/branch/master/graph/badge.svg)](https://codecov.io/gh/spyder-ide/spyder)
 
+
 ## Overview
 
 ![screenshot](./img_src/screenshot.png)
 
-Spyder is a Python development environment with a lot of features:
+Spyder is a Python development environment with many features for research,
+data analysis, and scientific package creation:
 
 * **Editor**
 
@@ -28,9 +32,9 @@ Spyder is a Python development environment with a lot of features:
 
 * **Interactive console**
 
-    Python or IPython consoles with workspace and debugging support to
-    instantly evaluate the code written in the Editor. It also comes
-    with Matplotlib figures integration.
+    IPython consoles with workspace and debugging support to
+    instantly evaluate the code written in the Editor.
+    Spyder consoles also come with Matplotlib figures integration.
 
 * **Documentation viewer**
 
@@ -45,7 +49,8 @@ Spyder is a Python development environment with a lot of features:
 
 * **Find in files**
 
-    Supporting regular expressions and Mercurial repositories
+    Search for queries across multiple files in your project,
+    with full support for regular expressions.
 
 * **File explorer**
 
@@ -53,129 +58,125 @@ Spyder is a Python development environment with a lot of features:
 
 * **History log**
 
-Spyder may also be used as a PyQt5/PyQt4 extension library (module
-`spyder`). For example, the Python interactive shell widget used in
+    Browse an automatically de-duplicated listing of every command you run
+    on any Spyder console.
+
+Spyder may also be used as a PyQt5/PyQt4 extension library (module `spyder`).
+For example, the Python interactive shell widget used in
 Spyder may be embedded in your own PyQt5/PyQt4 application.
 
 
 ## Documentation
 
-You can read the Spyder documentation at:
-
-http://pythonhosted.org/spyder/
+You can read the Spyder documentation online on
+[PythonHosted](http://pythonhosted.org/spyder/).
 
 
 ## Installation
 
 This section explains how to install the latest stable release of
 Spyder. If you prefer testing the development version, please use
-the `bootstrap` script (see next section).
+the `bootstrap` script (see the [appropriate section](#running-from-source) ).
+
+For a more detail guide to installing Spyder, please refer to our
+[installation instructions](http://pythonhosted.org/spyder/installation.html).
 
 ### The Easy/Recommended Way: Anaconda
 
-The easiest way to install Spyder for any of our platform, and
-the way we recommend to avoid unexpected issues we aren't able to
-help you with, is to download it as part of the
-[Anaconda](https://www.anaconda.com/download/) distribution, and keep
-it updated and install other packages with the `conda` package
-and environment manager.
+The easiest way to install Spyder on any of our supported platforms
+is to download it as part of the [Anaconda](https://www.anaconda.com/download/)
+distribution, and use the `conda` package and environment manager to keep it
+and your other packages installed and up to date.
 
-If in doubt, you should install via this method; it generally has the
+If in doubt, you should always install Spyder via this method to avoid
+unexpected issues we are unable to help you with; it generally has the
 least likelihood of potential pitfalls for non-experts, and we may be
 able to provide limited assistance if you do run into trouble.
 
-### The Harder Way: Alternative Distributions
+### The Harder Way: Alternative distributions
 
-**Important Note:** While we offer alternative options for users who
-desire them, if you encounter installation issues you are unable to
-solve on your own, we recommend you use Anaconda instead, as we are
-generally unable to offer individual assistance for problems specific
-to installing via these alternative distributions.
+**Important Note:** While we offer alternative Spyder installation options
+for users who desire them, we currently lack the resources to offer individual
+assistance for problems specific to installing via these alternative distributions.
+Therefore, we recommend you switch to Anaconda if you encounter installation
+issues you are unable to solve on your own.
 
 **Windows**
 
-Spyder is included in these other scientific Python distributions:
-
-* [WinPython](https://winpython.github.io/)
-* [Python(x,y)](http://python-xy.github.io)
+Spyder is also included in the [WinPython](https://winpython.github.io/)
+scientific Python distribution, although some users have reported bugs
+specific to it.
 
 **macOS**
 
-Spyder can be obtained through through
-[MacPorts](http://www.macports.org/).
+Spyder can also be obtained through through [MacPorts](http://www.macports.org/),
+though like its WinPython counterpart, the included version may be out of date
+or have other MacPorts specific issues outside of Spyder's control.
 
 **GNU/Linux**
 
-* You can often get Spyder through your distribution's package
-manager (i.e. `apt-get`, `yum`, etc), or install from source
-(see below).
+You can often install Spyder through your distribution's package
+manager (i.e. `apt-get`, `yum`, etc).
 
-### The Expert/Cross-platform Way: Installing from source with pip
+### The Expert Way: Installing with pip
 
 **Warning:** While this installation method is a viable option for
 experienced users, installing Spyder (and other SciPy stack packages)
-with `pip` can encounter a number of tricky issues. While you are welcome
-to try this on your own if you're an expert, we are unable to help if you
-do run into problems, except to recommend using Anaconda instead.
+with `pip` can lead to a number of tricky issues. While you are welcome
+to try this on your own, we unfortunately do not have the resources to help you
+if you do run into problems, except to recommend using Anaconda instead.
 
-You can also install Spyder with the `pip` package manager, which comes by
-default with most Python installations. To do so, you need to use the command:
-```
-    pip install spyder
-```
-To upgrade Spyder to its latest version, if it was installed before, you need
-to run:
-```
-    pip install --upgrade spyder
-```
+You can install Spyder with the `pip` package manager, which comes by
+default with most Python installations, with the command:
 
-**Important note**: This does not install the graphical Python libraries (i.e.
-PyQt5 or PyQt4) that Spyder depends on. Those have to be installed separately
-after installing Python.
+`pip install spyder`
+
+Once installed, you can upgrade Spyder to its latest version, by running:
+
+`pip install --upgrade spyder`
+
+Also, you may need to install a Qt binding with `pip` if running Python 2;
+PyQt5 is strongly recommended though the legacy PyQt4 is also still supported.
 
 
-For more details on supported platforms, please refer to our
-[installation instructions](http://pythonhosted.org/spyder/installation.html).
+## Running from a Github clone
 
-
-## Running from source
-
-The fastest way to run Spyder is to run form source, hosted on the
+Spyder can be run directly from the source code, hosted on the
 [Spyder github repo](https://github.com/spyder-ide/spyder).
 You may want to do this for fixing bugs in Spyder, adding new
-features, learning how Spyder works or just getting a taste of it.
-Make sure to copy the path listed under the "Clone or Download" button there,
-or just use https://github.com/spyder-ide/spyder.git .
+features, learning how Spyder works or to try out development versions before
+they are officially released.
 
-If using `conda` (strongly recommended), run the following from
-the command line (the Anaconda Prompt, if on Windows):
+If using `conda` (strongly recommended), this can be done by running the
+following from the command line (the Anaconda Prompt, if on Windows):
+
 ```
 conda install spyder
 conda remove spyder
-git clone PATH_FROM_SPYDER_REPO
-cd DIR_YOU_CLONED_IT_TO
+git clone https://github.com/spyder-ide/spyder.git
+cd spyder
 python bootstrap.py
 ```
 
-Alternatively, you can install PyQt5 (or PyQt4) separately and use `pip`
-to install the *runtime dependencies* discussed below, but this is
-for experts only and is not recommend, so you'll have to solve any
+Alternatively, you can use `pip` to install PyQt5 (or PyQt4) separately and
+the other *runtime dependencies* listed below. However, beware:
+this method is recommended for experts only, and you'll need to solve any
 problems on your own. See the
 [installation instructions](http://pythonhosted.org/spyder/installation.html)
-for more detail.
+for more details.
 
 
 ## Dependencies
 
 **Important note**: Most if not all the dependencies listed below come
-with *Anaconda*, *WinPython* and *Python(x,y)*, so you don't need to install
+with *Anaconda* or other scien, so you don't need to install
 them separately when installing one of these Scientific Python
 distributions.
 
 ### Build dependencies
 
 When installing Spyder from its source package, the only requirement is to have
-a Python version greater than 2.7 (Python 3.2 is not supported anymore).
+a Python version greater than 2.7 or 3.3 (Python <=3.2 is not supported anymore).
 
 ### Runtime dependencies
 
@@ -212,15 +213,14 @@ a Python version greater than 2.7 (Python 3.2 is not supported anymore).
 
 ## Contributing
 
-Everyone is welcome to contribute. Please read our
-[contributing instructions](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md),
+Everyone is welcome to help with Spyder. Please read our
+[contributing instructions](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
 to get started!
 
 
 ## Troubleshooting
 
-Before posting a report, *please* carefully read our
-**[Troubleshooting Guide](https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ)**
+Before posting a report, *please* carefully read our **[Troubleshooting Guide](https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ)**
 and search the [issue tracker](https://github.com/spyder-ide/spyder/issues)
 for your error message and problem description, as the great majority of bugs
 are either duplicates, or can be fixed on the user side with a few easy steps.
@@ -229,7 +229,7 @@ Thanks!
 
 ## More information
 
-* For code development please go to:
+* For Spyder development details:
 
     <https://github.com/spyder-ide/spyder>
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,8 @@ You can read the Spyder documentation online on
 
 ## Installation
 
-This section explains how to install the latest stable release of
-Spyder. If you prefer testing the development version, please use
-the `bootstrap` script (see the [appropriate section](#running-from-source) ).
-
-For a more detail guide to installing Spyder, please refer to our
+For a detailed guide to installing Spyder, please refer to our
 [installation instructions](http://pythonhosted.org/spyder/installation.html).
-
-### The Easy/Recommended Way: Anaconda
 
 The easiest way to install Spyder on any of our supported platforms
 is to download it as part of the [Anaconda](https://www.anaconda.com/download/)
@@ -93,50 +87,16 @@ unexpected issues we are unable to help you with; it generally has the
 least likelihood of potential pitfalls for non-experts, and we may be
 able to provide limited assistance if you do run into trouble.
 
-### The Harder Way: Alternative distributions
+Other install options exist, including the 
 
-**Important Note:** While we offer alternative Spyder installation options
-for users who desire them, we currently lack the resources to offer individual
-assistance for problems specific to installing via these alternative distributions.
-Therefore, we recommend you switch to Anaconda if you encounter installation
-issues you are unable to solve on your own.
+* The [WinPython](https://winpython.github.io/) distribution for Windows
+* The [MacPorts](http://www.macports.org/), project for macOS, and
+* Your distribution's package manager (i.e. `apt-get`, `yum`, etc) on Linux, and
+* The `pip` package manager, included with most Python installations
 
-**Windows**
-
-Spyder is also included in the [WinPython](https://winpython.github.io/)
-scientific Python distribution, although some users have reported bugs
-specific to it.
-
-**macOS**
-
-Spyder can also be obtained through through [MacPorts](http://www.macports.org/),
-though like its WinPython counterpart, the included version may be out of date
-or have other MacPorts specific issues outside of Spyder's control.
-
-**GNU/Linux**
-
-You can often install Spyder through your distribution's package
-manager (i.e. `apt-get`, `yum`, etc).
-
-### The Expert Way: Installing with pip
-
-**Warning:** While this installation method is a viable option for
-experienced users, installing Spyder (and other SciPy stack packages)
-with `pip` can lead to a number of tricky issues. While you are welcome
-to try this on your own, we unfortunately do not have the resources to help you
-if you do run into problems, except to recommend using Anaconda instead.
-
-You can install Spyder with the `pip` package manager, which comes by
-default with most Python installations, with the command:
-
-`pip install spyder`
-
-Once installed, you can upgrade Spyder to its latest version, by running:
-
-`pip install --upgrade spyder`
-
-Also, you may need to install a Qt binding with `pip` if running Python 2;
-PyQt5 is strongly recommended though the legacy PyQt4 is also still supported.
+**However,** we lack the resources to provide individual support for users who
+install via these methods, and they may be out of date or contain bugs outside
+our control, so we recommend the Anaconda version instead if you run into issues.
 
 
 ## Running from a Github clone
@@ -169,9 +129,8 @@ for more details.
 ## Dependencies
 
 **Important note**: Most if not all the dependencies listed below come
-with *Anaconda* or other scien, so you don't need to install
-them separately when installing one of these Scientific Python
-distributions.
+with *Anaconda* or other scientific Python distributions, so you don't need 
+to install them seperatly in those cases.
 
 ### Build dependencies
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -175,6 +175,10 @@ Common solutions
     can have issues with one or the other.
 *   Reinstall it into your local startup drive, to a directory path and user
     account without spaces, special characters, or unusual permissions.
+*   Disable any security software you may be using, such as a firewall or
+    antivirus, as these products can occasionally interfere with Spyder or
+    its related packages. Make sure to re-enable it if it doesn't fix the
+    problem, and if it does, add a rule or exception for Spyder.
 *   Run Spyder with administrator rights just in case it is some sort of
     permissions issue
 *   Check and repair/reset permissions, your disk, and OS if all else fails

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,492 @@
+Spyder Troubleshooting Guide
+============================
+
+For an up to date, more comprehensive version of this guide, covering
+solutions to specific commonly reported issues along with these more general
+troubleshooting strategies, please refer to:
+<https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ>
+Thanks, and best of luck!
+
+
+Trouble with Spyder? Read this first!
+-------------------------------------
+
+If Spyder crashes or you receive an error message, please read the following
+troubleshooting steps before opening a new ticket.  There's a good chance
+that someone else has already experienced the same issue, so solving it
+yourself will likely get Spyder working again for you as quickly as possible.
+
+**Important Note:** To make sure you're getting the most relevant help for
+your problem, please make sure the issue is actually related to Spyder:
+
+*   If the problem appears to be a result of *your own code*,
+    Stack Overflow <https://stackoverflow.com/> is a better place to start;
+*   If the bug also occurs in the *standard python, IPython, or qtconsole*
+    environments, or only with *a specific package*, it is unlikely to be
+    something in Spyder, and you should report it to those sources instead.
+*   If the problem lies with *your specific install*, uninstalling and clean-
+    reinstalling the Anaconda distribution from
+    <https://www.anaconda.com/download/> is strongly recommended. As the other
+    methods of installing Spyder have many pitfalls for the unwary, we
+    generally aren't able to give individual support for install issues.
+
+Just like the programs you code in it, Spyder is written in Python, so
+you can often figure out many a problem just by reading the last line of the
+traceback or error message from the error dialog or Spyder's internal console,
+the latter available from ``Panels`` > ``Internal Console`` under the ``View``
+menu. Oftentimes, that alone will tell you how to fix the problem on your own,
+but if not, we're here to help.
+
+If you check out our list of issue categories and problem descriptions
+and see a question, error message or traceback that looks
+familiar, the relevant sub-section will likely be of the most specific help
+solving your issue as quickly as possible. If those steps don't work, or
+you can't find a similar problem, you can try some **Basic First Aid** (next
+section) or, if Spyder won't launch, some **Emergency CPR** (section after)
+and see if that clears it up.
+
+Finally, if you still can't get it to work, and the problem is indeed
+Spyder-related (see above note), you should consult the the
+**Calling for Help** section for other resources to explore and details on how
+to submit an issue  to our Github tracker, so the problem can be fixed for
+everyone. Thanks for taking the team to read this, and best of luck!
+
+
+
+Basic First Aid: General troubleshooting
+========================================
+
+These suggestions, while more of a shotgun approach, tend to fix the majority
+of reported issues just on their own. In the rough order you should try them:
+
+
+Recommended troubleshooting steps
+---------------------------------
+
+*   **Restart Spyder**, and try what you were doing before again.
+*   **Upgrade Spyder** to the latest release, and you might find your issue is
+    resolved (along with new features, enhancements, and other bug fixes).
+    Minor releases come out every two months, so unless you've updated
+    recently, there is a good chance your version isn't the latest; you can
+    find out with the ``Check for updates`` command under the ``Help`` menu.
+    To perform the update with ``conda`` (strongly recommended), just run
+    ``conda update spyder`` from the Anaconda Prompt/Terminal/command line
+    (on Windows/Mac/Linux).
+*   **Update Spyder's dependencies and environment**, either by installing the
+    latest version of your distribution (e.g. the recommended Anaconda), or
+    with the relevant "update all" command in the Anaconda Prompt/Terminal/
+    command line (on Windows/Mac/Linux). Using ``conda``, you can run
+    ``conda update anaconda`` to get the latest stable version of everything.
+*   **Restart your machine**, in case the problem lies with a lingering process
+    or another such issue.
+*   From the Anaconda Prompt/Terminal/command line (on Windows/Mac/Linux),
+    **run the command ``spyder --reset``**, which will restore Spyder's config
+    files to their defaults, which solves a huge variety of Spyder issues.
+    **Note:** This will reset your preferences, as well as any custom keyboard
+    shortcuts or syntax highlighting schemes, so you should back up the
+    ``.spyder-py3`` folder in your user home directory if you particularly
+    care about any of those, so you can restore them should this not solve
+    the problem.
+*   **Try installing Spyder into a new ``conda`` environment** (recommended) or
+    ``virtualenv``, and only installing its dependencies there, and seeing if
+    the issue reoccurs. If it does not, it is likely due to another package
+    installed on your system, particularly if done with ``pip``, which can
+    cause many problems and should be avoided if at all possible.
+*   If none of these solve your issue, you should do a full uninstall of Spyder
+    by whatever means you originally installed it, and then do a
+    **clean install of the latest version of the Anaconda distribution**
+    <https://www.anaconda.com/download/>, which is how we recommend you
+    install Spyder and keep in up to date. While you are welcome to get Spyder
+    working on your own by one of the many other means we offer, we are only
+    able to provide individual support for install-related issues for users
+    of the Anaconda distribution. In particular, ``pip`` installation, while
+    doable, is only really for experts, as there are many pitfalls involved and
+    different issues specific to your setup, which is why we recommend using
+    ``conda`` whenever possible.
+
+
+Standard approach to isolating problems
+---------------------------------------
+
+If you get the error while running a specific line, block, or script/program,
+it may not be an issue with Spyder, but rather something lower down in the
+"stack" it depends on. Try running it in the following, in order, if and until
+it starts working as you expect, and report the bug, if there is one,
+to the last one it *doesn't* work in.
+
+1.  Spyder, of course! Make sure you can reproduce the error, if possible.
+2.  **A bare ``qtconsole`` instance**, e.g. launched from Anaconda navigator or
+    from the Anaconda Prompt/Terminal/command line (Windows/Mac/Linux) with
+    ``jupyter qtconsole``. ``qtconsole`` is the GUI console backend Spyder
+    depends on to run its code, so most issues involving Spyder's Console are
+    actually something with ``qtconsole`` instead, and can be reported to their
+    issue tracker: <https://github.com/jupyter/qtconsole/issues/>
+3.  **An IPython command line shell**, launched with e.g. ``ipython`` from the
+    Anaconda Prompt/Terminal/command line (Windows/Mac/Linux). Reproducable
+    bugs can be reported to their Github page, though make sure to read thier
+    guidelines and docs first: <https://github.com/ipython/ipython/issues>
+4.  A stock Python interpreter, either run as a script file with
+    ``python path/to/your/file.py`` or launched interactively with ``python``,
+    from your Anaconda Prompt/Terminal/command line (Windows/Mac/Linux).
+    While its not impossible it is a Python bug, t much more likely to be an
+    issue with the code itself or a package you are using, or else a
+    fundamental behavior, design choice or limitation of the Python language
+    that likely won't be fixed anytime soon, so your best sources are the
+    Python docs: <https://www.python.org/doc/>, and the other resources listed
+    above.
+
+Remember, if the problem reoccurs in a similar or identical way with any of
+these methods (other than only Spyder itself), then it is almost certainly not
+an issue with Spyder, and would be best handled elsewhere. As as we aren't able
+to do much of anything about issues not related to Spyder, a forum like
+Stack Overflow <https://stackoverflow.com/> or the relevant package's docs is
+a much better place to get  help or report the issue in that case;
+see the **Emergency Numbers** section near the end of the document for
+other places to look for information and assistance. Best of luck!
+
+
+
+Emergency CPR: Spyder won't launch
+==================================
+
+Just like in the real world, while it may be scary or disconcerting to have
+Spyder not come to life for you, these situations are almost always fixable
+so long as you stay calm, keep a cool head, and carefully follow the steps
+above and below.
+
+
+Common solutions
+----------------
+
+*   The **basic troubleshooting steps** discussed in the section above, as
+    they usually resolve the vast majority of Spyder install-related issues.
+*   **Make sure Spyder isn't already running** and no Spyder related windows
+    (*e.g.* Variable Explorer dialogs) are left open, and check that the
+    preference setting "Use a single instance" (under ``Preferences`` >
+    ``General`` > ``Advanced Settings``) isn't checked.
+*   Try **starting Spyder via a different means**, such as from a shortcut,
+    Anaconda navigator, or the Anaconda Prompt/Terminal/command line
+    (on Windows/Mac/Linux) by simply typing ``spyder`` then enter/return,
+    and see if any of those work. If so, then something's wrong with your
+    install, not Spyder itself, and so we recommend uninstalling and doing a
+    clean install of the latest Anaconda <https://www.anaconda.com/download/>.
+*   If Anaconda is currently installed "for just you", try uninstalling and
+    reinstalling it "for all users" instead, and vice versa, as some systems
+    can have issues with one or the other.
+*   Reinstall it into your local startup drive, to a directory path and user
+    account without spaces, special characters, or unusual permissions.
+*   Run Spyder with administrator rights just in case it is some sort of
+    permissions issue
+*   Check and repair/reset permissions, your disk, and OS if all else fails
+
+
+Advanced tricks
+---------------
+
+If none of the above solves the problem, you can try starting Spyder directly
+from its Python source files which may either get it running, or at least
+provide very useful information to help debug the problem further.
+The procedure is described on, *e.g.*, this Github issue
+<https://github.com/spyder-ide/spyder/issues/6023#issuecomment-354389413>,
+which allowed the user to solve a seemingly difficult situation.
+
+The technique essentially boils down to starting Spyder from the
+Anaconda Prompt/Terminal/command line (on Windows/Mac/Linux) by manually
+running the Spyder startup routine, ``start.py``, with a known
+good Python interpreter, and observing the results. To do so, you'll need to
+navigate to the Spyder ``app`` directory from the command line, the location
+of which varies depending on how you installed it.
+
+With Anaconda, the distribution we recommend, you can find the location(s) of
+your packages directory(s) with the command ``conda info``, where the directory
+you want is listed under ``package cache``. For a systemwide Anaconda install,
+it is usually ``Anaconda3/pkgs`` at the root of your drive, while it varies
+depending on your operating system for a per-user install. If both are shown,
+you'll need to remember how you first installed Spyder with Anaconda, or just
+check both. Inside the Anaconda directory, you should find the directory you're
+looking for under ``spyder-3.#.#-py##_#/Lib/site-packages/spyder/app``, where
+the ``#``s correspond to the most recent version present.
+
+If using ``pip``, which we don't officially support, you can typically find
+the needed directory, from the root of your drive, under
+``/Python##/Lib/site-packages/spyder/app``.
+
+In case you're unfamiliar, you can change directories with the
+``cd`` command followed by the name of the directory you'd like to navigate to.
+Once inside the ``app`` directory, run ``python start.py`` to launch Spyder.
+If it doesn't launch, then you should see an error traceback printed; carefully
+copy that for future reference and also run ``python mainwindow.py``,
+and record your results as well.
+
+In case the command window disappears immediately after the error on Windows,
+as is sometimes the case, so you cannot see what it printed  just create a
+batch file in the ``app`` directory with with the following content::
+
+    C:/Absolute/Path/To/Your/Python/Executable/python.exe start.py
+
+    pause
+
+which should to the trick. Replace the path with the actual path to the
+Python interpreter you want to use, e.g. the one with Anaconda at
+``C:/Anaconda#/python.exe`` if installed for all users, or
+``C:/Users/YOURUSERNAME/AppData/Local/conda/conda/Python#/python.exe`` if for
+just you, replacing # with the Python major version (2 or 3) of the Anaconda
+you downloaded. If you're unsure, you can get the correct path by entering
+``where python`` in the Anaconda Prompt, and using the first path shown there.
+Then, just doulbe click the batch file to run it, and you should see the
+output you need.
+
+If reading the output, particularly the last line, doesn't solve the problem,
+then record all of it carefully, and post it as part of your bug report
+as described under the **Calling for Help** seciton near the end of this
+document.
+
+
+
+Advanced Treatments: Debugging and patching
+===========================================
+
+If you know your way around Python, you can often diagnose and even fix or
+patch issues yourself. You can explore the error messages
+you're receiving and Spyder's inner workings with the ``Internal Console`` under
+the menu item ``View`` > ``Panes`` > ``Internal Console``. If you want more
+detailed debug output, open an Anaconda Prompt/Terminal/command line
+(on Windows/Mac/Linux), set the enviroment variable SPYDER_DEBUG to the value
+"3" (on ``cmd``, use ``set SPYDER_DEBUG=3``; with ``bash``, execute
+``SPYDER_DEBUG="3"``, and for ``tcsh``, run ``setenv SPYDER_DEBUG 3``.
+Then, launch Spyder from that same shell with ``spyder``, and observe the
+results. Even if you don't manage to fix the problem yourself, this output
+can be immensely helpful in aiding us to quickly narrow down and solve your
+issue for you.
+
+However, if you do feel up to it and think you know where to look and what to
+change, you are welcome to take a stab at patching the bug. Just ``clone``
+the relevant development version of Spyder (``3.x`` for bug fixes) from our
+Github repo: <https://github.com/spyder-ide/spyder/>, edit the relevant Python
+code in your favorite editor or IDE (or Spyder itself!), and test your changes
+by running it from the cloned repo with ``python bootstrap.py`` from the repo's
+root directory (*e.g.* ``spyder``). Then, commit your changes to a github
+branch, and submit a Pull Request to the Spyder repo for them to be included in
+the next main Spyder distribution!
+
+For a quick, step by step guide to the process, see our ``CONTRIBUTING``
+document on Github:
+<https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md>,
+and for even more about developing Spyder, check out our Github wiki:
+<https://github.com/spyder-ide/spyder/wiki>. Thanks for your help!
+
+
+
+Emergency Numbers: Additional helpful resources to consult
+==========================================================
+
+Aside from this document, there are a number of other sources of documentation
+and troubleshooting information you should at least search or skim, before
+submitting an issue, as they might already offer an answer or at least help
+you better understand the following. Even if we aren't able to help you,
+these places might.
+
+
+Spyder-related platforms
+------------------------
+
+*   **Spyder documentation**: <https://pythonhosted.org/spyder/>
+    It explains how to use Spyder's basic features and addresses a number of
+    common "How can I?" questions that arise. Its still a work in progress,
+    so if you discover something missing from the docs, please submit an
+    issue or pull request to add it!
+*   **Spyder dev documentation**: <https://github.com/spyder-ide/spyder/wiki>
+    Along with additional general information about Spyder and its features,
+    our wiki has information about how to develop and test Spyder, our
+    development roadmap and the features planned in the next release, other
+    common questions, the changelog, and much more.
+*   **Spyder website**: <https://spyder-ide.github.io/>
+    While it is still under very early alpha development and isn't polished for
+    public consumption, it does contain basic information about Spyder and
+    links to many other helpful resources.
+*   **Spyder Google Group**: <http://groups.google.com/group/spyderlib>
+    Great for your more help-related questions, particularly those
+    you aren't sure are a full-on Spyder issue, or you'd like to give
+    more general feedback or ask questions of the team.
+*   **Spyder Gitter**: <https://gitter.im/spyder-ide/public>
+    If you've got a quick question to ask the team and are looking for a quick
+    answer, this is a great place to chat directly with the Spyder developers.
+*   **Stack Overflow**: <https://stackoverflow.com/questions/tagged/spyder>
+    Particularly if your question is more programming related, or has more to
+    do with something particular to your own code that you just can't get
+    working, this is a great place to start searching and posting. It has an
+    active Spyder community as well, with new Spyder-related questions posted
+    every day, and the developers, especially the lead maintainer, are active
+    in answering them.
+
+
+Python help and problems
+------------------------
+
+*   **Google/your favorite search engine:** One never fails to be surprised
+    how many problems can be solved by a simple Google search!
+*   **Official Python Help page**: <https://www.python.org/about/help/>
+    A great resource that lists a number of places you can get help, support
+    and learning resources for the Python language and its packages.
+*   **Python Documentation**: <https://www.python.org/doc/>
+    A number of issues can be explained due to quirks in the language
+    itself or misunderstandings as to how it behaves, and so those and much
+    more can be found here.
+*   **r/Python**: <https://www.reddit.com/r/Python/> and
+    **r/learnpython**: <https://www.reddit.com/r/learnpython/>
+    The former is aimed more at general Python usage and the latter more at
+    beginners, but both are popular places to ask about and discuss issues
+    with Python and its packages.
+
+
+Data science/SciPy resources:
+-----------------------------
+
+*   **Anaconda Support**: <https://www.anaconda.com/support/>
+    Offers free community help and documentation for the Anaconda applications,
+    installing the Anaconda distribution, and using the `conda` package and
+    environment manager, as well as paid support options.
+*   **SciPy.org Website**: <https://www.scipy.org/>
+    The central home of the scipy stack, with information, documentation,
+    help, and bug tracking for many of the core packages used with Spyder,
+    including NumPy, SciPy, Matplotlib, Pandas, Sympy, and IPython.
+*   **Project Jupyter**: <https://jupyter.org/>
+    Development hub for IPython, Spyder's ``qtconsole``, Jupyter notebooks
+    used with the ``spyder-notebook`` plugin, and more.
+*   **Data Science Stack Exchange**: <https://datascience.stackexchange.com/>
+    For questions that relate more to data science than programming
+    specifically, data science stack exchange is a good place to ask and
+    answer them.
+
+
+
+Calling For Help: Still have a problem?
+=======================================
+
+If you can't find your issue here, you're fairly sure its Spyder-related,
+and a full course of general troubleshooting didn't solve it, then you'll
+want to submit it to our issue tracker so our team can take a look at it
+for you. You'll need a github account to do that, so make sure you have one
+before you begin (a good idea anyway).
+
+**Important Note:** Before you submit an issue, make sure you've searched a
+description of the problem, and a relevant portion of the error traceback, on
+both Google and the Spyder repository/Issue tracker (see above or below) to
+make sure it hasn't been submitted before. We currently have over 5,000
+submitted issues in the past few years, along with over 1,500 stack overflow
+questions tagged ``spyder`` and thousands of Google Groups posts, among others,
+so it is quite likely your issue or problem has been reported/solved before.
+If that's the case, your issue will be closed your issue as a duplicate,
+so be sure to check first!
+
+
+Ways to submit an issue
+-----------------------
+
+**If you are able to launch Spyder**, the best way to do so is to simply
+select ``Submit Issue`` from the ``Help`` menu or, better yet, right from
+the error dialog if present, which will automatically take you to the
+correct page; prefill an error report with your environment details, key
+versions and dependencies; give you a basic structure to fill in as needed;
+and (if the latter) automatically insert the error/traceback for you.
+
+**If Spyder won't launch** (or otherwise isn't available), you can also
+submit a report manually at our Issues page on Github
+<https://github.com/spyder-ide/spyder/issues>. Unlike the above,
+you'll need to manually provide the versions of everything
+(Spyder, Python, OS, Qt/PyQt, Anaconda, and Spyder's dependencies)
+as listed in the error report template; see below for more on that.
+
+
+Must-have and helpful items to include
+--------------------------------------
+
+**Please include as much as possible of the following in your report**
+to maximize your chances of getting relevant help and our ability to diagnose,
+reproduce and solve your issue. In particular, *be sure to include the first
+two items, as without these we will usually be unable to isolate the problem
+in order to confirm and fix it, and the issue will be automatically closed
+after one week (7 days) if we don't hear from you.*
+
+The key items, in rough order of priority:
+
+*   The full, **complete error message or traceback** copy/pasted or
+    automatically entered exactly as displayed by Spyder:
+
+    -   Auto-generated reports directly from the error dialog should include
+        this automatically, but double check to make sure.
+    -   You can copy and paste this from the the "Show Details" section of the
+        error dialog.
+    -   If not present, or a dialog is not displayed, you can also find it
+        printed to Spyder's Internal Console, located under the ``View`` menu
+        at ``Panels`` > ``Internal Console``.
+    -   If you prefer, or if Spyder won't start, you can start Spyder from the
+        Anaconda Prompt/Terminal/command line (Windows/Mac/Linux) with
+        ``spyder`` and copy the output printed there.
+
+    It is a common problem that tracebacks, whether automatic or copy/pasted,
+    are incomplete/cut off, which tends to omit the information (the last
+    few lines) most critical to diagnosing or solving the issue. Accordingly,
+    carefully check the included traceback to be sure this isn't the case,
+    and try one of the other sources in the list above if so, as otherwise
+    we'll probably have to close your issue as we can't solve it without that.
+
+    *If you are reporting a specific behavior* rather than an error, or the
+    message does not fully explain what occurs, please *describe in detail
+    what actually happened, and what you expected Spyder to do*.
+
+*   A **detailed, step by step description of exactly what you did** leading up
+    to the error/crash/behavior occurring, complete with (minimal) code that
+    triggers it, if possible/applicable. The more specific you are here, the
+    easier and faster the problem can be reproduced and fixed.
+
+*   **Information about Spyder and its environment**, as listed in the error
+    report template (if not already filled in automatically by Spyder, via
+    ``Help`` > ``Report Issue``), which you can find under ``About Spyder`` in
+    the ``Help`` menu, along with its key dependencies, shown in the dialog
+    under ``Help`` > ``Dependencies`` (there's a button to copy-paste them).
+    If Spyder won't launch, you can get the Core Components information from
+    ``conda`` or Anaconda Navigator, and paste output of ``conda list`` from
+    Anaconda Prompt/Terminal/command line (on Windows/Mac/Linux) for the rest.
+
+*   **How you installed Spyder** and any other relevant packages,
+    *e.g.* Anaconda/``conda`` (highly recommended), another
+    distribution like WinPython, through MacPorts or your distribution's
+    package manner, using ``pip``, manually from source, etc, and **whether
+    Spyder has worked before** since you installed it. *Note that
+    unfortunately, we generally cannot provide individual support for
+    installation issues with methods other than ``conda``/Anaconda.
+
+*   **What else you've tried to fix it**, *e.g.* from this guide or elsewhere
+    on the web, whether you've seen it reported anywhere else, replicated it
+    on multiple machines, or (if appropriate) **tried to reproduce it in
+    standalone Qtconsole, IPython, and/or the plain Python** interpreter.
+
+*   **Whether the problem occurred consistently before** in similar situations,
+    only some of the time, or is this the first time you observed it?
+
+*   **Anything else special or unusual** about your system, environment,
+    packages, or specific usage that might have anything to do with the problem
+
+
+Important note about pasting code into Github
+---------------------------------------------
+
+If including block(s) of code in your report, be sure to precede and follow it
+with a line of three backticks \`\`\` to get a code block like this::
+
+    Your Code Here!
+
+Otherwise, your code will likely contain random formatting or missing
+indentation, making it difficult or impossible for others to examine and run
+to reproduce and fix your issue. Plus, it looks much nicer, too.
+
+
+Next steps and thank you!
+-------------------------
+
+Once you submit your report, our team will try to get back to you as soon as
+possible, often within 24 hours or less, to try to isolate the problem on our
+end and help you fix/work around it on yours.
+
+Thanks for using Spyder, and we appreciate your help making it even better!

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,6 +19,7 @@ Spyder websites:
 
 * Downloads, bug reports and feature requests: https://github.com/spyder-ide/spyder
 * Discussions: http://groups.google.com/group/spyderlib
+* Troubleshooting Guide and FAQ: https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ
             
 
 Contents:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,31 +3,31 @@ Spyder - Documentation
 
 Spyder is the Scientific PYthon Development EnviRonment:
 
-* a powerful interactive development environment for the Python language with 
+* A powerful interactive development environment for the Python language with
   advanced editing, interactive testing, debugging and introspection features
-  
-* and a numerical computing environment thanks to the support of `IPython` 
-  (enhanced interactive Python interpreter) and popular Python libraries 
-  such as `NumPy` (linear algebra), `SciPy` (signal and image processing) 
-  or `matplotlib` (interactive 2D/3D plotting).
+* A numerical computing environment thanks to the support of `IPython`
+  (an enhanced interactive Python interpreter) and popular Python libraries
+  such as `NumPy` (linear algebra), `SciPy` (signal and image processing)
+  and `matplotlib` (interactive 2D/3D plotting).
 
-Spyder may also be used as a library providing powerful console-related widgets 
-for your PyQt-based applications -- for example, it may be used to integrate a 
+Spyder may also be used as a library providing powerful console-related widgets
+for your PyQt-based applications -- for example, it may be used to integrate a
 debugging console directly in the layout of your graphical user interface.
 
 Spyder websites:
 
 * Downloads, bug reports and feature requests: https://github.com/spyder-ide/spyder
 * Discussions: http://groups.google.com/group/spyderlib
-* Troubleshooting Guide and FAQ: https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ
-            
+* Troubleshooting Guide and FAQ
+  https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ
+
 
 Contents:
 
 .. toctree::
     :maxdepth: 2
     :glob:
-    
+
     overview
     installation
     options

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -73,7 +73,7 @@ might need.
 
 **Ubuntu**:
 
-   * Using the official package manager: ``sudo apt-get install spyder``.
+Using the official package manager: ``sudo apt-get install spyder``.
 
      .. note::
 
@@ -83,29 +83,29 @@ might need.
 
 **Debian Unstable**:
 
-   Using the package manager: ``sudo apt-get install spyder``
+Using the package manager: ``sudo apt-get install spyder``
 
-   The Spyder's official Debian package is available `here`__
+The Spyder's official Debian package is available `here`__
 
-   __ http://packages.debian.org/fr/sid/spyder.
+__ http://packages.debian.org/fr/sid/spyder.
 
 
 **Other Distributions**
 
-   Spyder is also available in other GNU/Linux distributions, like
+Spyder is also available in other GNU/Linux distributions, like
 
-   * `Archlinux <https://aur.archlinux.org/packages/?K=spyder>`_
+* `Archlinux <https://aur.archlinux.org/packages/?K=spyder>`_
 
-   * `Fedora <https://admin.fedoraproject.org/pkgdb/acls/name/spyder?_csrf_token=ab2ac812ed6df3abdf42981038a56d3d87b34128>`_
+* `Fedora <https://admin.fedoraproject.org/pkgdb/acls/name/spyder?_csrf_token=ab2ac812ed6df3abdf42981038a56d3d87b34128>`_
 
-   * `Gentoo <http://packages.gentoo.org/package/dev-python/spyder>`_
+* `Gentoo <http://packages.gentoo.org/package/dev-python/spyder>`_
 
-   * `openSUSE <https://build.opensuse.org/package/show?package=python-spyder&project=home%3Aocefpaf>`_
+* `openSUSE <https://build.opensuse.org/package/show?package=python-spyder&project=home%3Aocefpaf>`_
 
-   * `Mageia <http://mageia.madb.org/package/show/name/spyder>`_
+* `Mageia <http://mageia.madb.org/package/show/name/spyder>`_
 
-   Please refer to your distribution's documentation to learn how to install it
-   there.
+Please refer to your distribution's documentation to learn how to install it
+there.
 
 |
 
@@ -209,13 +209,10 @@ Before installing Spyder itself by this method, you need at least:
 
 * `The Python programming language <http://www.python.org/>`_
 * `PyQt5 <http://www.riverbankcomputing.co.uk/software/pyqt/download5>`_ (recommended)
- or `PyQt4 <http://www.riverbankcomputing.co.uk/software/pyqt/download>`_
+  or `PyQt4 <http://www.riverbankcomputing.co.uk/software/pyqt/download>`_
 
 
-Then, to install Spyder and its other dependencies, run
-``
-    pip install spyder
-``
+Then, to install Spyder and its other dependencies, run ``pip install spyder``
 
 **Important note**: This does not install the graphical Python libraries (i.e.
 PyQt5 or PyQt4) that Spyder depends on. Those have to be installed separately
@@ -244,23 +241,18 @@ Updating Spyder
 You can update Spyder by:
 
 * Updating Anaconda (recommended), WinPython, Python(x,y), MacPorts, or
-through your system package manager, if you installed via those options.
+  through your system package manager, if you installed via those options.
 
-    With Anaconda, just run
-    ``
-        conda update spyder
-    ``
-    to update Spyder specifically, and
-    ``
-        conda update anaconda
-    ``
-    to update the rest of the distribution as desired.
+  With Anaconda, just run (in Anaconda Prompt if on Windows)
+  ``conda update spyder``
+  to update Spyder specifically, and
+  ``conda update anaconda``
+  to update the rest of the distribution, as desired.
 
 * Or, if having installed Spyder via the advanced/crossplatform method,
-``pip``, run::
-    ``
-        pip install --upgrade spyder
-    ``
+  ``pip``, run
+  ``pip install --upgrade spyder``
+
   .. note::
 
      This command will also update all Spyder dependencies
@@ -282,14 +274,13 @@ To do so:
 
 #. Install Spyder `requirements`_
 
-    The recommended and easiest way to do this is with ``conda``:
-    ``
-        conda install spyder
-        conda remove spyder
-    ``
+   The recommended and easiest way to do this is with ``conda``:
+    ``conda install spyder``
+    then
+    ``conda remove spyder``
 
-    This installs all of Spyder's dependencies into the environment along with
-    the stable/packaged version of Spyder itself, and then removes the latter.
+   This installs all of Spyder's dependencies into the environment along with
+   the stable/packaged version of Spyder itself, and then removes the latter.
 
 #. Install `Git <http://git-scm.com/downloads>`_, a powerful
    source control management tool.
@@ -308,7 +299,7 @@ To do so:
    inside the cloned directory.
 
 #. (*Optional*) If you want to read the documentation, you must build it first
-    with the command
+   with the command
 
    ``python setup.py build_doc``
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -4,71 +4,50 @@ Installation
 Spyder is quite easy to install on Windows, Linux and macOS. Just the read the
 following instructions with care.
 
-Installing on Windows Vista/7/8/10
+This section explains how to install the latest stable release of
+Spyder. If you prefer testing the development version, please use
+the `bootstrap` script (see next section).
+
+
+The Easy/Recommended Way: Anaconda
 ----------------------------------
 
-The easy way
-~~~~~~~~~~~~
+Thanks to the Spyder team and `Anaconda <https://www.anaconda.com/>`_, Spyder is
+included in the `Anaconda <https://www.anaconda.com/download/>`_ Python distribution,
+which comes with everything you need to get started in an all-in-one package.
 
-Spyder is already included in these *Python Scientific Distributions*:
+This is the easiest way to install Spyder for any of our platform, and
+the way we recommend to avoid unexpected issues we aren't able to
+help you with. If in doubt, you should install via this method;
+it generally has the least likelihood of potential pitfalls for non-experts,
+and we may be able to provide limited assistance if you do run into trouble.
 
-* `Anaconda <https://www.anaconda.com/download/>`_
+
+The Harder Way: Alternative Distributions
+----------------------------------------------------
+
+**Important Note:** While we offer alternative options for users who
+desire them, if you encounter installation issues you are unable to
+solve on your own, we recommend you use Anaconda instead, as we are
+generally unable to offer individual assistance for problems specific
+to installing via these alternative distributions.
+
+Windows
+~~~~~~~
+
+Spyder is included in these other scientific Python distributions:
+
 * `WinPython <https://winpython.github.io/>`_
 * `Python(x,y) <https://code.google.com/p/pythonxy>`_
 
-You can start using it immediately after installing one of them (you only need
-to install one!).
+You can start using it immediately after installing one of them
+(you only need to install one!), just like with Anaconda.
 
+macOS
+~~~~~
 
-The hard way
-~~~~~~~~~~~~
-
-If you want to install Spyder directly, you need to follow these steps:
-
-#. Install the essential requirements:
-
-   * `The Python programming language <http://www.python.org/>`_
-   * `PyQt5 <http://www.riverbankcomputing.co.uk/software/pyqt/download5>`_ (recommended)
-     or `PyQt4 <http://www.riverbankcomputing.co.uk/software/pyqt/download>`_
-
-#. Install Spyder and its dependencies by running this command::
-
-       pip install spyder
-
-
-Updating Spyder
-~~~~~~~~~~~~~~~
-
-You can update Spyder by:
-
-* Updating Anaconda, WinPython or Python(x,y).
-
-* Or using this command (in case you *don't* use any of those scientific
-  distributions)::
-
-        pip install --upgrade spyder
-
-  .. note::
-
-     This command will also update all Spyder dependencies
-
-|
-
-Installing on macOS
--------------------
-
-The easy way
-~~~~~~~~~~~~
-
-Thanks to the Spyder team and `Anaconda <https://www.anaconda.com/>`_, Spyder is included
-in the `Anaconda <https://www.anaconda.com/download/>`_ Python distribution,
-which comes with everything you need to get started in an all-in-one package.
-
-
-The hard way
-~~~~~~~~~~~~
-
-Thanks to the *MacPorts* project, Spyder can be installed using its ``port`` package manager.
+Thanks to the `*MacPorts* project <http://www.macports.org/>`_, Spyder can be
+installed using its ``port`` package manager.
 There are `several versions`__ available from which you can choose from.
 
 __ http://www.macports.org/ports.php?by=name&substr=spyder
@@ -77,28 +56,17 @@ __ http://www.macports.org/ports.php?by=name&substr=spyder
 
      It is known that the MacPorts version of Spyder is raising this error:
      ``ValueError: unknown locale: UTF-8``, which doesn't let it start correctly.
-   
+
      To fix it you will have to set these environment variables in your
      ``~/.profile`` (or ``~/.bashrc``) manually::
-        
+
         export LANG=en_US.UTF-8
         export LC_ALL=en_US.UTF-8
 
 |
 
-Installing on Linux
--------------------
-
-The easy way
-~~~~~~~~~~~~
-
-Thanks to the Spyder team and `Anaconda <https://www.anaconda.com/>`_, Spyder is included
-in the `Anaconda <https://www.anaconda.com/download/>`_ Python distribution,
-which comes with everything you need to get started in an all-in-one package.
-
-
-The harder way
-~~~~~~~~~~~~~~
+GNU/Linux
+~~~~~~~~~
 
 Please refer to the `Requirements`_ section to see what other packages you
 might need.
@@ -112,18 +80,13 @@ might need.
         This package could be slightly outdated. If you find that is the case,
         please use the Debian package mentioned below.
 
-   * Using the `pip <https://pypi.python.org/pypi/pip/>`_ package manager:
 
-     * Installing: ``sudo pip install spyder``
-     * Updating: ``sudo pip install -U spyder``
-
-     
 **Debian Unstable**:
-  
+
    Using the package manager: ``sudo apt-get install spyder``
 
-   The Spyder's official Debian package is available `here`__ 
-  
+   The Spyder's official Debian package is available `here`__
+
    __ http://packages.debian.org/fr/sid/spyder.
 
 
@@ -146,8 +109,16 @@ might need.
 
 |
 
-Installing or running directly from source
-------------------------------------------
+
+The Expert Way: Installing or running directly from source
+----------------------------------------------------------
+
+**Warning:** While this installation method is a viable option for
+experienced users, installing Spyder (and other SciPy stack packages)
+with `pip` can encounter a number of tricky issues. While you are welcome
+to try this on your own if you're an expert, we are unable to help if you
+do run into problems, except to recommend using Anaconda instead.
+
 
 Requirements
 ~~~~~~~~~~~~
@@ -199,7 +170,7 @@ The requirements to run Spyder are:
 
 * `Chardet <https://github.com/chardet/chardet>`_ >=2.0.0-- Character encoding auto-detection
   in Python.
-  
+
 * `Numpydoc <https://github.com/numpy/numpydoc>`_ Used by Jedi to get return types for
   functions with Numpydoc docstrings.
 
@@ -232,13 +203,23 @@ Optional modules
 Installation procedure
 ~~~~~~~~~~~~~~~~~~~~~~
 
-If you use Anaconda, you need to run this command to install Spyder:
+You can install Spyder with the ``pip`` package manager, which comes by
+default with most Python installations.
+Before installing Spyder itself by this method, you need at least:
 
-   ``conda install spyder``
+* `The Python programming language <http://www.python.org/>`_
+* `PyQt5 <http://www.riverbankcomputing.co.uk/software/pyqt/download5>`_ (recommended)
+ or `PyQt4 <http://www.riverbankcomputing.co.uk/software/pyqt/download>`_
 
-If you don't use Anaconda, you need to run:
 
-   ``pip install --upgrade spyder``
+Then, to install Spyder and its other dependencies, run
+``
+    pip install spyder
+``
+
+**Important note**: This does not install the graphical Python libraries (i.e.
+PyQt5 or PyQt4) that Spyder depends on. Those have to be installed separately
+after installing Python. Please see their documentation for more on that.
 
 
 Run without installing
@@ -246,22 +227,69 @@ Run without installing
 
 You can execute Spyder without installing it first by following these steps:
 
-#. Unzip the source package
+#. Unzip the source package (or clone from Github, see next section)
 #. Change current directory to the unzipped directory
 #. Run Spyder with the command ``python bootstrap.py``
 #. (*Optional*) Build the documentation with ``python setup.py build_doc``.
 
-This is especially useful for beta-testing, troubleshooting and development 
+This is especially useful for beta-testing, troubleshooting and development
 of Spyder itself.
 
 |
 
+
+Updating Spyder
+---------------
+
+You can update Spyder by:
+
+* Updating Anaconda (recommended), WinPython, Python(x,y), MacPorts, or
+through your system package manager, if you installed via those options.
+
+    With Anaconda, just run
+    ``
+        conda update spyder
+    ``
+    to update Spyder specifically, and
+    ``
+        conda update anaconda
+    ``
+    to update the rest of the distribution as desired.
+
+* Or, if having installed Spyder via the advanced/crossplatform method,
+``pip``, run::
+    ``
+        pip install --upgrade spyder
+    ``
+  .. note::
+
+     This command will also update all Spyder dependencies
+
+|
+
+
 Installing the development version
 ----------------------------------
 
-If you want to try the next Spyder version, you have to:
+If you want to try the next Spyder version, you can!
+You may want to do this for fixing bugs in Spyder, adding new
+features, learning how Spyder works or just getting a taste of it.
+For more information, please see the CONTRIBUTING.md document included
+with the Spyder source or on Github, or for further detail consult the
+`online development wiki <https://github.com/spyder-ide/spyder/wiki>`_ .
+
+To do so:
 
 #. Install Spyder `requirements`_
+
+    The recommended and easiest way to do this is with ``conda``:
+    ``
+        conda install spyder
+        conda remove spyder
+    ``
+
+    This installs all of Spyder's dependencies into the environment along with
+    the stable/packaged version of Spyder itself, and then removes the latter.
 
 #. Install `Git <http://git-scm.com/downloads>`_, a powerful
    source control management tool.
@@ -270,18 +298,22 @@ If you want to try the next Spyder version, you have to:
 
    ``git clone https://github.com/spyder-ide/spyder.git``
 
+#. Run Spyder with the ``bootstrap.py`` script from within the cloned directory:
+   ``python bootstrap.py``
+
 #. To keep your repository up-to-date, run
 
    ``git pull``
-   
+
    inside the cloned directory.
 
-#. (*Optional*) If you want to read the documentation, you must build it first with
-   the command
-  
+#. (*Optional*) If you want to read the documentation, you must build it first
+    with the command
+
    ``python setup.py build_doc``
 
 |
+
 
 Help and support
 ----------------
@@ -290,5 +322,7 @@ Spyder websites:
 
 * For bug reports and feature requests you can go to our
   `website <https://github.com/spyder-ide/spyder/issues>`_.
+* For general and development-oriented information, visit
+  `our Github wiki <https://github.com/spyder-ide/spyder/wiki>`_.
 * For discussions and help requests, you can suscribe to our
   `Google Group <http://groups.google.com/group/spyderlib>`_.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,12 +1,14 @@
 Installation
 ============
 
-Spyder is quite easy to install on Windows, Linux and macOS. Just the read the
-following instructions with care. This section explains how to install the 
-latest stable release of Spyder. If you prefer testing the development version,
-please use the ``bootstrap`` script (see next section).
+Spyder is quite easy to install on Windows, Linux and macOS; just read the
+following instructions with care.
 
-If you run into problems, before posting a report, 
+This section explains how to install the latest stable release of Spyder.
+If you prefer testing the development version, please use the
+``bootstrap`` script (see next section).
+
+If you run into problems, before posting a report,
 *please* consult our comprehensive
 `Troubleshooting Guide <https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ>`_
 and search the `issue tracker <https://github.com/spyder-ide/spyder/issues>`_
@@ -15,79 +17,43 @@ fix or at least isolate the vast majority of install-related problems.
 Thanks!
 
 
-Installing on Windows Vista/7/8/10
-----------------------------------
-
-The easy way
-~~~~~~~~~~~~
-
-Spyder is already included in these *Python Scientific Distributions*:
-
-* `Anaconda <https://www.anaconda.com/download/>`_
-* `WinPython <https://winpython.github.io/>`_
-* `Python(x,y) <https://code.google.com/p/pythonxy>`_
-
-You can start using it immediately after installing one of them (you only need
-to install one!).
-
-
-The hard way
-~~~~~~~~~~~~
-
-If you want to install Spyder directly, you need to follow these steps:
-
-#. Install the essential requirements:
-
-   * `The Python programming language <http://www.python.org/>`_
-   * `PyQt5 <http://www.riverbankcomputing.co.uk/software/pyqt/download5>`_ (recommended)
-     or `PyQt4 <http://www.riverbankcomputing.co.uk/software/pyqt/download>`_
-
-#. Install Spyder and its dependencies by running this command::
-
-       pip install spyder
-
->>>>>>> 6a9dad480... Add FAQ link and blurb to docs, contributing and readme
-
-
 The Easy/Recommended Way: Anaconda
 ----------------------------------
 
-Thanks to the Spyder team and `Anaconda <https://www.anaconda.com/>`_, Spyder is
-included in the `Anaconda <https://www.anaconda.com/download/>`_ Python distribution,
-which comes with everything you need to get started in an all-in-one package.
+Spyder is included in the `Anaconda <https://www.anaconda.com/download/>`_
+Python distribution, which comes with everything you need to get started in
+an all-in-one package.
 
-This is the easiest way to install Spyder for any of our platform, and
-the way we recommend to avoid unexpected issues we aren't able to
+This is the easiest way to install Spyder for any of our supported platforms,
+and the way we recommend to avoid unexpected issues we aren't able to
 help you with. If in doubt, you should install via this method;
 it generally has the least likelihood of potential pitfalls for non-experts,
 and we may be able to provide limited assistance if you do run into trouble.
 
 
-The Harder Way: Alternative Distributions
-----------------------------------------------------
+The Harder Way: Alternative distributions
+-----------------------------------------
 
-**Important Note:** While we offer alternative options for users who
-desire them, if you encounter installation issues you are unable to
-solve on your own, we recommend you use Anaconda instead, as we are
-generally unable to offer individual assistance for problems specific
-to installing via these alternative distributions.
+**Important Note:** While we offer alternative Spyder installation options
+for users who desire them, we currently lack the resources to offer individual
+assistance for problems specific to installing via these alternative distributions.
+Therefore, we recommend you switch to Anaconda if you encounter installation
+issues you are unable to solve on your own.
 
 Windows
 ~~~~~~~
 
-Spyder is included in these other scientific Python distributions:
-
-* `WinPython <https://winpython.github.io/>`_
-* `Python(x,y) <https://code.google.com/p/pythonxy>`_
-
-You can start using it immediately after installing one of them
-(you only need to install one!), just like with Anaconda.
+Spyder is also included in the `WinPython <https://winpython.github.io/>`_
+scientific Python distribution, although some users have reported bugs specific
+to it. You can use it immediately after installing, just like with Anaconda.
 
 macOS
 ~~~~~
 
 Thanks to the `*MacPorts* project <http://www.macports.org/>`_, Spyder can be
-installed using its ``port`` package manager.
+installed using its ``port`` package manager; however, it may be out of date
+or have MacPorts-specific issues outside of Spyder's control.
+
 There are `several versions`__ available from which you can choose from.
 
 __ http://www.macports.org/ports.php?by=name&substr=spyder
@@ -150,14 +116,14 @@ there.
 |
 
 
-The Expert Way: Installing or running directly from source
-----------------------------------------------------------
+The Expert Way: Installing with pip
+-----------------------------------
 
 **Warning:** While this installation method is a viable option for
 experienced users, installing Spyder (and other SciPy stack packages)
-with `pip` can encounter a number of tricky issues. While you are welcome
-to try this on your own if you're an expert, we are unable to help if you
-do run into problems, except to recommend using Anaconda instead.
+with `pip` can lead to a number of tricky issues. While you are welcome
+to try this on your own, we unfortunately do not have the resources to help you
+if you do run into problems, except to recommend using Anaconda instead.
 
 
 Requirements
@@ -245,18 +211,12 @@ Installation procedure
 
 You can install Spyder with the ``pip`` package manager, which comes by
 default with most Python installations.
-Before installing Spyder itself by this method, you need at least:
+Before installing Spyder itself by this method, you need to acquire the
+`Python programming language <http://www.python.org/>`_
 
-* `The Python programming language <http://www.python.org/>`_
-* `PyQt5 <http://www.riverbankcomputing.co.uk/software/pyqt/download5>`_ (recommended)
-  or `PyQt4 <http://www.riverbankcomputing.co.uk/software/pyqt/download>`_
-
-
-Then, to install Spyder and its other dependencies, run ``pip install spyder``
-
-**Important note**: This does not install the graphical Python libraries (i.e.
-PyQt5 or PyQt4) that Spyder depends on. Those have to be installed separately
-after installing Python. Please see their documentation for more on that.
+Then, to install Spyder and its other dependencies, run ``pip install spyder``.
+You may need to separately install a Qt binding with ``pip`` if running Python 2;
+PyQt5 is strongly recommended though the legacy PyQt4 is also still supported.
 
 
 Run without installing
@@ -264,13 +224,15 @@ Run without installing
 
 You can execute Spyder without installing it first by following these steps:
 
-#. Unzip the source package (or clone from Github, see next section)
+#. Unzip the source package available for download on the
+   `Spyder Github repo <https://github.com/spyder-ide/spyder>`_
+   (or clone from Github, see the next section)
 #. Change current directory to the unzipped directory
 #. Run Spyder with the command ``python bootstrap.py``
 #. (*Optional*) Build the documentation with ``python setup.py build_doc``.
 
-This is especially useful for beta-testing, troubleshooting and development
-of Spyder itself.
+This is especially useful for beta-testing, troubleshooting and helping develop
+Spyder itself.
 
 |
 
@@ -280,7 +242,7 @@ Updating Spyder
 
 You can update Spyder by:
 
-* Updating Anaconda (recommended), WinPython, Python(x,y), MacPorts, or
+* Updating Anaconda (recommended), WinPython, MacPorts, or
   through your system package manager, if you installed via those options.
 
   With Anaconda, just run (in Anaconda Prompt if on Windows)
@@ -289,7 +251,7 @@ You can update Spyder by:
   ``conda update anaconda``
   to update the rest of the distribution, as desired.
 
-* Or, if having installed Spyder via the advanced/crossplatform method,
+* If you installed Spyder via the advanced/crossplatform method,
   ``pip``, run
   ``pip install --upgrade spyder``
 
@@ -303,7 +265,7 @@ You can update Spyder by:
 Installing the development version
 ----------------------------------
 
-If you want to try the next Spyder version, you can!
+If you want to try the next Spyder version before it is released, you can!
 You may want to do this for fixing bugs in Spyder, adding new
 features, learning how Spyder works or just getting a taste of it.
 For more information, please see the CONTRIBUTING.md document included
@@ -358,5 +320,5 @@ Spyder websites:
   `website <https://github.com/spyder-ide/spyder/issues>`_.
 * For general and development-oriented information, visit
   `our Github wiki <https://github.com/spyder-ide/spyder/wiki>`_.
-* For discussions and help requests, you can suscribe to our
+* For discussions and help requests, you can subscribe to our
   `Google Group <http://groups.google.com/group/spyderlib>`_.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -2,14 +2,12 @@ Installation
 ============
 
 Spyder is quite easy to install on Windows, Linux and macOS. Just the read the
-following instructions with care.
+following instructions with care. This section explains how to install the 
+latest stable release of Spyder. If you prefer testing the development version,
+please use the ``bootstrap`` script (see next section).
 
-This section explains how to install the latest stable release of
-Spyder. If you prefer testing the development version, please use
-the `bootstrap` script (see next section).
-
-If you run into problems, before posting a
-report, *please* consult our comprehensive
+If you run into problems, before posting a report, 
+*please* consult our comprehensive
 `Troubleshooting Guide <https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ>`_
 and search the `issue tracker <https://github.com/spyder-ide/spyder/issues>`_
 for your error message and problem description, as these methods are known to

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -10,8 +10,8 @@ the `bootstrap` script (see next section).
 
 If you run into problems, before posting a
 report, *please* consult our comprehensive
-**[Troubleshooting Guide](https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ)**
-and search the [issue tracker](https://github.com/spyder-ide/spyder/issues)
+`Troubleshooting Guide <https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ>`_
+and search the `issue tracker <https://github.com/spyder-ide/spyder/issues>`_
 for your error message and problem description, as these methods are known to
 fix or at least isolate the vast majority of install-related problems.
 Thanks!
@@ -354,8 +354,8 @@ Help and support
 Spyder websites:
 
 * For a comprehensive guide to spyder troubleshooting, including
-  installation issues, read our Troubleshooting Guide and FAQ
-  <https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ>
+  installation issues, read our `Troubleshooting Guide and FAQ
+  <https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ>`_.
 * For bug reports and feature requests you can go to our
   `website <https://github.com/spyder-ide/spyder/issues>`_.
 * For general and development-oriented information, visit

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -8,6 +8,48 @@ This section explains how to install the latest stable release of
 Spyder. If you prefer testing the development version, please use
 the `bootstrap` script (see next section).
 
+If you run into problems, before posting a
+report, *please* consult our comprehensive
+**[Troubleshooting Guide](https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ)**
+and search the [issue tracker](https://github.com/spyder-ide/spyder/issues)
+for your error message and problem description, as these methods are known to
+fix or at least isolate the vast majority of install-related problems.
+Thanks!
+
+
+Installing on Windows Vista/7/8/10
+----------------------------------
+
+The easy way
+~~~~~~~~~~~~
+
+Spyder is already included in these *Python Scientific Distributions*:
+
+* `Anaconda <https://www.anaconda.com/download/>`_
+* `WinPython <https://winpython.github.io/>`_
+* `Python(x,y) <https://code.google.com/p/pythonxy>`_
+
+You can start using it immediately after installing one of them (you only need
+to install one!).
+
+
+The hard way
+~~~~~~~~~~~~
+
+If you want to install Spyder directly, you need to follow these steps:
+
+#. Install the essential requirements:
+
+   * `The Python programming language <http://www.python.org/>`_
+   * `PyQt5 <http://www.riverbankcomputing.co.uk/software/pyqt/download5>`_ (recommended)
+     or `PyQt4 <http://www.riverbankcomputing.co.uk/software/pyqt/download>`_
+
+#. Install Spyder and its dependencies by running this command::
+
+       pip install spyder
+
+>>>>>>> 6a9dad480... Add FAQ link and blurb to docs, contributing and readme
+
 
 The Easy/Recommended Way: Anaconda
 ----------------------------------
@@ -311,6 +353,9 @@ Help and support
 
 Spyder websites:
 
+* For a comprehensive guide to spyder troubleshooting, including
+  installation issues, read our Troubleshooting Guide and FAQ
+  <https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ>
 * For bug reports and feature requests you can go to our
   `website <https://github.com/spyder-ide/spyder/issues>`_.
 * For general and development-oriented information, visit


### PR DESCRIPTION
To partially address #6075 as well as a related problem that @csabella and I reproduced that prevented installing from source, as well as more generally make clear our recommendation to use `conda`/Anaconda over `pip` and other distributions and our inability to intervene to solve installation issues with those who choose the latter (as we get many every day on our repo), I've revised the readme, CONTRIBUTING.md and installation documentation accordingly. As part of that, as I'd been hoping to for a while, I took the opportunity to reorganize those sections to eliminate redundancy and outline the alternatives clearly, as well as associated minor cleanup and copyediting. I left the dependancy, etc. and other sections as alone as possible to avoid possible conflicts when forward-porting to `master`.