### PR TITLE
PR: Make pyqt5 a wheel dependency only for Python 3

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,9 +16,9 @@ To release a new version of Spyder you need to follow these steps:
 
 * python setup.py sdist upload
 
-* python2 setup.py bdist_wheel upload
+* activate py2env-with-latest-setuptools && python2 setup.py bdist_wheel upload
 
-* python3 setup.py bdist_wheel upload
+* activate py3env-with-latest-setuptools && python3 setup.py bdist_wheel upload
 
 * git tag -a vX.X.X -m 'Release X.X.X'
 

--- a/setup.py
+++ b/setup.py
@@ -289,7 +289,9 @@ install_requires = [
     'pyzmq',
     'chardet>=2.0.0',
     'numpydoc',
-    'pyqt5',
+    # Packages for pyqt5 are only available in
+    # Python 3
+    'pyqt5;python_version>"3"',
     # This is only needed for our wheels on Linux.
     # See issue #3332
     'pyopengl;platform_system=="Linux"'


### PR DESCRIPTION
Fixes #6075.