### PR TITLE
PR: Fix segfault on shortcut preferences when using mouse

### DIFF
--- a/spyder/plugins/shortcuts.py
+++ b/spyder/plugins/shortcuts.py
@@ -16,7 +16,7 @@ import sys
 from qtpy import PYQT5
 from qtpy.compat import from_qvariant, to_qvariant
 from qtpy.QtCore import (QAbstractTableModel, QModelIndex, QRegExp,
-                         QSortFilterProxyModel, Qt)
+                         QSortFilterProxyModel, Qt, Slot)
 from qtpy.QtGui import (QKeySequence, QRegExpValidator)
 from qtpy.QtWidgets import (QAbstractItemView, QApplication, QDialog,
                             QDialogButtonBox, QGridLayout, QHBoxLayout, QLabel,
@@ -203,6 +203,24 @@ class ShortcutEditor(QDialog):
         # Signals
         bbox.accepted.connect(self.accept)
         bbox.rejected.connect(self.reject)
+
+    @Slot()
+    def reject(self):
+        """Slot for rejected signal."""
+        # Added for issue #5426.  Due to the focusPolicy of Qt.NoFocus for the
+        # buttons, if the cancel button was clicked without first setting focus
+        # to the button, it would cause a seg fault crash.
+        self.button_cancel.setFocus()
+        super().reject()
+
+    @Slot()
+    def accept(self):
+        """Slot for accepted signal."""
+        # Added for issue #5426.  Due to the focusPolicy of Qt.NoFocus for the
+        # buttons, if the ok button was clicked without first setting focus to
+        # the button, it would cause a seg fault crash.
+        self.button_ok.setFocus()
+        super().accept()
 
     def keyPressEvent(self, e):
         """Qt override."""


### PR DESCRIPTION
For issue #5426.

To recreate the issue (at least on Ubuntu):
- Open Preferences and click on Keyboard Shortcuts.  
- Select a shortcut to edit, either by using Enter on the keyboard or by double clicking the line (meaning that mouse vs. keyboard isn't important at this step). 
- Without this change, if you immediately click Cancel, the seg fault occurs.  
- However, if instead of clicking, you use the keyboard 'Tab' to highlight cancel (as the text in the dialog suggests to do to switch focus), then you can press Enter on the Cancel button and not get the seg fault. 
- The same thing happens with the OK button.

This seemed to be a difference between keyboard entry and mouse clicking on the buttons.   In the code, the only difference was setting widget focus, so by adding focus to the mouse click, it prevents the seg fault.

I don't know the underlying cause, so this may be a hack in order to fix it, but it does work.




