### PR TITLE
PR: Remove unnecessary flaky from introspection test, minor cleanup

### DIFF
--- a/spyder/plugins/tests/test_editor_introspection.py
+++ b/spyder/plugins/tests/test_editor_introspection.py
@@ -5,12 +5,12 @@
 #
 """Tests for the Editor plugin."""
 
-# Third party imports
-import pytest
+# Standard library imports
 import os
 import os.path as osp
-from flaky import flaky
 
+# Third party imports
+import pytest
 try:
     from unittest.mock import Mock
 except ImportError:
@@ -58,7 +58,6 @@ def setup_editor(qtbot, monkeypatch):
     editor.introspector.plugin_manager.close()
 
 
-@flaky(max_runs=3)
 @pytest.mark.skipif(os.environ.get('CI', None) is not None,
                     reason="This test fails too much in the CI :(")
 @pytest.mark.skipif(not JEDI_010,


### PR DESCRIPTION
I would have lumped this in with another PR as it is so small, but I didn't want it to go out of scope. Basically, I previously added flaky to the introspection test as it was failing, but both locally and on the CIs (when I tested enabling it), it didn't help; it either failed no runs or all of them, and takes an incredibly long among of time (over 30s per run), so I disabled it again and removed the import, as well as some minor cleanup around the lines that I changed. Sorry about that, and no need to rush it out for 3.2.6 if its anywhere near the critical path.