### PR TITLE
PR: Fix mime type error detection in the File Explorer

### DIFF
--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -153,12 +153,16 @@ class IconProvider(QFileIconProvider):
                     icon = ima.icon(self.OFFICE_FILES[extension])
 
                 if mime_type is not None:
-                    # The replace is a fix for issue 5080.  In the Windows
-                    # registry, .sql has a mimetype of text\plain instead of
-                    # text/plain therefore mimetypes is returning
-                    # it incorrectly.
-                    mime_type.replace('\\', '/')
-                    file_type, bin_name = mime_type.split('/')
+                    try:
+                        # Fix for issue 5080.  Even though mimetypes.guess_type
+                        # documentation states that the return value will be
+                        # None or a tuple of the form type/subtype, in the
+                        # Windows registry, .sql has a mimetype of text\plain
+                        # instead of text/plain therefore mimetypes is
+                        # returning it incorrectly.
+                        file_type, bin_name = mime_type.split('/')
+                    except ValueError:
+                        file_type = 'text'
                     if file_type == 'text':
                         icon = ima.icon('TextFileIcon')
                     elif file_type == 'audio':

--- a/spyder/widgets/explorer.py
+++ b/spyder/widgets/explorer.py
@@ -153,6 +153,11 @@ class IconProvider(QFileIconProvider):
                     icon = ima.icon(self.OFFICE_FILES[extension])
 
                 if mime_type is not None:
+                    # The replace is a fix for issue 5080.  In the Windows
+                    # registry, .sql has a mimetype of text\plain instead of
+                    # text/plain therefore mimetypes is returning
+                    # it incorrectly.
+                    mime_type.replace('\\', '/')
                     file_type, bin_name = mime_type.split('/')
                     if file_type == 'text':
                         icon = ima.icon('TextFileIcon')


### PR DESCRIPTION
Fixes #5080.

On Windows, the Windows registry has the entry for `.sql` as `text\plain` instead of `text/plain`.  `mimetypes` is returning the value as stored, even though the docs say it should be `None` or in the format `type/subtype`.

I'm going to see if this is an open CPython bug or if the documentation needs to be changed.