### PR TITLE
PR: Allow tab cycling shortcuts to be configurable in Editor

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -383,6 +383,8 @@ DEFAULTS = [
               'editor/go to line': 'Ctrl+L',
               'editor/go to previous file': 'Ctrl+Shift+Tab',
               'editor/go to next file': 'Ctrl+Tab',
+              'editor/cycle to previous file': 'Ctrl+PgUp',
+              'editor/cycle to next file': 'Ctrl+PgDown',
               'editor/new file': "Ctrl+N",
               'editor/open last closed':"Ctrl+Shift+T",
               'editor/open file': "Ctrl+O",

--- a/spyder/plugins/shortcuts.py
+++ b/spyder/plugins/shortcuts.py
@@ -447,10 +447,9 @@ class ShortcutEditor(QDialog):
         self.key_text = [k.upper() for k in self.key_text]
 
         # Fix Backtab, Tab issue
-        if os.name == 'nt':
-            if Qt.Key_Backtab in self.key_non_modifiers:
-                idx = self.key_non_modifiers.index(Qt.Key_Backtab)
-                self.key_non_modifiers[idx] = Qt.Key_Tab
+        if Qt.Key_Backtab in self.key_non_modifiers:
+            idx = self.key_non_modifiers.index(Qt.Key_Backtab)
+            self.key_non_modifiers[idx] = Qt.Key_Tab
 
         if len(self.key_modifiers) == 0:
             # Filter single key allowed

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -626,6 +626,12 @@ class EditorStack(QWidget):
                               name='Go to previous file', parent=self)
         tabshift = config_shortcut(self.tab_navigation_mru, context='Editor',
                                    name='Go to next file', parent=self)
+        prevtab = config_shortcut(lambda: self.tabs.tab_navigate(-1),
+                                  context='Editor',
+                                  name='Cycle to previous file', parent=self)
+        nexttab = config_shortcut(lambda: self.tabs.tab_navigate(1),
+                                  context='Editor',
+                                  name='Cycle to next file', parent=self)
         run_selection = config_shortcut(self.run_selection, context='Editor',
                                         name='Run selection', parent=self)
         new_file = config_shortcut(lambda : self.sig_new_file[()].emit(),
@@ -706,7 +712,8 @@ class EditorStack(QWidget):
                 save_all, save_as, close_all, prev_edit_pos, prev_cursor,
                 next_cursor, zoom_in_1, zoom_in_2, zoom_out, zoom_reset,
                 close_file_1, close_file_2, run_cell, run_cell_and_advance,
-                go_to_next_cell, go_to_previous_cell, re_run_last_cell]
+                go_to_next_cell, go_to_previous_cell, re_run_last_cell,
+                prevtab, nexttab]
 
     def get_shortcut_data(self):
         """

--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -385,6 +385,16 @@ class BaseTabs(QTabWidget):
                 handled = True
         if not handled:
             QTabWidget.keyPressEvent(self, event)
+
+    def tab_navigate(self, delta=1):
+        """Ctrl+Tab"""
+        if delta > 0 and self.currentIndex() == self.count()-1:
+            index = delta-1
+        elif delta < 0 and self.currentIndex() == 0:
+            index = self.count()+delta
+        else:
+            index = self.currentIndex()+delta
+        self.setCurrentIndex(index)
         
     def set_close_function(self, func):
         """Setting Tabs close function
@@ -434,16 +444,6 @@ class Tabs(BaseTabs):
                         context='editor', name='close file 1', parent=parent)
         config_shortcut(lambda: self.sig_close_tab.emit(self.currentIndex()),
                         context='editor', name='close file 2', parent=parent)
-
-    def tab_navigate(self, delta=1):
-        """Ctrl+Tab"""
-        if delta > 0 and self.currentIndex() == self.count()-1:
-            index = delta-1
-        elif delta < 0 and self.currentIndex() == 0:
-            index = self.count()+delta
-        else:
-            index = self.currentIndex()+delta
-        self.setCurrentIndex(index)
 
     @Slot(int, int)
     def move_tab(self, index_from, index_to):


### PR DESCRIPTION
Fixes #4842.  

- Added shortcuts to cycle through files.
- If statement to convert `Backtab` to `Shift+Tab` was only for 'nt', but problem existed on linux too, so removed the conditional.
- Tab navigation routine already existed in `Tabs` class, so moved it to `BaseTabs` class for it to be used in the editor (which creates a `BaseTabs` widget) without affecting existing code (like in iPython console).
  