### PR TITLE
PR: Prevent an error in the FileSwitcher when all tabs are closed in the last focused widget.

### DIFF
--- a/spyder/widgets/fileswitcher.py
+++ b/spyder/widgets/fileswitcher.py
@@ -346,7 +346,7 @@ class FileSwitcher(QDialog):
 
     @property
     def current_path(self):
-        return self.paths_by_widget[self.get_widget()]
+        return self.paths_by_widget.get(self.get_widget(), None)
 
     @property
     def paths_by_widget(self):


### PR DESCRIPTION
Fixes #5384 

The issue this PR fix and the steps to reproduce it are described here: https://github.com/spyder-ide/spyder/issues/5384#issuecomment-334753512