### PR TITLE
PR: Enable the display of many more numpy array types in the Variable Explorer

### DIFF
--- a/spyder/widgets/variableexplorer/utils.py
+++ b/spyder/widgets/variableexplorer/utils.py
@@ -50,14 +50,16 @@ class FakeObject(object):
 #==============================================================================
 try:
     from numpy import (ndarray, array, matrix, recarray,
-                       int64, int32, float64, float32,
-                       complex64, complex128)
+                       int64, int32, int16, int8, uint64, uint32, uint16, uint8,
+                       float64, float32, float16, complex64, complex128, bool_)
     from numpy.ma import MaskedArray
     from numpy import savetxt as np_savetxt
     from numpy import get_printoptions, set_printoptions
 except:
     ndarray = array = matrix = recarray = MaskedArray = np_savetxt = \
-    int64 = int32 = float64 = float32 = complex64 = complex128 = FakeObject
+     int64 = int32 = int16 = int8 = uint64 = uint32 = uint16 = uint8 = \
+     float64 = float32 = float16 = complex64 = complex128 = bool_ = FakeObject
+
 
 def get_numpy_dtype(obj):
     """Return NumPy data type associated to obj
@@ -342,8 +344,10 @@ def value_to_display(value, minmax=False, level=0):
     np_threshold = FakeObject
 
     try:
-        numeric_numpy_types = (int64, int32, float64, float32,
-                               complex128, complex64)
+        numeric_numpy_types = (int64, int32, int16, int8,
+                               uint64, uint32, uint16, uint8,
+                               float64, float32, float16,
+                               complex128, complex64, bool_)
         if ndarray is not FakeObject:
             # Save threshold
             np_threshold = get_printoptions().get('threshold')
@@ -365,11 +369,11 @@ def value_to_display(value, minmax=False, level=0):
                         display = 'Min: %r\nMax: %r' % (value.min(), value.max())
                     except (TypeError, ValueError):
                         if value.dtype.type in numeric_numpy_types:
-                            display = repr(value)
+                            display = str(value)
                         else:
                             display = default_display(value)
                 elif value.dtype.type in numeric_numpy_types:
-                    display = repr(value)
+                    display = str(value)
                 else:
                     display = default_display(value)
             else:


### PR DESCRIPTION
Currently, numpy arrays of types int64, int32, float64, float32, complex64, and complex128 are displayed with `repr` instead of `str`, leading to unnecessarily/redundant clutter being displayed (that its an array, and its dtype usually, both already displayed natively by VarExp. Further, the types  int16, int8, uint64, uint32, uint16, uint8, float16, and bool aren't displayed at all; just as ``ndarray object of numpy module``. Therefore, this PR fixes both of those issues.

Before:
![image](https://user-images.githubusercontent.com/17051931/34563748-8508c6c6-f119-11e7-9df4-789e94a1ba98.png)

After:
![image](https://user-images.githubusercontent.com/17051931/34563768-9428110c-f119-11e7-9eb1-15c0f474d8d7.png)

TODO: Add simple tests for proper display