### PR TITLE
PR: Run slow tests only in our CIs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,17 @@
+# Taken from the Pytest docs
+
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--run-slow", action="store_true",
+                     default=False, help="run slow tests")
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-slow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+
+    skip_slow = pytest.mark.skip(reason="need --run-slow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/runtests.py
+++ b/runtests.py
@@ -20,15 +20,30 @@ import pytest
 os.environ['SPYDER_PYTEST'] = 'True'
 
 
+# To run our slow tests only in our CIs
+run_slow = False
+if os.environ.get('CI', None) is not None:
+    run_slow = True
+
+
 def main():
     """
     Run pytest tests.
     """
-    errno = pytest.main(['-x', 'spyder',  'spyder_profiler',
-                         '-vv', '-rw',
-                         '--durations=10', '--cov=spyder',
-                         '--cov=spyder_profiler',
-                         '--cov-report=term-missing'])
+    pytest_args = ['spyder',
+                   'spyder_profiler',
+                   '-x',
+                   '-vv',
+                   '-rw',
+                   '--durations=10',
+                   '--cov=spyder',
+                   '--cov=spyder_profiler',
+                   '--cov-report=term-missing']
+
+    if run_slow:
+        pytest_args.append('--run-slow')
+
+    errno = pytest.main(pytest_args)
 
     # sys.exit doesn't work here because some things could be running
     # in the background (e.g. closing the main window) when this point

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -137,11 +137,11 @@ def main_window(request):
 #==============================================================================
 # IMPORTANT NOTE: Please leave this test to be the first one here to
 # avoid possible timeouts in Appveyor
+@pytest.mark.use_introspection
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.environ.get('CI', None) is not None or os.name == 'nt',
+@pytest.mark.skipif(os.environ.get('CI', None) is not None or os.name == 'nt' or PY2,
                     reason="It times out in our CIs, and apparently Windows.")
 @pytest.mark.timeout(timeout=60, method='thread')
-@pytest.mark.use_introspection
 def test_calltip(main_window, qtbot):
     """Hide the calltip in the editor when a matching ')' is found."""
     # Load test file
@@ -169,6 +169,7 @@ def test_calltip(main_window, qtbot):
     main_window.editor.close_file()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt' or PY2 or PYQT4,
                     reason="It fails sometimes")
@@ -226,6 +227,7 @@ def test_move_to_first_breakpoint(main_window, qtbot):
     main_window.editor.close_file()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.environ.get('CI', None) is None,
                     reason="It's not meant to be run locally")
@@ -281,6 +283,7 @@ def test_runconfig_workdir(main_window, qtbot, tmpdir):
     CONF.set('run', 'configurations', [])
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt' and PY2, reason="It's failing there")
 def test_dedicated_consoles(main_window, qtbot):
@@ -331,6 +334,7 @@ def test_dedicated_consoles(main_window, qtbot):
     CONF.set('run', 'configurations', [])
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 def test_connection_to_external_kernel(main_window, qtbot):
     """Test that only Spyder kernels are connected to the Variable Explorer."""
@@ -370,6 +374,7 @@ def test_connection_to_external_kernel(main_window, qtbot):
     km.shutdown_kernel(now=True)
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_np_threshold(main_window, qtbot):
@@ -396,6 +401,7 @@ def test_np_threshold(main_window, qtbot):
     assert np.isnan(shell.get_value('t'))
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_change_types_in_varexp(main_window, qtbot):
@@ -422,6 +428,7 @@ def test_change_types_in_varexp(main_window, qtbot):
     assert shell.get_value('a') == 10
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.parametrize("test_directory", [u"non_ascii_ñ_í_ç", u"test_dir"])
 def test_change_cwd_ipython_console(main_window, qtbot, tmpdir, test_directory):
@@ -451,6 +458,7 @@ def test_change_cwd_ipython_console(main_window, qtbot, tmpdir, test_directory):
     assert osp.normpath(treewidget.get_current_folder()) == osp.normpath(temp_dir)
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.parametrize("test_directory", [u"non_ascii_ñ_í_ç", u"test_dir"])
 def test_change_cwd_explorer(main_window, qtbot, tmpdir, test_directory):
@@ -479,6 +487,7 @@ def test_change_cwd_explorer(main_window, qtbot, tmpdir, test_directory):
     assert osp.normpath(temp_dir) == osp.normpath(shell._cwd)
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt' or not is_module_installed('Cython'),
                     reason="It times out sometimes on Windows and Cython is needed")
@@ -529,6 +538,7 @@ def test_run_cython_code(main_window, qtbot):
     main_window.editor.close_file()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It fails on Windows.")
 def test_open_notebooks_from_project_explorer(main_window, qtbot):
@@ -571,6 +581,7 @@ def test_open_notebooks_from_project_explorer(main_window, qtbot):
     projects.close_project()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_set_new_breakpoints(main_window, qtbot):
@@ -608,6 +619,7 @@ def test_set_new_breakpoints(main_window, qtbot):
     main_window.editor.close_file()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_run_code(main_window, qtbot):
@@ -716,6 +728,7 @@ def test_run_code(main_window, qtbot):
     main_window.editor.close_file()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt' or os.environ.get('CI', None) is None or PYQT5,
                     reason="It times out sometimes on Windows, it's not "
@@ -744,6 +757,7 @@ def test_open_files_in_new_editor_window(main_window, qtbot):
     assert editorstack.get_stack_count() == 2
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 def test_close_when_file_is_changed(main_window, qtbot):
     """Test closing spyder when there is a file with modifications open."""
@@ -762,6 +776,7 @@ def test_close_when_file_is_changed(main_window, qtbot):
     qtbot.wait(3000)
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 def test_maximize_minimize_plugins(main_window, qtbot):
     """Test that the maximize button is working correctly."""
@@ -822,6 +837,7 @@ def test_issue_4066(main_window, qtbot):
     qtbot.wait(3000)
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_varexp_edit_inline(main_window, qtbot):
@@ -853,6 +869,7 @@ def test_varexp_edit_inline(main_window, qtbot):
     qtbot.wait(3000)
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_c_and_n_pdb_commands(main_window, qtbot):
@@ -919,6 +936,7 @@ def test_c_and_n_pdb_commands(main_window, qtbot):
     main_window.editor.close_file()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_stop_dbg(main_window, qtbot):
@@ -960,6 +978,7 @@ def test_stop_dbg(main_window, qtbot):
     main_window.editor.close_file()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_change_cwd_dbg(main_window, qtbot):
@@ -999,6 +1018,7 @@ def test_change_cwd_dbg(main_window, qtbot):
     assert tempfile.gettempdir() in control.toPlainText()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt' or PY2, reason="It times out sometimes")
 def test_varexp_magic_dbg(main_window, qtbot):
@@ -1031,6 +1051,7 @@ def test_varexp_magic_dbg(main_window, qtbot):
     assert shell._control.toHtml().count('img src') == 1
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.environ.get('CI', None) is None,
                     reason="It's not meant to be run outside of a CI")
@@ -1085,6 +1106,7 @@ def test_fileswitcher(main_window, qtbot):
        assert '...' in item_text
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(not PYQT5, reason="It times out.")
 def test_run_static_code_analysis(main_window, qtbot):

--- a/spyder/plugins/tests/test_ipythonconsole.py
+++ b/spyder/plugins/tests/test_ipythonconsole.py
@@ -429,7 +429,8 @@ def test_read_stderr(ipyconsole, qtbot):
 
 
 @flaky(max_runs=10)
-@pytest.mark.skipif(os.environ.get('CI', None) is not None or PY2,
+@pytest.mark.no_xvfb
+@pytest.mark.skipif(os.environ.get('CI', None) is not None,
                     reason="It times out in our CIs")
 def test_values_dbg(ipyconsole, qtbot):
     """

--- a/spyder/plugins/tests/test_ipythonconsole.py
+++ b/spyder/plugins/tests/test_ipythonconsole.py
@@ -101,6 +101,7 @@ def ipyconsole(request):
 #==============================================================================
 # Tests
 #==============================================================================
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_tab_rename_for_slaves(ipyconsole, qtbot):
@@ -122,6 +123,7 @@ def test_tab_rename_for_slaves(ipyconsole, qtbot):
     assert 'foo' in ipyconsole.get_clients()[1].get_name()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_no_repeated_tabs_name(ipyconsole, qtbot):
@@ -138,6 +140,7 @@ def test_no_repeated_tabs_name(ipyconsole, qtbot):
     assert '2' in client_name
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_tabs_preserve_name_after_move(ipyconsole, qtbot):
@@ -153,6 +156,7 @@ def test_tabs_preserve_name_after_move(ipyconsole, qtbot):
     assert '2' in client_name
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_conf_env_vars(ipyconsole, qtbot):
@@ -170,6 +174,7 @@ def test_conf_env_vars(ipyconsole, qtbot):
     assert shell.get_value('a') == 'False'
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 @pytest.mark.no_stderr_file
@@ -188,9 +193,10 @@ def test_no_stderr_file(ipyconsole, qtbot):
     assert shell.get_value('a') == 1
 
 
+@pytest.mark.slow
+@pytest.mark.non_ascii_dir
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
-@pytest.mark.non_ascii_dir
 def test_non_ascii_stderr_file(ipyconsole, qtbot):
     """Test the creation of a console with a stderr file in a non-ascii dir."""
     # Wait until the window is fully up
@@ -206,6 +212,7 @@ def test_non_ascii_stderr_file(ipyconsole, qtbot):
     assert shell.get_value('a') == 1
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_console_import_namespace(ipyconsole, qtbot):
@@ -222,6 +229,7 @@ def test_console_import_namespace(ipyconsole, qtbot):
     assert shell.get_value('e') == 2.718281828459045
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 def test_console_disambiguation(ipyconsole, qtbot):
     """Test the disambiguation of dedicated consoles."""
@@ -256,6 +264,7 @@ def test_console_disambiguation(ipyconsole, qtbot):
     assert client.get_name() == 'c.py - b/A'
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 def test_console_coloring(ipyconsole, qtbot):
 
@@ -280,6 +289,7 @@ def test_console_coloring(ipyconsole, qtbot):
     assert console_font_color.strip() == editor_font_color.strip()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It doesn't work on Windows")
 def test_get_env(ipyconsole, qtbot):
@@ -307,6 +317,7 @@ def test_get_env(ipyconsole, qtbot):
     assert env_contents['FOO'] == 'bar'
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It doesn't work on Windows")
 def test_get_syspath(ipyconsole, qtbot):
@@ -340,6 +351,7 @@ def test_get_syspath(ipyconsole, qtbot):
         pass
 
 
+@pytest.mark.slow
 @flaky(max_runs=10)
 @pytest.mark.skipif(os.name == 'nt', reason="It doesn't work on Windows")
 def test_browse_history_dbg(ipyconsole, qtbot):
@@ -373,6 +385,7 @@ def test_browse_history_dbg(ipyconsole, qtbot):
     assert '!aa = 10' in control.toPlainText()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt' or PY2,
                     reason="It times out sometimes on Windows and doesn't work on PY2")
@@ -397,6 +410,7 @@ def test_unicode_vars(ipyconsole, qtbot):
     assert shell.get_value('д') == 20
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 def test_read_stderr(ipyconsole, qtbot):
     """
@@ -415,7 +429,7 @@ def test_read_stderr(ipyconsole, qtbot):
 
 
 @flaky(max_runs=10)
-@pytest.mark.skipif(os.environ.get('CI', None) is not None,
+@pytest.mark.skipif(os.environ.get('CI', None) is not None or PY2,
                     reason="It times out in our CIs")
 def test_values_dbg(ipyconsole, qtbot):
     """
@@ -460,6 +474,7 @@ def test_values_dbg(ipyconsole, qtbot):
     assert "*** NameError: name 'aa' is not defined" in control.toPlainText()
 
 
+@pytest.mark.slow
 @flaky(max_runs=10)
 @pytest.mark.skipif(os.name == 'nt', reason="It doesn't work on Windows")
 def test_plot_magic_dbg(ipyconsole, qtbot):
@@ -490,6 +505,7 @@ def test_plot_magic_dbg(ipyconsole, qtbot):
     assert shell._control.toHtml().count('img src') == 1
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out on Windows")
 def test_run_doctest(ipyconsole, qtbot):
@@ -526,6 +542,7 @@ def test_run_doctest(ipyconsole, qtbot):
     assert "TestResults(failed=0, attempted=2)" in shell._control.toPlainText()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt' or (PY2 and PYQT5) or PYQT4,
                     reason="It times out frequently")
@@ -584,6 +601,7 @@ def test_ctrl_c_dbg(ipyconsole, qtbot):
     assert 'For copying text while debugging, use Ctrl+Shift+C' in control.toPlainText()
 
 
+@pytest.mark.slow
 @flaky(max_runs=10)
 @pytest.mark.skipif(os.name == 'nt', reason="It doesn't work on Windows")
 def test_clear_and_reset_magics_dbg(ipyconsole, qtbot):
@@ -625,6 +643,7 @@ def test_clear_and_reset_magics_dbg(ipyconsole, qtbot):
     assert "*** NameError: name 'bb' is not defined" in control.toPlainText()
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out on Windows")
 def test_restart_kernel(ipyconsole, qtbot):
@@ -648,6 +667,7 @@ def test_restart_kernel(ipyconsole, qtbot):
     assert not shell.is_defined('a')
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out on Windows")
 def test_load_kernel_file_from_id(ipyconsole, qtbot):
@@ -670,6 +690,7 @@ def test_load_kernel_file_from_id(ipyconsole, qtbot):
     assert new_client.id_ == dict(int_id='1', str_id='B')
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt' or (PY3 and PYQT4),
                     reason="It segfaults frequently")
@@ -695,6 +716,7 @@ def test_load_kernel_file_from_location(ipyconsole, qtbot):
     assert len(ipyconsole.get_clients()) == 2
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt' or PYQT4,
                     reason="It segfaults frequently")
@@ -722,6 +744,7 @@ def test_load_kernel_file(ipyconsole, qtbot):
     assert shell.get_value('a') == new_shell.get_value('a')
 
 
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out on Windows")
 def test_sys_argv_clear(ipyconsole, qtbot):

--- a/spyder/widgets/variableexplorer/tests/test_dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_dataframeeditor.py
@@ -292,7 +292,7 @@ def test_dataframemodel_set_data_overflow(monkeypatch):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.environ.get('CI', None) is not None and
+@pytest.mark.skipif(os.environ.get('CI', None) is not None or
                     platform.startswith('linux'),
                     reason="Fails on Travis CI for unknown reasons.")
 def test_dataframeeditor_edit_overflow(qtbot, monkeypatch):


### PR DESCRIPTION
@spyder-ide/core-developers, @spyder-ide/junior-developers:

I added a new `@pytest.mark.slow` marker to mark slow tests (i.e. most of the main window and IPython console ones), so they are run only in Travis and AppVeyor.

This will make far more easier to run our test suite locally.