### PR TITLE
PR: Add Troubleshooting links and blurb to various appropriate places in Spyder and doc

### DIFF
--- a/spyder/__init__.py
+++ b/spyder/__init__.py
@@ -33,6 +33,7 @@ __version__ = '.'.join(map(str, version_info))
 __license__ = __doc__
 __project_url__ = 'https://github.com/spyder-ide/spyder'
 __forum_url__   = 'http://groups.google.com/group/spyderlib'
+__trouble_url__ = __project_url__ + '/wiki/Troubleshooting-Guide-and-FAQ'
 
 # Dear (Debian, RPM, ...) package makers, please feel free to customize the
 # following path to module's data (images) and translations:

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -140,7 +140,8 @@ else:
 #==============================================================================
 # Local utility imports
 #==============================================================================
-from spyder import __version__, __project_url__, __forum_url__, get_versions
+from spyder import (__version__, __project_url__, __forum_url__,
+                    __trouble_url__, get_versions)
 from spyder.config.base import (get_conf_path, get_module_data_path,
                                 get_module_source_path, STDERR, DEBUG,
                                 debug_print, MAC_APP_NAME, get_home_dir,

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -937,6 +937,9 @@ class MainWindow(QMainWindow):
         self.set_splash(_("Setting up main window..."))
 
         # Help menu
+        trouble_action = create_action(self,
+                                        _("Troubleshooting..."),
+                                        triggered=self.trouble_guide)
         dep_action = create_action(self, _("Dependencies..."),
                                     triggered=self.show_dependencies,
                                     icon=ima.icon('advanced'))
@@ -1011,7 +1014,8 @@ class MainWindow(QMainWindow):
 
         self.help_menu_actions = [doc_action, tut_action, shortcuts_action,
                                   self.tours_menu,
-                                  MENU_SEPARATOR, report_action, dep_action,
+                                  MENU_SEPARATOR, trouble_action,
+                                  report_action, dep_action,
                                   self.check_updates_action, support_action,
                                   MENU_SEPARATOR]
         # Python documentation
@@ -2459,6 +2463,9 @@ class MainWindow(QMainWindow):
             if title:
                 url.addEncodedQueryItem("title", quote(title))
 
+    @Slot()
+    def trouble_guide(self):
+        url = QUrl(__trouble_url__)
         QDesktopServices.openUrl(url)
 
     @Slot()

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3125,7 +3125,8 @@ def main():
         CONF.set('main', 'crash', False)
         if SPLASH is not None:
             SPLASH.hide()
-        QMessageBox.information(None, "Spyder",
+        QMessageBox.information(
+            None, "Spyder",
             "Spyder crashed during last session.<br><br>"
             "If Spyder does not start at all and <u>before submitting a "
             "bug report</u>, please try to reset settings to defaults by "
@@ -3135,12 +3136,15 @@ def main():
             "<span style=\'color: #ff5555\'><b>Warning:</b></span> "
             "this command will remove all your Spyder configuration files "
             "located in '%s').<br><br>"
-            "If restoring the default settings does not help, please take "
+            "If Spyder still fails to launch, you should consult our "
+            "comprehensive <b><a href=\"%s\">Troubleshooting Guide</a></b>, "
+            "which when followed carefully solves the vast majority of "
+            "crashes; also, take "
             "the time to search for <a href=\"%s\">known bugs</a> or "
             "<a href=\"%s\">discussions</a> matching your situation before "
-            "eventually creating a new issue <a href=\"%s\">here</a>. "
+            "submitting a report to our <a href=\"%s\">issue tracker</a>. "
             "Your feedback will always be greatly appreciated."
-            "" % (get_conf_path(), __project_url__,
+            "" % (get_conf_path(), __trouble_url__, __project_url__,
                   __forum_url__, __project_url__))
 
     # Create main window

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2350,9 +2350,10 @@ class MainWindow(QMainWindow):
             <br>Developed and maintained by the
             <a href="%s/blob/master/AUTHORS">Spyder Project Contributors</a>.
             <br>Many thanks to all the Spyder beta testers and regular users.
-            <p>For bug reports and feature requests, please go
-            to our <a href="%s">Github website</a>. For discussions around the
-            project, please go to our <a href="%s">Google Group</a>
+            <p>For help with Spyder errors and crashes, please read our
+            <a href="%s">Troubleshooting page</a>, and for bug reports and
+            feature requests, visit our <a href="%s">Github website</a>.
+            For project discussion, see our <a href="%s">Google Group</a>.
             <p>This project is part of a larger effort to promote and
             facilitate the use of Python for scientific and engineering
             software development. The popular Python distributions
@@ -2368,7 +2369,7 @@ class MainWindow(QMainWindow):
             <a href="http://www.oxygen-icons.org/">
             The Oxygen icon theme</a></small>.
             """
-            % (versions['spyder'], revlink, __project_url__,
+            % (versions['spyder'], revlink, __project_url__, __trouble_url__,
                __project_url__, __forum_url__, versions['python'],
                versions['bitness'], versions['qt'], versions['qt_api'],
                versions['qt_api_ver'], versions['system']))


### PR DESCRIPTION
Adds a link and a short blurb regarding the new troubleshooting guide/FAQ in various appropriate places around the Spyder UI, including:

- About dialog
- Blurb/link as part of any crash/error dialog
- Blurb/link as part of the "crashed last time" startup message recommending spyder --reset
- Blurb/link in default Spyder issue template under .github/ISSUE_TEMPLATE.md
- And the auto-created/submitted one
- In the Readme, contributing.md, documentation index, and install doc
- Menu item in the help menu

Also some associated cleanup and polishing of related error and help guidance text, to help better guide users.

Finally, also includes a ``TROUBLESHOOTING.md`` document, along the lines of ``CONTRIBUTING.md`` which features a link and blurb to the full online guide/FAQ, as well as a few of the static sections that are likely to stay relatively unchanged, i.e, general troubleshooting tips and strategy, how to submit an issue, etc. Therefore, there is no need to hassle with maintaining it regularly, as it won't really become stale; and as its Markdown just like the wiki, it doesn't restrict compatibility whatsoever, and the relevant sections, if updated, can be easily copied and pasted in every once in a while if desired.

Thanks!
  