### PR TITLE
PR: Mark introspection test slow as its the slowest in the entire suite

### DIFF
--- a/spyder/plugins/tests/test_editor_introspection.py
+++ b/spyder/plugins/tests/test_editor_introspection.py
@@ -15,12 +15,13 @@ try:
     from unittest.mock import Mock
 except ImportError:
     from mock import Mock  # Python 2
-
 from qtpy.QtWidgets import QWidget, QApplication
 from qtpy.QtCore import Qt
 
+# Local imports
 from spyder.utils.introspection.jedi_plugin import JEDI_010
 from spyder.utils.qthelpers import qapplication
+from spyder.py3compat import PY2
 
 # Location of this file
 LOCATION = osp.realpath(osp.join(os.getcwd(), osp.dirname(__file__)))
@@ -59,6 +60,7 @@ def setup_editor(qtbot, monkeypatch):
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(PY2, reason="Strange segfaults with other tests on Py2.")
 @pytest.mark.skipif(not JEDI_010,
                     reason="This feature is only supported in jedy >= 0.10")
 def test_introspection(setup_editor):

--- a/spyder/plugins/tests/test_editor_introspection.py
+++ b/spyder/plugins/tests/test_editor_introspection.py
@@ -15,6 +15,7 @@ try:
     from unittest.mock import Mock
 except ImportError:
     from mock import Mock  # Python 2
+from qtpy import PYQT4
 from qtpy.QtWidgets import QWidget, QApplication
 from qtpy.QtCore import Qt
 
@@ -60,7 +61,8 @@ def setup_editor(qtbot, monkeypatch):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(PY2, reason="Strange segfaults with other tests on Py2.")
+@pytest.mark.skipif(PY2 or PYQT4,
+                    reason="Segfaults with other tests on Py2 and PyQt4.")
 @pytest.mark.skipif(not JEDI_010,
                     reason="This feature is only supported in jedy >= 0.10")
 def test_introspection(setup_editor):

--- a/spyder/plugins/tests/test_editor_introspection.py
+++ b/spyder/plugins/tests/test_editor_introspection.py
@@ -58,6 +58,7 @@ def setup_editor(qtbot, monkeypatch):
     editor.introspector.plugin_manager.close()
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(os.environ.get('CI', None) is not None,
                     reason="This test fails too much in the CI :(")
 @pytest.mark.skipif(not JEDI_010,

--- a/spyder/plugins/tests/test_editor_introspection.py
+++ b/spyder/plugins/tests/test_editor_introspection.py
@@ -59,8 +59,6 @@ def setup_editor(qtbot, monkeypatch):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(os.environ.get('CI', None) is not None,
-                    reason="This test fails too much in the CI :(")
 @pytest.mark.skipif(not JEDI_010,
                     reason="This feature is only supported in jedy >= 0.10")
 def test_introspection(setup_editor):


### PR DESCRIPTION
A one line PR: Just mark the ``editor_introspection`` test as ``slow``, as due to the timeouts required to make it pass reliably on all systems, it is the slowest in the entire suite, taking over 30s just by itself. Therefore, mark it as such.