### PR TITLE
PR: Add shortcut to Find in Files in Search menu

### DIFF
--- a/spyder/plugins/findinfiles.py
+++ b/spyder/plugins/findinfiles.py
@@ -16,7 +16,8 @@ import sys
 
 # Third party imports
 from qtpy.QtWidgets import QApplication
-from qtpy.QtCore import Signal, Slot
+from qtpy.QtCore import Signal, Slot, Qt
+from qtpy.QtGui import QKeySequence
 
 # Local imports
 from spyder.config.base import _
@@ -141,10 +142,12 @@ class FindInFiles(FindInFilesWidget, SpyderPluginMixin):
         self.main.editor.open_file_update.connect(self.set_current_opened_file)
 
         findinfiles_action = create_action(self, _("&Find in files"),
-                                   icon=ima.icon('findf'),
-                                   triggered=self.findinfiles_callback,
-                                   tip=_("Search text in multiple files"))        
-        
+                                   icon=ima.icon('findf'),        
+                                   triggered=self.switch_to_plugin,
+                                   shortcut=QKeySequence(self.shortcut),
+                                   context=Qt.WidgetShortcut,
+                                   tip=_("Search text in multiple files"))
+
         self.main.search_menu_actions += [MENU_SEPARATOR, findinfiles_action]
         self.main.search_toolbar_actions += [MENU_SEPARATOR,
                                              findinfiles_action]

--- a/spyder/plugins/findinfiles.py
+++ b/spyder/plugins/findinfiles.py
@@ -141,8 +141,9 @@ class FindInFiles(FindInFilesWidget, SpyderPluginMixin):
         self.main.projects.sig_project_closed.connect(self.unset_project_path)
         self.main.editor.open_file_update.connect(self.set_current_opened_file)
 
-        findinfiles_action = create_action(self, _("&Find in files"),
-                                   icon=ima.icon('findf'),        
+        findinfiles_action = create_action(
+                                   self, _("&Find in files"),
+                                   icon=ima.icon('findf'),
                                    triggered=self.switch_to_plugin,
                                    shortcut=QKeySequence(self.shortcut),
                                    context=Qt.WidgetShortcut,


### PR DESCRIPTION
Fixes #4111.

- Add shortcut to action item on search menu.  The shortcut context avoids an ambiguous shortcut overload message. 
- Changed triggered event so that the 'Find in Files' option would be checked in View -> Panes. 
  