### PR TITLE
PR: Find/replace - Copy search text to replace textbox on tabbing between them

### DIFF
--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -194,6 +194,9 @@ class FindReplace(QWidget):
                     self.return_pressed.emit()
 
             if key == Qt.Key_Tab:
+                if self.search_text.hasFocus():
+                    self.replace_text.set_current_text(
+                        self.search_text.currentText())
                 self.focusNextChild()
 
         return super(FindReplace, self).eventFilter(widget, event)

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -517,7 +517,7 @@ def test_tab_copies_find_to_replace(editor_find_replace_bot):
     finder.search_text.set_current_text('This is some test text!')
     qtbot.keyPress(finder.search_text, Qt.Key_Tab)
     qtbot.wait(100)
-    assert finder.replace_text.currentText == 'This is some test text!'
+    assert finder.replace_text.currentText() == 'This is some test text!'
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/tests/test_editor.py.bak
+++ b/spyder/widgets/tests/test_editor.py.bak
@@ -120,7 +120,7 @@ def test_find_number_matches(qtbot):
 
 def test_move_current_line_up(editor_bot):
     editor_stack, editor, qtbot = editor_bot
-        
+
     # Move second line up when nothing is selected.
     editor.go_to_line(2)
     editor.move_line_up()
@@ -129,26 +129,26 @@ def test_move_current_line_up(editor_bot):
                          '\n'
                          'x = 2\n')
     assert editor.toPlainText() == expected_new_text
-    
+
     # Move line up when already at the top.
     editor.move_line_up()
     assert editor.toPlainText() == expected_new_text
-    
+
     # Move fourth line up when part of the line is selected.
-    editor.go_to_line(4)    
+    editor.go_to_line(4)
     editor.moveCursor(QTextCursor.Right, QTextCursor.MoveAnchor)
     for i in range(2):
         editor.moveCursor(QTextCursor.Right, QTextCursor.KeepAnchor)
     editor.move_line_up()
     expected_new_text = ('print(a)\n'
-                         'a = 1\n'                         
+                         'a = 1\n'
                          'x = 2\n'
                          '\n')
     assert editor.toPlainText()[:] == expected_new_text
-    
+
 def test_move_current_line_down(editor_bot):
     editor_stack, editor, qtbot = editor_bot
-        
+
     # Move fourth line down when nothing is selected.
     editor.go_to_line(4)
     editor.move_line_down()
@@ -158,11 +158,11 @@ def test_move_current_line_down(editor_bot):
                          '\n'
                          'x = 2')
     assert editor.toPlainText() == expected_new_text
-    
+
     # Move line down when already at the bottom.
     editor.move_line_down()
     assert editor.toPlainText() == expected_new_text
-        
+
     # Move first line down when part of the line is selected.
     editor.go_to_line(1)
     editor.moveCursor(QTextCursor.Right, QTextCursor.MoveAnchor)
@@ -175,10 +175,10 @@ def test_move_current_line_down(editor_bot):
                          '\n'
                          'x = 2')
     assert editor.toPlainText() == expected_new_text
-    
+
 def test_move_multiple_lines_up(editor_bot):
     editor_stack, editor, qtbot = editor_bot
-    
+
     # Move second and third lines up.
     editor.go_to_line(2)
     cursor = editor.textCursor()
@@ -186,20 +186,20 @@ def test_move_multiple_lines_up(editor_bot):
     cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor)
     editor.setTextCursor(cursor)
     editor.move_line_up()
-    
+
     expected_new_text = ('print(a)\n'
                          '\n'
                          'a = 1\n'
                          'x = 2\n')
-    assert editor.toPlainText() == expected_new_text     
- 
+    assert editor.toPlainText() == expected_new_text
+
     # Move first and second lines up (to test already at top condition).
     editor.move_line_up()
     assert editor.toPlainText() == expected_new_text
 
 def test_move_multiple_lines_down(editor_bot):
     editor_stack, editor, qtbot = editor_bot
-    
+
     # Move third and fourth lines down.
     editor.go_to_line(3)
     cursor = editor.textCursor()
@@ -207,18 +207,18 @@ def test_move_multiple_lines_down(editor_bot):
     cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor)
     editor.setTextCursor(cursor)
     editor.move_line_down()
-    
+
     expected_new_text = ('a = 1\n'
                          'print(a)\n'
                          '\n'
                          '\n'
                          'x = 2')
     assert editor.toPlainText() == expected_new_text
-    
+
     # Move fourht and fifth lines down (to test already at bottom condition).
     editor.move_line_down()
     assert editor.toPlainText() == expected_new_text
-    
+
 def test_run_top_line(editor_bot):
     editor_stack, editor, qtbot = editor_bot
     editor.go_to_line(1) # line number is one based
@@ -509,11 +509,10 @@ def test_tab_moves_focus_from_search_to_replace(editor_find_replace_bot):
 
 def test_tab_copies_find_to_replace(editor_find_replace_bot):
     """Check that text in the find box is copied to the replace box on tab
-    keypress. Regression test #4482."""
+    keypress"""
     editor_stack, editor, finder, qtbot = editor_find_replace_bot
     finder.show()
     finder.show_replace()
-    finder.search_text.setFocus()
     finder.search_text.set_current_text('This is some test text!')
     qtbot.keyPress(finder.search_text, Qt.Key_Tab)
     qtbot.wait(100)


### PR DESCRIPTION
Fixes #4482

When the search field is highlighted in find/replace and TAB is pressed, the search text is copied to the replace field for modification.
  
  