### PR TITLE
PR: Use a checkbox in error dialog to dismiss it instead of a button

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -464,10 +464,9 @@ class MainWindow(QMainWindow):
         if options.window_title is not None:
             title += ' -- ' + options.window_title
 
-        if DEBUG or PYTEST:
-            # Show errors in internal console when developing or testing.
-            CONF.set('main', 'show_internal_console_if_traceback', True)
-
+        if PYTEST:
+            # Show errors in internal console when testing.
+            CONF.set('main', 'show_internal_errors', False)
 
         self.base_title = title
         self.update_window_title()

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -94,7 +94,7 @@ DEFAULTS = [
               'use_custom_margin': True,
               'custom_margin': 0,
               'use_custom_cursor_blinking': False,
-              'show_internal_console_if_traceback': False,
+              'show_internal_errors': True,
               'check_updates_on_startup': True,
               'toolbars_visible': True,
               # Global Spyder fonts
@@ -636,7 +636,7 @@ DEFAULTS = [
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '42.0.0'
+CONF_VERSION = '43.0.0'
 
 # Main configuration instance
 try:

--- a/spyder/plugins/configdialog.py
+++ b/spyder/plugins/configdialog.py
@@ -830,9 +830,8 @@ class MainConfigPage(GeneralConfigPage):
                                           "Python files in an already running "
                                           "instance (Requires a restart)"))
         prompt_box = newcb(_("Prompt when exiting"), 'prompt_on_exit')
-        popup_console_box = newcb(_("Pop up internal console when internal "
-                                    "errors appear"),
-                                  'show_internal_console_if_traceback')
+        popup_console_box = newcb(_("Show internal Spyder errors to report "
+                                    "them to Github"), 'show_internal_errors')
         check_updates = newcb(_("Check for updates on startup"),
                               'check_updates_on_startup')
 

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -97,7 +97,7 @@ class Console(SpyderPluginWidget):
         # Traceback MessageBox
         self.error_dlg = None
         self.error_traceback = ""
-        self.dimiss_error = False
+        self.dismiss_error = False
 
     #------ Private API --------------------------------------------------------
     def set_historylog(self, historylog):
@@ -211,7 +211,7 @@ class Console(SpyderPluginWidget):
         Show a QDialog or the internal console to warn the user.
         """
         # Skip errors without traceback or dismiss
-        if (not is_traceback and self.error_dlg is None) or self.dimiss_error:
+        if (not is_traceback and self.error_dlg is None) or self.dismiss_error:
             return
 
         if CONF.get('main', 'show_internal_console_if_traceback'):
@@ -220,19 +220,16 @@ class Console(SpyderPluginWidget):
         else:
             if self.error_dlg is None:
                 self.error_dlg = SpyderErrorDialog(self)
-
-                self.error_dlg.dimiss_btn.clicked.connect(
-                    self.dismiss_error_dlg)
+                self.error_dlg.close_btn.clicked.connect(self.close_error_dlg)
                 self.error_dlg.rejected.connect(self.remove_error_dlg)
                 self.error_dlg.details.go_to_error.connect(self.go_to_error)
-
                 self.error_dlg.show()
-
             self.error_dlg.append_traceback(text)
 
-    def dismiss_error_dlg(self):
-        """Dismiss error dialog."""
-        self.dimiss_error = True
+    def close_error_dlg(self):
+        """Close error dialog."""
+        if self.error_dlg.dismiss_box.isChecked():
+            self.dismiss_error = True
         self.error_dlg.reject()
 
     def remove_error_dlg(self):

--- a/spyder/plugins/console.py
+++ b/spyder/plugins/console.py
@@ -23,7 +23,7 @@ from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QInputDialog, QLineEdit, QMenu, QVBoxLayout
 
 # Local imports
-from spyder.config.base import _, debug_print
+from spyder.config.base import _, DEV, debug_print
 from spyder.config.main import CONF
 from spyder.utils import icon_manager as ima
 from spyder.utils.environ import EnvDialog
@@ -214,10 +214,7 @@ class Console(SpyderPluginWidget):
         if (not is_traceback and self.error_dlg is None) or self.dismiss_error:
             return
 
-        if CONF.get('main', 'show_internal_console_if_traceback'):
-            self.dockwidget.show()
-            self.dockwidget.raise_()
-        else:
+        if CONF.get('main', 'show_internal_errors'):
             if self.error_dlg is None:
                 self.error_dlg = SpyderErrorDialog(self)
                 self.error_dlg.close_btn.clicked.connect(self.close_error_dlg)
@@ -225,6 +222,9 @@ class Console(SpyderPluginWidget):
                 self.error_dlg.details.go_to_error.connect(self.go_to_error)
                 self.error_dlg.show()
             self.error_dlg.append_traceback(text)
+        elif DEV:
+            self.dockwidget.show()
+            self.dockwidget.raise_()
 
     def close_error_dlg(self):
         """Close error dialog."""

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -123,7 +123,7 @@ class SpyderErrorDialog(QDialog):
 
         # Dialog main label
         self.main_label = QLabel(
-            _("""<b>Spyder has encountered a problem!!</b><hr>
+            _("""<b>Spyder has encountered an internal problem</b><hr>
               Please enter below a step-by-step description of 
               your problem (in English). Issue reports without 
               a clear way to reproduce them will be closed.

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -23,6 +23,11 @@ from spyder.widgets.mixins import BaseEditMixin, TracebackLinksMixin
 from spyder.widgets.sourcecode.base import ConsoleBaseWidget
 
 
+# Minimum number of characters to introduce in the description
+# field before being able to send the report to Github.
+MIN_CHARS = 20
+
+
 class DescriptionWidget(CodeEditor):
     """Widget to enter error description."""
 
@@ -141,7 +146,8 @@ class SpyderErrorDialog(QDialog):
 
         # Label to show missing chars
         self.initial_chars = len(self.input_description.toPlainText())
-        self.chars_label = QLabel(_("Enter at least 15 characters"))
+        self.chars_label = QLabel(_("Enter at least {} "
+                                    "characters".format(MIN_CHARS)))
 
         # Checkbox to dismiss future errors
         self.dismiss_box = QCheckBox()
@@ -224,12 +230,13 @@ class SpyderErrorDialog(QDialog):
     def _description_changed(self):
         """Activate submit_btn if we have a long enough description."""
         chars = len(self.input_description.toPlainText()) - self.initial_chars
-        if chars < 15:
+        if chars < MIN_CHARS:
             self.chars_label.setText(
-                u"{} {}".format(15 - chars, _("more characters to go...")))
+                u"{} {}".format(MIN_CHARS - chars,
+                                _("more characters to go...")))
         else:
             self.chars_label.setText(_("Ready to submit! Thanks!"))
-        self.submit_btn.setEnabled(chars >= 15)
+        self.submit_btn.setEnabled(chars >= MIN_CHARS)
 
 
 def test():

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -151,7 +151,7 @@ class SpyderErrorDialog(QDialog):
 
         # Checkbox to dismiss future errors
         self.dismiss_box = QCheckBox()
-        self.dismiss_box.setText(_("Don't show again"))
+        self.dismiss_box.setText(_("Don't show again during this session"))
 
         # Labels layout
         labels_layout = QHBoxLayout()
@@ -183,7 +183,7 @@ class SpyderErrorDialog(QDialog):
         vlayout.addLayout(buttons_layout)
         self.setLayout(vlayout)
 
-        self.resize(550, 420)
+        self.resize(600, 420)
         self.input_description.setFocus()
 
     def _submit_to_github(self):
@@ -219,7 +219,7 @@ class SpyderErrorDialog(QDialog):
             self.details.hide()
             self.details_btn.setText(_('Show details'))
         else:
-            self.resize(550, 550)
+            self.resize(600, 550)
             self.details.document().setPlainText('')
             self.details.append_text_to_shell(self.error_traceback,
                                               error=True,

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -10,8 +10,8 @@
 import sys
 
 # Third party imports
-from qtpy.QtWidgets import (QApplication, QDialog, QHBoxLayout, QLabel,
-                            QPlainTextEdit, QPushButton, QVBoxLayout)
+from qtpy.QtWidgets import (QApplication, QCheckBox, QDialog, QHBoxLayout,
+                            QLabel, QPlainTextEdit, QPushButton, QVBoxLayout)
 from qtpy.QtCore import Qt, Signal
 
 # Local Imports
@@ -139,6 +139,19 @@ class SpyderErrorDialog(QDialog):
         self.details.set_pythonshell_font(get_font())
         self.details.hide()
 
+        # Label to show missing chars
+        self.initial_chars = len(self.input_description.toPlainText())
+        self.chars_label = QLabel(_("Enter at least 15 characters"))
+
+        # Checkbox to dismiss future errors
+        self.dismiss_box = QCheckBox()
+        self.dismiss_box.setText(_("Don't show again"))
+
+        # Labels layout
+        labels_layout = QHBoxLayout()
+        labels_layout.addWidget(self.chars_label)
+        labels_layout.addWidget(self.dismiss_box, 0, Qt.AlignRight)
+
         # Dialog buttons
         self.submit_btn = QPushButton(_('Submit to Github'))
         self.submit_btn.setEnabled(False)
@@ -147,28 +160,24 @@ class SpyderErrorDialog(QDialog):
         self.details_btn = QPushButton(_('Show details'))
         self.details_btn.clicked.connect(self._show_details)
 
-        self.dimiss_btn = QPushButton(_('Dismiss'))
-
-        # Label to show missing chars
-        self.initial_chars = len(self.input_description.toPlainText())
-        self.chars_label = QLabel(_("Enter at least 15 characters"))
+        self.close_btn = QPushButton(_('Close'))
 
         # Buttons layout
-        hlayout = QHBoxLayout()
-        hlayout.addWidget(self.submit_btn)
-        hlayout.addWidget(self.details_btn)
-        hlayout.addWidget(self.dimiss_btn)
+        buttons_layout = QHBoxLayout()
+        buttons_layout.addWidget(self.submit_btn)
+        buttons_layout.addWidget(self.details_btn)
+        buttons_layout.addWidget(self.close_btn)
 
         # Main layout
         vlayout = QVBoxLayout()
         vlayout.addWidget(self.main_label)
         vlayout.addWidget(self.input_description)
         vlayout.addWidget(self.details)
-        vlayout.addWidget(self.chars_label)
-        vlayout.addLayout(hlayout)
+        vlayout.addLayout(labels_layout)
+        vlayout.addLayout(buttons_layout)
         self.setLayout(vlayout)
 
-        self.resize(500, 420)
+        self.resize(550, 420)
         self.input_description.setFocus()
 
     def _submit_to_github(self):
@@ -204,7 +213,7 @@ class SpyderErrorDialog(QDialog):
             self.details.hide()
             self.details_btn.setText(_('Show details'))
         else:
-            self.resize(500, 550)
+            self.resize(550, 550)
             self.details.document().setPlainText('')
             self.details.append_text_to_shell(self.error_traceback,
                                               error=True,

--- a/spyder/widgets/tests/test_reporterror.py
+++ b/spyder/widgets/tests/test_reporterror.py
@@ -11,7 +11,7 @@ import pytest
 from qtpy.QtCore import Qt
 
 # Local imports
-from spyder.widgets.reporterror import SpyderErrorDialog
+from spyder.widgets.reporterror import MIN_CHARS, SpyderErrorDialog
 
 
 @pytest.fixture
@@ -25,7 +25,7 @@ def setup_dialog(qtbot):
 def test_dialog(qtbot):
     """Run dialog tests."""
     dlg = setup_dialog(qtbot)
-    text = "123456789123456"
+    text = "1" * MIN_CHARS
 
     # Assert Submit button is disabled at first
     assert not dlg.submit_btn.isEnabled()
@@ -57,7 +57,7 @@ def test_dialog(qtbot):
     assert dlg.input_description.toPlainText() == dlg.input_description.header
 
     # Assert chars label works as expected
-    assert dlg.chars_label.text() == '15 more characters to go...'
+    assert dlg.chars_label.text() == '{} more characters to go...'.format(MIN_CHARS)
     qtbot.keyClicks(dlg.input_description, text)
     assert dlg.chars_label.text() == 'Ready to submit! Thanks!'
 


### PR DESCRIPTION
Screenshot:

![seleccion_001](https://user-images.githubusercontent.com/365293/35444435-8dcd8020-027c-11e8-8bee-c2f2610446dd.png)

@CAM-Gerlach, what do you think?

----

TODO:

- [x] Increase character count
- [x] Reword Preferences option about showing the internal console.