### PR TITLE
PR: Fix Profiler error when run is stopped

### DIFF
--- a/spyder_profiler/widgets/profilergui.py
+++ b/spyder_profiler/widgets/profilergui.py
@@ -471,7 +471,7 @@ class ProfilerDataTree(QTreeWidget):
         """Load profiler data saved by profile/cProfile module"""
         import pstats
         try:
-            stats_indi = [pstats.Stats(profdatafile),]
+            stats_indi = [pstats.Stats(profdatafile), ]
         except (OSError, IOError):
             return
         self.profdata = stats_indi[0]


### PR DESCRIPTION
Fixes #6220.

This pull request addresses a few aspects of the issue reported.

- When the `Stop` button was clicked when a profile was running, Spyder still attempted to display the profiler results even know there wouldn't have been any.  The profiler only writes results when it finishes.  The fix is to recognize the button event and display a different text to the user, along with clearing the datatree.

- The `load_data` method in the `ProfilerDataTree` class assumed that the default results file existed, but if the run had been canceled, then this file doesn't exist.  A try/except was added to this to catch file errors.  Note that item 1 should prevent this from being called.