### PR TITLE
PR: Install and run window manager in Travis to fix focus issues and unskip now-passing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,16 @@ matrix:
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+  # Avoid annoying focus problems when running tests
+  # See discussion in e.g. https://github.com/spyder-ide/spyder/pull/6132
+  - sudo apt-get -qq update
+  - sudo apt-get install -y matchbox-window-manager
 
 install:
   - ./continuous_integration/travis/install.sh;
   - ./continuous_integration/travis/install-qt.sh;
+  - DISPLAY=:99 matchbox-window-manager &
+  - sleep 5
 
 script:
   - ./continuous_integration/travis/runtests.sh || ./continuous_integration/travis/runtests.sh || ./continuous_integration/travis/runtests.sh;

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -161,11 +161,11 @@ def main_window(request):
 # avoid possible timeouts in Appveyor
 @pytest.mark.use_introspection
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.environ.get('CI', None) is not None or os.name == 'nt' or PY2,
-                    reason="It times out in our CIs, and apparently Windows.")
-@pytest.mark.timeout(timeout=60, method='thread')
+@pytest.mark.skipif(os.name == 'nt',
+                    reason="It times out on Windows locally and on AppVeyor.")
+@pytest.mark.timeout(timeout=45, method='thread')
 def test_calltip(main_window, qtbot):
-    """Hide the calltip in the editor when a matching ')' is found."""
+    """Test that the calltip in editor is hidden when matching ')' is found."""
     # Load test file
     text = 'a = [1,2,3]\n(max'
     main_window.editor.new(fname="test.py", text=text)

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -159,6 +159,7 @@ def main_window(request):
 #==============================================================================
 # IMPORTANT NOTE: Please leave this test to be the first one here to
 # avoid possible timeouts in Appveyor
+@pytest.mark.slow
 @pytest.mark.use_introspection
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt',

--- a/spyder/plugins/tests/test_ipythonconsole.py
+++ b/spyder/plugins/tests/test_ipythonconsole.py
@@ -456,6 +456,7 @@ def test_read_stderr(ipyconsole, qtbot):
     assert content == client._read_stderr()
 
 
+@pytest.mark.slow
 @flaky(max_runs=10)
 @pytest.mark.no_xvfb
 @pytest.mark.skipif(os.environ.get('CI', None) is not None and os.name == 'nt',

--- a/spyder/plugins/tests/test_ipythonconsole.py
+++ b/spyder/plugins/tests/test_ipythonconsole.py
@@ -458,8 +458,9 @@ def test_read_stderr(ipyconsole, qtbot):
 
 @flaky(max_runs=10)
 @pytest.mark.no_xvfb
-@pytest.mark.skipif(os.environ.get('CI', None) is not None,
-                    reason="It times out in our CIs")
+@pytest.mark.skipif(os.environ.get('CI', None) is not None and os.name == 'nt',
+                    reason="It times out on AppVeyor.")
+@pytest.mark.timeout(timeout=20, method='thread')
 def test_values_dbg(ipyconsole, qtbot):
     """
     Test that getting, setting, copying and removing values is working while

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -121,7 +121,7 @@ def test_find_number_matches(qtbot):
 
 def test_move_current_line_up(editor_bot):
     editor_stack, editor, qtbot = editor_bot
-
+        
     # Move second line up when nothing is selected.
     editor.go_to_line(2)
     editor.move_line_up()
@@ -130,26 +130,26 @@ def test_move_current_line_up(editor_bot):
                          '\n'
                          'x = 2\n')
     assert editor.toPlainText() == expected_new_text
-
+    
     # Move line up when already at the top.
     editor.move_line_up()
     assert editor.toPlainText() == expected_new_text
-
+    
     # Move fourth line up when part of the line is selected.
-    editor.go_to_line(4)
+    editor.go_to_line(4)    
     editor.moveCursor(QTextCursor.Right, QTextCursor.MoveAnchor)
     for i in range(2):
         editor.moveCursor(QTextCursor.Right, QTextCursor.KeepAnchor)
     editor.move_line_up()
     expected_new_text = ('print(a)\n'
-                         'a = 1\n'
+                         'a = 1\n'                         
                          'x = 2\n'
                          '\n')
     assert editor.toPlainText()[:] == expected_new_text
-
+    
 def test_move_current_line_down(editor_bot):
     editor_stack, editor, qtbot = editor_bot
-
+        
     # Move fourth line down when nothing is selected.
     editor.go_to_line(4)
     editor.move_line_down()
@@ -159,11 +159,11 @@ def test_move_current_line_down(editor_bot):
                          '\n'
                          'x = 2')
     assert editor.toPlainText() == expected_new_text
-
+    
     # Move line down when already at the bottom.
     editor.move_line_down()
     assert editor.toPlainText() == expected_new_text
-
+        
     # Move first line down when part of the line is selected.
     editor.go_to_line(1)
     editor.moveCursor(QTextCursor.Right, QTextCursor.MoveAnchor)
@@ -176,10 +176,10 @@ def test_move_current_line_down(editor_bot):
                          '\n'
                          'x = 2')
     assert editor.toPlainText() == expected_new_text
-
+    
 def test_move_multiple_lines_up(editor_bot):
     editor_stack, editor, qtbot = editor_bot
-
+    
     # Move second and third lines up.
     editor.go_to_line(2)
     cursor = editor.textCursor()
@@ -187,20 +187,20 @@ def test_move_multiple_lines_up(editor_bot):
     cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor)
     editor.setTextCursor(cursor)
     editor.move_line_up()
-
+    
     expected_new_text = ('print(a)\n'
                          '\n'
                          'a = 1\n'
                          'x = 2\n')
-    assert editor.toPlainText() == expected_new_text
-
+    assert editor.toPlainText() == expected_new_text     
+ 
     # Move first and second lines up (to test already at top condition).
     editor.move_line_up()
     assert editor.toPlainText() == expected_new_text
 
 def test_move_multiple_lines_down(editor_bot):
     editor_stack, editor, qtbot = editor_bot
-
+    
     # Move third and fourth lines down.
     editor.go_to_line(3)
     cursor = editor.textCursor()
@@ -208,18 +208,18 @@ def test_move_multiple_lines_down(editor_bot):
     cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor)
     editor.setTextCursor(cursor)
     editor.move_line_down()
-
+    
     expected_new_text = ('a = 1\n'
                          'print(a)\n'
                          '\n'
                          '\n'
                          'x = 2')
     assert editor.toPlainText() == expected_new_text
-
+    
     # Move fourht and fifth lines down (to test already at bottom condition).
     editor.move_line_down()
     assert editor.toPlainText() == expected_new_text
-
+    
 def test_run_top_line(editor_bot):
     editor_stack, editor, qtbot = editor_bot
     editor.go_to_line(1) # line number is one based

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -9,6 +9,7 @@ Tests for editor.py
 """
 
 # Standard library imports
+import os
 from sys import platform
 try:
     from unittest.mock import Mock, MagicMock
@@ -120,7 +121,7 @@ def test_find_number_matches(qtbot):
 
 def test_move_current_line_up(editor_bot):
     editor_stack, editor, qtbot = editor_bot
-        
+
     # Move second line up when nothing is selected.
     editor.go_to_line(2)
     editor.move_line_up()
@@ -129,26 +130,26 @@ def test_move_current_line_up(editor_bot):
                          '\n'
                          'x = 2\n')
     assert editor.toPlainText() == expected_new_text
-    
+
     # Move line up when already at the top.
     editor.move_line_up()
     assert editor.toPlainText() == expected_new_text
-    
+
     # Move fourth line up when part of the line is selected.
-    editor.go_to_line(4)    
+    editor.go_to_line(4)
     editor.moveCursor(QTextCursor.Right, QTextCursor.MoveAnchor)
     for i in range(2):
         editor.moveCursor(QTextCursor.Right, QTextCursor.KeepAnchor)
     editor.move_line_up()
     expected_new_text = ('print(a)\n'
-                         'a = 1\n'                         
+                         'a = 1\n'
                          'x = 2\n'
                          '\n')
     assert editor.toPlainText()[:] == expected_new_text
-    
+
 def test_move_current_line_down(editor_bot):
     editor_stack, editor, qtbot = editor_bot
-        
+
     # Move fourth line down when nothing is selected.
     editor.go_to_line(4)
     editor.move_line_down()
@@ -158,11 +159,11 @@ def test_move_current_line_down(editor_bot):
                          '\n'
                          'x = 2')
     assert editor.toPlainText() == expected_new_text
-    
+
     # Move line down when already at the bottom.
     editor.move_line_down()
     assert editor.toPlainText() == expected_new_text
-        
+
     # Move first line down when part of the line is selected.
     editor.go_to_line(1)
     editor.moveCursor(QTextCursor.Right, QTextCursor.MoveAnchor)
@@ -175,10 +176,10 @@ def test_move_current_line_down(editor_bot):
                          '\n'
                          'x = 2')
     assert editor.toPlainText() == expected_new_text
-    
+
 def test_move_multiple_lines_up(editor_bot):
     editor_stack, editor, qtbot = editor_bot
-    
+
     # Move second and third lines up.
     editor.go_to_line(2)
     cursor = editor.textCursor()
@@ -186,20 +187,20 @@ def test_move_multiple_lines_up(editor_bot):
     cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor)
     editor.setTextCursor(cursor)
     editor.move_line_up()
-    
+
     expected_new_text = ('print(a)\n'
                          '\n'
                          'a = 1\n'
                          'x = 2\n')
-    assert editor.toPlainText() == expected_new_text     
- 
+    assert editor.toPlainText() == expected_new_text
+
     # Move first and second lines up (to test already at top condition).
     editor.move_line_up()
     assert editor.toPlainText() == expected_new_text
 
 def test_move_multiple_lines_down(editor_bot):
     editor_stack, editor, qtbot = editor_bot
-    
+
     # Move third and fourth lines down.
     editor.go_to_line(3)
     cursor = editor.textCursor()
@@ -207,18 +208,18 @@ def test_move_multiple_lines_down(editor_bot):
     cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor)
     editor.setTextCursor(cursor)
     editor.move_line_down()
-    
+
     expected_new_text = ('a = 1\n'
                          'print(a)\n'
                          '\n'
                          '\n'
                          'x = 2')
     assert editor.toPlainText() == expected_new_text
-    
+
     # Move fourht and fifth lines down (to test already at bottom condition).
     editor.move_line_down()
     assert editor.toPlainText() == expected_new_text
-    
+
 def test_run_top_line(editor_bot):
     editor_stack, editor, qtbot = editor_bot
     editor.go_to_line(1) # line number is one based
@@ -471,7 +472,7 @@ def test_editor_splitter_init(editor_splitter_bot):
 
 
 def test_tab_keypress_properly_caught_find_replace(editor_find_replace_bot):
-    """Check that tab works in find/replace dialog. Regression test #3674.
+    """Test that tab works in find/replace dialog. Regression test for #3674.
     Mock test—more isolated but less flimsy."""
     editor_stack, editor, finder, qtbot = editor_find_replace_bot
     text = '  \nspam \nspam \nspam '
@@ -485,10 +486,11 @@ def test_tab_keypress_properly_caught_find_replace(editor_find_replace_bot):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(platform.startswith('linux'),
-                    reason="This test fails on Linux, for unknown reasons.")
+@pytest.mark.skipif(os.environ.get('CI', None) is None and
+                    platform.startswith('linux'),
+                    reason="Fails on some Linux platforms locally.")
 def test_tab_moves_focus_from_search_to_replace(editor_find_replace_bot):
-    """Check that tab works in find/replace dialog. Regression test #3674.
+    """Test that tab works in find/replace dialog. Regression test for #3674.
     "Real world" test—more comprehensive but potentially less robust."""
     editor_stack, editor, finder, qtbot = editor_find_replace_bot
     text = '  \nspam \nspam \nspam '

--- a/spyder/widgets/variableexplorer/tests/test_dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_dataframeeditor.py
@@ -275,7 +275,7 @@ def test_sort_dataframe_with_category_dtypes(qtbot):  # cf. issue 5361
 
 
 def test_dataframemodel_set_data_overflow(monkeypatch):
-    """Unit test #6114: entry of an overflow int caught and handled properly"""
+    """Test for #6114: Overflowing ints are caught and handled properly"""
     MockQMessageBox = Mock()
     attr_to_patch = ('spyder.widgets.variableexplorer' +
                      '.dataframeeditor.QMessageBox')
@@ -301,10 +301,11 @@ def test_dataframemodel_set_data_overflow(monkeypatch):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(platform.startswith('linux'),
-                    reason="Fails on some Linux platforms locally and Travis.")
+@pytest.mark.skipif(os.environ.get('CI', None) is None and
+                    platform.startswith('linux'),
+                    reason="Fails on some Linux platforms locally.")
 def test_dataframeeditor_edit_overflow(qtbot, monkeypatch):
-    """Test #6114: entry of an overflow int is caught and handled properly"""
+    """Test #6114: Entry of an overflow int is caught and handled properly"""
     MockQMessageBox = Mock()
     attr_to_patch = ('spyder.widgets.variableexplorer' +
                      '.dataframeeditor.QMessageBox')
@@ -346,7 +347,7 @@ def test_dataframeeditor_edit_overflow(qtbot, monkeypatch):
 
 
 def test_dataframemodel_set_data_complex(monkeypatch):
-    """Unit test #6115: editing complex dtypes raises error in df editor"""
+    """Test for #6115: Editing complex dtypes raises error in df editor"""
     MockQMessageBox = Mock()
     attr_to_patch = ('spyder.widgets.variableexplorer' +
                      '.dataframeeditor.QMessageBox')
@@ -366,9 +367,6 @@ def test_dataframemodel_set_data_complex(monkeypatch):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.environ.get('CI', None) is not None or
-                    platform.startswith('linux'),
-                    reason="Fails on Travis for no good reason.")
 def test_dataframeeditor_edit_complex(qtbot, monkeypatch):
     """Test for #6115: editing complex dtypes raises error in df editor"""
     MockQMessageBox = Mock()
@@ -408,7 +406,7 @@ def test_dataframeeditor_edit_complex(qtbot, monkeypatch):
 
 
 def test_dataframemodel_set_data_bool(monkeypatch):
-    """Unit test that bools are editible in df and false-y strs are detected"""
+    """Test that bools are editible in df and false-y strs are detected"""
     MockQMessageBox = Mock()
     attr_to_patch = ('spyder.widgets.variableexplorer' +
                      '.dataframeeditor.QMessageBox')
@@ -429,11 +427,8 @@ def test_dataframemodel_set_data_bool(monkeypatch):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.environ.get('CI', None) is not None or
-                    platform.startswith('linux'),
-                    reason="Fails on Travis for no good reason.")
 def test_dataframeeditor_edit_bool(qtbot, monkeypatch):
-    """Unit test that bools are editible in df and false-y strs are detected"""
+    """Test that bools are editible in df and false-y strs are detected"""
     MockQMessageBox = Mock()
     attr_to_patch = ('spyder.widgets.variableexplorer' +
                      '.dataframeeditor.QMessageBox')


### PR DESCRIPTION
I've been noticing consistent problems with tests failing on Travis when focus and other GUI elements are involved. Accordingly, in #6132 @ccordoba12 suggested installing a window manager, as that fixed similar issues with CircleCI in #4151 . Therefore, this is a shot at doing the same for Travis, which would hopefully resolve a ton of frustration I'm having with a the tests in a number of recent PRs. First crack at it will just ensure the code runs without error, and then I'll try enabling tests that failed due to focus/etc. issues to see if this fixes it. However, it can be limited to ensure this PR can get merged quickly; the primary objective is to verify this is actually working and fixes at least some of the problems.