### PR TITLE
PR: Fix and catch typeerror thrown when from_index is None while moving plugin tab

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -163,7 +163,7 @@ def main_window(request):
 @pytest.mark.use_introspection
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt' or (not PY2 and PYQT_VERSION < "5.9.0"),
-                    reason="It times out on AppVeyor and fails on PY3 and PyQt 5.6")
+                    reason="Times out on AppVeyor and fails on PY3/PyQt 5.6")
 @pytest.mark.timeout(timeout=45, method='thread')
 def test_calltip(main_window, qtbot):
     """Test that the calltip in editor is hidden when matching ')' is found."""
@@ -181,7 +181,7 @@ def test_calltip(main_window, qtbot):
 
     qtbot.keyPress(code_editor, Qt.Key_ParenLeft, delay=3000)
     qtbot.keyPress(code_editor, Qt.Key_A, delay=1000)
-    qtbot.waitUntil(lambda: calltip.isVisible(), timeout=1000)
+    qtbot.waitUntil(lambda: calltip.isVisible(), timeout=3000)
 
     qtbot.keyPress(code_editor, Qt.Key_ParenRight, delay=1000)
     qtbot.keyPress(code_editor, Qt.Key_Space)

--- a/spyder/plugins/__init__.py
+++ b/spyder/plugins/__init__.py
@@ -96,7 +96,7 @@ class TabFilter(QObject):
             new_pos = self.dock_tabbar.mapToGlobal(QPoint(x + delta, y))
             cursor.setPos(new_pos)
 
-    def eventFilter(self,  obj,  event):
+    def eventFilter(self, obj, event):
         """Filter mouse press events.
 
         Events that are captured and not propagated return True. Events that
@@ -107,8 +107,11 @@ class TabFilter(QObject):
             self.tab_pressed(event)
             return False
         if event_type == QEvent.MouseMove:
-            self.tab_moved(event)
-            return True
+            try:
+                self.tab_moved(event)
+                return True
+            except TypeError:
+                pass
         if event_type == QEvent.MouseButtonRelease:
             self.tab_released(event)
             return True

--- a/spyder/plugins/__init__.py
+++ b/spyder/plugins/__init__.py
@@ -109,9 +109,9 @@ class TabFilter(QObject):
         if event_type == QEvent.MouseMove:
             try:
                 self.tab_moved(event)
-                return True
             except TypeError:
                 pass
+            return True
         if event_type == QEvent.MouseButtonRelease:
             self.tab_released(event)
             return True
@@ -141,11 +141,11 @@ class TabFilter(QObject):
             QApplication.setOverrideCursor(Qt.ClosedHandCursor)
             self.moving = True
 
-        if self.to_index == -1:
+        if self.to_index in (-1, None):
             self.to_index = self.from_index
 
         from_index, to_index = self.from_index, self.to_index
-        if from_index != to_index and from_index != -1 and to_index != -1:
+        if from_index not in (to_index, -1, None):
             self.move_tab(from_index, to_index)
             self._fix_cursor(from_index, to_index)
             self.from_index = to_index

--- a/spyder/plugins/tests/test_init.py
+++ b/spyder/plugins/tests/test_init.py
@@ -56,6 +56,26 @@ def main_window(request):
 # =============================================================================
 # Tests
 # =============================================================================
+def test_tabfilter_typeerror_simple():
+    """Test for #5813 ; event filter handles None indicies when moving tabs."""
+    MockEvent = MagicMock()
+    MockEvent.return_value.type.return_value = QEvent.MouseMove
+    MockEvent.return_value.pos.return_value = 0
+    mockEvent_instance = MockEvent()
+
+    MockTabBar = MagicMock()
+    MockTabBar.return_value.tabAt.return_value = 0
+    mockTabBar_instance = MockTabBar()
+
+    test_tabfilter = TabFilter(mockTabBar_instance, main_window)
+    test_tabfilter.from_index = None
+    test_tabfilter.moving = True
+
+    assert test_tabfilter.eventFilter(None, mockEvent_instance)
+    mockEvent_instance.pos.assert_called_once()
+    mockTabBar_instance.tabAt.called_once()
+
+
 @flaky(max_runs=3)
 @pytest.mark.slow
 def test_tabfilter_typeerror_full(main_window):

--- a/spyder/plugins/tests/test_init.py
+++ b/spyder/plugins/tests/test_init.py
@@ -11,13 +11,67 @@
 # Standard library imports
 import os
 try:
-    from unittest.mock import Mock
+    from unittest.mock import MagicMock
 except ImportError:
-    from mock import Mock  # Python 2
+    from mock import MagicMock  # Python 2
 
 # 3rd party imports
 import pytest
 from flaky import flaky
+from qtpy.QtCore import QEvent
+from qtpy.QtWidgets import QTabBar
+
+# Local imports
+from spyder.plugins import TabFilter
+from spyder.app import start
+from spyder.config.main import CONF
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+@pytest.fixture
+def main_window(request):
+    """Main Window fixture"""
+    # Disable unneeded introspection to save on startup time
+    try:
+        os.environ.pop('SPY_TEST_USE_INTROSPECTION')
+    except KeyError:
+        pass
+
+    # Make sure single instance mode is disabled
+    CONF.set('main', 'single_instance', False)
+
+    # Start the window
+    window = start.main()
+
+    # Teardown
+    def close_window():
+        window.close()
+    request.addfinalizer(close_window)
+
+    return window
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+@flaky(max_runs=3)
+@pytest.mark.slow
+def test_tabfilter_typeerror_full(main_window):
+    """Test for #5813 ; event filter handles None indicies when moving tabs."""
+    MockEvent = MagicMock()
+    MockEvent.return_value.type.return_value = QEvent.MouseMove
+    MockEvent.return_value.pos.return_value = 0
+    mockEvent_instance = MockEvent()
+
+    test_tabbar = main_window.findChildren(QTabBar)[0]
+    test_tabfilter = TabFilter(test_tabbar, main_window)
+    test_tabfilter.from_index = None
+    test_tabfilter.moving = True
+
+    assert test_tabfilter.eventFilter(None, mockEvent_instance)
+    mockEvent_instance.pos.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/tests/test_init.py
+++ b/spyder/plugins/tests/test_init.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+# -----------------------------------------------------------------------------
+
+"""Tests for the base plugin classes ('__init__.py')."""
+
+# Standard library imports
+import os
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock  # Python 2
+
+# 3rd party imports
+import pytest
+from flaky import flaky
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/spyder/plugins/tests/test_init.py
+++ b/spyder/plugins/tests/test_init.py
@@ -9,48 +9,17 @@
 """Tests for the base plugin classes ('__init__.py')."""
 
 # Standard library imports
-import os
 try:
-    from unittest.mock import MagicMock
+    from unittest.mock import Mock, MagicMock
 except ImportError:
-    from mock import MagicMock  # Python 2
+    from mock import Mock, MagicMock  # Python 2
 
 # 3rd party imports
 import pytest
-from flaky import flaky
 from qtpy.QtCore import QEvent
-from qtpy.QtWidgets import QTabBar
 
 # Local imports
 from spyder.plugins import TabFilter
-from spyder.app import start
-from spyder.config.main import CONF
-
-
-# =============================================================================
-# Fixtures
-# =============================================================================
-@pytest.fixture
-def main_window(request):
-    """Main Window fixture"""
-    # Disable unneeded introspection to save on startup time
-    try:
-        os.environ.pop('SPY_TEST_USE_INTROSPECTION')
-    except KeyError:
-        pass
-
-    # Make sure single instance mode is disabled
-    CONF.set('main', 'single_instance', False)
-
-    # Start the window
-    window = start.main()
-
-    # Teardown
-    def close_window():
-        window.close()
-    request.addfinalizer(close_window)
-
-    return window
 
 
 # =============================================================================
@@ -67,31 +36,16 @@ def test_tabfilter_typeerror_simple():
     MockTabBar.return_value.tabAt.return_value = 0
     mockTabBar_instance = MockTabBar()
 
-    test_tabfilter = TabFilter(mockTabBar_instance, main_window)
+    MockMainWindow = Mock()
+    mockMainWindow_instance = MockMainWindow()
+
+    test_tabfilter = TabFilter(mockTabBar_instance, mockMainWindow_instance)
     test_tabfilter.from_index = None
     test_tabfilter.moving = True
 
     assert test_tabfilter.eventFilter(None, mockEvent_instance)
     assert mockEvent_instance.pos.call_count == 1
     assert mockTabBar_instance.tabAt.call_count == 1
-
-
-@flaky(max_runs=3)
-@pytest.mark.slow
-def test_tabfilter_typeerror_full(main_window):
-    """Test for #5813 ; event filter handles None indicies when moving tabs."""
-    MockEvent = MagicMock()
-    MockEvent.return_value.type.return_value = QEvent.MouseMove
-    MockEvent.return_value.pos.return_value = 0
-    mockEvent_instance = MockEvent()
-
-    test_tabbar = main_window.findChildren(QTabBar)[0]
-    test_tabfilter = TabFilter(test_tabbar, main_window)
-    test_tabfilter.from_index = None
-    test_tabfilter.moving = True
-
-    assert test_tabfilter.eventFilter(None, mockEvent_instance)
-    assert mockEvent_instance.pos.call_count == 1
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/tests/test_init.py
+++ b/spyder/plugins/tests/test_init.py
@@ -72,8 +72,8 @@ def test_tabfilter_typeerror_simple():
     test_tabfilter.moving = True
 
     assert test_tabfilter.eventFilter(None, mockEvent_instance)
-    mockEvent_instance.pos.assert_called_once()
-    mockTabBar_instance.tabAt.called_once()
+    assert mockEvent_instance.pos.call_count == 1
+    assert mockTabBar_instance.tabAt.call_count == 1
 
 
 @flaky(max_runs=3)
@@ -91,7 +91,7 @@ def test_tabfilter_typeerror_full(main_window):
     test_tabfilter.moving = True
 
     assert test_tabfilter.eventFilter(None, mockEvent_instance)
-    mockEvent_instance.pos.assert_called_once()
+    assert mockEvent_instance.pos.call_count == 1
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -509,7 +509,9 @@ def test_tab_moves_focus_from_search_to_replace(editor_find_replace_bot):
     assert finder.replace_text.hasFocus()
 
 
-@pytest.mark.skipif(platform.startswith('linux'), reason="Fails on Linux.")
+@flaky(max_runs=3)
+@pytest.mark.skipif(os.environ.get('CI', None) is None and
+                    platform.startswith('linux'), reason="Fails on Linux.")
 def test_tab_copies_find_to_replace(editor_find_replace_bot):
     """Check that text in the find box is copied to the replace box on tab
     keypress. Regression test #4482."""
@@ -518,8 +520,8 @@ def test_tab_copies_find_to_replace(editor_find_replace_bot):
     finder.show_replace()
     finder.search_text.setFocus()
     finder.search_text.set_current_text('This is some test text!')
-    qtbot.keyPress(finder.search_text, Qt.Key_Tab)
-    qtbot.wait(100)
+    qtbot.keyClick(finder.search_text, Qt.Key_Tab)
+    qtbot.wait(500)
     assert finder.replace_text.currentText() == 'This is some test text!'
 
 

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -510,8 +510,7 @@ def test_tab_moves_focus_from_search_to_replace(editor_find_replace_bot):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.environ.get('CI', None) is None and
-                    platform.startswith('linux'), reason="Fails on Linux.")
+@pytest.mark.skipif(platform.startswith('linux'), reason="Fails on Linux.")
 def test_tab_copies_find_to_replace(editor_find_replace_bot):
     """Check that text in the find box is copied to the replace box on tab
     keypress. Regression test #4482."""


### PR DESCRIPTION
Fixes #5813 .

We're not sure why this happens, but this PR adds several protections aimed at both avoiding its occurrence and catching it just in case it occurs anyway. Also added a simple unit and an integration test to check this, though they may not be perfect as they can't really get to the root cause, and fixed a few issues with a recently added test that was causing random test failures (and re-enabled it on the CIs, since it should run now that I added the window manager).

Wasn't exactly sure where to best catch the errors, so please comment on that decision. Thanks!