### PR TITLE
PR: Show Help if closed when opening tutorial to avoid user confusion

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1257,7 +1257,7 @@ def test_tabfilter_typeerror_full(main_window):
 
 @flaky(max_runs=3)
 @pytest.mark.slow
-def test_help_opens_when_show_tutorial(main_window, qtbot):
+def test_help_opens_when_show_tutorial_full(main_window, qtbot):
     """Test fix for #6317 : 'Show tutorial' opens the help plugin if closed."""
     HELP_STR = "Help"
 

--- a/spyder/plugins/help.py
+++ b/spyder/plugins/help.py
@@ -739,6 +739,10 @@ class Help(SpyderPluginWidget):
 
     @Slot()
     def show_tutorial(self):
+        """Show the Spyder tutorial in the Help plugin, opening it if needed"""
+        if not self.dockwidget.isVisible():
+            self.dockwidget.show()
+            self.toggle_view_action.setChecked(True)
         tutorial_path = get_module_source_path('spyder.utils.help')
         tutorial = osp.join(tutorial_path, 'tutorial.rst')
         text = open(tutorial).read()

--- a/spyder/plugins/tests/test_help.py
+++ b/spyder/plugins/tests/test_help.py
@@ -5,9 +5,11 @@
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
 # -----------------------------------------------------------------------------
-"""Test scripts for `findinfiles` plugin."""
+"""
+Tests for the Spyder `help` plugn, `help.py`.
+"""
 
-# 3rd party imports
+# Third party imports
 from qtpy.QtWebEngineWidgets import WEBENGINE
 import pytest
 
@@ -16,6 +18,9 @@ from spyder.plugins.help import Help
 from spyder.utils.introspection.utils import default_info_response
 
 
+# =============================================================================
+# Fixtures
+# =============================================================================
 @pytest.fixture
 def help_plugin(qtbot):
     """Help plugin fixture"""
@@ -31,6 +36,9 @@ def help_plugin(qtbot):
     return help_plugin
 
 
+# =============================================================================
+# Tests
+# =============================================================================
 def check_text(widget, text):
     """Check if some text is present in a widget."""
     if WEBENGINE:
@@ -54,7 +62,7 @@ def test_no_docs_message(help_plugin, qtbot):
     help_plugin.render_sphinx_doc(default_info_response())
     qtbot.waitUntil(lambda: check_text(help_plugin._webpage,
                                        "No documentation available"),
-                                       timeout=2000)
+                    timeout=2000)
 
 
 def test_no_further_docs_message(help_plugin, qtbot):
@@ -69,7 +77,7 @@ def test_no_further_docs_message(help_plugin, qtbot):
     help_plugin.render_sphinx_doc(info)
     qtbot.waitUntil(lambda: check_text(help_plugin._webpage,
                                        "No further documentation available"),
-                                       timeout=2000)
+                    timeout=2000)
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/tests/test_help.py
+++ b/spyder/plugins/tests/test_help.py
@@ -12,6 +12,7 @@ Tests for the Spyder `help` plugn, `help.py`.
 # Third party imports
 from qtpy.QtWebEngineWidgets import WEBENGINE
 import pytest
+from flaky import flaky
 
 # Local imports
 from spyder.plugins.help import Help
@@ -54,6 +55,7 @@ def check_text(widget, text):
         return text in widget.toHtml()
 
 
+@flaky(max_runs=3)
 def test_no_docs_message(help_plugin, qtbot):
     """
     Test that no docs message is shown when instrospection plugins
@@ -62,9 +64,10 @@ def test_no_docs_message(help_plugin, qtbot):
     help_plugin.render_sphinx_doc(default_info_response())
     qtbot.waitUntil(lambda: check_text(help_plugin._webpage,
                                        "No documentation available"),
-                    timeout=2000)
+                    timeout=4000)
 
 
+@flaky(max_runs=3)
 def test_no_further_docs_message(help_plugin, qtbot):
     """
     Test that no further docs message is shown when instrospection
@@ -77,7 +80,7 @@ def test_no_further_docs_message(help_plugin, qtbot):
     help_plugin.render_sphinx_doc(info)
     qtbot.waitUntil(lambda: check_text(help_plugin._webpage,
                                        "No further documentation available"),
-                    timeout=2000)
+                    timeout=3000)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #6317 .

The actual change is a simple one, just showing the help plugin if it is closed or hidden when the user selects the tutorial from the help menu, for a better Ux and to avoid user confusion particularly when trying to learn the basics of Spyder. However, the more extensive changes are in some cleanup and minor fixes to the newly added help tests, and both unit and integration tests to cover this scenario as well as general help functionality.

Not a huge priority, but fits in the realm of user help/doc/error/quality of life improvements that 3.2.7 is centered around, so would be nice to have it in that. 