### PR TITLE
PR: Harmonized the toolbar of the Outline Explorer with its context menu.

### DIFF
--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -534,13 +534,16 @@ class OutlineExplorerWidget(QWidget):
                              icon=ima.icon('fromcursor'),
                              tip=_('Go to cursor position'),
                              triggered=self.treewidget.go_to_cursor_position)
-        collapse_btn = create_toolbutton(self)
-        collapse_btn.setDefaultAction(self.treewidget.collapse_selection_action)
-        expand_btn = create_toolbutton(self)
-        expand_btn.setDefaultAction(self.treewidget.expand_selection_action)
-        restore_btn = create_toolbutton(self)
-        restore_btn.setDefaultAction(self.treewidget.restore_action)
-        return (fromcursor_btn, collapse_btn, expand_btn, restore_btn)
+
+        buttons = [fromcursor_btn]
+        for action in [self.treewidget.collapse_all_action,
+                       self.treewidget.expand_all_action,
+                       self.treewidget.restore_action,
+                       self.treewidget.collapse_selection_action,
+                       self.treewidget.expand_selection_action]:
+            buttons.append(create_toolbutton(self))
+            buttons[-1].setDefaultAction(action)
+        return buttons
         
     def set_current_editor(self, editor, fname, update, clear):
         if clear:

--- a/spyder/widgets/editortools.py
+++ b/spyder/widgets/editortools.py
@@ -528,10 +528,11 @@ class OutlineExplorerWidget(QWidget):
             current_editor.setFocus()
             if state:
                 self.outlineexplorer_is_visible.emit()
-        
+
     def setup_buttons(self):
-        fromcursor_btn = create_toolbutton(self,
-                             icon=ima.icon('fromcursor'),
+        """Setup the buttons of the outline explorer widget toolbar."""
+        fromcursor_btn = create_toolbutton(
+                             self, icon=ima.icon('fromcursor'),
                              tip=_('Go to cursor position'),
                              triggered=self.treewidget.go_to_cursor_position)
 
@@ -544,7 +545,7 @@ class OutlineExplorerWidget(QWidget):
             buttons.append(create_toolbutton(self))
             buttons[-1].setDefaultAction(action)
         return buttons
-        
+
     def set_current_editor(self, editor, fname, update, clear):
         if clear:
             self.remove_editor(editor)


### PR DESCRIPTION
Fixes #6361

Added the `Collapse All` and `Expand All` buttons to the toolbar of the Outline Explorer and placed the buttons in the same order as their corresponding actions in the context menu.

![image](https://user-images.githubusercontent.com/10170372/35687402-9cab62aa-073c-11e8-96b1-41c9e79b4ded.png)