### PR TITLE
included newline with ctrl+shift+enter

### DIFF
--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2596,6 +2596,9 @@ class CodeEditor(TextEditBaseWidget):
                     TextEditBaseWidget.keyPressEvent(self, event)
                     self.fix_indent(comment_or_string=cmt_or_str)
                     self.textCursor().endEditBlock()
+            elif shift and ctrl:
+                self.stdkey_end(False, False)  # Go to end of line
+                self.insert_text(self.get_line_seperator())  # Add new line
             elif shift:
                 self.run_cell_and_advance.emit()
             elif ctrl:


### PR DESCRIPTION
A keybind to start a new line without breaking the current (bevore it ends) is included in many editors. This is very handy for people using automatic bracket closing.
Inspired by this [stackoverflow Q/A](https://stackoverflow.com/questions/28182566/how-to-add-new-line-keyboard-shortcuts-in-spyder/48713637#48713637)
