### PR TITLE
PR: Add Ctrl+Shift+Enter to enter a new line in the Editor

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -348,6 +348,7 @@ DEFAULTS = [
               'editor/unindent': 'Ctrl+[',
               'editor/move line up': "Alt+Up",
               'editor/move line down': "Alt+Down",
+              'editor/go to new line': "Ctrl+Shift+Return",
               'editor/go to definition': "Ctrl+G",
               'editor/toggle comment': "Ctrl+1",
               'editor/blockcomment': "Ctrl+4",

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -974,6 +974,11 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         """Move down current line or selected text"""
         self.__move_line_or_selection(after_current_line=True)
         
+    def go_to_new_line(self):
+        """Go to the end of the current line and create a new line"""
+        self.stdkey_end(False, False)
+        self.insert_text(self.get_line_separator())
+        
     def extend_selection_to_complete_lines(self):
         """Extend current selection to complete lines"""
         cursor = self.textCursor()

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -546,6 +546,8 @@ class CodeEditor(TextEditBaseWidget):
                                      name='Move line up', parent=self)
         movelinedown = config_shortcut(self.move_line_down, context='Editor',
                                        name='Move line down', parent=self)
+        gotonewline = config_shortcut(self.go_to_new_line, context='Editor',
+                                      name='Go to new line', parent=self)
         gotodef = config_shortcut(self.do_go_to_definition, context='Editor',
                                   name='Go to definition', parent=self)
         toggle_comment = config_shortcut(self.toggle_comment, context='Editor',
@@ -646,7 +648,7 @@ class CodeEditor(TextEditBaseWidget):
                                       name='enter array table', parent=self)
 
         return [codecomp, duplicate_line, copyline, deleteline, movelineup,
-                movelinedown, gotodef, toggle_comment, blockcomment,
+                movelinedown, gotonewline, gotodef, toggle_comment, blockcomment,
                 unblockcomment, transform_uppercase, transform_lowercase, 
                 line_start, line_end, prev_line, next_line,
                 prev_char, next_char, prev_word, next_word, kill_line_end,
@@ -2834,9 +2836,6 @@ class CodeEditor(TextEditBaseWidget):
                     TextEditBaseWidget.keyPressEvent(self, event)
                     self.fix_indent(comment_or_string=cmt_or_str)
                     self.textCursor().endEditBlock()
-            elif shift and ctrl:
-                self.stdkey_end(False, False)  # Go to end of the line
-                self.insert_text(self.get_line_separator())  # Add a new line
             elif shift:
                 self.run_cell_and_advance.emit()
             elif ctrl:

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2834,6 +2834,9 @@ class CodeEditor(TextEditBaseWidget):
                     TextEditBaseWidget.keyPressEvent(self, event)
                     self.fix_indent(comment_or_string=cmt_or_str)
                     self.textCursor().endEditBlock()
+            elif shift and ctrl:
+                self.stdkey_end(False, False) # Go to end of the line
+                self.insert_text(self.get_line_separator()) # Add a new line
             elif shift:
                 self.run_cell_and_advance.emit()
             elif ctrl:

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -2835,8 +2835,8 @@ class CodeEditor(TextEditBaseWidget):
                     self.fix_indent(comment_or_string=cmt_or_str)
                     self.textCursor().endEditBlock()
             elif shift and ctrl:
-                self.stdkey_end(False, False) # Go to end of the line
-                self.insert_text(self.get_line_separator()) # Add a new line
+                self.stdkey_end(False, False)  # Go to end of the line
+                self.insert_text(self.get_line_separator())  # Add a new line
             elif shift:
                 self.run_cell_and_advance.emit()
             elif ctrl:


### PR DESCRIPTION
Fixes #5466

A keybind to start a new line without breaking the current (bevore it ends) is included in many editors. This is very handy for people using autocompletition for brackets