### PR TITLE
PR: Delay check whether we are running under pytest until run time

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -123,9 +123,9 @@ MAIN_APP.setWindowIcon(APP_ICON)
 #==============================================================================
 # Create splash screen out of MainWindow to reduce perceived startup time. 
 #==============================================================================
-from spyder.config.base import _, get_image_path, DEV, PYTEST
+from spyder.config.base import _, get_image_path, DEV, running_under_pytest
 
-if not PYTEST:
+if not running_under_pytest():
     SPLASH = QSplashScreen(QPixmap(get_image_path('splash.svg')))
     SPLASH_FONT = SPLASH.font()
     SPLASH_FONT.setPixelSize(10)
@@ -451,7 +451,7 @@ class MainWindow(QMainWindow):
         self.layout_toolbar = None
         self.layout_toolbar_actions = []
 
-        if PYTEST:
+        if running_under_pytest():
             # Show errors in internal console when testing.
             CONF.set('main', 'show_internal_errors', False)
 
@@ -3114,7 +3114,7 @@ def run_spyder(app, options, args):
     # the window
     app.focusChanged.connect(main.change_last_focused_widget)
 
-    if not PYTEST:
+    if not running_under_pytest():
         app.exec_()
     return main
 
@@ -3124,7 +3124,7 @@ def run_spyder(app, options, args):
 #==============================================================================
 def main():
     """Main function"""
-    if PYTEST:
+    if running_under_pytest():
         try:
             from unittest.mock import Mock
         except ImportError:

--- a/spyder/app/start.py
+++ b/spyder/app/start.py
@@ -21,8 +21,8 @@ except:
 
 # Local imports
 from spyder.app.cli_options import get_options
-from spyder.config.base import (
-        get_conf_path, running_in_mac_app, running_under_pytest)
+from spyder.config.base import (get_conf_path, running_in_mac_app,
+                                running_under_pytest)
 from spyder.config.main import CONF
 from spyder.utils.external import lockfile
 from spyder.py3compat import is_unicode

--- a/spyder/app/start.py
+++ b/spyder/app/start.py
@@ -21,7 +21,8 @@ except:
 
 # Local imports
 from spyder.app.cli_options import get_options
-from spyder.config.base import PYTEST, get_conf_path, running_in_mac_app
+from spyder.config.base import (
+        get_conf_path, running_in_mac_app, running_under_pytest)
 from spyder.config.main import CONF
 from spyder.utils.external import lockfile
 from spyder.py3compat import is_unicode
@@ -64,7 +65,7 @@ def main():
     options to the application.
     """
     # Parse command line options
-    if PYTEST:
+    if running_under_pytest():
         try:
             from unittest.mock import Mock
         except ImportError:
@@ -146,7 +147,7 @@ def main():
             # executing this script because it doesn't make
             # sense
             from spyder.app import mainwindow
-            if PYTEST:
+            if running_under_pytest():
                 return mainwindow.main()
             else:
                 mainwindow.main()
@@ -155,7 +156,7 @@ def main():
         if lock_created:
             # Start a new instance
             from spyder.app import mainwindow
-            if PYTEST:
+            if running_under_pytest():
                 return mainwindow.main()
             else:
                 mainwindow.main()
@@ -169,7 +170,7 @@ def main():
                       "instance, please pass to it the --new-instance option")
     else:
         from spyder.app import mainwindow
-        if PYTEST:
+        if running_under_pytest():
             return mainwindow.main()
         else:
             mainwindow.main()

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -39,9 +39,14 @@ DEV = os.environ.get('SPYDER_DEV')
 TEST = os.environ.get('SPYDER_TEST')
 
 
-# To do some adjustments for pytest
-# This env var is defined in runtests.py
-PYTEST = os.environ.get('SPYDER_PYTEST')
+def running_under_pytest():
+    """
+    Return True if currently running under py.test.
+
+    This function is used to do some adjustment for testing. The environment
+    variable SPYDER_PYTEST is defined in conftest.py.
+    """
+    return bool(os.environ.get('SPYDER_PYTEST'))
 
 
 #==============================================================================
@@ -119,7 +124,7 @@ def get_home_dir():
 def get_conf_path(filename=None):
     """Return absolute path for configuration file with specified filename"""
     # Define conf_dir
-    if PYTEST:
+    if running_under_pytest():
         import py
         from _pytest.tmpdir import get_user
         conf_dir = osp.join(str(py.path.local.get_temproot()),
@@ -139,7 +144,7 @@ def get_conf_path(filename=None):
 
     # Create conf_dir
     if not osp.isdir(conf_dir):
-        if PYTEST:
+        if running_under_pytest():
             os.makedirs(conf_dir)
         else:
             os.mkdir(conf_dir)
@@ -293,7 +298,7 @@ def get_interface_language():
         locale_language = DEFAULT_LANGUAGE
 
     # Tests expect English as the interface language
-    if PYTEST:
+    if running_under_pytest():
         locale_language = DEFAULT_LANGUAGE
 
     language = DEFAULT_LANGUAGE

--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -30,7 +30,7 @@ from qtpy.QtWidgets import (QAction, QActionGroup, QApplication, QDialog,
 
 # Local imports
 from spyder import dependencies
-from spyder.config.base import _, get_conf_path, PYTEST
+from spyder.config.base import _, get_conf_path, running_under_pytest
 from spyder.config.main import (CONF, RUN_CELL_SHORTCUT,
                                 RUN_CELL_AND_ADVANCE_SHORTCUT)
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
@@ -452,7 +452,8 @@ class Editor(SpyderPluginWidget):
 
         # Don't start IntrospectionManager when running tests because
         # it consumes a lot of memory
-        if PYTEST and not os.environ.get('SPY_TEST_USE_INTROSPECTION'):
+        if (running_under_pytest()
+                and not os.environ.get('SPY_TEST_USE_INTROSPECTION')):
             try:
                 from unittest.mock import Mock
             except ImportError:
@@ -1861,7 +1862,7 @@ class Editor(SpyderPluginWidget):
                                             osp.splitext(filename0)[1])
             else:
                 selectedfilter = ''
-            if not PYTEST:
+            if not running_under_pytest():
                 filenames, _sf = getopenfilenames(
                                     parent_widget,
                                     _("Open file"), basedir,
@@ -2370,7 +2371,8 @@ class Editor(SpyderPluginWidget):
                 if self.dialog_size is not None:
                     dialog.resize(self.dialog_size)
                 dialog.setup(fname)
-                if CONF.get('run', 'open_at_least_once', not PYTEST):
+                if CONF.get('run', 'open_at_least_once',
+                            not running_under_pytest()):
                     # Open Run Config dialog at least once: the first time 
                     # a script is ever run in Spyder, so that the user may 
                     # see it at least once and be conscious that it exists

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -43,7 +43,7 @@ except ImportError:
 # Local imports
 from spyder import dependencies
 from spyder.config.base import (_, DEV, get_conf_path, get_home_dir,
-                                get_module_path, PYTEST)
+                                get_module_path, running_under_pytest)
 from spyder.config.main import CONF
 from spyder.plugins import SpyderPluginWidget
 from spyder.plugins.configdialog import PluginConfigPage
@@ -1094,7 +1094,7 @@ class IPythonConsole(SpyderPluginWidget):
             import1 = "import sys"
             # We need to add spy_dir to sys.path so this test can be
             # run in our CIs
-            if PYTEST:
+            if running_under_pytest():
                 if os.name == 'nt':
                     import1 = (import1 +
                                '; sys.path.append(""{}"")'.format(spy_dir))

--- a/spyder/utils/external/lockfile.py
+++ b/spyder/utils/external/lockfile.py
@@ -20,7 +20,7 @@ import errno, os
 from time import time as _uniquefloat
 
 import psutil
-from spyder.config.base import PYTEST
+from spyder.config.base import running_under_pytest
 from spyder.py3compat import PY2, to_binary_string
 
 def unique():
@@ -185,7 +185,7 @@ class FilesystemLock:
 
                         # Valid names for main script
                         names = set(['spyder', 'spyder3', 'bootstrap.py'])
-                        if PYTEST:
+                        if running_under_pytest():
                             names.add('runtests.py')
 
                         # Check the first three command line arguments

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -29,7 +29,7 @@ from qtpy.QtWidgets import (QAction, QApplication, QFileDialog, QHBoxLayout,
                             QVBoxLayout, QWidget, QListWidget, QListWidgetItem)
 
 # Local imports
-from spyder.config.base import _, DEBUG, PYTEST, STDERR, STDOUT
+from spyder.config.base import _, DEBUG, STDERR, STDOUT, running_under_pytest
 from spyder.config.gui import config_shortcut, get_shortcut
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
                                  get_filter, is_kde_desktop, is_anaconda)
@@ -595,7 +595,7 @@ class EditorStack(QWidget):
         self.edit_filters = None
 
         # For testing
-        self.save_dialog_on_tests = not PYTEST
+        self.save_dialog_on_tests = not running_under_pytest()
 
     @Slot()
     def show_in_external_file_explorer(self, fnames=None):


### PR DESCRIPTION
Currently, the test whether the environment variable `SPYDER_PYTEST` is set (which indicates whether we are running under pytest) is done at import time. However, if the tests are run using the unittest plugin, this import happens before the environment variable is actually set. Thus, this PR delays the test until run time.

With this PR and spyder-ide/spyder-unittest#114, I can run the Spyder test suite successfully within Spyder. :tada: 