### PR TITLE
PR: Remove ipyconsole and editor attrs from the Help plugin

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -30,6 +30,7 @@ from qtpy import PYQT4, PYQT5, PYQT_VERSION
 from qtpy.QtCore import Qt, QTimer, QEvent, QUrl
 from qtpy.QtTest import QTest
 from qtpy.QtWidgets import QApplication, QFileDialog, QLineEdit, QTabBar
+from qtpy.QtWebEngineWidgets import WEBENGINE
 
 # Local imports
 from spyder import __trouble_url__, __project_url__
@@ -40,6 +41,7 @@ from spyder.config.main import CONF
 from spyder.plugins import TabFilter
 from spyder.plugins.help import ObjectComboBox
 from spyder.plugins.runconfig import RunConfiguration
+from spyder.plugins.tests.test_help import check_text
 from spyder.py3compat import PY2, to_text_string
 from spyder.utils.ipython.kernelspec import SpyderKernelSpec
 from spyder.utils.programs import is_module_installed
@@ -207,6 +209,52 @@ def test_calltip(main_window, qtbot):
     qtbot.keyPress(code_editor, Qt.Key_Enter, delay=1000)
 
     main_window.editor.close_file()
+
+
+@pytest.mark.slow
+@flaky(max_runs=3)
+@pytest.mark.use_introspection
+def test_get_help(main_window, qtbot):
+    """
+    Test that Help is working when called from the Editor and the
+    IPython console.
+    """
+    shell = main_window.ipyconsole.get_current_shellwidget()
+    control = shell._control
+    qtbot.waitUntil(lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
+
+    help_plugin = main_window.help
+    webview = help_plugin.rich_text.webview._webview
+    if WEBENGINE:
+        webpage = webview.page()
+    else:
+        webpage = webview.page().mainFrame()
+
+    # --- From the console ---
+    # Write some object in the console
+    qtbot.keyClicks(control, 'runfile')
+
+    # Get help
+    control.inspect_current_object()
+
+    # Check that a expected text is part of the page
+    qtbot.waitUntil(lambda: check_text(webpage, "namespace"), timeout=4000)
+
+    # --- From the editor ---
+    qtbot.wait(2000)
+    main_window.editor.new()
+    code_editor = main_window.editor.get_focus_widget()
+    editorstack = main_window.editor.get_current_editorstack()
+
+    # Write some object in the editor
+    code_editor.set_text('range')
+    code_editor.move_cursor(len('range'))
+
+    # Get help
+    editorstack.inspect_current_object()
+
+    # Check that a expected text is part of the page
+    qtbot.waitUntil(lambda: check_text(webpage, "range"), timeout=4000)
 
 
 @pytest.mark.slow

--- a/spyder/plugins/help.py
+++ b/spyder/plugins/help.py
@@ -330,25 +330,14 @@ class Help(SpyderPluginWidget):
     # Signals
     focus_changed = Signal()
 
-    def __init__(self, parent=None, testing=False):
+    def __init__(self, parent=None):
         if PYQT5:
             SpyderPluginWidget.__init__(self, parent, main = parent)
         else:
             SpyderPluginWidget.__init__(self, parent)
-        self.testing = testing
 
         self.internal_shell = None
         self.console = None
-
-        # Mock ipyconsole and editor while testing
-        if self.testing:
-            try:
-                from unittest.mock import Mock
-            except ImportError:
-                from mock import Mock # Python 2
-            self.main = Mock()
-            self.main.ipyconsole = None
-            self.main.editor = None
 
         # Initialize plugin
         self.initialize_plugin()

--- a/spyder/plugins/help.py
+++ b/spyder/plugins/help.py
@@ -330,14 +330,25 @@ class Help(SpyderPluginWidget):
     # Signals
     focus_changed = Signal()
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, testing=False):
         if PYQT5:
             SpyderPluginWidget.__init__(self, parent, main = parent)
         else:
             SpyderPluginWidget.__init__(self, parent)
+        self.testing = testing
 
         self.internal_shell = None
         self.console = None
+
+        # Mock ipyconsole and editor while testing
+        if self.testing:
+            try:
+                from unittest.mock import Mock
+            except ImportError:
+                from mock import Mock # Python 2
+            self.main = Mock()
+            self.main.ipyconsole = None
+            self.main.editor = None
 
         # Initialize plugin
         self.initialize_plugin()

--- a/spyder/plugins/help.py
+++ b/spyder/plugins/help.py
@@ -338,8 +338,6 @@ class Help(SpyderPluginWidget):
 
         self.internal_shell = None
         self.console = None
-        self.ipyconsole = None
-        self.editor = None
 
         # Initialize plugin
         self.initialize_plugin()
@@ -507,8 +505,6 @@ class Help(SpyderPluginWidget):
 
         self.internal_shell = self.main.console.shell
         self.console = self.main.console
-        self.ipyconsole = self.main.ipyconsole
-        self.editor = self.main.editor
 
     def closing_plugin(self, cancelable=False):
         """Perform actions before parent main window is closed"""
@@ -549,8 +545,8 @@ class Help(SpyderPluginWidget):
             self.toggle_math_mode(math_o)
 
         # To make auto-connection changes take place instantly
-        self.editor.apply_plugin_settings(options=[connect_n])
-        self.ipyconsole.apply_plugin_settings(options=[connect_n])
+        self.main.editor.apply_plugin_settings(options=[connect_n])
+        self.main.ipyconsole.apply_plugin_settings(options=[connect_n])
 
     #------ Public API (related to Help's source) -------------------------
     def source_is_console(self):
@@ -821,8 +817,8 @@ class Help(SpyderPluginWidget):
                     (force or text != self._last_texts[index])):
                 dockwidgets = self.main.tabifiedDockWidgets(self.dockwidget)
                 if (self.console.dockwidget not in dockwidgets and
-                        self.ipyconsole is not None and
-                        self.ipyconsole.dockwidget not in dockwidgets):
+                        self.main.ipyconsole is not None and
+                        self.main.ipyconsole.dockwidget not in dockwidgets):
                     self.dockwidget.show()
                     self.dockwidget.raise_()
         self._last_texts[index] = text
@@ -904,8 +900,8 @@ class Help(SpyderPluginWidget):
                 (hasattr(self.shell, 'is_running') and
                  not self.shell.is_running())):
             self.shell = None
-            if self.ipyconsole is not None:
-                shell = self.ipyconsole.get_current_shellwidget()
+            if self.main.ipyconsole is not None:
+                shell = self.main.ipyconsole.get_current_shellwidget()
                 if shell is not None and shell.kernel_client is not None:
                     self.shell = shell
             if self.shell is None:
@@ -915,8 +911,8 @@ class Help(SpyderPluginWidget):
     def render_sphinx_doc(self, doc, context=None):
         """Transform doc string dictionary to HTML and show it"""
         # Math rendering option could have changed
-        if self.editor is not None:
-            fname = self.editor.get_current_filename()
+        if self.main.editor is not None:
+            fname = self.main.editor.get_current_filename()
             dname = osp.dirname(fname)
         else:
             dname = ''

--- a/spyder/plugins/tests/test_help.py
+++ b/spyder/plugins/tests/test_help.py
@@ -32,9 +32,9 @@ from spyder.utils.introspection.utils import default_info_response
 @pytest.fixture
 def help_plugin(qtbot):
     """Help plugin fixture"""
-    help_plugin = Help()
-    webview = help_plugin.rich_text.webview._webview
+    help_plugin = Help(testing=True)
 
+    webview = help_plugin.rich_text.webview._webview
     if WEBENGINE:
         help_plugin._webpage = webview.page()
     else:
@@ -93,7 +93,7 @@ def test_no_further_docs_message(help_plugin, qtbot):
                     timeout=3000)
 
 
-def test_help_opens_when_show_tutorial_unit(help_plugin, qtbot,):
+def test_help_opens_when_show_tutorial_unit(help_plugin, qtbot):
     """Test fix for #6317 : 'Show tutorial' opens the help plugin if closed."""
     MockDockwidget = MagicMock()
     MockDockwidget.return_value.isVisible.return_value = False

--- a/spyder/plugins/tests/test_help.py
+++ b/spyder/plugins/tests/test_help.py
@@ -17,6 +17,7 @@ except ImportError:
     from mock import Mock, MagicMock  # Python 2
 
 # Third party imports
+from qtpy.QtWidgets import QWidget
 from qtpy.QtWebEngineWidgets import WEBENGINE
 import pytest
 from flaky import flaky
@@ -32,7 +33,15 @@ from spyder.utils.introspection.utils import default_info_response
 @pytest.fixture
 def help_plugin(qtbot):
     """Help plugin fixture"""
-    help_plugin = Help(testing=True)
+
+    class MainMock(QWidget):
+        def __getattr__(self, attr):
+            if attr == 'ipyconsole' or attr == 'editor':
+                return None
+            else:
+                return Mock()
+
+    help_plugin = Help(parent=MainMock())
 
     webview = help_plugin.rich_text.webview._webview
     if WEBENGINE:


### PR DESCRIPTION
Fixes #6519.

----

The problem is those plugins are initialized after Help, so we can't set a reference to them in register_plugin.