### PR TITLE
fix-syntax-error-and-undefined-names

### DIFF
--- a/rope_profiling/src/script.py
+++ b/rope_profiling/src/script.py
@@ -1,2 +1,2 @@
 import numpy
-numpy.
+# numpy.

--- a/spyder/utils/iofuncs.py
+++ b/spyder/utils/iofuncs.py
@@ -441,7 +441,7 @@ class IOFunctions(object):
                 other_funcs.append((mod.FORMAT_EXT, mod.FORMAT_NAME,
                                     mod.FORMAT_LOAD, mod.FORMAT_SAVE))
             except AttributeError as error:
-                print("%s: %s" % (mod, str(error)), file=STDERR)
+                print("%s: %s" % (mod, str(error)), file=sys.stderr)
         return other_funcs
 
     def save(self, data, filename):

--- a/spyder/widgets/projects/type/python.py
+++ b/spyder/widgets/projects/type/python.py
@@ -11,6 +11,7 @@ import os
 import os.path as osp
 
 from spyder.config.base import _
+from spyder.widgets.explorer import fixpath
 from spyder.widgets.projects.type import EmptyProject
 
 


### PR DESCRIPTION
### Before:
$ python2 -m flake8 . --count --select=E901,E999,F821,F822,F823  --show-source --statistics
```
./rope_profiling/src/script.py:2:6: E999 SyntaxError: invalid syntax
numpy.     ^
./spyder/utils/iofuncs.py:444:58: F821 undefined name 'STDERR'
                print("%s: %s" % (mod, str(error)), file=STDERR)
                                                         ^
./spyder/utils/ipython/start_kernel.py:208:10: F821 undefined name 'get_ipython'
    ip = get_ipython()       #analysis:ignore
         ^
./spyder/widgets/projects/type/python.py:40:16: F821 undefined name 'fixpath'
        return fixpath(dirname) in [fixpath(_p) for _p in self.pythonpath]
               ^
./spyder/widgets/projects/type/python.py:40:37: F821 undefined name 'fixpath'
        return fixpath(dirname) in [fixpath(_p) for _p in self.pythonpath]
                                    ^
1     E999 SyntaxError: invalid syntax
4     F821 undefined name 'STDERR'
5
```

### After:
```
$ python2 -m flake8 . --count --select=E901,E999,F821,F822,F823  --show-source --statistics
./spyder/utils/ipython/start_kernel.py:208:10: F821 undefined name 'get_ipython'
    ip = get_ipython()       #analysis:ignore
         ^
1     F821 undefined name 'get_ipython'
1
```