### PR TITLE
PR: Change time elapsed calculation to prevent OSError

### DIFF
--- a/spyder/plugins/tests/test_ipythonconsole.py
+++ b/spyder/plugins/tests/test_ipythonconsole.py
@@ -821,5 +821,33 @@ def test_sys_argv_clear(ipyconsole, qtbot):
     assert argv == ['']
 
 
+@pytest.mark.slow
+@flaky(max_runs=3)
+def test_set_elapsed_time(ipyconsole, qtbot):
+    """Test timer."""
+    shell = ipyconsole.get_current_shellwidget()
+    client = ipyconsole.get_current_client()
+    qtbot.waitUntil(lambda: shell._prompt_html is not None,
+                    timeout=SHELL_TIMEOUT)
+
+    # Set time to 2 minutes ago.
+    client.t0 -= 120
+    with qtbot.waitSignal(client.timer.timeout):
+        ipyconsole.set_elapsed_time(client)
+    assert '00:02:00' in client.time_label.text()
+
+    with qtbot.waitSignal(client.timer.timeout):
+        pass
+    assert '00:02:01' in client.time_label.text()
+
+    # Make previous time later than current time.
+    client.t0 += 2000
+    with qtbot.waitSignal(client.timer.timeout):
+        pass
+    assert '00:00:00' in client.time_label.text()
+
+    client.timer.timeout.disconnect(client.show_time)
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/plugins/tests/test_ipythonconsole.py
+++ b/spyder/plugins/tests/test_ipythonconsole.py
@@ -832,17 +832,17 @@ def test_set_elapsed_time(ipyconsole, qtbot):
 
     # Set time to 2 minutes ago.
     client.t0 -= 120
-    with qtbot.waitSignal(client.timer.timeout):
+    with qtbot.waitSignal(client.timer.timeout, timeout=3000):
         ipyconsole.set_elapsed_time(client)
     assert '00:02:00' in client.time_label.text()
 
-    with qtbot.waitSignal(client.timer.timeout):
+    with qtbot.waitSignal(client.timer.timeout, timeout=3000):
         pass
     assert '00:02:01' in client.time_label.text()
 
     # Make previous time later than current time.
     client.t0 += 2000
-    with qtbot.waitSignal(client.timer.timeout):
+    with qtbot.waitSignal(client.timer.timeout, timeout=3000):
         pass
     assert '00:00:00' in client.time_label.text()
 

--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -18,7 +18,7 @@ import os
 import os.path as osp
 from string import Template
 from threading import Thread
-from time import ctime, time, strftime, gmtime
+import time
 
 # Third party imports (qtpy)
 from qtpy.QtCore import QUrl, QTimer, Signal, Slot
@@ -58,6 +58,11 @@ BLANK = open(osp.join(TEMPLATES_PATH, 'blank.html')).read()
 LOADING = open(osp.join(TEMPLATES_PATH, 'loading.html')).read()
 KERNEL_ERROR = open(osp.join(TEMPLATES_PATH, 'kernel_error.html')).read()
 
+try:
+    time.monotonic  # time.monotonic new in 3.3
+except AttributeError:
+    time.monotonic = time.time
+
 
 #-----------------------------------------------------------------------------
 # Auxiliary functions
@@ -84,7 +89,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
     to print different messages there.
     """
 
-    SEPARATOR = '{0}## ---({1})---'.format(os.linesep*2, ctime())
+    SEPARATOR = '{0}## ---({1})---'.format(os.linesep*2, time.ctime())
     INITHISTORY = ['# -*- coding: utf-8 -*-',
                    '# *** Spyder Python Console History Log ***',]
 
@@ -566,8 +571,13 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         """Text to show in time_label."""
         if self.time_label is None:
             return
-        elapsed_time = time() - self.t0
-        if elapsed_time > 24 * 3600: # More than a day...!
+
+        elapsed_time = time.monotonic() - self.t0
+        # System time changed to past date, so reset start.
+        if elapsed_time < 0:
+            self.t0 = time.monotonic()
+            elapsed_time = 0
+        if elapsed_time > 24 * 3600:  # More than a day...!
             fmt = "%d %H:%M:%S"
         else:
             fmt = "%H:%M:%S"
@@ -576,7 +586,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         else:
             color = "#AA6655"
         text = "<span style=\'color: %s\'><b>%s" \
-               "</b></span>" % (color, strftime(fmt, gmtime(elapsed_time)))
+               "</b></span>" % (color,
+                                time.strftime(fmt, time.gmtime(elapsed_time)))
         self.time_label.setText(text)
 
     def update_time_label_visibility(self):

--- a/spyder/widgets/ipythonconsole/namespacebrowser.py
+++ b/spyder/widgets/ipythonconsole/namespacebrowser.py
@@ -9,7 +9,7 @@ Widget that handle communications between the IPython Console and
 the Variable Explorer
 """
 
-from time import time
+import time
 
 from qtpy.QtCore import QEventLoop
 from qtpy.QtWidgets import QMessageBox
@@ -19,6 +19,12 @@ from qtconsole.rich_jupyter_widget import RichJupyterWidget
 
 from spyder.config.base import _, debug_print
 from spyder.py3compat import PY2, to_text_string
+
+
+try:
+    time.monotonic  # time.monotonic new in 3.3
+except AttributeError:
+    time.monotonic = time.time
 
 
 class NamepaceBrowserWidget(RichJupyterWidget):
@@ -211,7 +217,7 @@ class NamepaceBrowserWidget(RichJupyterWidget):
                 self.set_namespace_view_settings()
                 self.refresh_namespacebrowser()
             self._kernel_is_starting = False
-            self.ipyclient.t0 = time()
+            self.ipyclient.t0 = time.monotonic()
 
         # Handle silent execution of kernel methods
         if info and info.kind == 'silent_exec_method' and not self._hidden:
@@ -230,7 +236,7 @@ class NamepaceBrowserWidget(RichJupyterWidget):
         if state == 'starting':
             # This is needed to show the time a kernel
             # has been alive in each console.
-            self.ipyclient.t0 = time()
+            self.ipyclient.t0 = time.monotonic()
             self.ipyclient.timer.timeout.connect(self.ipyclient.show_time)
             self.ipyclient.timer.start(1000)
 
@@ -243,6 +249,6 @@ class NamepaceBrowserWidget(RichJupyterWidget):
             if self.namespacebrowser is not None:
                 self.set_namespace_view_settings()
                 self.refresh_namespacebrowser()
-            self.ipyclient.t0 = time()
+            self.ipyclient.t0 = time.monotonic()
         else:
             super(NamepaceBrowserWidget, self)._handle_status(msg)


### PR DESCRIPTION
Fixes #6682.

On Windows, `time.gmtime` doesn't work for large negative values, but that function is used to show the elapsed time in the console.  If the system clock is changed to a past date, then the 'start' time is later than the 'current' time, which creates a negative elapsed time, and could result in an OSError.  

- Use `time.monotonic()` when possible (Python 3.3+).  `time.monotonic` doesn't use the system clock, so there is no risk of it being negative.
- For releases before 3.3, continue to use `time.time()`, but add a check to make sure that the elapsed time isn't negative.  If it is negative, reset the start time to be the current time, which restarts the counter.