### PR TITLE
PR: Set parent for Variable Explorer editors so Spyder closes properly

### DIFF
--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -442,7 +442,7 @@ class CollectionsDelegate(QItemDelegate):
                    or not is_known_type(value)
         #---editor = CollectionsEditor
         if isinstance(value, (list, tuple, dict)):
-            editor = CollectionsEditor()
+            editor = CollectionsEditor(parent)
             editor.setup(value, key, icon=self.parent().windowIcon(),
                          readonly=readonly)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
@@ -472,7 +472,7 @@ class CollectionsDelegate(QItemDelegate):
         #--editor = DataFrameEditor
         elif isinstance(value, (DataFrame, DatetimeIndex, Series)) \
           and DataFrame is not FakeObject:
-            editor = DataFrameEditor()
+            editor = DataFrameEditor(parent)
             if not editor.setup_and_check(value, title=key):
                 return
             editor.dataModel.set_format(index.model().dataframe_format)
@@ -494,9 +494,10 @@ class CollectionsDelegate(QItemDelegate):
                 return editor
         #---editor = TextEditor
         elif is_text_string(value) and len(value) > 40:
-            te = TextEditor(None)
+            te = TextEditor(None, parent=parent)
             if te.setup_and_check(value):
-                editor = TextEditor(value, key, readonly=readonly)
+                editor = TextEditor(value, key,
+                                    readonly=readonly, parent=parent)
                 self.create_dialog(editor, dict(model=index.model(),
                                                 editor=editor, key=key,
                                                 readonly=readonly))
@@ -517,7 +518,7 @@ class CollectionsDelegate(QItemDelegate):
                 return editor
         #---editor = CollectionsEditor for an arbitrary object
         else:
-            editor = CollectionsEditor()
+            editor = CollectionsEditor(parent)
             editor.setup(value, key, icon=self.parent().windowIcon(),
                          readonly=readonly)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -445,7 +445,7 @@ class CollectionsDelegate(QItemDelegate):
                     or not is_known_type(value))
         # CollectionsEditor for a list, tuple, dict, etc.
         if isinstance(value, (list, tuple, dict)):
-            editor = CollectionsEditor(parent)
+            editor = CollectionsEditor(parent=parent)
             editor.setup(value, key, icon=self.parent().windowIcon(),
                          readonly=readonly)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
@@ -454,7 +454,7 @@ class CollectionsDelegate(QItemDelegate):
         # ArrayEditor for a Numpy array
         elif isinstance(value, (ndarray, MaskedArray)) \
           and ndarray is not FakeObject:
-            editor = ArrayEditor(parent)
+            editor = ArrayEditor(parent=parent)
             if not editor.setup_and_check(value, title=key, readonly=readonly):
                 return
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
@@ -464,7 +464,7 @@ class CollectionsDelegate(QItemDelegate):
         elif isinstance(value, Image) and ndarray is not FakeObject \
           and Image is not FakeObject:
             arr = array(value)
-            editor = ArrayEditor(parent)
+            editor = ArrayEditor(parent=parent)
             if not editor.setup_and_check(arr, title=key, readonly=readonly):
                 return
             conv_func = lambda arr: Image.fromarray(arr, mode=value.mode)
@@ -475,7 +475,7 @@ class CollectionsDelegate(QItemDelegate):
         # DataFrameEditor for a pandas dataframe, series or index
         elif isinstance(value, (DataFrame, DatetimeIndex, Series)) \
           and DataFrame is not FakeObject:
-            editor = DataFrameEditor(parent)
+            editor = DataFrameEditor(parent=parent)
             if not editor.setup_and_check(value, title=key):
                 return
             editor.dataModel.set_format(index.model().dataframe_format)
@@ -489,9 +489,9 @@ class CollectionsDelegate(QItemDelegate):
                 return None
             else:
                 if isinstance(value, datetime.datetime):
-                    editor = QDateTimeEdit(value, parent)
+                    editor = QDateTimeEdit(value, parent=parent)
                 else:
-                    editor = QDateEdit(value, parent)
+                    editor = QDateEdit(value, parent=parent)
                 editor.setCalendarPopup(True)
                 editor.setFont(get_font(font_size_delta=DEFAULT_SMALL_DELTA))
                 return editor
@@ -510,7 +510,7 @@ class CollectionsDelegate(QItemDelegate):
             if readonly:
                 return None
             else:
-                editor = QLineEdit(parent)
+                editor = QLineEdit(parent=parent)
                 editor.setFont(get_font(font_size_delta=DEFAULT_SMALL_DELTA))
                 editor.setAlignment(Qt.AlignLeft)
                 # This is making Spyder crash because the QLineEdit that it's
@@ -521,7 +521,7 @@ class CollectionsDelegate(QItemDelegate):
                 return editor
         # CollectionsEditor for an arbitrary Python object
         else:
-            editor = CollectionsEditor(parent)
+            editor = CollectionsEditor(parent=parent)
             editor.setup(value, key, icon=self.parent().windowIcon(),
                          readonly=readonly)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-#
+# -----------------------------------------------------------------------------
 # Copyright © Spyder Project Contributors
+#
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
+# ----------------------------------------------------------------------------
 
 """
-Collections (i.e. dictionary, list and tuple) editor widget and dialog
+Collections (i.e. dictionary, list and tuple) editor widget and dialog.
 """
 
 #TODO: Multiple selection: open as many editors (array/dict/...) as necessary,
@@ -33,7 +35,7 @@ from qtpy.QtWidgets import (QAbstractItemDelegate, QApplication, QDateEdit,
                             QInputDialog, QItemDelegate, QLineEdit, QMenu,
                             QMessageBox, QTableView, QVBoxLayout, QWidget)
 
-# Local import
+# Local imports
 from spyder.config.base import _
 from spyder.config.fonts import DEFAULT_SMALL_DELTA
 from spyder.config.gui import get_font
@@ -61,6 +63,7 @@ if DataFrame is not FakeObject:
 
 LARGE_NROWS = 100
 ROWS_TO_LOAD = 50
+
 
 class ProxyObject(object):
     """Dictionary proxy to an unknown object."""
@@ -438,9 +441,9 @@ class CollectionsDelegate(QItemDelegate):
                                    ) % to_text_string(msg))
             return
         key = index.model().get_key(index)
-        readonly = isinstance(value, tuple) or self.parent().readonly \
-                   or not is_known_type(value)
-        #---editor = CollectionsEditor
+        readonly = (isinstance(value, tuple) or self.parent().readonly
+                    or not is_known_type(value))
+        # CollectionsEditor for a list, tuple, dict, etc.
         if isinstance(value, (list, tuple, dict)):
             editor = CollectionsEditor(parent)
             editor.setup(value, key, icon=self.parent().windowIcon(),
@@ -448,7 +451,7 @@ class CollectionsDelegate(QItemDelegate):
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
                                             key=key, readonly=readonly))
             return None
-        #---editor = ArrayEditor
+        # ArrayEditor for a Numpy array
         elif isinstance(value, (ndarray, MaskedArray)) \
           and ndarray is not FakeObject:
             editor = ArrayEditor(parent)
@@ -457,7 +460,7 @@ class CollectionsDelegate(QItemDelegate):
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
                                             key=key, readonly=readonly))
             return None
-        #---showing image
+        # ArrayEditor for an images
         elif isinstance(value, Image) and ndarray is not FakeObject \
           and Image is not FakeObject:
             arr = array(value)
@@ -469,7 +472,7 @@ class CollectionsDelegate(QItemDelegate):
                                             key=key, readonly=readonly,
                                             conv=conv_func))
             return None
-        #--editor = DataFrameEditor
+        # DataFrameEditor for a pandas dataframe, series or index
         elif isinstance(value, (DataFrame, DatetimeIndex, Series)) \
           and DataFrame is not FakeObject:
             editor = DataFrameEditor(parent)
@@ -480,7 +483,7 @@ class CollectionsDelegate(QItemDelegate):
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
                                             key=key, readonly=readonly))
             return None
-        #---editor = QDateEdit or QDateTimeEdit
+        # QDateEdit and QDateTimeEdit for a dates or datetime respectively
         elif isinstance(value, datetime.date):
             if readonly:
                 return None
@@ -492,7 +495,7 @@ class CollectionsDelegate(QItemDelegate):
                 editor.setCalendarPopup(True)
                 editor.setFont(get_font(font_size_delta=DEFAULT_SMALL_DELTA))
                 return editor
-        #---editor = TextEditor
+        # TextEditor for a long string
         elif is_text_string(value) and len(value) > 40:
             te = TextEditor(None, parent=parent)
             if te.setup_and_check(value):
@@ -502,7 +505,7 @@ class CollectionsDelegate(QItemDelegate):
                                                 editor=editor, key=key,
                                                 readonly=readonly))
             return None
-        #---editor = QLineEdit
+        # QLineEdit for an individual value (int, float, short string, etc)
         elif is_editable_type(value):
             if readonly:
                 return None
@@ -516,7 +519,7 @@ class CollectionsDelegate(QItemDelegate):
                 # act doesn't exist anymore.
                 # editor.returnPressed.connect(self.commitAndCloseEditor)
                 return editor
-        #---editor = CollectionsEditor for an arbitrary object
+        # CollectionsEditor for an arbitrary Python object
         else:
             editor = CollectionsEditor(parent)
             editor.setup(value, key, icon=self.parent().windowIcon(),
@@ -524,7 +527,7 @@ class CollectionsDelegate(QItemDelegate):
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
                                             key=key, readonly=readonly))
             return None
-            
+
     def create_dialog(self, editor, data):
         self._editors[id(editor)] = data
         editor.accepted.connect(

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -12,9 +12,9 @@ import os  # Example module for testing display inside collecitoneditor
 import copy
 import datetime
 try:
-    from unittest.mock import Mock, ANY
+    from unittest.mock import Mock
 except ImportError:
-    from mock import Mock, ANY  # Python 2
+    from mock import Mock  # Python 2
 
 # Third party imports
 import pandas
@@ -167,9 +167,10 @@ def test_rename_and_duplicate_item_in_collection_editor():
 
 
 def test_edit_mutable_and_immutable_types(monkeypatch):
-    """Check to ensure mutable types (lists, dicts) and individual values are
-    editable, but not immutable ones (tuples) or anything inside of them,
-    per #5991"""
+    """
+    Test that mutable types (lists, dicts) and individual values are editable,
+    but not immutable ones (tuples) or anything inside of them, to fix #5991 .
+    """
     MockQLineEdit = Mock()
     attr_to_patch_qlineedit = ('spyder.widgets.variableexplorer.' +
                                'collectionseditor.QLineEdit')
@@ -208,7 +209,7 @@ def test_edit_mutable_and_immutable_types(monkeypatch):
     editor_list.delegate.createEditor(None, None,
                                       editor_list.model.createIndex(1, 3))
     assert MockTextEditor.call_count == 2
-    MockTextEditor.assert_called_with(ANY, ANY, readonly=False)
+    assert not MockTextEditor.call_args[1]["readonly"]
 
     # Datetime inside list
     editor_list_datetime = editor_list.delegate.createEditor(
@@ -220,17 +221,13 @@ def test_edit_mutable_and_immutable_types(monkeypatch):
     editor_list.delegate.createEditor(None, None,
                                       editor_list.model.createIndex(3, 3))
     assert mockCollectionsEditor_instance.show.call_count == 1
-    mockCollectionsEditor_instance.setup.assert_called_with(ANY, ANY,
-                                                            icon=ANY,
-                                                            readonly=False)
+    assert not mockCollectionsEditor_instance.setup.call_args[1]["readonly"]
 
     # Tuple inside list
     editor_list.delegate.createEditor(None, None,
                                       editor_list.model.createIndex(4, 3))
     assert mockCollectionsEditor_instance.show.call_count == 2
-    mockCollectionsEditor_instance.setup.assert_called_with(ANY, ANY,
-                                                            icon=ANY,
-                                                            readonly=True)
+    assert mockCollectionsEditor_instance.setup.call_args[1]["readonly"]
 
     # Tests for immutable type (tuple) #
     editor_tup = CollectionsEditorTableView(None, tup_test)
@@ -245,7 +242,7 @@ def test_edit_mutable_and_immutable_types(monkeypatch):
     editor_tup.delegate.createEditor(None, None,
                                      editor_tup.model.createIndex(1, 3))
     assert MockTextEditor.call_count == 4
-    MockTextEditor.assert_called_with(ANY, ANY, readonly=True)
+    assert MockTextEditor.call_args[1]["readonly"]
 
     # Datetime inside tuple
     editor_tup_datetime = editor_tup.delegate.createEditor(
@@ -257,23 +254,21 @@ def test_edit_mutable_and_immutable_types(monkeypatch):
     editor_tup.delegate.createEditor(None, None,
                                      editor_tup.model.createIndex(3, 3))
     assert mockCollectionsEditor_instance.show.call_count == 3
-    mockCollectionsEditor_instance.setup.assert_called_with(ANY, ANY,
-                                                            icon=ANY,
-                                                            readonly=True)
+    assert mockCollectionsEditor_instance.setup.call_args[1]["readonly"]
 
     # Tuple inside tuple
     editor_tup.delegate.createEditor(None, None,
                                      editor_tup.model.createIndex(4, 3))
     assert mockCollectionsEditor_instance.show.call_count == 4
-    mockCollectionsEditor_instance.setup.assert_called_with(ANY, ANY,
-                                                            icon=ANY,
-                                                            readonly=True)
+    assert mockCollectionsEditor_instance.setup.call_args[1]["readonly"]
 
 
 @flaky(max_runs=3)
 def test_view_module_in_coledit():
-    """Check that modules don't produce an error when trying to open them in
-    Variable Explorer, and are set as readonly. Regression test for #6080"""
+    """
+    Check that modules don't produce an error when trying to open them in
+    Variable Explorer, and are set as readonly. Regression test for #6080
+    """
     editor = CollectionsEditor()
     editor.setup(os, "module_test", readonly=False)
     assert editor.widget.editor.readonly

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
-#
+# -----------------------------------------------------------------------------
 # Copyright © Spyder Project Contributors
+#
 # Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+# ----------------------------------------------------------------------------
 
 """
-Tests for collectionseditor.py
+Tests for collectionseditor.py .
 """
 
 # Standard library imports
@@ -29,16 +32,20 @@ from spyder.widgets.variableexplorer.collectionseditor import (
     LARGE_NROWS, ROWS_TO_LOAD)
 
 
-# Helper functions
+# =============================================================================
+# Utility functions
+# =============================================================================
 def data(cm, i, j):
     return cm.data(cm.createIndex(i, j))
+
 
 def data_table(cm, n_rows, n_cols):
     return [[data(cm, i, j) for i in range(n_rows)] for j in range(n_cols)]
 
-# --- Tests
-# -----------------------------------------------------------------------------
 
+# =============================================================================
+# Tests
+# ============================================================================
 def test_create_dataframeeditor_with_correct_format(qtbot, monkeypatch):
     MockDataFrameEditor = Mock()
     mockDataFrameEditor_instance = MockDataFrameEditor()
@@ -170,8 +177,9 @@ def test_rename_and_duplicate_item_in_collection_editor():
 
 def test_edit_mutable_and_immutable_types(monkeypatch):
     """
-    Test that mutable types (lists, dicts) and individual values are editable,
-    but not immutable ones (tuples) or anything inside of them, to fix #5991 .
+    Test that mutable objs/vals are editable in VarExp; immutable ones aren't.
+
+    Regression test for #5991 .
     """
     MockQLineEdit = Mock()
     attr_to_patch_qlineedit = ('spyder.widgets.variableexplorer.' +
@@ -268,8 +276,9 @@ def test_edit_mutable_and_immutable_types(monkeypatch):
 @flaky(max_runs=3)
 def test_view_module_in_coledit():
     """
-    Check that modules don't produce an error when trying to open them in
-    Variable Explorer, and are set as readonly. Regression test for #6080
+    Test that modules don't produce an error when opening in Variable Explorer.
+
+    Also check that they are set as readonly. Regression test for #6080 .
     """
     editor = CollectionsEditor()
     editor.setup(os, "module_test", readonly=False)
@@ -297,7 +306,11 @@ def test_notimplementederror_multiindex():
 
 
 def test_editor_parent_set(monkeypatch):
-    """Test that editors have parent set so they close with Spyder (#5696)"""
+    """
+    Test that editors have their parent set so they close with Spyder.
+
+    Regression test for #5696 .
+    """
     # Mocking and setup
     test_parent = QWidget()
 


### PR DESCRIPTION
Fix #5696 .

Currently, any window launched from the Variable Explorer (Dataframe Editor, Collections Editor, etc) will cause Spyder to stay open even if the main window is closed, leading to extra resources and cluter, user confusion and general sub-optimal Ux. Therefore, this PR sets that properly to fix it, and additionally adds a specific test for this as well as improves the existing ones to make them less brittle (as this change broke one of them, my own). Also, updated file/section headers to the consistent standard and did a few bits of minor cleanup around lines that were changed.