### PR TITLE
PR: Fix NotImplementedError when browsing a MultiIndex in the Collection Editor

### DIFF
--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -74,8 +74,14 @@ class ProxyObject(object):
         return len(get_object_attrs(self.__obj__))
 
     def __getitem__(self, key):
-        """Get attribute corresponding to key."""
-        return getattr(self.__obj__, key)
+        """Get the attribute corresponding to given key."""
+        # Fix #6284 where pandas MultiIndex returns NotImplementedError
+        # Due to NA checking not being supported on a multiindex.
+        try:
+            attribute_toreturn = getattr(self.__obj__, key)
+        except NotImplementedError:
+            attribute_toreturn = None
+        return attribute_toreturn
 
     def __setitem__(self, key, value):
         """Set attribute corresponding to key with value."""

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -279,5 +279,26 @@ def test_view_module_in_coledit():
     assert editor.widget.editor.readonly
 
 
+def test_notimplementederror_multiindex():
+    """
+    Test that the NotImplementedError when scrolling a MultiIndex is handled.
+
+    Regression test for #6284.
+    """
+    time_deltas = [pandas.Timedelta(minutes=minute)
+                   for minute in range(5, 35, 5)]
+    time_delta_multiindex = pandas.MultiIndex.from_product([[0, 1, 2, 3, 4],
+                                                            time_deltas])
+#    coll = {'rng': rng}
+    col_model = CollectionsModel(None, time_delta_multiindex)
+    assert col_model.rowCount() == col_model.rows_loaded == ROWS_TO_LOAD
+    assert col_model.columnCount() == 4
+    col_model.fetchMore()
+    assert col_model.rowCount() == 2 * ROWS_TO_LOAD
+    for _ in range(3):
+        col_model.fetchMore()
+    assert col_model.rowCount() == 5 * ROWS_TO_LOAD
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Fix #6284 .

Just catch and pass the error, allowing for the viewing of MultiIndexes as generic Python objects in the CollectionEditor without it raising errors and refusing to load the rest of the object as previously. Also added a test for it.