### PR TITLE
Add .pytest_cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Notepad++ files
 nppBackup/
 
+# Pytest dirs/files
+.pytest_cache/
+
 # Special dirs and files
 build/
 dist/


### PR DESCRIPTION
On recent builds, running pytest results in this dir, which clutters ``git status``. This PR fixes that.