### PR TITLE
PR: Replace deprecated function in inline CollectionsEditor tests and add recently supported data types

### DIFF
--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1456,7 +1456,7 @@ def get_test_data():
     """Create test data."""
     import numpy as np
     from spyder.pil_patch import Image
-    image = Image.fromarray(np.random.random_integers(255, size=(100, 100)),
+    image = Image.fromarray(np.random.randint(256, size=(100, 100)),
                             mode='P')
     testdict = {'d': 1, 'a': np.random.rand(10, 10), 'b': [1, 2]}
     testdate = datetime.date(1945, 5, 8)
@@ -1501,7 +1501,7 @@ def get_test_data():
 
 
 def editor_test():
-    """Collections editor test"""
+    """Test Collections editor."""
     from spyder.utils.qthelpers import qapplication
 
     app = qapplication()             #analysis:ignore
@@ -1512,14 +1512,14 @@ def editor_test():
 
 
 def remote_editor_test():
-    """Remote collections editor test"""
+    """Test remote collections editor."""
     from spyder.utils.qthelpers import qapplication
     app = qapplication()
 
     from spyder.plugins.variableexplorer import VariableExplorer
     from spyder.widgets.variableexplorer.utils import make_remote_view
 
-    remote = make_remote_view(get_test_data(), 
+    remote = make_remote_view(get_test_data(),
                               VariableExplorer(None).get_settings())
     dialog = CollectionsEditor()
     dialog.setup(remote, remote=True)

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1460,6 +1460,23 @@ def get_test_data():
                             mode='P')
     testdict = {'d': 1, 'a': np.random.rand(10, 10), 'b': [1, 2]}
     testdate = datetime.date(1945, 5, 8)
+    test_timedelta = datetime.timedelta(days=-1, minutes=42, seconds=13)
+
+    try:
+        import pandas as pd
+    except (ModuleNotFoundError, ImportError):
+        test_timestamp, test_pd_td, test_dtindex, test_series, test_df = None
+    else:
+        test_timestamp = pd.Timestamp("1945-05-08T23:01:00.12345")
+        test_pd_td = pd.Timedelta(days=2193, hours=12)
+        test_dtindex = pd.DatetimeIndex(start="1939-09-01T",
+                                              end="1939-10-06",
+                                              freq="12H")
+        test_series = pd.Series({"series_name": [0, 1, 2, 3, 4, 5]})
+        test_df = pd.DataFrame({"string_col": ["a", "b", "c", "d"],
+                                "int_col": [0, 1, 2, 3],
+                                "float_col": [1.1, 2.2, 3.3, 4.4],
+                                "bool_col": [True, False, False, True]})
 
     class Foobar(object):
 
@@ -1470,28 +1487,43 @@ def get_test_data():
 
     foobar = Foobar()
     return {'object': foobar,
+            'module': np,
             'str': 'kjkj kj k j j kj k jkj',
             'unicode': to_text_string('éù', 'utf-8'),
             'list': [1, 3, [sorted, 5, 6], 'kjkj', None],
-            'tuple': ([1, testdate, testdict], 'kjkj', None),
+            'tuple': ([1, testdate, testdict, test_timedelta], 'kjkj', None),
             'dict': testdict,
             'float': 1.2233,
             'int': 223,
             'bool': True,
-            'array': np.random.rand(10, 10),
+            'array': np.random.rand(10, 10).astype(np.int64),
             'masked_array': np.ma.array([[1, 0], [1, 0]],
                                         mask=[[True, False], [False, False]]),
-            '1D-array': np.linspace(-10, 10),
+            '1D-array': np.linspace(-10, 10).astype(np.float16),
+            '3D-array': np.random.randint(2, size=(5, 5, 5)).astype(np.bool_),
             'empty_array': np.array([]),
             'image': image,
             'date': testdate,
-            'datetime': datetime.datetime(1945, 5, 8),
+            'datetime': datetime.datetime(1945, 5, 8, 23, 1, 0, int(1.5e5)),
+            'timedelta': test_timedelta,
             'complex': 2+1j,
             'complex64': np.complex64(2+1j),
+            'complex128': np.complex128(9j),
             'int8_scalar': np.int8(8),
             'int16_scalar': np.int16(16),
             'int32_scalar': np.int32(32),
+            'int64_scalar': np.int64(64),
+            'float16_scalar': np.float16(16),
+            'float32_scalar': np.float32(32),
+            'float64_scalar': np.float64(64),
             'bool_scalar': np.bool(8),
+            'bool__scalar': np.bool_(8),
+            'timestamp': test_timestamp,
+            'timedelta_pd': test_pd_td,
+            'datetimeindex': test_dtindex,
+            'series': test_series,
+            'ddataframe': test_df,
+            'None': None,
             'unsupported1': np.arccos,
             'unsupported2': np.cast,
             # Test for Issue #3518


### PR DESCRIPTION
In the inline tests for CollectionsEditor, ``np.random.random_integers`` is called, which has been deprecated for quite some time. To avoid problems when/if it is finally removed, I replaced it with ``np.random.randint``. Also, added a number of additional datatypes which we now support in the years since the test was written, for full coverage, and did some minor cleanup/refinements to the docstrings.