### PR TITLE
PR: Fix various bugs in Variable Explorer, including an application crash to desktop

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include spyder *.pot *.po *.svg *.png *.css *.qss *.c, *.cpp, *.html, *.java, *.md, *.R, *.csv, *.pyx, *.ipynb
+recursive-include spyder *.pot *.po *.svg *.png *.css *.qss *.c *.cpp *.html *.java *.md *.R *.csv *.pyx *.ipynb *.xml
 recursive-include spyder_breakpoints *.pot *.po *.svg *.png
 recursive-include spyder_profiler *.pot *.po *.svg *.png
 recursive-include spyder_pylint *.pot *.po *.svg *.png

--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,7 @@ else:
 #==============================================================================
 EXTLIST = ['.mo', '.svg', '.png', '.css', '.html', '.js', '.chm', '.ini',
            '.txt', '.rst', '.qss', '.ttf', '.json', '.c', '.cpp', '.java',
-           '.md', '.R', '.csv', '.pyx', '.ipynb']
+           '.md', '.R', '.csv', '.pyx', '.ipynb', '.xml']
 if os.name == 'nt':
     SCRIPTS += ['spyder.bat']
     EXTLIST += ['.ico']

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -101,6 +101,9 @@ class ProxyObject(object):
             setattr(self.__obj__, key, value)
         except (TypeError, AttributeError, NotImplementedError):
             pass
+        except Exception as e:
+            if "cannot set values for" not in str(e):
+                raise
 
 
 class ReadOnlyCollectionsModel(QAbstractTableModel):

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -94,9 +94,12 @@ class ProxyObject(object):
 
     def __setitem__(self, key, value):
         """Set attribute corresponding to key with value."""
+        # Catch AttributeError to gracefully handle inability to set an
+        # attribute due to it not being writeable or set-table.
+        # Fix issue #6728 . Also, catch NotImplementedError for safety.
         try:
             setattr(self.__obj__, key, value)
-        except TypeError:
+        except (TypeError, AttributeError, NotImplementedError):
             pass
 
 

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -83,10 +83,12 @@ class ProxyObject(object):
         # Catch AttributeError to fix #5642 in certain special classes like xml
         # when this method is called on certain attributes.
         # Catch TypeError to prevent fatal Python crash to desktop after
-        # modifying certain pandas objects ( Issue #6727 ).
+        # modifying certain pandas objects. Fix issue #6727 .
+        # Catch ValueError to allow viewing and editing of pandas offsets.
+        # Fix issue #6728 .
         try:
             attribute_toreturn = getattr(self.__obj__, key)
-        except (NotImplementedError, AttributeError, TypeError):
+        except (NotImplementedError, AttributeError, TypeError, ValueError):
             attribute_toreturn = None
         return attribute_toreturn
 

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -81,10 +81,12 @@ class ProxyObject(object):
         # Catch NotImplementedError to fix #6284 in pandas MultiIndex
         # due to NA checking not being supported on a multiindex.
         # Catch AttributeError to fix #5642 in certain special classes like xml
-        # when this method is called on certain attributes
+        # when this method is called on certain attributes.
+        # Catch TypeError to prevent fatal Python crash to desktop after
+        # modifying certain pandas objects ( Issue #6727 ).
         try:
             attribute_toreturn = getattr(self.__obj__, key)
-        except (NotImplementedError, AttributeError):
+        except (NotImplementedError, AttributeError, TypeError):
             attribute_toreturn = None
         return attribute_toreturn
 

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -77,12 +77,14 @@ class ProxyObject(object):
         return len(get_object_attrs(self.__obj__))
 
     def __getitem__(self, key):
-        """Get the attribute corresponding to given key."""
-        # Fix #6284 where pandas MultiIndex returns NotImplementedError
-        # Due to NA checking not being supported on a multiindex.
+        """Get the attribute corresponding to the given key."""
+        # Catch NotImplementedError to fix #6284 in pandas MultiIndex
+        # due to NA checking not being supported on a multiindex.
+        # Catch AttributeError to fix #5642 in certain special classes like xml
+        # when this method is called on certain attributes
         try:
             attribute_toreturn = getattr(self.__obj__, key)
-        except NotImplementedError:
+        except (NotImplementedError, AttributeError):
             attribute_toreturn = None
         return attribute_toreturn
 

--- a/spyder/widgets/variableexplorer/tests/dom_element_test.xml
+++ b/spyder/widgets/variableexplorer/tests/dom_element_test.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<note>
+  <to>Carlos</to>
+  <from>Pierre</from>
+  <heading>Spyder</heading>
+  <body>Spyder is an amazing IDE!</body>
+</note>

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -12,8 +12,10 @@ Tests for the Variable Explorer Collections Editor.
 
 # Standard library imports
 import os  # Example module for testing display inside CollecitonsEditor
+from os import path
 import copy
 import datetime
+from xml.dom.minidom import parseString
 try:
     from unittest.mock import Mock
 except ImportError:
@@ -30,6 +32,13 @@ from qtpy.QtWidgets import QWidget
 from spyder.widgets.variableexplorer.collectionseditor import (
     CollectionsEditorTableView, CollectionsModel, CollectionsEditor,
     LARGE_NROWS, ROWS_TO_LOAD)
+
+
+# =============================================================================
+# Constants
+# =============================================================================
+# Full path to this file's parent directory for loading data
+LOCATION = path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 
 # =============================================================================
@@ -351,6 +360,26 @@ def test_editor_parent_set(monkeypatch):
                                          col_editor.model.createIndex(idx, 3))
         assert mock_class.call_count == 1 + (idx // 3)
         assert mock_class.call_args[1]["parent"] is test_parent
+
+
+def test_xml_dom_element_view():
+    """
+    Test that XML DOM ``Element``s are able to be viewied in CollectionsEditor.
+
+    Regression test for issue #5642 .
+    """
+    xml_path = path.join(LOCATION, 'dom_element_test.xml')
+    with open(xml_path) as xml_file:
+        xml_data = xml_file.read()
+
+    xml_content = parseString(xml_data)
+    xml_element = xml_content.getElementsByTagName("note")[0]
+
+    col_editor = CollectionsEditor(None)
+    col_editor.setup(xml_element)
+    col_editor.show()
+    assert col_editor.get_value()
+    col_editor.accept()
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -7,11 +7,11 @@
 # ----------------------------------------------------------------------------
 
 """
-Tests for collectionseditor.py .
+Tests for the Variable Explorer Collections Editor.
 """
 
 # Standard library imports
-import os  # Example module for testing display inside collecitoneditor
+import os  # Example module for testing display inside CollecitonsEditor
 import copy
 import datetime
 try:
@@ -179,7 +179,7 @@ def test_edit_mutable_and_immutable_types(monkeypatch):
     """
     Test that mutable objs/vals are editable in VarExp; immutable ones aren't.
 
-    Regression test for #5991 .
+    Regression test for issue #5991 .
     """
     MockQLineEdit = Mock()
     attr_to_patch_qlineedit = ('spyder.widgets.variableexplorer.' +
@@ -278,7 +278,7 @@ def test_view_module_in_coledit():
     """
     Test that modules don't produce an error when opening in Variable Explorer.
 
-    Also check that they are set as readonly. Regression test for #6080 .
+    Also check that they are set as readonly. Regression test for issue #6080 .
     """
     editor = CollectionsEditor()
     editor.setup(os, "module_test", readonly=False)
@@ -289,7 +289,7 @@ def test_notimplementederror_multiindex():
     """
     Test that the NotImplementedError when scrolling a MultiIndex is handled.
 
-    Regression test for #6284.
+    Regression test for issue #6284 .
     """
     time_deltas = [pandas.Timedelta(minutes=minute)
                    for minute in range(5, 35, 5)]
@@ -309,7 +309,7 @@ def test_editor_parent_set(monkeypatch):
     """
     Test that editors have their parent set so they close with Spyder.
 
-    Regression test for #5696 .
+    Regression test for issue #5696 .
     """
     # Mocking and setup
     test_parent = QWidget()

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -414,5 +414,40 @@ def test_set_nonsettable_objects(qtbot):
     assert col_model.get_data().__obj__ == expected_period
 
 
+@flaky(max_runs=3)
+@pytest.mark.no_xvfb
+def test_edit_nonsettable_objects(qtbot):
+    """
+    Test that errors trying to edit attributes in ColEdit are handled properly.
+
+    Integration regression test for issue #6728 .
+    """
+    test_period = pandas.Period("2018-03")
+    expected_period = pandas.Period("2018-03")
+    test_str = "2"
+    row_to_test = 7
+
+    col_editor = CollectionsEditor(None)
+    col_editor.setup(test_period)
+    col_editor.show()
+    qtbot.waitForWindowShown(col_editor)
+    view = col_editor.widget.editor
+
+    for _ in range(3):
+        qtbot.keyClick(view, Qt.Key_Right)
+    for _ in range(row_to_test):
+        qtbot.keyClick(view, Qt.Key_Down)
+    qtbot.keyClick(view, Qt.Key_Space)
+    qtbot.keyClick(view.focusWidget(), Qt.Key_Backspace)
+    qtbot.keyClicks(view.focusWidget(), test_str)
+    qtbot.keyClick(view.focusWidget(), Qt.Key_Down)
+    qtbot.wait(100)
+    assert col_editor.get_value() == expected_period
+
+    col_editor.accept()
+    qtbot.wait(200)
+    assert test_period == expected_period
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -382,5 +382,19 @@ def test_xml_dom_element_view():
     col_editor.accept()
 
 
+def test_pandas_dateoffset_view():
+    """
+    Test that pandas ``DateOffset`` objs can be viewied in CollectionsEditor.
+
+    Regression test for issue #6729 .
+    """
+    test_dateoffset = pandas.DateOffset()
+    col_editor = CollectionsEditor(None)
+    col_editor.setup(test_dateoffset)
+    col_editor.show()
+    assert col_editor.get_value()
+    col_editor.accept()
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -26,6 +26,7 @@ import numpy
 import pandas
 import pytest
 from flaky import flaky
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QWidget
 
 # Local imports
@@ -394,6 +395,23 @@ def test_pandas_dateoffset_view():
     col_editor.show()
     assert col_editor.get_value()
     col_editor.accept()
+
+
+def test_set_nonsettable_objects(qtbot):
+    """
+    Test that errors trying to set attributes in ColEdit are handled properly.
+
+    Unit regression test for issue #6728 .
+    """
+    test_period = pandas.Period("2018-03")
+    expected_period = pandas.Period("2018-03")
+
+    col_model = CollectionsModel(None, test_period)
+
+    assert col_model.setData(col_model.createIndex(7, 3), "2")
+    assert col_model.setData(col_model.createIndex(8, 3), "3")
+    qtbot.wait(100)
+    assert col_model.get_data().__obj__ == expected_period
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/variableexplorer/tests/test_dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_dataframeeditor.py
@@ -476,7 +476,7 @@ def test_dataframeeditor_edit_bool(qtbot, monkeypatch):
         qtbot.waitForWindowShown(dialog)
         view = dialog.dataTable
 
-        qtbot.keyPress(view, Qt.Key_Right)
+        qtbot.keyClick(view, Qt.Key_Right)
         for test_str in test_strs:
             qtbot.keyClick(view, Qt.Key_Space)
             qtbot.keyClick(view.focusWidget(), Qt.Key_Backspace)


### PR DESCRIPTION
Fix #5642 .
Fix #6727 .
Fix #6728 .
Fix #6729 .

Spent all night and morning going down this rabbit hole on what was supposed to be a "quick" PR, finding, fixing and testing numerous additional related issues ultimately stemming from the same line(s) on top of the original problem (nominally #6727 on my end, with the orignal impetus starting all the way back in the abortive #5999 ) including a full on application crash, but here we are, and everything is fixed so not only are the errors handled gracefully, but everything actually works perfectly.
