### PR TITLE
PR: Error report stopgap to make instructions harder to miss

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,8 @@ install:
   - "pip install git+https://github.com/jupyter/qtconsole.git"
   # Run with tornado < 5.0 to avoid hangs
   - "conda install tornado=4.5.3"
+  # Fix connection to external kernels
+  - "conda install jupyter_client=5.2.2"
 
 build: false
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -33,7 +33,13 @@ if [ "$TRAVIS_PYTHON_VERSION" = "3.5" ] && [ "$USE_PYQT" = "pyqt5" ]; then
 
     # Run with tornado < 5.0 to avoid hangs
     pip install tornado==4.5.3
+
+    # Fix connection to external kernels
+    pip install jupyter-client==5.2.2
 else
     # Run with tornado < 5.0 to avoid hangs
     conda install tornado=4.5.3
+
+    # Fix connection to external kernels
+    conda install jupyter_client=5.2.2
 fi

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -28,7 +28,7 @@ from spyder.widgets.sourcecode.base import ConsoleBaseWidget
 
 # Minimum number of characters to introduce in the description field
 # before being able to send the report to Github.
-MIN_CHARS = 20
+MIN_CHARS = 50
 
 
 class DescriptionWidget(CodeEditor):

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -142,7 +142,7 @@ class SpyderErrorDialog(QDialog):
         self.main_label.setOpenExternalLinks(True)
         self.main_label.setWordWrap(True)
         self.main_label.setAlignment(Qt.AlignJustify)
-        self.main_label.setStyleSheet('font-size: 11pt;')
+        self.main_label.setStyleSheet('font-size: 12px;')
 
         # Field to input the description of the problem
         self.input_description = DescriptionWidget(self)

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -142,6 +142,7 @@ class SpyderErrorDialog(QDialog):
         self.main_label.setOpenExternalLinks(True)
         self.main_label.setWordWrap(True)
         self.main_label.setAlignment(Qt.AlignJustify)
+        self.main_label.setStyleSheet('font-size: 11pt;')
 
         # Field to input the description of the problem
         self.input_description = DescriptionWidget(self)
@@ -212,8 +213,9 @@ class SpyderErrorDialog(QDialog):
         QApplication.clipboard().setText(issue_text)
 
         # Submit issue to Github
-        issue_body = ("<!--- IMPORTANT: Paste the contents of your clipboard "
-                      "here to complete reporting the problem. --->\n\n")
+        issue_body = (
+            " \n<!---   *** BEFORE SUBMITTING: PASTE CLIPBOARD HERE TO "
+            "COMPLETE YOUR REPORT ***   ---!>\n")
         main.report_issue(body=issue_body,
                           title="Automatic error report")
 


### PR DESCRIPTION
To help raise the bar slightly as to the quality of reports and avoid user mistakes, this PR bumps up the font size on the issue dialog (as its currently quite small), makes the "Paste clipboard here" text on the automatic github report even more blaring, and increases the minimum character count to 50 so users put a little more thought into their reports.

Screenshot of issue dialog with larger font:

![image](https://user-images.githubusercontent.com/17051931/37302451-909e0216-25f9-11e8-92a3-d10f75d9c9ad.png)
