### PR TITLE
PR: Enclose python exe path in double quotes

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2535,8 +2535,7 @@ class MainWindow(QMainWindow):
                 if CONF.get('main_interpreter', 'default'):
                     executable = get_python_executable()
                 else:
-                    executable = CONF.get('main_interpreter', 'executable',
-                                          get_python_executable())
+                    executable = CONF.get('main_interpreter', 'executable')
                 programs.run_python_script_in_terminal(
                         fname, wdir, args, interact, debug, python_args,
                         executable)

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -157,7 +157,7 @@ from spyder.utils import encoding, programs
 from spyder.utils import icon_manager as ima
 from spyder.utils.introspection import module_completion
 from spyder.utils.programs import is_module_installed
-from spyder.utils.misc import select_port, getcwd_or_home
+from spyder.utils.misc import select_port, getcwd_or_home, get_python_executable
 from spyder.widgets.fileswitcher import FileSwitcher
 
 #==============================================================================
@@ -2532,8 +2532,14 @@ class MainWindow(QMainWindow):
         if systerm:
             # Running script in an external system terminal
             try:
-                programs.run_python_script_in_terminal(fname, wdir, args,
-                                                interact, debug, python_args)
+                if CONF.get('main_interpreter', 'default'):
+                    executable = get_python_executable()
+                else:
+                    executable = CONF.get('main_interpreter', 'executable',
+                                          get_python_executable())
+                programs.run_python_script_in_terminal(
+                        fname, wdir, args, interact, debug, python_args,
+                        executable)
             except NotImplementedError:
                 QMessageBox.critical(self, _("Run"),
                                      _("Running an external system terminal "

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -253,13 +253,14 @@ def get_python_args(fname, python_args, interact, debug, end_args):
 
 
 def run_python_script_in_terminal(fname, wdir, args, interact,
-                                  debug, python_args):
+                                  debug, python_args, executable=None):
     """
     Run Python script in an external system terminal.
 
     :str wdir: working directory, may be empty.
     """
-    python_exe = get_python_executable()
+    if executable is None:
+        executable = get_python_executable()
 
     # If fname or python_exe contains spaces, it can't be ran on Windows, so we
     # have to enclose them in quotes. Also wdir can come with / as os.sep, so
@@ -267,10 +268,12 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
     if os.name == 'nt':
         fname = '"' + fname + '"'
         wdir = wdir.replace('/', '\\')
-        python_exe = '"' + python_exe + '"'
+        executable = '"' + executable + '"'
 
-    p_args = [python_exe]
+    p_args = [executable]
     p_args += get_python_args(fname, python_args, interact, debug, args)
+    
+    print(executable)
 
     if os.name == 'nt':
         cmd = 'start cmd.exe /c "cd %s && ' % wdir + ' '.join(p_args) + '"'

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -272,8 +272,6 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
 
     p_args = [executable]
     p_args += get_python_args(fname, python_args, interact, debug, args)
-    
-    print(executable)
 
     if os.name == 'nt':
         cmd = 'start cmd.exe /c "cd %s && ' % wdir + ' '.join(p_args) + '"'

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -259,16 +259,19 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
 
     :str wdir: working directory, may be empty.
     """
-    # If fname has spaces on it it can't be ran on Windows, so we have to
-    # enclose it in quotes. Also wdir can come with / as os.sep, so we
-    # need to take care of it
+    python_exe = get_python_executable()
+
+    # If fname or python_exe contains spaces, it can't be ran on Windows, so we
+    # have to enclose them in quotes. Also wdir can come with / as os.sep, so
+    # we need to take care of it.
     if os.name == 'nt':
         fname = '"' + fname + '"'
         wdir = wdir.replace('/', '\\')
-    
-    p_args = [get_python_executable()]
+        python_exe = '"' + python_exe + '"'
+
+    p_args = [python_exe]
     p_args += get_python_args(fname, python_args, interact, debug, args)
-    
+
     if os.name == 'nt':
         cmd = 'start cmd.exe /c "cd %s && ' % wdir + ' '.join(p_args) + '"'
         # Command line and cwd have to be converted to the filesystem


### PR DESCRIPTION
Fixes #6746

Enclose the path of the python executable in double quotes so that executing a script in an external system terminal works correctly when the path to the Python interpreter contains spaces.
