### PR TITLE
PR: Change Editor's tab switcher from Qt.SubWindow to Qt.Popup for tiling window managers

### DIFF
--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -423,6 +423,17 @@ class TabSwitcherWidget(QListWidget):
         elif event.key() == Qt.Key_Up:
             self.select_row(-1)
 
+    def focusOutEvent(self, event):
+        """Reimplement Qt method to close the widget when loosing focus."""
+        event.ignore()
+        # Inspired from CompletionWidget.focusOutEvent() in file
+        # widgets/sourcecode/base.py line 212
+        if sys.platform == "darwin":
+            if event.reason() != Qt.ActiveWindowFocusReason:
+                self.close()
+        else:
+            self.close()
+
 
 class EditorStack(QWidget):
     reset_statusbar = Signal()

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -338,7 +338,7 @@ class TabSwitcherWidget(QListWidget):
 
     def __init__(self, parent, stack_history, tabs):
         QListWidget.__init__(self, parent)
-        self.setWindowFlags(Qt.SubWindow | Qt.FramelessWindowHint | Qt.Dialog)
+        self.setWindowFlags(Qt.Popup | Qt.FramelessWindowHint | Qt.Dialog)
 
         self.editor = parent
         self.stack_history = stack_history

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -338,7 +338,7 @@ class TabSwitcherWidget(QListWidget):
 
     def __init__(self, parent, stack_history, tabs):
         QListWidget.__init__(self, parent)
-        self.setWindowFlags(Qt.Popup | Qt.FramelessWindowHint | Qt.Dialog)
+        self.setWindowFlags(Qt.FramelessWindowHint | Qt.Dialog)
 
         self.editor = parent
         self.stack_history = stack_history


### PR DESCRIPTION
The file switcher widget is now `Qt.Popup` instead of `Qt.SubWindow`.
This makes it usable with tiling window manager since it appears as floating and do not move the main spyder window.

Fixes #6834
Fixes #6743