### PR TITLE
PR: Initialize start time to a time and not None

### DIFF
--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -140,7 +140,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
         # Elapsed time
         self.time_label = None
-        self.t0 = None
+        self.t0 = time.monotonic()
         self.timer = QTimer(self)
 
         # --- Layout


### PR DESCRIPTION
Fixes #6767.

No reason to initialize self.t0 to None since time is already imported.  Initialize it to a valid time and then allow the other methods to update it just as they have been doing.  That way it will always have a valid value even if the kernel fails to start.