### PR TITLE
PR: Fix a bug when running a file in the IPython console with a single quote character in its name

### DIFF
--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -2376,11 +2376,15 @@ class Editor(SpyderPluginWidget):
         if editorstack.save():
             editor = self.get_current_editor()
             fname = osp.abspath(self.get_current_filename())
-            
+
+            # Get fname's dirname before we escape the single and double
+            # quotes (Fixes Issue #6771)
+            dirname = osp.dirname(fname)
+
             # Escape single and double quotes in fname (Fixes Issue 2158)
             fname = fname.replace("'", r"\'")
             fname = fname.replace('"', r'\"')
-            
+
             runconf = get_run_configuration(fname)
             if runconf is None:
                 dialog = RunConfigOneDialog(self)
@@ -2412,7 +2416,7 @@ class Editor(SpyderPluginWidget):
             clear_namespace = runconf.clear_namespace
 
             if runconf.file_dir:
-                wdir = osp.dirname(fname)
+                wdir = dirname
             elif runconf.cw_dir:
                 wdir = ''
             elif osp.isdir(runconf.dir):


### PR DESCRIPTION
Fixes  #6771

In [spyder/plugins/editor.py](https://github.com/spyder-ide/spyder/blob/v3.2.8/spyder/plugins/editor.py), single and double quotes are escaped before running a file from the editor with:

https://github.com/spyder-ide/spyder/blob/v3.2.8/spyder/plugins/editor.py#L2380
```
# Escape single and double quotes in fname (Fixes Issue 2158)
fname = fname.replace("'", r"\'")
fname = fname.replace('"', r'\"')
```

In windows, this cause `osp.dirname(fname)` to return the wrong path if there was a `'` or `"` character in the name of the file. For example : 

```
import os.path as osp
fname="C:\test'path.py"
fname = fname.replace("'", r"\'")
osp.dirname(fname)
```

returns in Windows `'C:\test'` instead of `'C:`. Therefore, to fix this issue, fname's dirname must be saved in a temporary variable before the single or double quote are escaped.

Note:
In Windows, the following characters are not allowed for folder or file names : 
![image](https://user-images.githubusercontent.com/10170372/37500682-35abc794-28a1-11e8-83ba-bfdf9ef2af91.png)
