### PR TITLE
PR: Add instance pattern "cls" for class methods

### DIFF
--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -291,6 +291,7 @@ def make_python_patterns(additional_keywords=[], additional_builtins=[]):
     builtin = r"([^.'\"\\#]\b|^)" + any("builtin", builtinlist) + r"\b"
     comment = any("comment", [r"#[^\n]*"])
     instance = any("instance", [r"\bself\b",
+                                r"\bcls\b",
                                 (r"^\s*@([a-zA-Z_][a-zA-Z0-9_]*)"
                                      r"(\.[a-zA-Z_][a-zA-Z0-9_]*)*")])
     number = any("number",


### PR DESCRIPTION
It's the same as [#6804](https://github.com/spyder-ide/spyder/pull/6804) except this is for branch 3.x

The word "cls" usually use in the class method.
I thought we should highlight "cls" just like "self".

For example
```
class Foo:
    @classmethod
    def clsmethod(cls, x):
        pass
```