### PR TITLE
PR: Add option to use Jedi in the IPython console + warning on greedy completer

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -158,6 +158,7 @@ DEFAULTS = [
               'startup/use_run_file': False,
               'startup/run_file': '',
               'greedy_completer': False,
+              'ipy_jedi_completer': False,
               'autocall': 0,
               'symbolic_math': False,
               'in_prompt': '',

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -158,7 +158,7 @@ DEFAULTS = [
               'startup/use_run_file': False,
               'startup/run_file': '',
               'greedy_completer': False,
-              'ipy_jedi_completer': False,
+              'jedi_completer': False,
               'autocall': 0,
               'symbolic_math': False,
               'in_prompt': '',

--- a/spyder/defaults/defaults-3.0.0.ini
+++ b/spyder/defaults/defaults-3.0.0.ini
@@ -106,6 +106,7 @@ startup/run_lines =
 startup/run_file = 
 pylab/inline/figure_format = 0
 greedy_completer = False
+ipy_jedi_completer = False
 pylab/inline/resolution = 72
 font/family = ['Ubuntu Mono', 'Monospace', 'DejaVu Sans Mono', 'Consolas', 'Monaco', 'Bitstream Vera Sans Mono', 'Andale Mono', 'Liberation Mono', 'Courier New', 'Courier', 'monospace', 'Fixed', 'Terminal']
 dark_color = False

--- a/spyder/defaults/defaults-3.0.0.ini
+++ b/spyder/defaults/defaults-3.0.0.ini
@@ -106,7 +106,6 @@ startup/run_lines =
 startup/run_file = 
 pylab/inline/figure_format = 0
 greedy_completer = False
-ipy_jedi_completer = False
 pylab/inline/resolution = 72
 font/family = ['Ubuntu Mono', 'Monospace', 'DejaVu Sans Mono', 'Consolas', 'Monaco', 'Bitstream Vera Sans Mono', 'Andale Mono', 'Liberation Mono', 'Courier New', 'Courier', 'monospace', 'Fixed', 'Terminal']
 dark_color = False

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -477,26 +477,26 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         run_file_group.setLayout(run_file_layout)
         
         # ---- Advanced settings ----
-        # Enable Jedi completion in IPyhton Console
-        ipy_jedi_group = QGroupBox(_("Jedi completion"))
-        ipy_jedi_label = QLabel(_("Enable Jedi-based <tt>Tab</tt> completion "
+        # Enable Jedi completion
+        jedi_group = QGroupBox(_("Jedi completion"))
+        jedi_label = QLabel(_("Enable Jedi-based <tt>Tab</tt> completion "
                                   "in the IPython console; similar to the "
                                   "greedy completer, but without evaluating "
                                   "the code.<br>"
                                   "<b>Warning:</b> Slows down your console "
                                   "when working with large dataframes!"))
-        ipy_jedi_label.setWordWrap(True)
-        ipy_jedi_box = newcb(_("Use Jedi completion in the IPython console"), 
-                             "ipy_jedi_completer",
+        jedi_label.setWordWrap(True)
+        jedi_box = newcb(_("Use Jedi completion in the IPython console"), 
+                             "jedi_completer",
                              tip="<b>Warning</b>: "
                                  "Slows down your console when working with "
                                  "large dataframes!<br>"
                                  "Allows completion of nested lists etc.")
         
-        ipy_jedi_layout = QVBoxLayout()
-        ipy_jedi_layout.addWidget(ipy_jedi_label)
-        ipy_jedi_layout.addWidget(ipy_jedi_box)
-        ipy_jedi_group.setLayout(ipy_jedi_layout)
+        jedi_layout = QVBoxLayout()
+        jedi_layout.addWidget(jedi_label)
+        jedi_layout.addWidget(jedi_box)
+        jedi_group.setLayout(jedi_layout)
                 
         # Greedy completer group
         greedy_group = QGroupBox(_("Greedy completion"))
@@ -601,7 +601,7 @@ class IPythonConsoleConfigPage(PluginConfigPage):
                                     _("Graphics"))
         tabs.addTab(self.create_tab(run_lines_group, run_file_group),
                                     _("Startup"))
-        tabs.addTab(self.create_tab(ipy_jedi_group, greedy_group, autocall_group, sympy_group,
+        tabs.addTab(self.create_tab(jedi_group, greedy_group, autocall_group, sympy_group,
                                     prompts_group), _("Advanced Settings"))
 
         vlayout = QVBoxLayout()

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -477,15 +477,42 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         run_file_group.setLayout(run_file_layout)
         
         # ---- Advanced settings ----
+        # Enable Jedi completion in Ipyhton Console
+        ipy_jedi_group = QGroupBox(_("Jedi completion in Ipython console"))
+        ipy_jedi_label = QLabel(_("Enable Jedi based <tt>Tab</tt> completion in"
+                                "the Ipython console. E.g. completion of"
+                                "nested lits etc. This is similar to the "
+                                "greedy compiler, but without evaluating the code<br>"
+                                "<b>Attention:</b> This can slow down your console "
+                                "interaction when working with large dataframes!"))
+        ipy_jedi_label.setWordWrap(True)
+        ipy_jedi_box = newcb(_("Use Jedi Completer in Ipython"), "ipy_jedi_completer",
+                           tip="<b>Warning</b>: This can slow down your console"
+                                "when working with large dataframes ")
+        
+        ipy_jedi_layout = QVBoxLayout()
+        ipy_jedi_layout.addWidget(ipy_jedi_label)
+        ipy_jedi_layout.addWidget(ipy_jedi_box)
+        ipy_jedi_group.setLayout(ipy_jedi_layout)
+                
         # Greedy completer group
-        greedy_group = QGroupBox(_("Greedy completion"))
+        greedy_group = QGroupBox(_("Greedy completion in Ipython console"))
         greedy_label = QLabel(_("Enable <tt>Tab</tt> completion on elements "
                                 "of lists, results of function calls, etc, "
                                 "<i>without</i> assigning them to a "
                                 "variable.<br>"
                                 "For example, you can get completions on "
                                 "things like <tt>li[0].&lt;Tab&gt;</tt> or "
-                                "<tt>ins.meth().&lt;Tab&gt;</tt>"))
+                                "<tt>ins.meth().&lt;Tab&gt;</tt> <br><br>"
+                                "<b>ATTENTION:<br> Ipython's Greedy completer has "
+                                "a bug</b> that requires a leading "
+                                "<tt>&lt;Space&gt;</tt> "
+                                "for some completions to work. e.g. chane "
+                                "<tt>np.sin(np.&lt;Tab&gt;</tt> "
+                                "to <tt>np.sin(&lt;Space&gt;np.&lt;Tab&gt;</tt> "
+                                ", and completion for string filenames has "
+                                "to start with a space to work e.g.: "
+                                "' filena<tt>&lt;Tab&gt;</tt> "))
         greedy_label.setWordWrap(True)
         greedy_box = newcb(_("Use the greedy completer"), "greedy_completer",
                            tip="<b>Warning</b>: It can be unsafe because the "
@@ -575,7 +602,7 @@ class IPythonConsoleConfigPage(PluginConfigPage):
                                     _("Graphics"))
         tabs.addTab(self.create_tab(run_lines_group, run_file_group),
                                     _("Startup"))
-        tabs.addTab(self.create_tab(greedy_group, autocall_group, sympy_group,
+        tabs.addTab(self.create_tab(ipy_jedi_group, greedy_group , autocall_group, sympy_group,
                                     prompts_group), _("Advanced Settings"))
 
         vlayout = QVBoxLayout()

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -479,16 +479,19 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         # ---- Advanced settings ----
         # Enable Jedi completion in IPyhton Console
         ipy_jedi_group = QGroupBox(_("Jedi completion"))
-        ipy_jedi_label = QLabel(_("Enable Jedi-based <tt>Tab</tt> completion in "
-                                "the IPython console; similar to the "
-                                "greedy completer, but without evaluating the code.<br>"
-                                "<b>Warning:</b> Slows down your console when working "
-                                "with large dataframes!"))
+        ipy_jedi_label = QLabel(_("Enable Jedi-based <tt>Tab</tt> completion "
+                                  "in the IPython console; similar to the "
+                                  "greedy completer, but without evaluating "
+                                  "the code.<br>"
+                                  "<b>Warning:</b> Slows down your console "
+                                  "when working with large dataframes!"))
         ipy_jedi_label.setWordWrap(True)
-        ipy_jedi_box = newcb(_("Use Jedi completion in the IPython console"), "ipy_jedi_completer",
-                             tip="<b>Warning</b>: Slows down your console when working "
-                                "with large dataframes!<br>"
-                                "Allows completion of nested lists etc.")
+        ipy_jedi_box = newcb(_("Use Jedi completion in the IPython console"), 
+                             "ipy_jedi_completer",
+                             tip="<b>Warning</b>: "
+                                 "Slows down your console when working with "
+                                 "large dataframes!<br>"
+                                 "Allows completion of nested lists etc.")
         
         ipy_jedi_layout = QVBoxLayout()
         ipy_jedi_layout.addWidget(ipy_jedi_label)
@@ -505,14 +508,15 @@ class IPythonConsoleConfigPage(PluginConfigPage):
                                 "<b>Warning:</b> Due to a bug, IPython's "
                                 "greedy completer requires a leading "
                                 "<tt>&lt;Space&gt;</tt> for some completions; "
-                                "e.g.  <tt>np.sin(&lt;Space&gt;np.&lt;Tab&gt;</tt> "
-                                "works while <tt>np.sin(np.&lt;Tab&gt;</tt> "
-                                "doesn't."))
+                                "e.g.  <tt>np.sin(&lt;Space&gt;np.&lt;Tab&gt;"
+                                "</tt> works while <tt>np.sin(np.&lt;Tab&gt; "
+                                "</tt> doesn't."))
         greedy_label.setWordWrap(True)
-        greedy_box = newcb(_("Use greedy completion in the IPython console"), "greedy_completer",
+        greedy_box = newcb(_("Use greedy completion in the IPython console"),
+                           "greedy_completer",
                            tip="<b>Warning</b>: It can be unsafe because the "
-                                "code is actually evaluated when you press "
-                                "<tt>Tab</tt>.")
+                               "code is actually evaluated when you press "
+                               "<tt>Tab</tt>.")
         
         greedy_layout = QVBoxLayout()
         greedy_layout.addWidget(greedy_label)
@@ -522,10 +526,10 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         # Autocall group
         autocall_group = QGroupBox(_("Autocall"))
         autocall_label = QLabel(_("Autocall makes IPython automatically call "
-                                "any callable object even if you didn't type "
-                                "explicit parentheses.<br>"
-                                "For example, if you type <i>str 43</i> it "
-                                "becomes <i>str(43)</i> automatically."))
+                                  "any callable object even if you didn't "
+                                  "type explicit parentheses.<br>"
+                                  "For example, if you type <i>str 43</i> it "
+                                  "becomes <i>str(43)</i> automatically."))
         autocall_label.setWordWrap(True)
         
         smart = _('Smart')

--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -477,18 +477,18 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         run_file_group.setLayout(run_file_layout)
         
         # ---- Advanced settings ----
-        # Enable Jedi completion in Ipyhton Console
-        ipy_jedi_group = QGroupBox(_("Jedi completion in Ipython console"))
-        ipy_jedi_label = QLabel(_("Enable Jedi based <tt>Tab</tt> completion in"
-                                "the Ipython console. E.g. completion of"
-                                "nested lits etc. This is similar to the "
-                                "greedy compiler, but without evaluating the code<br>"
-                                "<b>Attention:</b> This can slow down your console "
-                                "interaction when working with large dataframes!"))
+        # Enable Jedi completion in IPyhton Console
+        ipy_jedi_group = QGroupBox(_("Jedi completion"))
+        ipy_jedi_label = QLabel(_("Enable Jedi-based <tt>Tab</tt> completion in "
+                                "the IPython console; similar to the "
+                                "greedy completer, but without evaluating the code.<br>"
+                                "<b>Warning:</b> Slows down your console when working "
+                                "with large dataframes!"))
         ipy_jedi_label.setWordWrap(True)
-        ipy_jedi_box = newcb(_("Use Jedi Completer in Ipython"), "ipy_jedi_completer",
-                           tip="<b>Warning</b>: This can slow down your console"
-                                "when working with large dataframes ")
+        ipy_jedi_box = newcb(_("Use Jedi completion in the IPython console"), "ipy_jedi_completer",
+                             tip="<b>Warning</b>: Slows down your console when working "
+                                "with large dataframes!<br>"
+                                "Allows completion of nested lists etc.")
         
         ipy_jedi_layout = QVBoxLayout()
         ipy_jedi_layout.addWidget(ipy_jedi_label)
@@ -496,25 +496,20 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         ipy_jedi_group.setLayout(ipy_jedi_layout)
                 
         # Greedy completer group
-        greedy_group = QGroupBox(_("Greedy completion in Ipython console"))
+        greedy_group = QGroupBox(_("Greedy completion"))
         greedy_label = QLabel(_("Enable <tt>Tab</tt> completion on elements "
                                 "of lists, results of function calls, etc, "
-                                "<i>without</i> assigning them to a "
-                                "variable.<br>"
-                                "For example, you can get completions on "
-                                "things like <tt>li[0].&lt;Tab&gt;</tt> or "
-                                "<tt>ins.meth().&lt;Tab&gt;</tt> <br><br>"
-                                "<b>ATTENTION:<br> Ipython's Greedy completer has "
-                                "a bug</b> that requires a leading "
-                                "<tt>&lt;Space&gt;</tt> "
-                                "for some completions to work. e.g. chane "
-                                "<tt>np.sin(np.&lt;Tab&gt;</tt> "
-                                "to <tt>np.sin(&lt;Space&gt;np.&lt;Tab&gt;</tt> "
-                                ", and completion for string filenames has "
-                                "to start with a space to work e.g.: "
-                                "' filena<tt>&lt;Tab&gt;</tt> "))
+                                "<i>without</i> assigning them to a variable, "
+                                "like <tt>li[0].&lt;Tab&gt;</tt> or "
+                                "<tt>ins.meth().&lt;Tab&gt;</tt> <br>"
+                                "<b>Warning:</b> Due to a bug, IPython's "
+                                "greedy completer requires a leading "
+                                "<tt>&lt;Space&gt;</tt> for some completions; "
+                                "e.g.  <tt>np.sin(&lt;Space&gt;np.&lt;Tab&gt;</tt> "
+                                "works while <tt>np.sin(np.&lt;Tab&gt;</tt> "
+                                "doesn't."))
         greedy_label.setWordWrap(True)
-        greedy_box = newcb(_("Use the greedy completer"), "greedy_completer",
+        greedy_box = newcb(_("Use greedy completion in the IPython console"), "greedy_completer",
                            tip="<b>Warning</b>: It can be unsafe because the "
                                 "code is actually evaluated when you press "
                                 "<tt>Tab</tt>.")
@@ -602,7 +597,7 @@ class IPythonConsoleConfigPage(PluginConfigPage):
                                     _("Graphics"))
         tabs.addTab(self.create_tab(run_lines_group, run_file_group),
                                     _("Startup"))
-        tabs.addTab(self.create_tab(ipy_jedi_group, greedy_group , autocall_group, sympy_group,
+        tabs.addTab(self.create_tab(ipy_jedi_group, greedy_group, autocall_group, sympy_group,
                                     prompts_group), _("Advanced Settings"))
 
         vlayout = QVBoxLayout()

--- a/spyder/utils/ipython/kernelspec.py
+++ b/spyder/utils/ipython/kernelspec.py
@@ -124,7 +124,7 @@ class SpyderKernelSpec(KernelSpec):
             'SPY_RUN_FILE_O': CONF.get('ipython_console', 'startup/run_file'),
             'SPY_AUTOCALL_O': CONF.get('ipython_console', 'autocall'),
             'SPY_GREEDY_O': CONF.get('ipython_console', 'greedy_completer'),
-            'SPY_IPY_JEDI_O': CONF.get('ipython_console', 'ipy_jedi_completer'),
+            'SPY_JEDI_O': CONF.get('ipython_console', 'jedi_completer'),
             'SPY_SYMPY_O': CONF.get('ipython_console', 'symbolic_math'),
             'SPY_RUN_CYTHON': self.is_cython
         }

--- a/spyder/utils/ipython/kernelspec.py
+++ b/spyder/utils/ipython/kernelspec.py
@@ -124,6 +124,7 @@ class SpyderKernelSpec(KernelSpec):
             'SPY_RUN_FILE_O': CONF.get('ipython_console', 'startup/run_file'),
             'SPY_AUTOCALL_O': CONF.get('ipython_console', 'autocall'),
             'SPY_GREEDY_O': CONF.get('ipython_console', 'greedy_completer'),
+            'SPY_IPY_JEDI_O': CONF.get('ipython_console', 'ipy_jedi_completer'),
             'SPY_SYMPY_O': CONF.get('ipython_console', 'symbolic_math'),
             'SPY_RUN_CYTHON': self.is_cython
         }

--- a/spyder/utils/ipython/start_kernel.py
+++ b/spyder/utils/ipython/start_kernel.py
@@ -69,7 +69,7 @@ def kernel_config():
     # Until we implement Issue 1052
     spy_cfg.InteractiveShell.xmode = 'Plain'
 
-    # Jedi completer in IPpthon console
+    # Jedi completer
     jedi_o = os.environ.get('SPY_JEDI_O') == 'True'
     # - Using Jedi slow completions a lot for objects with big repr's.
     # - Jedi completions are not available in Python 2.

--- a/spyder/utils/ipython/start_kernel.py
+++ b/spyder/utils/ipython/start_kernel.py
@@ -69,7 +69,7 @@ def kernel_config():
     # Until we implement Issue 1052
     spy_cfg.InteractiveShell.xmode = 'Plain'
 
-    # Jedi completer in iypthon console
+    # Jedi completer in IPpthon console
     ipy_jedi_o = os.environ.get('SPY_IPY_JEDI_O') == 'True'
     # - Using Jedi slow completions a lot for objects with big repr's.
     # - Jedi completions are not available in Python 2.

--- a/spyder/utils/ipython/start_kernel.py
+++ b/spyder/utils/ipython/start_kernel.py
@@ -69,10 +69,12 @@ def kernel_config():
     # Until we implement Issue 1052
     spy_cfg.InteractiveShell.xmode = 'Plain'
 
+    # Jedi completer in iypthon console
+    ipy_jedi_o = os.environ.get('SPY_IPY_JEDI_O') == 'True'
     # - Using Jedi slow completions a lot for objects with big repr's.
     # - Jedi completions are not available in Python 2.
     if not PY2:
-        spy_cfg.IPCompleter.use_jedi = False
+        spy_cfg.IPCompleter.use_jedi = ipy_jedi_o
 
     # Run lines of code at startup
     run_lines_o = os.environ.get('SPY_RUN_LINES_O')

--- a/spyder/utils/ipython/start_kernel.py
+++ b/spyder/utils/ipython/start_kernel.py
@@ -70,11 +70,11 @@ def kernel_config():
     spy_cfg.InteractiveShell.xmode = 'Plain'
 
     # Jedi completer in IPpthon console
-    ipy_jedi_o = os.environ.get('SPY_IPY_JEDI_O') == 'True'
+    jedi_o = os.environ.get('SPY_JEDI_O') == 'True'
     # - Using Jedi slow completions a lot for objects with big repr's.
     # - Jedi completions are not available in Python 2.
     if not PY2:
-        spy_cfg.IPCompleter.use_jedi = ipy_jedi_o
+        spy_cfg.IPCompleter.use_jedi = jedi_o
 
     # Run lines of code at startup
     run_lines_o = os.environ.get('SPY_RUN_LINES_O')


### PR DESCRIPTION
This adds an  option for Jedi Code completion in the ipython shell.

It also adds a warning text for the Greedy completer, to inform users, that the current version of the Greedy completer in ipython needs an extra space to split commands.
Related Spyder-ide issues: #6803 #6700 

Related Ipython Console Issues:
https://github.com/ipython/ipython/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+greedy+completer

![spyder_gui_jedi_update3](https://user-images.githubusercontent.com/12088794/37963737-86c1416e-31bf-11e8-9141-2aa5d5713483.png)
