### PR TITLE
PR: Improve and update wording of funding announcement, and put screenshot above it

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 [![Coverage Status](https://coveralls.io/repos/github/spyder-ide/spyder/badge.svg?branch=master)](https://coveralls.io/github/spyder-ide/spyder?branch=master)
 [![codecov](https://codecov.io/gh/spyder-ide/spyder/branch/master/graph/badge.svg)](https://codecov.io/gh/spyder-ide/spyder)
 
+![Screenshot of Spyder's main window](./img_src/screenshot.png)
+
 ----
 
 ## Important Announcement: Spyder is unfunded!
@@ -36,9 +38,6 @@ If you want to know more about this, please read this
 [page](https://github.com/spyder-ide/spyder/wiki/Anaconda-stopped-funding-Spyder).
 
 ----
-
-![Screenshot of Spyder's main window](./img_src/screenshot.png)
-
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -22,24 +22,27 @@
 
 ## Important Announcement: Spyder needs your support!
 
-Since mid November 2017, [Anaconda, Inc](https://www.anaconda.com/) has
+Since mid-November 2017, [Anaconda, Inc](https://www.anaconda.com/) has
 stopped funding Spyder development, after doing so for the past 18
 months. Therefore, without additional funds, development will shift to
-maintaining Spyder 3 at a much slower pace than before, while slowly working
+maintaining Spyder 3 at a slower pace than before, while working
 toward an eventual Spyder 4 feature release sometime in the future.
 
 However, with your contribution of effort and funding, we will be able to
-both continue to maintain Spyder 3 at a faster pace, and fund development
-of the new features you've been requesting for Spyder 4 at a greatly
-accelerated rate. There are many ways to [help with development](
+both continue to maintain Spyder 3 at a faster pace, and fund development of
+new features for Spyder 4 (such as a major overhaul to improve
+code completion, and a much-improved new debugger, both of which you've been
+requesting) at a greatly accelerated rate.
+
+There are many ways to [help with development](
 https://github.com/spyder-ide/spyder/wiki/Contributing-to-Spyder), many of
-which don't even require any programming, and if you're able to make a
+which don't require any programming, and if you're able to make a
 financial contribution to help support your favorite community IDE, you can
 donate through our [OpenCollective](https://opencollective.com/spyder).
 
 We appreciate all the help you can provide us and can't thank you enough for
-supporting the work of Spyder devs and Spyder development! If you want to learn
-more about the current situation and our future plans, please read this [page](
+supporting the work of the Spyder devs and Spyder development! To learn more
+about the current situation and our future plans, please read this [page](
 https://github.com/spyder-ide/spyder/wiki/Anaconda-stopped-funding-Spyder).
 
 ----

--- a/README.md
+++ b/README.md
@@ -20,22 +20,27 @@
 
 ----
 
-## Important Announcement: Spyder is unfunded!
+## Important Announcement: Spyder needs your support!
 
-Since mid November/2017, [Anaconda, Inc](https://www.anaconda.com/) has
-stopped funding Spyder development, after doing it for the past 18
-months. Because of that, development will focus from now on maintaining
-Spyder 3 at a much slower pace than before.
+Since mid November 2017, [Anaconda, Inc](https://www.anaconda.com/) has
+stopped funding Spyder development, after doing so for the past 18
+months. Therefore, without additional funds, development will shift to
+maintaining Spyder 3 at a much slower pace than before, while slowly working
+toward an eventual Spyder 4 feature release sometime in the future.
 
-If you want to contribute to maintain Spyder, please consider donating at
-
-https://opencollective.com/spyder
+However, with your contribution of effort and funding, we will be able to
+both continue to maintain Spyder 3 at a faster pace, and fund development
+of the new features you've been requesting for Spyder 4 at a greatly
+accelerated rate. There are many ways to [help with development](
+https://github.com/spyder-ide/spyder/wiki/Contributing-to-Spyder), many of
+which don't even require any programming, and if you're able to make a
+financial contribution  to help support your favorite community IDE, you can
+donate through our [OpenCollective](https://opencollective.com/spyder).
 
 We appreciate all the help you can provide us and can't thank you enough for
-supporting the work of Spyder devs and Spyder development.
-
-If you want to know more about this, please read this
-[page](https://github.com/spyder-ide/spyder/wiki/Anaconda-stopped-funding-Spyder).
+supporting the work of Spyder devs and Spyder development! If you want to learn
+more about the current situation and our future plans, please read this [page](
+https://github.com/spyder-ide/spyder/wiki/Anaconda-stopped-funding-Spyder).
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ of the new features you've been requesting for Spyder 4 at a greatly
 accelerated rate. There are many ways to [help with development](
 https://github.com/spyder-ide/spyder/wiki/Contributing-to-Spyder), many of
 which don't even require any programming, and if you're able to make a
-financial contribution  to help support your favorite community IDE, you can
+financial contribution to help support your favorite community IDE, you can
 donate through our [OpenCollective](https://opencollective.com/spyder).
 
 We appreciate all the help you can provide us and can't thank you enough for


### PR DESCRIPTION
As somewhat of a follow-on to #6909 except just for ``master``, this PR:

* Positions the screenshot above the funding announcement, with the rationale that it is more important to hook users' interest about the application itself first, showing them what it can do, before hitting them with a plea for funds for an application they don't yet have any compelling reason to support, and potentially scaring them into thinking it is no longer modern or actively developed.
* Improves the text of the announcement itself, including:
    * Fixes grammar errors, awkward/unidiomatic prose, and unclear portions
    * Updates the blurb to better reflect the current situation
    * Tries to give it a more optimistic and productive tone to avoid scaring potential users into thinking the project is in decline, while still conveying the need for community support, by focusing on the benefits users' help can bring to the project rather than the bad consequences if we don't get it.
    * Cleans up formatting and adds some useful embedded links.