### PR TITLE
PR: Skip tests numpy_returns and matplotlib_figure_returns for now on jedi >=0.12 and pin CIs to 0.11.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,11 +47,13 @@ install:
   - "conda install jupyter_client=5.2.2"
   # Fix problems with latest pyqt
   - "conda install pyqt=5.6*"
+  # Fix test issues with the latest jedi 0.12 for now
+  - "conda install jedi=0.11.1"
 
 build: false
 
 test_script:
   - "%CMD_IN_ENV% python runtests.py || %CMD_IN_ENV% python runtests.py || %CMD_IN_ENV% python runtests.py"
-  
+
 on_success:
   - codecov

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -36,10 +36,16 @@ if [ "$TRAVIS_PYTHON_VERSION" = "3.5" ] && [ "$USE_PYQT" = "pyqt5" ]; then
 
     # Fix connection to external kernels
     pip install jupyter-client==5.2.2
+
+    # Avoid test failures with the latest jedi 0.12 for now
+    pip install jedi==0.11.1
 else
     # Run with tornado < 5.0 to avoid hangs
     conda install tornado=4.5.3
 
     # Fix connection to external kernels
     conda install jupyter_client=5.2.2
+
+    # Avoid test failures with the latest jedi 0.12 for now
+    conda install jedi=0.11.1
 fi

--- a/spyder/utils/introspection/tests/test_jedi_plugin.py
+++ b/spyder/utils/introspection/tests/test_jedi_plugin.py
@@ -5,12 +5,13 @@
 
 """Tests for jedi_plugin.py"""
 
+import os
+import os.path as osp
 from textwrap import dedent
 
 import pytest
-import os
-import os.path as osp
 
+from spyder.utils.programs import is_module_installed
 from spyder.utils.introspection import jedi_plugin
 from spyder.utils.introspection.jedi_plugin import JEDI_010
 from spyder.utils.introspection.manager import CodeInfo
@@ -97,6 +98,8 @@ def test_default_info():
 
 @pytest.mark.skipif(not(numpy and numpydoc),
                     reason="numpy and numpydoc required")
+@pytest.mark.skipif(not is_module_installed('jedi', '<0.12.0'),
+                    reason="Fails under jedi >=0.12")
 def test_numpy_returns():
     source_code = dedent('''
     import numpy as np

--- a/spyder/utils/introspection/tests/test_jedi_plugin.py
+++ b/spyder/utils/introspection/tests/test_jedi_plugin.py
@@ -112,6 +112,8 @@ def test_numpy_returns():
 
 @pytest.mark.skipif(not(matplotlib and numpydoc),
                     reason="matplotlib required")
+@pytest.mark.skipif(not is_module_installed('jedi', '<0.12.0'),
+                    reason="Fails under jedi >=0.12")
 def test_matplotlib_fig_returns():
     source_code = dedent('''
     import matplotlib.pyplot as plt


### PR DESCRIPTION
On the newest CI builds, the jedi tests ``test_numpy_returns`` and ``test_matplotlib_figure_returns`` are failing to get completions, causing the test to fail. @ccordoba12 determined this was due to ``jedi`` 0.12, and thus we're skipping the test for now on this version and later until a more permanent fix can be devised.