### PR TITLE
PR: Adapt sphinxify for changes in Sphinx 1.8

### DIFF
--- a/spyder/utils/help/sphinxify.py
+++ b/spyder/utils/help/sphinxify.py
@@ -166,15 +166,14 @@ def sphinxify(docstring, context, buildername='html'):
 
     srcdir = mkdtemp()
     srcdir = encoding.to_unicode_from_fs(srcdir)
+    destdir = osp.join(srcdir, '_build')
 
-    base_name = osp.join(srcdir, 'docstring')
-    rst_name = base_name + '.rst'
-
+    rst_name = osp.join(srcdir, 'docstring.rst')
     if buildername == 'html':
         suffix = '.html'
     else:
         suffix = '.txt'
-    output_name = base_name + suffix
+    output_name = osp.join(destdir, 'docstring' + suffix)
 
     # This is needed so users can type \\ on latex eqnarray envs inside raw
     # docstrings
@@ -208,7 +207,7 @@ def sphinxify(docstring, context, buildername='html'):
 
     doctreedir = osp.join(srcdir, 'doctrees')
 
-    sphinx_app = Sphinx(srcdir, confdir, srcdir, doctreedir, buildername,
+    sphinx_app = Sphinx(srcdir, confdir, destdir, doctreedir, buildername,
                         confoverrides, status=None, warning=None,
                         freshenv=True, warningiserror=False, tags=None)
     try:


### PR DESCRIPTION
In sphinx 1.8 (dev), the source and destination directory cannot be the same for a build, so `sphinxify` fails. This sets the destination directory to be a subdirectory.