### PR TITLE
PR: Load libGL using low-level function without requiring pyopengl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -291,10 +291,7 @@ install_requires = [
     'numpydoc',
     # Packages for pyqt5 are only available in
     # Python 3
-    'pyqt5<5.10;python_version>="3"',
-    # This is only needed for our wheels on Linux.
-    # See issue #3332
-    'pyopengl;platform_system=="Linux"'
+    'pyqt5<5.10;python_version>="3"'
 ]
 
 extras_require = {

--- a/spyder/app/start.py
+++ b/spyder/app/start.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Std imports
+import ctypes
 import os
 import os.path as osp
 import random
@@ -12,10 +13,10 @@ import time
 # See issue 5324
 import zmq
 
-# This import is needed to fix errors with OpenGL when installed using pip
-# See issue 3332
+# Load GL library to prevent segmentation faults on some Linux systems
+# See issues 3226 and 3332
 try:
-    from OpenGL import GL
+    ctypes.CDLL("libGL.so.1", mode=ctypes.RTLD_GLOBAL)
 except:
     pass
 


### PR DESCRIPTION
Fixes #6968.

Loading libGL at the very start fixes a segmentation fault on some Linux systems (including mine!). This uses a low-level function from cdll to load libGL instead of requiring and importing pyopengl which implicitly loads libGL (I guess). Thus, we also drop the pyopengl requirement.

See discussion at ContinuumIO/anaconda-issues#9199 (where @ccordoba12 approved this approach) and #3226.