### PR TITLE
PR: Add --safe-mode option to start with a clean config directory

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -12,6 +12,8 @@ See Issue 741
 """
 
 # pylint: disable=C0103
+# pylint: disable=C0412
+# pylint: disable=C0413
 
 import time
 time_start = time.time()

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -176,12 +176,12 @@ if options.test:
         shutil.rmtree(conf_dir)
 
 print("04. Running Spyder")
-from spyder.app import start
+from spyder.app import start  # analysis:ignore
 
-time_lapse = time.time()-time_start
-print("Bootstrap completed in " +
-    time.strftime("%H:%M:%S.", time.gmtime(time_lapse)) +  
-    # gmtime() converts float into tuple, but loses milliseconds
-    ("%.4f" % time_lapse).split('.')[1])
+time_lapse = time.time() - time_start
+print("Bootstrap completed in "
+      + time.strftime("%H:%M:%S.", time.gmtime(time_lapse))
+      # gmtime() converts float into tuple, but loses milliseconds
+      + ("%.4f" % time_lapse).split('.')[1])
 
 start.main()

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -42,8 +42,8 @@ parser.add_option('--show-console', action='store_true', default=False,
                   "is to show the console")
 parser.add_option('--hide-console', action='store_true',
                   default=False, help="Hide parent console window (Windows only)")
-parser.add_option('--test', dest="test", action='store_true', default=False,
-                  help="Test Spyder with a clean settings dir")
+parser.add_option('--clean', dest="clean", action='store_true', default=False,
+                  help="Start Spyder with a clean settings directory")
 parser.add_option('--no-apport', action='store_true',
                   default=False, help="Disable Apport exception hook (Ubuntu)")
 parser.add_option('--debug', action='store_true',
@@ -57,9 +57,9 @@ os.environ['SPYDER_BOOTSTRAP_ARGS'] = str(sys.argv[1:])
 assert options.gui in (None, 'pyqt5', 'pyqt', 'pyside'), \
        "Invalid GUI toolkit option '%s'" % options.gui
 
-# For testing purposes
-if options.test:
-    os.environ['SPYDER_TEST'] = 'True'
+# Start Spyder with a clean configuration directory for testing purposes
+if options.clean:
+    os.environ['SPYDER_CLEAN'] = 'True'
 
 # Prepare arguments for Spyder's main script
 sys.argv = [sys.argv[0]] + args
@@ -168,8 +168,8 @@ if options.hide_console and os.name == 'nt':
     print("0x. Hiding parent console (Windows only)")
     sys.argv.append("--hide-console")  # Windows only: show parent console
 
-# Reset temporary config directory if in --test mode
-if options.test:
+# Reset temporary config directory if in --clean mode
+if options.clean:
     from spyder.config.base import get_conf_path  # analysis:ignore
     conf_dir = get_conf_path()
     if osp.isdir(conf_dir):

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -20,6 +20,7 @@ import os
 import os.path as osp
 import sys
 import optparse
+import shutil
 
 
 # --- Parse command line
@@ -164,6 +165,13 @@ if options.show_console:
 if options.hide_console and os.name == 'nt':
     print("0x. Hiding parent console (Windows only)")
     sys.argv.append("--hide-console")  # Windows only: show parent console
+
+# Reset temporary config directory if in --test mode
+if options.test:
+    from spyder.config.base import get_conf_path  # analysis:ignore
+    conf_dir = get_conf_path()
+    if osp.isdir(conf_dir):
+        shutil.rmtree(conf_dir)
 
 print("04. Running Spyder")
 from spyder.app import start

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -42,8 +42,9 @@ parser.add_option('--show-console', action='store_true', default=False,
                   "is to show the console")
 parser.add_option('--hide-console', action='store_true',
                   default=False, help="Hide parent console window (Windows only)")
-parser.add_option('--clean', dest="clean", action='store_true', default=False,
-                  help="Start Spyder with a clean settings directory")
+parser.add_option('--safe-mode', dest="safe_mode",
+                  action='store_true', default=False,
+                  help="Start Spyder with a clean configuration directory")
 parser.add_option('--no-apport', action='store_true',
                   default=False, help="Disable Apport exception hook (Ubuntu)")
 parser.add_option('--debug', action='store_true',
@@ -58,8 +59,8 @@ assert options.gui in (None, 'pyqt5', 'pyqt', 'pyside'), \
        "Invalid GUI toolkit option '%s'" % options.gui
 
 # Start Spyder with a clean configuration directory for testing purposes
-if options.clean:
-    os.environ['SPYDER_CLEAN'] = 'True'
+if options.safe_mode:
+    os.environ['SPYDER_SAFE_MODE'] = 'True'
 
 # Prepare arguments for Spyder's main script
 sys.argv = [sys.argv[0]] + args
@@ -168,8 +169,8 @@ if options.hide_console and os.name == 'nt':
     print("0x. Hiding parent console (Windows only)")
     sys.argv.append("--hide-console")  # Windows only: show parent console
 
-# Reset temporary config directory if in --clean mode
-if options.clean:
+# Reset temporary config directory if starting in --safe-mode
+if options.safe_mode:
     from spyder.config.base import get_conf_path  # analysis:ignore
     conf_dir = get_conf_path()
     if osp.isdir(conf_dir):

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -170,7 +170,7 @@ if options.hide_console and os.name == 'nt':
     sys.argv.append("--hide-console")  # Windows only: show parent console
 
 # Reset temporary config directory if starting in --safe-mode
-if options.safe_mode:
+if options.safe_mode or os.environ.get('SPYDER_SAFE_MODE'):
     from spyder.config.base import get_conf_path  # analysis:ignore
     conf_dir = get_conf_path()
     if osp.isdir(conf_dir):

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -124,7 +124,7 @@ def get_home_dir():
 def get_conf_path(filename=None):
     """Return absolute path for configuration file with specified filename"""
     # Define conf_dir
-    if running_under_pytest():
+    if running_under_pytest() or TEST:
         import py
         from _pytest.tmpdir import get_user
         conf_dir = osp.join(str(py.path.local.get_temproot()),
@@ -144,7 +144,7 @@ def get_conf_path(filename=None):
 
     # Create conf_dir
     if not osp.isdir(conf_dir):
-        if running_under_pytest():
+        if running_under_pytest() or TEST:
             os.makedirs(conf_dir)
         else:
             os.mkdir(conf_dir)
@@ -152,7 +152,7 @@ def get_conf_path(filename=None):
         return conf_dir
     else:
         return osp.join(conf_dir, filename)
-        
+
 
 def get_module_path(modname):
     """Return module *modname* base path"""

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -34,9 +34,9 @@ from spyder.py3compat import (is_unicode, TEXT_TYPES, INT_TYPES, PY3,
 # SPYDER_DEV is (and *only* has to be) set in bootstrap.py
 DEV = os.environ.get('SPYDER_DEV')
 
-# For testing purposes
-# SPYDER_TEST can be set using the --test option of bootstrap.py
-TEST = os.environ.get('SPYDER_TEST')
+# Make Spyder use a temp clean configuration directory for testing purposes
+# SPYDER_CLEAN can be set using the --clean option of bootstrap.py
+CLEAN = os.environ.get('SPYDER_CLEAN')
 
 
 def running_under_pytest():
@@ -124,7 +124,7 @@ def get_home_dir():
 def get_conf_path(filename=None):
     """Return absolute path to the config file with the specified filename."""
     # Define conf_dir
-    if running_under_pytest() or TEST:
+    if running_under_pytest() or CLEAN:
         # Use clean config dir if running tests or the user requests it.
         import getpass  # analysis:ignore
         if sys.platform.startswith("win"):
@@ -149,7 +149,7 @@ def get_conf_path(filename=None):
 
     # Create conf_dir
     if not osp.isdir(conf_dir):
-        if running_under_pytest() or TEST:
+        if running_under_pytest() or CLEAN:
             os.makedirs(conf_dir)
         else:
             os.mkdir(conf_dir)

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -20,6 +20,8 @@ import os.path as osp
 import os
 import shutil
 import sys
+import getpass
+import tempfile
 
 # Local imports
 from spyder.utils import encoding
@@ -121,20 +123,27 @@ def get_home_dir():
         raise RuntimeError('Please define environment variable $HOME')
 
 
+def get_clean_conf_dir():
+    """
+    Return the path to a temp clean configuration dir, for tests and safe mode.
+    """
+    if sys.platform.startswith("win"):
+        current_user = ''
+    else:
+        current_user = '-' + str(getpass.getuser())
+
+    conf_dir = osp.join(str(tempfile.gettempdir()),
+                        'pytest-spyder{0!s}'.format(current_user),
+                        SUBFOLDER)
+    return conf_dir
+
+
 def get_conf_path(filename=None):
     """Return absolute path to the config file with the specified filename."""
     # Define conf_dir
     if running_under_pytest() or SAFE_MODE:
         # Use clean config dir if running tests or the user requests it.
-        import getpass  # analysis:ignore
-        if sys.platform.startswith("win"):
-            current_user = ''
-        else:
-            current_user = '-' + str(getpass.getuser())
-        import tempfile  # analysis:ignore
-        conf_dir = osp.join(str(tempfile.gettempdir()),
-                            'pytest-spyder{0!s}'.format(current_user),
-                            SUBFOLDER)
+        conf_dir = get_clean_conf_dir()
     elif sys.platform.startswith('linux'):
         # This makes us follow the XDG standard to save our settings
         # on Linux, as it was requested on Issue 2629

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -155,8 +155,8 @@ def get_conf_path(filename=None):
             os.mkdir(conf_dir)
     if filename is None:
         return conf_dir
-
-    return osp.join(conf_dir, filename)
+    else:
+        return osp.join(conf_dir, filename)
 
 
 def get_module_path(modname):

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -35,8 +35,8 @@ from spyder.py3compat import (is_unicode, TEXT_TYPES, INT_TYPES, PY3,
 DEV = os.environ.get('SPYDER_DEV')
 
 # Make Spyder use a temp clean configuration directory for testing purposes
-# SPYDER_CLEAN can be set using the --clean option of bootstrap.py
-CLEAN = os.environ.get('SPYDER_CLEAN')
+# SPYDER_SAFE_MODE can be set using the --safe-mode option of bootstrap.py
+SAFE_MODE = os.environ.get('SPYDER_SAFE_MODE')
 
 
 def running_under_pytest():
@@ -124,7 +124,7 @@ def get_home_dir():
 def get_conf_path(filename=None):
     """Return absolute path to the config file with the specified filename."""
     # Define conf_dir
-    if running_under_pytest() or CLEAN:
+    if running_under_pytest() or SAFE_MODE:
         # Use clean config dir if running tests or the user requests it.
         import getpass  # analysis:ignore
         if sys.platform.startswith("win"):
@@ -149,7 +149,7 @@ def get_conf_path(filename=None):
 
     # Create conf_dir
     if not osp.isdir(conf_dir):
-        if running_under_pytest() or CLEAN:
+        if running_under_pytest() or SAFE_MODE:
             os.makedirs(conf_dir)
         else:
             os.mkdir(conf_dir)

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -150,8 +150,8 @@ def get_conf_path(filename=None):
             os.mkdir(conf_dir)
     if filename is None:
         return conf_dir
-    else:
-        return osp.join(conf_dir, filename)
+
+    return osp.join(conf_dir, filename)
 
 
 def get_module_path(modname):

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -122,13 +122,18 @@ def get_home_dir():
 
 
 def get_conf_path(filename=None):
-    """Return absolute path for configuration file with specified filename"""
+    """Return absolute path to the config file with the specified filename."""
     # Define conf_dir
     if running_under_pytest() or TEST:
-        import py
-        from _pytest.tmpdir import get_user
-        conf_dir = osp.join(str(py.path.local.get_temproot()),
-                            'pytest-of-{}'.format(get_user()),
+        # Use clean config dir if running tests or the user requests it.
+        import getpass  # analysis:ignore
+        if sys.platform.startswith("win"):
+            current_user = ''
+        else:
+            current_user = '-' + str(getpass.getuser())
+        import tempfile  # analysis:ignore
+        conf_dir = osp.join(str(tempfile.gettempdir()),
+                            'pytest-spyder{0!s}'.format(current_user),
                             SUBFOLDER)
     elif sys.platform.startswith('linux'):
         # This makes us follow the XDG standard to save our settings

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -12,8 +12,8 @@ quickly load a user config file
 """
 
 import os
-import sys
 import os.path as osp
+import sys
 
 # Local import
 from spyder.config.base import (CHECK_ALL, EXCLUDED_NAMES, get_home_dir,
@@ -24,9 +24,9 @@ from spyder.config.utils import IMPORT_EXT
 from spyder.utils import codeanalysis
 
 
-#==============================================================================
+# =============================================================================
 # Main constants
-#==============================================================================
+# =============================================================================
 # Find in files exclude patterns
 EXCLUDE_PATTERNS = [r'\.pyc$|\.pyo$|\.git']
 
@@ -629,9 +629,9 @@ DEFAULTS = [
             ]
 
 
-#==============================================================================
+# =============================================================================
 # Config instance
-#==============================================================================
+# =============================================================================
 # IMPORTANT NOTES:
 # 1. If you want to *change* the default value of a current option, you need to
 #    do a MINOR update in config version, e.g. from 3.0.0 to 3.1.0
@@ -646,7 +646,7 @@ try:
     CONF = UserConfig('spyder', defaults=DEFAULTS, load=True,
                       version=CONF_VERSION, subfolder=SUBFOLDER, backup=True,
                       raw_mode=True)
-except:
+except Exception:
     CONF = UserConfig('spyder', defaults=DEFAULTS, load=False,
                       version=CONF_VERSION, subfolder=SUBFOLDER, backup=True,
                       raw_mode=True)

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -17,7 +17,7 @@ import os.path as osp
 
 # Local import
 from spyder.config.base import (CHECK_ALL, EXCLUDED_NAMES, get_home_dir,
-                                SUBFOLDER, TEST)
+                                SUBFOLDER)
 from spyder.config.fonts import BIG, MEDIUM, MONOSPACE, SANS_SERIF
 from spyder.config.user import UserConfig
 from spyder.config.utils import IMPORT_EXT
@@ -643,7 +643,7 @@ CONF_VERSION = '43.1.0'
 
 # Main configuration instance
 try:
-    CONF = UserConfig('spyder', defaults=DEFAULTS, load=(not TEST),
+    CONF = UserConfig('spyder', defaults=DEFAULTS, load=True,
                       version=CONF_VERSION, subfolder=SUBFOLDER, backup=True,
                       raw_mode=True)
 except:

--- a/spyder/config/user.py
+++ b/spyder/config/user.py
@@ -15,8 +15,8 @@ from __future__ import print_function
 # Std imports
 import ast
 import os
-import re
 import os.path as osp
+import re
 import shutil
 import time
 
@@ -106,10 +106,10 @@ class DefaultsConfig(cp.ConfigParser):
                 with open(fname, 'w', encoding='utf-8') as configfile:
                     self.write(configfile)
 
-        try: # the "easy" way
+        try:  # the "easy" way
             _write_file(fname)
         except IOError:
-            try: # the "delete and sleep" way
+            try:  # the "delete and sleep" way
                 if osp.isfile(fname):
                     os.remove(fname)
                 time.sleep(0.05)

--- a/spyder/config/user.py
+++ b/spyder/config/user.py
@@ -22,7 +22,7 @@ import time
 
 # Local imports
 from spyder.config.base import (get_conf_path, get_home_dir,
-                                get_module_source_path, TEST)
+                                get_module_source_path)
 from spyder.utils.programs import check_version
 from spyder.py3compat import configparser as cp
 from spyder.py3compat import PY2, is_text_string, to_text_string
@@ -92,10 +92,6 @@ class DefaultsConfig(cp.ConfigParser):
         """
         Save config into the associated .ini file
         """
-        # Don't save settings if we are on testing mode
-        if TEST:
-            return
-
         # See Issue 1086 and 1242 for background on why this
         # method contains all the exception handling.
         fname = self.filename()


### PR DESCRIPTION
<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] ~~Wrote at least one-line docstrings for any new functions~~
* [x] ~~Added at least one unit test covering the changes, if at all possible~~
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] ~~Included a screenshot, if this PR makes any visible changes to the UI~~


## Description of Changes

<!--- Describe what you've changed and why. --->

Thanks to @bcolsen for his detailed report leading to this PR.

Currently, passing the ``--test`` flag to ``bootstrap.py`` just sets the ``SPYDER_TEST`` env variable which instead tells spyder to not load and save the user's individual settings file, e.g. ``spyder.ini``, while not affecting handling of anything else inside for ``spyder-py3`` directory, including the history logs for the normal and internal consoles, along with your pylint, profiler, working dir, help, and online help histories, your language and ``rope`` settings, any third party plugins you may have installed, and your default ``temp.py`` and ``template.py`` (new file template) files. Obviously, this is not particularly desirable for most testing scenarios—one would want "clean" to be truly "clean", without such cruft. 

Therefore, this PR just makes ``--test`` set the Spyder config dir to a clean temp one, just like ``SPYDER_PYTEST`` currently does. It also makes sure to clean the current temp directory if one exists, removes the old, unnecessary code to just load a clean config file, and does some minor cleanup immediately around changed lines.

It seems its not really possible to include a unit test for this as the Pytest suite already does this anyway, and has other checks for it, if its otherwise even really possible to test for.

### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #7112


<!--- Thanks for your help making Spyder better for everyone! --->
