### PR TITLE
PR: Change behavior of Variable Explorer editor buttons

### DIFF
--- a/spyder/widgets/variableexplorer/arrayeditor.py
+++ b/spyder/widgets/variableexplorer/arrayeditor.py
@@ -606,6 +606,8 @@ class ArrayEditor(QDialog):
         self.arraywidget = None
         self.stack = None
         self.layout = None
+        self.btn_apply = None
+        self.btn_ok = None
         # Values for 3d array editor
         self.dim_indexes = [{}, {}, {}]
         self.last_dim = 0  # Adjust this for changing the startup dimension
@@ -727,12 +729,14 @@ class ArrayEditor(QDialog):
                                    "to masked array won't be reflected in "\
                                    "array's data (and vice-versa)."))
                 btn_layout.addWidget(label)
-            btn_layout.addStretch()
 
-        self.btn_apply = QPushButton(_('Apply'))
-        self.btn_apply.setDisabled(True)
-        self.btn_apply.clicked.connect(self.accept)
-        btn_layout.addWidget(self.btn_apply)
+        btn_layout.addStretch()
+
+        if not readonly:
+            self.btn_apply = QPushButton(_('Apply'))
+            self.btn_apply.setDisabled(True)
+            self.btn_apply.clicked.connect(self.accept)
+            btn_layout.addWidget(self.btn_apply)
 
         self.btn_ok = QPushButton(_('OK'))
         self.btn_ok.setAutoDefault(True)
@@ -750,9 +754,10 @@ class ArrayEditor(QDialog):
 
     def apply_enable(self):
         """Handle the data change event to enable the apply button."""
-        self.btn_apply.setEnabled(True)
-        self.btn_apply.setAutoDefault(True)
-        self.btn_apply.setDefault(True)
+        if self.btn_apply:
+            self.btn_apply.setEnabled(True)
+            self.btn_apply.setAutoDefault(True)
+            self.btn_apply.setDefault(True)
 
     def current_widget_changed(self, index):
         self.arraywidget = self.stack.widget(index)

--- a/spyder/widgets/variableexplorer/arrayeditor.py
+++ b/spyder/widgets/variableexplorer/arrayeditor.py
@@ -607,7 +607,7 @@ class ArrayEditor(QDialog):
         self.stack = None
         self.layout = None
         self.btn_save_and_close = None
-        self.btn_ok = None
+        self.btn_close = None
         # Values for 3d array editor
         self.dim_indexes = [{}, {}, {}]
         self.last_dim = 0  # Adjust this for changing the startup dimension
@@ -739,11 +739,11 @@ class ArrayEditor(QDialog):
             self.btn_save_and_close.clicked.connect(self.accept)
             btn_layout.addWidget(self.btn_save_and_close)
 
-        self.btn_ok = QPushButton(_('Close'))
-        self.btn_ok.setAutoDefault(True)
-        self.btn_ok.setDefault(True)
-        self.btn_ok.clicked.connect(self.reject)
-        btn_layout.addWidget(self.btn_ok)
+        self.btn_close = QPushButton(_('Close'))
+        self.btn_close.setAutoDefault(True)
+        self.btn_close.setDefault(True)
+        self.btn_close.clicked.connect(self.reject)
+        btn_layout.addWidget(self.btn_close)
         self.layout.addLayout(btn_layout, 2, 0)
 
         self.setMinimumSize(400, 300)
@@ -753,7 +753,8 @@ class ArrayEditor(QDialog):
         
         return True
 
-    def save_and_close_enable(self):
+    @Slot(QModelIndex, QModelIndex)
+    def save_and_close_enable(self, left_top, bottom_right):
         """Handle the data change event to enable the save and close button."""
         if self.btn_save_and_close:
             self.btn_save_and_close.setEnabled(True)

--- a/spyder/widgets/variableexplorer/arrayeditor.py
+++ b/spyder/widgets/variableexplorer/arrayeditor.py
@@ -524,6 +524,7 @@ class ArrayView(QTableView):
 
 
 class ArrayEditorWidget(QWidget):
+
     def __init__(self, parent, data, readonly=False,
                  xlabels=None, ylabels=None):
         QWidget.__init__(self, parent)
@@ -671,6 +672,7 @@ class ArrayEditor(QDialog):
             self.stack.addWidget(ArrayEditorWidget(self, data, readonly,
                                                    xlabels, ylabels))
         self.arraywidget = self.stack.currentWidget()
+        self.arraywidget.model.dataChanged.connect(self.apply_enable)
         self.stack.currentChanged.connect(self.current_widget_changed)
         self.layout.addWidget(self.stack, 1, 0)
 
@@ -725,10 +727,17 @@ class ArrayEditor(QDialog):
                                    "array's data (and vice-versa)."))
                 btn_layout.addWidget(label)
             btn_layout.addStretch()
-        bbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        bbox.accepted.connect(self.accept)
-        bbox.rejected.connect(self.reject)
-        btn_layout.addWidget(bbox)
+
+        self.btn_apply = QPushButton(_('Apply'))
+        self.btn_apply.setDisabled(True)
+        self.btn_apply.clicked.connect(self.accept)
+        btn_layout.addWidget(self.btn_apply)
+
+        self.btn_ok = QPushButton(_('OK'))
+        self.btn_ok.setAutoDefault(True)
+        self.btn_ok.setDefault(True)
+        self.btn_ok.clicked.connect(self.reject)
+        btn_layout.addWidget(self.btn_ok)
         self.layout.addLayout(btn_layout, 2, 0)
 
         self.setMinimumSize(400, 300)
@@ -737,9 +746,14 @@ class ArrayEditor(QDialog):
         self.setWindowFlags(Qt.Window)
         
         return True
-            
+
+    def apply_enable(self):
+        """Handle the data change event to enable the apply button."""
+        self.btn_apply.setEnabled(True)
+
     def current_widget_changed(self, index):
-        self.arraywidget = self.stack.widget(index)     
+        self.arraywidget = self.stack.widget(index)
+        self.arraywidget.model.dataChanged.connect(self.apply_enable)
             
     def change_active_widget(self, index):
         """

--- a/spyder/widgets/variableexplorer/arrayeditor.py
+++ b/spyder/widgets/variableexplorer/arrayeditor.py
@@ -738,7 +738,7 @@ class ArrayEditor(QDialog):
             self.btn_apply.clicked.connect(self.accept)
             btn_layout.addWidget(self.btn_apply)
 
-        self.btn_ok = QPushButton(_('OK'))
+        self.btn_ok = QPushButton(_('Close'))
         self.btn_ok.setAutoDefault(True)
         self.btn_ok.setDefault(True)
         self.btn_ok.clicked.connect(self.reject)

--- a/spyder/widgets/variableexplorer/arrayeditor.py
+++ b/spyder/widgets/variableexplorer/arrayeditor.py
@@ -672,7 +672,8 @@ class ArrayEditor(QDialog):
             self.stack.addWidget(ArrayEditorWidget(self, data, readonly,
                                                    xlabels, ylabels))
         self.arraywidget = self.stack.currentWidget()
-        self.arraywidget.model.dataChanged.connect(self.apply_enable)
+        if self.arraywidget:
+            self.arraywidget.model.dataChanged.connect(self.apply_enable)
         self.stack.currentChanged.connect(self.current_widget_changed)
         self.layout.addWidget(self.stack, 1, 0)
 
@@ -750,6 +751,8 @@ class ArrayEditor(QDialog):
     def apply_enable(self):
         """Handle the data change event to enable the apply button."""
         self.btn_apply.setEnabled(True)
+        self.btn_apply.setAutoDefault(True)
+        self.btn_apply.setDefault(True)
 
     def current_widget_changed(self, index):
         self.arraywidget = self.stack.widget(index)

--- a/spyder/widgets/variableexplorer/arrayeditor.py
+++ b/spyder/widgets/variableexplorer/arrayeditor.py
@@ -606,7 +606,7 @@ class ArrayEditor(QDialog):
         self.arraywidget = None
         self.stack = None
         self.layout = None
-        self.btn_apply = None
+        self.btn_save_and_close = None
         self.btn_ok = None
         # Values for 3d array editor
         self.dim_indexes = [{}, {}, {}]
@@ -675,7 +675,8 @@ class ArrayEditor(QDialog):
                                                    xlabels, ylabels))
         self.arraywidget = self.stack.currentWidget()
         if self.arraywidget:
-            self.arraywidget.model.dataChanged.connect(self.apply_enable)
+            self.arraywidget.model.dataChanged.connect(
+                                                    self.save_and_close_enable)
         self.stack.currentChanged.connect(self.current_widget_changed)
         self.layout.addWidget(self.stack, 1, 0)
 
@@ -733,10 +734,10 @@ class ArrayEditor(QDialog):
         btn_layout.addStretch()
 
         if not readonly:
-            self.btn_apply = QPushButton(_('Apply'))
-            self.btn_apply.setDisabled(True)
-            self.btn_apply.clicked.connect(self.accept)
-            btn_layout.addWidget(self.btn_apply)
+            self.btn_save_and_close = QPushButton(_('Save and Close'))
+            self.btn_save_and_close.setDisabled(True)
+            self.btn_save_and_close.clicked.connect(self.accept)
+            btn_layout.addWidget(self.btn_save_and_close)
 
         self.btn_ok = QPushButton(_('Close'))
         self.btn_ok.setAutoDefault(True)
@@ -752,16 +753,16 @@ class ArrayEditor(QDialog):
         
         return True
 
-    def apply_enable(self):
-        """Handle the data change event to enable the apply button."""
-        if self.btn_apply:
-            self.btn_apply.setEnabled(True)
-            self.btn_apply.setAutoDefault(True)
-            self.btn_apply.setDefault(True)
+    def save_and_close_enable(self):
+        """Handle the data change event to enable the save and close button."""
+        if self.btn_save_and_close:
+            self.btn_save_and_close.setEnabled(True)
+            self.btn_save_and_close.setAutoDefault(True)
+            self.btn_save_and_close.setDefault(True)
 
     def current_widget_changed(self, index):
         self.arraywidget = self.stack.widget(index)
-        self.arraywidget.model.dataChanged.connect(self.apply_enable)
+        self.arraywidget.model.dataChanged.connect(self.save_and_close_enable)
             
     def change_active_widget(self, index):
         """

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1370,7 +1370,7 @@ class CollectionsEditor(QDialog):
             self.btn_apply.clicked.connect(self.accept)
             btn_layout.addWidget(self.btn_apply)
 
-        self.btn_ok = QPushButton(_('OK'))
+        self.btn_ok = QPushButton(_('Close'))
         self.btn_ok.setAutoDefault(True)
         self.btn_ok.setDefault(True)
         self.btn_ok.clicked.connect(self.reject)

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -110,6 +110,8 @@ class ProxyObject(object):
 class ReadOnlyCollectionsModel(QAbstractTableModel):
     """CollectionsEditor Read-Only Table Model"""
 
+    sig_setting_data = Signal()
+
     def __init__(self, parent, data, title="", names=False,
                  minmax=False, dataframe_format=None, remote=False):
         QAbstractTableModel.__init__(self, parent)
@@ -176,7 +178,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
             self.rows_loaded = ROWS_TO_LOAD
         else:
             self.rows_loaded = self.total_rows
-
+        self.sig_setting_data.emit()
         self.set_size_and_type()
         self.reset()
 
@@ -358,8 +360,6 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
 
 class CollectionsModel(ReadOnlyCollectionsModel):
     """Collections Table Model"""
-
-    sig_setting_data = Signal()
 
     def set_value(self, index, value):
         """Set value"""
@@ -1325,7 +1325,7 @@ class CollectionsEditor(QDialog):
 
         self.data_copy = None
         self.widget = None
-        self.btn_apply = None
+        self.btn_save_and_close = None
         self.btn_ok = None
 
     def setup(self, data, title='', readonly=False, width=650, remote=False,
@@ -1353,9 +1353,8 @@ class CollectionsEditor(QDialog):
         self.widget = CollectionsEditorWidget(self, self.data_copy,
                                               title=title, readonly=readonly,
                                               remote=remote)
-        if not readonly:
-            self.widget.editor.model.sig_setting_data.connect(
-                                                            self.apply_enable)
+        self.widget.editor.model.sig_setting_data.connect(
+                                                    self.save_and_close_enable)
         layout = QVBoxLayout()
         layout.addWidget(self.widget)
         self.setLayout(layout)
@@ -1365,10 +1364,10 @@ class CollectionsEditor(QDialog):
         btn_layout.addStretch()
 
         if not readonly:
-            self.btn_apply = QPushButton(_('Apply'))
-            self.btn_apply.setDisabled(True)
-            self.btn_apply.clicked.connect(self.accept)
-            btn_layout.addWidget(self.btn_apply)
+            self.btn_save_and_close = QPushButton(_('Save and Close'))
+            self.btn_save_and_close.setDisabled(True)
+            self.btn_save_and_close.clicked.connect(self.accept)
+            btn_layout.addWidget(self.btn_save_and_close)
 
         self.btn_ok = QPushButton(_('Close'))
         self.btn_ok.setAutoDefault(True)
@@ -1390,12 +1389,12 @@ class CollectionsEditor(QDialog):
         # Make the dialog act as a window
         self.setWindowFlags(Qt.Window)
 
-    def apply_enable(self):
-        """Handle the data change event to enable the apply button."""
-        if self.btn_apply:
-            self.btn_apply.setEnabled(True)
-            self.btn_apply.setAutoDefault(True)
-            self.btn_apply.setDefault(True)
+    def save_and_close_enable(self):
+        """Handle the data change event to enable the save and close button."""
+        if self.btn_save_and_close:
+            self.btn_save_and_close.setEnabled(True)
+            self.btn_save_and_close.setAutoDefault(True)
+            self.btn_save_and_close.setDefault(True)
 
     def get_value(self):
         """Return modified copy of dictionary or list"""

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -33,7 +33,7 @@ from qtpy.QtGui import QColor, QKeySequence
 from qtpy.QtWidgets import (QAbstractItemDelegate, QApplication, QDateEdit,
                             QDateTimeEdit, QDialog, QHBoxLayout,
                             QInputDialog, QItemDelegate, QLineEdit, QMenu,
-                            QMessageBox, QPushButton,QTableView,
+                            QMessageBox, QPushButton, QTableView,
                             QVBoxLayout, QWidget)
 
 # Local imports
@@ -177,7 +177,6 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
         else:
             self.rows_loaded = self.total_rows
 
-        self.sig_setting_data.emit()
         self.set_size_and_type()
         self.reset()
 
@@ -1326,6 +1325,8 @@ class CollectionsEditor(QDialog):
 
         self.data_copy = None
         self.widget = None
+        self.btn_apply = None
+        self.btn_ok = None
 
     def setup(self, data, title='', readonly=False, width=650, remote=False,
               icon=None, parent=None):
@@ -1352,13 +1353,16 @@ class CollectionsEditor(QDialog):
         self.widget = CollectionsEditorWidget(self, self.data_copy,
                                               title=title, readonly=readonly,
                                               remote=remote)
-        self.widget.editor.model.sig_setting_data.connect(self.apply_enable)
+        if not readonly:
+            self.widget.editor.model.sig_setting_data.connect(
+                                                            self.apply_enable)
         layout = QVBoxLayout()
         layout.addWidget(self.widget)
         self.setLayout(layout)
 
         # Buttons configuration
         btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
 
         if not readonly:
             self.btn_apply = QPushButton(_('Apply'))
@@ -1388,9 +1392,10 @@ class CollectionsEditor(QDialog):
 
     def apply_enable(self):
         """Handle the data change event to enable the apply button."""
-        self.btn_apply.setEnabled(True)
-        self.btn_apply.setAutoDefault(True)
-        self.btn_apply.setDefault(True)
+        if self.btn_apply:
+            self.btn_apply.setEnabled(True)
+            self.btn_apply.setAutoDefault(True)
+            self.btn_apply.setDefault(True)
 
     def get_value(self):
         """Return modified copy of dictionary or list"""

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1326,7 +1326,7 @@ class CollectionsEditor(QDialog):
         self.data_copy = None
         self.widget = None
         self.btn_save_and_close = None
-        self.btn_ok = None
+        self.btn_close = None
 
     def setup(self, data, title='', readonly=False, width=650, remote=False,
               icon=None, parent=None):
@@ -1369,11 +1369,11 @@ class CollectionsEditor(QDialog):
             self.btn_save_and_close.clicked.connect(self.accept)
             btn_layout.addWidget(self.btn_save_and_close)
 
-        self.btn_ok = QPushButton(_('Close'))
-        self.btn_ok.setAutoDefault(True)
-        self.btn_ok.setDefault(True)
-        self.btn_ok.clicked.connect(self.reject)
-        btn_layout.addWidget(self.btn_ok)
+        self.btn_close = QPushButton(_('Close'))
+        self.btn_close.setAutoDefault(True)
+        self.btn_close.setDefault(True)
+        self.btn_close.clicked.connect(self.reject)
+        btn_layout.addWidget(self.btn_close)
 
         layout.addLayout(btn_layout)
 
@@ -1389,6 +1389,7 @@ class CollectionsEditor(QDialog):
         # Make the dialog act as a window
         self.setWindowFlags(Qt.Window)
 
+    @Slot()
     def save_and_close_enable(self):
         """Handle the data change event to enable the save and close button."""
         if self.btn_save_and_close:

--- a/spyder/widgets/variableexplorer/dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/dataframeeditor.py
@@ -692,7 +692,7 @@ class DataFrameEditor(QDialog):
         self.resize(600, 500)
 
         self.dataModel = DataFrameModel(data, parent=self)
-        self.dataModel.dataChanged.connect(self.apply_enable)
+        self.dataModel.dataChanged.connect(self.save_and_close_enable)
         self.dataTable = DataFrameView(self, self.dataModel)
 
         self.layout.addWidget(self.dataTable)
@@ -725,10 +725,10 @@ class DataFrameEditor(QDialog):
 
         btn_layout.addStretch()
 
-        self.btn_apply = QPushButton(_('Apply'))
-        self.btn_apply.setDisabled(True)
-        self.btn_apply.clicked.connect(self.accept)
-        btn_layout.addWidget(self.btn_apply)
+        self.btn_save_and_close = QPushButton(_('Save and Close'))
+        self.btn_save_and_close.setDisabled(True)
+        self.btn_save_and_close.clicked.connect(self.accept)
+        btn_layout.addWidget(self.btn_save_and_close)
 
         self.btn_ok = QPushButton(_('Close'))
         self.btn_ok.setAutoDefault(True)
@@ -740,11 +740,11 @@ class DataFrameEditor(QDialog):
 
         return True
 
-    def apply_enable(self):
-        """Handle the data change event to enable the apply button."""
-        self.btn_apply.setEnabled(True)
-        self.btn_apply.setAutoDefault(True)
-        self.btn_apply.setDefault(True)
+    def save_and_close_enable(self):
+        """Handle the data change event to enable the save and close button."""
+        self.btn_save_and_close.setEnabled(True)
+        self.btn_save_and_close.setAutoDefault(True)
+        self.btn_save_and_close.setDefault(True)
 
     def change_bgcolor_enable(self, state):
         """

--- a/spyder/widgets/variableexplorer/dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/dataframeeditor.py
@@ -730,17 +730,18 @@ class DataFrameEditor(QDialog):
         self.btn_save_and_close.clicked.connect(self.accept)
         btn_layout.addWidget(self.btn_save_and_close)
 
-        self.btn_ok = QPushButton(_('Close'))
-        self.btn_ok.setAutoDefault(True)
-        self.btn_ok.setDefault(True)
-        self.btn_ok.clicked.connect(self.reject)
-        btn_layout.addWidget(self.btn_ok)
+        self.btn_close = QPushButton(_('Close'))
+        self.btn_close.setAutoDefault(True)
+        self.btn_close.setDefault(True)
+        self.btn_close.clicked.connect(self.reject)
+        btn_layout.addWidget(self.btn_close)
 
         self.layout.addLayout(btn_layout, 2, 0)
 
         return True
 
-    def save_and_close_enable(self):
+    @Slot(QModelIndex, QModelIndex)
+    def save_and_close_enable(self, top_left, bottom_right):
         """Handle the data change event to enable the save and close button."""
         self.btn_save_and_close.setEnabled(True)
         self.btn_save_and_close.setAutoDefault(True)

--- a/spyder/widgets/variableexplorer/dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/dataframeeditor.py
@@ -743,6 +743,8 @@ class DataFrameEditor(QDialog):
     def apply_enable(self):
         """Handle the data change event to enable the apply button."""
         self.btn_apply.setEnabled(True)
+        self.btn_apply.setAutoDefault(True)
+        self.btn_apply.setDefault(True)
 
     def change_bgcolor_enable(self, state):
         """

--- a/spyder/widgets/variableexplorer/dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/dataframeeditor.py
@@ -382,6 +382,7 @@ class DataFrameModel(QAbstractTableModel):
                                      .format(type(current_value).__name__))
                 return False
         self.max_min_col_update()
+        self.dataChanged.emit(index, index)
         return True
 
     def get_data(self):
@@ -691,6 +692,7 @@ class DataFrameEditor(QDialog):
         self.resize(600, 500)
 
         self.dataModel = DataFrameModel(data, parent=self)
+        self.dataModel.dataChanged.connect(self.apply_enable)
         self.dataTable = DataFrameView(self, self.dataModel)
 
         self.layout.addWidget(self.dataTable)
@@ -722,14 +724,25 @@ class DataFrameEditor(QDialog):
         btn_layout.addWidget(self.bgcolor_global)
 
         btn_layout.addStretch()
-        bbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        bbox.accepted.connect(self.accept)
-        bbox.rejected.connect(self.reject)
-        btn_layout.addWidget(bbox)
+
+        self.btn_apply = QPushButton(_('Apply'))
+        self.btn_apply.setDisabled(True)
+        self.btn_apply.clicked.connect(self.accept)
+        btn_layout.addWidget(self.btn_apply)
+
+        self.btn_ok = QPushButton(_('OK'))
+        self.btn_ok.setAutoDefault(True)
+        self.btn_ok.setDefault(True)
+        self.btn_ok.clicked.connect(self.reject)
+        btn_layout.addWidget(self.btn_ok)
 
         self.layout.addLayout(btn_layout, 2, 0)
 
         return True
+
+    def apply_enable(self):
+        """Handle the data change event to enable the apply button."""
+        self.btn_apply.setEnabled(True)
 
     def change_bgcolor_enable(self, state):
         """

--- a/spyder/widgets/variableexplorer/dataframeeditor.py
+++ b/spyder/widgets/variableexplorer/dataframeeditor.py
@@ -730,7 +730,7 @@ class DataFrameEditor(QDialog):
         self.btn_apply.clicked.connect(self.accept)
         btn_layout.addWidget(self.btn_apply)
 
-        self.btn_ok = QPushButton(_('OK'))
+        self.btn_ok = QPushButton(_('Close'))
         self.btn_ok.setAutoDefault(True)
         self.btn_ok.setDefault(True)
         self.btn_ok.clicked.connect(self.reject)

--- a/spyder/widgets/variableexplorer/texteditor.py
+++ b/spyder/widgets/variableexplorer/texteditor.py
@@ -37,7 +37,7 @@ class TextEditor(QDialog):
         self.setAttribute(Qt.WA_DeleteOnClose)
         
         self.text = None
-        self.btn_apply = None
+        self.btn_save_and_close = None
         
         # Display text as unicode if it comes as bytes, so users see 
         # its right representation
@@ -64,10 +64,10 @@ class TextEditor(QDialog):
         btn_layout = QHBoxLayout()
         btn_layout.addStretch()
         if not readonly:
-            self.btn_apply = QPushButton(_('Apply'))
-            self.btn_apply.setDisabled(True)
-            self.btn_apply.clicked.connect(self.accept)
-            btn_layout.addWidget(self.btn_apply)
+            self.btn_save_and_close = QPushButton(_('Save and Close'))
+            self.btn_save_and_close.setDisabled(True)
+            self.btn_save_and_close.clicked.connect(self.accept)
+            btn_layout.addWidget(self.btn_save_and_close)
 
         self.btn_ok = QPushButton(_('Close'))
         self.btn_ok.setAutoDefault(True)
@@ -92,10 +92,10 @@ class TextEditor(QDialog):
             self.text = to_binary_string(self.edit.toPlainText(), 'utf8')
         else:
             self.text = to_text_string(self.edit.toPlainText())
-        if self.btn_apply:
-            self.btn_apply.setEnabled(True)
-            self.btn_apply.setAutoDefault(True)
-            self.btn_apply.setDefault(True)
+        if self.btn_save_and_close:
+            self.btn_save_and_close.setEnabled(True)
+            self.btn_save_and_close.setAutoDefault(True)
+            self.btn_save_and_close.setDefault(True)
 
     def get_value(self):
         """Return modified text"""

--- a/spyder/widgets/variableexplorer/texteditor.py
+++ b/spyder/widgets/variableexplorer/texteditor.py
@@ -126,8 +126,6 @@ dedekdh elkd ezd ekjd lekdj elkdfjelfjk e"""
     dialog.exec_()
 
     dlg_text = dialog.get_value()
-    print(text)
-    print(dlg_text)
     assert text == dlg_text
 
 

--- a/spyder/widgets/variableexplorer/texteditor.py
+++ b/spyder/widgets/variableexplorer/texteditor.py
@@ -12,7 +12,7 @@ Text editor dialog
 from __future__ import print_function
 
 # Third party imports
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import (QDialog, QHBoxLayout, QPushButton, QTextEdit,
                             QVBoxLayout)
 
@@ -69,11 +69,11 @@ class TextEditor(QDialog):
             self.btn_save_and_close.clicked.connect(self.accept)
             btn_layout.addWidget(self.btn_save_and_close)
 
-        self.btn_ok = QPushButton(_('Close'))
-        self.btn_ok.setAutoDefault(True)
-        self.btn_ok.setDefault(True)
-        self.btn_ok.clicked.connect(self.reject)
-        btn_layout.addWidget(self.btn_ok)
+        self.btn_close = QPushButton(_('Close'))
+        self.btn_close.setAutoDefault(True)
+        self.btn_close.setDefault(True)
+        self.btn_close.clicked.connect(self.reject)
+        btn_layout.addWidget(self.btn_close)
 
         self.layout.addLayout(btn_layout)
 
@@ -84,7 +84,8 @@ class TextEditor(QDialog):
         self.setWindowTitle(_("Text editor") + \
                             "%s" % (" - "+str(title) if str(title) else ""))
         self.resize(size[0], size[1])
-    
+
+    @Slot()
     def text_changed(self):
         """Text has changed"""
         # Save text as bytes, if it was initially bytes

--- a/spyder/widgets/variableexplorer/texteditor.py
+++ b/spyder/widgets/variableexplorer/texteditor.py
@@ -60,7 +60,7 @@ class TextEditor(QDialog):
 
         # Buttons configuration
         btn_layout = QHBoxLayout()
-
+        btn_layout.addStretch()
         if not readonly:
             self.btn_apply = QPushButton(_('Apply'))
             self.btn_apply.setDisabled(True)

--- a/spyder/widgets/variableexplorer/texteditor.py
+++ b/spyder/widgets/variableexplorer/texteditor.py
@@ -13,7 +13,8 @@ from __future__ import print_function
 
 # Third party imports
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QDialog, QDialogButtonBox, QTextEdit, QVBoxLayout
+from qtpy.QtWidgets import (QDialog, QHBoxLayout, QPushButton, QTextEdit,
+                            QVBoxLayout)
 
 # Local import
 from spyder.config.base import _
@@ -50,7 +51,6 @@ class TextEditor(QDialog):
 
         # Text edit
         self.edit = QTextEdit(parent)
-        self.edit.textChanged.connect(self.text_changed)
         self.edit.setReadOnly(readonly)
         self.edit.setPlainText(text)
         if font is None:
@@ -59,20 +59,29 @@ class TextEditor(QDialog):
         self.layout.addWidget(self.edit)
 
         # Buttons configuration
-        buttons = QDialogButtonBox.Ok
+        btn_layout = QHBoxLayout()
+
         if not readonly:
-            buttons = buttons | QDialogButtonBox.Cancel
-        bbox = QDialogButtonBox(buttons)
-        bbox.accepted.connect(self.accept)
-        bbox.rejected.connect(self.reject)
-        self.layout.addWidget(bbox)
-        
+            self.btn_apply = QPushButton(_('Apply'))
+            self.btn_apply.setDisabled(True)
+            self.btn_apply.clicked.connect(self.accept)
+            btn_layout.addWidget(self.btn_apply)
+
+        self.btn_ok = QPushButton(_('OK'))
+        self.btn_ok.setAutoDefault(True)
+        self.btn_ok.setDefault(True)
+        self.btn_ok.clicked.connect(self.reject)
+        btn_layout.addWidget(self.btn_ok)
+
+        self.layout.addLayout(btn_layout)
+
         # Make the dialog act as a window
         self.setWindowFlags(Qt.Window)
         
         self.setWindowIcon(ima.icon('edit'))
         self.setWindowTitle(_("Text editor") + \
                             "%s" % (" - "+str(title) if str(title) else ""))
+        self.edit.textChanged.connect(self.text_changed)
         self.resize(size[0], size[1])
     
     def text_changed(self):
@@ -82,7 +91,10 @@ class TextEditor(QDialog):
             self.text = to_binary_string(self.edit.toPlainText(), 'utf8')
         else:
             self.text = to_text_string(self.edit.toPlainText())
-        
+        self.btn_apply.setEnabled(True)
+        self.btn_apply.setAutoDefault(True)
+        self.btn_apply.setDefault(True)
+
     def get_value(self):
         """Return modified text"""
         # It is import to avoid accessing Qt C++ object as it has probably

--- a/spyder/widgets/variableexplorer/texteditor.py
+++ b/spyder/widgets/variableexplorer/texteditor.py
@@ -37,6 +37,7 @@ class TextEditor(QDialog):
         self.setAttribute(Qt.WA_DeleteOnClose)
         
         self.text = None
+        self.btn_apply = None
         
         # Display text as unicode if it comes as bytes, so users see 
         # its right representation
@@ -52,6 +53,7 @@ class TextEditor(QDialog):
         # Text edit
         self.edit = QTextEdit(parent)
         self.edit.setReadOnly(readonly)
+        self.edit.textChanged.connect(self.text_changed)
         self.edit.setPlainText(text)
         if font is None:
             font = get_font()
@@ -67,7 +69,7 @@ class TextEditor(QDialog):
             self.btn_apply.clicked.connect(self.accept)
             btn_layout.addWidget(self.btn_apply)
 
-        self.btn_ok = QPushButton(_('OK'))
+        self.btn_ok = QPushButton(_('Close'))
         self.btn_ok.setAutoDefault(True)
         self.btn_ok.setDefault(True)
         self.btn_ok.clicked.connect(self.reject)
@@ -81,7 +83,6 @@ class TextEditor(QDialog):
         self.setWindowIcon(ima.icon('edit'))
         self.setWindowTitle(_("Text editor") + \
                             "%s" % (" - "+str(title) if str(title) else ""))
-        self.edit.textChanged.connect(self.text_changed)
         self.resize(size[0], size[1])
     
     def text_changed(self):
@@ -91,9 +92,10 @@ class TextEditor(QDialog):
             self.text = to_binary_string(self.edit.toPlainText(), 'utf8')
         else:
             self.text = to_text_string(self.edit.toPlainText())
-        self.btn_apply.setEnabled(True)
-        self.btn_apply.setAutoDefault(True)
-        self.btn_apply.setDefault(True)
+        if self.btn_apply:
+            self.btn_apply.setEnabled(True)
+            self.btn_apply.setAutoDefault(True)
+            self.btn_apply.setDefault(True)
 
     def get_value(self):
         """Return modified text"""
@@ -124,6 +126,8 @@ dedekdh elkd ezd ekjd lekdj elkdfjelfjk e"""
     dialog.exec_()
 
     dlg_text = dialog.get_value()
+    print(text)
+    print(dlg_text)
     assert text == dlg_text
 
 


### PR DESCRIPTION
<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings for any new functions
* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] Included a screenshot, if this PR makes any visible changes to the UI


## Description of Changes

<!--- Describe what you've changed and why. --->

Change behavior of default `OK` and `Cancel` buttons. Now `OK` is `Save and close` (disabled by default) and `Cancel` is the `Close` button.

### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #7156 


<!--- Thanks for your help making Spyder better for everyone! --->
