### PR TITLE
PR: Limit length of serialized values in Variable Explorer when applying modifications

### DIFF
--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -303,9 +303,10 @@ class NamespaceBrowser(QWidget):
                 self.shellwidget.set_value(name, svalue)
             else:
                 QMessageBox.warning(self, _("Warning"),
-                                    _("For performance reasons is not "
-                                      "possible to save the changes "
-                                      "made to the variable"))
+                                    _("The object you are trying to modify is "
+                                      "too big to be sent back to the kernel. "
+                                      "Therefore, your modifications won't "
+                                      "take place."))
         except TypeError as e:
             QMessageBox.critical(self, _("Error"),
                                  "TypeError: %s" % to_text_string(e))


### PR DESCRIPTION
<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings for any new functions
* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] Included a screenshot, if this PR makes any visible changes to the UI


## Description of Changes

<!--- Describe what you've changed and why. --->

Add a validation of the length of the serialized values send to the kernel in the Variable Explorer.


### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #7158


<!--- Thanks for your help making Spyder better for everyone! --->
