### PR TITLE
PR: Improve pythonw detection

### DIFF
--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -20,6 +20,7 @@ import sys
 import tempfile
 
 # Local imports
+from spyder.config.utils import is_anaconda
 from spyder.utils import encoding
 from spyder.utils.misc import get_python_executable
 from spyder.py3compat import PY2, is_text_string, to_text_string
@@ -475,11 +476,31 @@ def is_python_interpreter_valid_name(filename):
 def is_python_interpreter(filename):
     """Evaluate wether a file is a python interpreter or not."""
     real_filename = os.path.realpath(filename)  # To follow symlink if existent
-    if (not osp.isfile(real_filename) or encoding.is_text_file(real_filename)
-        or not is_python_interpreter_valid_name(filename)):
+    if (not osp.isfile(real_filename) or 
+        not is_python_interpreter_valid_name(filename)):
         return False
     elif is_pythonw(filename):
-        return True
+        if os.name == 'nt':
+            # pythonw is a binary on Windows
+            if not encoding.is_text_file(real_filename):
+                return True
+            else:
+                return False
+        elif sys.platform == 'darwin':
+            # pythonw is a text file in Anaconda but a binary in
+            # the system
+            if is_anaconda() and encoding.is_text_file(real_filename):
+                return True
+            elif not encoding.is_text_file(real_filename):
+                return True
+            else:
+                return False
+        else:
+            # There's no pythonw in other systems
+            return False
+    elif encoding.is_text_file(real_filename):
+        # At this point we can't have a text file
+        return False
     else:
         return check_python_help(filename)
 

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -26,11 +26,13 @@ if os.name == 'nt':
 else:
     home_dir = os.environ['HOME']
     VALID_INTERPRETER = os.path.join(home_dir, 'miniconda', 'bin', 'python')
+    VALID_W_INTERPRETER = os.path.join(home_dir, 'miniconda', 'bin', 'pythonw')
     INVALID_INTERPRETER = os.path.join(home_dir, 'miniconda', 'bin', 'ipython')
 
 
-@pytest.mark.skipif(not os.name == 'nt' or os.environ.get('CI', None) is None,
-                    reason='It only runs in CI services.'
+@pytest.mark.skipif((sys.platform.startswith('linux') or
+                     os.environ.get('CI', None) is None),
+                    reason='It only runs in CI services and '
                            'Linux does not have pythonw executables.')
 def test_is_valid_w_interpreter():
     assert is_python_interpreter(VALID_W_INTERPRETER)


### PR DESCRIPTION
It turns out Anaconda defines `pythonw` as a script on macOS.