### PR TITLE
PR: Stop editor from jumping around when adding/removing lines with breakpoints while debugging

### DIFF
--- a/spyder/utils/site/sitecustomize.py
+++ b/spyder/utils/site/sitecustomize.py
@@ -490,7 +490,8 @@ def reset(self):
 #     specific behaviour desired?)
 @monkeypatch_method(pdb.Pdb, 'Pdb')
 def postcmd(self, stop, line):
-    self.notify_spyder(self.curframe)
+    if line != "!get_ipython().kernel._set_spyder_breakpoints()":
+        self.notify_spyder(self.curframe)
     return self._old_Pdb_postcmd(stop, line)
 
 


### PR DESCRIPTION


<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings for any new functions
* [ ] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] Included a screenshot, if this PR makes any visible changes to the UI


## Description of Changes

<!--- Describe what you've changed and why. --->

I want to be able to add a breakpoint somewhere without spyder jumping to another tab.


### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #5201


<!--- Thanks for your help making Spyder better for everyone! --->
