### PR TITLE
PR: Improve message about the lack of spyder-kernels in external interpreters

### DIFF
--- a/spyder/plugins/ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole.py
@@ -1082,13 +1082,15 @@ class IPythonConsole(SpyderPluginWidget):
             if not has_spyder_kernels:
                 client.show_kernel_error(
                         _("Your Python environment or installation doesn't "
-                          "have the <tt>spyder-kernels</tt> module installed "
-                          "on it. Without this module is not possible for "
+                          "have the <tt>spyder-kernels</tt> module or the "
+                          "right version of it installed. "
+                          "Without this module is not possible for "
                           "Spyder to create a console for you.<br><br>"
-                          "You can install it by running in a system terminal"
-                          ":<br><br><tt>conda install spyder-kernels</tt>"
+                          "You can install it by running in a system terminal:"
+                          "<br><br>"
+                          "<tt>conda install spyder-kernels=0.*</tt>"
                           "<br><br>or<br><br>"
-                          "<tt>pip install spyder-kernels</tt>"))
+                          "<tt>pip install spyder-kernels==0.*</tt>"))
                 return
 
         self.connect_client_to_kernel(client, is_cython=is_cython)


### PR DESCRIPTION
The message needed to be clearer about the right version of `spyder-kernels` needed in our stable branch.