### PR TITLE
PR: Fix tabulation spacing by setting tab spacing after the font

### DIFF
--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -1067,8 +1067,8 @@ class EditorStack(QWidget):
         self.tab_stop_width_spaces = tab_stop_width_spaces
         if self.data:
             for finfo in self.data:
-                finfo.editor.setTabStopWidth(tab_stop_width_spaces
-                                             * self.fontMetrics().width('9'))
+                finfo.editor.tab_stop_width_spaces = tab_stop_width_spaces
+                finfo.editor.update_tab_stop_width_spaces()
 
     def set_help_enabled(self, state):
         self.help_enabled = state

--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -293,8 +293,8 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         self.update_tab_stop_width_spaces()
 
     def update_tab_stop_width_spaces(self):
-        self.setTabStopWidth(self.fontMetrics().width(
-                '9' * self.tab_stop_width_spaces))
+        self.setTabStopWidth(self.fontMetrics().width(' ')
+                             * self.tab_stop_width_spaces)
 
     def set_palette(self, background, foreground):
         """

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -709,7 +709,6 @@ class CodeEditor(TextEditBaseWidget):
         self.set_add_colons_enabled(add_colons)
         self.set_auto_unindent_enabled(auto_unindent)
         self.set_indent_chars(indent_chars)
-        self.set_tab_stop_width_spaces(tab_stop_width_spaces)
 
         # Scrollbar flag area
         self.set_scrollflagarea_enabled(scrollflagarea)
@@ -752,6 +751,9 @@ class CodeEditor(TextEditBaseWidget):
             self.set_font(font, color_scheme)
         elif color_scheme is not None:
             self.set_color_scheme(color_scheme)
+
+        # Set tab spacing after font is set
+        self.set_tab_stop_width_spaces(tab_stop_width_spaces)
 
         self.toggle_wrap_mode(wrap)
 


### PR DESCRIPTION
<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings for any new functions
* [ ] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] Included a screenshot, if this PR makes any visible changes to the UI


## Description of Changes

<!--- Describe what you've changed and why. --->
Sets the width of tabulations after the font is set so they are arn't set to the width of the default font.

Before:
![tabs](https://user-images.githubusercontent.com/10513354/42715672-408467e4-86b5-11e8-9de7-0c9ed7809e85.png)


After:
![tabs_right](https://user-images.githubusercontent.com/10513354/42745258-f6350582-888e-11e8-9dfa-fe935278a585.png)



### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #7432

### Issue(s) Not Resolved
Still dosen't update the spacing when changing the font face/size.
I guess there needs to be a callback somewhere?

<!--- Thanks for your help making Spyder better for everyone! --->
