### PR TITLE
PR: Setting tab stop width by using the width of multiple spaces

### DIFF
--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -293,8 +293,8 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         self.update_tab_stop_width_spaces()
 
     def update_tab_stop_width_spaces(self):
-        self.setTabStopWidth(self.fontMetrics().width(' ')
-                             * self.tab_stop_width_spaces)
+        self.setTabStopWidth(self.fontMetrics().width(
+                             ' ' * self.tab_stop_width_spaces))
 
     def set_palette(self, background, foreground):
         """


### PR DESCRIPTION
## Description of Changes
The width of one space in text is not always an integer number. So multiplying the width of a single space does not always give the right result. I think it is better to take the width of multiple spaces instead.

### Issue(s) Resolved

Fixes #7432
