### PR TITLE
PR: Fix misspelling in Japanese translation

### DIFF
--- a/spyder/locale/ja/LC_MESSAGES/spyder.po
+++ b/spyder/locale/ja/LC_MESSAGES/spyder.po
@@ -2142,7 +2142,7 @@ msgstr "使用法"
 
 #: spyder/plugins/help.py:706
 msgid "New to Spyder? Read our"
-msgstr "Spypderは初めてですか？ 読んでください。"
+msgstr "Spyderは初めてですか？ 読んでください。"
 
 #: spyder/plugins/help.py:707
 msgid "tutorial"
@@ -3617,7 +3617,7 @@ msgid ""
 "<b>%s</b> is unavailable (this file may have been removed, moved or renamed "
 "outside Spyder).<br>Do you want to close it?"
 msgstr ""
-"<b>%s</b> は利用できません (このファイルはSpypder外で削除、移動あるいは名前変"
+"<b>%s</b> は利用できません (このファイルはSpyder外で削除、移動あるいは名前変"
 "更されています)。<br>閉じますか?"
 
 #: spyder/widgets/editor.py:1999
@@ -4449,7 +4449,7 @@ msgid ""
 "Spyder without having to configure sys.path. <br>Do you want to clear "
 "contents of PYTHONPATH before adding Spyder's path list?"
 msgstr ""
-"sys.pathを変更することなくSpypder外でPythonモジュールを実行できるように、"
+"sys.pathを変更することなくSpyder外でPythonモジュールを実行できるように、"
 "Spyderのパスはユーザーの <b>PYTHONPATH</b> 環境変数に同期されます。 "
 "<br>Spyderのパスリストを追加する前にPYTHONPATHの値をクリアしますか？"
 


### PR DESCRIPTION
<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] <del>Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style</del>(not applicable)
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] <del>Wrote at least one-line docstrings for any new functions</del>(not applicable)
* [x] <del>Added at least one unit test covering the changes, if at all possible</del>(not applicable)
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] Included a screenshot, if this PR makes any visible changes to the UI

## Description of Changes

<!--- Describe what you've changed and why. --->

In Japanese message file (spyder/locale/ja/LC_MESSAGES/spyder.po), I found that some of "Spyder"'s are misspelled as "Spypder". This pull request fixes it.

![20180724-spypder](https://user-images.githubusercontent.com/20628/43123517-63a60c20-8f5f-11e8-8036-ec4e4fddd814.png)

<!--- Thanks for your help making Spyder better for everyone! --->
