### PR TITLE
PR: Do not automatically open Project Explorer when opening project if user closed it

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -259,7 +259,8 @@ DEFAULTS = [
              {
               'name_filters': NAME_FILTERS,
               'show_all': True,
-              'show_hscrollbar': True
+              'show_hscrollbar': True,
+              'visible_if_project_open': True
               }),
             ('explorer',
              {

--- a/spyder/plugins/projects.py
+++ b/spyder/plugins/projects.py
@@ -231,7 +231,7 @@ class Projects(ProjectExplorerWidget, SpyderPluginMixin):
         dlg.sig_project_creation_requested.connect(self.sig_project_created)
         if dlg.exec_():
             if (active_project is None
-                and self.get_option('visible_if_project_open')):
+                    and self.get_option('visible_if_project_open')):
                 self.show_explorer()
             self.sig_pythonpath_changed.emit()
             self.restart_consoles()

--- a/spyder/plugins/projects.py
+++ b/spyder/plugins/projects.py
@@ -377,11 +377,18 @@ class Projects(ProjectExplorerWidget, SpyderPluginMixin):
                                       default=getcwd_or_home())
 
     def save_config(self):
-        """Save configuration: opened projects & tree widget state"""
+        """
+        Save configuration: opened projects & tree widget state.
+
+        Also save whether dock widget is visible if a project is open.
+        """
         self.set_option('recent_projects', self.recent_projects)
         self.set_option('expanded_state', self.treewidget.get_expanded_state())
         self.set_option('scrollbar_position',
                         self.treewidget.get_scrollbar_position())
+        if self.current_active_project and self.dockwidget:
+            self.set_option('visible_if_project_open',
+                            self.dockwidget.isVisible())
 
     def load_config(self):
         """Load configuration: opened projects & tree widget state"""

--- a/spyder/plugins/projects.py
+++ b/spyder/plugins/projects.py
@@ -302,6 +302,8 @@ class Projects(ProjectExplorerWidget, SpyderPluginMixin):
             self.sig_pythonpath_changed.emit()
 
             if self.dockwidget is not None:
+                self.set_option('visible_if_project_open',
+                                self.dockwidget.isVisible())
                 self.dockwidget.close()
 
             self.clear()

--- a/spyder/plugins/projects.py
+++ b/spyder/plugins/projects.py
@@ -230,8 +230,8 @@ class Projects(ProjectExplorerWidget, SpyderPluginMixin):
         dlg.sig_project_creation_requested.connect(self._create_project)
         dlg.sig_project_creation_requested.connect(self.sig_project_created)
         if dlg.exec_():
-            pass
-            if active_project is None:
+            if (active_project is None
+                and self.get_option('visible_if_project_open')):
                 self.show_explorer()
             self.sig_pythonpath_changed.emit()
             self.restart_consoles()
@@ -267,7 +267,8 @@ class Projects(ProjectExplorerWidget, SpyderPluginMixin):
                 self.editor.save_open_files()
             if self.editor is not None:
                 self.editor.set_option('last_working_dir', getcwd_or_home())
-            self.show_explorer()
+            if self.get_option('visible_if_project_open'):
+                self.show_explorer()
         else:
             # We are switching projects
             if self.editor is not None:

--- a/spyder/plugins/tests/test_projects.py
+++ b/spyder/plugins/tests/test_projects.py
@@ -69,7 +69,9 @@ def test_close_project_sets_visible_config(projects_with_dockwindow, tmpdir,
     projects.set_option('visible_if_project_open', not value)
 
     projects.open_project(path=to_text_string(tmpdir))
-    if value is False:
+    if value:
+        projects.show_explorer()
+    else:
         projects.dockwidget.close()
     projects.close_project()
     assert projects.get_option('visible_if_project_open') == value
@@ -87,10 +89,22 @@ def test_closing_plugin_sets_visible_config(
     assert projects.get_option('visible_if_project_open') == (not value)
 
     projects.open_project(path=to_text_string(tmpdir))
-    if value is False:
+    if value:
+        projects.show_explorer()
+    else:
         projects.dockwidget.close()
     projects.close_project()
     assert projects.get_option('visible_if_project_open') == value
+
+@pytest.mark.parametrize('value', [True, False])
+def test_open_project_uses_visible_config(
+        projects_with_dockwindow, tmpdir, value):
+    """Test that when a project is opened, the project explorer is only opened
+    if the config option visible_if_project_open is set."""
+    projects = projects_with_dockwindow
+    projects.set_option('visible_if_project_open', value)
+    projects.open_project(path=to_text_string(tmpdir))
+    assert projects.dockwidget.isVisible() == value
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/tests/test_projects.py
+++ b/spyder/plugins/tests/test_projects.py
@@ -29,6 +29,7 @@ def projects(qtbot):
     qtbot.addWidget(projects)
     return projects
 
+
 @pytest.fixture
 def projects_with_dockwindow(projects, mocker):
     """Fixture for Projects plugin with a dockwindow"""
@@ -58,6 +59,7 @@ def test_open_project(projects, tmpdir, test_directory):
     # Close project
     projects.close_project()
 
+
 @pytest.mark.parametrize('value', [True, False])
 def test_close_project_sets_visible_config(projects_with_dockwindow, tmpdir,
                                            value):
@@ -75,6 +77,7 @@ def test_close_project_sets_visible_config(projects_with_dockwindow, tmpdir,
         projects.dockwidget.close()
     projects.close_project()
     assert projects.get_option('visible_if_project_open') == value
+
 
 @pytest.mark.parametrize('value', [True, False])
 def test_closing_plugin_sets_visible_config(
@@ -95,6 +98,7 @@ def test_closing_plugin_sets_visible_config(
         projects.dockwidget.close()
     projects.close_project()
     assert projects.get_option('visible_if_project_open') == value
+
 
 @pytest.mark.parametrize('value', [True, False])
 def test_open_project_uses_visible_config(

--- a/spyder/plugins/tests/test_projects.py
+++ b/spyder/plugins/tests/test_projects.py
@@ -14,7 +14,7 @@ Tests for the Projects plugin.
 import pytest
 
 # Local imports
-import spyder.plugins.base
+import spyder.plugins
 from spyder.plugins.projects import Projects
 from spyder.py3compat import to_text_string
 
@@ -34,7 +34,7 @@ def projects(qtbot):
 def projects_with_dockwindow(projects, mocker):
     """Fixture for Projects plugin with a dockwindow"""
     projects.shortcut = None
-    mocker.patch.object(spyder.plugins.base.SpyderDockWidget,
+    mocker.patch.object(spyder.plugins.SpyderDockWidget,
                         'install_tab_event_filter')
     mocker.patch.object(projects, 'toggle_view_action')
     projects.create_dockwidget()

--- a/spyder/plugins/tests/test_projects.py
+++ b/spyder/plugins/tests/test_projects.py
@@ -74,5 +74,24 @@ def test_close_project_sets_visible_config(projects_with_dockwindow, tmpdir,
     projects.close_project()
     assert projects.get_option('visible_if_project_open') == value
 
+@pytest.mark.parametrize('value', [True, False])
+def test_closing_plugin_sets_visible_config(
+        projects_with_dockwindow, tmpdir, value):
+    """Test that closing_plugin() sets config option visible_if_project_open
+    if a project is open."""
+    projects = projects_with_dockwindow
+    projects.set_option('visible_if_project_open', not value)
+    projects.closing_plugin()
+
+    # No project is open so config option should remain unchanged
+    assert projects.get_option('visible_if_project_open') == (not value)
+
+    projects.open_project(path=to_text_string(tmpdir))
+    if value is False:
+        projects.dockwidget.close()
+    projects.close_project()
+    assert projects.get_option('visible_if_project_open') == value
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/plugins/tests/test_projects.py
+++ b/spyder/plugins/tests/test_projects.py
@@ -14,6 +14,7 @@ Tests for the Projects plugin.
 import pytest
 
 # Local imports
+import spyder.plugins.base
 from spyder.plugins.projects import Projects
 from spyder.py3compat import to_text_string
 
@@ -26,6 +27,16 @@ def projects(qtbot):
     """Projects plugin fixture"""
     projects = Projects(parent=None, testing=True)
     qtbot.addWidget(projects)
+    return projects
+
+@pytest.fixture
+def projects_with_dockwindow(projects, mocker):
+    """Fixture for Projects plugin with a dockwindow"""
+    projects.shortcut = None
+    mocker.patch.object(spyder.plugins.base.SpyderDockWidget,
+                        'install_tab_event_filter')
+    mocker.patch.object(projects, 'toggle_view_action')
+    projects.create_dockwidget()
     return projects
 
 
@@ -46,6 +57,22 @@ def test_open_project(projects, tmpdir, test_directory):
 
     # Close project
     projects.close_project()
+
+@pytest.mark.parametrize('value', [True, False])
+def test_close_project_sets_visible_config(projects_with_dockwindow, tmpdir,
+                                           value):
+    """Test that when project is closed, the config option
+    visible_if_project_open is set to the correct value."""
+    projects = projects_with_dockwindow
+
+    # Set config to opposite value so that we can check that it's set correctly
+    projects.set_option('visible_if_project_open', not value)
+
+    projects.open_project(path=to_text_string(tmpdir))
+    if value is False:
+        projects.dockwidget.close()
+    projects.close_project()
+    assert projects.get_option('visible_if_project_open') == value
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings for any new functions
* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [ ] Included a screenshot, if this PR makes any visible changes to the UI **N/A**


## Description of Changes

Create a new config option for the projects plugin called `visible_if_project_open`, defaulting to `True` to mimic current behaviour. When closing a project or quitting Spyder with a project open, set or clear this according to whether the Project Explorer is open. When creating a new project or opening an existing project, open the Project Explorer only if the config option is set.

The effect is that if a user opens a project, closes the Project Explorer and then restarts Spyder, the Project Explorer is not opened again, as opposed to the current situation where it is opened.

### Issue(s) Resolved

Fixes #6292
