### PR TITLE
PR: Make editor for collection types which copy incorrectly read-only

### DIFF
--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1351,17 +1351,17 @@ class CollectionsEditor(QDialog):
                 readonly = True
                 self.data_copy = data
             datalen = len(get_object_attrs(data))
-        self.widget = CollectionsEditorWidget(self, self.data_copy,
-                                              title=title, readonly=readonly,
-                                              remote=remote)
-        self.widget.editor.model.sig_setting_data.connect(
-                                                    self.save_and_close_enable)
 
         # If the copy has a different type, then do not allow editing, because
         # this would change the type after saving; cf. issue #6936
         if type(self.data_copy) != type(data):
             readonly = True
 
+        self.widget = CollectionsEditorWidget(self, self.data_copy,
+                                              title=title, readonly=readonly,
+                                              remote=remote)
+        self.widget.editor.model.sig_setting_data.connect(
+                                                    self.save_and_close_enable)
         layout = QVBoxLayout()
         layout.addWidget(self.widget)
         self.setLayout(layout)

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1356,6 +1356,12 @@ class CollectionsEditor(QDialog):
                                               remote=remote)
         self.widget.editor.model.sig_setting_data.connect(
                                                     self.save_and_close_enable)
+
+        # If the copy has a different type, then do not allow editing, because
+        # this would change the type after saving; cf. issue #6936
+        if type(self.data_copy) != type(data):
+            readonly = True
+
         layout = QVBoxLayout()
         layout.addWidget(self.widget)
         self.setLayout(layout)

--- a/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_collectioneditor.py
@@ -474,5 +474,34 @@ def test_edit_nonsettable_objects(qtbot, nonsettable_objects_data):
                     == getattr(expected_obj, key) for key in keys])
 
 
+def test_collectionseditor_with_class_having_buggy_copy(qtbot):
+    """
+    Test that editor for object whose .copy() returns a different type is
+    readonly; cf. issue #6936.
+    """
+    class MyDictWithBuggyCopy(dict):
+        pass
+
+    md = MyDictWithBuggyCopy({1: 2})
+    editor = CollectionsEditor()
+    editor.setup(md)
+    assert editor.widget.editor.readonly
+
+
+def test_collectionseditor_with_class_having_correct_copy(qtbot):
+    """
+    Test that editor for object whose .copy() returns the same type is not
+    readonly; cf. issue #6936.
+    """
+    class MyDictWithCorrectCopy(dict):
+        def copy(self):
+            return MyDictWithCorrectCopy(self)
+
+    md = MyDictWithCorrectCopy({1: 2})
+    editor = CollectionsEditor()
+    editor.setup(md)
+    assert not editor.widget.editor.readonly
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] <s>Wrote at least one-line docstrings for any new functions</s> **N/A**
* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] <s>Included a screenshot, if this PR makes any visible changes to the UI</s> **N/A**

## Description of Changes

If a CollectionEditor is created then Spyder tries to copy the object which
is being edited. If the .copy() method is not implemented correctly, then
the copy will not be a true copy but have a different type. If that is the
case, we make the editor read-only so that the user does not inadvertently
change the type of the object.

### Issue(s) Resolved

Fixes #6936