### PR TITLE
PR: Add option to select OpenGL implementation used by Qt

### DIFF
--- a/spyder/app/cli_options.py
+++ b/spyder/app/cli_options.py
@@ -41,7 +41,7 @@ def get_options():
     parser.add_option('--window-title', type=str, default=None,
                       help="String to show in the main window title")
     parser.add_option('-p', '--project', default=None, type=str,
-                      dest="open_project",
+                      dest="project",
                       help="Path that contains an Spyder project")
     parser.add_option('--opengl', default=None, type='choice',
                       dest="opengl_implementation",

--- a/spyder/app/cli_options.py
+++ b/spyder/app/cli_options.py
@@ -43,5 +43,11 @@ def get_options():
     parser.add_option('-p', '--project', default=None, type=str,
                       dest="open_project",
                       help="Path that contains an Spyder project")
+    parser.add_option('--opengl', default=None, type='choice',
+                      dest="opengl_implementation",
+                      choices=['software', 'desktop'],
+                      help=("OpenGL implementation to pass to Qt. Possible "
+                            "options are 'software' and 'desktop'")
+                      )
     options, args = parser.parse_args()
     return options, args

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -265,7 +265,7 @@ class MainWindow(QMainWindow):
         self.profile = options.profile
         self.multithreaded = options.multithreaded
         self.new_instance = options.new_instance
-        self.open_project = options.open_project
+        self.open_project = options.project
         self.window_title = options.window_title
 
         self.debug_print("Start of MainWindow constructor")
@@ -3109,7 +3109,7 @@ def main():
         options.profile = False
         options.multithreaded = False
         options.new_instance = False
-        options.open_project = None
+        options.project = None
         options.window_title = None
         options.opengl_implementation = None
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -102,7 +102,8 @@ from qtawesome.iconic_font import FontError
 from spyder.config.main import CONF
 
 if hasattr(Qt, 'AA_EnableHighDpiScaling'):
-    QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling, CONF.get('main', 'high_dpi_scaling'))
+    QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling,
+                                  CONF.get('main', 'high_dpi_scaling'))
 
 
 #==============================================================================
@@ -3110,6 +3111,7 @@ def main():
         options.new_instance = False
         options.open_project = None
         options.window_title = None
+        options.opengl_implementation = None
 
         app = initialize()
         window = run_spyder(app, options, None)
@@ -3120,6 +3122,17 @@ def main():
     # It's important to collect options before monkey patching sys.exit,
     # otherwise, optparse won't be able to exit if --help option is passed
     options, args = get_options()
+
+    if options.opengl_implementation:
+        if options.opengl_implementation == 'software':
+            QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
+        elif options.opengl_implementation == 'desktop':
+            QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
+    else:
+        if CONF.get('main', 'opengl') == 'software':
+            QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
+        elif CONF.get('main', 'opengl') == 'desktop':
+            QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
 
     if options.show_console:
         print("(Deprecated) --show console does nothing, now the default "

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -69,6 +69,7 @@ DEFAULTS = [
             ('main',
              {
               'icon_theme': 'spyder 3',
+              'opengl': 'automatic',
               'single_instance': True,
               'open_files_port': OPEN_FILES_PORT,
               'tear_off_menus': False,

--- a/spyder/plugins/configdialog.py
+++ b/spyder/plugins/configdialog.py
@@ -869,16 +869,28 @@ class MainConfigPage(GeneralConfigPage):
 
         # --- Interface
         general_group = QGroupBox(_("General"))
+
         languages = LANGUAGE_CODES.items()
         language_choices = sorted([(val, key) for key, val in languages])
-        language_combo = self.create_combobox(_('Language'), language_choices,
+        language_combo = self.create_combobox(_('Language:'),
+                                              language_choices,
                                               'interface_language',
                                               restart=True)
+
+        opengl_options = ['Automatic', 'Desktop', 'Software']
+        opengl_choices = list(zip(opengl_options,
+                                  [c.lower() for c in opengl_options]))
+        opengl_combo = self.create_combobox(_('Rendering engine:'),
+                                            opengl_choices,
+                                            'opengl',
+                                            restart=True)
+
         single_instance_box = newcb(_("Use a single instance"),
                                     'single_instance',
                                     tip=_("Set this to open external<br> "
                                           "Python files in an already running "
                                           "instance (Requires a restart)"))
+
         prompt_box = newcb(_("Prompt when exiting"), 'prompt_on_exit')
         popup_console_box = newcb(_("Show internal Spyder errors to report "
                                     "them to Github"), 'show_internal_errors')
@@ -890,8 +902,17 @@ class MainConfigPage(GeneralConfigPage):
             self.set_option("single_instance", True)
             single_instance_box.setEnabled(False)
 
+        comboboxes_advanced_layout = QHBoxLayout()
+        cbs_adv_grid = QGridLayout()
+        cbs_adv_grid.addWidget(language_combo.label, 0, 0)
+        cbs_adv_grid.addWidget(language_combo.combobox, 0, 1)
+        cbs_adv_grid.addWidget(opengl_combo.label, 1, 0)
+        cbs_adv_grid.addWidget(opengl_combo.combobox, 1, 1)
+        comboboxes_advanced_layout.addLayout(cbs_adv_grid)
+        comboboxes_advanced_layout.addStretch(1)
+
         general_layout = QVBoxLayout()
-        general_layout.addWidget(language_combo)
+        general_layout.addLayout(comboboxes_advanced_layout)
         general_layout.addWidget(single_instance_box)
         general_layout.addWidget(prompt_box)
         general_layout.addWidget(popup_console_box)


### PR DESCRIPTION
To try to avoid the many issues people are finding with WebEngine, we will allow them to select the OpenGL implementation used by Qt, like this:

![seleccion_008](https://user-images.githubusercontent.com/365293/44173853-c5e5ff00-a0a6-11e8-9105-2657f742e126.png)

They could also select it with a new `--opengl` command line option, that can have two options: `software` and `desktop`.

----

Note: We are following RStudio's lead in this camp. See:

https://github.com/spyder-ide/spyder/issues/7447#issuecomment-412700201

and

https://github.com/rstudio/rstudio/issues/3185#issuecomment-412575262

for the details.