### PR TITLE
PR: Fix cog menu not showing in the variable explorer when more than one IPython console is opened

### DIFF
--- a/spyder/plugins/variableexplorer.py
+++ b/spyder/plugins/variableexplorer.py
@@ -140,6 +140,10 @@ class VariableExplorer(SpyderPluginWidget):
     # ----- Stack accesors ----------------------------------------------------
     def set_current_widget(self, nsb):
         self.stack.setCurrentWidget(nsb)
+        # We update the actions of the options button (cog menu) and we move
+        # it to the layout of the current widget.
+        self.refresh_actions()
+        nsb.setup_options_button()
 
     def current_widget(self):
         return self.stack.currentWidget()
@@ -164,9 +168,7 @@ class VariableExplorer(SpyderPluginWidget):
         shellwidget_id = id(shellwidget)
         if shellwidget_id not in self.shellwidgets:
             self.options_button.setVisible(True)
-            nsb = NamespaceBrowser(self,
-                                   options_button=self.options_button,
-                                   plugin_actions=[self.undock_action])
+            nsb = NamespaceBrowser(self, options_button=self.options_button)
             nsb.set_shellwidget(shellwidget)
             nsb.setup(**self.get_settings())
             nsb.sig_option_changed.connect(self.change_option)
@@ -225,8 +227,8 @@ class VariableExplorer(SpyderPluginWidget):
 
     def get_plugin_actions(self):
         """Return a list of actions related to plugin"""
-        return []
-    
+        return self.current_widget().actions if self.current_widget() else []
+
     def register_plugin(self):
         """Register plugin in Spyder's main window"""
         self.main.add_dockwidget(self)

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -54,7 +54,7 @@ class NamespaceBrowser(QWidget):
         
         self.shellwidget = None
         self.is_visible = True
-        self.setup_in_progress = False
+        self.setup_in_progress = None
 
         # Remote dict editor settings
         self.check_all = None
@@ -118,7 +118,7 @@ class NamespaceBrowser(QWidget):
                         shellwidget=self.shellwidget,
                         dataframe_format=dataframe_format)
 
-        self.editor.sig_option_changed.connect(self.option_changed)
+        self.editor.sig_option_changed.connect(self.sig_option_changed.emit)
         self.editor.sig_files_dropped.connect(self.import_data)
         self.editor.sig_free_memory.connect(self.sig_free_memory.emit)
 
@@ -139,6 +139,8 @@ class NamespaceBrowser(QWidget):
         layout = create_plugin_layout(self.tools_layout, self.editor)
         self.setLayout(layout)
 
+        self.sig_option_changed.connect(self.option_changed)
+        
     def set_shellwidget(self, shellwidget):
         """Bind shellwidget instance to namespace browser"""
         self.shellwidget = shellwidget
@@ -178,30 +180,30 @@ class NamespaceBrowser(QWidget):
                 tip=_("Exclude references which name starts"
                             " with an underscore"),
                 toggled=lambda state:
-                self.option_changed('exclude_private', state))
+                self.sig_option_changed.emit('exclude_private', state))
         self.exclude_private_action.setChecked(exclude_private)
-
+        
         self.exclude_uppercase_action = create_action(self,
                 _("Exclude all-uppercase references"),
                 tip=_("Exclude references which name is uppercase"),
                 toggled=lambda state:
-                self.option_changed('exclude_uppercase', state))
+                self.sig_option_changed.emit('exclude_uppercase', state))
         self.exclude_uppercase_action.setChecked(exclude_uppercase)
-
+        
         self.exclude_capitalized_action = create_action(self,
                 _("Exclude capitalized references"),
                 tip=_("Exclude references which name starts with an "
                       "uppercase character"),
                 toggled=lambda state:
-                self.option_changed('exclude_capitalized', state))
+                self.sig_option_changed.emit('exclude_capitalized', state))
         self.exclude_capitalized_action.setChecked(exclude_capitalized)
-
+        
         self.exclude_unsupported_action = create_action(self,
                 _("Exclude unsupported data types"),
                 tip=_("Exclude references to unsupported data types"
                             " (i.e. which won't be handled/saved correctly)"),
                 toggled=lambda state:
-                self.option_changed('exclude_unsupported', state))
+                self.sig_option_changed.emit('exclude_unsupported', state))
         self.exclude_unsupported_action.setChecked(exclude_unsupported)
 
         self.actions = [
@@ -234,8 +236,6 @@ class NamespaceBrowser(QWidget):
         setattr(self, to_text_string(option), value)
         self.shellwidget.set_namespace_view_settings()
         self.refresh_table()
-        if self.setup_in_progress is False:
-            self.sig_option_changed.emit(option, value)
 
     def get_view_settings(self):
         """Return dict editor view settings"""

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -54,7 +54,7 @@ class NamespaceBrowser(QWidget):
         
         self.shellwidget = None
         self.is_visible = True
-        self.setup_in_progress = None
+        self.setup_in_progress = False
 
         # Remote dict editor settings
         self.check_all = None
@@ -119,7 +119,7 @@ class NamespaceBrowser(QWidget):
                         shellwidget=self.shellwidget,
                         dataframe_format=dataframe_format)
 
-        self.editor.sig_option_changed.connect(self.sig_option_changed.emit)
+        self.editor.sig_option_changed.connect(self.option_changed)
         self.editor.sig_files_dropped.connect(self.import_data)
         self.editor.sig_free_memory.connect(self.sig_free_memory.emit)
 
@@ -158,8 +158,6 @@ class NamespaceBrowser(QWidget):
         layout = create_plugin_layout(blayout, self.editor)
         self.setLayout(layout)
 
-        self.sig_option_changed.connect(self.option_changed)
-        
     def set_shellwidget(self, shellwidget):
         """Bind shellwidget instance to namespace browser"""
         self.shellwidget = shellwidget
@@ -199,30 +197,30 @@ class NamespaceBrowser(QWidget):
                 tip=_("Exclude references which name starts"
                             " with an underscore"),
                 toggled=lambda state:
-                self.sig_option_changed.emit('exclude_private', state))
+                self.option_changed('exclude_private', state))
         self.exclude_private_action.setChecked(exclude_private)
-        
+
         self.exclude_uppercase_action = create_action(self,
                 _("Exclude all-uppercase references"),
                 tip=_("Exclude references which name is uppercase"),
                 toggled=lambda state:
-                self.sig_option_changed.emit('exclude_uppercase', state))
+                self.option_changed('exclude_uppercase', state))
         self.exclude_uppercase_action.setChecked(exclude_uppercase)
-        
+
         self.exclude_capitalized_action = create_action(self,
                 _("Exclude capitalized references"),
                 tip=_("Exclude references which name starts with an "
                       "uppercase character"),
                 toggled=lambda state:
-                self.sig_option_changed.emit('exclude_capitalized', state))
+                self.option_changed('exclude_capitalized', state))
         self.exclude_capitalized_action.setChecked(exclude_capitalized)
-        
+
         self.exclude_unsupported_action = create_action(self,
                 _("Exclude unsupported data types"),
                 tip=_("Exclude references to unsupported data types"
                             " (i.e. which won't be handled/saved correctly)"),
                 toggled=lambda state:
-                self.sig_option_changed.emit('exclude_unsupported', state))
+                self.option_changed('exclude_unsupported', state))
         self.exclude_unsupported_action.setChecked(exclude_unsupported)
 
         self.actions = [
@@ -238,6 +236,8 @@ class NamespaceBrowser(QWidget):
         setattr(self, to_text_string(option), value)
         self.shellwidget.set_namespace_view_settings()
         self.refresh_table()
+        if self.setup_in_progress is False:
+            self.sig_option_changed.emit(option, value)
 
     def get_view_settings(self):
         """Return dict editor view settings"""

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -125,8 +125,10 @@ class NamespaceBrowser(QWidget):
 
         # Setup layout
         blayout = QHBoxLayout()
-        toolbar = self.setup_toolbar(exclude_private, exclude_uppercase,
-                                     exclude_capitalized, exclude_unsupported)
+        self.setup_option_actions(exclude_private, exclude_uppercase,
+                                  exclude_capitalized, exclude_unsupported)
+
+        toolbar = self.setup_toolbar()
         for widget in toolbar:
             blayout.addWidget(widget)
 
@@ -167,12 +169,8 @@ class NamespaceBrowser(QWidget):
         """Get actions of the widget."""
         return self.actions
 
-    def setup_toolbar(self, exclude_private, exclude_uppercase,
-                      exclude_capitalized, exclude_unsupported):
+    def setup_toolbar(self):
         """Setup toolbar"""
-        self.setup_in_progress = True
-        toolbar = []
-
         load_button = create_toolbutton(self, text=_('Import data'),
                                         icon=ima.icon('fileimport'),
                                         triggered=lambda: self.import_data())
@@ -188,8 +186,13 @@ class NamespaceBrowser(QWidget):
                 self, text=_("Remove all variables"),
                 icon=ima.icon('editdelete'), triggered=self.reset_namespace)
 
-        toolbar += [load_button, self.save_button, save_as_button,
-                    reset_namespace_button]
+        return [load_button, self.save_button, save_as_button,
+                reset_namespace_button]
+
+    def setup_option_actions(self, exclude_private, exclude_uppercase,
+                             exclude_capitalized, exclude_unsupported):
+        """Setup the actions to show in the cog menu."""
+        self.setup_in_progress = True
 
         self.exclude_private_action = create_action(self,
                 _("Exclude private references"),
@@ -221,10 +224,14 @@ class NamespaceBrowser(QWidget):
                 toggled=lambda state:
                 self.sig_option_changed.emit('exclude_unsupported', state))
         self.exclude_unsupported_action.setChecked(exclude_unsupported)
-        
+
+        self.actions = [
+            self.exclude_private_action, self.exclude_uppercase_action,
+            self.exclude_capitalized_action, self.exclude_unsupported_action]
+        if is_module_installed('numpy'):
+            self.actions.extend([MENU_SEPARATOR, self.editor.minmax_action])
+
         self.setup_in_progress = False
-        
-        return toolbar
 
     def option_changed(self, option, value):
         """Option has changed"""

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -222,7 +222,6 @@ class NamespaceBrowser(QWidget):
             self.options_menu = QMenu(self)
             add_actions(self.options_menu, actions)
             self.options_button.setMenu(self.options_menu)
-            self.set_options_button(self.options_button)
 
         if self.tools_layout.itemAt(self.tools_layout.count() - 1) is None:
             self.tools_layout.insertWidget(


### PR DESCRIPTION
<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings for any new functions
* [ ] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] Included a screenshot, if this PR makes any visible changes to the UI


## Description of Changes

<!--- Describe what you've changed and why. --->

The layout of the `VariableExplorer` plugin consists mainly of a `StackWidget`.  When an IPython console is created, a corresponding `NamespaceBrowser` is instantiated and added to the stack.

The cog menu button (cmb) is created by the variable explorer plugin and passed as a class argument when instantiating a new namespace browser (nsb ), which is later added to its layout during the setup. So this means that the cmb is shared among all the nsb of the stack.

The problem is that, when the current IPython console change, and so the current nsb of the stack widget, there is no mechanism to update the cmb  actions and to move it from the previous current nsb layout to that of the new current nsb. In order to solve this issue, this PR:

- Add the code infrastructure to update the cmb actions when the current nsb of the stack change.
- Add the code infrastructure to move the cmb to the current nsb layout.

The changes at the plugin layer are minimal and use the public interface already in place for plugins. Almost all changes were made at the widget layer.

### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #7704


<!--- Thanks for your help making Spyder better for everyone! --->
