### PR TITLE
PR: Fix variable explorer actions are disabled when undocked in a new window

### DIFF
--- a/spyder/plugins/variableexplorer.py
+++ b/spyder/plugins/variableexplorer.py
@@ -72,6 +72,7 @@ class VariableExplorer(SpyderPluginWidget):
 
     CONF_SECTION = 'variable_explorer'
     CONFIGWIDGET_CLASS = VariableExplorerConfigPage
+    DISABLE_ACTIONS_WHEN_HIDDEN = False
     INITIAL_FREE_MEMORY_TIME_TRIGGER = 60 * 1000  # ms
     SECONDARY_FREE_MEMORY_TIME_TRIGGER = 180 * 1000  # ms
     sig_option_changed = Signal(str, object)


### PR DESCRIPTION
## Description of Changes

This is a follow up of PR #7710.

Because `VariableExplorer.get_plugin_actions` was implemented in  PR #7710 so that it actually returns the actions of the plugin instead of an empty list, we need to set the plugin option `DISABLE_ACTIONS_WHEN_HIDDEN` to `False` or else the plugin actions will be disabled when the plugin is undocked in a new window.

![image](https://user-images.githubusercontent.com/10170372/44300401-5ead9200-a2d4-11e8-9ec5-3d76a1d6ec83.png)
