### PR TITLE
PR: Implement a workaround to toggle on/off fullscreen mode for Windows systems

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -482,9 +482,9 @@ class MainWindow(QMainWindow):
         # The following flag remember the maximized state even when
         # the window is in fullscreen mode:
         self.maximized_flag = None
+        # The following flag is used to restore window's geometry when
+        # toggling out of fullscreen mode in Windows.
         self.saved_normal_geometry = None
-        # This flag is used to restore window's geometry when toggling out of
-        # fullscreen mode in Windows.
 
         # To keep track of the last focused widget
         self.last_focused_widget = None

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2301,7 +2301,7 @@ class MainWindow(QMainWindow):
         self.__update_maximize_action()
 
     def __update_fullscreen_action(self):
-        if self.isFullScreen():
+        if self.fullscreen_flag:
             icon = ima.icon('window_nofullscreen')
         else:
             icon = ima.icon('window_fullscreen')
@@ -2311,15 +2311,34 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def toggle_fullscreen(self):
-        if self.isFullScreen():
+        if self.fullscreen_flag:
             self.fullscreen_flag = False
+            if os.name == 'nt':
+                self.setWindowFlags(
+                    self.windowFlags()
+                    ^ (Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint))
+                self.setGeometry(self.saved_normal_geometry)
             self.showNormal()
             if self.maximized_flag:
                 self.showMaximized()
         else:
             self.maximized_flag = self.isMaximized()
             self.fullscreen_flag = True
-            self.showFullScreen()
+            self.saved_normal_geometry = self.normalGeometry()
+            if os.name == 'nt':
+                # Due to limitations of the Windows DWM, compositing is not
+                # handled correctly for OpenGL based windows when going into
+                # full screen mode, so we need to use this workaround.
+                # See Issue #4291.
+                self.setWindowFlags(self.windowFlags()
+                                    | Qt.FramelessWindowHint
+                                    | Qt.WindowStaysOnTopHint)
+                r = QApplication.desktop().screenGeometry()
+                self.setGeometry(
+                    r.left()-1, r.top()-1, r.width()+2, r.height()+2)
+                self.showNormal()
+            else:
+                self.showFullScreen()
         self.__update_fullscreen_action()
 
     def add_to_toolbar(self, toolbar, widget):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2338,7 +2338,7 @@ class MainWindow(QMainWindow):
                                     | Qt.WindowStaysOnTopHint)
                 r = QApplication.desktop().screenGeometry()
                 self.setGeometry(
-                    r.left()-1, r.top()-1, r.width()+2, r.height()+2)
+                    r.left() - 1, r.top() - 1, r.width() + 2, r.height() + 2)
                 self.showNormal()
             else:
                 self.showFullScreen()

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -478,10 +478,13 @@ class MainWindow(QMainWindow):
         self.current_quick_layout = None
         self.previous_layout_settings = None  # TODO: related to quick layouts
         self.last_plugin = None
-        self.fullscreen_flag = None # isFullscreen does not work as expected
+        self.fullscreen_flag = None  # isFullscreen does not work as expected
         # The following flag remember the maximized state even when
         # the window is in fullscreen mode:
         self.maximized_flag = None
+        self.saved_normal_geometry = None
+        # This flag is used to restore window's geometry when toggling out of
+        # fullscreen mode in Windows.
 
         # To keep track of the last focused widget
         self.last_focused_widget = None


### PR DESCRIPTION
## Description of Changes

<!--- Describe what you've changed and why. --->

Due to limitations of the Windows DWM, compositing is not handled correctly for OpenGL based windows when going into full screen mode.

To get around this issue, this PR propose to use the workaround described here:
https://bugreports.qt.io/browse/QTBUG-41309


### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #4291


<!--- Thanks for your help making Spyder better for everyone! --->
