### PR TITLE
PR: Make the text of the About Spyder message box selectable

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2338,8 +2338,8 @@ class MainWindow(QMainWindow):
             rev = versions['revision']
             revlink = " (<a href='https://github.com/spyder-ide/spyder/"\
                       "commit/%s'>Commit: %s</a>)" % (rev, rev)
-        QMessageBox.about(self,
-            _("About %s") % "Spyder",
+        msgBox = QMessageBox(self)
+        msgBox.setText(
             """<b>Spyder %s</b> %s
             <br>The Scientific Python Development Environment
             <br>Copyright &copy; The Spyder Project Contributors
@@ -2359,17 +2359,24 @@ class MainWindow(QMainWindow):
             <a href="https://winpython.github.io/">WinPython</a>
             also contribute to this plan.
             <p>Python %s %dbits, Qt %s, %s %s on %s
-            <p><small>Most of the icons for the Spyder 2 theme come from the Crystal
-            Project (&copy; 2006-2007 Everaldo Coelho). Other icons for that
-            theme come from <a href="http://p.yusukekamiyamane.com/"> Yusuke
-            Kamiyamane</a> (all rights reserved) and from
+            <p><small>Most of the icons for the Spyder 2 theme come from the
+            Crystal Project (&copy; 2006-2007 Everaldo Coelho).
+            Other icons for that theme come from
+            <a href="http://p.yusukekamiyamane.com/">
+            Yusuke Kamiyamane</a> (all rights reserved) and from
             <a href="http://www.oxygen-icons.org/">
             The Oxygen icon theme</a></small>.
             """
             % (versions['spyder'], revlink, __project_url__, __trouble_url__,
                __project_url__, __forum_url__, versions['python'],
                versions['bitness'], versions['qt'], versions['qt_api'],
-               versions['qt_api_ver'], versions['system']))
+               versions['qt_api_ver'], versions['system'])
+        )
+        msgBox.setWindowTitle(_("About %s") % "Spyder")
+        msgBox.setStandardButtons(QMessageBox.Ok)
+        msgBox.setIconPixmap(APP_ICON.pixmap(QSize(64, 64)))
+        msgBox.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        msgBox.exec_()
 
     @Slot()
     def show_dependencies(self):


### PR DESCRIPTION
<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings for any new functions
* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] Included a screenshot, if this PR makes any visible changes to the UI


## Description of Changes

<!--- Describe what you've changed and why. --->

To make the text of a `QMessageBox` selectable in Windows 10 when using the `WindowsVista` theme, the `setTextInteractionFlags` of the message box has to be set to `Qt.TextSelectableByMouse`.

To my knowledge, this is not possible to do this by using the `QMessageBox.about()` function of the static functions API. So a custom about message box has to be constructed manually instead.

![image](https://user-images.githubusercontent.com/10170372/44366380-759de100-a49a-11e8-840d-8b7d404b1500.png)

### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #6535
<!--- Thanks for your help making Spyder better for everyone! --->
