### PR TITLE
PR: Add a "get_cursor_line_number" method to OutlineExplorerProxyEditor

### DIFF
--- a/spyder/plugins/outlineexplorer/editor.py
+++ b/spyder/plugins/outlineexplorer/editor.py
@@ -26,7 +26,8 @@ class OutlineExplorerProxyEditor(OutlineExplorerProxy):
 
     def get_outlineexplorer_data(self):
         oe_data = self._editor.get_outlineexplorer_data()
-        self._editor.has_cell_separators = oe_data.pop('found_cell_separators', False)
+        self._editor.has_cell_separators = oe_data.pop(
+            'found_cell_separators', False)
         return oe_data
 
     def get_line_count(self):

--- a/spyder/plugins/outlineexplorer/editor.py
+++ b/spyder/plugins/outlineexplorer/editor.py
@@ -20,6 +20,9 @@ class OutlineExplorerProxyEditor(OutlineExplorerProxy):
     def give_focus(self):
         self._editor.clearFocus()
         self._editor.setFocus()
+        
+    def get_cursor_line_number(self):
+        return self._editor.get_cursor_line_number()
 
     def get_outlineexplorer_data(self):
         oe_data = self._editor.get_outlineexplorer_data()

--- a/spyder/plugins/outlineexplorer/editor.py
+++ b/spyder/plugins/outlineexplorer/editor.py
@@ -20,7 +20,7 @@ class OutlineExplorerProxyEditor(OutlineExplorerProxy):
     def give_focus(self):
         self._editor.clearFocus()
         self._editor.setFocus()
-        
+
     def get_cursor_line_number(self):
         return self._editor.get_cursor_line_number()
 

--- a/spyder/plugins/outlineexplorer/tests/test_widgets.py
+++ b/spyder/plugins/outlineexplorer/tests/test_widgets.py
@@ -16,8 +16,9 @@ from qtpy.QtCore import Qt
 
 # Local imports
 from spyder.plugins.outlineexplorer.editor import OutlineExplorerProxyEditor
-from spyder.plugins.outlineexplorer.widgets import (OutlineExplorerWidget,
-    FileRootItem, FunctionItem, CommentItem, CellItem, ClassItem)
+from spyder.plugins.outlineexplorer.widgets import (
+    OutlineExplorerWidget, FileRootItem, FunctionItem, CommentItem,
+    CellItem, ClassItem)
 from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 
 
@@ -186,11 +187,23 @@ def test_outline_explorer(outlineexplorer_bot):
             assert item.is_method() == expected_result[2]
 
 
-# def test_go_to_cursor_position(setup_outline_explorer):
-#     outlineexplorer, qtbot = outline_explorer_bot
-#     qtbot.mouseClick(outlineexplorer.fromcursor_btn, Qt.LeftButton)
-    
-#     outlineexplorer.treewidget.current_editor
+def test_go_to_cursor_position(outlineexplorer_bot):
+    """
+    Test that clicking on the 'Go to cursor position' button located in the
+    toolbar of the outline explorer is working as expected.
+    """
+    outlineexplorer, qtbot = outlineexplorer_bot(TEXT, 'test.py')
+
+    # Move the mouse cursor in the editor to line 31 :
+    editor = outlineexplorer.treewidget.current_editor
+    editor._editor.go_to_line(31)
+    assert editor._editor.get_text_line(31) == "        if False:"
+
+    # Click on the 'Go to cursor position' button of the outline explorer's
+    # toolbar :
+    qtbot.mouseClick(outlineexplorer.fromcursor_btn, Qt.LeftButton)
+    current_item = outlineexplorer.treewidget.currentItem()
+    assert current_item.text(0) == 'method1'
 
 
 def test_code_cell_grouping(outlineexplorer_bot):

--- a/spyder/plugins/outlineexplorer/tests/test_widgets.py
+++ b/spyder/plugins/outlineexplorer/tests/test_widgets.py
@@ -12,6 +12,7 @@ from textwrap import dedent
 
 # Third party imports
 import pytest
+from qtpy.QtCore import Qt
 
 # Local imports
 from spyder.plugins.outlineexplorer.editor import OutlineExplorerProxyEditor
@@ -20,7 +21,7 @@ from spyder.plugins.outlineexplorer.widgets import (OutlineExplorerWidget,
 from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 
 
-text = ("# -*- coding: utf-8 -*-\n"
+TEXT = ("# -*- coding: utf-8 -*-\n"
         "\n"
         "# %% functions\n"
         "\n"
@@ -60,7 +61,7 @@ text = ("# -*- coding: utf-8 -*-\n"
         "        except AssertionError:\n"
         "            pass")
 
-code = """# -*- coding: utf-8 -*-
+CODE = """# -*- coding: utf-8 -*-
 
     def function0(x):
         return x
@@ -126,42 +127,40 @@ code = """# -*- coding: utf-8 -*-
         x = 'test'
 """
 
-# Qt Test Fixtures
-# --------------------------------
 
+# ---- Qt Test Fixtures
 @pytest.fixture
-def outline_explorer_bot(qtbot):
-    code_editor = CodeEditor(None)
-    code_editor.set_language('py', 'test_outline_explorer.py')
-    code_editor.set_text(text)
+def outlineexplorer_bot(qtbot):
+    def _create_bot(code, filename):
+        code_editor = CodeEditor(None)
+        code_editor.set_language('py', filename)
+        code_editor.set_text(code)
 
-    editor = OutlineExplorerProxyEditor(code_editor,
-                                        'test_outline_explorer.py')
+        editor = OutlineExplorerProxyEditor(code_editor, filename)
 
-    outline_explorer = OutlineExplorerWidget()
-    outline_explorer.set_current_editor(editor, False, False)
+        outlineexplorer = OutlineExplorerWidget()
+        outlineexplorer.set_current_editor(editor, False, False)
+        outlineexplorer.show()
+        outlineexplorer.setFixedSize(400, 350)
 
-    qtbot.addWidget(outline_explorer)
+        qtbot.addWidget(outlineexplorer)
+        return outlineexplorer, qtbot
+    return _create_bot
 
-    return outline_explorer, qtbot
 
-
-# Test OutlineExplorerWidget
-# -------------------------------
-
-def test_outline_explorer(outline_explorer_bot):
+# ---- Test OutlineExplorerWidget
+def test_outline_explorer(outlineexplorer_bot):
     """
     Test to assert the outline explorer is initializing correctly and
     is showing the expected number of items, the expected type of items, and
     the expected text for each item.
     """
-    outline_explorer, qtbot = outline_explorer_bot
-    outline_explorer.show()
-    outline_explorer.setFixedSize(400, 350)
-    assert outline_explorer
+    outlineexplorer, qtbot = outlineexplorer_bot(
+        TEXT, 'test_outline_explorer.py')
+    assert outlineexplorer
 
-    outline_explorer.treewidget.expandAll()
-    tree_widget = outline_explorer.treewidget
+    outlineexplorer.treewidget.expandAll()
+    tree_widget = outlineexplorer.treewidget
     all_items = tree_widget.get_top_level_items() + tree_widget.get_items()
 
     # Assert that the expected number, text and type of items is displayed in
@@ -187,39 +186,22 @@ def test_outline_explorer(outline_explorer_bot):
             assert item.is_method() == expected_result[2]
 
 
-# Qt Test Fixtures
-# --------------------------------
-@pytest.fixture
-def outline_explorer_bot2(qtbot):
-    code_editor = CodeEditor()
-    code_editor = CodeEditor(None)
-    code_editor.set_language('py', 'test_file.py')
-    code_editor.set_text(dedent(code))
-
-    editor = OutlineExplorerProxyEditor(code_editor,
-                                        'test_file.py')
-
-    outline_explorer = OutlineExplorerWidget()
-    outline_explorer.set_current_editor(editor, False, False)
-
-    qtbot.addWidget(outline_explorer)
-
-    return outline_explorer, qtbot
+# def test_go_to_cursor_position(setup_outline_explorer):
+#     outlineexplorer, qtbot = outline_explorer_bot
+#     qtbot.mouseClick(outlineexplorer.fromcursor_btn, Qt.LeftButton)
+    
+#     outlineexplorer.treewidget.current_editor
 
 
-# Test OutlineExplorerWidget
-# -------------------------------
-def test_code_cell_grouping(outline_explorer_bot2):
+def test_code_cell_grouping(outlineexplorer_bot):
     """
     Test to assert the outline explorer is initializing correctly and
     is showing the expected number of items, the expected type of items, and
     the expected text for each item. In addition this tests ancestry, code
     cells comments, code cell grouping and disabling this feature.
     """
-    outline_explorer, qtbot = outline_explorer_bot2
-    outline_explorer.show()
-    outline_explorer.setFixedSize(400, 350)
-    assert outline_explorer
+    outlineexplorer, qtbot = outlineexplorer_bot(dedent(CODE), 'test_file.py')
+    assert outlineexplorer
 
     expected_results = [
         ('test_file.py', FileRootItem),
@@ -251,8 +233,8 @@ def test_code_cell_grouping(outline_explorer_bot2):
         ('MGroup4', CellItem, 'MGroup3', 'test_file.py')
         ]
 
-    outline_explorer.treewidget.expandAll()
-    tree_widget = outline_explorer.treewidget
+    outlineexplorer.treewidget.expandAll()
+    tree_widget = outlineexplorer.treewidget
     cell_items = tree_widget.get_top_level_items() + tree_widget.get_items()
 
     # Assert that the expected number, text, ancestry and type of cell items is

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -558,12 +558,11 @@ class OutlineExplorerWidget(QWidget):
 
     def setup_buttons(self):
         """Setup the buttons of the outline explorer widget toolbar."""
-        fromcursor_btn = create_toolbutton(
-                             self, icon=ima.icon('fromcursor'),
-                             tip=_('Go to cursor position'),
-                             triggered=self.treewidget.go_to_cursor_position)
+        self.fromcursor_btn = create_toolbutton(
+            self, icon=ima.icon('fromcursor'), tip=_('Go to cursor position'),
+            triggered=self.treewidget.go_to_cursor_position)
 
-        buttons = [fromcursor_btn]
+        buttons = [self.fromcursor_btn]
         for action in [self.treewidget.collapse_all_action,
                        self.treewidget.expand_all_action,
                        self.treewidget.restore_action,


### PR DESCRIPTION
### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings for any new functions
* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] Included a screenshot, if this PR makes any visible changes to the UI

## Description of Changes

- [x] Fix the bug
- [x] Add a test

### Issue(s) Resolved
Fixes #7729


