### PR TITLE
Make Group cells setting persistent when restarting spyder

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -268,6 +268,7 @@ DEFAULTS = [
               'enable': True,
               'show_fullpath': False,
               'show_all_files': False,
+              'group_cells': True,
               'show_comments': True,
               }),
             ('project_explorer',

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1645,6 +1645,7 @@ class Editor(SpyderPluginWidget):
                                   self.toolbar_list, self.menu_list,
                                   show_fullpath=oe_options['show_fullpath'],
                                   show_all_files=oe_options['show_all_files'],
+                                  group_cells=oe_options['group_cells'],
                                   show_comments=oe_options['show_comments'])
         window.add_toolbars_to_menu("&View", window.get_toolbars())
         window.load_toolbars()

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2803,7 +2803,7 @@ class EditorSplitter(QSplitter):
 
 class EditorWidget(QSplitter):
     def __init__(self, parent, plugin, menu_actions, show_fullpath,
-                 show_all_files, show_comments):
+                 show_all_files, group_cells, show_comments):
         QSplitter.__init__(self, parent)
         self.setAttribute(Qt.WA_DeleteOnClose)
 
@@ -2823,6 +2823,7 @@ class EditorWidget(QSplitter):
         self.outlineexplorer = OutlineExplorerWidget(self,
                                             show_fullpath=show_fullpath,
                                             show_all_files=show_all_files,
+                                            group_cells=group_cells,
                                             show_comments=show_comments)
         self.outlineexplorer.edit_goto.connect(
                      lambda filenames, goto, word:
@@ -2891,7 +2892,7 @@ class EditorWidget(QSplitter):
 
 class EditorMainWindow(QMainWindow):
     def __init__(self, plugin, menu_actions, toolbar_list, menu_list,
-                 show_fullpath, show_all_files, show_comments):
+                 show_fullpath, show_all_files, group_cells, show_comments):
         QMainWindow.__init__(self)
         self.setAttribute(Qt.WA_DeleteOnClose)
 
@@ -2899,7 +2900,7 @@ class EditorMainWindow(QMainWindow):
 
         self.editorwidget = EditorWidget(self, plugin, menu_actions,
                                          show_fullpath, show_all_files,
-                                         show_comments)
+                                         group_cells, show_comments)
         self.setCentralWidget(self.editorwidget)
 
         # Give focus to current editor to update/show all status bar widgets
@@ -3104,7 +3105,7 @@ class EditorPluginExample(QSplitter):
         window = EditorMainWindow(self, self.menu_actions,
                                   self.toolbar_list, self.menu_list,
                                   show_fullpath=False, show_all_files=False,
-                                  show_comments=True)
+                                  group_cells=True, show_comments=True)
         window.resize(self.size())
         window.show()
         self.register_editorwindow(window)

--- a/spyder/plugins/outlineexplorer/plugin.py
+++ b/spyder/plugins/outlineexplorer/plugin.py
@@ -32,6 +32,7 @@ class OutlineExplorer(SpyderPluginWidget):
 
         show_fullpath = self.get_option('show_fullpath')
         show_all_files = self.get_option('show_all_files')
+        group_cells = self.get_option('group_cells')
         show_comments = self.get_option('show_comments')
 
         # Initialize plugin
@@ -40,6 +41,7 @@ class OutlineExplorer(SpyderPluginWidget):
                                        self,
                                        show_fullpath=show_fullpath,
                                        show_all_files=show_all_files,
+                                       group_cells=group_cells,
                                        show_comments=show_comments,
                                        options_button=self.options_button)
 

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -157,12 +157,12 @@ def remove_from_tree_cache(tree_cache, line=None, item=None):
 
 
 class OutlineExplorerTreeWidget(OneColumnTree):
-    def __init__(self, parent, show_fullpath=False,
-                 show_all_files=True, show_comments=True, group_cells=True):
+    def __init__(self, parent, show_fullpath=False, show_all_files=True,
+                 group_cells=True, show_comments=True):
         self.show_fullpath = show_fullpath
         self.show_all_files = show_all_files
-        self.show_comments = show_comments
         self.group_cells = group_cells
+        self.show_comments = show_comments
         OneColumnTree.__init__(self, parent)
         self.freeze = False # Freezing widget to avoid any unwanted update
         self.editor_items = {}
@@ -520,13 +520,14 @@ class OutlineExplorerWidget(QWidget):
     edit = Signal(str)
     is_visible = Signal()
     
-    def __init__(self, parent=None, show_fullpath=True,
-                 show_all_files=True, show_comments=True, options_button=None):
+    def __init__(self, parent=None, show_fullpath=True, show_all_files=True,
+                 group_cells=True, show_comments=True, options_button=None):
         QWidget.__init__(self, parent)
 
         self.treewidget = OutlineExplorerTreeWidget(self,
                                             show_fullpath=show_fullpath,
                                             show_all_files=show_all_files,
+                                            group_cells=group_cells,
                                             show_comments=show_comments)
 
         self.visibility_action = create_action(self,
@@ -587,6 +588,7 @@ class OutlineExplorerWidget(QWidget):
         """
         return dict(show_fullpath=self.treewidget.show_fullpath,
                     show_all_files=self.treewidget.show_all_files,
+                    group_cells=self.treewidget.group_cells,
                     show_comments=self.treewidget.show_comments,
                     expanded_state=self.treewidget.get_expanded_state(),
                     scrollbar_position=self.treewidget.get_scrollbar_position(),


### PR DESCRIPTION
<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [ ] Wrote at least one-line docstrings for any new functions
* [ ] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [ ] Included a screenshot, if this PR makes any visible changes to the UI


## Description of Changes

<!--- Describe what you've changed and why. --->
This need to make the "Group code cells" setting for the outline explorer persistent 



### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #7736 


<!--- Thanks for your help making Spyder better for everyone! --->
