### PR TITLE
PR: Make the "Go to cursor position" button of the outline explorer work also when the cursor is in the last item of the Editor

### DIFF
--- a/spyder/plugins/outlineexplorer/tests/test_widgets.py
+++ b/spyder/plugins/outlineexplorer/tests/test_widgets.py
@@ -201,10 +201,31 @@ def test_go_to_cursor_position(outlineexplorer_bot):
 
     # Click on the 'Go to cursor position' button of the outline explorer's
     # toolbar :
+    assert outlineexplorer.treewidget.currentItem() is None
+    qtbot.mouseClick(outlineexplorer.fromcursor_btn, Qt.LeftButton)
+    assert outlineexplorer.treewidget.currentItem().text(0) == 'method1'
+    
+def test_go_to_last_item(outlineexplorer_bot):
+    """
+    Test that clicking on the 'Go to cursor position' button located in the
+    toolbar of the outline explorer is working as expected when the cursor
+    is located in the editor in the last item of the outline.
+    Catch Issue #
+    """
+    outlineexplorer, qtbot = outlineexplorer_bot(TEXT, 'test.py')
+
+    # Move the mouse cursor in the editor to the last line :
+    editor = outlineexplorer.treewidget.current_editor
+    line_count = editor._editor.document().blockCount() - 1
+    editor._editor.go_to_line(line_count)
+    assert editor._editor.get_text_line(line_count) == "            pass"
+    
+    # Click on the 'Go to cursor position' button of the outline explorer's
+    # toolbar :
+    assert outlineexplorer.treewidget.currentItem() is None
     qtbot.mouseClick(outlineexplorer.fromcursor_btn, Qt.LeftButton)
     current_item = outlineexplorer.treewidget.currentItem()
-    assert current_item.text(0) == 'method1'
-
+    assert outlineexplorer.treewidget.currentItem().text(0) == 'method2'
 
 def test_code_cell_grouping(outlineexplorer_bot):
     """

--- a/spyder/plugins/outlineexplorer/tests/test_widgets.py
+++ b/spyder/plugins/outlineexplorer/tests/test_widgets.py
@@ -191,6 +191,8 @@ def test_go_to_cursor_position(outlineexplorer_bot):
     """
     Test that clicking on the 'Go to cursor position' button located in the
     toolbar of the outline explorer is working as expected.
+
+    Regression test for issue #7729.
     """
     outlineexplorer, qtbot = outlineexplorer_bot(TEXT, 'test.py')
 
@@ -210,8 +212,9 @@ def test_go_to_last_item(outlineexplorer_bot):
     """
     Test that clicking on the 'Go to cursor position' button located in the
     toolbar of the outline explorer is working as expected when the cursor
-    is located in the editor in the last item of the outline.
-    Catch Issue #
+    is located in the editor under the last item of the outline tree widget.
+
+    Regression test for issue #7744.
     """
     outlineexplorer, qtbot = outlineexplorer_bot(TEXT, 'test.py')
 

--- a/spyder/plugins/outlineexplorer/tests/test_widgets.py
+++ b/spyder/plugins/outlineexplorer/tests/test_widgets.py
@@ -204,7 +204,8 @@ def test_go_to_cursor_position(outlineexplorer_bot):
     assert outlineexplorer.treewidget.currentItem() is None
     qtbot.mouseClick(outlineexplorer.fromcursor_btn, Qt.LeftButton)
     assert outlineexplorer.treewidget.currentItem().text(0) == 'method1'
-    
+
+
 def test_go_to_last_item(outlineexplorer_bot):
     """
     Test that clicking on the 'Go to cursor position' button located in the
@@ -219,13 +220,14 @@ def test_go_to_last_item(outlineexplorer_bot):
     line_count = editor._editor.document().blockCount() - 1
     editor._editor.go_to_line(line_count)
     assert editor._editor.get_text_line(line_count) == "            pass"
-    
+
     # Click on the 'Go to cursor position' button of the outline explorer's
     # toolbar :
     assert outlineexplorer.treewidget.currentItem() is None
     qtbot.mouseClick(outlineexplorer.fromcursor_btn, Qt.LeftButton)
     current_item = outlineexplorer.treewidget.currentItem()
     assert outlineexplorer.treewidget.currentItem().text(0) == 'method2'
+
 
 def test_code_cell_grouping(outlineexplorer_bot):
     """

--- a/spyder/plugins/outlineexplorer/tests/test_widgets.py
+++ b/spyder/plugins/outlineexplorer/tests/test_widgets.py
@@ -228,7 +228,6 @@ def test_go_to_last_item(outlineexplorer_bot):
     # toolbar :
     assert outlineexplorer.treewidget.currentItem() is None
     qtbot.mouseClick(outlineexplorer.fromcursor_btn, Qt.LeftButton)
-    current_item = outlineexplorer.treewidget.currentItem()
     assert outlineexplorer.treewidget.currentItem().text(0) == 'method2'
 
 

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -138,6 +138,8 @@ def item_at_line(root_item, line):
         if item.line > line:
             return previous_item
         previous_item = item
+    else:
+        return item
 
 
 def remove_from_tree_cache(tree_cache, line=None, item=None):

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -125,6 +125,7 @@ class CellItem(TreeItem):
         self.setToolTip(0, _("Cell starts at line %s") % str(self.line))
 
 def get_item_children(item):
+    """Return a sorted list of all the children items of 'item'."""
     children = [item.child(index) for index in range(item.childCount())]
     for child in children[:]:
         others = get_item_children(child)
@@ -132,7 +133,12 @@ def get_item_children(item):
             children += others
     return sorted(children, key=lambda child: child.line)
 
+
 def item_at_line(root_item, line):
+    """
+    Find and return the item of the outline explorer under which is located
+    the specified 'line' of the editor.
+    """
     previous_item = root_item
     for item in get_item_children(root_item):
         if item.line > line:


### PR DESCRIPTION
<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings for any new functions
* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] Included a screenshot, if this PR makes any visible changes to the UI


## Description of Changes

<!--- Describe what you've changed and why. --->

- [x] Add a test to catch the bug
- [x] Add docsting to function where missing
- [x] Fix the issue #7744

![last_item_oe](https://user-images.githubusercontent.com/10170372/44485910-21bd0480-a620-11e8-84f5-d84115b28174.gif)

### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #7744


<!--- Thanks for your help making Spyder better for everyone! --->
