### PR TITLE
PR: Protecting calls to unregister_editorstack_cb and pin sip in our tests

### DIFF
--- a/continuous_integration/travis/install-qt.sh
+++ b/continuous_integration/travis/install-qt.sh
@@ -16,7 +16,7 @@ if [ "$USE_CONDA" = "no" ]; then
     # Install spyder-kernels from Github
     pip install -q git+https://github.com/spyder-ide/spyder-kernels@0.x
 else
-    conda install -q qt=5.* pyqt=5.* qtconsole matplotlib
+    conda install -q qt=5* pyqt=5.* sip=4.19.8 qtconsole matplotlib
 
     # Install spyder-kernels from Github
     pip install -q --no-deps git+https://github.com/spyder-ide/spyder-kernels@0.x

--- a/spyder/widgets/editor.py
+++ b/spyder/widgets/editor.py
@@ -2454,9 +2454,9 @@ class EditorSplitter(QSplitter):
             print("method 'editorstack_closed':", file=STDOUT)
             print("    self  :", self, file=STDOUT)
 #            print >>STDOUT, "    sender:", self.sender()
-        self.unregister_editorstack_cb(self.editorstack)
-        self.editorstack = None
         try:
+            self.unregister_editorstack_cb(self.editorstack)
+            self.editorstack = None
             close_splitter = self.count() == 1
         except RuntimeError:
             # editorsplitter has been destroyed (happens when closing a

--- a/spyder/widgets/variableexplorer/tests/test_arrayeditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_arrayeditor.py
@@ -101,7 +101,7 @@ def test_arrayeditor_with_masked_array(qtbot):
 
 def test_arrayeditor_with_record_array(qtbot):
     arr = np.zeros((2, 2), {'names': ('red', 'green', 'blue'),
-                           'formats': (np.float32, np.float32, np.float32)})
+                            'formats': (np.float32, np.float32, np.float32)})
     assert_array_equal(arr, launch_arrayeditor(arr, "record array"))
 
 

--- a/spyder/widgets/variableexplorer/tests/test_arrayeditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_arrayeditor.py
@@ -93,6 +93,7 @@ def test_arrayeditor_with_unicode_array(qtbot):
     assert arr == launch_arrayeditor(arr, "unicode array")
 
 
+@pytest.mark.skipif(sys.platform == 'darwin', reason="It fails on macOS")
 def test_arrayeditor_with_masked_array(qtbot):
     arr = np.ma.array([[1, 0], [1, 0]], mask=[[True, False], [False, False]])
     assert_array_equal(arr, launch_arrayeditor(arr, "masked array"))

--- a/spyder/widgets/variableexplorer/tests/test_arrayeditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_arrayeditor.py
@@ -87,6 +87,7 @@ def test_arrayeditor_with_string_array(qtbot):
     assert arr == launch_arrayeditor(arr, "string array")
 
 
+@pytest.mark.skipif(sys.platform == 'darwin', reason="It fails on macOS")
 def test_arrayeditor_with_unicode_array(qtbot):
     arr = np.array([u"ñññéáíó"])
     assert arr == launch_arrayeditor(arr, "unicode array")

--- a/spyder/widgets/variableexplorer/tests/test_arrayeditor.py
+++ b/spyder/widgets/variableexplorer/tests/test_arrayeditor.py
@@ -87,13 +87,11 @@ def test_arrayeditor_with_string_array(qtbot):
     assert arr == launch_arrayeditor(arr, "string array")
 
 
-@pytest.mark.skipif(sys.platform == 'darwin', reason="It fails on macOS")
 def test_arrayeditor_with_unicode_array(qtbot):
     arr = np.array([u"ñññéáíó"])
     assert arr == launch_arrayeditor(arr, "unicode array")
 
 
-@pytest.mark.skipif(sys.platform == 'darwin', reason="It fails on macOS")
 def test_arrayeditor_with_masked_array(qtbot):
     arr = np.ma.array([[1, 0], [1, 0]], mask=[[True, False], [False, False]])
     assert_array_equal(arr, launch_arrayeditor(arr, "masked array"))


### PR DESCRIPTION
## Description of Changes

From time to time, a test is failing on our CI with this error:

https://travis-ci.org/spyder-ide/spyder/jobs/422626738#L932
```python
==================================== ERRORS ====================================
 ERROR at setup of test_reorder_filenames[filenames2-expected_filenames2-None-None] 
SETUP ERROR: Qt exceptions in virtual methods:
________________________________________________________________________________
Traceback (most recent call last):
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/widgets/editor.py", line 2629, in <lambda>
    self.editorstack.destroyed.connect(lambda: self.editorstack_closed())
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/widgets/editor.py", line 2654, in editorstack_closed
    self.unregister_editorstack_cb(self.editorstack)
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/plugin.py", line 1525, in unregister_editorstack
    self.remove_last_focus_editorstack(editorstack)
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/plugin.py", line 1375, in remove_last_focus_editorstack
    for editorwindow, widget in list(self.last_focus_editorstack.items()):
RuntimeError: wrapped C/C++ object of type Editor has been deleted
________________________________________________________________________________
Traceback (most recent call last):
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/widgets/editor.py", line 2629, in <lambda>
    self.editorstack.destroyed.connect(lambda: self.editorstack_closed())
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/widgets/editor.py", line 2654, in editorstack_closed
    self.unregister_editorstack_cb(self.editorstack)
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/plugin.py", line 1525, in unregister_editorstack
    self.remove_last_focus_editorstack(editorstack)
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/plugin.py", line 1375, in remove_last_focus_editorstack
    for editorwindow, widget in list(self.last_focus_editorstack.items()):
RuntimeError: wrapped C/C++ object of type Editor has been deleted
________________________________________________________________________________
Traceback (most recent call last):
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/widgets/editor.py", line 2629, in <lambda>
    self.editorstack.destroyed.connect(lambda: self.editorstack_closed())
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/widgets/editor.py", line 2654, in editorstack_closed
    self.unregister_editorstack_cb(self.editorstack)
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/plugin.py", line 1525, in unregister_editorstack
    self.remove_last_focus_editorstack(editorstack)
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/plugin.py", line 1375, in remove_last_focus_editorstack
    for editorwindow, widget in list(self.last_focus_editorstack.items()):
RuntimeError: wrapped C/C++ object of type Editor has been deleted
________________________________________________________________________________
---------------------------- Captured stderr setup -----------------------------
Qt exceptions in virtual methods:
________________________________________________________________________________
Traceback (most recent call last):
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/widgets/editor.py", line 2629, in <lambda>
    self.editorstack.destroyed.connect(lambda: self.editorstack_closed())
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/widgets/editor.py", line 2654, in editorstack_closed
    self.unregister_editorstack_cb(self.editorstack)
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/plugin.py", line 1525, in unregister_editorstack
    self.remove_last_focus_editorstack(editorstack)
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/plugin.py", line 1375, in remove_last_focus_editorstack
    for editorwindow, widget in list(self.last_focus_editorstack.items()):
RuntimeError: wrapped C/C++ object of type Editor has been deleted
________________________________________________________________________________
Qt exceptions in virtual methods:
________________________________________________________________________________
Traceback (most recent call last):
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/widgets/editor.py", line 2629, in <lambda>
    self.editorstack.destroyed.connect(lambda: self.editorstack_closed())
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/widgets/editor.py", line 2654, in editorstack_closed
    self.unregister_editorstack_cb(self.editorstack)
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/plugin.py", line 1525, in unregister_editorstack
    self.remove_last_focus_editorstack(editorstack)
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/plugin.py", line 1375, in remove_last_focus_editorstack
    for editorwindow, widget in list(self.last_focus_editorstack.items()):
RuntimeError: wrapped C/C++ object of type Editor has been deleted
________________________________________________________________________________
Qt exceptions in virtual methods:
________________________________________________________________________________
Traceback (most recent call last):
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/widgets/editor.py", line 2629, in <lambda>
    self.editorstack.destroyed.connect(lambda: self.editorstack_closed())
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/widgets/editor.py", line 2654, in editorstack_closed
    self.unregister_editorstack_cb(self.editorstack)
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/plugin.py", line 1525, in unregister_editorstack
    self.remove_last_focus_editorstack(editorstack)
  File "/home/travis/build/spyder-ide/spyder/spyder/plugins/editor/plugin.py", line 1375, in remove_last_focus_editorstack
    for editorwindow, widget in list(self.last_focus_editorstack.items()):
RuntimeError: wrapped C/C++ object of type Editor has been deleted
________________________________________________________________________________
```

This happens during the deconstruction phase of a test when an instance of an `EditorMainWindow` is closed. The problem occurs when the `Editor` have already been destroyed when the signal to unregister the `Editor` is received.

In order to avoid that, we need to protect `self.unregister_editorstack_cb(self.editorstack)` and `self.editorstack = None` in the `try` statement. The reason to do this is already documented in the code:

```python
try:
    self.unregister_editorstack_cb(self.editorstack)
    self.editorstack = None
    close_splitter = self.count() == 1
except RuntimeError:
     # editorsplitter has been destroyed (happens when closing a
     # EditorMainWindow instance)
     return
```