### PR TITLE
PR: Split "test_mainwindow.test_help" and skip tests on Windows CI because they are timing out.

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -266,6 +266,8 @@ def test_filter_numpy_warning(main_window, qtbot):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
+@pytest.mark.skipif(os.name == 'nt' and os.environ.get('CI') is not None,
+                    reason="Times out on AppVeyor")
 @pytest.mark.use_introspection
 def test_get_help_ipython_console(main_window, qtbot):
     """Test that Help works when called from the IPython console."""
@@ -290,6 +292,8 @@ def test_get_help_ipython_console(main_window, qtbot):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
+@pytest.mark.skipif(os.name == 'nt' and os.environ.get('CI') is not None,
+                    reason="Times out on AppVeyor")
 @pytest.mark.use_introspection
 def test_get_help_editor(main_window, qtbot):
     """ Test that Help works when called from the Editor."""

--- a/spyder/plugins/editor/widgets/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/tests/test_warnings.py
@@ -102,6 +102,8 @@ def test_adding_warnings(qtbot, construct_editor):
             # assert expected in warning
 
 
+@pytest.mark.skipif(os.name == 'nt' and os.environ.get('CI') is not None,
+                    reason="Times out on AppVeyor")
 def test_move_warnings(qtbot, construct_editor):
     editor, lsp_manager = construct_editor
 

--- a/spyder/plugins/editor/widgets/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/tests/test_warnings.py
@@ -75,8 +75,8 @@ def construct_editor(qtbot, *args, **kwargs):
     lsp_manager.closing_plugin()
 
 
-@pytest.mark.skipif(os.name == 'nt' and not PY2,
-                    reason="Times out on AppVeyor and fails on PY3/PyQt 5.6")
+@pytest.mark.skipif(os.name == 'nt' and os.environ.get('CI') is not None,
+                    reason="Times out on AppVeyor")
 def test_adding_warnings(qtbot, construct_editor):
     """Test that warning are saved in the blocks of the editor."""
     editor, lsp_manager = construct_editor


### PR DESCRIPTION
## Description of Changes

It seems that tests related to the LSP are failing on AppVeyor with this error:

![image](https://user-images.githubusercontent.com/10170372/44872729-4f2f3100-ac64-11e8-83d1-9a5fb12e5b2d.png)

This PR proposes to skip the problematic tests on Windows CI. Note that the tests are passing locally on my Windows 10 laptop.

Also this PR proposes to split the `test_mainwindow.test_help` in two so that `Help` is tested independently when called from the Editor or from the IPython console. Otherwise, it is not possible to know if the test is timing out because of the action made in the Editor or in the IPython console.

Unfortunately, after the split, I found out that both tests were timing out on AppVeyor, so they had to be skipped. Still, I think splitting the test in two is an improvement, so I'm proposing it here anyway.


### Issue(s) Resolved

This PR will allow the tests on Appveyor to pass for the following three PR:

PR #7790
PR #7789
PR #7768


<!--- Thanks for your help making Spyder better for everyone! --->
