### PR TITLE
PR: Correctly handling pydoc._start_server on Python 3.7

### DIFF
--- a/spyder/widgets/pydocgui.py
+++ b/spyder/widgets/pydocgui.py
@@ -36,7 +36,14 @@ class PydocServer(QThread):
         import pydoc
         if PY3:
             # Python 3
-            self.callback(pydoc._start_server(pydoc._url_handler, self.port))
+            try:
+                self.callback(pydoc._start_server(pydoc._url_handler,
+                                                  port=self.port))
+            except:
+                # Python 3.7
+                self.callback(pydoc._start_server(pydoc._url_handler,
+                                              hostname='localhost',
+                                              port=self.port))
         else:
             # Python 2
             pydoc.serve(self.port, self.callback, self.completer)

--- a/spyder/widgets/pydocgui.py
+++ b/spyder/widgets/pydocgui.py
@@ -39,11 +39,11 @@ class PydocServer(QThread):
             try:
                 self.callback(pydoc._start_server(pydoc._url_handler,
                                                   port=self.port))
-            except:
+            except TypeError:
                 # Python 3.7
                 self.callback(pydoc._start_server(pydoc._url_handler,
-                                              hostname='localhost',
-                                              port=self.port))
+                                                  hostname='localhost',
+                                                  port=self.port))
         else:
             # Python 2
             pydoc.serve(self.port, self.callback, self.completer)


### PR DESCRIPTION
<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [X] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [X] Based your PR on the latest version of the correct branch (master or 3.x)
* [X] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [X] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [X] Wrote at least one-line docstrings for any new functions
* [X] Added at least one unit test covering the changes, if at all possible
* [X] Described your changes and the motivation for them below
* [X] Noted what issue(s) this pull request resolves, creating one if needed
* [X] Included a screenshot, if this PR makes any visible changes to the UI


## Description of Changes

<!--- Describe what you've changed and why. --->

Added a try/except to handle the difference in parameters on pydoc library between py 3.6 and 3.7.


### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #7721


<!--- Thanks for your help making Spyder better for everyone! --->
