### PR TITLE
PR: Don't ignore all files when exclude pattern is empty

### DIFF
--- a/spyder/widgets/findinfiles.py
+++ b/spyder/widgets/findinfiles.py
@@ -561,7 +561,8 @@ class FindOptions(QWidget):
 
         if not exclude_re:
             items = [fnmatch.translate(item.strip())
-                     for item in exclude.split(",")]
+                     for item in exclude.split(",")
+                     if item.strip() != '']
             exclude = '|'.join(items)
 
         # Validate regular expressions:

--- a/spyder/widgets/findinfiles.py
+++ b/spyder/widgets/findinfiles.py
@@ -557,14 +557,15 @@ class FindOptions(QWidget):
         file_search = self.path_selection_combo.is_file_search()
         path = self.path_selection_combo.get_current_searchpath()
 
-        # Finding text occurrences
+        if not exclude_re:
+            items = [fnmatch.translate(item.strip())
+                     for item in exclude.split(",")]
+            exclude = '|'.join(items)
+
+        # Validate regular expressions:
+
         try:
-            if not exclude_re:
-                items = [fnmatch.translate(item.strip())
-                         for item in exclude.split(",")]
-                exclude = '|'.join(items)
-            else:
-                exclude = re.compile(exclude)
+            exclude = re.compile(exclude)
         except Exception:
             exclude_edit = self.exclude_pattern.lineEdit()
             exclude_edit.setStyleSheet(self.REGEX_INVALID)

--- a/spyder/widgets/findinfiles.py
+++ b/spyder/widgets/findinfiles.py
@@ -101,7 +101,8 @@ class SearchThread(QThread):
         self.rootpath = path
         self.python_path = False
         self.hg_manifest = False
-        self.exclude = re.compile(exclude)
+        if exclude:
+            self.exclude = re.compile(exclude)
         self.texts = texts
         self.text_re = text_re
         self.is_file = is_file
@@ -143,14 +144,15 @@ class SearchThread(QThread):
                         if self.stopped:
                             return False
                     dirname = os.path.join(path, d)
-                    if re.search(self.exclude, dirname + os.sep):
+                    if self.exclude \
+                       and re.search(self.exclude, dirname + os.sep):
                         dirs.remove(d)
                 for f in files:
                     with QMutexLocker(self.mutex):
                         if self.stopped:
                             return False
                     filename = os.path.join(path, f)
-                    if re.search(self.exclude, filename):
+                    if self.exclude and re.search(self.exclude, filename):
                         continue
                     if is_text_file(filename):
                         self.find_string_in_file(filename)
@@ -565,7 +567,8 @@ class FindOptions(QWidget):
         # Validate regular expressions:
 
         try:
-            exclude = re.compile(exclude)
+            if exclude:
+                exclude = re.compile(exclude)
         except Exception:
             exclude_edit = self.exclude_pattern.lineEdit()
             exclude_edit.setStyleSheet(self.REGEX_INVALID)

--- a/spyder/widgets/tests/test_findinfiles.py
+++ b/spyder/widgets/tests/test_findinfiles.py
@@ -146,6 +146,17 @@ def test_exclude_extension_string(qtbot):
     assert files_filtered
 
 
+def test_exclude_extension_empty_regex(qtbot):
+    find_in_files = setup_findinfiles(qtbot, exclude="")
+    find_in_files.set_search_text("spam")
+    find_in_files.find_options.set_directory(osp.join(LOCATION, "data"))
+    find_in_files.find()
+    blocker = qtbot.waitSignal(find_in_files.sig_finished)
+    blocker.wait()
+    matches = process_search_results(find_in_files.result_browser.data)
+    assert expected_results() == matches
+
+
 def test_exclude_extension_multiple_string(qtbot):
     find_in_files = setup_findinfiles(qtbot, exclude="*.py, *.cpp",
                                       exclude_regexp=False)

--- a/spyder/widgets/tests/test_findinfiles.py
+++ b/spyder/widgets/tests/test_findinfiles.py
@@ -157,6 +157,18 @@ def test_exclude_extension_empty_regex(qtbot):
     assert expected_results() == matches
 
 
+def test_exclude_extension_string(qtbot):
+    find_in_files = setup_findinfiles(qtbot, exclude="",
+                                      exclude_regexp=False)
+    find_in_files.set_search_text("spam")
+    find_in_files.find_options.set_directory(osp.join(LOCATION, "data"))
+    find_in_files.find()
+    blocker = qtbot.waitSignal(find_in_files.sig_finished)
+    blocker.wait()
+    matches = process_search_results(find_in_files.result_browser.data)
+    assert expected_results() == matches
+
+
 def test_exclude_extension_multiple_string(qtbot):
     find_in_files = setup_findinfiles(qtbot, exclude="*.py, *.cpp",
                                       exclude_regexp=False)


### PR DESCRIPTION
<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings for any new functions
* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] Included a screenshot, if this PR makes any visible changes to the UI

## Description of Changes

This addresses issue #7811, making findinfiles not ignore all files if the exclude pattern is empty.


### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #7811 


<!--- Thanks for your help making Spyder better for everyone! --->
