### PR TITLE
PR: Don't import objects in collectionseditor that are not dicts

### DIFF
--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1150,6 +1150,9 @@ class BaseTableView(QTableView):
     def import_from_string(self, text, title=None):
         """Import data from string"""
         data = self.model.get_data()
+        # Check if data is a dict
+        if not hasattr(data, "keys"):
+            return
         editor = ImportWizard(self, text, title=title,
                               contents_title=_("Clipboard contents"),
                               varname=fix_reference_name("data",


### PR DESCRIPTION
It was raising an AttributeError when `data` was a list, and not a dict

<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [ ] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [ ] Wrote at least one-line docstrings for any new functions
* [ ] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [ ] Included a screenshot, if this PR makes any visible changes to the UI


## Description of Changes

<!--- Describe what you've changed and why. --->

On `collectioneditor` Ctrl+V handler, `data` could be a list and not a dict, so it would raise an `AttributeError` while trying to call `data.keys()`



### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #7244

<!--- Thanks for your help making Spyder better for everyone! --->
