### PR TITLE
PR: Fix tests after ci-helpers updated conda version

### DIFF
--- a/.circleci/install.sh
+++ b/.circleci/install.sh
@@ -14,8 +14,8 @@ export PIP_DEPENDENCIES="coveralls pytest-qt pytest-mock pytest-xvfb flaky jedi 
 echo -e "PYTHON = $PYTHON_VERSION \n============"
 git clone git://github.com/astropy/ci-helpers.git > /dev/null
 source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
-export PATH="$HOME/miniconda/bin:$PATH"
-source activate test
+source $HOME/miniconda/etc/profile.d/conda.sh
+conda activate test
 
 # Install spyder-kernels
-pip install -q --no-deps git+https://github.com/spyder-ide/spyder-kernels@0.x
+pip install --no-deps git+https://github.com/spyder-ide/spyder-kernels@0.x

--- a/continuous_integration/travis/install-qt.sh
+++ b/continuous_integration/travis/install-qt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export PATH="$HOME/miniconda/bin:$PATH"
-source activate test
+source $HOME/miniconda/etc/profile.d/conda.sh
+conda activate test
 
 if [ "$USE_CONDA" = "no" ]; then
     # Remove pytest-xvfb because it causes hangs

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -18,8 +18,8 @@ fi
 echo -e "PYTHON = $TRAVIS_PYTHON_VERSION \n============"
 git clone git://github.com/astropy/ci-helpers.git > /dev/null
 source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
-export PATH="$HOME/miniconda/bin:$PATH"
-source activate test
+source $HOME/miniconda/etc/profile.d/conda.sh
+conda activate test
 
 
 if [ "$USE_CONDA" = "no" ]; then
@@ -27,5 +27,5 @@ if [ "$USE_CONDA" = "no" ]; then
     pip install git+https://github.com/jupyter/qtconsole.git
 
     # Install Spyder and its dependencies
-    pip install -q -e .[test]
+    pip install .[test]
 fi

--- a/continuous_integration/travis/runtests.sh
+++ b/continuous_integration/travis/runtests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export PATH="$HOME/miniconda/bin:$PATH"
-source activate test
+source $HOME/miniconda/etc/profile.d/conda.sh
+conda activate test
 
 python bootstrap.py -- --reset
 


### PR DESCRIPTION
This uses `conda activate` to activate the test env. This is the new way to activate envs since conda 4.5, updated by ci-helpers.