### PR TITLE
PR: Remove '--cov-report=term-missing' from pytest args

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -31,8 +31,7 @@ def main():
                    '-vv',
                    '-rw',
                    '--durations=10',
-                   '--cov=spyder',
-                   '--cov-report=term-missing']
+                   '--cov=spyder']
 
     if run_slow:
         pytest_args.append('--run-slow')


### PR DESCRIPTION
This is a simple change to remove the detailed info about lines not covered by tests from our `pytest` reports.

This option adds a lot of noise to our reports. Besides, this information can be consulted on [codecov](https://codecov.io/gh) or [coverall](https://coveralls.io) in a much nicer format.

### After

![image](https://user-images.githubusercontent.com/10170372/45222158-a4c99600-b281-11e8-8985-1fadf17c2c59.png)

### Before

![image](https://user-images.githubusercontent.com/10170372/45221068-549d0480-b27e-11e8-83e8-1e11b95cd4a0.png)
