### PR TITLE
PR: Set selected OpenGL implementation for QtQuick too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -233,7 +233,7 @@ install_requires = [
     'pylint',
     'psutil',
     'qtawesome>=0.4.1',
-    'qtpy>=1.2.0',
+    'qtpy>=1.5.0',
     'pickleshare',
     'pyzmq',
     'chardet>=2.0.0',

--- a/spyder/app/cli_options.py
+++ b/spyder/app/cli_options.py
@@ -45,7 +45,7 @@ def get_options():
                       help="Path that contains an Spyder project")
     parser.add_option('--opengl', default=None, type='choice',
                       dest="opengl_implementation",
-                      choices=['software', 'desktop'],
+                      choices=['software', 'desktop', 'gles'],
                       help=("OpenGL implementation to pass to Qt. Possible "
                             "options are 'software' and 'desktop'")
                       )

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -91,6 +91,12 @@ from qtpy import QtSvg  # analysis:ignore
 # Avoid a bug in Qt: https://bugreports.qt.io/browse/QTBUG-46720
 from qtpy import QtWebEngineWidgets  # analysis:ignore
 
+# For issue 7447
+try:
+    from qtpy.QtQuick import QQuickWindow, QSGRendererInterface
+except Exception:
+    QQuickWindow = QSGRendererInterface = None
+
 # To catch font errors in QtAwesome
 from qtawesome.iconic_font import FontError
 
@@ -3155,11 +3161,19 @@ def main():
     if options.opengl_implementation:
         if options.opengl_implementation == 'software':
             QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
+            # Fix issue 7447
+            if QQuickWindow is not None:
+                QQuickWindow.setSceneGraphBackend(
+                        QSGRendererInterface.Software)
         elif options.opengl_implementation == 'desktop':
             QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
     else:
         if CONF.get('main', 'opengl') == 'software':
             QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
+            # Fix issue 7447
+            if QQuickWindow is not None:
+                QQuickWindow.setSceneGraphBackend(
+                        QSGRendererInterface.Software)
         elif CONF.get('main', 'opengl') == 'desktop':
             QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -196,7 +196,7 @@ CWD = getcwd_or_home()
 
 
 #==============================================================================
-# Spyder's main window widgets utilities
+# Utility functions
 #==============================================================================
 def get_python_doc_path():
     """
@@ -217,6 +217,26 @@ def get_python_doc_path():
     python_doc = osp.join(doc_path, "index.html")
     if osp.isfile(python_doc):
         return file_uri(python_doc)
+
+
+def set_opengl_implementation(option):
+    """
+    Set the OpenGL implementation used by Spyder.
+
+    See issue 7447 for the details.
+    """
+    if option == 'software':
+        QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
+        if QQuickWindow is not None:
+            QQuickWindow.setSceneGraphBackend(QSGRendererInterface.Software)
+    elif option == 'desktop':
+        QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
+        if QQuickWindow is not None:
+            QQuickWindow.setSceneGraphBackend(QSGRendererInterface.OpenGL)
+    elif option == 'gles':
+        QCoreApplication.setAttribute(Qt.AA_UseOpenGLES)
+        if QQuickWindow is not None:
+            QQuickWindow.setSceneGraphBackend(QSGRendererInterface.OpenGL)
 
 
 #==============================================================================
@@ -3143,30 +3163,6 @@ def run_spyder(app, options, args):
 #==============================================================================
 def main():
     """Main function"""
-
-    def set_opengl_implementation(option):
-        """
-        Auxiliary function to set the OpenGL implementation used by
-        Spyder.
-
-        See issue 7447 for the details.
-        """
-        if option == 'software':
-            QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
-            if QQuickWindow is not None:
-                QQuickWindow.setSceneGraphBackend(
-                        QSGRendererInterface.Software)
-        elif option == 'desktop':
-            QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
-            if QQuickWindow is not None:
-                QQuickWindow.setSceneGraphBackend(
-                        QSGRendererInterface.OpenGL)
-        elif option == 'gles':
-            QCoreApplication.setAttribute(Qt.AA_UseOpenGLES)
-            if QQuickWindow is not None:
-                QQuickWindow.setSceneGraphBackend(
-                        QSGRendererInterface.OpenGL)
-
     # **** For Pytest ****
     # We need to create MainWindow **here** to avoid passing pytest
     # options to Spyder

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -224,6 +224,18 @@ def test_calltip(main_window, qtbot):
 
 
 @pytest.mark.slow
+@pytest.mark.parametrize('main_window', [{'spy_config': ('main', 'opengl', 'software')}], indirect=True)
+def test_opengl_implementation(main_window, qtbot):
+    """
+    Test that we are setting the selected OpenGL implementation
+    """
+    assert main_window._test_setting_opengl('software')
+
+    # Restore default config value
+    CONF.set('main', 'opengl', 'automatic')
+
+
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(np.__version__ < '1.14.0', reason="This only happens in Numpy 1.14+")
 @pytest.mark.parametrize('main_window', [{'spy_config': ('variable_explorer', 'minmax', True)}], indirect=True)

--- a/spyder/plugins/configdialog.py
+++ b/spyder/plugins/configdialog.py
@@ -868,7 +868,7 @@ class MainConfigPage(GeneralConfigPage):
                                               'interface_language',
                                               restart=True)
 
-        opengl_options = ['Automatic', 'Desktop', 'Software']
+        opengl_options = ['Automatic', 'Desktop', 'Software', 'GLES']
         opengl_choices = list(zip(opengl_options,
                                   [c.lower() for c in opengl_options]))
         opengl_combo = self.create_combobox(_('Rendering engine:'),


### PR DESCRIPTION
Fixes #7447.

This also adds `GLES` to the list of available OpenGL implementations users can select from.