### PR TITLE
PR: Correct next/previous word shortcut callback

### DIFF
--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -596,9 +596,9 @@ class CodeEditor(TextEditBaseWidget):
         next_char = config_shortcut(cb_maker('Right'), context='Editor',
                                     name='Next char', parent=self)
 
-        prev_word = config_shortcut(cb_maker('StartOfWord'), context='Editor',
+        prev_word = config_shortcut(cb_maker('PreviousWord'), context='Editor',
                                     name='Previous word', parent=self)
-        next_word = config_shortcut(cb_maker('EndOfWord'), context='Editor',
+        next_word = config_shortcut(cb_maker('NextWord'), context='Editor',
                                     name='Next word', parent=self)
 
         kill_line_end = config_shortcut(self.kill_line_end, context='Editor',


### PR DESCRIPTION
### Issue(s) Resolved

<!--- Pull requests should typically resolve one, preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

- Fixes #7872 for the 3.x branch
- PR #7874 was opened to fix the same issue in Master

## Description of Changes

<!--- Describe what you've changed and why. --->

Replace the `StartOfWord` and `EndOfWord` variable name by `PreviousWord` and `NextWord` for the `Previous Word` and `Next Word` shortcut, so that the right callback is associated with these shortcuts.

Due to the situation with builtin shortcuts in 3.x, it is not worth doing more than that:

The builtin `Ctrl+Left` and `Ctrl+Right` works by default as valid key sequence for these shortcuts.
These two key sequences are reserved and will not work when used for another shortcut anyway as explained in PR #7768. So there is no point in assigning them by default here.

<!--- Thanks for your help making Spyder better for everyone! --->

### Affirmation

By submitting this Pull Request, I affirm that:
* I release the content of this PR under Spyder's MIT (Expat) license.
* I hold the copyright to all the content in this PR, have not copied any of it
  directly or indirectly from any source other than the public domain,
  and no other party owns the rights to this work.

<!--- TYPE YOUR GITHUB USERNAME OR FULL NAME AFTER THE BELOW STATEMENT ---!>
I affirm all of the above: Jean-Sébastien Gosselin

<!--- Note that you (not Spyder) retain copyright ownership of your work, --->
<!--- and may license it to other parties under the terms of your choice. --->
<!--- Contact us if you would like to include content from other sources. --->
