### PR TITLE
PR: Improve how keyboard shortcuts are handled in the Editor (Take 2)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2803,6 +2803,10 @@ class CodeEditor(TextEditBaseWidget):
             # The event was handled by one of the editor extension.
             return
 
+        if key in [Qt.Key_Control, Qt.Key_Shift, Qt.Key_Alt,
+                   Qt.Key_Meta, Qt.KeypadModifier]:
+            # The user pressed only a modifier key.
+            return
 
         # ---- Handle hard coded and builtin actions
         has_selection = self.has_selected_text()

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -253,7 +253,6 @@ class CodeEditor(TextEditBaseWidget):
     sig_run_cell_and_advance = Signal()
     sig_run_cell = Signal()
     sig_re_run_last_cell = Signal()
-    sig_go_to_line = Signal()
     go_to_definition_regex = Signal(str, int, int)
     sig_cursor_position_changed = Signal(int, int)
     sig_new_file = Signal(str)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -28,7 +28,7 @@ import time
 
 # Third party imports
 from qtpy.compat import to_qvariant
-from qtpy.QtCore import QRegExp, Qt, QTimer, Signal, Slot
+from qtpy.QtCore import QRegExp, Qt, QTimer, Signal, Slot, QEvent
 from qtpy.QtGui import (QColor, QCursor, QFont, QIntValidator,
                         QKeySequence, QPaintEvent, QPainter, QMouseEvent,
                         QTextBlockUserData, QTextCharFormat, QTextCursor,
@@ -2785,6 +2785,14 @@ class CodeEditor(TextEditBaseWidget):
         self.timer_syntax_highlight.start()
         super(CodeEditor, self).keyReleaseEvent(event)
         event.ignore()
+
+    def event(self, event):
+        """Qt method override."""
+        if event.type() == QEvent.ShortcutOverride:
+            event.ignore()
+            return False
+        else:
+            return super(CodeEditor, self).event(event)
 
     def keyPressEvent(self, event):
         """Reimplement Qt method"""

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2296,7 +2296,6 @@ class EditorStack(QWidget):
         editor.sig_run_cell_and_advance.connect(self.run_cell_and_advance)
         editor.sig_re_run_last_cell.connect(self.re_run_last_cell)
         editor.sig_new_file.connect(self.sig_new_file.emit)
-        editor.sig_go_to_line.connect(self.go_to_line)
         language = get_file_language(fname, txt)
         editor.setup_editor(
                 linenumbers=self.linenumbers_enabled,

--- a/spyder/plugins/editor/widgets/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/tests/test_shortcuts.py
@@ -75,6 +75,9 @@ def test_default_keybinding_values():
     assert get_shortcut('editor', 'previous word') == 'Ctrl+Left'
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    reason="It fails on Linux due to the lack of a proper X server.")
 def test_start_and_end_of_document_shortcuts(editor_bot):
     """
     Test that the start of document and end of document shortcut are working
@@ -95,6 +98,9 @@ def test_start_and_end_of_document_shortcuts(editor_bot):
     assert editor.get_cursor_line_column() == (0, 0)
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    reason="It fails on Linux due to the lack of a proper X server.")
 def test_del_undo_redo_shortcuts(editor_bot):
     """
     Test that the undo and redo keyboard shortcuts are working as expected
@@ -123,6 +129,9 @@ def test_del_undo_redo_shortcuts(editor_bot):
     assert editor.toPlainText() == 'Line1\nLine2\nLine3\nLine4\n'
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    reason="It fails on Linux due to the lack of a proper X server.")
 def test_copy_cut_paste_shortcuts(editor_bot):
     """
     Test that the copy, cut, and paste keyboard shortcuts are working as
@@ -154,6 +163,9 @@ def test_copy_cut_paste_shortcuts(editor_bot):
     assert editor.toPlainText() == '\nLine2\nLine3\nLine4\n'
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    reason="It fails on Linux due to the lack of a proper X server.")
 def test_select_all_shortcut(editor_bot):
     """
     Test that the select all keyboard shortcut is working as
@@ -167,6 +179,9 @@ def test_select_all_shortcut(editor_bot):
     assert editor.get_selected_text() == 'Line1\nLine2\nLine3\nLine4\n'
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    reason="It fails on Linux due to the lack of a proper X server.")
 def test_delete_line_shortcut(editor_bot):
     """
     Test that the delete line keyboard shortcut is working as
@@ -181,6 +196,9 @@ def test_delete_line_shortcut(editor_bot):
     assert editor.toPlainText() == 'Line1\nLine3\nLine4\n'
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    reason="It fails on Linux due to the lack of a proper X server.")
 def test_go_to_line_shortcut(editor_bot, mocker):
     """
     Test that the go to line keyboard shortcut is working
@@ -197,6 +215,9 @@ def test_go_to_line_shortcut(editor_bot, mocker):
     assert editor.get_cursor_line_column() == (2, 0)
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    reason="It fails on Linux due to the lack of a proper X server.")
 def test_transform_to_lowercase_shortcut(editor_bot):
     """
     Test that the transform to lowercase shorcut is working as expected with
@@ -211,6 +232,9 @@ def test_transform_to_lowercase_shortcut(editor_bot):
     assert editor.toPlainText() == 'line1\nline2\nline3\nline4\n'
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    reason="It fails on Linux due to the lack of a proper X server.")
 def test_transform_to_uppercase_shortcut(editor_bot):
     """
     Test that the transform to uppercase shorcuts is working as expected with
@@ -226,6 +250,9 @@ def test_transform_to_uppercase_shortcut(editor_bot):
     assert editor.toPlainText() == 'LINE1\nLINE2\nLINE3\nLINE4\n'
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    reason="It fails on Linux due to the lack of a proper X server.")
 def test_next_and_previous_word_shortcuts(editor_bot):
     """
     Test that the next word and previous word shortcuts are working as


### PR DESCRIPTION
### Issue(s) Resolved

Fixes #7883
Blocking #7929

## Description of Changes

In this PR, we propose to revert some of the changes made in PR #7768 and to go back to use `QShortcut` to manage local keyboard shortcuts in the Editor.

The reason is that I found a way to fix all the problems we had with builtin shortcuts in the editor using the Qt Framework and the same architecture that is used everywhere to manage shortcuts in Spyder.

### Developer Certificate of Origin Affirmation

By submitting this Pull Request or typing my name below, I affirm the
[Developer Certificate of Origin](https://developercertificate.org/)
with respect to both the content of the contribution itself and this post,
and understand I am releasing it under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin