### PR TITLE
PR: Improvement to navigation and file switching in the Outline Explorer

### DIFF
--- a/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
@@ -97,7 +97,7 @@ def test_load_files(empty_editor_bot, python_files):
     editorstack.tabs.currentIndex() == 0
 
     results = [item.text(0) for item in treewidget.get_visible_items()]
-    assert results == ['foo1.py', 'foo']
+    assert results == ['foo1.py']
 
     # Load the second file and assert the content of the outline explorer tree.
     editorstack.load(python_files[1])
@@ -105,7 +105,7 @@ def test_load_files(empty_editor_bot, python_files):
     editorstack.tabs.currentIndex() == 1
 
     results = [item.text(0) for item in treewidget.get_visible_items()]
-    assert results == ['foo1.py', 'foo2.py', '---- a comment']
+    assert results == ['foo1.py', 'foo2.py']
 
 
 def test_close_editor(editor_bot):
@@ -138,7 +138,7 @@ def test_close_a_file(editor_bot):
     # tree has been updated.
     editorstack.close_file(index=1)
     results = [item.text(0) for item in treewidget.get_visible_items()]
-    assert results == ['foo1.py', 'foo']
+    assert results == ['foo1.py']
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -513,16 +513,22 @@ class OutlineExplorerTreeWidget(OneColumnTree):
 
     def activated(self, item):
         """Double-click event"""
+        editor_item = self.editor_items.get(
+            self.editor_ids.get(self.current_editor))
         line = 0
-        if isinstance(item, TreeItem):
+        if item == editor_item:
+            line = 1
+        elif isinstance(item, TreeItem):
             line = item.line
-        root_item = self.get_root_item(item)
+
         self.freeze = True
+        root_item = self.get_root_item(item)
         if line:
             self.parent().edit_goto.emit(root_item.path, line, item.text(0))
         else:
             self.parent().edit.emit(root_item.path)
         self.freeze = False
+
         parent = self.current_editor.parent()
         for editor_id, i_item in list(self.editor_items.items()):
             if i_item is root_item:

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -475,13 +475,14 @@ class OutlineExplorerTreeWidget(OneColumnTree):
 
     def root_item_selected(self, item):
         """Root item has been selected: expanding it and collapsing others"""
-        for index in range(self.topLevelItemCount()):
-            root_item = self.topLevelItem(index)
+        if self.show_all_files:
+            return
+        for root_item in self.get_top_level_items():
             if root_item is item:
                 self.expandItem(root_item)
             else:
                 self.collapseItem(root_item)
-                
+
     def restore(self):
         """Reimplemented OneColumnTree method"""
         if self.current_editor is not None:


### PR DESCRIPTION
### Issue(s) Resolved

Fixes #7214

### Pull Request Checklist

* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described the changes and the motivation for them below
* [x] Included a screenshot, if this PR makes any visible changes to the UI

## Description of Changes

First, when `Show all Files` is selected in the `Outline explorer`, the root item will not automatically expand and collapse when the current `Editor` change. IMO, this change brings 3 UX improvements:
- The Outline Explorer can now be used more easily as a "vertical tab bar".
- Double clicking a root file item will now expand/contract that item, like it does for the other tree items.
- This allows to keep more than one file expanded at the same time, which is very convenient to navigate between elements that are not saved in a same file.

![outline_navigation](https://user-images.githubusercontent.com/10170372/46233433-8fa3cc80-c340-11e8-92d2-9869f180400f.gif)

Second, if a root file item is clicked and that item corresponds to the current Editor, the cursor will be moved at the start of the file. Double-clicking a root file item, whether this item correspond to the current Editor or not, will expand/contract the item and move the cursor at the beginning of the file. This behavior is also coherent with what happens when double-clicking on a normal tree item.

Note that, the user can always go back to the previous position of the cursor with `Source > Previous cursor position` or by doing the `previous cursor position` keyboard shortcut (which is `Ctrl+Alt+Left`  by default).

![outline_navigation_top_file](https://user-images.githubusercontent.com/10170372/46233426-89adeb80-c340-11e8-839a-6db40c57f8f6.gif)

### Developer Certificate of Origin Affirmation

By submitting this Pull Request or typing my name below, I affirm the
[Developer Certificate of Origin](https://developercertificate.org/)
with respect to both the content of the contribution itself and this post,
and understand I am releasing it under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin

