### PR TITLE
PR: Sync Outline Explorer at startup and preserve the file order in the tabbar

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2948,13 +2948,15 @@ class Editor(SpyderPluginWidget):
                 index = filenames.index(cfname)
                 # First we load the last focused file.
                 self.load(filenames[index], goto=clines[index], set_focus=True)
-                # Then we load the files located before the last focused file
-                # in the tabbar.
+                # Then we load the files located to the left of the last
+                # focused file in the tabbar, while keeping the focus on
+                # the last focused file.
                 if index > 0:
                     self.load(filenames[index::-1], goto=clines[index::-1],
                               set_focus=False, add_where='start')
-                # Finally we load the files located after the last focused file
-                # in the tabbar.
+                # Finally we load the files located to the right of the last
+                # focused file in the tabbar, while keeping the focus on
+                # the last focused file.
                 if index < (len(filenames) - 1):
                     self.load(filenames[index+1:], goto=clines[index:],
                               set_focus=False, add_where='end')

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2933,7 +2933,7 @@ class Editor(SpyderPluginWidget):
         self.set_create_new_file_if_empty(False)
         active_project_path = None
         if self.projects is not None:
-             active_project_path = self.projects.get_active_project_path()
+            active_project_path = self.projects.get_active_project_path()
 
         if active_project_path:
             filenames = self.projects.get_project_filenames()

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2943,7 +2943,6 @@ class Editor(SpyderPluginWidget):
         self.close_all_files()
 
         if filenames and any([osp.isfile(f) for f in filenames]):
-            filenames = self.reorder_filenames(filenames)
             layout = self.get_option('layout_settings', None)
             is_vertical, cfname, clines = layout.get('splitsettings')[0]
             self.load(filenames, goto=clines)
@@ -2958,39 +2957,6 @@ class Editor(SpyderPluginWidget):
         else:
             self.__load_temp_file()
         self.set_create_new_file_if_empty(True)
-
-    def reorder_filenames(self, filenames):
-        """Take the last session filenames and put the last open on first.
-
-        It takes a list of filenames and using the current filename from the
-        layout settings, sets the one that had focused last in the position 0.
-        It also reorders the current lines for each file (supposing that they
-        are in the same order as the filenames) and sets them back in the
-        layout settings.
-        """
-        layout = self.get_option('layout_settings', None)
-        if layout is None:
-            return filenames
-        splitsettings = layout.get('splitsettings')
-        index_first_file = 0
-        reordered_splitsettings = []
-        for index, (is_vertical, cfname, clines) in enumerate(splitsettings):
-            #the first element of filenames is now the one that last had focus
-            if index == 0:
-                if cfname in filenames:
-                    index_first_file = filenames.index(cfname)
-                    filenames.pop(index_first_file)
-                    filenames.insert(0, cfname)
-                    clines_first_file = clines[index_first_file]
-                    clines.pop(index_first_file)
-                    clines.insert(0, clines_first_file)
-                else:
-                    cfname = filenames[0]
-                    index_first_file = 0
-            reordered_splitsettings.append((is_vertical, cfname, clines))
-        layout['splitsettings'] = reordered_splitsettings
-        self.set_option('layout_settings', layout)
-        return filenames
 
     def save_open_files(self):
         """Save the list of open files"""

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2960,6 +2960,7 @@ class Editor(SpyderPluginWidget):
                               set_focus=False, add_where='end')
             else:
                 self.load(filenames, goto=clines)
+            self.get_current_editorstack()._refresh_outlineexplorer()
             if layout is not None:
                 self.editorsplitter.set_layout_settings(layout,
                                                         dont_goto=filenames[0])

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -108,10 +108,12 @@ def test_setup_open_files(setup_editor, last_focused_filename,
     editor.get_option = get_option
 
     editor.setup_open_files()
-    assert (editor.get_current_editorstack().get_current_filename() ==
-            expected_current_filename)
-    assert (editor.get_current_editorstack().get_filenames() ==
-            expected_filenames)
+    current_filename = editor.get_current_editorstack().get_current_filename()
+    current_filename = osp.normpath(current_filename)
+    assert current_filename == expected_current_filename
+    filenames = editor.get_current_editorstack().get_filenames()
+    filenames = [osp.normpanormpath(f) for f in filenames]
+    assert filenames == expected_filenames
 
 
 def test_renamed_tree(setup_editor, mocker):

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -112,7 +112,7 @@ def test_setup_open_files(setup_editor, last_focused_filename,
     current_filename = osp.normpath(current_filename)
     assert current_filename == expected_current_filename
     filenames = editor.get_current_editorstack().get_filenames()
-    filenames = [osp.normpanormpath(f) for f in filenames]
+    filenames = [osp.normpath(f) for f in filenames]
     assert filenames == expected_filenames
 
 

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -59,7 +59,9 @@ def setup_editor(qtbot, monkeypatch):
 def python_files(tmpdir_factory):
     """Create and save some python codes in temporary files."""
     tmpdir = tmpdir_factory.mktemp("files")
-    filenames = [osp.join(tmpdir.strpath, f) for f in
+    tmpdir = osp.normpath(tmpdir.strpath)
+
+    filenames = [osp.join(tmpdir, f) for f in
                  ('file1.py', 'file2.py', 'file3.py', 'file4.py')]
     for filename in filenames:
         with open(filename, 'w') as f:
@@ -93,12 +95,11 @@ def test_setup_open_files(setup_editor, last_focused_filename,
     """
     editor, qtbot = setup_editor
     expected_filenames, tmpdir = python_files
-    expected_current_filename = osp.join(tmpdir.strpath,
-                                         expected_current_filename)
+    expected_current_filename = osp.join(tmpdir, expected_current_filename)
 
     def get_option(option, default=None):
         splitsettings = [(False,
-                          osp.join(tmpdir.strpath, last_focused_filename),
+                          osp.join(tmpdir, last_focused_filename),
                           [1, 1, 1, 1])]
         return {'layout_settings': {'splitsettings': splitsettings},
                 'filenames': expected_filenames,

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -23,6 +23,7 @@ from qtpy.QtWidgets import QWidget
 from spyder.utils.qthelpers import qapplication
 
 
+# ---- Qt Test Fixtures
 @pytest.fixture
 def setup_editor(qtbot, monkeypatch):
     """Set up the Editor plugin."""
@@ -54,6 +55,20 @@ def setup_editor(qtbot, monkeypatch):
     yield editor, qtbot
 
 
+@pytest.fixture(scope="module")
+def python_files(tmpdir_factory):
+    """Create and save some python codes in temporary files."""
+    tmpdir = tmpdir_factory.mktemp("files")
+    filenames = [osp.join(tmpdir.strpath, f) for f in
+                 ('file1.py', 'file2.py', 'file3.py', 'file4.py')]
+    for filename in filenames:
+        with open(filename, 'w') as f:
+            f.write("# -*- coding: utf-8 -*-\n"
+                    "print(Hello World!)\n")
+
+    return filenames, tmpdir
+
+
 def test_basic_initialization(setup_editor):
     """Test Editor plugin initialization."""
     editor, qtbot = setup_editor
@@ -63,36 +78,38 @@ def test_basic_initialization(setup_editor):
 
 
 @pytest.mark.parametrize(
-    'filenames, expected_filenames, splitsettings, expected_splitsettings', [
-        (['/file1.py', '/file2.py', '/file3.py', '/file4.py'],
-         ['/file1.py', '/file2.py', '/file3.py', '/file4.py'],
-         [(False, '/other_file.py', [2, 4, 8, 12])],
-         [(False, '/file1.py', [2, 4, 8, 12])]),
-        (['/file1.py', '/file2.py', '/file3.py', '/file4.py'],
-         ['/file2.py', '/file1.py', '/file3.py', '/file4.py'],
-         [(False, '/file2.py', [2, 4, 8, 12])],
-         [(False, '/file2.py', [4, 2, 8, 12])]),
-        (['/file1.py', '/file2.py', '/file3.py', '/file4.py'],
-         ['/file1.py', '/file2.py', '/file3.py', '/file4.py'],
-         None,
-         None, )
-    ])
-def test_reorder_filenames(setup_editor, expected_filenames, filenames,
-                           splitsettings, expected_splitsettings):
+    'last_focused_filename, expected_current_filename',
+    [('other_file.py', 'file1.py'),
+     ('file1.py', 'file1.py'),
+     ('file2.py', 'file2.py'),
+     ('file4.py', 'file4.py')
+     ])
+def test_setup_open_files(setup_editor, last_focused_filename,
+                          expected_current_filename, python_files):
+    """Test Editor plugin open files setup.
+
+    Test that the file order is preserved during the Editor plugin setup and
+    that the current file correspond to the last focused file.
+    """
     editor, qtbot = setup_editor
+    expected_filenames, tmpdir = python_files
+    expected_current_filename = osp.join(tmpdir, expected_current_filename)
 
-    def get_option(*args):
-        if splitsettings is None:
-            return None
-        return {'splitsettings': splitsettings}
-
-    def set_option(name, layout_settings):
-        assert layout_settings['splitsettings'] == expected_splitsettings
-
+    def get_option(option, default=None):
+        splitsettings = [(False,
+                          osp.join(tmpdir, last_focused_filename),
+                          [1, 1, 1, 1])]
+        return {'layout_settings': {'splitsettings': splitsettings},
+                'filenames': expected_filenames,
+                'max_recent_files': 20
+                }.get(option)
     editor.get_option = get_option
-    editor.set_option = set_option
 
-    assert expected_filenames == editor.reorder_filenames(filenames)
+    editor.setup_open_files()
+    assert (editor.get_current_editorstack().get_current_filename() ==
+            expected_current_filename)
+    assert (editor.get_current_editorstack().get_filenames() ==
+            expected_filenames)
 
 
 def test_renamed_tree(setup_editor, mocker):
@@ -142,3 +159,8 @@ def test_no_template(setup_editor):
 
     # Revert template back
     shutil.move(osp.join(osp.dirname(template), 'template.py.old'), template)
+
+
+if __name__ == "__main__":
+    import os
+    pytest.main(['-x', os.path.basename(__file__), '-vv', '-rw'])

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -93,11 +93,12 @@ def test_setup_open_files(setup_editor, last_focused_filename,
     """
     editor, qtbot = setup_editor
     expected_filenames, tmpdir = python_files
-    expected_current_filename = osp.join(tmpdir, expected_current_filename)
+    expected_current_filename = osp.join(tmpdir.strpath,
+                                         expected_current_filename)
 
     def get_option(option, default=None):
         splitsettings = [(False,
-                          osp.join(tmpdir, last_focused_filename),
+                          osp.join(tmpdir.strpath, last_focused_filename),
                           [1, 1, 1, 1])]
         return {'layout_settings': {'splitsettings': splitsettings},
                 'filenames': expected_filenames,

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -59,7 +59,7 @@ def setup_editor(qtbot, monkeypatch):
 def python_files(tmpdir_factory):
     """Create and save some python codes in temporary files."""
     tmpdir = tmpdir_factory.mktemp("files")
-    tmpdir = osp.normpath(tmpdir.strpath)
+    tmpdir = osp.normcase(tmpdir.strpath)
 
     filenames = [osp.join(tmpdir, f) for f in
                  ('file1.py', 'file2.py', 'file3.py', 'file4.py')]
@@ -109,10 +109,10 @@ def test_setup_open_files(setup_editor, last_focused_filename,
 
     editor.setup_open_files()
     current_filename = editor.get_current_editorstack().get_current_filename()
-    current_filename = osp.normpath(current_filename)
+    current_filename = osp.normcase(current_filename)
     assert current_filename == expected_current_filename
     filenames = editor.get_current_editorstack().get_filenames()
-    filenames = [osp.normpath(f) for f in filenames]
+    filenames = [osp.normcase(f) for f in filenames]
     assert filenames == expected_filenames
 
 

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1295,9 +1295,10 @@ class EditorStack(QWidget):
         else:
             return text % (osp.basename(filename), osp.dirname(filename))
 
-    def add_to_data(self, finfo, set_current):
+    def add_to_data(self, finfo, set_current, add_where='end'):
         finfo.editor.oe_proxy = None
-        self.data.append(finfo)
+        index = 0 if add_where == 'start' else len(self.data)
+        self.data.insert(index, finfo)
         index = self.data.index(finfo)
         editor = finfo.editor
         self.tabs.insertTab(index, editor, self.get_tab_text(index))
@@ -2264,7 +2265,7 @@ class EditorStack(QWidget):
         self.reload(index)
 
     def create_new_editor(self, fname, enc, txt, set_current, new=False,
-                          cloned_from=None):
+                          cloned_from=None, add_where='end'):
         """
         Create a new editor instance
         Returns finfo object (instead of editor as in previous releases)
@@ -2281,7 +2282,7 @@ class EditorStack(QWidget):
         finfo = FileInfo(fname, enc, editor, new, self.threadmanager,
                          self.introspector)
 
-        self.add_to_data(finfo, set_current)
+        self.add_to_data(finfo, set_current, add_where)
         finfo.send_to_help.connect(self.send_to_help)
         finfo.analysis_results_changed.connect(
                                   lambda: self.analysis_results_changed.emit())
@@ -2410,7 +2411,7 @@ class EditorStack(QWidget):
             finfo.editor.document().setModified(False)
         return finfo
 
-    def load(self, filename, set_current=True):
+    def load(self, filename, set_current=True, add_where='end'):
         """
         Load filename, create an editor instance and return it
         *Warning* This is loading file, creating editor but not executing
@@ -2420,7 +2421,8 @@ class EditorStack(QWidget):
         filename = osp.abspath(to_text_string(filename))
         self.starting_long_process.emit(_("Loading %s...") % filename)
         text, enc = encoding.read(filename)
-        finfo = self.create_new_editor(filename, enc, text, set_current)
+        finfo = self.create_new_editor(filename, enc, text, set_current,
+                                       add_where=add_where)
         index = self.data.index(finfo)
         self._refresh_outlineexplorer(index, update=True)
         self.ending_long_process.emit("")


### PR DESCRIPTION
### Issue(s) Resolved

Fixes #7338

### Pull Request Checklist

* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described the changes and the motivation for them below
* [x] Included a screenshot, if this PR makes any visible changes to the UI

## Description of Changes

### Before :

![image](https://user-images.githubusercontent.com/10170372/46253267-f6121300-c444-11e8-80ae-fc63910b5644.png)

### After :

![image](https://user-images.githubusercontent.com/10170372/46253254-a895a600-c444-11e8-9f09-a600a2b4cb56.png)



### Developer Certificate of Origin Affirmation

By submitting this Pull Request or typing my name below, I affirm the
[Developer Certificate of Origin](https://developercertificate.org/)
with respect to both the content of the contribution itself and this post,
and understand I am releasing it under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin
