### PR TITLE
PR: Fix Go to definition feature in the Editor in Windows after the changes introduced with the new LSP

### DIFF
--- a/spyder/plugins/editor/lsp/providers/document.py
+++ b/spyder/plugins/editor/lsp/providers/document.py
@@ -18,9 +18,11 @@ from spyder.plugins.editor.lsp.decorators import handles, send_request
 if PY2:
     import pathlib2 as pathlib
     from urlparse import urlparse
+    from urllib import url2pathname
 else:
     import pathlib
     from urllib.parse import urlparse
+    from urllib.request import url2pathname
 
 
 def path_as_uri(path):
@@ -179,7 +181,10 @@ class DocumentProvider:
             if len(result) > 0:
                 result = result[0]
                 uri = urlparse(result['uri'])
-                result['file'] = osp.join(uri.netloc, uri.path)
+                netloc, path = uri.netloc, uri.path
+                # Prepend UNC share notation if we have a UNC path.
+                netloc = '\\\\' + netloc if netloc else netloc
+                result['file'] = url2pathname(netloc + path)
             else:
                 result = None
         if req_id in self.req_reply:


### PR DESCRIPTION
### Issue(s) Resolved

Fixes #7726

## Description of Changes

Basically, I simply followed what was suggested in the following StackOverflow answer, which in turn was based on code from the pip project.

https://stackoverflow.com/a/43925228

I tested it in Windows 7 with Python 3.6 and `Go to definition` is working with the proposed changes, I must say even better than before the changes introduced with the new LSP.


### Developer Certificate of Origin Affirmation

By submitting this Pull Request or typing my name below, I affirm the
[Developer Certificate of Origin](https://developercertificate.org/)
with respect to both the content of the contribution itself and this post,
and understand I am releasing it under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin






