### PR TITLE
PR: Show the root file item of files that are not Python files in the Outline Explorer

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2066,19 +2066,14 @@ class EditorStack(QWidget):
             return
         if index is None:
             index = self.get_stack_index()
-        enable = False
         if self.data:
             finfo = self.data[index]
-            if finfo.editor.is_python():
-                enable = True
-                oe.setEnabled(True)
-                if finfo.editor.oe_proxy is None:
-                    finfo.editor.oe_proxy = OutlineExplorerProxyEditor(
-                        finfo.editor, finfo.filename)
-                oe.set_current_editor(finfo.editor.oe_proxy,
-                                      update=update, clear=clear)
-        if not enable:
-            oe.setEnabled(False)
+            oe.setEnabled(True)
+            if finfo.editor.oe_proxy is None:
+                finfo.editor.oe_proxy = OutlineExplorerProxyEditor(
+                    finfo.editor, finfo.filename)
+            oe.set_current_editor(finfo.editor.oe_proxy,
+                                  update=update, clear=clear)
 
     def __refresh_statusbar(self, index):
         """Refreshing statusbar widgets"""

--- a/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
@@ -25,8 +25,8 @@ from spyder.plugins.outlineexplorer.widgets import OutlineExplorerWidget
 
 # ---- Qt Test Fixtures
 @pytest.fixture(scope="module")
-def python_files(tmpdir_factory):
-    """Create and save some python codes in temporary files."""
+def test_files(tmpdir_factory):
+    """Create and save some python codes and text in temporary files."""
     tmpdir = tmpdir_factory.mktemp("files")
 
     filename1 = osp.join(tmpdir.strpath, 'foo1.py')
@@ -40,12 +40,17 @@ def python_files(tmpdir_factory):
         f.write("# -*- coding: utf-8 -*-\n"
                 "# ---- a comment\n")
 
-    return [filename1, filename2]
+    filename3 = osp.join(tmpdir.strpath, 'text1.txt')
+    with open(filename3, 'w') as f:
+        f.write("This is a simple text file for\n"
+                "testing the Outline Explorer.\n")
+
+    return [filename1, filename2, filename3]
 
 
 @pytest.fixture
-def empty_editor_bot(qtbot):
-    """Set up an empty EditorStack with an OutlineExplorerWidget."""
+def outlineexplorer(qtbot):
+    """Set up an OutlineExplorerWidget."""
     outlineexplorer = OutlineExplorerWidget(
         show_fullpath=False, show_all_files=True, group_cells=False,
         show_comments=True)
@@ -56,66 +61,61 @@ def empty_editor_bot(qtbot):
     qtbot.addWidget(outlineexplorer)
     outlineexplorer.show()
 
-    editorstack = editor.EditorStack(None, [])
-    editorstack.set_introspector(Mock())
-    editorstack.set_find_widget(Mock())
-    editorstack.set_io_actions(Mock(), Mock(), Mock(), Mock())
-    editorstack.analysis_timer = Mock()
-    editorstack.save_dialog_on_tests = True
-    editorstack.set_outlineexplorer(outlineexplorer)
-
-    qtbot.addWidget(editorstack)
-    editorstack.show()
-
-    return editorstack, outlineexplorer, qtbot
+    return outlineexplorer
 
 
 @pytest.fixture
-def editor_bot(empty_editor_bot, python_files):
-    """
-    Set up an EditorStack with an OutlineExplorerWidget and load some files.
-    """
-    editorstack, outlineexplorer, qtbot = empty_editor_bot
-    for file in python_files:
-        editorstack.load(file)
+def editorstack(qtbot, outlineexplorer):
+    def _create_editorstack(files):
+        editorstack = editor.EditorStack(None, [])
+        editorstack.set_introspector(Mock())
+        editorstack.set_find_widget(Mock())
+        editorstack.set_io_actions(Mock(), Mock(), Mock(), Mock())
+        editorstack.analysis_timer = Mock()
+        editorstack.save_dialog_on_tests = True
+        editorstack.set_outlineexplorer(outlineexplorer)
 
-    return editorstack, outlineexplorer, qtbot
+        qtbot.addWidget(editorstack)
+        editorstack.show()
+
+        for file in files:
+            editorstack.load(file)
+
+        return editorstack
+    return _create_editorstack
 
 
 # ---- Tests
-def test_load_files(empty_editor_bot, python_files):
+def test_load_files(editorstack, outlineexplorer, test_files):
     """
     Test that the content of the outline explorer is updated correctly
     after a file is loaded in the editor.
     """
-    editorstack, outlineexplorer, qtbot = empty_editor_bot
+    editorstack = editorstack([])
     treewidget = outlineexplorer.treewidget
 
-    # Load the first file and assert the content of the outline explorer.
-    editorstack.load(python_files[0])
-    assert editorstack.get_current_filename() == python_files[0]
-    editorstack.tabs.currentIndex() == 0
+    # Load the test files one by one and assert the content of the
+    # outline explorer.
+    expected_result = [['foo1.py'],
+                       ['foo1.py', 'foo2.py'],
+                       ['foo1.py', 'foo2.py', 'text1.txt']]
+    for index, file in enumerate(test_files):
+        editorstack.load(file)
+        assert editorstack.get_current_filename() == file
+        editorstack.tabs.currentIndex() == index
 
-    results = [item.text(0) for item in treewidget.get_visible_items()]
-    assert results == ['foo1.py']
-
-    # Load the second file and assert the content of the outline explorer tree.
-    editorstack.load(python_files[1])
-    assert editorstack.get_current_filename() == python_files[1]
-    editorstack.tabs.currentIndex() == 1
-
-    results = [item.text(0) for item in treewidget.get_visible_items()]
-    assert results == ['foo1.py', 'foo2.py']
+        results = [item.text(0) for item in treewidget.get_visible_items()]
+        assert results == expected_result[index]
 
 
-def test_close_editor(editor_bot):
+def test_close_editor(editorstack, outlineexplorer, test_files):
     """
     Test that the content of the outline explorer is empty after the
     editorstack has been closed.
 
     Regression test for issue #7798.
     """
-    editorstack, outlineexplorer, qtbot = editor_bot
+    editorstack = editorstack(test_files)
     treewidget = outlineexplorer.treewidget
     assert treewidget.get_visible_items()
 
@@ -124,21 +124,21 @@ def test_close_editor(editor_bot):
     assert not treewidget.get_visible_items()
 
 
-def test_close_a_file(editor_bot):
+def test_close_a_file(editorstack, outlineexplorer, test_files):
     """
     Test that the content of the outline explorer is updated corrrectly
     after a file has been closed in the editorstack.
 
     Regression test for issue #7798.
     """
-    editorstack, outlineexplorer, qtbot = editor_bot
+    editorstack = editorstack(test_files)
     treewidget = outlineexplorer.treewidget
 
     # Close 'foo2.py' and assert that the content of the outline explorer
     # tree has been updated.
     editorstack.close_file(index=1)
     results = [item.text(0) for item in treewidget.get_visible_items()]
-    assert results == ['foo1.py']
+    assert results == ['foo1.py', 'text1.txt']
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/outlineexplorer/api.py
+++ b/spyder/plugins/outlineexplorer/api.py
@@ -32,6 +32,10 @@ class OutlineExplorerProxy(object):
     def __init__(self):
         self.fname = None
 
+    def is_python(self):
+        """Return whether the editor is a python file or not."""
+        raise NotImplementedError
+
     def get_id(self):
         """Return an unique id, used for identify objects in a dict"""
         raise NotImplementedError

--- a/spyder/plugins/outlineexplorer/editor.py
+++ b/spyder/plugins/outlineexplorer/editor.py
@@ -14,6 +14,9 @@ class OutlineExplorerProxyEditor(OutlineExplorerProxy):
         self._editor = editor
         self.fname = fname
 
+    def is_python(self):
+        return self._editor.is_python()
+
     def get_id(self):
         return self._editor.get_document_id()
 

--- a/spyder/plugins/outlineexplorer/tests/test_outline_explorer.py
+++ b/spyder/plugins/outlineexplorer/tests/test_outline_explorer.py
@@ -36,6 +36,9 @@ class OutlineExplorerProxyTest(OutlineExplorerProxy):
         self.fname = fname
         self.oe_data = oe_data
 
+    def is_python(self):
+        return True
+
     def get_id(self):
         return id(self)
 

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -26,10 +26,11 @@ from spyder.widgets.onecolumntree import OneColumnTree
 
 
 class FileRootItem(QTreeWidgetItem):
-    def __init__(self, path, treewidget):
+    def __init__(self, path, treewidget, is_python=True):
         QTreeWidgetItem.__init__(self, treewidget, QTreeWidgetItem.Type)
         self.path = path
-        self.setIcon(0, ima.icon('python'))
+        self.setIcon(
+            0, ima.icon('python') if is_python else ima.icon('TextFileIcon'))
         self.setToolTip(0, path)
         set_item_user_text(self, path)
         
@@ -269,7 +270,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         else:
     #        import time
     #        t0 = time.time()
-            root_item = FileRootItem(editor.fname, self)
+            root_item = FileRootItem(editor.fname, self, editor.is_python())
             root_item.set_text(fullpath=self.show_fullpath)
             tree_cache = self.populate_branch(editor, root_item)
             self.__sort_toplevel_items()

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -268,15 +268,12 @@ class OutlineExplorerTreeWidget(OneColumnTree):
                 self.populate_branch(editor, item, tree_cache)
                 self.restore_expanded_state()
         else:
-    #        import time
-    #        t0 = time.time()
             root_item = FileRootItem(editor.fname, self, editor.is_python())
             root_item.set_text(fullpath=self.show_fullpath)
             tree_cache = self.populate_branch(editor, root_item)
             self.__sort_toplevel_items()
             self.__hide_or_show_root_items(root_item)
             self.root_item_selected(root_item)
-    #        print >>STDOUT, "Elapsed time: %d ms" % round((time.time()-t0)*1000)
             self.editor_items[editor_id] = root_item
             self.editor_tree_cache[editor_id] = tree_cache
             self.resizeColumnToContents(0)

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -252,7 +252,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         """Reimplemented Qt method"""
         self.set_title('')
         OneColumnTree.clear(self)
-        
+
     def set_current_editor(self, editor, update):
         """Bind editor instance"""
         editor_id = editor.get_id()
@@ -283,7 +283,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         if editor not in self.editor_ids:
             self.editor_ids[editor] = editor_id
         self.current_editor = editor
-        
+
     def file_renamed(self, editor, new_filename):
         """File was renamed, updating outline explorer tree"""
         editor_id = editor.get_id()


### PR DESCRIPTION
### Issue(s) Resolved

<!--- Pull requests should typically resolve one, and preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234"; one per line. --->

Fixes #7982

### Pull Request Checklist

* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described the changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] Included a screenshot, if this PR makes any visible changes to the UI

## Description of Changes

- Outline Explorer stays enabled even if the file that has focus is not a python file.
- Root file items of non-python files are now listed in the Outline Explorer.
- Clicking on a non-python Root file items that already has the focus will move the cursor at the beginning of the file.
- Rework the tests to cover this new feature.
- @ccordoba12 I reworked the tests to take into account the comments you made about pytest fixtures in another PR. Tell me if this is Ok please.

![text_file_in_oe](https://user-images.githubusercontent.com/10170372/46361316-48b52000-c63b-11e8-8a56-2696cc41c8d6.gif)

### Developer Certificate of Origin Affirmation

By submitting this Pull Request or typing my name below, I affirm the
[Developer Certificate of Origin](https://developercertificate.org/)
with respect to both the content of the contribution itself and this post,
and understand I am releasing it under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin




