### PR TITLE
PR: Fix tests by pinning testpath and switching to Python 3.5 on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,7 @@ environment:
 
   matrix:
     - PYTHON_VERSION: "2.7"
-    #- PYTHON_VERSION: "3.5"
-    - PYTHON_VERSION: "3.6"
+    - PYTHON_VERSION: "3.5"
 
 platform:
   -x64

--- a/continuous_integration/posix/install.sh
+++ b/continuous_integration/posix/install.sh
@@ -12,7 +12,9 @@ else
     export CONDA_DEPENDENCIES_FLAGS="--quiet"
     export CONDA_DEPENDENCIES="rope pyflakes sphinx pygments pylint psutil nbconvert \
                                qtawesome cloudpickle pickleshare qtpy pyzmq chardet mock nomkl pandas \
-                               pytest pytest-cov numpydoc scipy cython pillow jedi pycodestyle keyring"
+                               pytest pytest-cov numpydoc scipy cython pillow jedi pycodestyle keyring \
+                               testpath"
+    export TESTPATH_VERSION="0.3.1"
     export PIP_DEPENDENCIES="coveralls pytest-qt pytest-mock pytest-timeout flaky"
 fi
 


### PR DESCRIPTION
Conda package for `testpath` **0.4.1** contains wrong METADATA and that's breaking pip.

Easy way to reproduce:

    conda create -n pip-break python=3.6 testpath
    conda activate pip-break
    pip install ipython

Then see the last command generate a long traceback.

Pinging @mingwandroid and @jjhelmus about this. This requires an urgent fix.