### PR TITLE
Variable Explorer: Use distinctive background for missings in DataFrames

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -45,7 +45,7 @@ from qtpy.QtWidgets import (QApplication, QCheckBox, QDialog, QGridLayout,
                             QMessageBox, QPushButton, QTableView,
                             QScrollBar, QTableWidget, QFrame,
                             QItemDelegate)
-from pandas import DataFrame, Index, Series
+from pandas import DataFrame, Index, Series, isna
 try:
     from pandas._libs.tslib import OutOfBoundsDatetime
 except ImportError:  # For pandas version < 0.20
@@ -272,7 +272,7 @@ class DataFrameModel(QAbstractTableModel):
         if not self.bgcolor_enabled:
             return
         value = self.get_value(index.row(), column)
-        if self.max_min_col[column] is None:
+        if self.max_min_col[column] is None or isna(value):
             color = QColor(BACKGROUND_NONNUMBER_COLOR)
             if is_text_string(value):
                 color.setAlphaF(BACKGROUND_STRING_ALPHA)

--- a/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
@@ -276,6 +276,27 @@ def test_dataframemodel_get_bgcolor_with_object():
     a = dataframeeditor.BACKGROUND_MISC_ALPHA
     assert colorclose(bgcolor(dfm, 0, 0), (h, s, v, a))
 
+
+def test_dataframemodel_get_bgcolor_with_missings():
+    """
+    Test that df bg colors are correct for missing values of various types.
+
+    The types `bool`, `object`, `datetime`, and `timedelta` are omitted,
+    because missings have no different background there yet.
+    """
+    df = DataFrame({'int': [1, None], 'float': [.1, None],
+                    'complex': [1j, None], 'string': ['a', None]})
+    df['category'] = df['string'].astype('category')
+    dfm = DataFrameModel(df)
+    h, s, v, __ = QColor(dataframeeditor.BACKGROUND_NONNUMBER_COLOR).getHsvF()
+    alpha = dataframeeditor.BACKGROUND_MISC_ALPHA
+    for idx, column in enumerate(df.columns):
+        assert not colorclose(bgcolor(dfm, 0, idx), (h, s, v, alpha)), \
+            'Wrong bg color for value of type ' + column
+        assert colorclose(bgcolor(dfm, 1, idx), (h, s, v, alpha)), \
+            'Wrong bg color for missing of type ' + column
+
+
 def test_dataframemodel_with_format_percent_d_and_nan():
     """
     Test DataFrameModel with format `%d` and dataframe containing NaN


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as practicable of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based this PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP 8](https://www.python.org/dev/peps/pep-0008/) code style
* [x] Ensured this pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings following PEP 257for any new functions
* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described the changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] Included a screenshot, if this PR makes any visible changes to the UI


### Developer Certificate of Origin Affirmation

By submitting this Pull Request or typing my name below, I affirm the
[Developer Certificate of Origin](https://developercertificate.org/)
with respect to both the content of the contribution itself and this post,
and understand I am releasing it under Spyder's MIT (Expat) license.


<!--- TYPE YOUR GITHUB USERNAME AFTER THE FOLLOWING STATEMENT ---!>
I certify the above statement is true and correct:
jondo

<!--- Note that you (not Spyder) retain copyright ownership of your work, --->
<!--- and may license it to other parties under the terms of your choice. --->
<!--- Contact us before incorporating any content from external projects. --->


## Description of Changes

<!--- Explain what you've done and why. --->
When opening a Pandas DataFrame with missing values in the Variable Explorer, the missings are displayed with red cell background, which is similar to the red background of the minimal values. So the missings are difficult to spot, see #8037.

I suggest using a white background for the missings instead:
![white-missings](https://user-images.githubusercontent.com/21648/46837628-92250e00-cda5-11e8-983a-3ec643b98cf2.png)

### Issue(s) Resolved

<!--- Pull requests should typically resolve one, and preferably only one --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234"; one per line. --->

Fixes #8037

<!--- Thanks for your help making Spyder better for everyone! --->
