### PR TITLE
PR: Accept event if Shift+Tab is pressed in the CodeEditor keyPressEvent to avoid losing focus

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2976,6 +2976,7 @@ class CodeEditor(TextEditBaseWidget):
             else:
                 # indent the selected text
                 self.unindent()
+            event.accept()
         elif not event.isAccepted():
             TextEditBaseWidget.keyPressEvent(self, event)
             if self.is_completion_widget_visible() and text:


### PR DESCRIPTION
### Issue(s) Resolved

Fixes  #8056

## Description of Changes

We need to accept the event in the `keyPressEvent` of the editor when the hardcoded `Shift+Tab` key sequence is pressed to unindent code, else the editor is loosing focus.

### Developer Certificate of Origin Affirmation

By submitting this Pull Request or typing my name below, I affirm the
[Developer Certificate of Origin](https://developercertificate.org/)
with respect to both the content of the contribution itself and this post,
and understand I am releasing it under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin
