### PR TITLE
PR: Hide plugins that do not have a layout

### DIFF
--- a/spyder/plugins/lspmanager.py
+++ b/spyder/plugins/lspmanager.py
@@ -669,6 +669,7 @@ class LSPManager(SpyderPluginWidget):
     def __init__(self, parent):
         SpyderPluginWidget.__init__(self, parent)
         self.options_button.hide()
+        self.hide()
 
         self.lsp_plugins = {}
         self.clients = {}

--- a/spyder/plugins/workingdirectory/plugin.py
+++ b/spyder/plugins/workingdirectory/plugin.py
@@ -49,6 +49,7 @@ class WorkingDirectory(SpyderPluginWidget):
     
     def __init__(self, parent, workdir=None, **kwds):
         SpyderPluginWidget.__init__(self, parent)
+        self.hide()
 
         self.toolbar = QToolBar(self)
 


### PR DESCRIPTION
### Issue(s) Resolved

Fixes #7111

This is a long standing issue that can be traced back to https://github.com/spyder-ide/spyder/commit/bdd1ed6d835abbd2895e8c7d9b02f075ecdacfce

## Description of Changes

The  plugins inherit from QWidget. If a plugin is meant to be used without a layout, it must be explicitly hidden or else, it will appear as an invisible rectangle in the top left corner of the MainWindow and will block mouse interaction with a part of the Toolbar.

Currently, this include the `LSPManager` and the `WorkingDirectory`.

In the screenshot below, you can see the empty `WorkingDirectory` in red, that span above the Toolbar, but below the Menus. The solution is simply to call `show` in the `__init__` of these plugins.

![image](https://user-images.githubusercontent.com/10170372/47226725-3b17ce00-d38f-11e8-86ce-9d32c9463c7a.png)


### Developer Certificate of Origin Affirmation

By submitting this Pull Request or typing my name below, I affirm the
[Developer Certificate of Origin](https://developercertificate.org/)
with respect to both the content of the contribution itself and this post,
and understand I am releasing it under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin
