### PR TITLE
PR: Improve usability of runtests locally and test output on the CIs

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -10,7 +10,6 @@ Script for running Spyder tests programmatically.
 
 # Standard library imports
 import os
-import sys
 import argparse
 
 # Third party imports
@@ -19,10 +18,9 @@ import pytest
 
 # To run our slow tests only in our CIs
 RUN_CI = os.environ.get('CI', None) is not None
-run_slow = RUN_CI
 
 
-def main(run_slow=run_slow, extra_args=None):
+def main(extra_args=None):
     """
     Run pytest tests for Spyder.
     """
@@ -33,11 +31,9 @@ def main(run_slow=run_slow, extra_args=None):
                    '--durations=10']
 
     if RUN_CI:
-        pytest_args.append('-x')
+        pytest_args += ['-x', '--run-slow']
     elif extra_args:
         pytest_args += extra_args
-    if run_slow and '--run-slow' not in pytest_args:
-        pytest_args.append('--run-slow')
 
     print("Pytest Arguments: " + str(pytest_args))
     errno = pytest.main(pytest_args)
@@ -52,10 +48,7 @@ def main(run_slow=run_slow, extra_args=None):
 if __name__ == '__main__':
     test_parser = argparse.ArgumentParser(
         usage='python runtests.py [--run-slow] [-- pytest_args]')
-    test_parser.add_argument('--run-slow', action='store_true',
-                             default=run_slow,
-                             help='Run the slow (mainly GUI/functional) tests')
     test_parser.add_argument('pytest_args', nargs='*',
                              help="Args to pass to pytest")
     test_args = test_parser.parse_args()
-    main(run_slow=test_args.run_slow, extra_args=test_args.pytest_args)
+    main(extra_args=test_args.pytest_args)

--- a/runtests.py
+++ b/runtests.py
@@ -5,7 +5,7 @@
 #
 
 """
-File for running tests programmatically.
+Script for running Spyder tests programmatically.
 """
 
 # Standard library imports
@@ -13,7 +13,6 @@ import os
 import sys
 
 # Third party imports
-import qtpy  # to ensure that Qt4 uses API v2
 import pytest
 
 
@@ -22,9 +21,10 @@ run_slow = False
 if os.environ.get('CI', None) is not None or '--run-slow' in sys.argv:
     run_slow = True
 
+
 def main():
     """
-    Run pytest tests.
+    Run pytest tests for Spyder.
     """
     pytest_args = ['spyder',
                    'spyder_profiler',
@@ -38,10 +38,9 @@ def main():
 
     errno = pytest.main(pytest_args)
 
-    # sys.exit doesn't work here because some things could be running
-    # in the background (e.g. closing the main window) when this point
-    # is reached. And if that's the case, sys.exit does't stop the
-    # script (as you would expected).
+    # sys.exit doesn't work here because some things could be running in the
+    # background (e.g. closing the main window) when this point is reached.
+    # If that's the case, sys.exit doesn't stop the script as you would expect.
     if errno != 0:
         raise SystemExit(errno)
 

--- a/runtests.py
+++ b/runtests.py
@@ -11,6 +11,7 @@ Script for running Spyder tests programmatically.
 # Standard library imports
 import os
 import sys
+import argparse
 
 # Third party imports
 import pytest
@@ -18,10 +19,10 @@ import pytest
 
 # To run our slow tests only in our CIs
 RUN_CI = os.environ.get('CI', None) is not None
-run_slow = RUN_CI or '--run-slow' in sys.argv
+run_slow = RUN_CI
 
 
-def main():
+def main(run_slow=run_slow, extra_args=None):
     """
     Run pytest tests for Spyder.
     """
@@ -33,9 +34,12 @@ def main():
 
     if RUN_CI:
         pytest_args.append('-x')
-    if run_slow:
+    elif extra_args:
+        pytest_args += extra_args
+    if run_slow and '--run-slow' not in pytest_args:
         pytest_args.append('--run-slow')
 
+    print("Pytest Arguments: " + str(pytest_args))
     errno = pytest.main(pytest_args)
 
     # sys.exit doesn't work here because some things could be running in the
@@ -46,4 +50,12 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    test_parser = argparse.ArgumentParser(
+        usage='python runtests.py [--run-slow] [-- pytest_args]')
+    test_parser.add_argument('--run-slow', action='store_true',
+                             default=run_slow,
+                             help='Run the slow (mainly GUI/functional) tests')
+    test_parser.add_argument('pytest_args', nargs='*',
+                             help="Args to pass to pytest")
+    test_args = test_parser.parse_args()
+    main(run_slow=test_args.run_slow, extra_args=test_args.pytest_args)

--- a/runtests.py
+++ b/runtests.py
@@ -17,9 +17,8 @@ import pytest
 
 
 # To run our slow tests only in our CIs
-run_slow = False
-if os.environ.get('CI', None) is not None or '--run-slow' in sys.argv:
-    run_slow = True
+RUN_CI = os.environ.get('CI', None) is not None
+run_slow = RUN_CI or '--run-slow' in sys.argv
 
 
 def main():
@@ -28,11 +27,12 @@ def main():
     """
     pytest_args = ['spyder',
                    'spyder_profiler',
-                   '-x',
                    '-vv',
                    '-rw',
                    '--durations=10']
 
+    if RUN_CI:
+        pytest_args.append('-x')
     if run_slow:
         pytest_args.append('--run-slow')
 

--- a/runtests.py
+++ b/runtests.py
@@ -31,10 +31,7 @@ def main():
                    '-x',
                    '-vv',
                    '-rw',
-                   '--durations=10',
-                   '--cov=spyder',
-                   '--cov=spyder_profiler',
-                   '--cov-report=term-missing']
+                   '--durations=10']
 
     if run_slow:
         pytest_args.append('--run-slow')

--- a/runtests.py
+++ b/runtests.py
@@ -31,7 +31,8 @@ def main(extra_args=None):
                    '--durations=10']
 
     if RUN_CI:
-        pytest_args += ['-x', '--run-slow']
+        pytest_args += ['-x', '--run-slow', '--cov=spyder',
+                        '--cov=spyder_profiler', '--no-cov-on-fail']
     elif extra_args:
         pytest_args += extra_args
 


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as practicable of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based this PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP 8](https://www.python.org/dev/peps/pep-0008/) code style
* [x] Ensured this pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings following PEP 257 for any new functions
* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described the changes and the motivation for them below


### Developer Certificate of Origin Affirmation

By submitting this Pull Request or typing my name below, I affirm the
[Developer Certificate of Origin](https://developercertificate.org/)
with respect to both the content of the contribution itself and this post,
and understand I am releasing it under Spyder's MIT (Expat) license.


<!--- TYPE YOUR GITHUB USERNAME AFTER THE FOLLOWING STATEMENT ---!>
I certify the above statement is true and correct: C.A.M. Gerlach

<!--- Note that you (not Spyder) retain copyright ownership of your work, --->
<!--- and may license it to other parties under the terms of your choice. --->
<!--- Contact us before incorporating any content from external projects. --->


## Description of Changes

<!--- Explain what you've done and why. --->

This PR does a few things to improve usability of both runtests locally (that have been bothering me and perhaps others for quite some time), as well as the CI reports for users developing both Spyder 3 and Spyder 4, and does a little opportunistic cleanup/refacotring of code that hasn't been touched between ``3.x`` and ``master``.

Namely, it:

* Adds the ability to pass any arbitrary additional pytest options of the users choosing through to pytest with ``argparse``, as well as some user-friendly help text and error handling
* Makes the ``-x`` option the default only on the CIs, so local users can see full test output without hacking ``runtests.py`` and can still pass  ``-x`` or Ctrl-C the test cycle manually if they so desire
* Removes the remaining % file coverage by default, as it can easily be re-enabled locally in the case the user really desires it for every file, and is already displayed in far more accessible form via two different dedicated services when run the CIs and otherwise just adds extra clutter to the logs
* Does some minor opportunistic cleanup/refactoring of non-conflicting ``3.x``/``master`` code

It was made against ``3.x``since both branches are still being actively developed, and thus the local and CI test output and runtests API would be inconsistent between them and have extra clutter. There should only be one small conflict—the Spyder profiler coverage stuff was removed, which was already removed in ``master``).


<!--- Thanks for your help making Spyder better for everyone! --->
