### PR TITLE
Fix various DeprecationWarnings and FutureWarnings in Spyder to prevent it breaking suddenly

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -349,12 +349,12 @@ def test_single_instance_and_edit_magic(main_window, qtbot, tmpdir):
 
     spy_dir = osp.dirname(get_module_path('spyder'))
     lock_code = ("import sys\n"
-                 "sys.path.append('{}')\n"
+                 "sys.path.append(r'{spy_dir_str}')\n"
                  "from spyder.config.base import get_conf_path\n"
                  "from spyder.utils.external import lockfile\n"
                  "lock_file = get_conf_path('spyder.lock')\n"
                  "lock = lockfile.FilesystemLock(lock_file)\n"
-                 "lock_created = lock.lock()".format(spy_dir))
+                 "lock_created = lock.lock()".format(spy_dir_str=spy_dir))
 
     # Test single instance
     with qtbot.waitSignal(shell.executed):

--- a/spyder/widgets/github/backend.py
+++ b/spyder/widgets/github/backend.py
@@ -142,8 +142,8 @@ class GithubBackend(BaseBackend):
             repo = gh.repos(self.gh_owner)(self.gh_repo)
             ret = repo.issues.post(title=title, body=body)
         except github.ApiError as e:
-            _logger().warn('failed to send bug report on github. response=%r' %
-                           e.response)
+            _logger().warning('Failed to send bug report on Github. '
+                              'response=%r', e.response)
             # invalid credentials
             if e.response.code == 401:
                 if self._show_msgbox:
@@ -287,7 +287,7 @@ class GithubBackend(BaseBackend):
                 files={'SpyderIDE.log': {"content": log_content}})
             qApp.restoreOverrideCursor()
         except github.ApiError:
-            _logger().warn('failed to upload log report as a gist')
-            return '"failed to upload log file as a gist"'
+            _logger().warning('Failed to upload log report as a gist')
+            return '"Failed to upload log file as a gist"'
         else:
             return ret['html_url']

--- a/spyder/widgets/tests/test_editor.py
+++ b/spyder/widgets/tests/test_editor.py
@@ -323,6 +323,7 @@ def test_replace_enter_press(editor_find_replace_bot):
     qtbot.keyPress(finder.search_text, Qt.Key_Return, modifier=Qt.ShiftModifier)
     assert editor.get_cursor_line_column() == (3,4)
 
+
 def test_replace_plain_regex(editor_find_replace_bot):
     """Test that regex reserved characters are displayed as plain text."""
     editor_stack, editor, finder, qtbot = editor_find_replace_bot
@@ -332,9 +333,10 @@ def test_replace_plain_regex(editor_find_replace_bot):
     finder.show()
     finder.show_replace()
     qtbot.keyClicks(finder.search_text, 'spam')
-    qtbot.keyClicks(finder.replace_text, '.\[()]*test')
+    qtbot.keyClicks(finder.replace_text, r'.\[()]*test')
     qtbot.keyPress(finder.replace_text, Qt.Key_Return)
     assert editor.toPlainText()[0:-1] == expected_new_text
+
 
 def test_replace_invalid_regex(editor_find_replace_bot):
     """Assert that replacing an invalid regexp does nothing."""

--- a/spyder/widgets/variableexplorer/arrayeditor.py
+++ b/spyder/widgets/variableexplorer/arrayeditor.py
@@ -780,11 +780,11 @@ class ArrayEditor(QDialog):
         slice_index[self.last_dim] = data_index
 
         stack_index = self.dim_indexes[self.last_dim].get(data_index)
-        if stack_index == None:
+        if stack_index is None:
             stack_index = self.stack.count()
             try:
-                self.stack.addWidget(ArrayEditorWidget(self,
-                                                       self.data[slice_index]))
+                self.stack.addWidget(ArrayEditorWidget(
+                    self, self.data[tuple(slice_index)]))
             except IndexError:  # Handle arrays of size 0 in one axis
                 self.stack.addWidget(ArrayEditorWidget(self, self.data))
             self.dim_indexes[self.last_dim][data_index] = stack_index

--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -192,17 +192,23 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
             fetch_more = False
         else:
             fetch_more = True
-        
-        if self.remote:
-            sizes = [ data[self.keys[index]]['size'] 
-                      for index in range(start, stop) ]
-            types = [ data[self.keys[index]]['type']
-                      for index in range(start, stop) ]
-        else:
-            sizes = [ get_size(data[self.keys[index]])
-                      for index in range(start, stop) ]
-            types = [ get_human_readable_type(data[self.keys[index]])
-                      for index in range(start, stop) ]
+
+        # Ignore pandas warnings that certain attributes are deprecated
+        # and will be removed, since they will only be accessed if they exist.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=(r"^\w+\.\w+ is deprecated and "
+                                   "will be removed in a future version"))
+            if self.remote:
+                sizes = [data[self.keys[index]]['size']
+                         for index in range(start, stop)]
+                types = [data[self.keys[index]]['type']
+                         for index in range(start, stop)]
+            else:
+                sizes = [get_size(data[self.keys[index]])
+                         for index in range(start, stop)]
+                types = [get_human_readable_type(data[self.keys[index]])
+                         for index in range(start, stop)]
 
         if fetch_more:
             self.sizes = self.sizes + sizes


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as practicable of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based this PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP 8](https://www.python.org/dev/peps/pep-0008/) code style
* [x] Ensured this pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Described the changes and the motivation for them below


### Developer Certificate of Origin Affirmation

By submitting this Pull Request or typing my name below, I affirm the
[Developer Certificate of Origin](https://developercertificate.org/)
with respect to both the content of the contribution itself and this post,
and understand I am releasing it under Spyder's MIT (Expat) license.


<!--- TYPE YOUR GITHUB USERNAME AFTER THE FOLLOWING STATEMENT ---!>
I certify the above statement is true and correct: CAM-Gerlach

<!--- Note that you (not Spyder) retain copyright ownership of your work, --->
<!--- and may license it to other parties under the terms of your choice. --->
<!--- Contact us before incorporating any content from external projects. --->


## Description of Changes

<!--- Explain what you've done and why. --->

Running our tests with the appropriate pytest flags reveal a number of ``DeprecationWarnings`` and ``FutureWarnings`` triggered by our (non-test) codebase in various third-party dependencies (and a few in Python itself), implying that if not fixed, Spyder could potentially break at any point once the dependency (etc) is updated to a newer version that raises an error or removes something we depended on entirely. Therefore, this was made in ``3.x``, to ensure our current stable users don't have Spyder break on them, and to ensure consistency between our two sets of test output. Fortunately, most of these are easy fixes. 

A number of other warnings seemed related to issues in third-party dependencies rather than anything under Spyder's control; they were notified/PRed where practicable. There were also a number of repetitive ``ImportWarnings`` which were ignored for now; ``ResourceWarnings`` and ``DeprecationWarnings`` due to unclosed files, using the old codecs.open or deprecated ``open()`` options, which will be fixed in a separate PR in master only; and warnings from Pytest about the tests themselves regarding things that will be removed in the next upcoming Pytest version, which will be fixed in another separate PR also targeting ``master``. Finally, there was the flood of Traitlets DeprecationWarnings, which are also handled separately.


<!--- Thanks for your help making Spyder better for everyone! --->
