### PR TITLE
PR: Save last accepted kernel settings in config

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
@@ -188,9 +188,9 @@ class KernelConnectionDialog(QDialog):
 
         try:
             import keyring
-            ssh_passphrase = keyring.get_password("existing_kernel",
+            ssh_passphrase = keyring.get_password("spyder_remote_kernel",
                                                   "ssh_key_passphrase")
-            ssh_password = keyring.get_password("existing_kernel",
+            ssh_password = keyring.get_password("spyder_remote_kernel",
                                                 "ssh_password")
             if ssh_passphrase:
                 self.kfp.setText(ssh_passphrase)
@@ -220,11 +220,11 @@ class KernelConnectionDialog(QDialog):
         try:
             import keyring
             if is_ssh_key:
-                keyring.set_password("existing_kernel",
+                keyring.set_password("spyder_remote_kernel",
                                      "ssh_key_passphrase",
                                      self.kfp.text())
             else:
-                keyring.set_password("existing_kernel",
+                keyring.set_password("spyder_remote_kernel",
                                      "ssh_password",
                                      self.pw.text())
         except Exception:

--- a/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
@@ -15,9 +15,10 @@ import os.path as osp
 from jupyter_core.paths import jupyter_runtime_dir
 from qtpy.compat import getopenfilename
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import (QDialog, QDialogButtonBox, QGridLayout, QGroupBox,
-                            QHBoxLayout, QLabel, QLineEdit, QPushButton,
-                            QRadioButton, QSpacerItem, QVBoxLayout, QCheckBox)
+from qtpy.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox, QGridLayout,
+                            QGroupBox, QHBoxLayout, QLabel, QLineEdit,
+                            QPushButton, QRadioButton, QSpacerItem,
+                            QVBoxLayout)
 
 # Local imports
 from spyder.config.base import _, get_home_dir
@@ -137,6 +138,7 @@ class KernelConnectionDialog(QDialog):
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
             Qt.Horizontal, self)
 
+        self.accept_btns.accepted.connect(self.save_connection_settings)
         self.accept_btns.accepted.connect(self.accept)
         self.accept_btns.rejected.connect(self.reject)
 
@@ -159,6 +161,7 @@ class KernelConnectionDialog(QDialog):
 
         self.load_connection_settings()
 
+    """Loads the user's previously-saved remote kernel connection settings."""
     def load_connection_settings(self):
         existing_kernel = CONF.get("existing-kernel", "settings", {})
 
@@ -197,6 +200,11 @@ class KernelConnectionDialog(QDialog):
             pass
 
     def save_connection_settings(self):
+        """Saves user's remote kernel connection settings."""
+
+        if not self.save_layout.isChecked():
+            return
+
         is_ssh_key = bool(self.kf_radio.isChecked())
         connection_settings = {
             "json_file_path": self.cf.text(),
@@ -222,7 +230,6 @@ class KernelConnectionDialog(QDialog):
         except Exception:
             pass
 
-
     def select_connection_file(self):
         cf = getopenfilename(self, _('Select kernel connection file'),
                              jupyter_runtime_dir(), '*.json;;*.*')[0]
@@ -240,8 +247,6 @@ class KernelConnectionDialog(QDialog):
         result = dialog.exec_()
         is_remote = bool(dialog.rm_group.isChecked())
         accepted = result == QDialog.Accepted
-        if accepted and dialog.save_layout.isChecked():
-            dialog.save_connection_settings()
 
         if is_remote:
             def falsy_to_none(arg):

--- a/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
@@ -162,7 +162,7 @@ class KernelConnectionDialog(QDialog):
         self.load_connection_settings()
 
     def load_connection_settings(self):
-        """Load the user's previously-saved remote kernel connection settings."""
+        """Load the user's previously-saved kernel connection settings."""
         existing_kernel = CONF.get("existing-kernel", "settings", {})
 
         connection_file_path = existing_kernel.get("json_file_path", "")
@@ -200,7 +200,7 @@ class KernelConnectionDialog(QDialog):
             pass
 
     def save_connection_settings(self):
-        """Save user's remote kernel connection settings."""
+        """Save user's kernel connection settings."""
 
         if not self.save_layout.isChecked():
             return

--- a/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
@@ -17,7 +17,7 @@ from qtpy.compat import getopenfilename
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (QDialog, QDialogButtonBox, QGridLayout, QGroupBox,
                             QHBoxLayout, QLabel, QLineEdit, QPushButton,
-                            QRadioButton, QSpacerItem, QVBoxLayout)
+                            QRadioButton, QSpacerItem, QVBoxLayout, QCheckBox)
 
 # Local imports
 from spyder.config.base import _, get_home_dir
@@ -30,14 +30,6 @@ class KernelConnectionDialog(QDialog):
     def __init__(self, parent=None):
         super(KernelConnectionDialog, self).__init__(parent)
         self.setWindowTitle(_('Connect to an existing kernel'))
-
-        cfp = CONF.get("existing-kernel", "json_file_path", "")
-        is_remote = CONF.get("existing-kernel", "is_remote", False)
-        username = CONF.get("existing-kernel", "username", "")
-        hostname = CONF.get("existing-kernel", "hostname", "")
-        port = str(CONF.get("existing-kernel", "port", 22))
-        is_ssh_kf = CONF.get("existing-kernel", "is_ssh_keyfile", False)
-        ssh_kf = CONF.get("existing-kernel", "ssh_key_file_path", "")
 
         main_label = QLabel(_(
             "<p>Please select the JSON connection file (<i>e.g.</i> "
@@ -56,8 +48,6 @@ class KernelConnectionDialog(QDialog):
         self.cf = QLineEdit()
         self.cf.setPlaceholderText(_('Kernel connection file path'))
         self.cf.setMinimumWidth(350)
-        if cfp != "":
-            self.cf.setText(cfp)
         cf_open_btn = QPushButton(_('Browse'))
         cf_open_btn.clicked.connect(self.select_connection_file)
 
@@ -72,17 +62,12 @@ class KernelConnectionDialog(QDialog):
         # SSH connection
         hn_label = QLabel(_('Hostname:'))
         self.hn = QLineEdit()
-        if hostname != "":
-            self.hn.setText(hostname)
         pn_label = QLabel(_('Port:'))
         self.pn = QLineEdit()
         self.pn.setMaximumWidth(75)
-        self.pn.setText(port)
 
         un_label = QLabel(_('Username:'))
         self.un = QLineEdit()
-        if username != "":
-            self.un.setText(username)
 
         # SSH authentication
         auth_group = QGroupBox(_("Authentication method:"))
@@ -102,8 +87,6 @@ class KernelConnectionDialog(QDialog):
         kf_layout = QHBoxLayout()
         kf_layout.addWidget(self.kf)
         kf_layout.addWidget(kf_open_btn)
-        if ssh_kf != "":
-            self.kf.setText(ssh_kf)
 
         kfp_label = QLabel(_('Passphase:'))
         self.kfp = QLineEdit()
@@ -147,10 +130,7 @@ class KernelConnectionDialog(QDialog):
         rm_layout.addWidget(auth_group)
         self.rm_group.setLayout(rm_layout)
         self.rm_group.setCheckable(True)
-        self.rm_group.setChecked(is_remote)
         self.rm_group.toggled.connect(self.pw_radio.setChecked)
-
-        self.kf_radio.setChecked(is_ssh_kf)
 
         # Ok and Cancel buttons
         self.accept_btns = QDialogButtonBox(
@@ -160,6 +140,10 @@ class KernelConnectionDialog(QDialog):
         self.accept_btns.accepted.connect(self.accept)
         self.accept_btns.rejected.connect(self.reject)
 
+        # save kernel checkbox
+        self.save_kernel_layout = QCheckBox(self)
+        self.save_kernel_layout.setText(_("Save kernel settings"))
+
         # Dialog layout
         layout = QVBoxLayout(self)
         layout.addWidget(main_label)
@@ -167,7 +151,33 @@ class KernelConnectionDialog(QDialog):
         layout.addLayout(cf_layout)
         layout.addSpacerItem(QSpacerItem(QSpacerItem(0, 12)))
         layout.addWidget(self.rm_group)
+        layout.addWidget(self.save_kernel_layout)
         layout.addWidget(self.accept_btns)
+
+        self.load_existing_kernel()
+
+    def load_existing_kernel(self):
+        existing_kernel = CONF.get("existing-kernel", "settings", {})
+
+        cfp = existing_kernel.get("json_file_path", "")
+        is_remote = existing_kernel.get("is_remote", False)
+        username = existing_kernel.get("username", "")
+        hostname = existing_kernel.get("hostname", "")
+        port = str(existing_kernel.get("port", 22))
+        is_ssh_kf = existing_kernel.get("is_ssh_keyfile", False)
+        ssh_kf = existing_kernel.get("ssh_key_file_path", "")
+
+        if cfp != "":
+            self.cf.setText(cfp)
+        if username != "":
+            self.un.setText(username)
+        if hostname != "":
+            self.hn.setText(hostname)
+        if ssh_kf != "":
+            self.kf.setText(ssh_kf)
+        self.rm_group.setChecked(is_remote)
+        self.pn.setText(port)
+        self.kf_radio.setChecked(is_ssh_kf)
 
     def select_connection_file(self):
         cf = getopenfilename(self, _('Select kernel connection file'),
@@ -186,16 +196,17 @@ class KernelConnectionDialog(QDialog):
         result = dialog.exec_()
         is_remote = bool(dialog.rm_group.isChecked())
         accepted = result == QDialog.Accepted
-        if accepted:
-            CONF.set("existing-kernel", "json_file_path", dialog.cf.text())
-            CONF.set("existing-kernel", "is_remote",
-                     bool(dialog.rm_group.isChecked()))
-            CONF.set("existing-kernel", "username", dialog.un.text())
-            CONF.set("existing-kernel", "hostname", dialog.hn.text())
-            CONF.set("existing-kernel", "port", dialog.pn.text())
-            CONF.set("existing-kernel", "is_ssh_keyfile",
-                     bool(dialog.kf_radio.isChecked()))
-            CONF.set("existing-kernel", "ssh_key_file_path", dialog.kf.text())
+        if accepted and dialog.save_kernel_layout.isChecked():
+            existing_kernel = {
+              "json_file_path": dialog.cf.text(),
+              "is_remote": is_remote,
+              "username": dialog.un.text(),
+              "hostname": dialog.hn.text(),
+              "port": dialog.pn.text(),
+              "is_ssh_keyfile": bool(dialog.kf_radio.isChecked()),
+              "ssh_key_file_path": dialog.kf.text()
+            }
+            CONF.set("existing-kernel", "settings", existing_kernel)
 
         if is_remote:
             def falsy_to_none(arg):

--- a/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
@@ -161,11 +161,11 @@ class KernelConnectionDialog(QDialog):
 
         self.load_connection_settings()
 
-    """Loads the user's previously-saved remote kernel connection settings."""
     def load_connection_settings(self):
+        """Load the user's previously-saved remote kernel connection settings."""
         existing_kernel = CONF.get("existing-kernel", "settings", {})
 
-        cfp = existing_kernel.get("json_file_path", "")
+        connection_file_path = existing_kernel.get("json_file_path", "")
         is_remote = existing_kernel.get("is_remote", False)
         username = existing_kernel.get("username", "")
         hostname = existing_kernel.get("hostname", "")
@@ -173,8 +173,8 @@ class KernelConnectionDialog(QDialog):
         is_ssh_kf = existing_kernel.get("is_ssh_keyfile", False)
         ssh_kf = existing_kernel.get("ssh_key_file_path", "")
 
-        if cfp != "":
-            self.cf.setText(cfp)
+        if connection_file_path != "":
+            self.cf.setText(connection_file_path)
         if username != "":
             self.un.setText(username)
         if hostname != "":
@@ -192,15 +192,15 @@ class KernelConnectionDialog(QDialog):
                                                   "ssh_key_passphrase")
             ssh_password = keyring.get_password("existing_kernel",
                                                 "ssh_password")
-            if ssh_passphrase != "":
+            if ssh_passphrase:
                 self.kfp.setText(ssh_passphrase)
-            if ssh_password != "":
+            if ssh_password:
                 self.pw.setText(ssh_password)
         except Exception:
             pass
 
     def save_connection_settings(self):
-        """Saves user's remote kernel connection settings."""
+        """Save user's remote kernel connection settings."""
 
         if not self.save_layout.isChecked():
             return

--- a/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
@@ -185,12 +185,14 @@ class KernelConnectionDialog(QDialog):
 
         try:
             import keyring
-            ssh_passphrase = keyring.get_password("existing_kernel", "ssh_key_passphrase")
-            ssh_password = keyring.get_password("existing_kernel", "ssh_password")
+            ssh_passphrase = keyring.get_password("existing_kernel",
+                                                  "ssh_key_passphrase")
+            ssh_password = keyring.get_password("existing_kernel",
+                                                "ssh_password")
             if ssh_passphrase != "":
-               self.kfp.setText(ssh_passphrase)
+                self.kfp.setText(ssh_passphrase)
             if ssh_password != "":
-               self.pw.setText(ssh_password)
+                self.pw.setText(ssh_password)
         except Exception:
             pass
 
@@ -208,11 +210,15 @@ class KernelConnectionDialog(QDialog):
         CONF.set("existing-kernel", "settings", connection_settings)
 
         try:
-          import keyring
-          if is_ssh_key:
-              keyring.set_password("existing_kernel", "ssh_key_passphrase", self.kfp.text())
-          else:
-              keyring.set_password("existing_kernel", "ssh_password", self.pw.text())
+            import keyring
+            if is_ssh_key:
+                keyring.set_password("existing_kernel",
+                                     "ssh_key_passphrase",
+                                     self.kfp.text())
+            else:
+                keyring.set_password("existing_kernel",
+                                     "ssh_password",
+                                     self.pw.text())
         except Exception:
             pass
 

--- a/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
@@ -55,12 +55,11 @@ def connection_dialog_factory(request):
 # =============================================================================
 # Tests
 # =============================================================================
-def test_kernel_connection_dialog_remembers_input_ssh_passphrase(
-    qtbot, connection_dialog_factory
-):
-    """Test to ensure that the dialog remembers user's kernel connection
+def test_kernel_connection_dialog_remember_input_ssh_passphrase(
+        qtbot, connection_dialog_factory):
+    """Test that the dialog remember user's kernel connection
        settings and ssh key passphrase when the user checks the
-       save checkbox"""
+       save checkbox."""
 
     dlg = connection_dialog_factory.get()
 
@@ -118,12 +117,11 @@ def test_kernel_connection_dialog_remembers_input_ssh_passphrase(
         assert new_dlg.kfp.text() == kfp
 
 
-def test_kernel_connection_dialog_doesnt_remembers_input_ssh_passphrase(
-    qtbot, connection_dialog_factory
-):
-    """Test to ensure that the dialog doesn't remembers user's kernel
+def test_kernel_connection_dialog_doesnt_remember_input_ssh_passphrase(
+        qtbot, connection_dialog_factory):
+    """Test that the dialog doesn't remember user's kernel
        connection settings and ssh key passphrase when the user doesn't
-       check the save checkbox"""
+       check the save checkbox."""
 
     dlg = connection_dialog_factory.get()
 
@@ -181,11 +179,10 @@ def test_kernel_connection_dialog_doesnt_remembers_input_ssh_passphrase(
         assert new_dlg.kfp.text() == ""
 
 
-def test_kernel_connection_dialog_remembers_input_password(
-    qtbot, connection_dialog_factory
-):
-    """Test to ensure that the dialog remembers user's kernel connection
-       settings and ssh password when the user checks the save checkbox"""
+def test_kernel_connection_dialog_remember_input_password(
+        qtbot, connection_dialog_factory):
+    """Test that the dialog remember user's kernel connection
+       settings and ssh password when the user checks the save checkbox."""
 
     dlg = connection_dialog_factory.get()
 
@@ -238,11 +235,10 @@ def test_kernel_connection_dialog_remembers_input_password(
 
 
 def test_kernel_connection_dialog_doesnt_remember_input_password(
-    qtbot, connection_dialog_factory
-):
-    """Test to ensure that the dialog doesn't remembers user's kernel
+        qtbot, connection_dialog_factory):
+    """Test that the dialog doesn't remember user's kernel
        connection settings and ssh password when the user doesn't
-       check the save checkbox"""
+       check the save checkbox."""
 
     dlg = connection_dialog_factory.get()
 

--- a/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
@@ -84,9 +84,9 @@ def connection_dialog_factory(qtbot, request):
 
         try:
             import keyring
-            keyring.set_password("existing_kernel",
+            keyring.set_password("spyder_remote_kernel",
                                  "ssh_key_passphrase", "")
-            keyring.set_password("existing_kernel",
+            keyring.set_password("spyder_remote_kernel",
                                  "ssh_password", "")
         except Exception:
             pass

--- a/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+# -----------------------------------------------------------------------------
+
+"""Tests for the Existing Kernel Connection widget."""
+
+# Third party imports
+import pytest
+from qtpy.QtCore import Qt
+
+# Local imports
+from spyder.plugins.ipythonconsole.widgets.kernelconnect import KernelConnectionDialog
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+@pytest.fixture
+def setup_dialog(qtbot):
+    """Set up error report dialog."""
+    widget = KernelConnectionDialog()
+    qtbot.addWidget(widget)
+    return widget
+
+

--- a/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
@@ -119,7 +119,7 @@ def test_kernel_connection_dialog_remember_input_ssh_passphrase(
        save checkbox."""
 
     connection_dialog_factory.submit_filled_dialog(use_keyfile=True,
-                                                 save_settings=True)
+                                                   save_settings=True)
 
     # create new dialog and check fields
     new_dlg = connection_dialog_factory.get_default_dialog()
@@ -141,7 +141,7 @@ def test_kernel_connection_dialog_doesnt_remember_input_ssh_passphrase(
        check the save checkbox."""
 
     connection_dialog_factory.submit_filled_dialog(use_keyfile=True,
-                                                 save_settings=False)
+                                                   save_settings=False)
 
     # create new dialog and check fields
     new_dlg = connection_dialog_factory.get_default_dialog()
@@ -162,7 +162,7 @@ def test_kernel_connection_dialog_remember_input_password(
        settings and ssh password when the user checks the save checkbox."""
 
     connection_dialog_factory.submit_filled_dialog(use_keyfile=False,
-                                                 save_settings=True)
+                                                   save_settings=True)
 
     # create new dialog and check fields
     new_dlg = connection_dialog_factory.get_default_dialog()
@@ -183,7 +183,7 @@ def test_kernel_connection_dialog_doesnt_remember_input_password(
        check the save checkbox."""
 
     connection_dialog_factory.submit_filled_dialog(use_keyfile=False,
-                                                 save_settings=False)
+                                                   save_settings=False)
 
     # create new dialog and check fields
     new_dlg = connection_dialog_factory.get_default_dialog()

--- a/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
@@ -107,10 +107,10 @@ def connection_dialog_factory(qtbot, request):
 # =============================================================================
 # Tests
 # =============================================================================
-def test_kernel_connection_dialog_remember_input_ssh_passphrase(
+def test_connection_dialog_remembers_input_with_ssh_passphrase(
         qtbot, connection_dialog_factory):
     """
-    Test that the dialog remember user's kernel connection
+    Test that the dialog remembers the user's kernel connection
     settings and ssh key passphrase when the user checks the
     save checkbox.
     """
@@ -135,7 +135,7 @@ def test_kernel_connection_dialog_remember_input_ssh_passphrase(
         assert new_dlg.kfp.text() == pytest.kfp
 
 
-def test_kernel_connection_dialog_doesnt_remember_input_ssh_passphrase(
+def test_connection_dialog_doesnt_remember_input_with_ssh_passphrase(
         qtbot, connection_dialog_factory):
     """
     Test that the dialog doesn't remember the user's kernel
@@ -163,10 +163,10 @@ def test_kernel_connection_dialog_doesnt_remember_input_ssh_passphrase(
         assert new_dlg.kfp.text() == ""
 
 
-def test_kernel_connection_dialog_remember_input_password(
+def test_connection_dialog_remembers_input_with_password(
         qtbot, connection_dialog_factory):
     """
-    Test that the dialog remember user's kernel connection
+    Test that the dialog remembers the user's kernel connection
     settings and ssh password when the user checks the save checkbox.
     """
 
@@ -189,10 +189,10 @@ def test_kernel_connection_dialog_remember_input_password(
         assert new_dlg.pw.text() == pytest.pw
 
 
-def test_kernel_connection_dialog_doesnt_remember_input_password(
+def test_connection_dialog_doesnt_remember_input_with_password(
         qtbot, connection_dialog_factory):
     """
-    Test that the dialog doesn't remember user's kernel
+    Test that the dialog doesn't remember the user's kernel
     connection settings and ssh password when the user doesn't
     check the save checkbox.
     """

--- a/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
@@ -18,8 +18,7 @@ import time
 
 # Local imports
 from spyder.plugins.ipythonconsole.widgets.kernelconnect import (
-    KernelConnectionDialog
-)
+    KernelConnectionDialog)
 from spyder.config.main import CONF
 
 
@@ -40,18 +39,18 @@ def connection_dialog_factory(qtbot, request):
 
             # fill out cf path
             dlg.cf.clear()
-            qtbot.keyClicks(dlg.cf, cf_path)
+            qtbot.keyClicks(dlg.cf, pytest.cf_path)
             # check the remote kernel box
             dlg.rm_group.setChecked(True)
             # fill out hostname
             dlg.hn.clear()
-            qtbot.keyClicks(dlg.hn, hn)
+            qtbot.keyClicks(dlg.hn, pytest.hn)
             # fill out port
             dlg.pn.clear()
-            qtbot.keyClicks(dlg.pn, str(pn))
+            qtbot.keyClicks(dlg.pn, str(pytest.pn))
             # fill out username
             dlg.un.clear()
-            qtbot.keyClicks(dlg.un, un)
+            qtbot.keyClicks(dlg.un, pytest.un)
 
             if use_keyfile:
                 # select ssh keyfile radio
@@ -60,11 +59,11 @@ def connection_dialog_factory(qtbot, request):
 
                 # fill out ssh keyfile
                 dlg.kf.clear()
-                qtbot.keyClicks(dlg.kf, kf)
+                qtbot.keyClicks(dlg.kf, pytest.kf)
 
                 # fill out passphrase
                 dlg.kfp.clear()
-                qtbot.keyClicks(dlg.kfp, kfp)
+                qtbot.keyClicks(dlg.kfp, pytest.kfp)
             else:
                 # select password radio
                 dlg.pw_radio.setChecked(True)
@@ -72,19 +71,15 @@ def connection_dialog_factory(qtbot, request):
 
                 # fill out password
                 dlg.pw.clear()
-                qtbot.keyClicks(dlg.pw, pw)
+                qtbot.keyClicks(dlg.pw, pytest.pw)
 
             # check save connection settings
             dlg.save_layout.setChecked(save_settings)
 
-            # Press ok and save connection settings
-            qtbot.mouseClick(dlg.accept_btns.button(QDialogButtonBox.Ok),
-                             Qt.LeftButton)
-
             return dlg
 
     def teardown():
-        """Clear existing-kernel config and keyring passwords"""
+        """Clear existing-kernel config and keyring passwords."""
         CONF.remove_section("existing-kernel")
 
         try:
@@ -96,17 +91,17 @@ def connection_dialog_factory(qtbot, request):
         except Exception:
             pass
 
+    # test form values
+    pytest.cf_path = "cf_path"
+    pytest.un = "test_username"
+    pytest.hn = "test_hostname"
+    pytest.pn = 123
+    pytest.kf = "test_kf"
+    pytest.kfp = "test_kfp"
+    pytest.pw = "test_pw"
+
     request.addfinalizer(teardown)
     return DialogFactory()
-
-
-cf_path = "test_cf_path"
-un = "test_username"
-hn = "test_hostname"
-pn = 123
-kf = "test_kf"
-kfp = "test_kfp"
-pw = "test_pw"
 
 
 # =============================================================================
@@ -114,34 +109,46 @@ pw = "test_pw"
 # =============================================================================
 def test_kernel_connection_dialog_remember_input_ssh_passphrase(
         qtbot, connection_dialog_factory):
-    """Test that the dialog remember user's kernel connection
-       settings and ssh key passphrase when the user checks the
-       save checkbox."""
+    """
+    Test that the dialog remember user's kernel connection
+    settings and ssh key passphrase when the user checks the
+    save checkbox.
+    """
 
-    connection_dialog_factory.submit_filled_dialog(use_keyfile=True,
-                                                   save_settings=True)
+    dlg = connection_dialog_factory.submit_filled_dialog(use_keyfile=True,
+                                                         save_settings=True)
+
+    # Press ok and save connection settings
+    qtbot.mouseClick(dlg.accept_btns.button(QDialogButtonBox.Ok),
+                     Qt.LeftButton)
 
     # create new dialog and check fields
     new_dlg = connection_dialog_factory.get_default_dialog()
-    assert new_dlg.cf.text() == cf_path
+    assert new_dlg.cf.text() == pytest.cf_path
     assert new_dlg.rm_group.isChecked()
-    assert new_dlg.hn.text() == hn
-    assert new_dlg.un.text() == un
-    assert new_dlg.pn.text() == str(pn)
-    assert new_dlg.kf.text() == kf
+    assert new_dlg.hn.text() == pytest.hn
+    assert new_dlg.un.text() == pytest.un
+    assert new_dlg.pn.text() == str(pytest.pn)
+    assert new_dlg.kf.text() == pytest.kf
     if (not sys.platform.startswith('linux') or
             not os.environ.get('CI') is not None):
-        assert new_dlg.kfp.text() == kfp
+        assert new_dlg.kfp.text() == pytest.kfp
 
 
 def test_kernel_connection_dialog_doesnt_remember_input_ssh_passphrase(
         qtbot, connection_dialog_factory):
-    """Test that the dialog doesn't remember user's kernel
-       connection settings and ssh key passphrase when the user doesn't
-       check the save checkbox."""
+    """
+    Test that the dialog doesn't remember the user's kernel
+    connection settings and ssh key passphrase when the user doesn't
+    check the save checkbox.
+    """
 
-    connection_dialog_factory.submit_filled_dialog(use_keyfile=True,
-                                                   save_settings=False)
+    dlg = connection_dialog_factory.submit_filled_dialog(use_keyfile=True,
+                                                         save_settings=False)
+
+    # Press ok and save connection settings
+    qtbot.mouseClick(dlg.accept_btns.button(QDialogButtonBox.Ok),
+                     Qt.LeftButton)
 
     # create new dialog and check fields
     new_dlg = connection_dialog_factory.get_default_dialog()
@@ -158,32 +165,44 @@ def test_kernel_connection_dialog_doesnt_remember_input_ssh_passphrase(
 
 def test_kernel_connection_dialog_remember_input_password(
         qtbot, connection_dialog_factory):
-    """Test that the dialog remember user's kernel connection
-       settings and ssh password when the user checks the save checkbox."""
+    """
+    Test that the dialog remember user's kernel connection
+    settings and ssh password when the user checks the save checkbox.
+    """
 
-    connection_dialog_factory.submit_filled_dialog(use_keyfile=False,
-                                                   save_settings=True)
+    dlg = connection_dialog_factory.submit_filled_dialog(use_keyfile=False,
+                                                         save_settings=True)
+
+    # Press ok and save connection settings
+    qtbot.mouseClick(dlg.accept_btns.button(QDialogButtonBox.Ok),
+                     Qt.LeftButton)
 
     # create new dialog and check fields
     new_dlg = connection_dialog_factory.get_default_dialog()
-    assert new_dlg.cf.text() == cf_path
+    assert new_dlg.cf.text() == pytest.cf_path
     assert new_dlg.rm_group.isChecked()
-    assert new_dlg.hn.text() == hn
-    assert new_dlg.un.text() == un
-    assert new_dlg.pn.text() == str(pn)
+    assert new_dlg.hn.text() == pytest.hn
+    assert new_dlg.un.text() == pytest.un
+    assert new_dlg.pn.text() == str(pytest.pn)
     if (not sys.platform.startswith('linux') or
             not os.environ.get('CI') is not None):
-        assert new_dlg.pw.text() == pw
+        assert new_dlg.pw.text() == pytest.pw
 
 
 def test_kernel_connection_dialog_doesnt_remember_input_password(
         qtbot, connection_dialog_factory):
-    """Test that the dialog doesn't remember user's kernel
-       connection settings and ssh password when the user doesn't
-       check the save checkbox."""
+    """
+    Test that the dialog doesn't remember user's kernel
+    connection settings and ssh password when the user doesn't
+    check the save checkbox.
+    """
 
-    connection_dialog_factory.submit_filled_dialog(use_keyfile=False,
-                                                   save_settings=False)
+    dlg = connection_dialog_factory.submit_filled_dialog(use_keyfile=False,
+                                                         save_settings=False)
+
+    # Press ok and save connection settings
+    qtbot.mouseClick(dlg.accept_btns.button(QDialogButtonBox.Ok),
+                     Qt.LeftButton)
 
     # create new dialog and check fields
     new_dlg = connection_dialog_factory.get_default_dialog()

--- a/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
@@ -11,18 +11,79 @@
 # Third party imports
 import pytest
 from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QDialogButtonBox
+import time
 
 # Local imports
-from spyder.plugins.ipythonconsole.widgets.kernelconnect import KernelConnectionDialog
+from spyder.plugins.ipythonconsole.widgets.kernelconnect import (
+    KernelConnectionDialog
+)
+from spyder.config.main import CONF
+
 
 # =============================================================================
 # Fixtures
 # =============================================================================
-@pytest.fixture
 def setup_dialog(qtbot):
-    """Set up error report dialog."""
+    """Set up kernel connection dialog."""
     widget = KernelConnectionDialog()
     qtbot.addWidget(widget)
+
     return widget
 
 
+# =============================================================================
+# Tests
+# =============================================================================
+def test_save(qtbot):
+    dlg = setup_dialog(qtbot)
+
+    cf_path = "test_cf_path"
+    un = "test_username"
+    hn = "test_hostname"
+    pn = 123
+    kf = "test_kf"
+    kfp = "test_kfp"
+
+    # fill out cf path
+    qtbot.keyClicks(dlg.cf, cf_path)
+    # check the remote kernel box
+    dlg.rm_group.setChecked(True)
+    # fill out hostname
+    qtbot.keyClicks(dlg.hn, hn)
+    # fill out port
+    dlg.pn.clear()
+    qtbot.keyClicks(dlg.pn, str(pn))
+    # fill out username
+    qtbot.keyClicks(dlg.un, un)
+
+    # select ssh keyfile radio
+    dlg.kf_radio.setChecked(True)
+    assert dlg.kf.isEnabled()
+
+    # fill out ssh keyfile
+    qtbot.keyClicks(dlg.kf, kf)
+
+    # fill out passphrase
+    dlg.kfp.clear()
+    qtbot.keyClicks(dlg.kfp, kfp)
+
+    # check save connection settings
+    dlg.save_layout.setChecked(True)
+
+    # save connection settings
+    dlg.save_connection_settings()
+
+    # create new dialog and check fields
+    new_dlg = setup_dialog(qtbot)
+    assert new_dlg.cf.text() == cf_path
+    assert new_dlg.rm_group.isChecked()
+    assert new_dlg.hn.text() == hn
+    assert new_dlg.un.text() == un
+    assert new_dlg.pn.text() == str(pn)
+    assert new_dlg.kf.text() == kf
+    assert new_dlg.kfp.text() == kfp
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
@@ -9,6 +9,8 @@
 """Tests for the Existing Kernel Connection widget."""
 
 # Third party imports
+import sys
+import os
 import pytest
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QDialogButtonBox
@@ -24,19 +26,43 @@ from spyder.config.main import CONF
 # =============================================================================
 # Fixtures
 # =============================================================================
-def setup_dialog(qtbot):
+@pytest.fixture
+def connection_dialog_factory(request):
     """Set up kernel connection dialog."""
-    widget = KernelConnectionDialog()
-    qtbot.addWidget(widget)
+    class DialogFactory(object):
+        def get(self):
+            dialog = KernelConnectionDialog()
+            request.addfinalizer(dialog.close)
+            return dialog
 
-    return widget
+    def teardown():
+        """Clear existing-kernel config and keyring passwords"""
+        CONF.remove_section("existing-kernel")
+
+        try:
+            import keyring
+            keyring.set_password("existing_kernel",
+                                 "ssh_key_passphrase", "")
+            keyring.set_password("existing_kernel",
+                                 "ssh_password", "")
+        except Exception:
+            pass
+
+    request.addfinalizer(teardown)
+    return DialogFactory()
 
 
 # =============================================================================
 # Tests
 # =============================================================================
-def test_save(qtbot):
-    dlg = setup_dialog(qtbot)
+def test_kernel_connection_dialog_remembers_input_ssh_passphrase(
+    qtbot, connection_dialog_factory
+):
+    """Test to ensure that the dialog remembers user's kernel connection
+       settings and ssh key passphrase when the user checks the
+       save checkbox"""
+
+    dlg = connection_dialog_factory.get()
 
     cf_path = "test_cf_path"
     un = "test_username"
@@ -46,15 +72,18 @@ def test_save(qtbot):
     kfp = "test_kfp"
 
     # fill out cf path
+    dlg.cf.clear()
     qtbot.keyClicks(dlg.cf, cf_path)
     # check the remote kernel box
     dlg.rm_group.setChecked(True)
     # fill out hostname
+    dlg.hn.clear()
     qtbot.keyClicks(dlg.hn, hn)
     # fill out port
     dlg.pn.clear()
     qtbot.keyClicks(dlg.pn, str(pn))
     # fill out username
+    dlg.un.clear()
     qtbot.keyClicks(dlg.un, un)
 
     # select ssh keyfile radio
@@ -62,6 +91,7 @@ def test_save(qtbot):
     assert dlg.kf.isEnabled()
 
     # fill out ssh keyfile
+    dlg.kf.clear()
     qtbot.keyClicks(dlg.kf, kf)
 
     # fill out passphrase
@@ -71,18 +101,197 @@ def test_save(qtbot):
     # check save connection settings
     dlg.save_layout.setChecked(True)
 
-    # save connection settings
-    dlg.save_connection_settings()
+    # Press ok and save connection settings
+    qtbot.mouseClick(dlg.accept_btns.button(QDialogButtonBox.Ok),
+                     Qt.LeftButton)
 
     # create new dialog and check fields
-    new_dlg = setup_dialog(qtbot)
+    new_dlg = connection_dialog_factory.get()
     assert new_dlg.cf.text() == cf_path
     assert new_dlg.rm_group.isChecked()
     assert new_dlg.hn.text() == hn
     assert new_dlg.un.text() == un
     assert new_dlg.pn.text() == str(pn)
     assert new_dlg.kf.text() == kf
-    assert new_dlg.kfp.text() == kfp
+    if (not sys.platform.startswith('linux') or
+            not os.environ.get('CI') is not None):
+        assert new_dlg.kfp.text() == kfp
+
+
+def test_kernel_connection_dialog_doesnt_remembers_input_ssh_passphrase(
+    qtbot, connection_dialog_factory
+):
+    """Test to ensure that the dialog doesn't remembers user's kernel
+       connection settings and ssh key passphrase when the user doesn't
+       check the save checkbox"""
+
+    dlg = connection_dialog_factory.get()
+
+    cf_path = "test_cf_path"
+    un = "test_username"
+    hn = "test_hostname"
+    pn = 123
+    kf = "test_kf"
+    kfp = "test_kfp"
+
+    # fill out cf path
+    dlg.cf.clear()
+    qtbot.keyClicks(dlg.cf, cf_path)
+    # check the remote kernel box
+    dlg.rm_group.setChecked(True)
+    # fill out hostname
+    dlg.hn.clear()
+    qtbot.keyClicks(dlg.hn, hn)
+    # fill out port
+    dlg.pn.clear()
+    qtbot.keyClicks(dlg.pn, str(pn))
+    # fill out username
+    dlg.un.clear()
+    qtbot.keyClicks(dlg.un, un)
+
+    # select ssh keyfile radio
+    dlg.kf_radio.setChecked(True)
+    assert dlg.kf.isEnabled()
+
+    # fill out ssh keyfile
+    dlg.kf.clear()
+    qtbot.keyClicks(dlg.kf, kf)
+
+    # fill out passphrase
+    dlg.kfp.clear()
+    qtbot.keyClicks(dlg.kfp, kfp)
+
+    # check save connection settings
+    dlg.save_layout.setChecked(False)
+
+    # Press ok and save connection settings
+    qtbot.mouseClick(dlg.accept_btns.button(QDialogButtonBox.Ok),
+                     Qt.LeftButton)
+
+    # create new dialog and check fields
+    new_dlg = connection_dialog_factory.get()
+    assert new_dlg.cf.text() == ""
+    assert not new_dlg.rm_group.isChecked()
+    assert new_dlg.hn.text() == ""
+    assert new_dlg.un.text() == ""
+    assert new_dlg.pn.text() == "22"
+    assert new_dlg.kf.text() == ""
+    if (not sys.platform.startswith('linux') or
+            not os.environ.get('CI') is not None):
+        assert new_dlg.kfp.text() == ""
+
+
+def test_kernel_connection_dialog_remembers_input_password(
+    qtbot, connection_dialog_factory
+):
+    """Test to ensure that the dialog remembers user's kernel connection
+       settings and ssh password when the user checks the save checkbox"""
+
+    dlg = connection_dialog_factory.get()
+
+    cf_path = "test_cf_path"
+    un = "test_username"
+    hn = "test_hostname"
+    pn = 123
+    pw = "test_pw"
+
+    # fill out cf path
+    # dlg.cf.clear()
+    qtbot.keyClicks(dlg.cf, cf_path)
+    # check the remote kernel box
+    dlg.rm_group.setChecked(True)
+    # fill out hostname
+    # dlg.hn.clear()
+    qtbot.keyClicks(dlg.hn, hn)
+    # fill out port
+    dlg.pn.clear()
+    qtbot.keyClicks(dlg.pn, str(pn))
+    # fill out username
+    dlg.un.clear()
+    qtbot.keyClicks(dlg.un, un)
+
+    # select password radio
+    dlg.pw_radio.setChecked(True)
+    assert dlg.pw.isEnabled()
+
+    # fill out password
+    dlg.pw.clear()
+    qtbot.keyClicks(dlg.pw, pw)
+
+    # check save connection settings
+    dlg.save_layout.setChecked(True)
+
+    # Press ok and save connection settings
+    qtbot.mouseClick(dlg.accept_btns.button(QDialogButtonBox.Ok),
+                     Qt.LeftButton)
+
+    # create new dialog and check fields
+    new_dlg = connection_dialog_factory.get()
+    assert new_dlg.cf.text() == cf_path
+    assert new_dlg.rm_group.isChecked()
+    assert new_dlg.hn.text() == hn
+    assert new_dlg.un.text() == un
+    assert new_dlg.pn.text() == str(pn)
+    if (not sys.platform.startswith('linux') or
+            not os.environ.get('CI') is not None):
+        assert new_dlg.pw.text() == pw
+
+
+def test_kernel_connection_dialog_doesnt_remember_input_password(
+    qtbot, connection_dialog_factory
+):
+    """Test to ensure that the dialog doesn't remembers user's kernel
+       connection settings and ssh password when the user doesn't
+       check the save checkbox"""
+
+    dlg = connection_dialog_factory.get()
+
+    cf_path = "test_cf_path"
+    un = "test_username"
+    hn = "test_hostname"
+    pn = 123
+    pw = "testpw"
+
+    # fill out cf path
+    dlg.cf.clear()
+    qtbot.keyClicks(dlg.cf, cf_path)
+    # check the remote kernel box
+    dlg.rm_group.setChecked(True)
+    # fill out hostname
+    dlg.hn.clear()
+    qtbot.keyClicks(dlg.hn, hn)
+    # fill out port
+    dlg.pn.clear()
+    qtbot.keyClicks(dlg.pn, str(pn))
+    # fill out username
+    dlg.un.clear()
+    qtbot.keyClicks(dlg.un, un)
+
+    # select password radio
+    dlg.pw_radio.setChecked(True)
+    assert dlg.pw.isEnabled()
+
+    # fill out password
+    dlg.pw.clear()
+    qtbot.keyClicks(dlg.pw, pw)
+
+    # check save connection settings
+    dlg.save_layout.setChecked(False)
+
+    # Press ok and save connection settings
+    qtbot.mouseClick(dlg.accept_btns.button(QDialogButtonBox.Ok),
+                     Qt.LeftButton)
+
+    # create new dialog and check fields
+    new_dlg = connection_dialog_factory.get()
+    assert new_dlg.cf.text() == ""
+    assert not new_dlg.rm_group.isChecked()
+    assert new_dlg.hn.text() == ""
+    assert new_dlg.un.text() == ""
+    assert new_dlg.pn.text() == "22"
+    if (not sys.platform.startswith('linux') or
+            not os.environ.get('CI') is not None):
+        assert new_dlg.pw.text() == ""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as practicable of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based this PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP 8](https://www.python.org/dev/peps/pep-0008/) code style
* [x] Ensured this pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings following PEP 257for any new functions
* [x] Added at least one unit test covering the changes, if at all possible
* [x] Described the changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed
* [x] Included a screenshot, if this PR makes any visible changes to the UI


### Developer Certificate of Origin Affirmation

By submitting this Pull Request or typing my name below, I affirm the
[Developer Certificate of Origin](https://developercertificate.org/)
with respect to both the content of the contribution itself and this post,
and understand I am releasing it under Spyder's MIT (Expat) license.


I certify the above statement is true and correct:
afzalive
<!--- Note that you (not Spyder) retain copyright ownership of your work, --->
<!--- and may license it to other parties under the terms of your choice. --->
<!--- Contact us before incorporating any content from external projects. --->


## Description of Changes

I use remote kernels quite often and every time I start a new kernel on a remote machine, I have to fill in all the fields. So finally, this change allows saving these fields so all you have to do is press enter.

In a new section called "existing-kernel" in the CONF, I'm saving the following fields when the user has checked "Save connection settings" checkbox and clicks "Ok" in the existing kernel dialog:

- json_file_path (default: blank)
- is_remote (default: unchecked)
- username (default: blank)
- hostname (default: blank)
- is_ssh_keyfile (default: password radio selected, so false)
- port (default: 22)
- ssh_key_file_path (default: blank)

And then populating these fields when the dialog is created (__init__). If these fields don't already exist in the CONF, default values (as mentioned above are used).

The following fields are saved in the keyring, under "spyder_remote_kernel":

- ssh password
- ssh key passphrase

There are 4 test cases to test this feature:

- Save user input and ssh key passphrase when save checkbox is checked
- Do not save user input and ssh key passphrase when save checkbox is not checked
- Save user input and ssh key password when save checkbox is checked
- Do not Save user input and ssh key password when save checkbox is not checked


### Screenshot

![image](https://user-images.githubusercontent.com/436057/49190176-415e7a00-f33f-11e8-9d9c-d929faee3af7.png)


### Issue(s) Resolved

Fixes #3689

Thank you

<!--- Thanks for your help making Spyder better for everyone! --->