### PR TITLE
PR: Prevent an error during the initialization of the Editor plugin

### DIFF
--- a/spyder/plugins/editor.py
+++ b/spyder/plugins/editor.py
@@ -418,6 +418,14 @@ class Editor(SpyderPluginWidget):
         self.dock_toolbar_actions = None
         self.edit_menu_actions = None #XXX: find another way to notify Spyder
         self.stack_menu_actions = None
+
+        self.__first_open_files_setup = True
+        self.editorstacks = []
+        self.last_focus_editorstack = {}
+        self.editorwindows = []
+        self.editorwindows_to_be_created = []
+        self.toolbar_list = None
+        self.menu_list = None
         
         # Initialize plugin
         self.initialize_plugin()
@@ -440,14 +448,6 @@ class Editor(SpyderPluginWidget):
         self.cursor_pos_history = []
         self.cursor_pos_index = None
         self.__ignore_cursor_position = True
-
-        self.__first_open_files_setup = True
-        self.editorstacks = []
-        self.last_focus_editorstack = {}
-        self.editorwindows = []
-        self.editorwindows_to_be_created = []
-        self.toolbar_list = None
-        self.menu_list = None
 
         # Don't start IntrospectionManager when running tests because
         # it consumes a lot of memory


### PR DESCRIPTION
## Description of Changes

This was introduced in PR https://github.com/spyder-ide/spyder/pull/8116

Some plugin variables need to be defined before the call to `self.initialize_plugin()` to prevent this error from happening.

### Issue(s) Resolved

Fixes #8216

### Developer Certificate of Origin Affirmation

By submitting this Pull Request or typing my name below, I affirm the
[Developer Certificate of Origin](https://developercertificate.org/)
with respect to both the content of the contribution itself and this post,
and understand I am releasing it under Spyder's MIT (Expat) license.

<!--- TYPE YOUR GITHUB USERNAME AFTER THE FOLLOWING STATEMENT ---!>
I certify the above statement is true and correct: Jean-Sébastien Gosselin

