### PR TITLE
PR: Include QDarkStyle as an explicitly installed dep for the dev builds in the Contributing Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,9 @@ Spyder's necessary dependencies. The easiest way to do so (with Anaconda) is
 This installs all of Spyder's dependencies into the environment along with
 the stable/packaged version of Spyder itself, and then removes the latter.
 
+If still having troubles with dependencies after the steps above, please also 
+install the libraries by using the `requirements` file as shown below. 
+
 If using `pip` and `virtualenv` (not recommended), you need to `cd` to
 the directory where your git clone is stored and run:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,15 +76,12 @@ Spyder's necessary dependencies. The easiest way to do so (with Anaconda) is
 
 ```bash
   $ conda install -c conda-forge/label/beta spyder=4.0.0b1
-  $ conda install -c conda-forge python-language-server
+  $ conda install -c conda-forge python-language-server qdarkstyle
   $ conda remove spyder
 ```
 
 This installs all of Spyder's dependencies into the environment along with
 the stable/packaged version of Spyder itself, and then removes the latter.
-
-If still having troubles with dependencies after the steps above, please also 
-install the libraries by using the `requirements` file as shown below. 
 
 If using `pip` and `virtualenv` (not recommended), you need to `cd` to
 the directory where your git clone is stored and run:


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as practicable of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based this PR on the latest version of the correct branch (master or 3.x)
* [ ] Followed [PEP 8](https://www.python.org/dev/peps/pep-0008/) code style
* [ ] Ensured this pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [ ] Wrote at least one-line docstrings following PEP 257for any new functions
* [ ] Added at least one unit test covering the changes, if at all possible
* [x] Described the changes and the motivation for them below
* [ ] Noted what issue(s) this pull request resolves, creating one if needed
* [ ] Included a screenshot, if this PR makes any visible changes to the UI

## Description of Changes

I was following the `CONTRIBUTING` file to contribute to Spyder and after doing all the installation using the `conda`s commands, I still ended up with dependencies problems. Specifically, I had trouble with the `QDarkStyle` package. After I run the command `pip install -r requirements/requirements.txt` it worked. So, I added a line saying that if the user had trouble with dependencies he/she should run this command, to fix it. 

### Issue(s) Resolved
No issues on this

Fixes #
