### PR TITLE
PR: Specify close_fds=False on Windows

### DIFF
--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -1549,10 +1549,16 @@ class IPythonConsole(SpyderPluginWidget):
             return (error_msg, None)
         kernel_manager._kernel_spec = kernel_spec
 
+        kwargs = {}
+        if os.name == 'nt':
+            # avoid closing fds on win+Python 3.7
+            # which prevents interrupts
+            # this should be fixed in a jupyter_client release (later than 5.2.3)
+            kwargs['close_fds'] = False
         # Catch any error generated when trying to start the kernel
         # See issue 7302
         try:
-            kernel_manager.start_kernel(stderr=stderr_handle)
+            kernel_manager.start_kernel(stderr=stderr_handle, **kwargs)
         except Exception:
             error_msg = _("The error is:<br><br>"
                           "<tt>{}</tt>").format(traceback.format_exc())

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -1553,7 +1553,7 @@ class IPythonConsole(SpyderPluginWidget):
         if os.name == 'nt':
             # avoid closing fds on win+Python 3.7
             # which prevents interrupts
-            # this should be fixed in a jupyter_client release (later than 5.2.3)
+            # jupyter_client > 5.2.3 will do this by default
             kwargs['close_fds'] = False
         # Catch any error generated when trying to start the kernel
         # See issue 7302


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

the default for close_fds changed to True in Python 3.7, resulting in closing the handles needed for interrupt and parent polling.

This is a workaround setting `close_fds=False` on Windows to keep kernels interruptible on Python 3.7
without having to wait for https://github.com/jupyter/jupyter_client/pull/408 to be released. jupyter-client > 5.2.3 will do the same thing by default.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8013


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Benjamin Ragan-Kelley

<!--- Thanks for your help making Spyder better for everyone! --->