### PR TITLE
Converts title arg to unicode with the function to_text_string

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/texteditor.py
+++ b/spyder/plugins/variableexplorer/widgets/texteditor.py
@@ -20,7 +20,7 @@ from qtpy.QtWidgets import (QDialog, QHBoxLayout, QPushButton, QTextEdit,
 from spyder.config.base import _
 from spyder.config.gui import get_font
 from spyder.py3compat import (is_binary_string, to_binary_string,
-                              to_text_string)
+                              to_text_string, PY3, PY2)
 from spyder.utils import icon_manager as ima
 
 
@@ -81,8 +81,21 @@ class TextEditor(QDialog):
         self.setWindowFlags(Qt.Window)
         
         self.setWindowIcon(ima.icon('edit'))
+        
+        if PY3:
+
+            if (title):
+                try:
+                    unicode_title=to_text_string(title)
+                except:
+                    title=u''
+            else:
+                unicode_title=''
+
+
+
         self.setWindowTitle(_("Text editor") + \
-                            "%s" % (" - "+str(title) if str(title) else ""))
+                            "%s" % (" - "+str(unicode_title) if str(unicode_title) else ""))
         self.resize(size[0], size[1])
 
     @Slot()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

I converted title arg to unicode with the function to_text_string to solve issue 7930 in python 3

![screen shot 2018-11-30 at 5 05 00 pm](https://user-images.githubusercontent.com/18587879/49326081-9a363a00-f51a-11e8-8301-befdeb4be46d.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes # 7930


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: juanis2112

<!--- Thanks for your help making Spyder better for everyone! --->
