### PR TITLE
PR: Change handling of server host and port config placeholders

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -667,7 +667,7 @@ DEFAULTS = [
                 'python': {
                     'index': 0,
                     'cmd': 'pyls',
-                    'args': '--host %(host)s --port %(port)s --tcp',
+                    'args': '--host {host} --port {port} --tcp',
                     'host': '127.0.0.1',
                     'port': 2087,
                     'external': False,
@@ -751,7 +751,7 @@ DEFAULTS = [
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '47.0.0'
+CONF_VERSION = '47.1.0'
 
 # Main configuration instance
 try:

--- a/spyder/plugins/editor/lsp/client.py
+++ b/spyder/plugins/editor/lsp/client.py
@@ -91,7 +91,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         self.server_capabilites = SERVER_CAPABILITES
         self.context = zmq.Context()
 
-        server_args = server_args_fmt % (server_settings)
+        server_args = server_args_fmt.format(**server_settings)
         # transport_args = self.local_server_fmt % (server_settings)
         # if self.external_server:
         transport_args = self.external_server_fmt % (server_settings)

--- a/spyder/plugins/lspmanager.py
+++ b/spyder/plugins/lspmanager.py
@@ -138,8 +138,8 @@ class LSPServerEditor(QDialog):
                         'and the host and port. Finally, '
                         'you need to provide the '
                         'arguments that the server accepts. '
-                        'The placeholders <tt>%(host)s</tt> and '
-                        '<tt>%(port)s</tt> refer to the host '
+                        'The placeholders <tt>{host}</tt> and '
+                        '<tt>{port}</tt> refer to the host '
                         'and the port, respectively.')
         server_settings_description = QLabel(description)
         server_settings_description.setWordWrap(True)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

Prevent resetting config files caused by an unwanted interpolation error while reading the `args` value of the python lsp-server after a minor CONF_VERSION bump.

For the record, the old-style string formatting is the same that ConfigParser uses to make interpolation.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #7875 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
