### PR TITLE
PR: Fix error when Editor's dockwidget is not yet initialized

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -677,6 +677,8 @@ class Editor(SpyderPluginWidget):
     def visibility_changed(self, enable):
         """DockWidget visibility has changed"""
         SpyderPluginWidget.visibility_changed(self, enable)
+        if self.dockwidget is None:
+            return
         if self.dockwidget.isWindow():
             self.dock_toolbar.show()
         else:


### PR DESCRIPTION
This error was reported on Windows by @CAM-Gerlach and @jnsebgosselin.