### PR TITLE
PR: Fix macOS tests by pinning to Qt 5.9.6 for now

### DIFF
--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -10,6 +10,11 @@ if [ "$USE_CONDA" = "yes" ]; then
 
     # Install spyder-kernels from Github with no deps
     pip install -q --no-deps git+https://github.com/spyder-ide/spyder-kernels
+
+    # macOS tests are failing with Qt 5.9.7
+    if [ $(uname) == Darwin ]; then
+        conda install -q -y qt=5.9.6
+    fi
 else
     # Update pip and setuptools
     pip install -U pip setuptools


### PR DESCRIPTION
@spyder-ide/core-developers, Anaconda updated Qt to 5.9.7 yesterday and it seems that broke our tests in macOS. 

The workaround (for now) is to use 5.9.6