### PR TITLE
PR: Fix Recent Project submenu actions in Projects menu.

### DIFF
--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -195,15 +195,13 @@ class Projects(SpyderPluginWidget):
             for project in self.recent_projects:
                 if self.is_valid_project(project):
                     name = project.replace(get_home_dir(), '~')
-
-                    def slot():
-                        self.switch_to_plugin()
-                        self.open_project(path=project)
-
-                    action = create_action(self,
+                    action = create_action(
+                        self,
                         name,
-                        icon = ima.icon('project'),
-                        triggered=slot)
+                        icon=ima.icon('project'),
+                        triggered=(
+                            lambda _, p=project: self.open_project(path=p))
+                        )
                     self.recent_projects_actions.append(action)
                 else:
                     self.recent_projects.remove(project)

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -186,7 +186,7 @@ class Projects(SpyderPluginWidget):
                 self.toggle_view_action.setChecked(True)
             self.visibility_changed(True)
 
-    #------ Public API ---------------------------------------------------------
+    # ------ Public API -------------------------------------------------------
     def setup_menu_actions(self):
         """Setup and update the menu actions."""
         self.recent_project_menu.clear()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->

I followed the solution proposed https://stackoverflow.com/a/46300450/4481445 to solve this Issue. 

Basically, it is required to use the lambda expression with solid variables, or else the path to the oldest project saved in the most recent project list is used as the `path` value for the action of every project.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8450


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
