### PR TITLE
PR: Handle non-existing saved editor layout when loading projects

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2904,25 +2904,31 @@ class Editor(SpyderPluginWidget):
 
         if filenames and any([osp.isfile(f) for f in filenames]):
             layout = self.get_option('layout_settings', None)
-            is_vertical, cfname, clines = layout.get('splitsettings')[0]
-            if cfname in filenames:
-                index = filenames.index(cfname)
-                # First we load the last focused file.
-                self.load(filenames[index], goto=clines[index], set_focus=True)
-                # Then we load the files located to the left of the last
-                # focused file in the tabbar, while keeping the focus on
-                # the last focused file.
-                if index > 0:
-                    self.load(filenames[index::-1], goto=clines[index::-1],
-                              set_focus=False, add_where='start')
-                # Finally we load the files located to the right of the last
-                # focused file in the tabbar, while keeping the focus on
-                # the last focused file.
-                if index < (len(filenames) - 1):
-                    self.load(filenames[index+1:], goto=clines[index:],
-                              set_focus=False, add_where='end')
+            # Check if no saved layout settings exist, e.g. clean prefs file
+            # If not, load with default focus/layout, to fix issue #8458 .
+            if layout:
+                is_vertical, cfname, clines = layout.get('splitsettings')[0]
+                if cfname in filenames:
+                    index = filenames.index(cfname)
+                    # First we load the last focused file.
+                    self.load(filenames[index], goto=clines[index],
+                              set_focus=True)
+                    # Then we load the files located to the left of the last
+                    # focused file in the tabbar, while keeping the focus on
+                    # the last focused file.
+                    if index > 0:
+                        self.load(filenames[index::-1], goto=clines[index::-1],
+                                  set_focus=False, add_where='start')
+                    # Finally we load the files to the right of the last
+                    # focused file in the tabbar, while keeping the focus on
+                    # the last focused file.
+                    if index < (len(filenames) - 1):
+                        self.load(filenames[index+1:], goto=clines[index:],
+                                  set_focus=False, add_where='end')
+                else:
+                    self.load(filenames, goto=clines)
             else:
-                self.load(filenames, goto=clines)
+                self.load(filenames)
 
             if self.__first_open_files_setup:
                 self.__first_open_files_setup = False

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -1,29 +1,33 @@
 # -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2009- Spyder Project Contributors
 #
-# Copyright © Spyder Project Contributors
-# Licensed under the terms of the MIT License
-#
+# Distributed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+# -----------------------------------------------------------------------------
+
 """Tests for the Editor plugin."""
 
 # Standard library imports
+import os
 import os.path as osp
 import shutil
-
-# Third party imports
-import pytest
-
 try:
     from unittest.mock import Mock
 except ImportError:
     from mock import Mock  # Python 2
 
+# Third party imports
+import pytest
 from qtpy.QtWidgets import QMainWindow
 
 # Local imports
 from spyder.utils.qthelpers import qapplication
 
 
-# ---- Qt Test Fixtures
+# =============================================================================
+# ---- Fixtures
+# =============================================================================
 @pytest.fixture
 def setup_editor(qtbot, monkeypatch):
     """Set up the Editor plugin."""
@@ -110,6 +114,9 @@ def editor_open_files(request, setup_editor, python_files):
     return _get_editor_open_files
 
 
+# =============================================================================
+# ---- Tests
+# =============================================================================
 def test_basic_initialization(setup_editor):
     """Test Editor plugin initialization."""
     editor = setup_editor
@@ -211,5 +218,4 @@ def test_no_template(setup_editor):
 
 
 if __name__ == "__main__":
-    import os
     pytest.main(['-x', os.path.basename(__file__), '-vv', '-rw'])

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -88,7 +88,7 @@ def editor_open_files(request, setup_editor, python_files):
     """
     def _get_editor_open_files(last_focused_filename,
                                expected_current_filename):
-        editor, qtbot = setup_editor
+        editor = setup_editor
         expected_filenames, tmpdir = python_files
         if expected_current_filename is None:
             expected_current_filename = expected_filenames[0]
@@ -109,7 +109,7 @@ def editor_open_files(request, setup_editor, python_files):
         editor.get_option = get_option
 
         editor.setup_open_files()
-        return editor, qtbot, expected_filenames, expected_current_filename
+        return editor, expected_filenames, expected_current_filename
 
     return _get_editor_open_files
 
@@ -140,7 +140,7 @@ def test_setup_open_files(editor_open_files, last_focused_filename,
     that the current file correspond to the last focused file.
     """
     editor_factory = editor_open_files
-    editor, qtbot, expected_filenames, expected_current_filename = (
+    editor, expected_filenames, expected_current_filename = (
         editor_factory(last_focused_filename, expected_current_filename))
 
     current_filename = editor.get_current_editorstack().get_current_filename()
@@ -157,7 +157,7 @@ def test_setup_open_files_cleanprefs(editor_open_files):
     Regression test for #8458 .
     """
     editor_factory = editor_open_files
-    editor, qtbot, expected_filenames, expected_current_filename = (
+    editor, expected_filenames, expected_current_filename = (
         editor_factory(None, None))
 
     filenames = editor.get_current_editorstack().get_filenames()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->

When opening a project with a clean preferences file, the project's previously opened files fail to load into the Editor, an exception is raised, and is the project is then closed or switched, the previously opened files are wiped; this even happens when closing a project and trying to load the prevously open files in the Editor. Therefore, here we check that the relevant preferences item exists before trying to get the saved layout (focused file, file position, etc) and if it no layout information is remembered, just load the files without restoring the focused line and file.

In functional testing both switching projects and opening and closing them, no errors were generated and all behavior was expected when examining opening, saving and restoring the correct files.

I used an if block ("LBYL") instead of a try/except block ("EAFP") since the former is what other blocks in the function used, and in this context an ``AttributeError`` due to something other than ``None`` being returned, if just caught and passed is likely indicative of changes in the config system rather than anything on the user end and would silently break the editor remembering its last focused file, position, split, etc. without any indication to us.

This also adds a test for this behavior, as well as refactors some of the existing tests into a fixture to avoid a significant amount of duplicated code.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8458


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM-Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
