### PR TITLE
PR: Connect option to show/hide code style warnings in the Editor

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1353,12 +1353,15 @@ class Editor(SpyderPluginWidget):
                     logger.error(e, exc_info=True)
                 # Run code analysis when `set_pep8_enabled` is toggled
                 if editorstack_method == 'set_pep8_enabled':
-                    # TODO: Connect this to the LSP
                     #for finfo in editorstack.data:
                     #    finfo.run_code_analysis(
                     #            self.get_option('code_analysis/pyflakes'),
                     #            checked)
-                    pass
+                    for finfo in editorstack.data:
+                        if conf_name == 'code_analysis/pep8':
+                            if not checked:
+                                finfo.editor.cleanup_code_analysis()
+                            finfo.editor.document_did_change()
         CONF.set('editor', conf_name, checked)
 
     #------ Focus tabwidget

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -782,7 +782,9 @@ class CodeEditor(TextEditBaseWidget):
 
     @handles(LSPRequestTypes.DOCUMENT_PUBLISH_DIAGNOSTICS)
     def linting_diagnostics(self, params):
-        self.process_code_analysis(params['params'])
+        enabled = CONF.get('editor', 'code_analysis/pep8')
+        if enabled:
+            self.process_code_analysis(params['params'])
 
     # ------------- LSP: Completion ---------------------------------------
 

--- a/spyder/plugins/editor/widgets/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/tests/test_warnings.py
@@ -13,6 +13,7 @@ import pytest
 from qtpy.QtCore import Signal, QObject
 
 # Local imports
+from spyder.config.main import CONF
 from spyder.utils.qthelpers import qapplication
 from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 from spyder.py3compat import to_binary_string
@@ -45,6 +46,9 @@ class LSPEditorWrapper(QObject):
 @pytest.fixture
 def construct_editor(qtbot, *args, **kwargs):
     os.environ['SPY_TEST_USE_INTROSPECTION'] = 'True'
+    # Tests assume show warnings as True
+    CONF.set('editor', 'code_analysis/pep8', True)
+
     app = qapplication()
     lsp_manager = LSPManager(parent=None)
     editor = CodeEditor(parent=None)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

The `Show code style warnings (pep8)` was doing nothing.

![warn](https://user-images.githubusercontent.com/16781833/50196828-c4f20200-0312-11e9-8f11-2fda15f72c3f.gif)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8121 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
