### PR TITLE
PR: Make indentation guides to go up to last line with text

### DIFF
--- a/spyder/plugins/editor/panels/indentationguides.py
+++ b/spyder/plugins/editor/panels/indentationguides.py
@@ -57,7 +57,8 @@ class IndentationGuide(Panel):
             end_of_sub_fold = block
             if last_line:
                 block = block.document().findBlockByNumber(last_line)
-                while block.blockNumber() and block.text().strip() == '':
+                while block.blockNumber() and block.text().strip() == '' or
+                    block.text().strip().startswith('#')):
                     block = block.previous()
                     last_line = block.blockNumber()
 

--- a/spyder/plugins/editor/panels/indentationguides.py
+++ b/spyder/plugins/editor/panels/indentationguides.py
@@ -36,6 +36,8 @@ class IndentationGuide(Panel):
         color = QColor(self.color)
         color.setAlphaF(.5)
         painter.setPen(color)
+        offset = self.editor.document().documentMargin() + \
+            self.editor.contentOffset().x()
 
         for _, line_number, block in self.editor.visible_blocks:
 
@@ -69,14 +71,13 @@ class IndentationGuide(Panel):
             indentation = TextBlockHelper.get_fold_lvl(block)
 
             for i in range(1, indentation):
-
                 if (line_number > last_line and
                         TextBlockHelper.get_fold_lvl(end_of_sub_fold.next())
                         <= i + 1):
                     continue
-
                 else:
-                    x = self.editor.fontMetrics().width(i * self.i_width * '9')
+                    x = self.editor.fontMetrics().width(i * self.i_width *
+                                                        '9') + offset
                     painter.drawLine(x, top, x, bottom)
 
     # --- Other methods

--- a/spyder/plugins/editor/panels/indentationguides.py
+++ b/spyder/plugins/editor/panels/indentationguides.py
@@ -38,11 +38,6 @@ class IndentationGuide(Panel):
         color.setAlphaF(.5)
         painter.setPen(color)
         
-        # offset taken from :https://github.com/ninja-ide/ninja-ide/blob/
-        # master/ninja_ide/gui/editor/extensions/indentation_guides.py
-        offset = self.editor.document().documentMargin() + \
-                 self.editor.contentOffset().x()
-
         for _, line_number, block in self.editor.visible_blocks:
 
             indentation = TextBlockHelper.get_fold_lvl(block)
@@ -81,7 +76,7 @@ class IndentationGuide(Panel):
 
                 else:
                     x = self.editor.fontMetrics().width(i * self.i_width *
-                                                        '9') + offset
+                                                        '9')
                     painter.drawLine(x, top, x, bottom)
 
     # --- Other methods

--- a/spyder/plugins/editor/panels/indentationguides.py
+++ b/spyder/plugins/editor/panels/indentationguides.py
@@ -1,3 +1,4 @@
+
 # -*- coding: utf-8 -*-
 #
 # Copyright © Spyder Project Contributors
@@ -22,13 +23,11 @@ class IndentationGuide(Panel):
     # -----------------------------------------------------------------
     def __init__(self, editor):
         """Initialize IndentationGuide panel.
-
         i_width(int): identation width in characters.
         """
         Panel.__init__(self, editor)
         self.color = Qt.darkGray
         self.i_width = 4
-
 
     def paintEvent(self, event):
         """Override Qt method."""
@@ -37,7 +36,9 @@ class IndentationGuide(Panel):
         color = QColor(self.color)
         color.setAlphaF(.5)
         painter.setPen(color)
-        
+        # offset = self.editor.document().documentMargin() + \
+        #     self.editor.contentOffset().x()
+
         for _, line_number, block in self.editor.visible_blocks:
 
             indentation = TextBlockHelper.get_fold_lvl(block)
@@ -57,8 +58,8 @@ class IndentationGuide(Panel):
             end_of_sub_fold = block
             if last_line:
                 block = block.document().findBlockByNumber(last_line)
-                while block.blockNumber() and block.text().strip() == '' or
-                       block.text().strip().startswith('#')):
+                while ((block.blockNumber()) and (block.text().strip() == ''
+                       or block.text().strip().startswith('#'))):
                     block = block.previous()
                     last_line = block.blockNumber()
 
@@ -66,18 +67,18 @@ class IndentationGuide(Panel):
             top = int(self.editor.blockBoundingGeometry(block).translated(
                 self.editor.contentOffset()).top())
             bottom = top + int(self.editor.blockBoundingRect(block).height())
+
             indentation = TextBlockHelper.get_fold_lvl(block)
 
             for i in range(1, indentation):
 
                 if (line_number > last_line and
                         TextBlockHelper.get_fold_lvl(end_of_sub_fold.next())
-                         <= i + 1):
+                        <= i + 1):
                     continue
 
                 else:
-                    x = self.editor.fontMetrics().width(i * self.i_width *
-                                                        '9')
+                    x = self.editor.fontMetrics().width(i * self.i_width * '9')
                     painter.drawLine(x, top, x, bottom)
 
     # --- Other methods

--- a/spyder/plugins/editor/panels/indentationguides.py
+++ b/spyder/plugins/editor/panels/indentationguides.py
@@ -14,6 +14,7 @@ from qtpy.QtGui import QPainter, QColor
 from spyder.plugins.editor.utils.editor import TextBlockHelper
 from spyder.api.panel import Panel
 
+
 class IndentationGuide(Panel):
     """Indentation guides to easy identify nested blocks."""
 
@@ -28,6 +29,7 @@ class IndentationGuide(Panel):
         self.color = Qt.darkGray
         self.i_width = 4
 
+
     def paintEvent(self, event):
         """Override Qt method."""
         painter = QPainter(self)
@@ -35,15 +37,52 @@ class IndentationGuide(Panel):
         color = QColor(self.color)
         color.setAlphaF(.5)
         painter.setPen(color)
+        
+        # offset taken from :https://github.com/ninja-ide/ninja-ide/blob/
+        # master/ninja_ide/gui/editor/extensions/indentation_guides.py
+        offset = self.editor.document().documentMargin() + \
+                 self.editor.contentOffset().x()
 
-        for top, line_number, block in self.editor.visible_blocks:
+        for _, line_number, block in self.editor.visible_blocks:
+
+            indentation = TextBlockHelper.get_fold_lvl(block)
+            ref_lvl = indentation
+            block = block.next()
+            last_line = block.blockNumber()
+            lvl = TextBlockHelper.get_fold_lvl(block)
+            if ref_lvl == lvl:  # for zone set programmatically such as imports
+                # in pyqode.python
+                ref_lvl -= 1
+
+            while (block.isValid() and
+                   TextBlockHelper.get_fold_lvl(block) > ref_lvl):
+                last_line = block.blockNumber()
+                block = block.next()
+
+            end_of_sub_fold = block
+            if last_line:
+                block = block.document().findBlockByNumber(last_line)
+                while block.blockNumber() and block.text().strip() == '':
+                    block = block.previous()
+                    last_line = block.blockNumber()
+
+            block = self.editor.document().findBlockByNumber(line_number)
+            top = int(self.editor.blockBoundingGeometry(block).translated(
+                self.editor.contentOffset()).top())
             bottom = top + int(self.editor.blockBoundingRect(block).height())
-
             indentation = TextBlockHelper.get_fold_lvl(block)
 
             for i in range(1, indentation):
-                x = self.editor.fontMetrics().width(i * self.i_width * '9')
-                painter.drawLine(x, top, x, bottom)
+
+                if (line_number > last_line and
+                        TextBlockHelper.get_fold_lvl(end_of_sub_fold.next())
+                         <= i + 1):
+                    continue
+
+                else:
+                    x = self.editor.fontMetrics().width(i * self.i_width *
+                                                        '9') + offset
+                    painter.drawLine(x, top, x, bottom)
 
     # --- Other methods
     # -----------------------------------------------------------------

--- a/spyder/plugins/editor/panels/indentationguides.py
+++ b/spyder/plugins/editor/panels/indentationguides.py
@@ -36,8 +36,6 @@ class IndentationGuide(Panel):
         color = QColor(self.color)
         color.setAlphaF(.5)
         painter.setPen(color)
-        # offset = self.editor.document().documentMargin() + \
-        #     self.editor.contentOffset().x()
 
         for _, line_number, block in self.editor.visible_blocks:
 

--- a/spyder/plugins/editor/panels/indentationguides.py
+++ b/spyder/plugins/editor/panels/indentationguides.py
@@ -58,7 +58,7 @@ class IndentationGuide(Panel):
             if last_line:
                 block = block.document().findBlockByNumber(last_line)
                 while block.blockNumber() and block.text().strip() == '' or
-                    block.text().strip().startswith('#')):
+                       block.text().strip().startswith('#')):
                     block = block.previous()
                     last_line = block.blockNumber()
 

--- a/spyder/plugins/editor/panels/indentationguides.py
+++ b/spyder/plugins/editor/panels/indentationguides.py
@@ -72,8 +72,7 @@ class IndentationGuide(Panel):
 
             for i in range(1, indentation):
                 if (line_number > last_line and
-                        TextBlockHelper.get_fold_lvl(end_of_sub_fold.next())
-                        <= i + 1):
+                        TextBlockHelper.get_fold_lvl(end_of_sub_fold) <= i):
                     continue
                 else:
                     x = self.editor.fontMetrics().width(i * self.i_width *


### PR DESCRIPTION
This resolves the issue Indent guides going too far down #7339

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

This PR solves the issue https://github.com/spyder-ide/spyder/issues/7339

Sample code before the fix
![spyder_issue_indentation_before](https://user-images.githubusercontent.com/22060413/50306825-74071880-048e-11e9-9b6c-91938eb9c232.JPG)

Sample code after the fix
![spyder_issue_indentation](https://user-images.githubusercontent.com/22060413/50306853-85502500-048e-11e9-8653-1862bc09c7e1.JPG)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #7339


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
