### PR TITLE
PR: Set dark background color for webview in the Help and IPython Console plugins

### DIFF
--- a/spyder/plugins/help/widgets.py
+++ b/spyder/plugins/help/widgets.py
@@ -14,13 +14,21 @@ import socket
 # Third party imports
 from qtpy.QtCore import  Signal
 from qtpy.QtWidgets import QSizePolicy, QVBoxLayout, QWidget
+from qtpy.QtGui import QColor
+from qtpy.QtWebEngineWidgets import WEBENGINE
 
 # Local imports
+from spyder.config.gui import is_dark_interface
 from spyder.py3compat import to_text_string
 from spyder.widgets.browser import FrameWebView
 from spyder.widgets.comboboxes import EditableComboBox
 from spyder.widgets.findreplace import FindReplace
 from spyder.plugins.editor.widgets import codeeditor
+
+if is_dark_interface():
+    MAIN_BG_COLOR = '#19232D'
+else:
+    MAIN_BG_COLOR = 'white'
 
 
 class ObjectComboBox(EditableComboBox):
@@ -88,6 +96,12 @@ class RichText(QWidget):
         QWidget.__init__(self, parent)
 
         self.webview = FrameWebView(self)
+        if WEBENGINE:
+            self.webview.web_widget.page().setBackgroundColor(
+                QColor(MAIN_BG_COLOR))
+        else:
+            self.webview.web_widget.setBackgroundColor(
+                QColor(MAIN_BG_COLOR))
         self.find_widget = FindReplace(self)
         self.find_widget.set_editor(self.webview.web_widget)
         self.find_widget.hide()

--- a/spyder/plugins/ipythonconsole/assets/templates/blank.html
+++ b/spyder/plugins/ipythonconsole/assets/templates/blank.html
@@ -15,6 +15,10 @@
 
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+  <link rel="stylesheet" href="file:///${css_path}/default.css" type="text/css"/>
 </head>
+
+<body>
+</body>
 
 </html>

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -26,9 +26,10 @@ import time
 
 # Third party imports (qtpy)
 from qtpy.QtCore import QUrl, QTimer, Signal, Slot
-from qtpy.QtGui import QKeySequence
+from qtpy.QtGui import QKeySequence, QColor
 from qtpy.QtWidgets import (QHBoxLayout, QLabel, QMenu, QMessageBox,
                             QToolButton, QVBoxLayout, QWidget)
+from qtpy.QtWebEngineWidgets import WEBENGINE
 
 # Local imports
 from spyder.config.base import (_, get_image_path, get_module_source_path,
@@ -63,6 +64,11 @@ TEMPLATES_PATH = osp.join(PLUGINS_PATH, 'ipythonconsole', 'assets', 'templates')
 BLANK = open(osp.join(TEMPLATES_PATH, 'blank.html')).read()
 LOADING = open(osp.join(TEMPLATES_PATH, 'loading.html')).read()
 KERNEL_ERROR = open(osp.join(TEMPLATES_PATH, 'kernel_error.html')).read()
+
+if is_dark_interface():
+    MAIN_BG_COLOR = '#19232D'
+else:
+    MAIN_BG_COLOR = 'white'
 
 try:
     time.monotonic  # time.monotonic new in 3.3
@@ -150,7 +156,12 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                                        external_kernel=external_kernel,
                                        local_kernel=True)
         self.infowidget = WebView(self)
+        if WEBENGINE:
+            self.infowidget.page().setBackgroundColor(QColor(MAIN_BG_COLOR))
+        else:
+            self.infowidget.setBackgroundColor(QColor(MAIN_BG_COLOR))
         self.set_infowidget_font()
+        self.blank_page = self._create_blank_page()
         self.loading_page = self._create_loading_page()
         self._show_loading_page()
 
@@ -671,6 +682,12 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                                            message=message)
         return page
 
+    def _create_blank_page(self):
+        """Create html page to show while the kernel is starting"""
+        loading_template = Template(BLANK)
+        page = loading_template.substitute(css_path=self.css_path)
+        return page
+
     def _show_loading_page(self):
         """Show animation while the kernel is loading."""
         self.shellwidget.hide()
@@ -682,7 +699,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         """Hide animation shown while the kernel is loading."""
         self.infowidget.hide()
         self.shellwidget.show()
-        self.infowidget.setHtml(BLANK,
+        self.infowidget.setHtml(self.blank_page,
                                 QUrl.fromLocalFile(self.css_path))
         self.shellwidget.sig_prompt_ready.disconnect(self._hide_loading_page)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

A white background was showing in the initialization of the Help and IPython Console plugins. This sets the background to the correct color in the dark theme.

A preview:

![blank](https://user-images.githubusercontent.com/16781833/50492703-2a1ab700-09e7-11e9-9fbb-93d6d9e8e7a7.gif)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8477 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
