### PR TITLE
PR: Fix handling background color of Webview when using QWebView

### DIFF
--- a/spyder/plugins/help/widgets.py
+++ b/spyder/plugins/help/widgets.py
@@ -100,8 +100,8 @@ class RichText(QWidget):
             self.webview.web_widget.page().setBackgroundColor(
                 QColor(MAIN_BG_COLOR))
         else:
-            self.webview.web_widget.setBackgroundColor(
-                QColor(MAIN_BG_COLOR))
+            self.webview.web_widget.setStyleSheet(
+                "background:{}".format(MAIN_BG_COLOR))
         self.find_widget = FindReplace(self)
         self.find_widget.set_editor(self.webview.web_widget)
         self.find_widget.hide()

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -159,7 +159,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         if WEBENGINE:
             self.infowidget.page().setBackgroundColor(QColor(MAIN_BG_COLOR))
         else:
-            self.infowidget.setBackgroundColor(QColor(MAIN_BG_COLOR))
+            self.infowidget.setStyleSheet(
+                "background:{}".format(MAIN_BG_COLOR))
         self.set_infowidget_font()
         self.blank_page = self._create_blank_page()
         self.loading_page = self._create_loading_page()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

Fix the background color setting when using QWebView in the IPython Console and Help plugins.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8506 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
