### PR TITLE
PR: Fix the "Copy Figure" shortcut of Plots pane with multiple consoles

### DIFF
--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -92,7 +92,7 @@ class FigureBrowser(QWidget):
 
         self.options_button = options_button
         self.plugin_actions = plugin_actions
-        self.shortcuts = self.create_shortcuts(parent)
+        self.shortcuts = self.create_shortcuts()
 
     def setup(self, mute_inline_plotting=None, show_plot_outline=None):
         """Setup the figure browser with provided settings."""
@@ -250,11 +250,11 @@ class FigureBrowser(QWidget):
         else:
             self.tools_layout.addWidget(self.options_button)
 
-    def create_shortcuts(self, parent):
+    def create_shortcuts(self):
         """Create shortcuts for this widget."""
         # Configurable
         copyfig = config_shortcut(self.copy_figure, context='plots',
-                                  name='copy', parent=parent)
+                                  name='copy', parent=self)
 
         return [copyfig]
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->
Fix the Plots widget's shortcut when there are multiple consoles.



### Issue(s) Resolved

![short_cut_fix](https://user-images.githubusercontent.com/22970578/50597630-62d8f580-0eeb-11e9-96ee-f4d43caee7ad.gif)


<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8511 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ok97465

<!--- Thanks for your help making Spyder better for everyone! --->
