### PR TITLE
PR: Fix delete project by moving the code from the project explorer to the plugin

### DIFF
--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -22,7 +22,7 @@ import pytest
 
 # Local imports
 import spyder.plugins.base
-from spyder.plugins.projects.plugin import Projects
+from spyder.plugins.projects.plugin import Projects, QMessageBox
 from spyder.py3compat import to_text_string
 
 
@@ -111,6 +111,24 @@ def test_open_project(projects, tmpdir, test_directory):
 
     # Close project
     projects.close_project()
+
+
+@pytest.mark.parametrize("test_directory", [u'測試', u'اختبار', u"test_dir"])
+def test_delete_project(projects, tmpdir, mocker, test_directory):
+    """Test that we can delete a project."""
+    # Create the directory
+    path = to_text_string(tmpdir.mkdir(test_directory))
+
+    # Open project in path
+    projects.open_project(path=path)
+    assert projects.is_valid_project(path)
+    assert osp.exists(osp.join(path, '.spyproject'))
+
+    # Delete project
+    mocker.patch.object(QMessageBox, 'warning', return_value=QMessageBox.Yes)
+    projects.delete_project()
+    assert not projects.is_valid_project(path)
+    assert not osp.exists(osp.join(path, '.spyproject'))
 
 
 @pytest.mark.parametrize('value', [True, False])

--- a/spyder/plugins/projects/widgets/explorer.py
+++ b/spyder/plugins/projects/widgets/explorer.py
@@ -230,32 +230,6 @@ class ProjectExplorerWidget(QWidget):
         # Setup the directory shown by the tree
         self.set_project_dir(directory)
 
-        # Signal to delete the project
-        self.treewidget.sig_delete_project.connect(self.delete_project)
-
-    def delete_project(self):
-        """Delete current project without deleting the files in the
-        directory."""
-        if self.current_active_project:
-            path = self.current_active_project.root_path
-            buttons = QMessageBox.Yes | QMessageBox.No
-            answer = QMessageBox.warning(self, _("Delete"),
-                                 _("Do you really want "
-                                   "to delete <b>{filename}</b>?<br><br>"
-                                   "<b>Note:</b> This action will only delete "
-                                   "the project. Its files are going to be "
-                                   "preserved on disk."
-                                   ).format(filename=osp.basename(path)),
-                                   buttons)
-            if answer == QMessageBox.Yes:
-                try:
-                    self.close_project()
-                    shutil.rmtree(osp.join(path,'.spyproject'))
-                except EnvironmentError as error:
-                    QMessageBox.critical(self, _("Project Explorer"),
-                                    _("<b>Unable to delete <i>{varpath}</i></b>"
-                                      "<br><br>The error message was:<br>{error}" )
-                                    .format(varpath=path,error=to_text_string(error)))
 
 #==============================================================================
 # Tests


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->

I simply moved the `delete_project` method from the `ProjectExplorerWidget` to the `Projects` plugin where the `current_active_project` variable was already defined. I also think this is more coherent to have the `delete_project` method defined there, alongside the `open_project` and `close_project` methods.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8515


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
