### PR TITLE
PR: Fix bad context menu stylesheet and figure blinking in the Plots plugin

### DIFF
--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -351,7 +351,7 @@ class FigureViewer(QScrollArea):
         self.setAlignment(Qt.AlignCenter)
         self.viewport().setObjectName("figviewport")
         self.viewport().setStyleSheet(
-            "#figviewport {background-color:" + background_color + "}")
+            "#figviewport {background-color:" + str(background_color) + "}")
         self.setFrameStyle(0)
 
         self.background_color = background_color
@@ -792,7 +792,7 @@ class FigureCanvas(QFrame):
         self.setMidLineWidth(1)
         self.setObjectName("figcanvas")
         self.setStyleSheet(
-            "#figcanvas {background-color:" + background_color + "}")
+            "#figcanvas {background-color:" + str(background_color) + "}")
 
         self.fig = None
         self.fmt = None

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -349,8 +349,9 @@ class FigureViewer(QScrollArea):
     def __init__(self, parent=None, background_color=None):
         super(FigureViewer, self).__init__(parent)
         self.setAlignment(Qt.AlignCenter)
+        self.viewport().setObjectName("figviewport")
         self.viewport().setStyleSheet(
-                "background-color: {}".format(background_color))
+            "#figviewport {background-color:" + background_color + "}")
         self.setFrameStyle(0)
 
         self.background_color = background_color
@@ -789,7 +790,9 @@ class FigureCanvas(QFrame):
         super(FigureCanvas, self).__init__(parent)
         self.setLineWidth(2)
         self.setMidLineWidth(1)
-        self.setStyleSheet("background-color: {}".format(background_color))
+        self.setObjectName("figcanvas")
+        self.setStyleSheet(
+            "#figcanvas {background-color:" + background_color + "}")
 
         self.fig = None
         self.fmt = None

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -794,6 +794,7 @@ class FigureCanvas(QFrame):
         self.fig = None
         self.fmt = None
         self.fwidth, self.fheight = 200, 200
+        self._blink_flag = False
 
         self.setContextMenuPolicy(Qt.CustomContextMenu)
         self.customContextMenuRequested.connect(self.context_menu_requested)
@@ -826,12 +827,11 @@ class FigureCanvas(QFrame):
     def blink_figure(self):
         """Blink figure once."""
         if self.fig:
-            timer = QTimer()
-            frame_rect = self.frameSize()
-            self.setFixedSize(0, 0)
-            timer.singleShot(40,
-                             lambda: self.setFixedSize(frame_rect.width(),
-                                                       frame_rect.height()))
+            self._blink_flag = not self._blink_flag
+            self.repaint()
+            if self._blink_flag:
+                timer = QTimer()
+                timer.singleShot(40, self.blink_figure)
 
     def clear_canvas(self):
         """Clear the figure that was painted on the widget."""
@@ -867,7 +867,7 @@ class FigureCanvas(QFrame):
                      self.size().width() - 2 * fw,
                      self.size().height() - 2 * fw)
 
-        if self.fig is None:
+        if self.fig is None or self._blink_flag:
             return
 
         # Check/update the qpixmap buffer :


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

- I've refactored the code to blink the plots so that the size of the figure canvas was not changed during blinking.
- I've prevented the stylesheet applied to the `FigureViewer` and `FigureCanvas`  to be propagated to their context menu.

![fix_copy_to_clipboard](https://user-images.githubusercontent.com/10170372/50720692-8d5bb780-107f-11e9-8edb-b798d779af43.gif)

Note: the blinking of the plot is not visible in the animation due to the low FPS of the captured animation.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8523


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
