### PR TITLE
PR: Make the directory tree view proxy model case insensitive on Windows

### DIFF
--- a/spyder/plugins/explorer/widgets.py
+++ b/spyder/plugins/explorer/widgets.py
@@ -970,18 +970,19 @@ class ProxyModel(QSortFilterProxyModel):
     def sort(self, column, order=Qt.AscendingOrder):
         """Reimplement Qt method"""
         self.sourceModel().sort(column, order)
-        
+
     def filterAcceptsRow(self, row, parent_index):
         """Reimplement Qt method"""
         if self.root_path is None:
             return True
         index = self.sourceModel().index(row, 0, parent_index)
-        path = osp.normpath(to_text_string(self.sourceModel().filePath(index)))
-        if self.root_path.startswith(path):
+        path = osp.normcase(osp.normpath(
+            to_text_string(self.sourceModel().filePath(index))))
+        if osp.normcase(self.root_path).startswith(path):
             # This is necessary because parent folders need to be scanned
             return True
         else:
-            for p in self.path_list:
+            for p in [osp.normcase(p) for p in self.path_list]:
                 if path == p or path.startswith(p+os.sep):
                     return True
             else:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

This is a follow up of PR #8456 to fix `test_project_explorer_tree_root` that was failing for Python 2.7 on Windows.

The idea is to use `os.path.normcase` before comparing paths.
https://docs.python.org/2/library/os.path.html#os.path.normcase

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
