### PR TITLE
PR: Pin pytest to a version less than 4.1

### DIFF
--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -1,19 +1,19 @@
 cloudpickle
-pygments>=2.0
-qtconsole>=4.2.0
+pygments >=2.0
+qtconsole >=4.2.0
 nbconvert
 sphinx
 pylint
 psutil
-qtawesome>=0.5.2
-qtpy>=1.2.0
+qtawesome >=0.5.2
+qtpy >=1.5.0
 pickleshare
 pyzmq
-chardet>=2.0.0
+chardet >=2.0.0
 numpydoc
-pyqt<5.10
+pyqt <5.10
 keyring
-spyder-kernels>=1.0
-python-language-server=0.19
-qdarkstyle>=2.6.4
+spyder-kernels >=1.2
+python-language-server =0.19
+qdarkstyle >=2.6.4
 atomicwrites

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
 mock
-pytest
+pytest <4.1
 pytest-mock
 pytest-cov
 pandas

--- a/setup.py
+++ b/setup.py
@@ -234,7 +234,7 @@ install_requires = [
 
 extras_require = {
     'test:python_version == "2.7"': ['mock'],
-    'test': ['pytest',
+    'test': ['pytest<4.1',
              'pytest-qt',
              'pytest-mock',
              'pytest-cov',

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,7 @@ install_requires = [
     'pyzmq',
     'chardet>=2.0.0',
     'numpydoc',
-    'spyder-kernels>=1.0',
+    'spyder-kernels>=1.2',
     'qdarkstyle>=2.6.4',
     'atomicwrites',
     # Don't require keyring for Python 2 and Linux


### PR DESCRIPTION
This is because flaky is incompatible with that version.