### PR TITLE
PR: Improve layout of Appearance entry in Preferences

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -85,7 +85,7 @@ DEFAULTS = [
               'window/position': (10, 10),
               'window/is_maximized': True,
               'window/is_fullscreen': False,
-              'window/prefs_dialog_size': (745, 411),
+              'window/prefs_dialog_size': (1050, 520),
               'show_status_bar': True,
               'memory_usage/enable': True,
               'memory_usage/timeout': 2000,
@@ -753,7 +753,7 @@ DEFAULTS = [
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '47.3.0'
+CONF_VERSION = '47.4.0'
 
 
 # Main configuration instance

--- a/spyder/preferences/configdialog.py
+++ b/spyder/preferences/configdialog.py
@@ -1139,37 +1139,37 @@ class ColorSchemeConfigPage(GeneralConfigPage):
         theme_group.setLayout(theme_layout)
 
         # Syntax coloring options
-        syntax_group = QGroupBox(_("Syntax highlighting"))
+        syntax_group = QGroupBox(_("Syntax highlighting theme"))
 
         # Syntax Widgets
         edit_button = QPushButton(_("Edit selected scheme"))
         create_button = QPushButton(_("Create new scheme"))
         self.delete_button = QPushButton(_("Delete scheme"))
+        self.reset_button = QPushButton(_("Reset to defaults"))
+
         self.preview_editor = CodeEditor(self)
         self.stacked_widget = QStackedWidget(self)
-        self.reset_button = QPushButton(_("Reset to defaults"))
         self.scheme_editor_dialog = SchemeEditor(parent=self,
                                                  stack=self.stacked_widget)
 
         self.scheme_choices_dict = {}
-        schemes_combobox_widget = self.create_combobox(_('Syntax scheme:'),
-                                                       [('', '')],
+        schemes_combobox_widget = self.create_combobox('', [('', '')],
                                                        'selected')
         self.schemes_combobox = schemes_combobox_widget.combobox
 
-        # Syntax Layouts
-        syntax_comboboxes_layout = QGridLayout()
-        syntax_comboboxes_layout.addWidget(schemes_combobox_widget.label, 0, 0)
-        syntax_comboboxes_layout.addWidget(schemes_combobox_widget.combobox,
-                                           0, 1)
+        # Adjust size so buttons don't expand to the full width
+        for btn in [edit_button, create_button, self.delete_button,
+                    self.reset_button, self.schemes_combobox]:
+            btn.setMaximumWidth(250)
 
-        buttons_layout = QVBoxLayout()
-        buttons_layout.addLayout(syntax_comboboxes_layout)
-        buttons_layout.addWidget(edit_button)
-        buttons_layout.addWidget(self.reset_button)
-        buttons_layout.addWidget(create_button)
-        buttons_layout.addWidget(self.delete_button)
-        syntax_group.setLayout(buttons_layout)
+        # Syntax layout
+        syntax_layout = QVBoxLayout()
+        syntax_layout.addWidget(self.schemes_combobox)
+        syntax_layout.addWidget(edit_button)
+        syntax_layout.addWidget(self.reset_button)
+        syntax_layout.addWidget(create_button)
+        syntax_layout.addWidget(self.delete_button)
+        syntax_group.setLayout(syntax_layout)
 
         # Fonts options
         fonts_group = QGroupBox(_("Fonts"))

--- a/spyder/preferences/configdialog.py
+++ b/spyder/preferences/configdialog.py
@@ -143,6 +143,7 @@ class ConfigDialog(QDialog):
 
         # Widgets
         self.pages_widget = QStackedWidget()
+        self.pages_widget.setMinimumWidth(600)
         self.contents_widget = QListWidget()
         self.button_reset = QPushButton(_('Reset to defaults'))
 
@@ -162,6 +163,7 @@ class ConfigDialog(QDialog):
         self.contents_widget.setSpacing(1)
         self.contents_widget.setCurrentRow(0)
         self.contents_widget.setMinimumWidth(220)
+        self.contents_widget.setMinimumHeight(400)
 
         # Layout
         hsplitter = QSplitter()

--- a/spyder/preferences/configdialog.py
+++ b/spyder/preferences/configdialog.py
@@ -1098,13 +1098,13 @@ class ColorSchemeConfigPage(GeneralConfigPage):
         custom_names = self.get_option("custom_names", [])
 
         # Interface options
-        theme_group = QGroupBox(_("Interface"))
+        theme_group = QGroupBox(_("Main interface"))
 
         # Interface Widgets
         ui_themes = ['Automatic', 'Light', 'Dark']
         ui_theme_choices = list(zip(ui_themes, [ui_theme.lower()
                                                 for ui_theme in ui_themes]))
-        ui_theme_combo = self.create_combobox(_('Interface theme:'),
+        ui_theme_combo = self.create_combobox(_('Interface theme'),
                                               ui_theme_choices,
                                               'ui_theme',
                                               restart=True)

--- a/spyder/preferences/configdialog.py
+++ b/spyder/preferences/configdialog.py
@@ -1097,15 +1097,6 @@ class ColorSchemeConfigPage(GeneralConfigPage):
             pass
         custom_names = self.get_option("custom_names", [])
 
-        # Layouts
-        manage_layout = QVBoxLayout()
-
-        # Description of the section
-        about_label = QLabel(_("Customize the look and feel of "
-                               "Spyder and its plugins.<br>"))
-        about_label.setWordWrap(True)
-        manage_layout.addWidget(about_label)
-
         # Interface options
         theme_group = QGroupBox(_("Interface"))
 
@@ -1220,21 +1211,14 @@ class ColorSchemeConfigPage(GeneralConfigPage):
         preview_layout.addWidget(self.preview_editor)
         preview_group.setLayout(preview_layout)
 
-        buttons_preview_layout = QGridLayout()
-        buttons_preview_layout.setRowStretch(0, 1)
-        buttons_preview_layout.setColumnStretch(0, 1)
-        buttons_preview_layout.setColumnStretch(1, 1)
-        buttons_preview_layout.addLayout(options_layout, 0, 0)
-        buttons_preview_layout.addWidget(preview_group, 0, 1)
-
-        # Groupbox for the section
-        manage_layout.addLayout(buttons_preview_layout)
-        manage_group = QGroupBox(_("Appearance"))
-        manage_group.setLayout(manage_layout)
-
-        vlayout = QVBoxLayout()
-        vlayout.addWidget(manage_group)
-        self.setLayout(vlayout)
+        # Combined layout
+        combined_layout = QGridLayout()
+        combined_layout.setRowStretch(0, 1)
+        combined_layout.setColumnStretch(0, 1)
+        combined_layout.setColumnStretch(1, 1)
+        combined_layout.addLayout(options_layout, 0, 0)
+        combined_layout.addWidget(preview_group, 0, 1)
+        self.setLayout(combined_layout)
 
         # Signals and slots
         create_button.clicked.connect(self.create_new_scheme)

--- a/spyder/preferences/configdialog.py
+++ b/spyder/preferences/configdialog.py
@@ -161,6 +161,7 @@ class ConfigDialog(QDialog):
         self.contents_widget.setMovement(QListView.Static)
         self.contents_widget.setSpacing(1)
         self.contents_widget.setCurrentRow(0)
+        self.contents_widget.setMinimumWidth(220)
 
         # Layout
         hsplitter = QSplitter()

--- a/spyder/preferences/configdialog.py
+++ b/spyder/preferences/configdialog.py
@@ -1172,6 +1172,7 @@ class ColorSchemeConfigPage(GeneralConfigPage):
         syntax_layout.addWidget(self.reset_button)
         syntax_layout.addWidget(create_button)
         syntax_layout.addWidget(self.delete_button)
+        syntax_layout.setContentsMargins(85, 12, 20, 12)
         syntax_group.setLayout(syntax_layout)
 
         # Fonts options

--- a/spyder/preferences/configdialog.py
+++ b/spyder/preferences/configdialog.py
@@ -1142,12 +1142,12 @@ class ColorSchemeConfigPage(GeneralConfigPage):
         syntax_group = QGroupBox(_("Syntax highlighting"))
 
         # Syntax Widgets
-        edit_button = QPushButton(_("Edit selected"))
+        edit_button = QPushButton(_("Edit selected scheme"))
         create_button = QPushButton(_("Create new scheme"))
-        self.delete_button = QPushButton(_("Delete"))
+        self.delete_button = QPushButton(_("Delete scheme"))
         self.preview_editor = CodeEditor(self)
         self.stacked_widget = QStackedWidget(self)
-        self.reset_button = QPushButton(_("Reset"))
+        self.reset_button = QPushButton(_("Reset to defaults"))
         self.scheme_editor_dialog = SchemeEditor(parent=self,
                                                  stack=self.stacked_widget)
 
@@ -1167,9 +1167,8 @@ class ColorSchemeConfigPage(GeneralConfigPage):
         buttons_layout.addLayout(syntax_comboboxes_layout)
         buttons_layout.addWidget(edit_button)
         buttons_layout.addWidget(self.reset_button)
-        buttons_layout.addWidget(self.delete_button)
-        buttons_layout.addStretch(1)
         buttons_layout.addWidget(create_button)
+        buttons_layout.addWidget(self.delete_button)
         syntax_group.setLayout(buttons_layout)
 
         # Fonts options

--- a/spyder/preferences/configdialog.py
+++ b/spyder/preferences/configdialog.py
@@ -728,13 +728,13 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
         if title:
             fontlabel = QLabel(title)
         else:
-            fontlabel = QLabel(_("Font: "))
+            fontlabel = QLabel(_("Font"))
         fontbox = QFontComboBox()
 
         if fontfilters is not None:
             fontbox.setFontFilters(fontfilters)
 
-        sizelabel = QLabel("  "+_("Size: "))
+        sizelabel = QLabel("  "+_("Size"))
         sizebox = QSpinBox()
         sizebox.setRange(7, 100)
         self.fontboxes[(fontbox, sizebox)] = option
@@ -1178,13 +1178,13 @@ class ColorSchemeConfigPage(GeneralConfigPage):
         # Fonts widgets
         plain_text_font = self.create_fontgroup(
             option='font',
-            title=_("Plain text font"),
+            title=_("Plain text"),
             fontfilters=QFontComboBox.MonospacedFonts,
             without_group=True)
 
         rich_text_font = self.create_fontgroup(
             option='rich_font',
-            title=_("Rich text font"),
+            title=_("Rich text"),
             without_group=True)
 
         # Fonts layouts

--- a/spyder/preferences/shortcuts.py
+++ b/spyder/preferences/shortcuts.py
@@ -715,7 +715,6 @@ class ShortcutsTable(QTableView):
 
     def adjust_cells(self):
         """Adjust column size based on contents."""
-        self.resizeRowsToContents()
         self.resizeColumnsToContents()
         fm = self.horizontalHeader().fontMetrics()
         names = [fm.width(s.name + ' '*9) for s in self.source_model.shortcuts]


### PR DESCRIPTION
This also improves the default size of our Preferences, which was too small for the new Appearance entry (precisely).

Before

![seleccion_005](https://user-images.githubusercontent.com/365293/50996004-d3d16c00-14ee-11e9-9bd8-a36325544367.png)

After
![seleccion_006](https://user-images.githubusercontent.com/365293/50996087-01b6b080-14ef-11e9-94f8-034ddba8b613.png)
