### PR TITLE
PR: Improve layout of Appearance entry in Preferences (2)

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -85,7 +85,7 @@ DEFAULTS = [
               'window/position': (10, 10),
               'window/is_maximized': True,
               'window/is_fullscreen': False,
-              'window/prefs_dialog_size': (1050, 520),
+              'window/prefs_dialog_size': (1050, 530),
               'show_status_bar': True,
               'memory_usage/enable': True,
               'memory_usage/timeout': 2000,
@@ -753,7 +753,7 @@ DEFAULTS = [
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '47.4.0'
+CONF_VERSION = '47.5.0'
 
 
 # Main configuration instance

--- a/spyder/preferences/configdialog.py
+++ b/spyder/preferences/configdialog.py
@@ -1160,20 +1160,16 @@ class ColorSchemeConfigPage(GeneralConfigPage):
                                                        'selected')
         self.schemes_combobox = schemes_combobox_widget.combobox
 
-        # Adjust size so buttons don't expand to the full width
-        for btn in [edit_button, create_button, self.delete_button,
-                    self.reset_button, self.schemes_combobox]:
-            btn.setMaximumWidth(250)
-
         # Syntax layout
-        syntax_layout = QVBoxLayout()
-        syntax_layout.addWidget(self.schemes_combobox)
-        syntax_layout.addWidget(edit_button)
-        syntax_layout.addWidget(self.reset_button)
-        syntax_layout.addWidget(create_button)
-        syntax_layout.addWidget(self.delete_button)
-        syntax_layout.setContentsMargins(85, 12, 20, 12)
-        syntax_group.setLayout(syntax_layout)
+        syntax_layout = QGridLayout(syntax_group)
+        btns = [self.schemes_combobox, edit_button, self.reset_button,
+                create_button, self.delete_button]
+        for i, btn in enumerate(btns):
+            syntax_layout.addWidget(btn, i, 1)
+        syntax_layout.setColumnStretch(0, 1)
+        syntax_layout.setColumnStretch(1, 2)
+        syntax_layout.setColumnStretch(2, 1)
+        syntax_layout.setContentsMargins(0, 12, 0, 12)
 
         # Fonts options
         fonts_group = QGroupBox(_("Fonts"))

--- a/spyder/preferences/configdialog.py
+++ b/spyder/preferences/configdialog.py
@@ -1217,8 +1217,7 @@ class ColorSchemeConfigPage(GeneralConfigPage):
         # Combined layout
         combined_layout = QGridLayout()
         combined_layout.setRowStretch(0, 1)
-        combined_layout.setColumnStretch(0, 1)
-        combined_layout.setColumnStretch(1, 1)
+        combined_layout.setColumnStretch(1, 100)
         combined_layout.addLayout(options_layout, 0, 0)
         combined_layout.addWidget(preview_group, 0, 1)
         self.setLayout(combined_layout)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

This PR builds on the work done in PR #8548. Two things are proposed:

- Stretches only the `Preview` panel
- Center the buttons without harcoding any length values.

These two changes allow the appearance preference dialog to adjust better to various screen, resolution, and theme and when the preference dialog width is increased by the user by mouse dragging.

![image](https://user-images.githubusercontent.com/10170372/51012431-01d4a180-152b-11e9-9490-acfcfd20e09b.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
