### PR TITLE
PR: Add parent reference to QLineEdit of EditTabNamePopup

### DIFF
--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -49,7 +49,7 @@ class EditTabNamePopup(QLineEdit):
         self.tab_index = None
 
         # Widget setup
-        QLineEdit.__init__(self, parent=None)
+        QLineEdit.__init__(self, parent=parent)
 
         # Slot to handle tab name update
         self.editingFinished.connect(self.edit_finished)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->




### Issue(s) Resolved
Setup parent reference to QLineEdit of EditTabNamePopup to ensure the set up of the dark style sheet for the dark theme.

Dark Theme
![dark](https://user-images.githubusercontent.com/22970578/51036482-9b19bb80-15f0-11e9-9b10-f6d4340351ec.gif)

Light Theme
![white](https://user-images.githubusercontent.com/22970578/51036496-a10f9c80-15f0-11e9-9edc-1641e1b0441d.gif)

I tested in windows 7, Linux.
Thank you

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #8068


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ok97465

<!--- Thanks for your help making Spyder better for everyone! --->
