### PR TITLE
PR: Avoid KeyError when closing Variable Explorer editors

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -592,11 +592,21 @@ class CollectionsDelegate(QItemDelegate):
             value = data['editor'].get_value()
             conv_func = data.get('conv', lambda v: v)
             self.set_value(index, conv_func(value))
-        self._editors.pop(editor_id)
+        # This is needed to avoid the problem reported on
+        # issue 8557
+        try:
+            self._editors.pop(editor_id)
+        except KeyError:
+            pass
         self.free_memory()
         
     def editor_rejected(self, editor_id):
-        self._editors.pop(editor_id)
+        # This is needed to avoid the problem reported on
+        # issue 8557
+        try:
+            self._editors.pop(editor_id)
+        except KeyError:
+            pass
         self.free_memory()
 
     def free_memory(self):


### PR DESCRIPTION
Fixes #8557.