### PR TITLE
PR: Prevent pasting non-text data from clipboard into the editor

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1582,6 +1582,8 @@ class CodeEditor(TextEditBaseWidget):
         text has 'CRLF' EOL chars
         """
         clipboard = QApplication.clipboard()
+        # This is here to prevent pasting mime data in the Editor.
+        # See issue 8566 for the details.
         if clipboard.mimeData().hasUrls():
             return
         else:

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1582,14 +1582,17 @@ class CodeEditor(TextEditBaseWidget):
         text has 'CRLF' EOL chars
         """
         clipboard = QApplication.clipboard()
-        text = to_text_string(clipboard.text())
-        if len(text.splitlines()) > 1:
-            eol_chars = self.get_line_separator()
-            text = eol_chars.join((text + eol_chars).splitlines())
-            clipboard.setText(text)
-        # Standard paste
-        TextEditBaseWidget.paste(self)
-        self.document_did_change(text)
+        if clipboard.mimeData().hasUrls():
+            return
+        else:
+            text = to_text_string(clipboard.text())
+            if len(text.splitlines()) > 1:
+                eol_chars = self.get_line_separator()
+                text = eol_chars.join((text + eol_chars).splitlines())
+                clipboard.setText(text)
+            # Standard paste
+            TextEditBaseWidget.paste(self)
+            self.document_did_change(text)
 
     @Slot()
     def undo(self):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

Old behaviour:
![copy_names_olddd](https://user-images.githubusercontent.com/22060413/51089562-2b7a0c80-1767-11e9-9dc5-8c2acce823ff.gif)


New behaviour
![copy_names_new](https://user-images.githubusercontent.com/22060413/51089563-2e74fd00-1767-11e9-847a-ffe36de3a1f7.gif)


<!--- Explain what you've done and why --->

This PR prevents pasting files/folders paths into Spyder editor when they are copied into the OS clipboard. Text data still can be pasted safely within spyder editor, from spyder editor to external file or from an external source into spyder editor.

Folders/files but can be pasted into Project/File explorers if #8494 is accepted and merged into the master.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8566


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@Khalilsqu 
<!--- Thanks for your help making Spyder better for everyone! --->
