### PR TITLE
PR: Enclose console warning about rendering of plots

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/figurebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/figurebrowser.py
@@ -61,11 +61,11 @@ class FigureBrowserWidget(RichJupyterWidget):
                     self.figurebrowser.mute_inline_plotting):
                 if not self.sended_render_message:
                     msg['content']['data']['text/plain'] = self._append_html(
-                      _('<hr>'
-                        '\nFigures now render in the Plots pane by default. '
-                        'To make them also appear inline in the Console, '
-                        'uncheck "Mute Inline Plotting" under the Plots '
-                        'pane options menu. \n<hr>'))
+                        _('<hr>'
+                          '\nFigures now render in the Plots pane by default. '
+                          'To make them also appear inline in the Console, '
+                          'uncheck "Mute Inline Plotting" under the Plots '
+                          'pane options menu. \n<hr>'))
                     self.sended_render_message = True
                 else:
                     msg['content']['data']['text/plain'] = ''

--- a/spyder/plugins/ipythonconsole/widgets/figurebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/figurebrowser.py
@@ -60,11 +60,11 @@ class FigureBrowserWidget(RichJupyterWidget):
             if (self.figurebrowser is not None and
                     self.figurebrowser.mute_inline_plotting):
                 if not self.sended_render_message:
-                    msg['content']['data']['text/plain'] = _(
-                        'Figures now render in the Plots pane by default. '
+                    msg['content']['data']['text/plain'] = self._append_html("<hr>"
+                        '\nFigures now render in the Plots pane by default. '
                         'To make them also appear inline in the Console, '
                         'uncheck "Mute Inline Plotting" under the Plots '
-                        'pane options menu.')
+                        'pane options menu. \n<hr>')
                     self.sended_render_message = True
                 else:
                     msg['content']['data']['text/plain'] = ''

--- a/spyder/plugins/ipythonconsole/widgets/figurebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/figurebrowser.py
@@ -60,11 +60,12 @@ class FigureBrowserWidget(RichJupyterWidget):
             if (self.figurebrowser is not None and
                     self.figurebrowser.mute_inline_plotting):
                 if not self.sended_render_message:
-                    msg['content']['data']['text/plain'] = self._append_html("<hr>"
+                    msg['content']['data']['text/plain'] = self._append_html(
+                      _('<hr>'
                         '\nFigures now render in the Plots pane by default. '
                         'To make them also appear inline in the Console, '
                         'uncheck "Mute Inline Plotting" under the Plots '
-                        'pane options menu. \n<hr>')
+                        'pane options menu. \n<hr>'))
                     self.sended_render_message = True
                 else:
                     msg['content']['data']['text/plain'] = ''


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

I enclosed the warning about plots being rendered in the Plots plugin in top and bottom horizontal bars to solve issue 8520

![screen shot 2019-01-15 at 11 37 44 pm](https://user-images.githubusercontent.com/18587879/51226834-498a6d00-191f-11e9-862e-682dcb10f6d3.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8520


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Juanis 2112

<!--- Thanks for your help making Spyder better for everyone! --->