### PR TITLE
PR: Adjust attribute icons size on Linux and Windows

### DIFF
--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -290,9 +290,9 @@ _qtaargs = {
     'private1':                [('spyder.circle-underscore',), {'color':'#e69c9c', 'scale_factor': SMALL_ATTR_FACTOR}],
     'method':                  [('mdi.alpha-m-box',), {'color':'#7ea67e', 'scale_factor': BIG_ATTR_FACTOR}],
     'function':                [('mdi.alpha-f-box',), {'color':'orange', 'scale_factor': BIG_ATTR_FACTOR}],
-    'blockcomment':            [('fa5s.hashtag',), {'color':'grey'}],
-    'cell':                    [('mdi.percent',), {'color':'red'}],
-    'no_match':                [('fa.circle',), {'color': 'gray'}],
+    'blockcomment':            [('fa5s.hashtag',), {'color':'grey', 'scale_factor': SMALL_ATTR_FACTOR}],
+    'cell':                    [('mdi.percent',), {'color':'red', 'scale_factor': SMALL_ATTR_FACTOR}],
+    'no_match':                [('fa.circle',), {'color': 'gray', 'scale_factor': SMALL_ATTR_FACTOR}],
     'github':                  [('fa.github',), {'color': MAIN_FG_COLOR}],
     # --- Spyder Tour --------------------------------------------------------
     'tour.close':              [('fa.close',), {'color': MAIN_FG_COLOR}],

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -6,6 +6,7 @@
 
 # Standard library imports
 import os.path as osp
+import sys
 
 # Third party imports
 from qtpy.QtGui import QIcon
@@ -23,7 +24,16 @@ if is_dark_interface():
 else:
     MAIN_FG_COLOR = 'black'
 
+# Magnification factors for attribute icons
+if sys.platform.startswith('linux'):
+    BIG_ATTR_FACTOR = 1.0
+    SMALL_ATTR_FACTOR = 0.9
+else:
+    BIG_ATTR_FACTOR = 1.3
+    SMALL_ATTR_FACTOR = 1.1
 
+# Icons for different programming language
+# extensions
 LANGUAGE_ICONS = {
     '.c': 'CFileIcon',
     '.h': 'CFileIcon',
@@ -268,13 +278,13 @@ _qtaargs = {
     'dock':                    [('fa.caret-square-o-down',), {'color': MAIN_FG_COLOR}],
     'close_pane':              [('fa.window-close-o',), {'color': MAIN_FG_COLOR}],
     # --- Autocompletion type icons --------------
-    'attribute':               [('mdi.alpha-a-box',), {'color': 'magenta', 'scale_factor': 1.3}],
-    'module':                  [('mdi.alpha-m-box',), {'color': '#daa520', 'scale_factor': 1.3}],
-    'class':                   [('mdi.alpha-c-box',), {'color':'#3775a9', 'scale_factor': 1.3}],
-    'private2':                [('spyder.circle-underscore',), {'color':'#e69c9c', 'scale_factor': 1.1}],
-    'private1':                [('spyder.circle-underscore',), {'color':'#e69c9c', 'scale_factor': 1.1}],
-    'method':                  [('mdi.alpha-m-box',), {'color':'#7ea67e', 'scale_factor': 1.3}],
-    'function':                [('mdi.alpha-f-box',), {'color':'orange', 'scale_factor': 1.3}],
+    'attribute':               [('mdi.alpha-a-box',), {'color': 'magenta', 'scale_factor': BIG_ATTR_FACTOR}],
+    'module':                  [('mdi.alpha-m-box',), {'color': '#daa520', 'scale_factor': BIG_ATTR_FACTOR}],
+    'class':                   [('mdi.alpha-c-box',), {'color':'#3775a9', 'scale_factor': BIG_ATTR_FACTOR}],
+    'private2':                [('spyder.circle-underscore',), {'color':'#e69c9c', 'scale_factor': SMALL_ATTR_FACTOR}],
+    'private1':                [('spyder.circle-underscore',), {'color':'#e69c9c', 'scale_factor': SMALL_ATTR_FACTOR}],
+    'method':                  [('mdi.alpha-m-box',), {'color':'#7ea67e', 'scale_factor': BIG_ATTR_FACTOR}],
+    'function':                [('mdi.alpha-f-box',), {'color':'orange', 'scale_factor': BIG_ATTR_FACTOR}],
     'blockcomment':            [('fa5s.hashtag',), {'color':'grey'}],
     'cell':                    [('mdi.percent',), {'color':'red'}],
     'no_match':                [('fa.circle',), {'color': 'gray'}],

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -5,6 +5,7 @@
 # (see spyder/__init__.py for details)
 
 # Standard library imports
+import os
 import os.path as osp
 import sys
 
@@ -25,9 +26,13 @@ else:
     MAIN_FG_COLOR = 'black'
 
 # Magnification factors for attribute icons
+# per platform
 if sys.platform.startswith('linux'):
     BIG_ATTR_FACTOR = 1.0
     SMALL_ATTR_FACTOR = 0.9
+elif os.name == 'nt':
+    BIG_ATTR_FACTOR = 1.1
+    SMALL_ATTR_FACTOR = 1.0
 else:
     BIG_ATTR_FACTOR = 1.3
     SMALL_ATTR_FACTOR = 1.1


### PR DESCRIPTION
We did the initial size selection on macOS with @juanis2112, but things need to be adjusted for other platforms.

This is how things look on Linux:

Before:

![seleccion_006](https://user-images.githubusercontent.com/365293/51417892-44f7cb80-1b4e-11e9-8fa9-54296e83f384.png)

After

![seleccion_005](https://user-images.githubusercontent.com/365293/51417861-1bd73b00-1b4e-11e9-8728-a1f81fefd0bc.png)