### PR TITLE
PR: Add ability to delete long nested directories on Windows from File/Project Explorers

### DIFF
--- a/spyder/plugins/explorer/tests/test_explorer.py
+++ b/spyder/plugins/explorer/tests/test_explorer.py
@@ -14,10 +14,11 @@ import os.path as osp
 
 # Third party imports
 import pytest
+from qtpy.QtWidgets import QMessageBox
 
 # Local imports
 from spyder.plugins.explorer.widgets import (FileExplorerTest,
-                                             ProjectExplorerTest, QMessageBox)
+                                             ProjectExplorerTest)
 from spyder.py3compat import to_text_string
 from spyder.plugins.projects.widgets.explorer import ProjectExplorerTest as \
     ProjectExplorerTest2

--- a/spyder/plugins/explorer/tests/test_explorer.py
+++ b/spyder/plugins/explorer/tests/test_explorer.py
@@ -39,11 +39,11 @@ def project_explorer(qtbot):
     return widget
 
 
-@pytest.fixture(params=[['script.py', 'dir1/dir2/dir3/dir4/dir5/dir6/dir7'],
+@pytest.fixture(params=[['script.py', 'dir1/dir2/dir3/dir4'],
                         ['script.py', 'script1.py', 'testdir/dir1/script2.py'],
-                        ['subdir/innerdir/dir3/text.txt',
-                         'dir1/dir2/dir3/dir4', 'dir1/dir2/dir3/file.txt',
-                         'dir1/dir2/dir3/dir4/dir5/dir6/dir7/python.py']])
+                        ['subdir/innerdir/dir3/text.txt', 'dir1/dir2/dir3',
+                         'dir1/dir2/dir3/file.txt',
+                         'dir1/dir2/dir3/dir4/python.py']])
 def create_folders_files(tmpdir, request):
     """A project directory with dirs and files for testing."""
     project_dir = to_text_string(tmpdir.mkdir('project'))

--- a/spyder/plugins/explorer/tests/test_explorer.py
+++ b/spyder/plugins/explorer/tests/test_explorer.py
@@ -8,12 +8,19 @@
 Tests for explorer.py
 """
 
-# Test library imports
+# Standard imports
+import os
+import os.path as osp
+
+# Third party imports
 import pytest
 
 # Local imports
 from spyder.plugins.explorer.widgets import (FileExplorerTest,
-                                             ProjectExplorerTest)
+                                             ProjectExplorerTest, QMessageBox)
+from spyder.py3compat import to_text_string
+from spyder.plugins.projects.widgets.explorer import ProjectExplorerTest as \
+    ProjectExplorerTest2
 
 
 @pytest.fixture
@@ -32,6 +39,48 @@ def project_explorer(qtbot):
     return widget
 
 
+@pytest.fixture(params=[['script.py', 'dir1/dir2/dir3/dir4/dir5/dir6/dir7'],
+                        ['script.py', 'script1.py', 'testdir/script2.py'],
+                        ['subdir/innerdir/dir3/text.txt',
+                         'dir1/dir2/dir3/dir4', 'dir1/dir2/dir3/file.txt',
+                         'dir1/dir2/dir3/dir4/dir5',
+                         'dir1/dir2/dir3/dir4/dir5/text.txt',
+                         'dir1/dir2/dir3/dir4/dir5/dir6/dir7/python.py']])
+def create_folders_files(tmpdir, request):
+    """A project directory with dirs and files for testing."""
+    project_dir = to_text_string(tmpdir.mkdir('project'))
+    list_paths = []
+    for item in request.param:
+        if osp.splitext(item)[1]:
+            if osp.split(item)[0]:
+                dirs, fname = osp.split(item)
+                dirpath = osp.join(project_dir, dirs)
+                if not osp.exists(dirpath):
+                    os.makedirs(dirpath)
+                    item_path = osp.join(dirpath, fname)
+            else:
+                item_path = osp.join(project_dir, item)
+        else:
+            dirpath = osp.join(project_dir, item)
+            if not osp.exists(dirpath):
+                os.makedirs(dirpath)
+                item_path = dirpath
+        if not osp.isdir(item_path):
+            with open(item_path, 'w') as fh:
+                fh.write("File Path:\n" + str(item_path) + '\n')
+        list_paths.append(item_path)
+    return list_paths, project_dir
+
+
+@pytest.fixture(params=[FileExplorerTest, ProjectExplorerTest2])
+def explorer_with_files(qtbot, create_folders_files, request):
+    """Setup Project/File Explorer widget."""
+    list_paths, project_dir = create_folders_files
+    project_explorer_orig = request.param(directory=project_dir)
+    qtbot.addWidget(project_explorer_orig)
+    return project_explorer_orig, list_paths
+
+
 def test_file_explorer(file_explorer):
     """Run FileExplorerTest."""
     file_explorer.resize(640, 480)
@@ -44,6 +93,15 @@ def test_project_explorer(project_explorer):
     project_explorer.resize(640, 480)
     project_explorer.show()
     assert project_explorer
+
+
+def test_delete_files_folders(explorer_with_files, mocker):
+    """Test delete file(s)/folders(s)."""
+    project, file_paths = explorer_with_files
+    mocker.patch.object(QMessageBox, 'warning', return_value=QMessageBox.Yes)
+    project.explorer.treewidget.delete(fnames=file_paths)
+    for item in file_paths:
+        assert not osp.exists(item)
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/explorer/widgets.py
+++ b/spyder/plugins/explorer/widgets.py
@@ -603,7 +603,14 @@ class DirView(QTreeView):
     def remove_tree(self, dirname):
         """Remove whole directory tree
         Reimplemented in project explorer widget"""
-        shutil.rmtree(dirname, onerror=misc.onerror)
+        while osp.exists(dirname):
+            try:
+                shutil.rmtree(dirname, onerror=misc.onerror)
+            # Windows Problem with shutil.rmtree. See issue #8567.
+            except Exception as e:
+                if type(e).__name__ == "OSError":
+                    error_path = to_text_string(e.filename)
+                    shutil.rmtree(error_path, ignore_errors=True)
     
     def delete_file(self, fname, multiple, yes_to_all):
         """Delete file"""
@@ -1293,11 +1300,15 @@ class ExplorerWidget(QWidget):
 # Tests
 #==============================================================================
 class FileExplorerTest(QWidget):
-    def __init__(self):
+    def __init__(self, directory=None):
         QWidget.__init__(self)
         vlayout = QVBoxLayout()
         self.setLayout(vlayout)
         self.explorer = ExplorerWidget(self, show_cd_only=None)
+        if directory is not None:
+            self.directory = directory
+        else:
+            self.directory = osp.dirname(osp.abspath(__file__))
         vlayout.addWidget(self.explorer)
         
         hlayout1 = QHBoxLayout()

--- a/spyder/plugins/explorer/widgets.py
+++ b/spyder/plugins/explorer/widgets.py
@@ -606,8 +606,9 @@ class DirView(QTreeView):
         while osp.exists(dirname):
             try:
                 shutil.rmtree(dirname, onerror=misc.onerror)
-            # Windows Problem with shutil.rmtree. See issue #8567.
             except Exception as e:
+                # This handles a Windows problem with shutil.rmtree.
+                # See issue #8567.
                 if type(e).__name__ == "OSError":
                     error_path = to_text_string(e.filename)
                     shutil.rmtree(error_path, ignore_errors=True)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->
As promised. Here is my solution of the issue: #8567.
The issue only happens in windows and the reason behind it is explained in [Here](https://github.com/pypa/pip/issues/4910) and [Here](https://github.com/ansible/ansible/issues/34335). 

Although the sub-folder(s) are deleted yet an error is raised stating that they are not empty which are in fact empty. therefore, we delete this sub-folder(s) silently and retry shutil.rmtree within a while loop. 
Another solution is to call the function `shutil.rmtree` recursively and introduce sleep before deleting the folder which raises the error as has been done [here](https://stackoverflow.com/a/25831267) and [here](https://github.com/hashdist/hashdist/blob/a322a66d4bcd4b989a6a163cd2569f3e71995f60/hashdist/core/fileutils.py#L69-L89).
I tested both method and they work fine, but found the implementation in this PR easier without the need to import new modules.

![delete_folder](https://user-images.githubusercontent.com/22060413/51435932-eda34980-1c7a-11e9-8b5b-92a06de65c90.gif)
`untitled1.py` is not inside the deleted directory.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8567


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@Khalilsqu 
<!--- Thanks for your help making Spyder better for everyone! --->
