### PR TITLE
PR: Use single row for file name and path and use gray for paths in file switcher

### DIFF
--- a/spyder/widgets/fileswitcher.py
+++ b/spyder/widgets/fileswitcher.py
@@ -229,6 +229,7 @@ class FileSwitcher(QDialog):
     # in a given file when using the '@' symbol.
     FILE_MODE, SYMBOL_MODE = [1, 2]
     MAX_WIDTH = 600
+    PATH_FG_COLOR = 'rgb(153, 153, 153)'
 
     def __init__(self, parent, plugin, tabs, data, icon):
         QDialog.__init__(self, parent)
@@ -663,13 +664,13 @@ class FileSwitcher(QDialog):
                     text_item += " [{0:} {1:}]".format(self.line_count[index],
                                                        _("lines"))
                 if max_width > self.list.width():
-                    text_item += (u" <i style='color:rgb(153,153,153)'>"
-                                  " {1:}</i>").format(
-                            ima.MAIN_FG_COLOR, short_paths[index])
+                    text_item += (u" <span style='color:{0:}'>{1:}"
+                                  "</span>").format(self.PATH_FG_COLOR,
+                                                    short_paths[index])
                 else:
-                    text_item += (u" <i style='color:rgb(153,153,153)'> "
-                                  " {1:}</i>").format(
-                            ima.MAIN_FG_COLOR, paths[index])
+                    text_item += (u" <span style='color:{0:}'>{1:}"
+                                  "</span>").format(self.PATH_FG_COLOR,
+                                                    paths[index])
                 if (trying_for_line_number and self.line_count[index] != 0 or
                         not trying_for_line_number):
                     results.append((score_value, index, text_item))

--- a/spyder/widgets/fileswitcher.py
+++ b/spyder/widgets/fileswitcher.py
@@ -664,11 +664,11 @@ class FileSwitcher(QDialog):
                     text_item += " [{0:} {1:}]".format(self.line_count[index],
                                                        _("lines"))
                 if max_width > self.list.width():
-                    text_item += (u" <span style='color:{0:}'>{1:}"
+                    text_item += (u" &nbsp; <span style='color:{0:}'>{1:}"
                                   "</span>").format(self.PATH_FG_COLOR,
                                                     short_paths[index])
                 else:
-                    text_item += (u" <span style='color:{0:}'>{1:}"
+                    text_item += (u" &nbsp; <span style='color:{0:}'>{1:}"
                                   "</span>").format(self.PATH_FG_COLOR,
                                                     paths[index])
                 if (trying_for_line_number and self.line_count[index] != 0 or

--- a/spyder/widgets/fileswitcher.py
+++ b/spyder/widgets/fileswitcher.py
@@ -663,10 +663,12 @@ class FileSwitcher(QDialog):
                     text_item += " [{0:} {1:}]".format(self.line_count[index],
                                                        _("lines"))
                 if max_width > self.list.width():
-                    text_item += u"<br><i style='color:{0:}'>{1:}</i>".format(
+                    text_item += (u" <i style='color:rgb(153,153,153)'>"
+                                  " {1:}</i>").format(
                             ima.MAIN_FG_COLOR, short_paths[index])
                 else:
-                    text_item += u"<br><i style='color:{0:}'>{1:}</i>".format(
+                    text_item += (u" <i style='color:rgb(153,153,153)'> "
+                                  " {1:}</i>").format(
                             ima.MAIN_FG_COLOR, paths[index])
                 if (trying_for_line_number and self.line_count[index] != 0 or
                         not trying_for_line_number):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

Changed file switcher to use a single row for a file name and its path and changed paths color to gray.

![screen shot 2019-01-25 at 8 10 09 am](https://user-images.githubusercontent.com/18587879/51747863-abae4500-2078-11e9-919a-4c21c566f5d6.png)

![screen shot 2019-01-25 at 3 57 25 pm](https://user-images.githubusercontent.com/18587879/51772461-0c11a680-20ba-11e9-984f-21c55c2301ee.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #8580 (Items 1 and 3)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Juanis2112

<!--- Thanks for your help making Spyder better for everyone! --->
