### PR TITLE
PR: Fix printing warning about rendering of plots below the new prompt

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/figurebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/figurebrowser.py
@@ -67,7 +67,7 @@ class FigureBrowserWidget(RichJupyterWidget):
                           'To make them also appear inline in the Console, '
                           'uncheck "Mute Inline Plotting" under the Plots '
                           'pane options menu. \n'
-                          '<hr><br>'))
+                          '<hr><br>'), before_prompt=True)
                     self.sended_render_message = True
                 else:
                     msg['content']['data']['text/plain'] = ''


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [X] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->




### Issue(s) Resolved
Fix printing warning about rendering of plots below the new prompt

![fix](https://user-images.githubusercontent.com/22970578/51611065-a7433880-1f61-11e9-83ed-64e321aba49f.png)


Fixes #8626


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ok97465

<!--- Thanks for your help making Spyder better for everyone! --->
