### PR TITLE
PR: Improve warning for when only some namespace objs couldn't be saved

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Spyder — The Scientific Python Development Environment](
 ./img_src/spyder_readme_banner.png)
 
-*Copyright © 2009–2018 [Spyder Project Contributors](
+*Copyright © 2009–2019 [Spyder Project Contributors](
 https://github.com/spyder-ide/spyder/graphs/contributors)*
 
 *Some source files and icons may be under other authorship/licenses; see

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2376,7 +2376,8 @@ class MainWindow(QMainWindow):
             <b>Spyder {spyder_ver}</b> {revision}
             <br>The Scientific Python Development Environment |
             <a href="{website_url}">Spyder-IDE.org</a>
-            <br>Copyright &copy; 2009-2018 Spyder Project Contributors
+            <br>Copyright &copy; 2009-2019 Spyder Project Contributors and
+            <a href="{github_url}/blob/master/AUTHORS.txt">others</a>
             <br>Distributed under the terms of the
             <a href="{github_url}/blob/master/LICENSE.txt">MIT License</a>.
 

--- a/spyder/widgets/variableexplorer/namespacebrowser.py
+++ b/spyder/widgets/variableexplorer/namespacebrowser.py
@@ -488,7 +488,14 @@ class NamespaceBrowser(QWidget):
         QApplication.restoreOverrideCursor()
         QApplication.processEvents()
         if error_message is not None:
-            QMessageBox.critical(self, _("Save data"),
-                            _("<b>Unable to save current workspace</b>"
-                              "<br><br>Error message:<br>%s") % error_message)
+            if 'Some objects could not be saved:' in error_message:
+                save_data_message = (
+                    _('<b>Some objects could not be saved:</b>')
+                    + '<br><br><code>{obj_list}</code>'.format(
+                        obj_list=error_message.split(': ')[1]))
+            else:
+                save_data_message = _(
+                    '<b>Unable to save current workspace</b>'
+                    '<br><br>Error message:<br>') + error_message
+            QMessageBox.critical(self, _("Save data"), save_data_message)
         self.save_button.setEnabled(self.filename is not None)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

We should presumably merge spyder-ide/spyder-kernels#81 first, just in case, so I marked it WiP (it should be done otherwise).

Once spyder-ide/spyder-kernels#81 is merged and released as part of Spyder-Kernels 0.4.0, Spyder-Kernels will include, as part of the error message, a list of the objects from the namespace that did not serialize successfully, although the operation as a whole did succeed. In that case, Spyder will currently state ``Unable to save current workspace`` followed by ``Some objects could not be saved: obj1, obj2, obj3...``. To be clearer for users while still fully backward and forward compatible in both directions, with the changes in this PR Spyder will automatically detect these strings and display a more appropriate warning message:

![image](https://user-images.githubusercontent.com/17051931/51655499-a5c64000-1f62-11e9-94b4-6bc184851c7b.png)

Also, it updates the copyright date in the readme and about dialog (and adds a link to the AUTHORS file in the latter).


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM-Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
