### PR TITLE
PR: Assign a keyboard shortcut for "next figure" and "previous figure" of the Plots pane

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -458,8 +458,8 @@ DEFAULTS = [
               'variable_explorer/copy': 'Ctrl+C',
               # ---- In widgets/plots/figurebrowser.py ----
               'plots/copy': 'Ctrl+C',
-              'plots/previous figure': 'Ctrl+Alt+Shift+U',
-              'plots/next figure': 'Ctrl+Alt+Shift+D',
+              'plots/previous figure': 'Ctrl+PgUp',
+              'plots/next figure': 'Ctrl+PgDown',
               # ---- In widgets/explorer ----
               'explorer/copy file': 'Ctrl+C',
               'explorer/paste file': 'Ctrl+V',

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -458,6 +458,8 @@ DEFAULTS = [
               'variable_explorer/copy': 'Ctrl+C',
               # ---- In widgets/plots/figurebrowser.py ----
               'plots/copy': 'Ctrl+C',
+              'plots/previous figure': 'Ctrl+PgUp',
+              'plots/next figure': 'Ctrl+PgDown',
               # ---- In widgets/explorer ----
               'explorer/copy file': 'Ctrl+C',
               'explorer/paste file': 'Ctrl+V',

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -458,8 +458,8 @@ DEFAULTS = [
               'variable_explorer/copy': 'Ctrl+C',
               # ---- In widgets/plots/figurebrowser.py ----
               'plots/copy': 'Ctrl+C',
-              'plots/previous figure': 'Ctrl+PgUp',
-              'plots/next figure': 'Ctrl+PgDown',
+              'plots/previous figure': 'Ctrl+Alt+Shift+U',
+              'plots/next figure': 'Ctrl+Alt+Shift+D',
               # ---- In widgets/explorer ----
               'explorer/copy file': 'Ctrl+C',
               'explorer/paste file': 'Ctrl+V',

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -168,14 +168,14 @@ class FigureBrowser(QWidget):
 
         goback_btn = create_toolbutton(
                 self, icon=ima.icon('ArrowBack'),
-                tip=_("Previous Figure (%s)" %
-                      get_shortcut('plots', 'previous figure')),
+                tip=_("Previous Figure ({})".format(
+                      get_shortcut('plots', 'previous figure'))),
                 triggered=self.go_previous_thumbnail)
 
         gonext_btn = create_toolbutton(
                 self, icon=ima.icon('ArrowForward'),
-                tip=_("Next Figure (%s)" %
-                      get_shortcut('plots', 'next figure')),
+                tip=_("Next Figure ({})".format(
+                      get_shortcut('plots', 'next figure'))),
                 triggered=self.go_next_thumbnail)
 
         vsep2 = QFrame()

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -168,12 +168,14 @@ class FigureBrowser(QWidget):
 
         goback_btn = create_toolbutton(
                 self, icon=ima.icon('ArrowBack'),
-                tip=_("Previous Figure"),
+                tip=_("Previous Figure (%s)" %
+                      get_shortcut('plots', 'previous figure')),
                 triggered=self.go_previous_thumbnail)
 
         gonext_btn = create_toolbutton(
                 self, icon=ima.icon('ArrowForward'),
-                tip=_("Next Figure"),
+                tip=_("Next Figure (%s)" %
+                      get_shortcut('plots', 'next figure')),
                 triggered=self.go_next_thumbnail)
 
         vsep2 = QFrame()
@@ -255,8 +257,12 @@ class FigureBrowser(QWidget):
         # Configurable
         copyfig = config_shortcut(self.copy_figure, context='plots',
                                   name='copy', parent=self)
+        prevfig = config_shortcut(self.go_previous_thumbnail, context='plots',
+                                  name='previous figure', parent=self)
+        nextfig = config_shortcut(self.go_next_thumbnail, context='plots',
+                                  name='next figure', parent=self)
 
-        return [copyfig]
+        return [copyfig, prevfig, nextfig]
 
     def get_shortcut_data(self):
         """


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [X] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->




### Issue(s) Resolved
![figure_shortcut](https://user-images.githubusercontent.com/22970578/51705718-b0b2ca80-205f-11e9-9723-5740548fc183.gif)

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8641 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ok97465

<!--- Thanks for your help making Spyder better for everyone! --->
