### PR TITLE
PR: Fall back to copy and delete if replace fails when restoring autosave

### DIFF
--- a/spyder/plugins/editor/widgets/recover.py
+++ b/spyder/plugins/editor/widgets/recover.py
@@ -9,6 +9,7 @@
 # Standard library imports
 from os import path as osp
 import os
+import shutil
 import time
 
 # Third party imports
@@ -21,8 +22,6 @@ from qtpy.QtWidgets import (QDialog, QDialogButtonBox, QHBoxLayout, QLabel,
 # Local imports
 from spyder.config.base import _, running_under_pytest
 from spyder.py3compat import PY2
-if PY2:
-    import shutil
 
 
 def gather_file_data(name):
@@ -221,7 +220,9 @@ class RecoveryDialog(QDialog):
         try:
             try:
                 os.replace(autosave['name'], orig_name)
-            except AttributeError:  # Python 2
+            except (AttributeError, OSError):
+                # os.replace() does not exist on Python 2 and fails if the
+                # files are on different file systems (issue #8631)
                 shutil.copy2(autosave['name'], orig_name)
                 os.remove(autosave['name'])
             self.deactivate(idx)

--- a/spyder/plugins/editor/widgets/recover.py
+++ b/spyder/plugins/editor/widgets/recover.py
@@ -21,7 +21,6 @@ from qtpy.QtWidgets import (QDialog, QDialogButtonBox, QHBoxLayout, QLabel,
 
 # Local imports
 from spyder.config.base import _, running_under_pytest
-from spyder.py3compat import PY2
 
 
 def gather_file_data(name):

--- a/spyder/plugins/editor/widgets/tests/test_recover.py
+++ b/spyder/plugins/editor/widgets/tests/test_recover.py
@@ -15,7 +15,7 @@ import shutil
 from qtpy.QtWidgets import QDialogButtonBox, QPushButton, QTableWidget
 
 # Local imports
-from spyder.py3compat import PY3
+from spyder.py3compat import PY2
 from spyder.plugins.editor.widgets.recover import (make_temporary_files,
                                                    RecoveryDialog)
 
@@ -180,8 +180,9 @@ def test_recoverydialog_restore_fallback(qtbot, recovery_env, mocker):
     Regression test for issue #8631.
     """
     orig_dir, autosave_dir, autosave_mapping = recovery_env
-    mocker.patch('spyder.plugins.editor.widgets.recover.os.replace',
-                 side_effect=OSError)
+    if not PY2:
+        mocker.patch('spyder.plugins.editor.widgets.recover.os.replace',
+                     side_effect=OSError)
     dialog = RecoveryDialog(autosave_dir, autosave_mapping)
     table = dialog.findChild(QTableWidget)
     button = table.cellWidget(0, 2).findChildren(QPushButton)[0]
@@ -202,8 +203,9 @@ def test_recoverydialog_restore_when_error(qtbot, recovery_env, mocker):
     in the grid is not deactivated.
     """
     orig_dir, autosave_dir, autosave_mapping = recovery_env
-    mocker.patch('spyder.plugins.editor.widgets.recover.os.replace',
-                 side_effect=OSError)
+    if not PY2:
+        mocker.patch('spyder.plugins.editor.widgets.recover.os.replace',
+                     side_effect=OSError)
     mocker.patch('spyder.plugins.editor.widgets.recover.shutil.copy2',
                  side_effect=IOError)
     mock_QMessageBox = mocker.patch(


### PR DESCRIPTION
## Description of Changes

The call to os.replace() fails if the original file and the autosave file are
stored on different file systems. In that case, we fall back to copying the
autosave file over the original file and then deleting the autosave file.

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI) **N/A**

<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8631 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: jitseniesen

<!--- Thanks for your help making Spyder better for everyone! --->
