### PR TITLE
PR: Avoid dropping predefined PYTHONPATH when using an external interpreter

### DIFF
--- a/spyder/utils/ipython/kernelspec.py
+++ b/spyder/utils/ipython/kernelspec.py
@@ -76,7 +76,7 @@ class SpyderKernelSpec(KernelSpec):
         pathlist = CONF.get('main', 'spyder_pythonpath', default=[])
         default_interpreter = CONF.get('main_interpreter', 'default')
         pypath = add_pathlist_to_PYTHONPATH([], pathlist, ipyconsole=True,
-                                            drop_env=(not default_interpreter))
+                                            drop_env=False)
 
         # Environment variables that we need to pass to our sitecustomize
         umr_namelist = CONF.get('main_interpreter', 'umr/namelist')

--- a/spyder/utils/ipython/tests/test_spyder_kernel.py
+++ b/spyder/utils/ipython/tests/test_spyder_kernel.py
@@ -12,9 +12,32 @@ import os
 import pytest
 
 from spyder.config.main import CONF
-from spyder.py3compat import PY2, is_binary_string
+from spyder.py3compat import PY2, is_binary_string, to_text_string
 from spyder.utils.encoding import to_fs_from_unicode
 from spyder.utils.ipython.kernelspec import SpyderKernelSpec
+
+
+@pytest.mark.parametrize('default_interpreter', [True, False])
+def test_preserve_pypath(tmpdir, default_interpreter):
+    """
+    Test that we preserve PYTHONPATH in the env vars passed to the kernel
+    when an external interpreter is used or not.
+
+    Regression test for issue 8681.
+    """
+    # Set default interpreter value
+    CONF.set('main_interpreter', 'default', default_interpreter)
+
+    # Add a path to PYTHONPATH env var
+    pypath = to_text_string(tmpdir.mkdir('test-pypath'))
+    os.environ['PYTHONPATH'] = pypath
+
+    # Check that PYTHONPATH is in our kernelspec
+    kernel_spec = SpyderKernelSpec()
+    assert pypath in kernel_spec.env['PYTHONPATH']
+
+    # Restore default value
+    CONF.set('main_interpreter', 'default', True)
 
 
 def test_python_interpreter(tmpdir):


### PR DESCRIPTION
Fixes #8681.