### PR TITLE
PR: Increase minimal required version of spyder-kernels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,7 @@ install_requires = [
     'pyzmq',
     'chardet>=2.0.0',
     'numpydoc',
-    'spyder-kernels<1.0',
+    'spyder-kernels>=0.4.0,<1.0',
     # Don't require keyring for Python 2 and Linux
     # because it depends on system packages
     'keyring;sys_platform!="linux2"',


### PR DESCRIPTION
This way users will get the very important fixes in that version related to saving the current namespace of the console.