### PR TITLE
PR: Add position to text completion

### DIFF
--- a/spyder/plugins/editor/tests/test_introspection.py
+++ b/spyder/plugins/editor/tests/test_introspection.py
@@ -155,8 +155,33 @@ def test_introspection(setup_editor):
     assert "degrees(x)" in [x['label'] for x in sig.args[0]]
 
     qtbot.keyPress(completion, Qt.Key_Enter, delay=1000)
+
+    # Complete math.a <tab> s <enter> to math.asin
+    qtbot.keyClicks(code_editor, 'math.a')
+    qtbot.wait(20000)
+    with qtbot.waitSignal(completion.sig_show_completions,
+                          timeout=10000) as sig:
+        qtbot.keyPress(code_editor, Qt.Key_Tab)
+    assert "asin(x)" in [x['label'] for x in sig.args[0]]
+    qtbot.keyClicks(completion, 's')
+    qtbot.keyPress(completion, Qt.Key_Enter, delay=1000)
+
+    # enter for new line
+    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=1000)
+
+    # Complete math.a <tab><enter> ... <enter> to math.acos
+    qtbot.keyClicks(code_editor, 'math.a')
+    qtbot.wait(20000)
+    with qtbot.waitSignal(completion.sig_show_completions,
+                          timeout=10000) as sig:
+        qtbot.keyPress(code_editor, Qt.Key_Tab)
+        qtbot.keyPress(code_editor, Qt.Key_Enter)
+    assert "acos(x)" in [x['label'] for x in sig.args[0]]
+    qtbot.keyPress(completion, Qt.Key_Enter, delay=1000)
+
     assert code_editor.toPlainText() == 'import math\nmath.degrees' \
-                                        '\nmath.degrees()\n'
+                                        '\nmath.degrees()\nmath.asin\n'\
+                                        'math.acos\n'
 
     # Modify PYTHONPATH
     # editor.introspector.change_extra_path([LOCATION])

--- a/spyder/plugins/editor/tests/test_introspection.py
+++ b/spyder/plugins/editor/tests/test_introspection.py
@@ -156,6 +156,9 @@ def test_introspection(setup_editor):
 
     qtbot.keyPress(completion, Qt.Key_Enter, delay=1000)
 
+    # enter for new line
+    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=1000)
+
     # Complete math.a <tab> ... s <enter> to math.asin
     qtbot.keyClicks(code_editor, 'math.a')
     qtbot.wait(20000)

--- a/spyder/plugins/editor/tests/test_introspection.py
+++ b/spyder/plugins/editor/tests/test_introspection.py
@@ -156,14 +156,14 @@ def test_introspection(setup_editor):
 
     qtbot.keyPress(completion, Qt.Key_Enter, delay=1000)
 
-    # Complete math.a <tab> s <enter> to math.asin
+    # Complete math.a <tab> ... s <enter> to math.asin
     qtbot.keyClicks(code_editor, 'math.a')
     qtbot.wait(20000)
     with qtbot.waitSignal(completion.sig_show_completions,
                           timeout=10000) as sig:
         qtbot.keyPress(code_editor, Qt.Key_Tab)
     assert "asin(x)" in [x['label'] for x in sig.args[0]]
-    qtbot.keyClicks(completion, 's')
+    qtbot.keyClicks(code_editor, 's')
     qtbot.keyPress(completion, Qt.Key_Enter, delay=1000)
 
     # enter for new line
@@ -179,9 +179,21 @@ def test_introspection(setup_editor):
     assert "acos(x)" in [x['label'] for x in sig.args[0]]
     qtbot.keyPress(completion, Qt.Key_Enter, delay=1000)
 
+    # There already is a \n
+
+    # Complete math.a <tab> s ...<enter> to math.asin
+    qtbot.keyClicks(code_editor, 'math.a')
+    qtbot.wait(20000)
+    with qtbot.waitSignal(completion.sig_show_completions,
+                          timeout=10000) as sig:
+        qtbot.keyPress(code_editor, Qt.Key_Tab)
+        qtbot.keyClicks(code_editor, 's')
+    assert "asin(x)" in [x['label'] for x in sig.args[0]]
+    qtbot.keyPress(completion, Qt.Key_Enter, delay=1000)
+
     assert code_editor.toPlainText() == 'import math\nmath.degrees' \
                                         '\nmath.degrees()\nmath.asin\n'\
-                                        'math.acos\n'
+                                        'math.acos\nmath.asin'
 
     # Modify PYTHONPATH
     # editor.introspector.change_extra_path([LOCATION])

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -193,7 +193,8 @@ class CompletionWidget(QListWidget):
             QListWidget.keyPressEvent(self, event)
 
     def update_current(self):
-        completion_text = to_text_string(self.textedit.completion_text)
+        completion_text = to_text_string(
+                self.textedit.get_current_word(completion=True))
         if completion_text:
             for row, completion in enumerate(self.completion_list):
                 if not self.is_internal_console:
@@ -1084,21 +1085,11 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
     def insert_completion(self, text, position):
         if text:
             cursor = self.textCursor()
-            cursor.setPosition(position)
+            if position is not None:
+                cursor.setPosition(position)
+            cursor.select(QTextCursor.WordUnderCursor)
+            cursor.removeSelectedText()
             self.setTextCursor(cursor)
-            word = self.get_current_word(completion=True) or ""
-            common_prefix = osp.commonprefix([text, word])
-            start = len(common_prefix) if common_prefix is not None else 0
-            if start == len(word):
-                text = text[start:]
-            else:
-                # Remove current word since the completion is not
-                # a perfect match
-                cursor = self.textCursor()
-                cursor.movePosition(QTextCursor.PreviousCharacter,
-                                    QTextCursor.KeepAnchor,
-                                    len(word))
-                cursor.removeSelectedText()
             self.insert_text(text)
             self.document_did_change()
 

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -1084,12 +1084,20 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
 
     def insert_completion(self, text, position):
         if text:
-            cursor = self.textCursor()
+            # Set position to where the request was made
             if position is not None:
+                cursor = self.textCursor()
                 cursor.setPosition(position)
+                self.setTextCursor(cursor)
+            # Move to the beginning of the selected word
+            _, position = self.get_current_word_and_position(completion=True)
+            cursor = self.textCursor()
+            cursor.setPosition(position)
+            # Remove the word under the cursor
             cursor.select(QTextCursor.WordUnderCursor)
             cursor.removeSelectedText()
             self.setTextCursor(cursor)
+            # Add text
             self.insert_text(text)
             self.document_did_change()
 

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -58,9 +58,10 @@ class CompletionWidget(QListWidget):
         self.resize(*size)
         self.setFont(font)
 
-    def show_list(self, completion_list):
+    def show_list(self, completion_list, position):
         # Completions are handled differently for the Internal
         # console.
+        self.position = position
         if not isinstance(completion_list[0], dict):
             self.is_internal_console = True
 
@@ -226,7 +227,8 @@ class CompletionWidget(QListWidget):
     def item_selected(self, item=None):
         if item is None:
             item = self.currentItem()
-        self.textedit.insert_completion(to_text_string(item.text()))
+        self.textedit.insert_completion(to_text_string(item.text()),
+                                        self.position)
         self.hide()
 
     @Slot(int)
@@ -1079,8 +1081,11 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         """Completion list is active, Enter was just pressed"""
         self.completion_widget.item_selected()
 
-    def insert_completion(self, text):
+    def insert_completion(self, text, position):
         if text:
+            cursor = self.textCursor()
+            cursor.setPosition(position)
+            self.setTextCursor(cursor)
             word = self.get_current_word(completion=True) or ""
             common_prefix = osp.commonprefix([text, word])
             start = len(common_prefix) if common_prefix is not None else 0

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -61,10 +61,16 @@ class CompletionWidget(QListWidget):
     def show_list(self, completion_list, position):
         # Completions are handled differently for the Internal
         # console.
-        if self.textedit.textCursor().position() < position:
+        if position is None:
+            # Somehow the position was not saved.
+            # Hope that the current position is still valid
+            self.position = self.textedit.textCursor().position()
+        elif self.textedit.textCursor().position() < position:
             # hide the text as we moved away from the position
             return
-        self.position = position
+        else:
+            self.position = position
+
         if not isinstance(completion_list[0], dict):
             self.is_internal_console = True
         self.completion_list = completion_list

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -184,8 +184,11 @@ class CompletionWidget(QListWidget):
             else:
                 QListWidget.keyPressEvent(self, event)
         elif len(text) or key == Qt.Key_Backspace:
-            if key == Qt.Key_Backspace and (
-                    self.textedit.textCursor().position() <= self.position):
+            # If the cursor goes behind the current position,
+            # the autocomplete is no longer relevant
+            if self.textedit.textCursor().position() < self.position or (
+                    key == Qt.Key_Backspace and (
+                    self.textedit.textCursor().position() <= self.position)):
                 self.hide()
                 self.textedit.keyPressEvent(event)
             else:

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -61,6 +61,9 @@ class CompletionWidget(QListWidget):
     def show_list(self, completion_list, position):
         # Completions are handled differently for the Internal
         # console.
+        if self.textedit.textCursor().position() < position:
+            # hide the text as we moved away from the position
+            return
         self.position = position
         if not isinstance(completion_list[0], dict):
             self.is_internal_console = True

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -173,7 +173,7 @@ class CompletionWidget(QListWidget):
         elif key in (Qt.Key_Return, Qt.Key_Enter,
                      Qt.Key_Left, Qt.Key_Right) or text in ('.', ':'):
             self.hide()
-            self.sendKeyToTextEdit(event)
+            self.textedit.keyPressEvent(event)
         elif key in (Qt.Key_Up, Qt.Key_Down, Qt.Key_PageUp, Qt.Key_PageDown,
                      Qt.Key_Home, Qt.Key_End,
                      Qt.Key_CapsLock) and not modifier:
@@ -184,26 +184,18 @@ class CompletionWidget(QListWidget):
             else:
                 QListWidget.keyPressEvent(self, event)
         elif len(text) or key == Qt.Key_Backspace:
-            self.sendKeyToTextEdit(event)
-            self.update_current()
+            if key == Qt.Key_Backspace and (
+                    self.textedit.textCursor().position() == self.position):
+                self.hide()
+                self.textedit.keyPressEvent(event)
+            else:
+                self.textedit.keyPressEvent(event)
+                self.update_current()
         elif modifier:
-            self.sendKeyToTextEdit(event)
+            self.textedit.keyPressEvent(event)
         else:
             self.hide()
             QListWidget.keyPressEvent(self, event)
-
-    def sendKeyToTextEdit(self, event):
-        """Send key to text edit and updates the position of
-        the text completion"""
-        keystroke_position_before = self.textedit.textCursor().position()
-        self.textedit.keyPressEvent(event)
-        keystroke_position_after = self.textedit.textCursor().position()
-        update = keystroke_position_before < self.position
-        if event.key() == Qt.Key_Backspace:
-            update = keystroke_position_before <= self.position
-        if update:
-            self.position += (
-                    keystroke_position_after - keystroke_position_before)
 
     def update_current(self):
         completion_text = to_text_string(

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -185,7 +185,7 @@ class CompletionWidget(QListWidget):
                 QListWidget.keyPressEvent(self, event)
         elif len(text) or key == Qt.Key_Backspace:
             if key == Qt.Key_Backspace and (
-                    self.textedit.textCursor().position() == self.position):
+                    self.textedit.textCursor().position() <= self.position):
                 self.hide()
                 self.textedit.keyPressEvent(event)
             else:

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -64,9 +64,6 @@ class CompletionWidget(QListWidget):
         self.position = position
         if not isinstance(completion_list[0], dict):
             self.is_internal_console = True
-
-        if not self.is_internal_console:
-            self.textedit.completion_text = ''
         self.completion_list = completion_list
         self.clear()
 
@@ -292,7 +289,6 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         self.codecompletion_auto = False
         self.codecompletion_case = True
         self.codecompletion_enter = False
-        self.completion_text = ""
         self.setup_completion()
 
         self.calltip_widget = CallTipWidget(self, hide_timer_on=False)

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -146,7 +146,8 @@ class CompletionWidget(QListWidget):
             for completion in completion_list:
                 completion['point'] = tooltip_point
 
-        if to_text_string(self.textedit.completion_text):
+        if to_text_string(to_text_string(
+                self.textedit.get_current_word(completion=True))):
             # When initialized, if completion text is not empty, we need
             # to update the displayed list:
             self.update_current()

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -473,6 +473,7 @@ class CodeEditor(TextEditBaseWidget):
         self.range_formatting_enabled = False
         self.formatting_characters = []
         self.rename_support = False
+        self.last_completion_position = None
 
         # Editor Extensions
         self.editor_extensions = EditorExtensionsManager(self)
@@ -777,6 +778,7 @@ class CodeEditor(TextEditBaseWidget):
             'line': line,
             'column': column
         }
+        self.last_completion_position = self.textCursor().position()
         return params
 
     @handles(LSPRequestTypes.DOCUMENT_COMPLETION)
@@ -784,7 +786,9 @@ class CodeEditor(TextEditBaseWidget):
         if len(params['params']) > 0:
             completion_list = sorted(
                 params['params'], key=lambda x: x['sortText'])
-            self.completion_widget.show_list(completion_list)
+            position = self.last_completion_position
+            self.last_completion_position = None
+            self.completion_widget.show_list(completion_list, position)
 
     # ------------- LSP: Signature Hints ------------------------------------
 

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2795,8 +2795,6 @@ class CodeEditor(TextEditBaseWidget):
                     cursor.removeSelectedText()
                 else:
                     TextEditBaseWidget.keyPressEvent(self, event)
-                    if self.is_completion_widget_visible():
-                        self.completion_text = self.completion_text[:-1]
         # elif key == Qt.Key_Period:
         #     self.insert_text(text)
         #     if (self.is_python_like()) and not \
@@ -2860,8 +2858,6 @@ class CodeEditor(TextEditBaseWidget):
             event.accept()
         elif not event.isAccepted():
             TextEditBaseWidget.keyPressEvent(self, event)
-            if self.is_completion_widget_visible() and text:
-                self.completion_text += text
         if len(text) > 0:
             self.document_did_change(text)
             # self.do_completion(automatic=True)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -787,7 +787,6 @@ class CodeEditor(TextEditBaseWidget):
             completion_list = sorted(
                 params['params'], key=lambda x: x['sortText'])
             position = self.last_completion_position
-            self.last_completion_position = None
             self.completion_widget.show_list(completion_list, position)
 
     # ------------- LSP: Signature Hints ------------------------------------

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -340,8 +340,9 @@ class BaseEditMixin(object):
         cursor = self.__select_text(position_from, position_to)
         cursor.removeSelectedText()
 
-    def get_current_word(self, completion=False):
-        """Return current word, i.e. word at cursor position"""
+    def get_current_word_and_position(self, completion=False):
+        """Return current word, i.e. word at cursor position,
+            and the start position"""
         cursor = self.textCursor()
 
         if cursor.hasSelection():
@@ -384,7 +385,13 @@ class BaseEditMixin(object):
         # find a valid python variable name
         match = re.findall(r'([^\d\W]\w*)', text, re.UNICODE)
         if match:
-            return match[0]
+            return match[0], cursor.selectionStart()
+
+    def get_current_word(self, completion=False):
+        """Return current word, i.e. word at cursor position"""
+        ret = self.get_current_word_and_position(completion)
+        if ret is not None:
+            return ret[0]
 
     def get_current_line(self):
         """Return current line's text"""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->
While an autocomplete is being processed, the cursor can move. Auto completing on another line is clearly not what is expected. The cursor is therefore moved back if this happens. 
Also, the selection of an option in the list was broken.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8727 
Fixes #8723 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Impact27
<!--- Thanks for your help making Spyder better for everyone! --->
