### PR TITLE
PR: Don't show empty kernel error messages

### DIFF
--- a/spyder/widgets/ipythonconsole/client.py
+++ b/spyder/widgets/ipythonconsole/client.py
@@ -668,9 +668,19 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
     def _read_stderr(self):
         """Read the stderr file of the kernel."""
+        # We need to read stderr_file as bytes to be able to
+        # detect its encoding with chardet
         f = open(self.stderr_file, 'rb')
+
         try:
             stderr_text = f.read()
+
+            # This is needed to avoid showing an empty error message
+            # when the kernel takes too much time to start.
+            # See issue 8581
+            if not stderr_text:
+                return ''
+
             # This is needed since the stderr file could be encoded
             # in something different to utf-8.
             # See issue 4191


### PR DESCRIPTION
If the kernel takes too much time to start, two things can be causing that:

1. Your system is slow (for whatever reason); or
2. There's a real error preventing the kernel to start.

Even if point 1. is the cause, we still try to read the kernel stderr_file for errors (this change was introduced by me in 3.3.2). But we were not detecting correctly if stderr_file contents are empty (and hence no error was generated) because its contents are read as bytes and then transformed to unicode, which gives `b''` in case of an empty bytes string instead of simply `''`.

What's worst (and the reason why a lot of people is seeing this error) is that we no longer display additional kernel errors after an initial error is shown. This was another change done by me in 3.3.2 to avoid updating the displayed error with the same traceback over and over again, in case a real kernel error is happening.

Fixes #8581.