### PR TITLE
PR: Use a single infowidget in the IPython console

### DIFF
--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -263,10 +263,23 @@ class IPythonConsole(SpyderPluginWidget):
         """Refresh tabwidget"""
         client = None
         if self.tabwidget.count():
-            # Give focus to the control widget of the selected tab
             client = self.tabwidget.currentWidget()
+
+            # Decide what to show for each client
+            if client.info_page != client.blank_page:
+                # Show info_page if it has content
+                client.set_info_page()
+                client.shellwidget.hide()
+                self.infowidget.show()
+            else:
+                self.infowidget.hide()
+                client.shellwidget.show()
+
+            # Give focus to the control widget of the selected tab
             control = client.get_control()
             control.setFocus()
+
+            # Create corner widgets
             buttons = [[b, -7] for b in client.get_toolbar_buttons()]
             buttons = sum(buttons, [])[:-1]
             widgets = [client.create_time_label()] + buttons

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -270,6 +270,7 @@ class IPythonConsole(SpyderPluginWidget):
                 # Show info_page if it has content
                 client.set_info_page()
                 client.shellwidget.hide()
+                client.layout.addWidget(self.infowidget)
                 self.infowidget.show()
             else:
                 self.infowidget.hide()

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -37,7 +37,7 @@ from zmq.ssh import tunnel as zmqtunnel
 # Local imports
 from spyder import dependencies
 from spyder.config.base import _, get_conf_path, get_home_dir
-from spyder.config.gui import is_dark_interface
+from spyder.config.gui import get_font, is_dark_interface
 from spyder.config.main import CONF
 from spyder.api.plugins import SpyderPluginWidget
 from spyder.py3compat import is_string, PY2, to_text_string
@@ -157,6 +157,7 @@ class IPythonConsole(SpyderPluginWidget):
 
         # Info widget
         self.infowidget = WebView(self)
+        self.set_infowidget_font()
         if WEBENGINE:
             self.infowidget.page().setBackgroundColor(QColor(MAIN_BG_COLOR))
         else:
@@ -1092,6 +1093,11 @@ class IPythonConsole(SpyderPluginWidget):
                 client.timer.timeout.connect(client.show_time)
                 client.timer.start(1000)
                 break
+
+    def set_infowidget_font(self):
+        """Set font for infowidget"""
+        font = get_font(option='rich_font')
+        self.infowidget.set_font(font)
 
     #------ Public API (for kernels) ------------------------------------------
     def ssh_tunnel(self, *args, **kwargs):

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -157,12 +157,12 @@ class IPythonConsole(SpyderPluginWidget):
 
         # Info widget
         self.infowidget = WebView(self)
-        self.set_infowidget_font()
         if WEBENGINE:
             self.infowidget.page().setBackgroundColor(QColor(MAIN_BG_COLOR))
         else:
             self.infowidget.setStyleSheet(
                 "background:{}".format(MAIN_BG_COLOR))
+        self.set_infowidget_font()
         layout.addWidget(self.infowidget)
 
         # Find/replace widget

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -26,6 +26,8 @@ from jupyter_core.paths import jupyter_config_dir, jupyter_runtime_dir
 from qtconsole.client import QtKernelClient
 from qtconsole.manager import QtKernelManager
 from qtpy.QtCore import Qt, Signal, Slot
+from qtpy.QtGui import QColor
+from qtpy.QtWebEngineWidgets import WEBENGINE
 from qtpy.QtWidgets import (QActionGroup, QApplication, QGridLayout,
                             QGroupBox, QHBoxLayout, QLabel, QMenu, QMessageBox,
                             QTabWidget, QVBoxLayout, QWidget)
@@ -35,6 +37,7 @@ from zmq.ssh import tunnel as zmqtunnel
 # Local imports
 from spyder import dependencies
 from spyder.config.base import _, get_conf_path, get_home_dir
+from spyder.config.gui import is_dark_interface
 from spyder.config.main import CONF
 from spyder.api.plugins import SpyderPluginWidget
 from spyder.py3compat import is_string, PY2, to_text_string
@@ -50,6 +53,7 @@ from spyder.utils.misc import get_error_match, remove_backslashes
 from spyder.widgets.findreplace import FindReplace
 from spyder.plugins.ipythonconsole.widgets import ClientWidget
 from spyder.plugins.ipythonconsole.widgets import KernelConnectionDialog
+from spyder.widgets.browser import WebView
 from spyder.widgets.tabs import Tabs
 
 
@@ -73,6 +77,11 @@ dependencies.add("IPython", _("IPython interactive python environment"),
 MATPLOTLIB_REQVER = '>=2.0.0'
 dependencies.add("matplotlib", _("Display 2D graphics in the IPython Console"),
                  required_version=MATPLOTLIB_REQVER, optional=True)
+
+if is_dark_interface():
+    MAIN_BG_COLOR = '#19232D'
+else:
+    MAIN_BG_COLOR = 'white'
 
 
 class IPythonConsole(SpyderPluginWidget):
@@ -145,6 +154,15 @@ class IPythonConsole(SpyderPluginWidget):
             layout.addWidget(tab_container)
         else:
             layout.addWidget(self.tabwidget)
+
+        # Info widget
+        self.infowidget = WebView(self)
+        if WEBENGINE:
+            self.infowidget.page().setBackgroundColor(QColor(MAIN_BG_COLOR))
+        else:
+            self.infowidget.setStyleSheet(
+                "background:{}".format(MAIN_BG_COLOR))
+        layout.addWidget(self.infowidget)
 
         # Find/replace widget
         self.find_widget = FindReplace(self)

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -26,10 +26,9 @@ import time
 
 # Third party imports (qtpy)
 from qtpy.QtCore import QUrl, QTimer, Signal, Slot
-from qtpy.QtGui import QKeySequence, QColor
+from qtpy.QtGui import QKeySequence
 from qtpy.QtWidgets import (QHBoxLayout, QLabel, QMenu, QMessageBox,
                             QToolButton, QVBoxLayout, QWidget)
-from qtpy.QtWebEngineWidgets import WEBENGINE
 
 # Local imports
 from spyder.config.base import (_, get_image_path, get_module_source_path,
@@ -44,7 +43,6 @@ from spyder.utils.qthelpers import (add_actions, create_action,
                                     create_toolbutton, DialogManager,
                                     MENU_SEPARATOR)
 from spyder.py3compat import to_text_string
-from spyder.widgets.browser import WebView
 from spyder.plugins.ipythonconsole.widgets import ShellWidget
 from spyder.widgets.mixins import SaveHistoryMixin
 from spyder.plugins.variableexplorer.widgets.collectionseditor import (
@@ -64,11 +62,6 @@ TEMPLATES_PATH = osp.join(PLUGINS_PATH, 'ipythonconsole', 'assets', 'templates')
 BLANK = open(osp.join(TEMPLATES_PATH, 'blank.html')).read()
 LOADING = open(osp.join(TEMPLATES_PATH, 'loading.html')).read()
 KERNEL_ERROR = open(osp.join(TEMPLATES_PATH, 'kernel_error.html')).read()
-
-if is_dark_interface():
-    MAIN_BG_COLOR = '#19232D'
-else:
-    MAIN_BG_COLOR = 'white'
 
 try:
     time.monotonic  # time.monotonic new in 3.3
@@ -97,8 +90,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
     """
     Client widget for the IPython Console
 
-    This is a widget composed of a shell widget and a WebView info widget
-    to print different messages there.
+    This widget is necessary to handle the interaction between the
+    plugin and each shell widget.
     """
 
     SEPARATOR = '{0}## ---({1})---'.format(os.linesep*2, time.ctime())
@@ -155,12 +148,8 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                                        interpreter_versions=interpreter_versions,
                                        external_kernel=external_kernel,
                                        local_kernel=True)
-        self.infowidget = WebView(self)
-        if WEBENGINE:
-            self.infowidget.page().setBackgroundColor(QColor(MAIN_BG_COLOR))
-        else:
-            self.infowidget.setStyleSheet(
-                "background:{}".format(MAIN_BG_COLOR))
+
+        self.infowidget = plugin.infowidget
         self.set_infowidget_font()
         self.blank_page = self._create_blank_page()
         self.loading_page = self._create_loading_page()
@@ -186,7 +175,6 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         vlayout.addLayout(hlayout)
         vlayout.setContentsMargins(0, 0, 0, 0)
         vlayout.addWidget(self.shellwidget)
-        vlayout.addWidget(self.infowidget)
         self.setLayout(vlayout)
 
         # --- Exit function

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -165,7 +165,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                                          toggled=self.set_elapsed_time_visible)
 
         # --- Layout
-        vlayout = QVBoxLayout()
+        self.layout = QVBoxLayout()
         toolbar_buttons = self.get_toolbar_buttons()
 
         hlayout = QHBoxLayout()
@@ -174,10 +174,11 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         for button in toolbar_buttons:
             hlayout.addWidget(button)
 
-        vlayout.addLayout(hlayout)
-        vlayout.setContentsMargins(0, 0, 0, 0)
-        vlayout.addWidget(self.shellwidget)
-        self.setLayout(vlayout)
+        self.layout.addLayout(hlayout)
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        self.layout.addWidget(self.shellwidget)
+        self.layout.addWidget(self.infowidget)
+        self.setLayout(self.layout)
 
         # --- Exit function
         self.exit_callback = lambda: plugin.close_client(client=self)

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -33,7 +33,7 @@ from qtpy.QtWidgets import (QHBoxLayout, QLabel, QMenu, QMessageBox,
 # Local imports
 from spyder.config.base import (_, get_image_path, get_module_source_path,
                                 running_under_pytest)
-from spyder.config.gui import get_font, get_shortcut, is_dark_interface
+from spyder.config.gui import get_shortcut, is_dark_interface
 from spyder.utils import icon_manager as ima
 from spyder.utils import sourcecode
 from spyder.utils.encoding import get_coding
@@ -150,7 +150,6 @@ class ClientWidget(QWidget, SaveHistoryMixin):
                                        local_kernel=True)
 
         self.infowidget = plugin.infowidget
-        self.set_infowidget_font()
         self.blank_page = self._create_blank_page()
         self.loading_page = self._create_loading_page()
         self._show_loading_page()
@@ -478,11 +477,6 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         """Set IPython widget's font"""
         self.shellwidget._control.setFont(font)
         self.shellwidget.font = font
-
-    def set_infowidget_font(self):
-        """Set font for infowidget"""
-        font = get_font(option='rich_font')
-        self.infowidget.set_font(font)
 
     def set_color_scheme(self, color_scheme, reset=True):
         """Set IPython color scheme."""


### PR DESCRIPTION
This avoids creating one infowidget per console, which in turn creates one QtWebEngineProcess. If the user creates lots of consoles, these processes start to consume a lot of memory which is not freed until Spyder is closed.

TODO:

- [x] Show/hide infowidget when changing between tabs.
- [x] Fix positioning of info messages in infowidget.

Fixes #7091.