### PR TITLE
avoid calling aliased object's methods twice

### DIFF
--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -450,6 +450,9 @@ class SpyderAction(QAction):
         """Intercept method calls and apply to both actions, except signals."""
         attr = super(SpyderAction, self).__getattribute__(name)
 
+        if super(SpyderAction, self).__getattribute__('_action_no_icon') is self:
+            return attr
+
         if hasattr(attr, '__call__') and name not in ['triggered', 'toggled',
                                                       'changed', 'hovered']:
             def newfunc(*args, **kwargs):

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -450,7 +450,8 @@ class SpyderAction(QAction):
         """Intercept method calls and apply to both actions, except signals."""
         attr = super(SpyderAction, self).__getattribute__(name)
 
-        if super(SpyderAction, self).__getattribute__('_action_no_icon') is self:
+        shadow = super(SpyderAction, self).__getattribute__('_action_no_icon')
+        if shadow is self:
             return attr
 
         if hasattr(attr, '__call__') and name not in ['triggered', 'toggled',


### PR DESCRIPTION
On non-darwin platforms, _action_no_icon simply points to self.
The original code thus ends up calling methods twice on the same object.

This change removes the assumption that calling methods twice has no
side-effects.

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
