### PR TITLE
PR: Avoid errors when using Pygments to detect the lexer used to highlight a file

### DIFF
--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -1196,16 +1196,18 @@ def guess_pygments_highlighter(filename):
     """
     try:
         from pygments.lexers import get_lexer_for_filename, get_lexer_by_name
-        from pygments.util import ClassNotFound
-    except ImportError:
+    except Exception:
         return TextSH
     root, ext = os.path.splitext(filename)
     if ext in custom_extension_lexer_mapping:
-        lexer = get_lexer_by_name(custom_extension_lexer_mapping[ext])
+        try:
+            lexer = get_lexer_by_name(custom_extension_lexer_mapping[ext])
+        except Exception:
+            return TextSH
     else:
         try:
             lexer = get_lexer_for_filename(filename)
-        except ClassNotFound:
+        except Exception:
             return TextSH
     class GuessedPygmentsSH(PygmentsSH):
         _lexer = lexer


### PR DESCRIPTION
Fixes #8764.