### PR TITLE
PR: Enclose logger.debug call in a try/except

### DIFF
--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -14,6 +14,6 @@ numpydoc
 pyqt <5.10
 keyring
 spyder-kernels >=1.2
-python-language-server >=0.19
+python-language-server >=0.19,<0.23
 qdarkstyle >=2.6.4
 atomicwrites

--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,7 @@ install_requires = [
     # pyqtwebengine module
     'pyqtwebengine<5.13',
     # Pyls with all its dependencies
-    'python-language-server[all]>=0.19.0',
+    'python-language-server[all]>=0.19.0,<0.23',
     # Required to get SSH connections to remote kernels
     'pexpect;platform_system!="Windows"',
     'paramiko;platform_system=="Windows"'

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1973,8 +1973,14 @@ class EditorStack(QWidget):
         self.stack_history.refresh()
         self.stack_history.remove_and_append(index)
 
-        logger.debug("Current changed: %d - %s" %
-                     (index, self.data[index].editor.filename))
+        # Needed to avoid an error generated after moving/renaming
+        # files outside Spyder while in debug mode.
+        # See issue 8749.
+        try:
+            logger.debug("Current changed: %d - %s" %
+                         (index, self.data[index].editor.filename))
+        except IndexError:
+            pass
 
         self.update_plugin_title.emit()
         if editor is not None:


### PR DESCRIPTION
This is needed to avoid an error generated after moving/renaming files outside Spyder while in debug mode.

Fixes #8749.