### PR TITLE
[WIP] PR: Provide an API for external plugins to load/save/create new files

### DIFF
--- a/spyder/api/plugins.py
+++ b/spyder/api/plugins.py
@@ -235,7 +235,6 @@ class SpyderPluginWidget(PluginWidget):
     """
 
     # ---------------------------- ATTRIBUTES ---------------------------------
-
     # Name of the configuration section that's going to be
     # used to record the plugin's permanent data in Spyder
     # config system (i.e. in spyder.ini)
@@ -275,7 +274,6 @@ class SpyderPluginWidget(PluginWidget):
     file_extensions = []
 
     # ------------------------------ METHODS ----------------------------------
-
     def get_plugin_title(self):
         """
         Return plugin title.
@@ -367,3 +365,12 @@ class SpyderPluginWidget(PluginWidget):
         your plugin too.
         """
         raise NotImplementedError
+
+    def get_current_filename(self):
+        """
+        Get the currently displayed file name.
+
+        This applies to plugins that can handle files in a QTabWiget, like
+        the Editor or spyder-notebook.
+        """
+        return None

--- a/spyder/api/plugins.py
+++ b/spyder/api/plugins.py
@@ -272,7 +272,7 @@ class SpyderPluginWidget(PluginWidget):
     # inside it.
     # Example: ['.ipynb'] for spyder-notebook
     # Status: Optional
-    registered_file_extensions = []
+    file_extensions = []
 
     # ------------------------------ METHODS ----------------------------------
 
@@ -362,5 +362,8 @@ class SpyderPluginWidget(PluginWidget):
     def open_file(self, filename=None):
         """
         Open filename inside the plugin.
+
+        To be able to use this method you need to define `file_extensions` for
+        your plugin too.
         """
         raise NotImplementedError

--- a/spyder/api/plugins.py
+++ b/spyder/api/plugins.py
@@ -273,6 +273,10 @@ class SpyderPluginWidget(PluginWidget):
     # Status: Optional
     file_extensions = []
 
+    # Declare if the plugin is able to save files
+    # Status: Optional
+    can_save_files = False
+
     # ------------------------------ METHODS ----------------------------------
     def get_plugin_title(self):
         """
@@ -366,9 +370,13 @@ class SpyderPluginWidget(PluginWidget):
         """
         raise NotImplementedError
 
+    def save_file(self):
+        """Save current file."""
+        pass
+
     def get_current_filename(self):
         """
-        Get the currently displayed file name.
+        Get the currently focused file name.
 
         This applies to plugins that can handle files in a QTabWiget, like
         the Editor or spyder-notebook.

--- a/spyder/api/plugins.py
+++ b/spyder/api/plugins.py
@@ -357,7 +357,7 @@ class SpyderPluginWidget(PluginWidget):
         valid = True
         return valid, message
 
-    def open_file(self, filename=None):
+    def open_file(self, filename):
         """
         Open filename inside the plugin.
 

--- a/spyder/api/plugins.py
+++ b/spyder/api/plugins.py
@@ -268,6 +268,12 @@ class SpyderPluginWidget(PluginWidget):
     # Status: Optional
     shortcut = None
 
+    # Registered file extesions that the plugin can open
+    # inside it.
+    # Example: ['.ipynb'] for spyder-notebook
+    # Status: Optional
+    registered_file_extensions = []
+
     # ------------------------------ METHODS ----------------------------------
 
     def get_plugin_title(self):
@@ -352,3 +358,9 @@ class SpyderPluginWidget(PluginWidget):
         message = ''
         valid = True
         return valid, message
+
+    def open_file(self, filename=None):
+        """
+        Open filename inside the plugin.
+        """
+        raise NotImplementedError

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2725,7 +2725,8 @@ class MainWindow(QMainWindow):
         if self.edit_filters is None:
             self.edit_filters = get_edit_filters()
 
-        # Try to get the current filename from the third-party plugins
+        # Try to get the current filename from the currently focused
+        # third-party plugin (if any)
         c_fname = None
         for plugin in self.thirdparty_plugins:
             if plugin.isAncestorOf(self.last_focused_widget):
@@ -2796,6 +2797,7 @@ class MainWindow(QMainWindow):
         for plugin in self.thirdparty_plugins:
             if ext in plugin.file_extensions:
                 plugin.open_file(fname)
+                return
 
         # Open file with the editor, the variable explorer or with
         # an external program

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2841,7 +2841,11 @@ class MainWindow(QMainWindow):
 
     def save_file(self):
         """Save currently focused file."""
-        self.editor.save()
+        for plugin in (self.widgetlist + self.thirdparty_plugins):
+            if (plugin.isAncestorOf(self.last_focused_widget) and
+                    plugin.can_save_files):
+                plugin.save_file()
+                return
 
     # ---- PYTHONPATH management, etc.
     def get_spyder_pythonpath(self):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2718,6 +2718,14 @@ class MainWindow(QMainWindow):
         """
         fname = to_text_string(fname)
         ext = osp.splitext(fname)[1]
+
+        # Go through third party plugins first
+        for plugin in self.thirdparty_plugins:
+            if ext in plugin.registered_file_extensions:
+                plugin.open_file(fname)
+
+        # Open file with the editor, the variable explorer or with
+        # an external program
         if encoding.is_text_file(fname):
             self.editor.load(fname)
         elif self.variableexplorer is not None and ext in IMPORT_EXT:

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -641,22 +641,32 @@ class MainWindow(QMainWindow):
                                "Use next layout")
         self.register_shortcut(self.toggle_previous_layout_action, "_",
                                "Use previous layout")
-        # File switcher shortcuts
+
+        # File toolbar actions
+        self.open_action = create_action(
+            self,
+            _("&Open..."),
+            icon=ima.icon('fileopen'),
+            tip=_("Open file"),
+            triggered=self.load_files,
+            context=Qt.ApplicationShortcut)
+        self.register_shortcut(self.open_action, context="_",
+                               name="Open file", add_sc_to_tip=True)
         self.file_switcher_action = create_action(
-                                    self,
-                                    _('File switcher...'),
-                                    icon=ima.icon('filelist'),
-                                    tip=_('Fast switch between files'),
-                                    triggered=self.open_fileswitcher,
-                                    context=Qt.ApplicationShortcut)
+            self,
+            _('File switcher...'),
+            icon=ima.icon('filelist'),
+            tip=_('Fast switch between files'),
+            triggered=self.open_fileswitcher,
+            context=Qt.ApplicationShortcut)
         self.register_shortcut(self.file_switcher_action, context="_",
-                               name="File switcher")
+                               name="File switcher", add_sc_to_tip=True)
         self.symbol_finder_action = create_action(
-                                    self, _('Symbol finder...'),
-                                    icon=ima.icon('symbol_find'),
-                                    tip=_('Fast symbol search in file'),
-                                    triggered=self.open_symbolfinder,
-                                    context=Qt.ApplicationShortcut)
+            self, _('Symbol finder...'),
+            icon=ima.icon('symbol_find'),
+            tip=_('Fast symbol search in file'),
+            triggered=self.open_symbolfinder,
+            context=Qt.ApplicationShortcut)
         self.register_shortcut(self.symbol_finder_action, context="_",
                                name="symbol finder", add_sc_to_tip=True)
         self.file_toolbar_actions = [self.file_switcher_action,

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -652,6 +652,15 @@ class MainWindow(QMainWindow):
             context=Qt.ApplicationShortcut)
         self.register_shortcut(self.open_action, context="_",
                                name="Open file", add_sc_to_tip=True)
+        self.save_action = create_action(
+            self,
+            _("&Save"),
+            icon=ima.icon('filesave'),
+            tip=_("Save file"),
+            triggered=self.save_file,
+            context=Qt.ApplicationShortcut)
+        self.register_shortcut(self.save_action, context="_",
+                               name="Save file", add_sc_to_tip=True)
         self.file_switcher_action = create_action(
             self,
             _('File switcher...'),
@@ -2829,6 +2838,10 @@ class MainWindow(QMainWindow):
             self.open_file(fname, external=True)
         elif osp.isfile(osp.join(CWD, fname)):
             self.open_file(osp.join(CWD, fname), external=True)
+
+    def save_file(self):
+        """Save currently focused file."""
+        self.editor.save()
 
     # ---- PYTHONPATH management, etc.
     def get_spyder_pythonpath(self):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2712,16 +2712,22 @@ class MainWindow(QMainWindow):
 
     def open_file(self, fname, external=False):
         """
-        Open filename with the appropriate application
-        Redirect to the right widget (txt -> editor, spydata -> workspace, ...)
-        or open file outside Spyder (if extension is not supported)
+        Open fname with the appropriate plugin.
+
+        This is the order we follow to do it:
+        1. We check all third-party plugin to see if one can open fname.
+        2. If fname is a plain text file, we open it with the Editor.
+        3. If fname is a type that can be imported in the Variable
+           Explorer, we open it there.
+        4. If none of the above applies, we use the OS application
+           registered to handle fname.
         """
         fname = to_text_string(fname)
         ext = osp.splitext(fname)[1]
 
         # Go through third party plugins first
         for plugin in self.thirdparty_plugins:
-            if ext in plugin.registered_file_extensions:
+            if ext in plugin.file_extensions:
                 plugin.open_file(fname)
 
         # Open file with the editor, the variable explorer or with

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -316,7 +316,7 @@ DEFAULTS = [
             ('shortcuts',
              {
               # ---- Global ----
-              # -- In app/spyder.py
+              # -- In app/mainwindow.py
               '_/close pane': "Shift+Ctrl+F4",
               '_/lock unlock panes': "Shift+Ctrl+F5",
               '_/use next layout': "Shift+Alt+PgDown",
@@ -330,6 +330,7 @@ DEFAULTS = [
               '_/spyder documentation': "F1",
               '_/restart': "Shift+Alt+R",
               '_/quit': "Ctrl+Q",
+              '_/open file': "Ctrl+O",
               # -- In plugins/editor
               '_/file switcher': 'Ctrl+P',
               '_/symbol finder': 'Ctrl+Alt+P',
@@ -413,7 +414,6 @@ DEFAULTS = [
               'editor/cycle to next file': 'Ctrl+PgDown',
               'editor/new file': "Ctrl+N",
               'editor/open last closed':"Ctrl+Shift+T",
-              'editor/open file': "Ctrl+O",
               'editor/save file': "Ctrl+S",
               'editor/save all': "Ctrl+Alt+S",
               'editor/save as': 'Ctrl+Shift+S',

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -331,6 +331,7 @@ DEFAULTS = [
               '_/restart': "Shift+Alt+R",
               '_/quit': "Ctrl+Q",
               '_/open file': "Ctrl+O",
+              '_/save file': "Ctrl+S",
               # -- In plugins/editor
               '_/file switcher': 'Ctrl+P',
               '_/symbol finder': 'Ctrl+Alt+P',
@@ -414,7 +415,6 @@ DEFAULTS = [
               'editor/cycle to next file': 'Ctrl+PgDown',
               'editor/new file': "Ctrl+N",
               'editor/open last closed':"Ctrl+Shift+T",
-              'editor/save file': "Ctrl+S",
               'editor/save all': "Ctrl+Alt+S",
               'editor/save as': 'Ctrl+Shift+S',
               'editor/close all': "Ctrl+Shift+W",

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -399,13 +399,6 @@ class Editor(SpyderPluginWidget):
                 icon=ima.icon('revert'), tip=_("Revert file from disk"),
                 triggered=self.revert)
 
-        self.save_action = create_action(self, _("&Save"),
-                icon=ima.icon('filesave'), tip=_("Save file"),
-                triggered=self.save,
-                context=Qt.WidgetShortcut)
-        self.register_shortcut(self.save_action, context="Editor",
-                               name="Save file", add_sc_to_tip=True)
-
         self.save_all_action = create_action(self, _("Sav&e all"),
                 icon=ima.icon('save_all'), tip=_("Save all files"),
                 triggered=self.save_all,
@@ -784,7 +777,7 @@ class Editor(SpyderPluginWidget):
                              self.open_last_closed_action,
                              self.recent_file_menu,
                              MENU_SEPARATOR,
-                             self.save_action,
+                             self.main.save_action,
                              self.save_all_action,
                              save_as_action,
                              save_copy_as_action,
@@ -799,7 +792,7 @@ class Editor(SpyderPluginWidget):
 
         self.main.file_menu_actions += file_menu_actions
         file_toolbar_actions = ([self.new_action, self.main.open_action,
-                                self.save_action, self.save_all_action] +
+                                self.main.save_action, self.save_all_action] +
                                 self.main.file_toolbar_actions)
 
         self.main.file_toolbar_actions = file_toolbar_actions
@@ -915,7 +908,7 @@ class Editor(SpyderPluginWidget):
                                              self.winpdb_action]
         self.cythonfile_compatible_actions = [run_action, configure_action]
         self.file_dependent_actions = self.pythonfile_dependent_actions + \
-                [self.save_action, save_as_action, save_copy_as_action,
+                [self.main.save_action, save_as_action, save_copy_as_action,
                  print_preview_action, self.print_action,
                  self.save_all_action, gotoline_action, workdir_action,
                  self.close_action, self.close_all_action,
@@ -1077,7 +1070,7 @@ class Editor(SpyderPluginWidget):
             = CONF.get('editor', 'autosave_mapping', {})
         editorstack.set_help(self.help)
         editorstack.set_io_actions(self.new_action, self.main.open_action,
-                                   self.save_action, self.revert_action)
+                                   self.main.save_action, self.revert_action)
         editorstack.set_tempfile_path(self.TEMPFILE_PATH)
 
         settings = (

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -395,13 +395,6 @@ class Editor(SpyderPluginWidget):
         self.register_shortcut(self.open_last_closed_action, context="Editor",
                                name="Open last closed")
 
-        self.open_action = create_action(self, _("&Open..."),
-                icon=ima.icon('fileopen'), tip=_("Open file"),
-                triggered=self.main.load_files,
-                context=Qt.WidgetShortcut)
-        self.register_shortcut(self.open_action, context="Editor",
-                               name="Open file", add_sc_to_tip=True)
-
         self.revert_action = create_action(self, _("&Revert"),
                 icon=ima.icon('revert'), tip=_("Revert file from disk"),
                 triggered=self.revert)
@@ -787,10 +780,9 @@ class Editor(SpyderPluginWidget):
 
         file_menu_actions = [self.new_action,
                              MENU_SEPARATOR,
-                             self.open_action,
+                             self.main.open_action,
                              self.open_last_closed_action,
                              self.recent_file_menu,
-                             MENU_SEPARATOR,
                              MENU_SEPARATOR,
                              self.save_action,
                              self.save_all_action,
@@ -806,7 +798,7 @@ class Editor(SpyderPluginWidget):
                              MENU_SEPARATOR]
 
         self.main.file_menu_actions += file_menu_actions
-        file_toolbar_actions = ([self.new_action, self.open_action,
+        file_toolbar_actions = ([self.new_action, self.main.open_action,
                                 self.save_action, self.save_all_action] +
                                 self.main.file_toolbar_actions)
 
@@ -1084,7 +1076,7 @@ class Editor(SpyderPluginWidget):
         editorstack.autosave_mapping \
             = CONF.get('editor', 'autosave_mapping', {})
         editorstack.set_help(self.help)
-        editorstack.set_io_actions(self.new_action, self.open_action,
+        editorstack.set_io_actions(self.new_action, self.main.open_action,
                                    self.save_action, self.revert_action)
         editorstack.set_tempfile_path(self.TEMPFILE_PATH)
 

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -92,6 +92,9 @@ class Editor(SpyderPluginWidget):
     open_file_update = Signal(str)
     sig_lsp_notification = Signal(dict, str)
 
+    # Public API
+    can_save_files = True
+
     def __init__(self, parent, ignore_last_opened_files=False):
         SpyderPluginWidget.__init__(self, parent)
 
@@ -948,6 +951,10 @@ class Editor(SpyderPluginWidget):
             for finfo in editorstack.data:
                 comp_widget = finfo.editor.completion_widget
                 comp_widget.setup_appearance(completion_size, font)
+
+    def save_file(self):
+        """Save the currently focused file."""
+        self.save()
 
     def _create_checkable_action(self, text, conf_name, editorstack_method):
         """Helper function to create a checkable action.

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -617,9 +617,6 @@ class EditorStack(QWidget):
         new_file = config_shortcut(lambda : self.sig_new_file[()].emit(),
                                    context='Editor', name='New file',
                                    parent=self)
-        open_file = config_shortcut(lambda : self.plugin_load[()].emit(),
-                                    context='Editor', name='Open file',
-                                    parent=self)
         save_file = config_shortcut(self.save, context='Editor',
                                     name='Save file', parent=self)
         save_all = config_shortcut(self.save_all, context='Editor',
@@ -708,7 +705,7 @@ class EditorStack(QWidget):
 
         # Return configurable ones
         return [inspect, set_breakpoint, set_cond_breakpoint, gotoline, tab,
-                tabshift, run_selection, new_file, open_file, save_file,
+                tabshift, run_selection, new_file, save_file,
                 save_all, save_as, close_all, prev_edit_pos, prev_cursor,
                 next_cursor, zoom_in_1, zoom_in_2, zoom_out, zoom_reset,
                 close_file_1, close_file_2, run_cell, run_cell_and_advance,

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -617,8 +617,6 @@ class EditorStack(QWidget):
         new_file = config_shortcut(lambda : self.sig_new_file[()].emit(),
                                    context='Editor', name='New file',
                                    parent=self)
-        save_file = config_shortcut(self.save, context='Editor',
-                                    name='Save file', parent=self)
         save_all = config_shortcut(self.save_all, context='Editor',
                                    name='Save all', parent=self)
         save_as = config_shortcut(lambda : self.sig_save_as.emit(),
@@ -705,7 +703,7 @@ class EditorStack(QWidget):
 
         # Return configurable ones
         return [inspect, set_breakpoint, set_cond_breakpoint, gotoline, tab,
-                tabshift, run_selection, new_file, save_file,
+                tabshift, run_selection, new_file,
                 save_all, save_as, close_all, prev_edit_pos, prev_cursor,
                 next_cursor, zoom_in_1, zoom_in_2, zoom_out, zoom_reset,
                 close_file_1, close_file_2, run_cell, run_cell_and_advance,


### PR DESCRIPTION
This PR provides a public API for external plugins to register their own functionality when the following buttons/actions are pressed in Spyder toolbar and its File menu:

- [ ] New file
- [x] Load file
- [x] Save file
- [ ] Save all
- [ ] Save as
- [ ] Recent files

Fixes #7794.

Temporal TODOs (just so I don't forget to address them):

- [ ] Save button is disabled when a file in the Editor is saved. It should be enabled/disabled in a per plugin basis.
- [ ] Rename PluginWidget to BasePluginWidget (update changelog about that).
- [ ] Add comments explaining what the signals in BasePluginWidget do.