### PR TITLE
PR: Don't show a file in the Editor immediately after it's selected in the switcher.

### DIFF
--- a/spyder/widgets/fileswitcher.py
+++ b/spyder/widgets/fileswitcher.py
@@ -193,6 +193,7 @@ class KeyPressFilter(QObject):
 
     sig_up_key_pressed = Signal()
     sig_down_key_pressed = Signal()
+    sig_enter_key_pressed = Signal()
 
     def eventFilter(self, src, e):
         if e.type() == QEvent.KeyPress:
@@ -200,9 +201,10 @@ class KeyPressFilter(QObject):
                 self.sig_up_key_pressed.emit()
             elif e.key() == Qt.Key_Down:
                 self.sig_down_key_pressed.emit()
+            elif e.key() == Qt.Key_Enter:
+                            sig_enter_key_pressed.emit()
 
         return super(KeyPressFilter, self).eventFilter(src, e)
-
 
 class FilesFilterLine(QLineEdit):
     """QLineEdit used to filter files by name."""
@@ -287,6 +289,7 @@ class FileSwitcher(QDialog):
         self.setLayout(layout)
 
         # Signals
+        self.filter.sig_enter_key_pressed.connect(self.enter)
         self.rejected.connect(self.restore_initial_state)
         self.filter.sig_up_key_pressed.connect(self.previous_row)
         self.filter.sig_down_key_pressed.connect(self.next_row)
@@ -609,13 +612,11 @@ class FileSwitcher(QDialog):
                 try:
                     stack_index = self.paths.index(self.filtered_path[row])
                     self.plugin = self.widgets[stack_index][1]
-                    plugin_index = self.plugins_instances.index(self.plugin)
+                    #plugin_index = self.plugins_instances.index(self.plugin)
                     # Count the real index in the tabWidget of the
                     # current plugin
-                    real_index = self.get_stack_index(stack_index,
-                                                      plugin_index)
-                    self.sig_goto_file.emit(real_index,
-                                            self.plugin.get_current_tab_manager())
+                    #real_index = self.get_stack_index(stack_index,
+                                                      #plugin_index)
                     self.goto_line(self.line_number)
                     try:
                         self.plugin.switch_to_plugin()
@@ -629,6 +630,23 @@ class FileSwitcher(QDialog):
             else:
                 line_number = self.filtered_symbol_lines[row]
                 self.goto_line(line_number)
+
+    def enter(self):
+        row = self.current_row()
+        if self.count() and row >= 0:
+            if '</b></big><br>' in self.list.currentItem().text() and row == 0:
+                self.next_row()
+            if self.mode == self.FILE_MODE:
+                try:
+                    stack_index = self.paths.index(self.filtered_path[row])
+                    self.plugin = self.widgets[stack_index][1]
+                    plugin_index = self.plugins_instances.index(self.plugin)
+                    real_index = self.get_stack_index(stack_index,
+                                                        plugin_index)
+                    self.sig_goto_file.emit(real_index,
+                                            self.plugin.get_current_tab_manager())
+                except ValueError:
+                    pass
 
     def setup_file_list(self, filter_text, current_path):
         """Setup list widget content for file list display."""

--- a/spyder/widgets/fileswitcher.py
+++ b/spyder/widgets/fileswitcher.py
@@ -191,11 +191,10 @@ def shorten_paths(path_list, is_unsaved):
 class KeyPressFilter(QObject):
     """Use with `installEventFilter` to get up/down arrow key press signal."""
     UP, DOWN = [-1, 1]  # Step constants
+
     sig_up_key_pressed = Signal()
     sig_down_key_pressed = Signal()
     sig_enter_key_pressed = Signal()
-    sig_mouse_clicked = Signal()
-    itemClicked = Signal()
 
     def eventFilter(self, src, e):
         if e.type() == QEvent.KeyPress:
@@ -206,6 +205,7 @@ class KeyPressFilter(QObject):
             elif (e.key() == Qt.Key_Return):
                 self.sig_enter_key_pressed.emit()
         return super(KeyPressFilter, self).eventFilter(src, e)
+
 
 class FilesFilterLine(QLineEdit):
     """QLineEdit used to filter files by name."""
@@ -227,7 +227,6 @@ class FilesFilterLine(QLineEdit):
 class FileSwitcher(QDialog):
     """A Sublime-like file switcher."""
     sig_goto_file = Signal(int, object)
-    sig_goto_file2 = Signal(object)
 
     # Constants that define the mode in which the list widget is working
     # FILE_MODE is for a list of files, SYMBOL_MODE if for a list of symbols

--- a/spyder/widgets/fileswitcher.py
+++ b/spyder/widgets/fileswitcher.py
@@ -201,8 +201,8 @@ class KeyPressFilter(QObject):
                 self.sig_up_key_pressed.emit()
             elif e.key() == Qt.Key_Down:
                 self.sig_down_key_pressed.emit()
-            elif e.key() == Qt.Key_Enter:
-                            sig_enter_key_pressed.emit()
+            elif (e.key() == Qt.Key_Enter) or (e.key() == Qt.Key_Return):
+                self.sig_enter_key_pressed.emit()
 
         return super(KeyPressFilter, self).eventFilter(src, e)
 
@@ -289,10 +289,10 @@ class FileSwitcher(QDialog):
         self.setLayout(layout)
 
         # Signals
-        self.filter.sig_enter_key_pressed.connect(self.enter)
         self.rejected.connect(self.restore_initial_state)
         self.filter.sig_up_key_pressed.connect(self.previous_row)
         self.filter.sig_down_key_pressed.connect(self.next_row)
+        self.filter.sig_enter_key_pressed.connect(self.enter)
         self.edit.returnPressed.connect(self.accept)
         self.edit.textChanged.connect(self.setup)
         self.list.itemSelectionChanged.connect(self.item_selection_changed)
@@ -612,11 +612,8 @@ class FileSwitcher(QDialog):
                 try:
                     stack_index = self.paths.index(self.filtered_path[row])
                     self.plugin = self.widgets[stack_index][1]
-                    #plugin_index = self.plugins_instances.index(self.plugin)
                     # Count the real index in the tabWidget of the
                     # current plugin
-                    #real_index = self.get_stack_index(stack_index,
-                                                      #plugin_index)
                     self.goto_line(self.line_number)
                     try:
                         self.plugin.switch_to_plugin()
@@ -633,20 +630,13 @@ class FileSwitcher(QDialog):
 
     def enter(self):
         row = self.current_row()
-        if self.count() and row >= 0:
-            if '</b></big><br>' in self.list.currentItem().text() and row == 0:
-                self.next_row()
-            if self.mode == self.FILE_MODE:
-                try:
-                    stack_index = self.paths.index(self.filtered_path[row])
-                    self.plugin = self.widgets[stack_index][1]
-                    plugin_index = self.plugins_instances.index(self.plugin)
-                    real_index = self.get_stack_index(stack_index,
-                                                        plugin_index)
-                    self.sig_goto_file.emit(real_index,
-                                            self.plugin.get_current_tab_manager())
-                except ValueError:
-                    pass
+        stack_index = self.paths.index(self.filtered_path[row])
+        self.plugin = self.widgets[stack_index][1]
+        plugin_index = self.plugins_instances.index(self.plugin)
+        real_index = self.get_stack_index(stack_index,
+                                          plugin_index)
+        self.sig_goto_file.emit(real_index,
+                                self.plugin.get_current_tab_manager())
 
     def setup_file_list(self, filter_text, current_path):
         """Setup list widget content for file list display."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

I implemented an enter function so that users have to press enter to switch files in the file switcher and it does not displays while charging the file with the arrows.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #
Item 8 of #8580 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Juanis2112

<!--- Thanks for your help making Spyder better for everyone! --->
