### PR TITLE
PR: Automatically use a separate but persistent configuration directory for non-stable releases

### DIFF
--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -15,14 +15,15 @@ sip API incompatibility issue in spyder's non-gui modules)
 from __future__ import print_function
 
 import codecs
+import getpass
 import locale
-import os.path as osp
 import os
+import os.path as osp
+import re
 import shutil
 import sys
-import warnings
-import getpass
 import tempfile
+import warnings
 
 # Local imports
 from spyder.utils import encoding
@@ -50,6 +51,23 @@ def running_under_pytest():
     variable SPYDER_PYTEST is defined in conftest.py.
     """
     return bool(os.environ.get('SPYDER_PYTEST'))
+
+
+def is_stable_version(version):
+    """
+    Return true if version is stable, i.e. with letters in the final component.
+
+    Stable version examples: ``1.2``, ``1.3.4``, ``1.0.5``.
+    Non-stable version examples: ``1.3.4beta``, ``0.1.0rc1``, ``3.0.0dev0``.
+    """
+    if not isinstance(version, tuple):
+        version = version.split('.')
+    last_part = version[-1]
+
+    if not re.search(r'[a-zA-Z]', last_part):
+        return True
+    else:
+        return False
 
 
 #==============================================================================

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -26,6 +26,7 @@ import tempfile
 import warnings
 
 # Local imports
+from spyder import __version__
 from spyder.utils import encoding
 from spyder.py3compat import (is_unicode, TEXT_TYPES, INT_TYPES, PY3,
                               to_text_string, is_text_string)
@@ -37,6 +38,9 @@ from spyder.py3compat import (is_unicode, TEXT_TYPES, INT_TYPES, PY3,
 # To activate/deactivate certain things for development
 # SPYDER_DEV is (and *only* has to be) set in bootstrap.py
 DEV = os.environ.get('SPYDER_DEV')
+
+# Manually override whether the dev configuration directory is used.
+USE_DEV_CONFIG_DIR = os.environ.get('SPYDER_USE_DEV_CONFIG_DIR')
 
 # Make Spyder use a temp clean configuration directory for testing purposes
 # SPYDER_SAFE_MODE can be set using the --safe-mode option of bootstrap.py
@@ -68,6 +72,16 @@ def is_stable_version(version):
         return True
     else:
         return False
+
+
+def use_dev_config_dir(use_dev_config_dir=USE_DEV_CONFIG_DIR):
+    """Return whether the dev configuration directory should used."""
+    if use_dev_config_dir is not None:
+        if use_dev_config_dir.lower() in {'false', '0'}:
+            use_dev_config_dir = False
+    else:
+        use_dev_config_dir = DEV or not is_stable_version(__version__)
+    return use_dev_config_dir
 
 
 #==============================================================================
@@ -120,6 +134,12 @@ else:
 #    completion) separately for each version
 if PY3:
     SUBFOLDER = SUBFOLDER + '-py3'
+
+
+# If running a development/beta version, save config in a seperate directory
+# to avoid wiping or contaiminating the user's saved stable configuration.
+if use_dev_config_dir():
+    SUBFOLDER = SUBFOLDER + '-dev'
 
 
 def get_home_dir():

--- a/spyder/config/tests/test_base.py
+++ b/spyder/config/tests/test_base.py
@@ -10,11 +10,18 @@
 Tests for the spyder.config.base module.
 """
 
+# Standard library imports
+import os.path as osp
+try:
+    from importlib import reload
+except ImportError:  # A builtin on Python 2
+    pass
+
 # Third party imports
 import pytest
 
 # Local imports
-from spyder.config.base import is_stable_version
+import spyder.config.base
 
 
 # ============================================================================
@@ -25,7 +32,22 @@ from spyder.config.base import is_stable_version
     ('3.3.2.dev0', False), ('beta', False), (('2', '0', 'alpha'), False)])
 def test_is_stable_version(version_input, expected_result):
     """Test that stable and non-stable versions are recognized correctly."""
-    assert is_stable_version(version_input) == expected_result
+    actual_result = spyder.config.base.is_stable_version(version_input)
+    assert actual_result == expected_result
+
+
+@pytest.mark.parametrize('use_dev_config_dir', [True, False])
+def test_get_conf_path(monkeypatch, use_dev_config_dir):
+    """Test that the config dir path is set under dev and release builds."""
+    monkeypatch.setenv('SPYDER_USE_DEV_CONFIG_DIR', str(use_dev_config_dir))
+    reload(spyder.config.base)
+    conf_path = spyder.config.base.get_conf_path()
+    assert conf_path
+    assert ((osp.basename(conf_path).split('-')[-1] == 'dev')
+            == use_dev_config_dir)
+    assert osp.isdir(conf_path)
+    monkeypatch.undo()
+    reload(spyder.config.base)
 
 
 if __name__ == '__main__':

--- a/spyder/config/tests/test_base.py
+++ b/spyder/config/tests/test_base.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2009- Spyder Project Contributors
+#
+# Distributed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+# -----------------------------------------------------------------------------
+
+"""
+Tests for the spyder.config.base module.
+"""
+
+# Third party imports
+import pytest
+
+# Local imports
+from spyder.config.base import is_stable_version
+
+
+# ============================================================================
+# ---- Tests
+# ============================================================================
+@pytest.mark.parametrize('version_input, expected_result', [
+    ('3.3.0', True), ('2', True), (('0', '5'), True), ('4.0.0b1', False),
+    ('3.3.2.dev0', False), ('beta', False), (('2', '0', 'alpha'), False)])
+def test_is_stable_version(version_input, expected_result):
+    """Test that stable and non-stable versions are recognized correctly."""
+    assert is_stable_version(version_input) == expected_result
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/spyder/config/tests/test_base.py
+++ b/spyder/config/tests/test_base.py
@@ -27,13 +27,13 @@ import spyder.config.base
 # ============================================================================
 # ---- Tests
 # ============================================================================
-@pytest.mark.parametrize('version_input, expected_result', [
-    ('3.3.0', True), ('2', True), (('0', '5'), True), ('4.0.0b1', False),
-    ('3.3.2.dev0', False), ('beta', False), (('2', '0', 'alpha'), False)])
-def test_is_stable_version(version_input, expected_result):
+def test_is_stable_version():
     """Test that stable and non-stable versions are recognized correctly."""
-    actual_result = spyder.config.base.is_stable_version(version_input)
-    assert actual_result == expected_result
+    for stable_version in ['3.3.0', '2', ('0', '5')]:
+        assert spyder.config.base.is_stable_version(stable_version)
+    for not_stable_version in ['4.0.0b1', '3.3.2.dev0',
+                               'beta', ('2', '0', 'alpha')]:
+        assert not spyder.config.base.is_stable_version(not_stable_version)
 
 
 @pytest.mark.parametrize('use_dev_config_dir', [True, False])

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -20,6 +20,7 @@ import sys
 import tempfile
 
 # Local imports
+from spyder.config.base import is_stable_version
 from spyder.config.utils import is_anaconda
 from spyder.utils import encoding
 from spyder.utils.misc import get_python_executable
@@ -336,23 +337,6 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
         # TODO: Add a fallback to OSX
     else:
         raise NotImplementedError
-
-
-def is_stable_version(version):
-    """
-    A stable version has no letters in the final component, but only numbers.
-
-    Stable version example: 1.2, 1.3.4, 1.0.5
-    Not stable version: 1.2alpha, 1.3.4beta, 0.1.0rc1, 3.0.0dev
-    """
-    if not isinstance(version, tuple):
-        version = version.split('.')
-    last_part = version[-1]
-
-    if not re.search(r'[a-zA-Z]', last_part):
-        return True
-    else:
-        return False
 
 
 def check_version(actver, version, cmp_op):

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -15,8 +15,7 @@ from spyder.utils.programs import (run_python_script_in_terminal,
                                    is_python_interpreter,
                                    is_python_interpreter_valid_name,
                                    find_program, shell_split, check_version,
-                                   is_module_installed, get_temp_dir,
-                                   is_stable_version)
+                                   is_module_installed, get_temp_dir)
 
 
 if os.name == 'nt':
@@ -137,13 +136,6 @@ def test_get_temp_dir_ensure_dir_exists():
 
     assert os.path.exists(another_call)
     assert another_call == temp_dir
-
-
-def test_is_stable_version():
-    """Test for is_stable_version."""
-    assert is_stable_version('3.3.0')
-    assert not is_stable_version('4.0.0b1')
-    assert not is_stable_version('3.3.2.dev0')
 
 
 if __name__ == '__main__':

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -16,10 +16,10 @@ from qtpy.QtCore import QObject, Signal
 
 # Local imports
 from spyder import __version__
-from spyder.config.base import _
+from spyder.config.base import _, is_stable_version
 from spyder.py3compat import PY3, is_text_string
 from spyder.config.utils import is_anaconda
-from spyder.utils.programs import check_version, is_stable_version
+from spyder.utils.programs import check_version
 
 
 if PY3:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->

Spyder betas and development versions (i.e. anything with alphabetical characters in the last version element), or with the ``SPYDER_DEV`` set) will automatically use a separate, but persistent config directory, in order to not pollute, modify or wipe the user's primary production config. This behavior can be customized/overriden (necessary for the test) with a environment variable ``SPYDER_USE_DEV_CONFIG_DIR`` environment variable. The tests took far more effort and complexity than they should to get working, but I finally got everything to play nice in the end.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #7680


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM-Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
