### PR TITLE
PR: Improve logging of PyLS server and our client in debug mode

### DIFF
--- a/spyder/plugins/editor/lsp/client.py
+++ b/spyder/plugins/editor/lsp/client.py
@@ -113,12 +113,19 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
 
         server_log = subprocess.PIPE
         if get_debug_level() > 0:
+            # Create server log file
             server_log_fname = 'server_{0}.log'.format(self.language)
             server_log_file = get_conf_path(osp.join('lsp_logs',
                                                      server_log_fname))
             if not osp.exists(osp.dirname(server_log_file)):
                 os.makedirs(osp.dirname(server_log_file))
             server_log = open(server_log_file, 'w')
+
+            # Start server with logging options
+            if get_debug_level() == 2:
+                self.server_args.append('-v')
+            elif get_debug_level() == 3:
+                self.server_args.append('-vv')
 
         if not self.external_server:
             logger.info('Starting server: {0}'.format(
@@ -135,6 +142,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
 
         client_log = subprocess.PIPE
         if get_debug_level() > 0:
+            # Client log file
             client_log_fname = 'client_{0}.log'.format(self.language)
             client_log_file = get_conf_path(osp.join('lsp_logs',
                                                      client_log_fname))

--- a/spyder/plugins/editor/lsp/client.py
+++ b/spyder/plugins/editor/lsp/client.py
@@ -111,13 +111,14 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         self.transport_args += ['--zmq-in-port', self.zmq_out_port,
                                 '--zmq-out-port', self.zmq_in_port]
 
-        self.lsp_server_log = subprocess.PIPE
+        server_log = subprocess.PIPE
         if get_debug_level() > 0:
-            lsp_server_file = 'lsp_server_{0}.log'.format(self.language)
-            log_file = get_conf_path(osp.join('lsp_logs', lsp_server_file))
-            if not osp.exists(osp.dirname(log_file)):
-                os.makedirs(osp.dirname(log_file))
-            self.lsp_server_log = open(log_file, 'w')
+            server_log_fname = 'server_{0}.log'.format(self.language)
+            server_log_file = get_conf_path(osp.join('lsp_logs',
+                                                     server_log_fname))
+            if not osp.exists(osp.dirname(server_log_file)):
+                os.makedirs(osp.dirname(server_log_file))
+            server_log = open(server_log_file, 'w')
 
         if not self.external_server:
             logger.info('Starting server: {0}'.format(
@@ -128,19 +129,18 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
                                   | 0x08000000)  # CREATE_NO_WINDOW
             self.lsp_server = subprocess.Popen(
                 self.server_args,
-                stdout=self.lsp_server_log,
+                stdout=server_log,
                 stderr=subprocess.STDOUT,
                 creationflags=creation_flags)
-            # self.transport_args += self.server_args
 
-        self.stdout_log = subprocess.PIPE
-        self.stderr_log = subprocess.PIPE
+        client_log = subprocess.PIPE
         if get_debug_level() > 0:
-            stderr_log_file = 'lsp_transport_{0}_err.log'.format(self.language)
-            log_file = get_conf_path(osp.join('lsp_logs', stderr_log_file))
-            if not osp.exists(osp.dirname(log_file)):
-                os.makedirs(osp.dirname(log_file))
-            self.stderr_log = open(log_file, 'w')
+            client_log_fname = 'client_{0}.log'.format(self.language)
+            client_log_file = get_conf_path(osp.join('lsp_logs',
+                                                     client_log_fname))
+            if not osp.exists(osp.dirname(client_log_file)):
+                os.makedirs(osp.dirname(client_log_file))
+            client_log = open(client_log_file, 'w')
 
         new_env = dict(os.environ)
         python_path = os.pathsep.join(sys.path)[1:]
@@ -149,8 +149,8 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         logger.info('Starting transport: {0}'
                     .format(' '.join(self.transport_args)))
         self.transport_client = subprocess.Popen(self.transport_args,
-                                                 stdout=self.stdout_log,
-                                                 stderr=self.stderr_log,
+                                                 stdout=subprocess.PIPE,
+                                                 stderr=client_log,
                                                  env=new_env)
 
         fid = self.zmq_in_socket.getsockopt(zmq.FD)

--- a/spyder/plugins/editor/lsp/transport/producer.py
+++ b/spyder/plugins/editor/lsp/transport/producer.py
@@ -64,26 +64,28 @@ class LanguageServerClient:
 
         LOGGER.info('Connecting to language server at {0}:{1}'.format(
             self.host, self.port))
-        connected = False
 
+        connected = False
         initial_time = time.time()
+        connection_error = None
         while not connected:
-            LOGGER.info('Attempting LSP server connection {0}:{1}'.
-                        format(self.host, self.port))
             try:
                 self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self.socket.connect((self.host, int(self.port)))
                 connected = True
             except Exception as e:
-                LOGGER.info('Connection error: {}'.format(e))
+                connection_error = e
 
             if time.time() - initial_time > self.MAX_TIMEOUT_TIME:
                 break
 
         if not connected:
             LOGGER.error("The client was unable to establish a connection "
-                         "with the language server, terminating process...")
-            raise Exception('Error!')
+                         "with the Language Server. The error was: "
+                         "{}".format(connection_error))
+            raise Exception("An error occurred while trying to create a "
+                            "client to connect to the Language Server! The "
+                            "error was\n\n{}".format(connection_error))
 
         self.socket.setblocking(True)
 

--- a/spyder/plugins/editor/lsp/transport/producer.py
+++ b/spyder/plugins/editor/lsp/transport/producer.py
@@ -38,7 +38,7 @@ LOGGER = logging.getLogger(__name__)
 class LanguageServerClient:
     """Implementation of a v3.0 compilant language server client."""
     CONTENT_LENGTH = 'Content-Length: {0}\r\n\r\n'
-    MAX_TIMEOUT_TIME = 5000
+    MAX_TIMEOUT_TIME = 20000
 
     def __init__(self, host='127.0.0.1', port=2087, workspace=getcwd(),
                  use_external_server=False, zmq_in_port=7000,


### PR DESCRIPTION
This PR solves the following problems:

1. We were not starting the PyLS server with logging options when Spyder is in debug mode, so nothing was logged from it.
2. Our client was logging thousands of failed connection attempts before the PyLS was really ready to receive connections. So this added a ton of useless info to the client's log.

Pinging @steff456 so she's aware of this change. I discovered these problems while trying to find why Rope completions are not working on the PyLS.