### PR TITLE
PR: Change default root_path for PyLS and refactor LSP related code

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -903,7 +903,7 @@ class MainWindow(QMainWindow):
 
         # Start LSP client
         self.set_splash(_("Launching LSP Client for Python..."))
-        self.lspmanager.start_client('python')
+        self.lspmanager.start_client(language='python')
 
         # Populating file menu entries
         quit_action = create_action(self, _("&Quit"),

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -903,7 +903,7 @@ class MainWindow(QMainWindow):
 
         # Start LSP client
         self.set_splash(_("Launching LSP Client for Python..."))
-        self.lspmanager.start_lsp_client('python')
+        self.lspmanager.start_client('python')
 
         # Populating file menu entries
         quit_action = create_action(self, _("&Quit"),

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -37,11 +37,11 @@ import importlib
 
 logger = logging.getLogger(__name__)
 
+
 #==============================================================================
 # Keeping a reference to the original sys.exit before patching it
 #==============================================================================
 ORIGINAL_SYS_EXIT = sys.exit
-
 
 #==============================================================================
 # Check requirements
@@ -50,7 +50,6 @@ from spyder import requirements
 requirements.check_path()
 requirements.check_qt()
 requirements.check_spyder_kernels()
-
 
 #==============================================================================
 # Windows only: support for hiding console window when started with python.exe
@@ -62,17 +61,6 @@ if os.name == 'nt':
     from spyder.utils.windows import (set_attached_console_visible,
                                       is_attached_console_visible,
                                       set_windows_appusermodelid)
-
-
-#==============================================================================
-# Workaround: importing rope.base.project here, otherwise this module can't
-# be imported if Spyder was executed from another folder than spyder
-#==============================================================================
-try:
-    import rope.base.project  # analysis:ignore
-except ImportError:
-    pass
-
 
 #==============================================================================
 # Qt imports
@@ -111,7 +99,6 @@ from spyder.config.main import CONF
 if hasattr(Qt, 'AA_EnableHighDpiScaling'):
     QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling,
                                   CONF.get('main', 'high_dpi_scaling'))
-
 
 #==============================================================================
 # Create our QApplication instance here because it's needed to render the
@@ -164,9 +151,7 @@ from spyder.utils import encoding, programs
 from spyder.utils import icon_manager as ima
 from spyder.utils.programs import is_module_installed
 from spyder.utils.misc import select_port, getcwd_or_home, get_python_executable
-from spyder.widgets.fileswitcher import FileSwitcher
 from spyder.plugins.help.utils.sphinxify import CSS_PATH, DARK_CSS_PATH
-from spyder.plugins.editor.lsp.manager import LSPManager
 from spyder.config.gui import is_dark_font_color
 
 #==============================================================================
@@ -199,7 +184,6 @@ import qdarkstyle
 # used in the last session
 #==============================================================================
 CWD = getcwd_or_home()
-
 
 #==============================================================================
 # Utility functions
@@ -265,11 +249,9 @@ def setup_logging(cli_options):
 # =============================================================================
 # Dependencies
 # =============================================================================
-
 QDARKSTYLE_REQVER = '>=2.6.4'
 dependencies.add("qdarkstyle", _("Dark style for the entire interface"),
                  required_version=QDARKSTYLE_REQVER)
-
 
 #==============================================================================
 # Main Window
@@ -872,6 +854,7 @@ class MainWindow(QMainWindow):
 
         # Language Server Protocol Client initialization
         self.set_splash(_("Starting Language Server Protocol manager..."))
+        from spyder.plugins.editor.lsp.manager import LSPManager
         self.lspmanager = LSPManager(self)
 
         # Working directory plugin
@@ -3057,6 +3040,7 @@ class MainWindow(QMainWindow):
     def add_to_fileswitcher(self, plugin, tabs, data, icon):
         """Add a plugin to the File Switcher."""
         if self.fileswitcher is None:
+            from spyder.widgets.fileswitcher import FileSwitcher
             self.fileswitcher = FileSwitcher(self, plugin, tabs, data, icon)
         else:
             self.fileswitcher.add_plugin(plugin, tabs, data, icon)

--- a/spyder/plugins/editor/lsp/client.py
+++ b/spyder/plugins/editor/lsp/client.py
@@ -59,10 +59,10 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
                         '--server-port %(port)s '
                         '--server %(cmd)s')
 
-    def __init__(self, parent, server_args_fmt='',
-                 server_settings={}, external_server=False,
-                 folder=getcwd_or_home(), language='python',
-                 plugin_configurations={}):
+    def __init__(self, parent,
+                 server_settings={},
+                 folder=getcwd_or_home(),
+                 language='python'):
         QObject.__init__(self)
         # LSPMethodProviderMixIn.__init__(self)
         self.manager = parent
@@ -83,14 +83,15 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
 
         self.transport_args = [sys.executable, '-u',
                                osp.join(LOCATION, 'transport', 'main.py')]
-        self.external_server = external_server
+        self.external_server = server_settings.get('external', False)
 
         self.folder = folder
-        self.plugin_configurations = plugin_configurations
+        self.plugin_configurations = server_settings.get('configurations', {})
         self.client_capabilites = CLIENT_CAPABILITES
         self.server_capabilites = SERVER_CAPABILITES
         self.context = zmq.Context()
 
+        server_args_fmt = server_settings.get('args', '')
         server_args = server_args_fmt.format(**server_settings)
         # transport_args = self.local_server_fmt % (server_settings)
         # if self.external_server:

--- a/spyder/plugins/editor/lsp/client.py
+++ b/spyder/plugins/editor/lsp/client.py
@@ -11,16 +11,19 @@ This client implements the calls and procedures required to
 communicate with a v3.0 Language Server Protocol server.
 """
 
+# Standard library imports
 import logging
 import os
 import os.path as osp
-import sys
 import signal
 import subprocess
+import sys
 
+# Third-party imports
 from qtpy.QtCore import QObject, Signal, QSocketNotifier, Slot
 import zmq
 
+# Local imports
 from spyder.py3compat import PY2
 from spyder.config.base import get_conf_path, get_debug_level
 from spyder.plugins.editor.lsp import (
@@ -32,17 +35,17 @@ from spyder.plugins.editor.lsp.decorators import (
 from spyder.plugins.editor.lsp.providers import LSPMethodProviderMixIn
 from spyder.utils.misc import getcwd_or_home
 
+# Conditional imports
 if PY2:
     import pathlib2 as pathlib
 else:
     import pathlib
 
-
+# Main constants
 LOCATION = osp.realpath(osp.join(os.getcwd(),
                                  osp.dirname(__file__)))
 PENDING = 'pending'
 SERVER_READY = 'server_ready'
-WINDOWS = os.name == 'nt'
 
 
 logger = logging.getLogger(__name__)
@@ -132,7 +135,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
             logger.info('Starting server: {0}'.format(
                 ' '.join(self.server_args)))
             creation_flags = 0
-            if WINDOWS:
+            if os.name == 'nt':
                 creation_flags = (subprocess.CREATE_NEW_PROCESS_GROUP
                                   | 0x08000000)  # CREATE_NO_WINDOW
             self.lsp_server = subprocess.Popen(
@@ -176,7 +179,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
             self.notifier.activated.disconnect(self.on_msg_received)
             self.notifier.setEnabled(False)
             self.notifier = None
-        # if WINDOWS:
+        # if os.name == 'nt':
         #     self.transport_client.send_signal(signal.CTRL_BREAK_EVENT)
         # else:
         self.transport_client.kill()

--- a/spyder/plugins/editor/lsp/manager.py
+++ b/spyder/plugins/editor/lsp/manager.py
@@ -72,7 +72,7 @@ class LSPManager(QObject):
         return path
 
     @Slot()
-    def reinit_all_lsp_clients(self):
+    def reinitialize_all_lsp_clients(self):
         """
         Send a new initialize message to each LSP server when the project
         path has changed so they can update the respective server root paths.

--- a/spyder/plugins/editor/lsp/manager.py
+++ b/spyder/plugins/editor/lsp/manager.py
@@ -96,7 +96,7 @@ class LSPManager(QObject):
         return path
 
     @Slot()
-    def reinitialize_all_lsp_clients(self):
+    def reinitialize_all_clients(self):
         """
         Send a new initialize message to each LSP server when the project
         path has changed so they can update the respective server root paths.
@@ -109,7 +109,8 @@ class LSPManager(QObject):
                 instance.folder = folder
                 instance.initialize()
 
-    def start_lsp_client(self, language):
+    def start_client(self, language):
+        """Start an LSP client for a given language."""
         started = False
         if language in self.clients:
             language_client = self.clients[language]
@@ -175,7 +176,7 @@ class LSPManager(QObject):
                     elif self.clients[language]['status'] == self.RUNNING:
                         self.close_client(language)
                         self.clients[language] = config
-                        self.start_lsp_client(language)
+                        self.start_client(language)
                 else:
                     if self.clients[language]['status'] == self.RUNNING:
                         client = self.clients[language]['instance']

--- a/spyder/plugins/editor/lsp/tests/test_client.py
+++ b/spyder/plugins/editor/lsp/tests/test_client.py
@@ -30,12 +30,11 @@ class LSPEditor(QObject):
 def lsp_client(qtbot):
     config = CONF.get('lsp-server', 'python')
     lsp_editor = LSPEditor()
-    lsp = LSPClient(None, config['args'], config, config['external'],
-                    plugin_configurations=config.get('configurations', {}),
+    lsp = LSPClient(parent=None,
+                    server_settings=config,
                     language='python')
     lsp.register_plugin_type(
         LSPEventTypes.DOCUMENT, lsp_editor.sig_lsp_notification)
-    # qtbot.addWidget(lsp)
     yield lsp, lsp_editor
     if os.name != 'nt':
         lsp.stop()

--- a/spyder/plugins/editor/lsp/transport/consumer.py
+++ b/spyder/plugins/editor/lsp/transport/consumer.py
@@ -27,7 +27,9 @@ if not os.name == 'nt':
 
 TIMEOUT = 5000
 PID = os.getpid()
-LOGGER = logging.getLogger(__name__)
+
+
+logger = logging.getLogger(__name__)
 
 
 class IncomingMessageThread(Thread):
@@ -55,7 +57,7 @@ class IncomingMessageThread(Thread):
         self.expect.expect('\r\n\r\n', timeout=None)
         headers = self.expect.before
         headers = self.parse_headers(headers)
-        LOGGER.debug(headers)
+        logger.debug(headers)
         content_length = int(headers[b'Content-Length'])
         body = self.expect.read(size=content_length)
         return self.encode_body(body, headers)
@@ -80,14 +82,14 @@ class IncomingMessageThread(Thread):
                         headers, buffer = split
                         continue_reading = False
             except socket.error as e:
-                LOGGER.error(e)
+                logger.error(e)
                 raise e
         headers = self.parse_headers(headers)
-        LOGGER.debug(headers)
+        logger.debug(headers)
         content_length = int(headers[b'Content-Length'])
         pending_bytes = content_length - len(buffer)
         while pending_bytes > 0:
-            LOGGER.debug('Pending bytes...' + str(pending_bytes))
+            logger.debug('Pending bytes...' + str(pending_bytes))
             recv = self.socket.recv(min(1024, pending_bytes))
             buffer += recv
             pending_bytes -= len(recv)
@@ -97,7 +99,7 @@ class IncomingMessageThread(Thread):
         while True:
             with self.mutex:
                 if self.stopped:
-                    LOGGER.debug('Stopping Thread...')
+                    logger.debug('Stopping Thread...')
                     break
             try:
                 body = self.read_sock()
@@ -106,17 +108,17 @@ class IncomingMessageThread(Thread):
                     body = json.loads(body)
                 except (ValueError, TypeError) as e:
                     err = True
-                    LOGGER.error(e)
+                    logger.error(e)
                 if not err:
-                    LOGGER.debug(body)
+                    logger.debug(body)
                     self.zmq_sock.send_pyobj(body)
-                    LOGGER.debug('Message sent')
+                    logger.debug('Message sent')
             except socket.error as e:
-                LOGGER.error(e)
-        LOGGER.debug('Thread stopped.')
+                logger.error(e)
+        logger.debug('Thread stopped.')
 
     def parse_headers(self, headers):
-        LOGGER.debug(headers)
+        logger.debug(headers)
         headers = headers.split(b'\r\n')
         header_dict = dict([x.split(b': ') for x in headers])
         return header_dict

--- a/spyder/plugins/editor/lsp/transport/main.py
+++ b/spyder/plugins/editor/lsp/transport/main.py
@@ -13,17 +13,20 @@ Spyder MS Language Server v3.0 transport proxy implementation.
 Main point-of-entry to start an LSP ZMQ/TCP transport proxy.
 """
 
-
+# Standard library imports
+import argparse
+import logging
 import os
 import psutil
 import signal
-import logging
-import argparse
+
+# Local imports
 from spyder.py3compat import getcwd
 from producer import LanguageServerClient
 
-LOGGER = logging.getLogger(__name__)
-WINDOWS = os.name == 'nt'
+
+logger = logging.getLogger(__name__)
+
 
 parser = argparse.ArgumentParser(
     description='ZMQ Python-based MS Language-Server v3.0 client for Spyder')
@@ -86,13 +89,13 @@ class SignalManager:
         self.original_sigterm = signal.getsignal(signal.SIGTERM)
         signal.signal(signal.SIGINT, self.exit_gracefully)
         signal.signal(signal.SIGTERM, self.exit_gracefully)
-        if WINDOWS:
+        if os.name == 'nt':
             self.original_sigbreak = signal.getsignal(signal.SIGBREAK)
             signal.signal(signal.SIGBREAK, self.exit_gracefully)
 
     def exit_gracefully(self, signum, frame):
         """Capture exit/kill signal and throw and exception."""
-        LOGGER.info('Termination signal ({}) captured, '
+        logger.info('Termination signal ({}) captured, '
                     'initiating exit sequence'.format(signum))
         raise TerminateSignal("Exit process!")
 
@@ -100,7 +103,7 @@ class SignalManager:
         """Restore signal handlers to their original settings."""
         signal.signal(signal.SIGINT, self.original_sigint)
         signal.signal(signal.SIGTERM, self.original_sigterm)
-        if WINDOWS:
+        if os.name == 'nt':
             signal.signal(signal.SIGBREAK, self.original_sigbreak)
 
 

--- a/spyder/plugins/editor/lsp/transport/main.py
+++ b/spyder/plugins/editor/lsp/transport/main.py
@@ -21,8 +21,8 @@ import psutil
 import signal
 
 # Local imports
-from spyder.py3compat import getcwd
 from spyder.plugins.editor.lsp.transport.producer import LanguageServerClient
+from spyder.py3compat import getcwd
 
 
 logger = logging.getLogger(__name__)

--- a/spyder/plugins/editor/lsp/transport/main.py
+++ b/spyder/plugins/editor/lsp/transport/main.py
@@ -22,7 +22,7 @@ import signal
 
 # Local imports
 from spyder.py3compat import getcwd
-from producer import LanguageServerClient
+from spyder.plugins.editor.lsp.transport.producer import LanguageServerClient
 
 
 logger = logging.getLogger(__name__)

--- a/spyder/plugins/editor/lsp/transport/producer.py
+++ b/spyder/plugins/editor/lsp/transport/producer.py
@@ -15,17 +15,21 @@ queue, encapsulates them into valid JSONRPC messages and sends them to an
 LSP server via TCP.
 """
 
-
-import os
-import zmq
+# Standard library imports
 import json
-import time
-import socket
-import sys
 import logging
+import os
+import socket
 import subprocess
+import sys
+import time
+
+# Third party imports
+import zmq
+
+# Local imports
+from spyder.plugins.editor.lsp.transport.consumer import IncomingMessageThread
 from spyder.py3compat import getcwd
-from consumer import IncomingMessageThread
 
 
 TIMEOUT = 5000

--- a/spyder/plugins/editor/lsp/transport/producer.py
+++ b/spyder/plugins/editor/lsp/transport/producer.py
@@ -34,9 +34,9 @@ from spyder.py3compat import getcwd
 
 TIMEOUT = 5000
 PID = os.getpid()
-WINDOWS = os.name == 'nt'
 
-LOGGER = logging.getLogger(__name__)
+
+logger = logging.getLogger(__name__)
 
 
 class LanguageServerClient:
@@ -56,17 +56,17 @@ class LanguageServerClient:
         self.server = None
         self.is_local_server_running = not use_external_server
         if not use_external_server:
-            LOGGER.info('Starting server: {0} {1} on {2}:{3}'.format(
+            logger.info('Starting server: {0} {1} on {2}:{3}'.format(
                 server, ' '.join(server_args), self.host, self.port))
             exec_line = [sys.executable, '-m', server] + server_args
-            LOGGER.info(' '.join(exec_line))
+            logger.info(' '.join(exec_line))
 
             self.server = subprocess.Popen(
                 exec_line,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
 
-        LOGGER.info('Connecting to language server at {0}:{1}'.format(
+        logger.info('Connecting to language server at {0}:{1}'.format(
             self.host, self.port))
 
         connected = False
@@ -84,7 +84,7 @@ class LanguageServerClient:
                 break
 
         if not connected:
-            LOGGER.error("The client was unable to establish a connection "
+            logger.error("The client was unable to establish a connection "
                          "with the Language Server. The error was: "
                          "{}".format(connection_error))
             raise Exception("An error occurred while trying to create a "
@@ -93,53 +93,43 @@ class LanguageServerClient:
 
         self.socket.setblocking(True)
 
-        # LOGGER.info('Initializing server connection...')
-        # self.__initialize()
-
-        LOGGER.info('Starting ZMQ connection...')
+        logger.info('Starting ZMQ connection...')
         self.context = zmq.Context()
         self.zmq_in_socket = self.context.socket(zmq.PAIR)
         self.zmq_in_socket.connect("tcp://localhost:{0}".format(zmq_in_port))
         self.zmq_out_socket = self.context.socket(zmq.PAIR)
         self.zmq_out_socket.connect("tcp://localhost:{0}".format(zmq_out_port))
-        LOGGER.info('Sending server_ready...')
+        logger.info('Sending server_ready...')
         self.zmq_out_socket.send_pyobj({'id': -1, 'method': 'server_ready',
                                         'params': {}})
 
-        LOGGER.info('Creating consumer Thread...')
+        logger.info('Creating consumer Thread...')
         self.reading_thread = IncomingMessageThread()
         self.reading_thread.initialize(self.socket, self.zmq_out_socket,
                                        self.req_status)
 
     def start(self):
         self.reading_thread.start()
-        LOGGER.info('Ready to receive/attend requests and responses!')
+        logger.info('Ready to receive/attend requests and responses!')
 
     def stop(self):
-        # LOGGER.info('Sending shutdown instruction to server')
-        # self.shutdown()
-        # LOGGER.info('Sending exit instruction to server')
-        # try:
-            # self.exit()
-        # except ConnectionAbortedError:
-            # pass
-        LOGGER.info('Closing TCP socket...')
+        logger.info('Closing TCP socket...')
         self.socket.close()
         if self.is_local_server_running:
-            LOGGER.info('Closing language server process...')
+            logger.info('Closing language server process...')
             self.server.terminate()
-        LOGGER.info('Closing consumer thread...')
+        logger.info('Closing consumer thread...')
         self.reading_thread.stop()
-        LOGGER.debug('Joining thread...')
+        logger.debug('Joining thread...')
         self.reading_thread.join()
-        LOGGER.debug('Exit routine should be complete')
+        logger.debug('Exit routine should be complete')
 
     def listen(self):
         events = self.zmq_in_socket.poll(TIMEOUT)
         # requests = []
         while events > 0:
             client_request = self.zmq_in_socket.recv_pyobj()
-            LOGGER.debug("Client Event: {0}".format(client_request))
+            logger.debug("Client Event: {0}".format(client_request))
             server_request = self.__compose_request(client_request['id'],
                                                     client_request['method'],
                                                     client_request['params'])
@@ -161,8 +151,8 @@ class LanguageServerClient:
         content = bytes(json_req.encode('utf-8'))
         content_length = len(content)
 
-        LOGGER.debug('Sending request of type: {0}'.format(request['method']))
-        LOGGER.debug(json_req)
+        logger.debug('Sending request of type: {0}'.format(request['method']))
+        logger.debug(json_req)
 
         content_length = self.CONTENT_LENGTH.format(
             content_length).encode('utf-8')

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -277,7 +277,7 @@ class Editor(SpyderPluginWidget):
         logger.debug('Call LSP for %s' % filename)
         language = options['language']
         callback = options['codeeditor']
-        stat = self.main.lspmanager.start_lsp_client(language.lower())
+        stat = self.main.lspmanager.start_client(language.lower())
         self.main.lspmanager.register_file(
             language.lower(), filename, callback)
         if stat:

--- a/spyder/plugins/editor/widgets/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/tests/test_warnings.py
@@ -57,7 +57,7 @@ def construct_editor(qtbot, *args, **kwargs):
     with qtbot.waitSignal(wrapper.sig_initialize, timeout=30000):
         editor.filename = 'test.py'
         editor.language = 'Python'
-        lsp_manager.start_lsp_client('python')
+        lsp_manager.start_client('python')
 
     text = ("def some_function():\n"  # D100, D103: Missing docstring
             "    \n"  # W293 trailing spaces

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -145,7 +145,7 @@ class Projects(SpyderPluginWidget):
             lambda v: self.main.workingdirectory.chdir(v))
         self.sig_project_loaded.connect(
             lambda v: self.main.set_window_title())
-        self.sig_project_loaded.connect(lspmgr.reinit_all_lsp_clients)
+        self.sig_project_loaded.connect(lspmgr.reinitialize_all_lsp_clients)
         self.sig_project_loaded.connect(
             lambda v: self.main.editor.setup_open_files())
         self.sig_project_loaded.connect(self.update_explorer)
@@ -154,7 +154,7 @@ class Projects(SpyderPluginWidget):
                 self.get_last_working_dir()))
         self.sig_project_closed.connect(
             lambda v: self.main.set_window_title())
-        self.sig_project_closed.connect(lspmgr.reinit_all_lsp_clients)
+        self.sig_project_closed.connect(lspmgr.reinitialize_all_lsp_clients)
         self.sig_project_closed.connect(
             lambda v: self.main.editor.setup_open_files())
         self.recent_project_menu.aboutToShow.connect(self.setup_menu_actions)

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -145,7 +145,7 @@ class Projects(SpyderPluginWidget):
             lambda v: self.main.workingdirectory.chdir(v))
         self.sig_project_loaded.connect(
             lambda v: self.main.set_window_title())
-        self.sig_project_loaded.connect(lspmgr.reinitialize_all_lsp_clients)
+        self.sig_project_loaded.connect(lspmgr.reinitialize_all_clients)
         self.sig_project_loaded.connect(
             lambda v: self.main.editor.setup_open_files())
         self.sig_project_loaded.connect(self.update_explorer)
@@ -154,7 +154,7 @@ class Projects(SpyderPluginWidget):
                 self.get_last_working_dir()))
         self.sig_project_closed.connect(
             lambda v: self.main.set_window_title())
-        self.sig_project_closed.connect(lspmgr.reinitialize_all_lsp_clients)
+        self.sig_project_closed.connect(lspmgr.reinitialize_all_clients)
         self.sig_project_closed.connect(
             lambda v: self.main.editor.setup_open_files())
         self.recent_project_menu.aboutToShow.connect(self.setup_menu_actions)


### PR DESCRIPTION
* Before we were using HOME by default for `root_path` and that was causing a huge delay when trying to get Rope completions. Now we use an empty dir inside our config one, just like we did in Spyder 3.
* This PR also refactors and renames several methods and constants related to our LSP integration.

@steff456, this should fix the Rope delays you found before. Please try it on your side (by enabling `rope_completion` and disabling `jedi_completion`) and let me know if it works for you or not.