### PR TITLE
PR: Increase minimal QtAwesome version to 0.5.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -232,7 +232,7 @@ install_requires = [
     'pycodestyle',
     'pylint',
     'psutil',
-    'qtawesome>=0.4.1',
+    'qtawesome>=0.5.7',
     'qtpy>=1.5.0',
     'pickleshare',
     'pyzmq',


### PR DESCRIPTION
That version fixes the problem with our icons not displaying correctly with PyQt 5.12

Fixes #8748.