### PR TITLE
PR: Fix force_refresh to only force with valid object entries (Help plugin)

### DIFF
--- a/spyder/plugins/help.py
+++ b/spyder/plugins/help.py
@@ -397,7 +397,7 @@ class Help(SpyderPluginWidget):
         self.combo.setMaxCount(self.get_option('max_history_entries'))
         self.combo.addItems( self.load_history() )
         self.combo.setItemText(0, '')
-        self.combo.valid.connect(lambda valid: self.force_refresh())
+        self.combo.valid.connect(lambda valid: self.force_refresh(valid))
 
         # Plain text docstring option
         self.docstring = True
@@ -750,11 +750,12 @@ class Help(SpyderPluginWidget):
             self.rich_text.webview.load(QUrl(url))
 
     #------ Public API ---------------------------------------------------------
-    def force_refresh(self):
-        if self.source_is_console():
-            self.set_object_text(None, force_refresh=True)
-        elif self._last_editor_doc is not None:
-            self.set_editor_doc(self._last_editor_doc, force_refresh=True)
+    def force_refresh(self, valid=True):
+        if valid:
+            if self.source_is_console():
+                self.set_object_text(None, force_refresh=True)
+            elif self._last_editor_doc is not None:
+                self.set_editor_doc(self._last_editor_doc, force_refresh=True)
 
     def set_object_text(self, text, force_refresh=False, ignore_unknown=False):
         """Set object analyzed by Help"""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

Use value of the `ObjectComboBox.valid` signal to ensure a force refresh only with valid values

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8762 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
