### PR TITLE
PR: Use generic Qt name instead of Qt4

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -445,9 +445,9 @@ the sympy module (e.g. plot)
                     calling_mayavi = True
                     break
         if calling_mayavi:
-            message = _("Changing backend to Qt4 for Mayavi")
+            message = _("Changing backend to Qt for Mayavi")
             self._append_plain_text(message + '\n')
-            self.silent_execute("%gui inline\n%gui qt4")
+            self.silent_execute("%gui inline\n%gui qt")
 
     def change_mpl_backend(self, command):
         """


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

Nowadays the Mayavi stack can use Qt5 instead of Qt4, so the message about Qt4 is outdated (and confuses users who submit bug reports to me). Now I see:
```
from mayavi import mlab
Changing backend to Qt for Mayavi
```
I suspect my `locale` changes are incomplete since I still see:
```
$ git grep "Changing backend to Qt4"
Binary file spyder/locale/de/LC_MESSAGES/spyder.mo matches
Binary file spyder/locale/es/LC_MESSAGES/spyder.mo matches
Binary file spyder/locale/fr/LC_MESSAGES/spyder.mo matches
Binary file spyder/locale/ja/LC_MESSAGES/spyder.mo matches
Binary file spyder/locale/pt_BR/LC_MESSAGES/spyder.mo matches
Binary file spyder/locale/ru/LC_MESSAGES/spyder.mo matches
```
Is there something I should do to update those? Some command that compiles the text files to create them...?

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

larsoner

<!--- Thanks for your help making Spyder better for everyone! --->
