### PR TITLE
PR: Set enabled value of start_button with is_valid (Static Code Analysis)

### DIFF
--- a/spyder_pylint/widgets/pylintgui.py
+++ b/spyder_pylint/widgets/pylintgui.py
@@ -219,6 +219,7 @@ class PylintWidget(QWidget):
         if self.rdata:
             self.remove_obsolete_items()
             self.filecombo.addItems(self.get_filenames())
+            self.start_button.setEnabled(self.filecombo.is_valid())
         else:
             self.start_button.setEnabled(False)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

Set enabled property of Analize button with `filecombobox.is_valid` to prevent running an analysis without a file path


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8841 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
