### PR TITLE
PR: Use generic Qt name instead of Qt4 when switching backend for Mayavi

### DIFF
--- a/spyder/widgets/ipythonconsole/shell.py
+++ b/spyder/widgets/ipythonconsole/shell.py
@@ -429,9 +429,9 @@ the sympy module (e.g. plot)
                     calling_mayavi = True
                     break
         if calling_mayavi:
-            message = _("Changing backend to Qt4 for Mayavi")
+            message = _("Changing backend to Qt for Mayavi")
             self._append_plain_text(message + '\n')
-            self.silent_execute("%gui inline\n%gui qt4")
+            self.silent_execute("%gui inline\n%gui qt")
 
     def change_mpl_backend(self, command):
         """


### PR DESCRIPTION
See #8908 -- this just goes to `3.x` instead of `master`. Updates message about Qt bindings for `mayavi`.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the Developer Certificate of Origin
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:

larsoner