### PR TITLE
PR: Don't raise an error if completion plugins fail to start

### DIFF
--- a/spyder/utils/introspection/plugin_client.py
+++ b/spyder/utils/introspection/plugin_client.py
@@ -101,7 +101,10 @@ class AsyncClient(QObject):
         self.process.finished.connect(self._on_finished)
         running = self.process.waitForStarted()
         if not running:
-            raise IOError('Could not start %s' % self)
+            # Don't raise an error if the plugin fails to start
+            # Fixes issue 8934
+            debug_print('Could not start %s' % self)
+            return
 
         # Set up the socket notifer.
         fid = self.socket.getsockopt(zmq.FD)


### PR DESCRIPTION
Since we completely replaced our completion architecture in Spyder 4, there's no point in trying to solve this issue, so we simply log the problem and pass.

Fixes #8934.