### PR TITLE
PR: Fix over-height resize of the Github login dialog

### DIFF
--- a/spyder/widgets/github/gh_login.py
+++ b/spyder/widgets/github/gh_login.py
@@ -33,7 +33,7 @@ class DlgGitHubLogin(QDialog):
 
     def __init__(self, parent, username, password, token, remember=False,
                  remember_token=False):
-        super(DlgGitHubLogin, self).__init__(parent)
+        QDialog.__init__(self, parent)
 
         title = _("Sign in to Github")
         self.resize(415, 375)
@@ -91,10 +91,10 @@ class DlgGitHubLogin(QDialog):
         basic_layout.addSpacerItem(QSpacerItem(QSpacerItem(0, 8)))
         basic_layout.addWidget(basic_lbl_msg)
         basic_layout.addSpacerItem(
-            QSpacerItem(QSpacerItem(0, 1000, vPolicy=QSizePolicy.Expanding)))
+            QSpacerItem(QSpacerItem(0, 50, vPolicy=QSizePolicy.Expanding)))
         basic_layout.addLayout(basic_form_layout)
         basic_layout.addSpacerItem(
-            QSpacerItem(QSpacerItem(0, 1000, vPolicy=QSizePolicy.Expanding)))
+            QSpacerItem(QSpacerItem(0, 50, vPolicy=QSizePolicy.Expanding)))
         basic_auth.setLayout(basic_layout)
         self.tabs.addTab(basic_auth, _("Password Only"))
 
@@ -137,10 +137,10 @@ class DlgGitHubLogin(QDialog):
         token_layout.addSpacerItem(QSpacerItem(QSpacerItem(0, 8)))
         token_layout.addWidget(token_lbl_msg)
         token_layout.addSpacerItem(
-            QSpacerItem(QSpacerItem(0, 1000, vPolicy=QSizePolicy.Expanding)))
+            QSpacerItem(QSpacerItem(0, 50, vPolicy=QSizePolicy.Expanding)))
         token_layout.addLayout(token_form_layout)
         token_layout.addSpacerItem(
-            QSpacerItem(QSpacerItem(0, 1000, vPolicy=QSizePolicy.Expanding)))
+            QSpacerItem(QSpacerItem(0, 50, vPolicy=QSizePolicy.Expanding)))
         token_auth.setLayout(token_layout)
         self.tabs.addTab(token_auth, _("Access Token"))
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

The height of the `QSpacerItem` used for the blank space in the dialog where excesive and trigger a resize to use all the height available in the screen.

A preview of the dialog with the change:

![github](https://user-images.githubusercontent.com/16781833/54733576-5407f380-4b68-11e9-82fb-1d502f12f330.gif)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8978 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
