### PR TITLE
PR: Simplify status bar content and reorganize code

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -141,11 +141,11 @@ class Editor(SpyderPluginWidget):
         # Configuration dialog size
         self.dialog_size = None
 
-        statusbar = self.main.statusBar()
-        self.readwrite_status = ReadWriteStatus(self, statusbar)
-        self.eol_status = EOLStatus(self, statusbar)
-        self.encoding_status = EncodingStatus(self, statusbar)
+        statusbar = parent.statusBar() # Create a status bar
         self.cursorpos_status = CursorPositionStatus(self, statusbar)
+        self.encoding_status = EncodingStatus(self, statusbar)
+        self.eol_status = EOLStatus(self, statusbar)
+        self.readwrite_status = ReadWriteStatus(self, statusbar)
 
         layout = QVBoxLayout()
         self.dock_toolbar = QToolBar(self)
@@ -1080,12 +1080,12 @@ class Editor(SpyderPluginWidget):
             editorstack.reset_statusbar.connect(self.encoding_status.hide)
             editorstack.reset_statusbar.connect(self.cursorpos_status.hide)
             editorstack.readonly_changed.connect(
-                                        self.readwrite_status.readonly_changed)
+                                        self.readwrite_status.update_readonly)
             editorstack.encoding_changed.connect(
-                                         self.encoding_status.encoding_changed)
+                                         self.encoding_status.update_encoding)
             editorstack.sig_editor_cursor_position_changed.connect(
-                                 self.cursorpos_status.cursor_position_changed)
-            editorstack.sig_refresh_eol_chars.connect(self.eol_status.eol_changed)
+                                 self.cursorpos_status.update_cursor_position)
+            editorstack.sig_refresh_eol_chars.connect(self.eol_status.update_eol)
 
         editorstack.autosave_mapping \
             = CONF.get('editor', 'autosave_mapping', {})

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -141,7 +141,7 @@ class Editor(SpyderPluginWidget):
         # Configuration dialog size
         self.dialog_size = None
 
-        statusbar = parent.statusBar() # Create a status bar
+        statusbar = parent.statusBar()  # Create a status bar
         self.cursorpos_status = CursorPositionStatus(self, statusbar)
         self.encoding_status = EncodingStatus(self, statusbar)
         self.eol_status = EOLStatus(self, statusbar)
@@ -1085,7 +1085,8 @@ class Editor(SpyderPluginWidget):
                                          self.encoding_status.update_encoding)
             editorstack.sig_editor_cursor_position_changed.connect(
                                  self.cursorpos_status.update_cursor_position)
-            editorstack.sig_refresh_eol_chars.connect(self.eol_status.update_eol)
+            editorstack.sig_refresh_eol_chars.connect(
+                self.eol_status.update_eol)
 
         editorstack.autosave_mapping \
             = CONF.get('editor', 'autosave_mapping', {})

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -47,8 +47,9 @@ from spyder.plugins.editor.widgets.editor import (EditorMainWindow, Printer,
 from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 from spyder.plugins.editor.utils.debugger import (clear_all_breakpoints,
                                                   clear_breakpoint)
-from spyder.widgets.status import (CursorPositionStatus, EncodingStatus,
-                                   EOLStatus, ReadWriteStatus)
+from spyder.plugins.editor.widgets.status import (CursorPositionStatus,
+                                                  EncodingStatus, EOLStatus,
+                                                  ReadWriteStatus)
 from spyder.api.plugins import SpyderPluginWidget
 from spyder.preferences.runconfig import (ALWAYS_OPEN_FIRST_RUN_OPTION,
                                           get_run_configuration,

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -52,8 +52,9 @@ from spyder.plugins.editor.widgets import codeeditor
 from spyder.plugins.editor.widgets.base import TextEditBaseWidget  # analysis:ignore
 from spyder.plugins.editor.widgets.codeeditor import Printer       # analysis:ignore
 from spyder.plugins.editor.widgets.codeeditor import get_file_language
-from spyder.widgets.status import (CursorPositionStatus, EncodingStatus,
-                                   EOLStatus, ReadWriteStatus)
+from spyder.plugins.editor.widgets.status import (CursorPositionStatus,
+                                                  EncodingStatus, EOLStatus,
+                                                  ReadWriteStatus)
 from spyder.widgets.tabs import BaseTabs
 from spyder.config.main import CONF
 from spyder.plugins.explorer.widgets import show_in_external_file_explorer

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2822,10 +2822,10 @@ class EditorWidget(QSplitter):
         self.setAttribute(Qt.WA_DeleteOnClose)
 
         statusbar = parent.statusBar() # Create a status bar
-        self.readwrite_status = ReadWriteStatus(self, statusbar)
-        self.eol_status = EOLStatus(self, statusbar)
-        self.encoding_status = EncodingStatus(self, statusbar)
         self.cursorpos_status = CursorPositionStatus(self, statusbar)
+        self.encoding_status = EncodingStatus(self, statusbar)
+        self.eol_status = EOLStatus(self, statusbar)
+        self.readwrite_status = ReadWriteStatus(self, statusbar)
 
         self.editorstacks = []
 

--- a/spyder/plugins/editor/widgets/status.py
+++ b/spyder/plugins/editor/widgets/status.py
@@ -12,7 +12,7 @@ from spyder.py3compat import to_text_string
 from spyder.widgets.status import StatusBarWidget
 
 
-class ReadWriteStatus(StatusBarWidget):    
+class ReadWriteStatus(StatusBarWidget):
     """Status bar widget for current file read/write mode."""
     TIP = _("File permissions")
 

--- a/spyder/plugins/editor/widgets/status.py
+++ b/spyder/plugins/editor/widgets/status.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""Status bar widgets."""
+
+# Local imports
+from spyder.config.base import _
+from spyder.py3compat import to_text_string
+from spyder.widgets.status import StatusBarWidget
+
+
+class ReadWriteStatus(StatusBarWidget):    
+    """Status bar widget for current file read/write mode."""
+    TIP = _("File permissions")
+
+    def update_readonly(self, readonly):
+        """Update read/write file status."""
+        value = "R" if readonly else "RW"
+        self.set_value(value.ljust(3))
+
+
+class EOLStatus(StatusBarWidget):
+    """Status bar widget for the current file end of line."""
+    TIP = _("End of line")
+
+    def update_eol(self, os_name):
+        """Update end of line status."""
+        os_name = to_text_string(os_name)
+        value = {"nt": "CRLF", "posix": "LF"}.get(os_name, "CR")
+        self.set_value(value)
+
+
+class EncodingStatus(StatusBarWidget):
+    """Status bar widget for the current file encoding."""
+    TIP = _("Encoding")
+
+    def update_encoding(self, encoding):
+        """Update encoding of current file."""
+        value = str(encoding).upper()
+        self.set_value(value)
+
+
+class CursorPositionStatus(StatusBarWidget):
+    """Status bar widget for the current file cursor postion."""
+    TIP = _("Cursor position")
+
+    def update_cursor_position(self, line, index):
+        """Update cursor position."""
+        value = 'Line {}, Col {}'.format(line + 1, index + 1)
+        self.set_value(value)
+
+
+def test():
+    from qtpy.QtWidgets import QMainWindow
+    from spyder.utils.qthelpers import qapplication
+
+    app = qapplication(test_time=5)
+    win = QMainWindow()
+    win.setWindowTitle("Status widgets test")
+    win.resize(900, 300)
+    statusbar = win.statusBar()
+    status_widgets = []
+    for status_class in (ReadWriteStatus, EOLStatus, EncodingStatus,
+                         CursorPositionStatus):
+        status_widget = status_class(win, statusbar)
+        status_widgets.append(status_widget)
+    win.show()
+    app.exec_()
+
+
+if __name__ == "__main__":
+    test()

--- a/spyder/plugins/editor/widgets/tests/test_status.py
+++ b/spyder/plugins/editor/widgets/tests/test_status.py
@@ -15,7 +15,9 @@ import pytest
 from qtpy.QtWidgets import QMainWindow
 
 # Local imports
-from spyder.widgets.status import MemoryStatus, CPUStatus
+from spyder.plugins.editor.widgets.status import (CursorPositionStatus,
+                                                  EncodingStatus, EOLStatus,
+                                                  ReadWriteStatus)
 
 
 @pytest.fixture
@@ -33,11 +35,12 @@ def test_status_bar(status_bar, qtbot):
     """Run StatusBarWidget."""
     win, statusbar = status_bar
     swidgets = []
-    for klass in (MemoryStatus, CPUStatus):
+    for klass in (ReadWriteStatus, EOLStatus, EncodingStatus,
+                  CursorPositionStatus):
         swidget = klass(win, statusbar)
         swidgets.append(swidget)
     assert win
-    assert len(swidgets) == 2
+    assert len(swidgets) == 4
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/status.py
+++ b/spyder/widgets/status.py
@@ -41,7 +41,7 @@ class StatusBarWidget(QWidget):
         self.label_value = QLabel()
 
         # Widget setup
-        self.text_font = get_font(option='rich_font')
+        self.text_font = get_font(option='font')
         self.text_font.setPointSize(self.font().pointSize())
         self.text_font.setBold(True)
         self.label_value.setAlignment(Qt.AlignRight)
@@ -131,7 +131,8 @@ class MemoryStatus(BaseTimerStatus):
     def get_value(self):
         """Return memory usage."""
         from spyder.utils.system import memory_usage
-        return '%d %%' % memory_usage()
+        text = '%d %%' % memory_usage()
+        return 'Mem ' + text.rjust(5)
 
 
 class CPUStatus(BaseTimerStatus):
@@ -149,51 +150,8 @@ class CPUStatus(BaseTimerStatus):
     def get_value(self):
         """Return CPU usage."""
         import psutil
-        return '%d %%' % psutil.cpu_percent(interval=0)
-
-
-# =============================================================================
-# Editor-related status bar widgets
-# =============================================================================
-class ReadWriteStatus(StatusBarWidget):    
-    """Status bar widget for current file read/write mode."""
-    TIP = _("File permissions")
-
-    def update_readonly(self, readonly):
-        """Update read/write file status."""
-        value = "R" if readonly else "RW"
-        self.set_value(value.ljust(3))
-
-
-class EOLStatus(StatusBarWidget):
-    """Status bar widget for the current file end of line."""
-    TIP = _("End of line")
-
-    def update_eol(self, os_name):
-        """Update end of line status."""
-        os_name = to_text_string(os_name)
-        value = {"nt": "CRLF", "posix": "LF"}.get(os_name, "CR")
-        self.set_value(value)
-
-
-class EncodingStatus(StatusBarWidget):
-    """Status bar widget for the current file encoding."""
-    TIP = _("Encoding")
-
-    def update_encoding(self, encoding):
-        """Update encoding of current file."""
-        value = str(encoding).upper()
-        self.set_value(value)
-
-
-class CursorPositionStatus(StatusBarWidget):
-    """Status bar widget for the current file cursor postion."""
-    TIP = _("Cursor position")
-
-    def update_cursor_position(self, line, index):
-        """Update cursor position."""
-        value = 'Line {}, Col {}'.format(line + 1, index + 1)
-        self.set_value(value)
+        text = '%d %%' % psutil.cpu_percent(interval=0)
+        return 'CPU ' + text.rjust(5)
 
 
 def test():
@@ -206,8 +164,7 @@ def test():
     win.resize(900, 300)
     statusbar = win.statusBar()
     status_widgets = []
-    for status_class in (ReadWriteStatus, EOLStatus, EncodingStatus,
-                         CursorPositionStatus, MemoryStatus, CPUStatus):
+    for status_class in (MemoryStatus, CPUStatus):
         status_widget = status_class(win, statusbar)
         status_widgets.append(status_widget)
     win.show()

--- a/spyder/widgets/status.py
+++ b/spyder/widgets/status.py
@@ -131,8 +131,8 @@ class MemoryStatus(BaseTimerStatus):
     def get_value(self):
         """Return memory usage."""
         from spyder.utils.system import memory_usage
-        text = '%d %%' % memory_usage()
-        return 'Mem ' + text.rjust(5)
+        text = '%d%%' % memory_usage()
+        return 'Mem ' + text.rjust(3)
 
 
 class CPUStatus(BaseTimerStatus):
@@ -150,8 +150,8 @@ class CPUStatus(BaseTimerStatus):
     def get_value(self):
         """Return CPU usage."""
         import psutil
-        text = '%d %%' % psutil.cpu_percent(interval=0)
-        return 'CPU ' + text.rjust(5)
+        text = '%d%%' % psutil.cpu_percent(interval=0)
+        return 'CPU ' + text.rjust(3)
 
 
 def test():


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9006

- The idea is to simplify the UI and remove the clutter. This removes unnecessary labels and uses monospace font to avoid jumps when using the CPU/Mem status widgets.
- The code has also been simplified as well.
- Also, the status widgets that belonged to the editor have been moved to `plugins.editor.widgets.status` as that is the place they should be.
- The lines and cols were moved to the front of all widgets, since that widget size will be changing constantly.

Before:
<img width="1440" alt="Screen Shot 2019-03-22 at 12 18 30" src="https://user-images.githubusercontent.com/3627835/54841148-a21e1380-4c9c-11e9-93fa-1951b8f96509.png">

After:
<img width="1440" alt="Screen Shot 2019-03-22 at 18 30 19" src="https://user-images.githubusercontent.com/3627835/54858064-964c4480-4cd0-11e9-9110-2cc3b4e44e2c.png">


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
