### PR TITLE
PR: Fix error at startup when updating warnings menu

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1379,7 +1379,7 @@ class Editor(SpyderPluginWidget):
 
     def update_warning_menu(self):
         """Update warning list menu"""
-        editor = self.get_current_editorstack().get_current_editor()
+        editor = self.get_current_editor()
         check_results = editor.get_current_warnings()
         self.warning_menu.clear()
         filename = self.get_current_filename()
@@ -1457,7 +1457,9 @@ class Editor(SpyderPluginWidget):
             self.open_file_update.emit(self.get_current_filename())
 
     def update_code_analysis_actions(self):
-        editor = self.get_current_editorstack().get_current_editor()
+        editor = self.get_current_editor()
+        if editor is None:
+            return
         results = editor.get_current_warnings()
         # Update code analysis buttons
         state = (self.get_option('code_analysis/pyflakes') \

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1459,7 +1459,9 @@ class Editor(SpyderPluginWidget):
             self.open_file_update.emit(self.get_current_filename())
 
     def update_code_analysis_actions(self):
+        """Update actions in the warnings menu."""
         editor = self.get_current_editor()
+        # To fix an error at startup
         if editor is None:
             return
         results = editor.get_current_warnings()

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -610,6 +610,7 @@ class Editor(SpyderPluginWidget):
                       "HACK/BUG/OPTIMIZE/!!!/???)"),
                 triggered=self.go_to_next_todo)
         self.todo_menu = QMenu(self)
+        self.todo_menu.setStyleSheet("QMenu {menu-scrollable: 1;}")
         self.todo_list_action.setMenu(self.todo_menu)
         self.todo_menu.aboutToShow.connect(self.update_todo_menu)
 
@@ -618,6 +619,7 @@ class Editor(SpyderPluginWidget):
                 tip=_("Show code analysis warnings/errors"),
                 triggered=self.go_to_next_warning)
         self.warning_menu = QMenu(self)
+        self.warning_menu.setStyleSheet("QMenu {menu-scrollable: 1;}")
         self.warning_list_action.setMenu(self.warning_menu)
         self.warning_menu.aboutToShow.connect(self.update_warning_menu)
         self.previous_warning_action = create_action(self,

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1677,7 +1677,7 @@ class CodeEditor(TextEditBaseWidget):
             data = block.userData()
             if data and data.code_analysis:
                 for warning in data.code_analysis:
-                    warnings.append([warning[-1], block.blockNumber()])
+                    warnings.append([warning[-1], block.blockNumber() + 1])
             block = block.next()
         return warnings
 

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2154,7 +2154,6 @@ class EditorStack(QWidget):
             editor = finfo.editor
             editor.setFocus()
             self._refresh_outlineexplorer(index, update=False)
-            self.update_code_analysis_actions.emit()
             self.__refresh_statusbar(index)
             self.__refresh_readonly(index)
             self.__check_file_status(index)

--- a/spyder/plugins/editor/widgets/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/tests/test_warnings.py
@@ -135,8 +135,8 @@ def test_menu_show_warnings(qtbot, construct_editor):
     # Get current warnings
     warnings = editor.get_current_warnings()
 
-    expected = [['W293 blank line contains whitespace', 1],
-                ['E261 at least two spaces before inline comment', 2],
-                ["undefined name 's'", 4]]
+    expected = [['W293 blank line contains whitespace', 2],
+                ['E261 at least two spaces before inline comment', 3],
+                ["undefined name 's'", 5]]
 
     assert warnings == expected

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1078,7 +1078,8 @@ def test_stderr_file_remains_two_kernels(ipyconsole, qtbot, monkeypatch):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.name == 'nt', reason="It fails on Windows")
+@pytest.mark.skipif(not sys.platform.startswith('linux'),
+                    reason="It only works on Linux")
 def test_kernel_crash(ipyconsole, mocker, qtbot):
     """Test that we show kernel error messages when a kernel crash occurs."""
     # Patch create_kernel_spec method to make it return a faulty

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -151,7 +151,7 @@ _qtaargs = {
     'todo_list':               [('fa.th-list', 'fa.check'), {'options': [{'color': '#999999'}, {'offset': (0.0, 0.2), 'color': '#3775a9', 'color_disabled': '#748fa6'}]}],
     'wng_list':                [('fa.th-list', 'fa.warning'), {'options': [{'color': '#999999'}, {'offset': (0.0, 0.2), 'scale_factor': 0.75, 'color': 'orange', 'color_disabled': '#face7e'}]}],
     'prev_wng':                [('fa.arrow-left', 'fa.warning'), {'options': [{'color': '#999999'}, {'offset': (0.0, 0.2), 'scale_factor': 0.75, 'color': 'orange', 'color_disabled': '#face7e'}]}],
-    'next_wng':                [('fa.arrow-right', 'fa.warning'), {'options': [{'color': '999999'}, {'offset': (0.0, 0.2), 'scale_factor': 0.75, 'color': 'orange', 'color_disabled': '#face7e'}]}],
+    'next_wng':                [('fa.arrow-right', 'fa.warning'), {'options': [{'color': '#999999'}, {'offset': (0.0, 0.2), 'scale_factor': 0.75, 'color': 'orange', 'color_disabled': '#face7e'}]}],
     'last_edit_location':      [('fa.caret-up',), {'color': MAIN_FG_COLOR}],
     'prev_cursor':             [('fa.hand-o-left',), {'color': MAIN_FG_COLOR}],
     'next_cursor':             [('fa.hand-o-right',), {'color': MAIN_FG_COLOR}],


### PR DESCRIPTION
This fixes a minor regression after PR #9011 and also:

* Makes todo and warning menus scrollable
* Fixes `next_wng` icon color.
* Fixes cursor positioning after clicking warning actions (it was off by one line).