### PR TITLE
PR: Automatically unbind conflicting shortcuts when pressing okay in shortcut manager

### DIFF
--- a/spyder/preferences/shortcuts.py
+++ b/spyder/preferences/shortcuts.py
@@ -412,7 +412,7 @@ class ShortcutEditor(QDialog):
                 tip_body += ' - {0}: {1}<br>'.format(s.context, s.name)
             tip_body = tip_body[:-4]  # Removing last <br>
             tip_override = '<br>Press <b>OK</b> to unbind '
-            tip_override += 'it' if len(conflicts)==1 else 'them'
+            tip_override += 'it' if len(conflicts) == 1 else 'them'
             tip_override += ' and assign it to <b>{}</b>'.format(self.name)
             tip = template.format(tip_title, tip_body, tip_override)
             icon = get_std_icon('MessageBoxWarning')

--- a/spyder/preferences/shortcuts.py
+++ b/spyder/preferences/shortcuts.py
@@ -476,6 +476,7 @@ class ShortcutEditor(QDialog):
         self.accept()
 
     def accept_override(self):
+        """Unbind all conflicted shortcuts, and accept the new one"""
         conflicts = self.check_conflicts()
         if conflicts:
             for shortcut in conflicts:

--- a/spyder/preferences/shortcuts.py
+++ b/spyder/preferences/shortcuts.py
@@ -272,7 +272,7 @@ class ShortcutEditor(QDialog):
         layout_sequence.addLayout(newseq_btnbar, 3, 3)
         layout_sequence.addWidget(self.label_warning, 4, 2, 1, 2)
         layout_sequence.setColumnStretch(2, 100)
-        layout_sequence.setRowStretch(4, 120)
+        layout_sequence.setRowStretch(4, 100)
 
         layout = QVBoxLayout()
         layout.addLayout(layout_sequence)

--- a/spyder/preferences/shortcuts.py
+++ b/spyder/preferences/shortcuts.py
@@ -214,8 +214,6 @@ class ShortcutEditor(QDialog):
         self.label_warning = QLabel()
         self.label_warning.setWordWrap(True)
         self.label_warning.setAlignment(Qt.AlignTop | Qt.AlignLeft)
-        self.label_warning.setMinimumHeight(
-            3 * self.label_warning.sizeHint().height())
 
         self.button_default = QPushButton(_('Default'))
         self.button_ok = QPushButton(_('Ok'))
@@ -443,6 +441,9 @@ class ShortcutEditor(QDialog):
         self.button_ok.setEnabled(
             self.warning in [NO_WARNING, SEQUENCE_CONFLICT])
         self.label_warning.setText(tip)
+        # Everytime after update warning message, update the label height
+        new_height = self.label_warning.sizeHint().height()
+        self.label_warning.setMaximumHeight(new_height)
 
     def set_sequence_from_str(self, sequence):
         """

--- a/spyder/preferences/tests/test_shorcuts.py
+++ b/spyder/preferences/tests/test_shorcuts.py
@@ -114,13 +114,13 @@ def test_clear_back_new_sequence(create_shortcut_editor, qtbot):
     qtbot.mouseClick(shortcut_editor.button_back_sequence, Qt.LeftButton)
     assert shortcut_editor.new_sequence == 'Ctrl+X, A, Ctrl+B'
     assert shortcut_editor.warning == SEQUENCE_CONFLICT
-    assert not shortcut_editor.button_ok.isEnabled()
+    assert shortcut_editor.button_ok.isEnabled()
 
     # Remove second to last key sequence entered.
     qtbot.mouseClick(shortcut_editor.button_back_sequence, Qt.LeftButton)
     assert shortcut_editor.new_sequence == 'Ctrl+X, A'
     assert shortcut_editor.warning == SEQUENCE_CONFLICT
-    assert not shortcut_editor.button_ok.isEnabled()
+    assert shortcut_editor.button_ok.isEnabled()
 
     # Clear all entered key sequences.
     qtbot.mouseClick(shortcut_editor.btn_clear_sequence, Qt.LeftButton)
@@ -140,13 +140,13 @@ def test_sequence_conflict(create_shortcut_editor, qtbot):
     qtbot.keyClick(shortcut_editor, Qt.Key_X, modifier=Qt.ControlModifier)
     assert shortcut_editor.new_sequence == 'Ctrl+X'
     assert shortcut_editor.warning == SEQUENCE_CONFLICT
-    assert not shortcut_editor.button_ok.isEnabled()
+    assert shortcut_editor.button_ok.isEnabled()
 
     # Check that the conflict is detected for a compound of key sequences.
     qtbot.keyClick(shortcut_editor, Qt.Key_X)
     assert shortcut_editor.new_sequence == 'Ctrl+X, X'
     assert shortcut_editor.warning == SEQUENCE_CONFLICT
-    assert not shortcut_editor.button_ok.isEnabled()
+    assert shortcut_editor.button_ok.isEnabled()
 
 
 def test_sequence_single_key(create_shortcut_editor, qtbot):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

Adds the ability to automatically unbind a conflicting shortcut when clicking okay in the shortcut manager.

I'm not an expert but want to contribute. So could anyone help me with this?

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8293 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: gepcel

<!--- Thanks for your help making Spyder better for everyone! --->