### PR TITLE
PR: Disable status timers if widget is not visible

### DIFF
--- a/spyder/widgets/status.py
+++ b/spyder/widgets/status.py
@@ -75,7 +75,9 @@ class BaseTimerStatus(StatusBarWidget):
 
     def __init__(self, parent, statusbar):
         """Status bar widget base for widgets that update based on timers."""
+        self.timer = None  # Needs to come before parent call
         super(BaseTimerStatus, self).__init__(parent, statusbar)
+        self._interval = 2000
 
         # Widget setup
         fm = self.label_value.fontMetrics()
@@ -85,13 +87,22 @@ class BaseTimerStatus(StatusBarWidget):
         if self.is_supported():
             self.timer = QTimer()
             self.timer.timeout.connect(self.update_status)
-            self.timer.start(2000)
+            self.timer.start(self._interval)
         else:
-            self.timer = None
             self.hide()
-    
+
+    def setVisible(self, value):
+        """Override Qt method to stops timers if widget is not visible."""
+        if self.timer is not None:
+            if value:
+                self.timer.start(self._interval)
+            else:
+                self.timer.stop()
+        super(BaseTimerStatus, self).setVisible(value)
+
     def set_interval(self, interval):
         """Set timer interval (ms)."""
+        self._interval = interval
         if self.timer is not None:
             self.timer.setInterval(interval)
     


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

When status widgets are disabled timers keep running on the background. This PR stops the timer if the widgets are not visible and restart's them once they become visible once again.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
