### PR TITLE
PR: Add Ctrl+Shift+G to switch to plots plugin

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -355,6 +355,7 @@ DEFAULTS = [
               '_/switch to variable_explorer': "Ctrl+Shift+V",
               '_/switch to find_in_files': "Ctrl+Shift+F",
               '_/switch to explorer': "Ctrl+Shift+X",
+              '_/switch to plots': "Ctrl+Shift+G",
               # -- In widgets/findreplace.py
               '_/find text': "Ctrl+F",
               '_/find next': "F3",


### PR DESCRIPTION
As in issue #8640, now with this change, Ctrl+Shift+G can switch to plots.

The feature `adding shortcuts for "next figure" and "previous figure" of plots pane`  mentioned in this issue is still not done.  There are ''Ctrl+PgUp" and "Ctrl+PgDown" in the plots plugin, but they only work when the plugin gets focused. If someone can give me some guidance, maybe I can do something more. Or I may have to leave it to others.

Fixes #8640.