### PR TITLE
PR: Add an "Fit plots to window" option to the plots pane

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -180,7 +180,7 @@ DEFAULTS = [
              {
               'mute_inline_plotting': True,
               'show_plot_outline': False,
-              'auto_fit_plotting': False
+              'auto_fit_plotting': True
              }),
             ('editor',
              {

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -180,6 +180,7 @@ DEFAULTS = [
              {
               'mute_inline_plotting': True,
               'show_plot_outline': False,
+              'auto_fit_plotting': False
              }),
             ('editor',
              {

--- a/spyder/plugins/plots/plugin.py
+++ b/spyder/plugins/plots/plugin.py
@@ -47,7 +47,8 @@ class Plots(SpyderPluginWidget):
     def get_settings(self):
         """Retrieve all Plots configuration settings."""
         return {name: self.get_option(name) for name in
-                ['mute_inline_plotting',  'show_plot_outline']}
+                ['mute_inline_plotting', 'show_plot_outline',
+                 'auto_fit_plotting']}
 
     # ---- Stack accesors
     def set_current_widget(self, fig_browser):

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -238,8 +238,8 @@ class FigureBrowser(QWidget):
         self.show_plot_outline_action.setChecked(show_plot_outline)
 
         self.auto_fit_action = create_action(
-            self, _("Auto fit plotting"),
-            tip=_("Auto fit plotting in the widget."),
+            self, _("Fit plots to window"),
+            tip=_("Automatically fit plots to Plot pane size."),
             toggled=self.change_auto_fit_plotting
             )
         self.auto_fit_action.setChecked(auto_fit_plotting)
@@ -308,7 +308,7 @@ class FigureBrowser(QWidget):
         self.option_changed('show_plot_outline', state)
 
     def change_auto_fit_plotting(self, state):
-        """Change the auto_fit_plotting option and scale images"""
+        """Change the auto_fit_plotting option and scale images."""
         self.option_changed('auto_fit_plotting', state)
         self.figviewer.auto_fit_plotting = state
         self.figviewer.scale_image()

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -490,11 +490,13 @@ class FigureViewer(QScrollArea):
             new_height = int(fheight * self._scalestep ** self._scalefactor)
 
         # Auto fit plotting
-        # Scale the image to fit figcanvas size while respect the ratio
+        # Scale the image to fit figviewer size while respect the ratio
         else:
             size = self.size()
-            width = size.width() - 15  # How to get the actual figcanvas size?
-            height = size.height() - 15
+            scrollbar_width = self.verticalScrollBar().sizeHint().width()
+            width = size.width() - scrollbar_width
+            scrollbar_height = self.horizontalScrollBar().sizeHint().height()
+            height = size.height() - scrollbar_height
             if (fwidth / fheight) > (width / height):
                 new_width = width
                 new_height = int(width / fwidth * fheight)

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -481,8 +481,8 @@ class FigureViewer(QScrollArea):
 
     def scale_image(self):
         """Scale the image size."""
-        fwidth = self.figcanvas.fwidth
-        fheight = self.figcanvas.fheight
+        fwidth = self.figcanvas.fwidth * 1.0
+        fheight = self.figcanvas.fheight * 1.0
 
         # Don't auto fit plotting
         if not self.auto_fit_plotting:
@@ -494,14 +494,14 @@ class FigureViewer(QScrollArea):
         else:
             size = self.size()
             scrollbar_width = self.verticalScrollBar().sizeHint().width()
-            width = size.width() - scrollbar_width
+            width = (size.width() - scrollbar_width) * 1.0
             scrollbar_height = self.horizontalScrollBar().sizeHint().height()
-            height = size.height() - scrollbar_height
+            height = (size.height() - scrollbar_height) * 1.0
             if (fwidth / fheight) > (width / height):
-                new_width = width
+                new_width = int(width)
                 new_height = int(width / fwidth * fheight)
             else:
-                new_height = height
+                new_height = int(height)
                 new_width = int(height / fheight * fwidth)
         self.figcanvas.setFixedSize(new_width, new_height)
 

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -85,25 +85,30 @@ class FigureBrowser(QWidget):
         # Options :
         self.mute_inline_plotting = None
         self.show_plot_outline = None
+        self.auto_fit_plotting = None
 
         # Option actions :
         self.mute_inline_action = None
         self.show_plot_outline_action = None
+        self.auto_fit_action = None
 
         self.options_button = options_button
         self.plugin_actions = plugin_actions
         self.shortcuts = self.create_shortcuts()
 
-    def setup(self, mute_inline_plotting=None, show_plot_outline=None):
+    def setup(self, mute_inline_plotting=None, show_plot_outline=None,
+              auto_fit_plotting=None):
         """Setup the figure browser with provided settings."""
         assert self.shellwidget is not None
 
         self.mute_inline_plotting = mute_inline_plotting
         self.show_plot_outline = show_plot_outline
+        self.auto_fit_plotting = auto_fit_plotting
 
         if self.figviewer is not None:
             self.mute_inline_action.setChecked(mute_inline_plotting)
             self.show_plot_outline_action.setChecked(show_plot_outline)
+            self.auto_fit_action.setChecked(auto_fit_plotting)
             return
 
         self.figviewer = FigureViewer(background_color=self.background_color)
@@ -117,7 +122,9 @@ class FigureBrowser(QWidget):
             self.figviewer, background_color=self.background_color)
 
         # Option actions :
-        self.setup_option_actions(mute_inline_plotting, show_plot_outline)
+        self.setup_option_actions(mute_inline_plotting,
+                                  show_plot_outline,
+                                  auto_fit_plotting)
 
         # Create the layout :
         main_widget = QSplitter()
@@ -211,7 +218,8 @@ class FigureBrowser(QWidget):
         return [savefig_btn, saveall_btn, copyfig_btn, closefig_btn,
                 closeall_btn, vsep1, goback_btn, gonext_btn, vsep2, zoom_pan]
 
-    def setup_option_actions(self, mute_inline_plotting, show_plot_outline):
+    def setup_option_actions(self, mute_inline_plotting, show_plot_outline,
+                             auto_fit_plotting):
         """Setup the actions to show in the cog menu."""
         self.setup_in_progress = True
         self.mute_inline_action = create_action(
@@ -229,7 +237,16 @@ class FigureBrowser(QWidget):
             )
         self.show_plot_outline_action.setChecked(show_plot_outline)
 
-        self.actions = [self.mute_inline_action, self.show_plot_outline_action]
+        self.auto_fit_action = create_action(
+            self, _("Auto fit plotting"),
+            tip=_("Auto fit plotting in the widget."),
+            toggled=self.change_auto_fit_plotting
+            )
+        self.auto_fit_action.setChecked(auto_fit_plotting)
+
+        self.actions = [self.mute_inline_action, self.show_plot_outline_action,
+                        self.auto_fit_action]
+
         self.setup_in_progress = False
 
     def setup_options_button(self):
@@ -289,6 +306,12 @@ class FigureBrowser(QWidget):
         else:
             self.figviewer.figcanvas.setStyleSheet("FigureCanvas{}")
         self.option_changed('show_plot_outline', state)
+
+    def change_auto_fit_plotting(self, state):
+        """Change the auto_fit_plotting option and scale images"""
+        self.option_changed('auto_fit_plotting', state)
+        self.figviewer.auto_fit_plotting = state
+        self.figviewer.scale_image()
 
     def set_shellwidget(self, shellwidget):
         """Bind the shellwidget instance to the figure browser"""
@@ -374,6 +397,8 @@ class FigureViewer(QScrollArea):
         self._sfmax = 10
         self._sfmin = -10
 
+        self.auto_fit_plotting = False
+
         # An internal flag that tracks when the figure is being panned.
         self._ispanning = False
 
@@ -456,10 +481,26 @@ class FigureViewer(QScrollArea):
 
     def scale_image(self):
         """Scale the image size."""
-        new_width = int(self.figcanvas.fwidth *
-                        self._scalestep ** self._scalefactor)
-        new_height = int(self.figcanvas.fheight *
-                         self._scalestep ** self._scalefactor)
+        fwidth = self.figcanvas.fwidth
+        fheight = self.figcanvas.fheight
+
+        # Don't auto fit plotting
+        if not self.auto_fit_plotting:
+            new_width = int(fwidth * self._scalestep ** self._scalefactor)
+            new_height = int(fheight * self._scalestep ** self._scalefactor)
+
+        # Auto fit plotting
+        # Scale the image to fit figcanvas size while respect the ratio
+        else:
+            size = self.size()
+            width = size.width() - 15  # How to get the actual figcanvas size?
+            height = size.height() - 15
+            if (fwidth / fheight) > (width / height):
+                new_width = width
+                new_height = width / fwidth * fheight
+            else:
+                new_height = height
+                new_width = height / fheight * fwidth
         self.figcanvas.setFixedSize(new_width, new_height)
 
     def get_scaling(self):

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -481,8 +481,8 @@ class FigureViewer(QScrollArea):
 
     def scale_image(self):
         """Scale the image size."""
-        fwidth = self.figcanvas.fwidth * 1.0
-        fheight = self.figcanvas.fheight * 1.0
+        fwidth = self.figcanvas.fwidth
+        fheight = self.figcanvas.fheight
 
         # Don't auto fit plotting
         if not self.auto_fit_plotting:
@@ -494,9 +494,9 @@ class FigureViewer(QScrollArea):
         else:
             size = self.size()
             scrollbar_width = self.verticalScrollBar().sizeHint().width()
-            width = (size.width() - scrollbar_width) * 1.0
+            width = size.width() - scrollbar_width
             scrollbar_height = self.horizontalScrollBar().sizeHint().height()
-            height = (size.height() - scrollbar_height) * 1.0
+            height = size.height() - scrollbar_height
             if (fwidth / fheight) > (width / height):
                 new_width = int(width)
                 new_height = int(width / fwidth * fheight)

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -497,10 +497,10 @@ class FigureViewer(QScrollArea):
             height = size.height() - 15
             if (fwidth / fheight) > (width / height):
                 new_width = width
-                new_height = width / fwidth * fheight
+                new_height = int(width / fwidth * fheight)
             else:
                 new_height = height
-                new_width = height / fheight * fwidth
+                new_width = int(height / fheight * fwidth)
         self.figcanvas.setFixedSize(new_width, new_height)
 
     def get_scaling(self):

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -373,7 +373,7 @@ def test_autofit_figure_viewer(figbrowser, tmpdir, fmt):
     # Calculate original figure size in pixels.
     qpix = QPixmap()
     qpix.loadFromData(fig, fmt.upper())
-    fwidth, fheight = qpix.width(), qpix.height()
+    fwidth, fheight = qpix.width() * 1.0, qpix.height() * 1.0
 
     # Test when `Fit plots to window` is set to True.
     # Otherwise, test should fall into `test_zoom_figure_viewer`
@@ -381,14 +381,14 @@ def test_autofit_figure_viewer(figbrowser, tmpdir, fmt):
     size = figviewer.size()
 
     scrollbar_width = figviewer.verticalScrollBar().sizeHint().width()
-    width = size.width() - scrollbar_width
+    width = (size.width() - scrollbar_width) * 1.0
     scrollbar_height = figviewer.horizontalScrollBar().sizeHint().height()
-    height = size.height() - scrollbar_height
+    height = (size.height() - scrollbar_height) * 1.0
     if (fwidth / fheight) > (width / height):
-        new_width = width
+        new_width = int(width)
         new_height = int(width / fwidth * fheight)
     else:
-        new_height = height
+        new_height = int(height)
         new_width = int(height / fheight * fwidth)
 
     assert figcanvas.width() == new_width

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -367,7 +367,8 @@ def test_autofit_figure_viewer(figbrowser, tmpdir, fmt):
     Test figure diplayed when `Fit plots to window` is True.
     """
     fig = add_figures_to_browser(figbrowser, 1, tmpdir, fmt)[0]
-    figcanvas = figbrowser.figviewer.figcanvas
+    figviewer = figbrowser.figviewer
+    figcanvas = figviewer.figcanvas
 
     # Calculate original figure size in pixels.
     qpix = QPixmap()
@@ -375,12 +376,14 @@ def test_autofit_figure_viewer(figbrowser, tmpdir, fmt):
     fwidth, fheight = qpix.width(), qpix.height()
 
     # Test when `Fit plots to window` is set to True.
-    # Otherwise, test should be `test_zoom_figure_viewer`
+    # Otherwise, test should fall into `test_zoom_figure_viewer`
     figbrowser.change_auto_fit_plotting(True)
-    size = figbrowser.figviewer.size()
-    # Need to change after figured out the actual figcanvas size?
-    width = size.width() - 15
-    height = size.height() - 15
+    size = figviewer.size()
+    
+    scrollbar_width = figviewer.verticalScrollBar().sizeHint().width()
+    width = size.width() - scrollbar_width
+    scrollbar_height = figviewer.horizontalScrollBar().sizeHint().height()
+    height = size.height() - scrollbar_height
     if (fwidth / fheight) > (width / height):
         new_width = width
         new_height = int(width / fwidth * fheight)

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -333,6 +333,9 @@ def test_zoom_figure_viewer(figbrowser, tmpdir, fmt):
     fig = add_figures_to_browser(figbrowser, 1, tmpdir, fmt)[0]
     figcanvas = figbrowser.figviewer.figcanvas
 
+    # Set `Fit plots to windows` to False before the test.
+    figbrowser.change_auto_fit_plotting(False)
+
     # Calculate original figure size in pixels.
     qpix = QPixmap()
     qpix.loadFromData(fig, fmt.upper())
@@ -356,6 +359,37 @@ def test_zoom_figure_viewer(figbrowser, tmpdir, fmt):
         assert figbrowser.zoom_disp.value() == np.floor(scale * 100)
         assert figcanvas.width() == np.floor(fwidth * scale)
         assert figcanvas.height() == np.floor(fheight * scale)
+
+
+@pytest.mark.parametrize("fmt", ['image/png', 'image/svg+xml'])
+def test_autofit_figure_viewer(figbrowser, tmpdir, fmt):
+    """
+    Test figure diplayed when `Fit plots to window` is True.
+    """
+    fig = add_figures_to_browser(figbrowser, 1, tmpdir, fmt)[0]
+    figcanvas = figbrowser.figviewer.figcanvas
+
+    # Calculate original figure size in pixels.
+    qpix = QPixmap()
+    qpix.loadFromData(fig, fmt.upper())
+    fwidth, fheight = qpix.width(), qpix.height()
+
+    # Test when `Fit plots to window` is set to True.
+    # Otherwise, test should be `test_zoom_figure_viewer`
+    figbrowser.change_auto_fit_plotting(True)
+    size = figbrowser.figviewer.size()
+    # Need to change after figured out the actual figcanvas size?
+    width = width = size.width() - 15
+    height = size.height() - 15
+    if (fwidth / fheight) > (width / height):
+        new_width = width
+        new_height = width / fwidth * fheight
+    else:
+        new_height = height
+        new_width = height / fheight * fwidth
+
+    assert figcanvas.width() == int(new_width)
+    assert figcanvas.height() == int(new_height)
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -39,7 +39,8 @@ def figbrowser(qtbot):
     """An empty figure browser widget fixture."""
     figbrowser = FigureBrowser()
     figbrowser.set_shellwidget(Mock())
-    figbrowser.setup(mute_inline_plotting=True, show_plot_outline=False)
+    figbrowser.setup(mute_inline_plotting=True, show_plot_outline=False,
+                     auto_fit_plotting=False)
     qtbot.addWidget(figbrowser)
     figbrowser.show()
     figbrowser.setMinimumSize(700, 500)

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -379,17 +379,17 @@ def test_autofit_figure_viewer(figbrowser, tmpdir, fmt):
     figbrowser.change_auto_fit_plotting(True)
     size = figbrowser.figviewer.size()
     # Need to change after figured out the actual figcanvas size?
-    width = width = size.width() - 15
+    width = size.width() - 15
     height = size.height() - 15
     if (fwidth / fheight) > (width / height):
         new_width = width
-        new_height = width / fwidth * fheight
+        new_height = int(width / fwidth * fheight)
     else:
         new_height = height
-        new_width = height / fheight * fwidth
+        new_width = int(height / fheight * fwidth)
 
-    assert figcanvas.width() == int(new_width)
-    assert figcanvas.height() == int(new_height)
+    assert figcanvas.width() == new_width
+    assert figcanvas.height() == new_height
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -379,7 +379,7 @@ def test_autofit_figure_viewer(figbrowser, tmpdir, fmt):
     # Otherwise, test should fall into `test_zoom_figure_viewer`
     figbrowser.change_auto_fit_plotting(True)
     size = figviewer.size()
-    
+
     scrollbar_width = figviewer.verticalScrollBar().sizeHint().width()
     width = size.width() - scrollbar_width
     scrollbar_height = figviewer.horizontalScrollBar().sizeHint().height()

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -11,6 +11,7 @@ Tests for the widgets used in the Plots plugin.
 """
 
 # Standard library imports
+from __future__ import division
 import os.path as osp
 try:
     from unittest.mock import Mock
@@ -373,7 +374,7 @@ def test_autofit_figure_viewer(figbrowser, tmpdir, fmt):
     # Calculate original figure size in pixels.
     qpix = QPixmap()
     qpix.loadFromData(fig, fmt.upper())
-    fwidth, fheight = qpix.width() * 1.0, qpix.height() * 1.0
+    fwidth, fheight = qpix.width(), qpix.height()
 
     # Test when `Fit plots to window` is set to True.
     # Otherwise, test should fall into `test_zoom_figure_viewer`
@@ -381,9 +382,9 @@ def test_autofit_figure_viewer(figbrowser, tmpdir, fmt):
     size = figviewer.size()
 
     scrollbar_width = figviewer.verticalScrollBar().sizeHint().width()
-    width = (size.width() - scrollbar_width) * 1.0
+    width = size.width() - scrollbar_width
     scrollbar_height = figviewer.horizontalScrollBar().sizeHint().height()
-    height = (size.height() - scrollbar_height) * 1.0
+    height = size.height() - scrollbar_height
     if (fwidth / fheight) > (width / height):
         new_width = int(width)
         new_height = int(width / fwidth * fheight)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->


While using the plotting plugin, I found it annoying to have to zoom in and out the image frequently when testing different sizes of image. Feels like an `Auto fit plotting` option is necessary.

So I tried adding one, like (default to False, aka, unchecked):
![option](https://user-images.githubusercontent.com/4179106/55171564-8b535180-51b3-11e9-8875-c676aa4b3505.png)

An example of the original behavior when dealing with different sizes of images (with the auto_fit_plotting option set to false):
![false](https://user-images.githubusercontent.com/4179106/55171307-0d8f4600-51b3-11e9-8867-a90bfa5f34ef.gif)

Compared to the new behavior when set to true:
![true](https://user-images.githubusercontent.com/4179106/55171399-40d1d500-51b3-11e9-83fe-d5089f3f8455.gif)

Example code:
```python
from matplotlib.pyplot import figure, text
def test_plot(w, h):
    figure(figsize=(w, h))
    text(.5, .5, f'figsize={w}, {h}', ha='center', fontsize=2.5*w)
    
test_plot(4, 3)
test_plot(15, 7)
test_plot(8, 12)
```


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: gepcel

<!--- Thanks for your help making Spyder better for everyone! --->
