### PR TITLE
PR: Fix completion popup dismissed after typing delimeters or operators

### DIFF
--- a/spyder/plugins/editor/extensions/closebrackets.py
+++ b/spyder/plugins/editor/extensions/closebrackets.py
@@ -37,6 +37,7 @@ class CloseBracketsExtension(EditorExtension):
 
         key = event.key()
         if key in self.BRACKETS_CHAR and self.enabled:
+            self.editor.completion_widget.hide()
             self._autoinsert_brackets(key)
             event.accept()
 

--- a/spyder/plugins/editor/extensions/closequotes.py
+++ b/spyder/plugins/editor/extensions/closequotes.py
@@ -54,6 +54,7 @@ class CloseQuotesExtension(EditorExtension):
 
         key = event.key()
         if key in (Qt.Key_QuoteDbl, Qt.Key_Apostrophe) and self.enabled:
+            self.editor.completion_widget.hide()
             self._autoinsert_quotes(key)
             event.accept()
 

--- a/spyder/plugins/editor/tests/test_introspection.py
+++ b/spyder/plugins/editor/tests/test_introspection.py
@@ -100,6 +100,20 @@ def test_space_completion(setup_editor):
 
 
 @pytest.mark.slow
+def test_hide_widget_completion(setup_editor):
+    """Validate hiding completion widget after a delimeter or operator."""
+    editor, qtbot = setup_editor
+    code_editor = editor.get_focus_widget()
+    completion = code_editor.completion_widget
+
+    # Set cursor to start
+    code_editor.go_to_line(1)
+
+    qtbot.keyClicks(code_editor, 'from numpy [')
+    assert completion.isVisible() is False
+
+
+@pytest.mark.slow
 @pytest.mark.skipif(PY2, reason="Segfaults with other tests on Py2.")
 @pytest.mark.skipif(os.name == 'nt' and not PY2,
                     reason="Times out on AppVeyor and fails on PY3")

--- a/spyder/plugins/editor/tests/test_introspection.py
+++ b/spyder/plugins/editor/tests/test_introspection.py
@@ -12,6 +12,7 @@ import os.path as osp
 # Third party imports
 import pytest
 import pytestqt
+import random
 try:
     from unittest.mock import Mock
 except ImportError:
@@ -99,13 +100,16 @@ def test_space_completion(setup_editor):
     assert code_editor.toPlainText() == 'from numpy import\n'
 
 
-@pytest.mark.slow
+# @pytest.mark.slow
 def test_hide_widget_completion(setup_editor):
     """Validate hiding completion widget after a delimeter or operator."""
     editor, qtbot = setup_editor
     code_editor = editor.get_focus_widget()
     completion = code_editor.completion_widget
 
+    delimiters = ['(', ')', '[', ']', '{', '}', ',', ':', ';', '@', '=', '->',
+                  '+=', '-=', '*=', '/=', '//=', '%=', '@=', '&=', '|=', '^=',
+                  '>>=', '<<=', '**=']
     # Set cursor to start
     code_editor.go_to_line(1)
 
@@ -121,11 +125,14 @@ def test_hide_widget_completion(setup_editor):
     # Check the completion widget is visible
     assert completion.isHidden() is False
 
-    # Write a delimeter on the code editor
-    qtbot.keyClicks(code_editor, '(')
+    # Write a random delimeter on the code editor
+    delimeter = random.choice(delimiters)
+    qtbot.keyClicks(code_editor, delimeter)
 
     # Check the completion widget is not visible
     assert completion.isHidden() is True
+
+    qtbot.keyPress(code_editor, Qt.Key_Enter)
 
 
 @pytest.mark.slow

--- a/spyder/plugins/editor/tests/test_introspection.py
+++ b/spyder/plugins/editor/tests/test_introspection.py
@@ -109,8 +109,23 @@ def test_hide_widget_completion(setup_editor):
     # Set cursor to start
     code_editor.go_to_line(1)
 
-    qtbot.keyClicks(code_editor, 'from numpy [')
-    assert completion.isVisible() is False
+    # Complete from numpy --> from numpy import
+    qtbot.keyClicks(code_editor, 'from numpy ')
+    qtbot.wait(20000)
+
+    # press tab and get completions
+    with qtbot.waitSignal(completion.sig_show_completions,
+                          timeout=10000) as sig:
+        qtbot.keyPress(code_editor, Qt.Key_Tab)
+
+    # Check the completion widget is visible
+    assert completion.isHidden() is False
+
+    # Write a delimeter on the code editor
+    qtbot.keyClicks(code_editor, '(')
+
+    # Check the completion widget is not visible
+    assert completion.isHidden() is True
 
 
 @pytest.mark.slow

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2869,6 +2869,7 @@ class CodeEditor(TextEditBaseWidget):
             TextEditBaseWidget.keyPressEvent(self, event)
         elif key == Qt.Key_Space and not shift and not ctrl \
              and not has_selection and self.auto_unindent_enabled:
+            self.completion_widget.hide()
             leading_text = self.get_text('sol', 'cursor')
             if leading_text.lstrip() in ('elif', 'except'):
                 ind = lambda txt: len(txt)-len(txt.lstrip())

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2778,9 +2778,9 @@ class CodeEditor(TextEditBaseWidget):
         shift = event.modifiers() & Qt.ShiftModifier
         operators = {'+', '-', '*', '**', '/', '//', '%', '@', '<<', '>>',
                      '&', '|', '^', '~', '<', '>', '<=', '>=', '==', '!='}
-        delimeters = {',', ':', ';', '@', '=', '->', '+=', '-=', '*=', '/=',
+        delimiters = {',', ':', ';', '@', '=', '->', '+=', '-=', '*=', '/=',
                       '//=', '%=', '@=', '&=', '|=', '^=', '>>=', '<<=', '**='}
-        if text in operators or text in delimeters:
+        if text in operators or text in delimiters:
             self.completion_widget.hide()
         if key in (Qt.Key_Enter, Qt.Key_Return):
             if not shift and not ctrl:

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2780,7 +2780,6 @@ class CodeEditor(TextEditBaseWidget):
                      '&', '|', '^', '~', '<', '>', '<=', '>=', '==', '!='}
         delimeters = {',', ':', ';', '@', '=', '->', '+=', '-=', '*=', '/=',
                       '//=', '%=', '@=', '&=', '|=', '^=', '>>=', '<<=', '**='}
-        logger.debug(text)
         if text in operators or text in delimeters:
             self.completion_widget.hide()
         if key in (Qt.Key_Enter, Qt.Key_Return):

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2600,7 +2600,6 @@ class CodeEditor(TextEditBaseWidget):
     def autoinsert_colons(self):
         """Decide if we want to autoinsert colons"""
         bracket_ext = self.editor_extensions.get(CloseBracketsExtension)
-        logger.debug('holowis')
         self.completion_widget.hide()
         line_text = self.get_text('sol', 'cursor')
         if not self.textCursor().atBlockEnd():

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2600,6 +2600,8 @@ class CodeEditor(TextEditBaseWidget):
     def autoinsert_colons(self):
         """Decide if we want to autoinsert colons"""
         bracket_ext = self.editor_extensions.get(CloseBracketsExtension)
+        logger.debug('holowis')
+        self.completion_widget.hide()
         line_text = self.get_text('sol', 'cursor')
         if not self.textCursor().atBlockEnd():
             return False
@@ -2775,6 +2777,13 @@ class CodeEditor(TextEditBaseWidget):
         has_selection = self.has_selected_text()
         ctrl = event.modifiers() & Qt.ControlModifier
         shift = event.modifiers() & Qt.ShiftModifier
+        operators = {'+', '-', '*', '**', '/', '//', '%', '@', '<<', '>>',
+                     '&', '|', '^', '~', '<', '>', '<=', '>=', '==', '!='}
+        delimeters = {',', ':', ';', '@', '=', '->', '+=', '-=', '*=', '/=', 
+                      '//=', '%=', '@=', '&=', '|=', '^=', '>>=', '<<=', '**='}
+        logger.debug(text)
+        if text in operators or text in delimeters:
+            self.completion_widget.hide()
         if key in (Qt.Key_Enter, Qt.Key_Return):
             if not shift and not ctrl:
                 if self.add_colons_enabled and self.is_python_like() and \

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2779,7 +2779,7 @@ class CodeEditor(TextEditBaseWidget):
         shift = event.modifiers() & Qt.ShiftModifier
         operators = {'+', '-', '*', '**', '/', '//', '%', '@', '<<', '>>',
                      '&', '|', '^', '~', '<', '>', '<=', '>=', '==', '!='}
-        delimeters = {',', ':', ';', '@', '=', '->', '+=', '-=', '*=', '/=', 
+        delimeters = {',', ':', ';', '@', '=', '->', '+=', '-=', '*=', '/=',
                       '//=', '%=', '@=', '&=', '|=', '^=', '>>=', '<<=', '**='}
         logger.debug(text)
         if text in operators or text in delimeters:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->
Dismiss the completion popup if a space is typed in the editor

![Mar-28-2019 18-08-15](https://user-images.githubusercontent.com/20992645/55198606-a2c71600-5184-11e9-8732-970ee5fd53a0.gif)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #8859 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: steff456

<!--- Thanks for your help making Spyder better for everyone! --->
