### PR TITLE
PR: Make several varexp editors stay on top

### DIFF
--- a/spyder/widgets/variableexplorer/collectionseditor.py
+++ b/spyder/widgets/variableexplorer/collectionseditor.py
@@ -1421,8 +1421,13 @@ class CollectionsEditor(QDialog):
         self.setWindowTitle(self.widget.get_title())
         if icon is None:
             self.setWindowIcon(ima.icon('dictedit'))
-        # Make the dialog act as a window
-        self.setWindowFlags(Qt.Window)
+
+        if sys.platform == 'darwin':
+            # See: https://github.com/spyder-ide/spyder/issues/9051
+            self.setWindowFlags(Qt.Tool)
+        else:
+            # Make the dialog act as a window
+            self.setWindowFlags(Qt.Window)
 
     @Slot()
     def save_and_close_enable(self):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->

On Mac we need to use `Qt.Tool` to obtain the desired behavior.

![varexp](https://user-images.githubusercontent.com/3627835/55661460-7e48ea80-57d1-11e9-8fa3-ad668bb217f3.gif)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9051



### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
