### PR TITLE
PR: Force darkstyle style on status bar

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -576,12 +576,15 @@ class MainWindow(QMainWindow):
         color_scheme = CONF.get('appearance', 'selected')
 
         if ui_theme == 'dark':
-            self.setStyleSheet(qdarkstyle.load_stylesheet_from_environment())
+            dark_qss = qdarkstyle.load_stylesheet_from_environment()
+            self.setStyleSheet(dark_qss)
+            self.statusBar().setStyleSheet(dark_qss)
             css_path = DARK_CSS_PATH
         elif ui_theme == 'automatic':
             if not is_dark_font_color(color_scheme):
-                self.setStyleSheet(
-                        qdarkstyle.load_stylesheet_from_environment())
+                dark_qss = qdarkstyle.load_stylesheet_from_environment()
+                self.setStyleSheet(dark_qss)
+                self.statusBar().setStyleSheet(dark_qss)
                 css_path = DARK_CSS_PATH
             else:
                 css_path = CSS_PATH


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9120

## Before
<img width="1440" alt="Screen Shot 2019-04-05 at 20 00 53" src="https://user-images.githubusercontent.com/3627835/55662965-75124a80-57de-11e9-980d-4314f1742925.png">

## After
<img width="1440" alt="Screen Shot 2019-04-05 at 19 48 38" src="https://user-images.githubusercontent.com/3627835/55662977-92dfaf80-57de-11e9-841b-915de9d7c885.png">

## Other option to talk?
@ccordoba12 @dpizetta, is this an option we could consider as a default on `QDarkStyle`?

It would require something like

```css
/* QStatusBar ------------------------------------------------------------- */

QStatusBar {
    background: #32414B;
    border: 1px solid #32414B;
}

QStatusBar QLabel {
    background-color: transparent;
}
```

<img width="1440" alt="Screen Shot 2019-04-05 at 19 50 33" src="https://user-images.githubusercontent.com/3627835/55662973-83606680-57de-11e9-8679-fe35ec4b4c7f.png">


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
