### PR TITLE
PR: Scroll to the selected item after go next thumbnail

### DIFF
--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -709,7 +709,7 @@ class ThumbnailScrollBar(QFrame):
             index = self._thumbnails.index(self.current_thumbnail) - 1
             index = index if index >= 0 else len(self._thumbnails) - 1
             self.set_current_index(index)
-            self.scroll_to_select_item(index)
+            self.scroll_to_item(index)
 
     def go_next_thumbnail(self):
         """Select thumbnail next to the currently selected one."""
@@ -717,9 +717,9 @@ class ThumbnailScrollBar(QFrame):
             index = self._thumbnails.index(self.current_thumbnail) + 1
             index = 0 if index >= len(self._thumbnails) else index
             self.set_current_index(index)
-            self.scroll_to_select_item(index)
+            self.scroll_to_item(index)
 
-    def scroll_to_select_item(self, index):
+    def scroll_to_item(self, index):
         """Scroll to the selected item of ThumbnailScrollBar."""
         spacing_between_items = self.scene.verticalSpacing()
         height_view = self.scrollarea.viewport().height()

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -721,23 +721,23 @@ class ThumbnailScrollBar(QFrame):
 
     def scroll_to_select_item(self, index):
         """Scroll to the selected item of ThumbnailScrollBar."""
-        space_item = self.scene.verticalSpacing()
+        spacing_between_items = self.scene.verticalSpacing()
         height_view = self.scrollarea.viewport().height()
         height_item = self.scene.itemAt(index).sizeHint().height()
-        height_remain = height_view - height_item
-        if height_remain < 0:
-            height_remain = 0
+        height_view_excluding_item = height_view - height_item
+        if height_view_excluding_item < 0:
+            height_view_excluding_item = 0
 
-        height_items_up = space_item
+        height_of_top_items = spacing_between_items
         for i in range(index):
             item = self.scene.itemAt(i)
-            height_items_up += item.sizeHint().height()
-            height_items_up += space_item
+            height_of_top_items += item.sizeHint().height()
+            height_of_top_items += spacing_between_items
 
-        height_items_up -= height_remain // 2
+        pos_scroll = height_of_top_items - height_view_excluding_item // 2
 
         vsb = self.scrollarea.verticalScrollBar()
-        vsb.setValue(height_items_up)
+        vsb.setValue(pos_scroll)
 
     # ---- ScrollBar Handlers
     def go_up(self):

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -709,6 +709,7 @@ class ThumbnailScrollBar(QFrame):
             index = self._thumbnails.index(self.current_thumbnail) - 1
             index = index if index >= 0 else len(self._thumbnails) - 1
             self.set_current_index(index)
+            self.scroll_to_select_item(index)
 
     def go_next_thumbnail(self):
         """Select thumbnail next to the currently selected one."""
@@ -716,17 +717,19 @@ class ThumbnailScrollBar(QFrame):
             index = self._thumbnails.index(self.current_thumbnail) + 1
             index = 0 if index >= len(self._thumbnails) else index
             self.set_current_index(index)
+            self.scroll_to_select_item(index)
 
-    def scroll_to_select_item(self):
+    def scroll_to_select_item(self, index):
+        """Scroll to the selected item of ThumbnailScrollBar."""
         space_item = self.scene.verticalSpacing()
         height_view = self.scrollarea.viewport().height()
-        height_item = self.scene.itemAt(self.idx).sizeHint().height()
+        height_item = self.scene.itemAt(index).sizeHint().height()
         height_remain = height_view - height_item
         if height_remain < 0:
             height_remain = 0
 
         height_items_up = space_item
-        for i in range(self.idx):
+        for i in range(index):
             item = self.scene.itemAt(i)
             height_items_up += item.sizeHint().height()
             height_items_up += space_item

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -722,6 +722,8 @@ class ThumbnailScrollBar(QFrame):
         height_view = self.scrollarea.viewport().height()
         height_item = self.scene.itemAt(self.idx).sizeHint().height()
         height_remain = height_view - height_item
+        if height_remain < 0:
+            height_remain = 0
 
         height_items_up = space_item
         for i in range(self.idx):

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -724,9 +724,7 @@ class ThumbnailScrollBar(QFrame):
         spacing_between_items = self.scene.verticalSpacing()
         height_view = self.scrollarea.viewport().height()
         height_item = self.scene.itemAt(index).sizeHint().height()
-        height_view_excluding_item = height_view - height_item
-        if height_view_excluding_item < 0:
-            height_view_excluding_item = 0
+        height_view_excluding_item = max(0, height_view - height_item)
 
         height_of_top_items = spacing_between_items
         for i in range(index):

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -717,6 +717,23 @@ class ThumbnailScrollBar(QFrame):
             index = 0 if index >= len(self._thumbnails) else index
             self.set_current_index(index)
 
+    def scroll_to_select_item(self):
+        space_item = self.scene.verticalSpacing()
+        height_view = self.scrollarea.viewport().height()
+        height_item = self.scene.itemAt(self.idx).sizeHint().height()
+        height_remain = height_view - height_item
+
+        height_items_up = space_item
+        for i in range(self.idx):
+            item = self.scene.itemAt(i)
+            height_items_up += item.sizeHint().height()
+            height_items_up += space_item
+
+        height_items_up -= height_remain // 2
+
+        vsb = self.scrollarea.verticalScrollBar()
+        vsb.setValue(height_items_up)
+
     # ---- ScrollBar Handlers
     def go_up(self):
         """Scroll the scrollbar of the scrollarea up by a single step."""

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -77,6 +77,8 @@ def add_figures_to_browser(figbrowser, nfig, tmpdir, fmt='image/png'):
         figs.append(create_figure(figname))
         figbrowser._handle_new_figure(figs[-1], fmt)
 
+    figbrowser.thumbnails_sb.scene.setVerticalSpacing(6)
+
     assert len(figbrowser.thumbnails_sb._thumbnails) == nfig
     assert figbrowser.thumbnails_sb.get_current_index() == nfig - 1
     assert figbrowser.thumbnails_sb.current_thumbnail.canvas.fig == figs[-1]
@@ -243,7 +245,7 @@ def test_scroll_to_select_item(figbrowser, tmpdir, qtbot):
 
     for __ in range(nfig // 2):
         figbrowser.go_next_thumbnail()
-        qtbot.wait(200)
+        qtbot.wait(500)
 
     vsb = figbrowser.thumbnails_sb.scrollarea.verticalScrollBar()
     assert vsb.value() == 134

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -238,7 +238,7 @@ def test_go_prev_next_thumbnail(figbrowser, tmpdir, fmt):
 def test_scroll_to_select_item(figbrowser, tmpdir, qtbot):
     """Test scroll to select item of ThumbnailScrollBar."""
     nfig = 10
-    figs = add_figures_to_browser(figbrowser, nfig, tmpdir, 'image/png')
+    add_figures_to_browser(figbrowser, nfig, tmpdir, 'image/png')
     figbrowser.setFixedSize(500, 500)
 
     for __ in range(nfig // 2):

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -247,8 +247,16 @@ def test_scroll_to_select_item(figbrowser, tmpdir, qtbot):
         figbrowser.go_next_thumbnail()
         qtbot.wait(500)
 
+    scene = figbrowser.thumbnails_sb.scene
+
+    spacing = scene.verticalSpacing()
+    height = scene.itemAt(0).sizeHint().height()
+    height_view = figbrowser.thumbnails_sb.scrollarea.viewport().height()
+
+    expected = (spacing * 5) + (height * 4) - ((height_view - height) // 2)
+
     vsb = figbrowser.thumbnails_sb.scrollarea.verticalScrollBar()
-    assert vsb.value() == 134
+    assert vsb.value() == expected
 
 
 @pytest.mark.parametrize("fmt", ['image/png', 'image/svg+xml'])

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -235,6 +235,20 @@ def test_go_prev_next_thumbnail(figbrowser, tmpdir, fmt):
     assert figbrowser.figviewer.figcanvas.fig == figs[1]
 
 
+def test_scroll_to_select_item(figbrowser, tmpdir, qtbot):
+    """Test scroll to select item of ThumbnailScrollBar."""
+    nfig = 10
+    figs = add_figures_to_browser(figbrowser, nfig, tmpdir, 'image/png')
+    figbrowser.setFixedSize(500, 500)
+
+    for __ in range(nfig // 2):
+        figbrowser.go_next_thumbnail()
+        qtbot.wait(200)
+
+    vsb = figbrowser.thumbnails_sb.scrollarea.verticalScrollBar()
+    assert vsb.value() == 134
+
+
 @pytest.mark.parametrize("fmt", ['image/png', 'image/svg+xml'])
 def test_mouse_clicking_thumbnails(figbrowser, tmpdir, qtbot, fmt):
     """

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -251,7 +251,8 @@ def test_scroll_to_item(figbrowser, tmpdir, qtbot):
     height = scene.itemAt(0).sizeHint().height()
     height_view = figbrowser.thumbnails_sb.scrollarea.viewport().height()
 
-    expected = (spacing * 5) + (height * 4) - ((height_view - height) // 2)
+    expected = (spacing * (nfig // 2)) + (height * (nfig // 2 - 1)) - \
+               ((height_view - height) // 2)
 
     vsb = figbrowser.thumbnails_sb.scrollarea.verticalScrollBar()
     assert vsb.value() == expected

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -77,8 +77,6 @@ def add_figures_to_browser(figbrowser, nfig, tmpdir, fmt='image/png'):
         figs.append(create_figure(figname))
         figbrowser._handle_new_figure(figs[-1], fmt)
 
-    figbrowser.thumbnails_sb.scene.setVerticalSpacing(6)
-
     assert len(figbrowser.thumbnails_sb._thumbnails) == nfig
     assert figbrowser.thumbnails_sb.get_current_index() == nfig - 1
     assert figbrowser.thumbnails_sb.current_thumbnail.canvas.fig == figs[-1]
@@ -237,8 +235,8 @@ def test_go_prev_next_thumbnail(figbrowser, tmpdir, fmt):
     assert figbrowser.figviewer.figcanvas.fig == figs[1]
 
 
-def test_scroll_to_select_item(figbrowser, tmpdir, qtbot):
-    """Test scroll to select item of ThumbnailScrollBar."""
+def test_scroll_to_item(figbrowser, tmpdir, qtbot):
+    """Test scroll to the item of ThumbnailScrollBar."""
     nfig = 10
     add_figures_to_browser(figbrowser, nfig, tmpdir, 'image/png')
     figbrowser.setFixedSize(500, 500)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

<!--- Explain what you've done and why --->
### Result of master
---

* ThumbnailScrollBar is not scrolled after the go_next_thumbnail button is pressed.
![Plots_current](https://user-images.githubusercontent.com/22970578/56078775-e11c3080-5e26-11e9-8023-46066714c076.gif)

### Result of PR
---

* ThumbnailScrollBar is scrolled after the go_next_thumbnail button is pressed.
![Plots_fix](https://user-images.githubusercontent.com/22970578/56078778-ec6f5c00-5e26-11e9-98db-f114f388ef4c.gif)



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ok97465

<!--- Thanks for your help making Spyder better for everyone! --->
