### PR TITLE
PR: Use a single LSP manager instance per module in our tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,16 +12,16 @@ import os
 import os.path as osp
 import shutil
 
+# To activate/deactivate certain things for pytest's only
+# NOTE: Please leave this before any other import here!!
+os.environ['SPYDER_PYTEST'] = 'True'
+
 import pytest
 
 # Local imports
 from spyder.tests.fixtures.file_fixtures import create_folders_files
 from spyder.tests.fixtures.bookmark_fixtures import (code_editor_bot,
                                                      setup_editor)
-
-
-# To activate/deactivate certain things for pytest's only
-os.environ['SPYDER_PYTEST'] = 'True'
 
 # Remove temp conf_dir before starting the tests
 from spyder.config.base import get_conf_path

--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,8 @@ import pytest
 from spyder.tests.fixtures.file_fixtures import create_folders_files
 from spyder.tests.fixtures.bookmark_fixtures import (code_editor_bot,
                                                      setup_editor)
+from spyder.plugins.editor.lsp.tests.fixtures import lsp_manager, qtbot_module
+from spyder.plugins.editor.widgets.tests.fixtures import lsp_codeeditor
 
 # Remove temp conf_dir before starting the tests
 from spyder.config.base import get_conf_path

--- a/runtests.py
+++ b/runtests.py
@@ -13,6 +13,10 @@ import os
 import sys
 import argparse
 
+# To activate/deactivate certain things for pytest's only
+# NOTE: Please leave this before any other import here!!
+os.environ['SPYDER_PYTEST'] = 'True'
+
 # Third party imports
 import pytest
 

--- a/spyder/plugins/editor/lsp/manager.py
+++ b/spyder/plugins/editor/lsp/manager.py
@@ -15,7 +15,7 @@ import os
 import os.path as osp
 
 # Third-party imports
-from qtpy.QtCore import QObject, Signal, Slot
+from qtpy.QtCore import QObject, Slot
 
 # Local imports
 from spyder.config.base import get_conf_path, running_under_pytest
@@ -35,9 +35,6 @@ class LSPManager(QObject):
     RUNNING = 'running'
     CONF_SECTION = 'lsp-server'
     LOCALHOST = ['127.0.0.1', 'localhost']
-
-    # For testing
-    sig_initialize = Signal(dict, str)
 
     def __init__(self, parent):
         QObject.__init__(self)
@@ -167,9 +164,6 @@ class LSPManager(QObject):
                 if self.main and self.main.editor:
                     language_client['instance'].sig_initialize.connect(
                         self.main.editor.register_lsp_server_settings)
-                elif running_under_pytest():
-                    language_client['instance'].sig_initialize.connect(
-                        self.sig_initialize.emit)
 
                 logger.info("Starting LSP client for {}...".format(language))
                 language_client['instance'].start()

--- a/spyder/plugins/editor/lsp/manager.py
+++ b/spyder/plugins/editor/lsp/manager.py
@@ -15,7 +15,7 @@ import os
 import os.path as osp
 
 # Third-party imports
-from qtpy.QtCore import QObject, Slot
+from qtpy.QtCore import QObject, Signal, Slot
 
 # Local imports
 from spyder.config.base import get_conf_path, running_under_pytest
@@ -35,6 +35,9 @@ class LSPManager(QObject):
     RUNNING = 'running'
     CONF_SECTION = 'lsp-server'
     LOCALHOST = ['127.0.0.1', 'localhost']
+
+    # For testing
+    sig_initialize = Signal(dict, str)
 
     def __init__(self, parent):
         QObject.__init__(self)
@@ -164,6 +167,9 @@ class LSPManager(QObject):
                 if self.main and self.main.editor:
                     language_client['instance'].sig_initialize.connect(
                         self.main.editor.register_lsp_server_settings)
+                elif running_under_pytest():
+                    language_client['instance'].sig_initialize.connect(
+                        self.sig_initialize.emit)
 
                 logger.info("Starting LSP client for {}...".format(language))
                 language_client['instance'].start()

--- a/spyder/plugins/editor/lsp/tests/fixtures.py
+++ b/spyder/plugins/editor/lsp/tests/fixtures.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+import os
+
+import pytest
+from pytestqt.plugin import QtBot
+
+from spyder.config.main import CONF
+from spyder.plugins.editor.lsp import SERVER_CAPABILITES
+from spyder.plugins.editor.lsp.manager import LSPManager
+
+
+@pytest.fixture(scope="module")
+def qtbot_module(qapp, request):
+    """Module fixture for qtbot."""
+    result = QtBot(request)
+    return result
+
+
+@pytest.fixture(scope="module")
+def lsp_manager(qtbot_module):
+    """Create an LSP manager instance."""
+    # Activate pycodestyle and pydocstyle
+    CONF.set('lsp-server', 'pycodestyle', True)
+    CONF.set('lsp-server', 'pydocstyle', True)
+
+    # Create the manager
+    os.environ['SPY_TEST_USE_INTROSPECTION'] = 'True'
+    manager = LSPManager(parent=None)
+
+    with qtbot_module.waitSignal(manager.sig_initialize, timeout=30000) as blocker:
+        manager.start_client('python')
+
+    settings, language = blocker.args
+    assert all([option in SERVER_CAPABILITES for option in settings.keys()])
+    manager.clients[language]['server_settings'] = settings
+
+    yield manager
+
+    # Tear down operations
+    manager.shutdown()
+    os.environ['SPY_TEST_USE_INTROSPECTION'] = 'False'
+    CONF.set('lsp-server', 'pycodestyle', False)
+    CONF.set('lsp-server', 'pydocstyle', False)

--- a/spyder/plugins/editor/lsp/tests/test_client.py
+++ b/spyder/plugins/editor/lsp/tests/test_client.py
@@ -13,8 +13,6 @@ from qtpy.QtCore import QObject, Signal, Slot
 from spyder.config.lsp import PYTHON_CONFIG
 from spyder.plugins.editor.lsp.client import LSPClient
 from spyder.plugins.editor.lsp import LSPRequestTypes
-from spyder.plugins.editor.widgets.tests.fixtures import (
-    lsp_manager, qtbot_module)
 
 
 class LSPEditor(QObject):
@@ -35,6 +33,7 @@ def lsp_client_and_editor(lsp_manager):
 
 
 @pytest.mark.slow
+@pytest.mark.third
 def test_didOpen(lsp_client_and_editor, qtbot):
     client, editor = lsp_client_and_editor
 
@@ -58,6 +57,7 @@ def test_didOpen(lsp_client_and_editor, qtbot):
 
 
 @pytest.mark.slow
+@pytest.mark.third
 def test_get_signature(lsp_client_and_editor, qtbot):
     client, editor = lsp_client_and_editor
 
@@ -95,6 +95,7 @@ def test_get_signature(lsp_client_and_editor, qtbot):
 
 
 @pytest.mark.slow
+@pytest.mark.third
 def test_get_completions(lsp_client_and_editor, qtbot):
     client, editor = lsp_client_and_editor
 
@@ -133,6 +134,7 @@ def test_get_completions(lsp_client_and_editor, qtbot):
 
 
 @pytest.mark.slow
+@pytest.mark.third
 def test_go_to_definition(lsp_client_and_editor, qtbot):
     client, editor = lsp_client_and_editor
 
@@ -171,6 +173,7 @@ def test_go_to_definition(lsp_client_and_editor, qtbot):
 
 
 @pytest.mark.slow
+@pytest.mark.third
 def test_local_signature(lsp_client_and_editor, qtbot):
     client, editor = lsp_client_and_editor
 

--- a/spyder/plugins/editor/widgets/tests/fixtures.py
+++ b/spyder/plugins/editor/widgets/tests/fixtures.py
@@ -63,7 +63,8 @@ def lsp_codeeditor(lsp_manager, qtbot_module, request):
     editor.filename = 'test.py'
     editor.language = 'Python'
     lsp_manager.register_file('python', 'test.py', editor)
-    editor.start_lsp_services(lsp_manager.clients['python']['server_settings'])
+    server_settings = lsp_manager.main.editor.lsp_editor_settings['python']
+    editor.start_lsp_services(server_settings)
 
     with qtbot_module.waitSignal(editor.lsp_response_signal, timeout=30000):
         editor.document_did_open()

--- a/spyder/plugins/editor/widgets/tests/fixtures.py
+++ b/spyder/plugins/editor/widgets/tests/fixtures.py
@@ -105,7 +105,7 @@ def lsp_codeeditor(lsp_manager, qtbot_module):
     with qtbot_module.waitSignal(editor.lsp_response_signal, timeout=30000):
         editor.document_did_open()
 
-    yield editor
+    yield editor, lsp_manager
 
     # Teardown operations
     editor.hide()

--- a/spyder/plugins/editor/widgets/tests/fixtures.py
+++ b/spyder/plugins/editor/widgets/tests/fixtures.py
@@ -9,7 +9,6 @@ Testing utilities to be used with pytest.
 """
 
 # Stdlib imports
-import os
 try:
     from unittest.mock import Mock
 except ImportError:
@@ -17,13 +16,9 @@ except ImportError:
 
 # Third party imports
 import pytest
-from pytestqt.plugin import QtBot
 from qtpy.QtGui import QFont
 
 # Local imports
-from spyder.config.main import CONF
-from spyder.plugins.editor.lsp import SERVER_CAPABILITES
-from spyder.plugins.editor.lsp.manager import LSPManager
 from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 from spyder.plugins.editor.widgets.editor import EditorStack
 from spyder.widgets.findreplace import FindReplace
@@ -46,40 +41,6 @@ def setup_editor(qtbot):
     finfo = editorStack.new('foo.py', 'utf-8', text)
     qtbot.addWidget(editorStack)
     return editorStack, finfo.editor
-
-
-@pytest.fixture(scope="module")
-def qtbot_module(qapp, request):
-    """Module fixture for qtbot."""
-    result = QtBot(request)
-    return result
-
-
-@pytest.fixture(scope="module")
-def lsp_manager(qtbot_module):
-    """Create an LSP manager instance."""
-    # Activate pycodestyle and pydocstyle
-    CONF.set('lsp-server', 'pycodestyle', True)
-    CONF.set('lsp-server', 'pydocstyle', True)
-
-    # Create the manager
-    os.environ['SPY_TEST_USE_INTROSPECTION'] = 'True'
-    manager = LSPManager(parent=None)
-
-    with qtbot_module.waitSignal(manager.sig_initialize, timeout=30000) as blocker:
-        manager.start_client('python')
-
-    settings, language = blocker.args
-    assert all([option in SERVER_CAPABILITES for option in settings.keys()])
-    manager.clients[language]['server_settings'] = settings
-
-    yield manager
-
-    # Tear down operations
-    manager.shutdown()
-    os.environ['SPY_TEST_USE_INTROSPECTION'] = 'False'
-    CONF.set('lsp-server', 'pycodestyle', False)
-    CONF.set('lsp-server', 'pydocstyle', False)
 
 
 @pytest.fixture

--- a/spyder/plugins/editor/widgets/tests/fixtures.py
+++ b/spyder/plugins/editor/widgets/tests/fixtures.py
@@ -22,6 +22,7 @@ from qtpy.QtGui import QFont
 
 # Local imports
 from spyder.config.main import CONF
+from spyder.plugins.editor.lsp import SERVER_CAPABILITES
 from spyder.plugins.editor.lsp.manager import LSPManager
 from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 from spyder.plugins.editor.widgets.editor import EditorStack
@@ -69,6 +70,7 @@ def lsp_manager(qtbot_module):
         manager.start_client('python')
 
     settings, language = blocker.args
+    assert all([option in SERVER_CAPABILITES for option in settings.keys()])
     manager.clients[language]['server_settings'] = settings
 
     yield manager

--- a/spyder/plugins/editor/widgets/tests/fixtures.py
+++ b/spyder/plugins/editor/widgets/tests/fixtures.py
@@ -44,7 +44,7 @@ def setup_editor(qtbot):
 
 
 @pytest.fixture
-def lsp_codeeditor(lsp_manager, qtbot_module):
+def lsp_codeeditor(lsp_manager, qtbot_module, request):
     """CodeEditor instance with LSP services activated."""
     # Create a CodeEditor instance
     editor = CodeEditor(parent=None)
@@ -68,8 +68,9 @@ def lsp_codeeditor(lsp_manager, qtbot_module):
     with qtbot_module.waitSignal(editor.lsp_response_signal, timeout=30000):
         editor.document_did_open()
 
-    yield editor, lsp_manager
+    def teardown():
+        editor.hide()
+        editor.completion_widget.hide()
 
-    # Teardown operations
-    editor.hide()
-    editor.completion_widget.hide()
+    request.addfinalizer(teardown)
+    return editor, lsp_manager

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -19,8 +19,6 @@ from qtpy.QtCore import Qt
 
 # Local imports
 from spyder.py3compat import PY2
-from spyder.plugins.editor.widgets.tests.fixtures import (
-    lsp_codeeditor, lsp_manager, qtbot_module)
 
 
 # Location of this file

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -19,8 +19,8 @@ from qtpy.QtCore import Qt
 
 # Local imports
 from spyder.py3compat import PY2
-from spyder.plugins.editor.widgets.tests.fixtures import (lsp_codeeditor,
-    lsp_manager, qtbot_module)
+from spyder.plugins.editor.widgets.tests.fixtures import (
+    lsp_codeeditor, lsp_manager, qtbot_module)
 
 
 # Location of this file
@@ -31,7 +31,7 @@ LOCATION = osp.realpath(osp.join(os.getcwd(), osp.dirname(__file__)))
 @pytest.mark.first
 def test_space_completion(lsp_codeeditor, qtbot):
     """Validate completion's space character handling."""
-    code_editor = lsp_codeeditor
+    code_editor, _ = lsp_codeeditor
     completion = code_editor.completion_widget
 
     # Set cursor to start
@@ -57,7 +57,7 @@ def test_space_completion(lsp_codeeditor, qtbot):
 @pytest.mark.first
 def test_hide_widget_completion(lsp_codeeditor, qtbot):
     """Validate hiding completion widget after a delimeter or operator."""
-    code_editor = lsp_codeeditor
+    code_editor, _ = lsp_codeeditor
     completion = code_editor.completion_widget
 
     delimiters = ['(', ')', '[', ']', '{', '}', ',', ':', ';', '@', '=', '->',
@@ -91,7 +91,7 @@ def test_hide_widget_completion(lsp_codeeditor, qtbot):
 @pytest.mark.first
 def test_completions(lsp_codeeditor, qtbot):
     """Exercise code completion in several ways."""
-    code_editor = lsp_codeeditor
+    code_editor, _ = lsp_codeeditor
     completion = code_editor.completion_widget
 
     # Set cursor to start

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -19,7 +19,8 @@ from qtpy.QtCore import Qt
 
 # Local imports
 from spyder.py3compat import PY2
-from spyder.plugins.editor.widgets.tests.fixtures import lsp_codeeditor
+from spyder.plugins.editor.widgets.tests.fixtures import (lsp_codeeditor,
+    lsp_manager, qtbot_module)
 
 
 # Location of this file

--- a/spyder/plugins/editor/widgets/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/tests/test_warnings.py
@@ -13,7 +13,8 @@ import os
 import pytest
 
 # Local imports
-from spyder.plugins.editor.widgets.tests.fixtures import lsp_codeeditor
+from spyder.plugins.editor.widgets.tests.fixtures import (lsp_codeeditor,
+    lsp_manager, qtbot_module)
 
 
 TEXT = ("def some_function():\n"  # D100, D103: Missing docstring

--- a/spyder/plugins/editor/widgets/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/tests/test_warnings.py
@@ -14,8 +14,6 @@ import pytest
 
 # Local imports
 from spyder.config.main import CONF
-from spyder.plugins.editor.widgets.tests.fixtures import (
-    lsp_codeeditor, lsp_manager, qtbot_module)
 
 
 TEXT = ("def some_function():\n"  # D100, D103: Missing docstring
@@ -27,7 +25,7 @@ TEXT = ("def some_function():\n"  # D100, D103: Missing docstring
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.second
 @pytest.mark.xfail
 def test_ignore_warnings(qtbot, lsp_codeeditor):
     """Test that the editor is ignoring some warnings."""
@@ -61,7 +59,7 @@ def test_ignore_warnings(qtbot, lsp_codeeditor):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.second
 def test_adding_warnings(qtbot, lsp_codeeditor):
     """Test that warnings are saved in the editor blocks."""
     editor, _ = lsp_codeeditor
@@ -93,7 +91,7 @@ def test_adding_warnings(qtbot, lsp_codeeditor):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.second
 def test_move_warnings(qtbot, lsp_codeeditor):
     """Test that moving to next/previous warnings is working."""
     editor, _ = lsp_codeeditor
@@ -125,7 +123,7 @@ def test_move_warnings(qtbot, lsp_codeeditor):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.second
 def test_get_warnings(qtbot, lsp_codeeditor):
     """Test that the editor is returning the right list of warnings."""
     editor, _ = lsp_codeeditor


### PR DESCRIPTION
This PR adds a new fixture called `lsp_manager` to avoid creating an LSP client per test (which is very costly). Now we create a client per module and run all tests with it.