### PR TITLE
PR: Prevent rehighlight() from setting changed_since_autosave_flag

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1704,6 +1704,7 @@ class EditorStack(QWidget):
                                  finfo.filename, finfo.filename)
 
             finfo.editor.document().setModified(False)
+            finfo.editor.document().changed_since_autosave = False
             self.modification_changed(index=index)
             self.analyze_script(index)
 
@@ -1713,10 +1714,6 @@ class EditorStack(QWidget):
             # patterns instead of only searching for class/def patterns which
             # would be sufficient for outline explorer data.
             finfo.editor.rehighlight()
-
-            # rehighlight() calls textChanged(), so the change_since_autosave
-            # flag should be cleared after rehighlight()
-            finfo.editor.document().changed_since_autosave = False
 
             self._refresh_outlineexplorer(index)
 
@@ -2189,6 +2186,7 @@ class EditorStack(QWidget):
         position = finfo.editor.get_position('cursor')
         finfo.editor.set_text(txt)
         finfo.editor.document().setModified(False)
+        finfo.editor.document().changed_since_autosave = False
         finfo.editor.set_cursor_position(position)
 
         #XXX CodeEditor-only: re-scan the whole text to rebuild outline
@@ -2197,10 +2195,6 @@ class EditorStack(QWidget):
         # patterns instead of only searching for class/def patterns which
         # would be sufficient for outline explorer data.
         finfo.editor.rehighlight()
-
-        # rehighlight() calls textChanged(), so the change_since_autosave
-        # flag should be cleared after rehighlight()
-        finfo.editor.document().changed_since_autosave = False
 
         self._refresh_outlineexplorer(index)
 
@@ -2278,7 +2272,7 @@ class EditorStack(QWidget):
         if cloned_from is None:
             editor.set_text(txt)
             editor.document().setModified(False)
-        editor.document().changed_since_autosave = False
+            editor.document().changed_since_autosave = False
         finfo.text_changed_at.connect(
                                     lambda fname, position:
                                     self.text_changed_at.emit(fname, position))

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -24,7 +24,6 @@ from qtpy.QtGui import QTextCursor
 
 # Local imports
 from spyder.config.base import get_conf_path
-from spyder.plugins.editor.widgets.tests.fixtures import setup_editor
 from spyder.plugins.editor.widgets.editor import EditorStack
 from spyder.widgets.findreplace import FindReplace
 from spyder.py3compat import PY2
@@ -677,9 +676,7 @@ def test_autosave_does_not_save_after_reload(base_editor_bot, mocker):
     mocker.patch.object(editor_stack, '_write_to_file')
     mocker.patch('spyder.plugins.editor.widgets.editor.encoding.read',
                  return_value=(txt, 'ascii'))
-    print(editor_stack.data[0].editor.document().changed_since_autosave)
     editor_stack.reload(0)
-    print(editor_stack.data[0].editor.document().changed_since_autosave)
     editor_stack.autosave.autosave(0)
     editor_stack._write_to_file.assert_not_called()
 

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -644,16 +644,21 @@ def test_autosave_does_not_save_new_files(editor_bot, mocker):
     editor_stack._write_to_file.assert_not_called()
 
 
-def test_autosave_does_not_save_after_open(base_editor_bot, mocker):
+@pytest.mark.parametrize('filename', ['ham.py', 'ham.txt'])
+def test_autosave_does_not_save_after_open(base_editor_bot, mocker, qtbot,
+                                           filename):
     """
     Test that autosave() does not save files immediately after opening.
 
     Files should only be autosaved after the user made changes.
+    Editors use different highlighters depending on the filename, so we test
+    both Python and text files. The latter covers issue #8654.
     """
     editor_stack = base_editor_bot
     txt = 'spam\n'
-    editor_stack.create_new_editor('ham.py', 'ascii', txt, set_current=True)
+    editor_stack.create_new_editor(filename, 'ascii', txt, set_current=True)
     mocker.patch.object(editor_stack, '_write_to_file')
+    qtbot.wait(100)  # Wait for PygmentsSH.makeCharlist() if applicable
     editor_stack.autosave.autosave(0)
     editor_stack._write_to_file.assert_not_called()
 

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -24,6 +24,7 @@ from qtpy.QtGui import QTextCursor
 
 # Local imports
 from spyder.config.base import get_conf_path
+from spyder.plugins.editor.widgets.tests.fixtures import setup_editor
 from spyder.plugins.editor.widgets.editor import EditorStack
 from spyder.widgets.findreplace import FindReplace
 from spyder.py3compat import PY2

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -280,7 +280,11 @@ class BaseSH(QSyntaxHighlighter):
     def rehighlight(self):
         self.outlineexplorer_data = {}
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        # rehighlight() triggers the textChanged signal, which in our editor
+        # switches changed_since_autosave to True; we need to prevent this.
+        old_changed = getattr(self.document(), 'changed_since_autosave', False)
         QSyntaxHighlighter.rehighlight(self)
+        self.document().changed_since_autosave = old_changed
         QApplication.restoreOverrideCursor()
 
 


### PR DESCRIPTION
## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

Previously, rehighlighting an open file may set the changed_since_autosave flag and thus trigger an autosave. To guard against this, I added code so that after loading a file, the changed_since_autosave is cleared. This worked for Python files. However, text files use a different highlighter, which delays the call to rehighlight(), so my solution did not work for it and text files always got autosaved.

This PR prevents rehighlight() from setting changed_since_autosave_flag, which is more robust, and also fixes the bug with text files.

### Issue(s) Resolved

Fixes #8654

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jitse Niesen
