### PR TITLE
PR: Highlight current entry in the Outline Explorer and update it on-the-fly

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1324,11 +1324,7 @@ class Editor(SpyderPluginWidget):
         oe_options = self.outlineexplorer.explorer.get_options()
         window = EditorMainWindow(
             self, self.stack_menu_actions, self.toolbar_list, self.menu_list,
-            show_fullpath=oe_options['show_fullpath'],
-            show_all_files=oe_options['show_all_files'],
-            group_cells=oe_options['group_cells'],
-            show_comments=oe_options['show_comments'],
-            sort_files_alphabetically=oe_options['sort_files_alphabetically'])
+            outline_explorer_options=oe_options)
         window.add_toolbars_to_menu("&View", window.get_toolbars())
         window.load_toolbars()
         window.resize(self.size())

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2800,9 +2800,7 @@ class EditorSplitter(QSplitter):
 
 
 class EditorWidget(QSplitter):
-    def __init__(self, parent, plugin, menu_actions, show_fullpath,
-                 show_all_files, group_cells, show_comments,
-                 sort_files_alphabetically):
+    def __init__(self, parent, plugin, menu_actions, outline_explorer_options):
         QSplitter.__init__(self, parent)
         self.setAttribute(Qt.WA_DeleteOnClose)
 
@@ -2821,12 +2819,14 @@ class EditorWidget(QSplitter):
         self.plugin.register_widget_shortcuts(self.find_widget)
         self.find_widget.hide()
         self.outlineexplorer = OutlineExplorerWidget(
-                self,
-                show_fullpath=show_fullpath,
-                show_all_files=show_all_files,
-                group_cells=group_cells,
-                show_comments=show_comments,
-                sort_files_alphabetically=sort_files_alphabetically)
+            self,
+            show_fullpath=outline_explorer_options['show_fullpath'],
+            show_all_files=outline_explorer_options['show_all_files'],
+            group_cells=outline_explorer_options['group_cells'],
+            show_comments=outline_explorer_options['show_comments'],
+            sort_files_alphabetically=outline_explorer_options[
+                'sort_files_alphabetically'],
+            )
         self.outlineexplorer.edit_goto.connect(
                      lambda filenames, goto, word:
                      plugin.load(filenames=filenames, goto=goto, word=word,
@@ -2891,8 +2891,7 @@ class EditorWidget(QSplitter):
 
 class EditorMainWindow(QMainWindow):
     def __init__(self, plugin, menu_actions, toolbar_list, menu_list,
-                 show_fullpath, show_all_files, group_cells, show_comments,
-                 sort_files_alphabetically):
+                 outline_explorer_options):
         QMainWindow.__init__(self)
         self.setAttribute(Qt.WA_DeleteOnClose)
 
@@ -2900,9 +2899,7 @@ class EditorMainWindow(QMainWindow):
         self.window_size = None
 
         self.editorwidget = EditorWidget(self, plugin, menu_actions,
-                                         show_fullpath, show_all_files,
-                                         group_cells, show_comments,
-                                         sort_files_alphabetically)
+                                         outline_explorer_options)
         self.setCentralWidget(self.editorwidget)
 
         # Setting interface theme

--- a/spyder/plugins/outlineexplorer/api.py
+++ b/spyder/plugins/outlineexplorer/api.py
@@ -22,14 +22,19 @@ outlineexplorer.set_current_editor(oe_proxy, update=True, clear=False)
 
 outlineexplorer.edit_goto.connect(handle_go_to)
 """
+from qtpy.QtCore import Signal, QObject
 
 
-class OutlineExplorerProxy(object):
+class OutlineExplorerProxy(QObject):
     """
     Proxy class between editors and OutlineExplorerWidget.
     """
 
+    sig_cursor_position_changed = Signal(int, int)
+    sig_outline_explorer_data_changed = Signal()
+
     def __init__(self):
+        super(OutlineExplorerProxy, self).__init__()
         self.fname = None
 
     def is_python(self):
@@ -58,7 +63,7 @@ class OutlineExplorerProxy(object):
         """Return the number of lines of the editor (int)."""
         raise NotImplementedError
 
-    def parent():
+    def parent(self):
         """This is used for diferenciate editors in multi-window mode."""
         return None
 

--- a/spyder/plugins/outlineexplorer/api.py
+++ b/spyder/plugins/outlineexplorer/api.py
@@ -67,6 +67,10 @@ class OutlineExplorerProxy(QObject):
         """This is used for diferenciate editors in multi-window mode."""
         return None
 
+    def get_cursor_line_number(self):
+        """Return the cursor line number."""
+        raise NotImplementedError
+
 
 class OutlineExplorerData(object):
     CLASS, FUNCTION, STATEMENT, COMMENT, CELL = list(range(5))

--- a/spyder/plugins/outlineexplorer/editor.py
+++ b/spyder/plugins/outlineexplorer/editor.py
@@ -11,8 +11,15 @@ from spyder.plugins.outlineexplorer.api import OutlineExplorerProxy
 
 class OutlineExplorerProxyEditor(OutlineExplorerProxy):
     def __init__(self, editor, fname):
+        super(OutlineExplorerProxyEditor, self).__init__()
         self._editor = editor
         self.fname = fname
+        editor.sig_cursor_position_changed.connect(
+            self.sig_cursor_position_changed)
+        editor.highlighter.sig_outline_explorer_data_changed.connect(
+            self.sig_outline_explorer_data_changed)
+        editor.blockCountChanged.connect(
+            self.sig_outline_explorer_data_changed)
 
     def is_python(self):
         return self._editor.is_python()

--- a/spyder/plugins/outlineexplorer/tests/test_outline_explorer.py
+++ b/spyder/plugins/outlineexplorer/tests/test_outline_explorer.py
@@ -33,6 +33,7 @@ oe_data = [
 
 class OutlineExplorerProxyTest(OutlineExplorerProxy):
     def __init__(self, fname, oe_data):
+        super(OutlineExplorerProxyTest, self).__init__()
         self.fname = fname
         self.oe_data = oe_data
 

--- a/spyder/plugins/outlineexplorer/tests/test_outline_explorer.py
+++ b/spyder/plugins/outlineexplorer/tests/test_outline_explorer.py
@@ -59,6 +59,9 @@ class OutlineExplorerProxyTest(OutlineExplorerProxy):
     def parent(self):
         return None
 
+    def get_cursor_line_number(self):
+        return 1
+
 
 def click_item(treewidget, item, qtbot):
     """Click an item in a treewidget."""

--- a/spyder/plugins/outlineexplorer/tests/test_widgets.py
+++ b/spyder/plugins/outlineexplorer/tests/test_widgets.py
@@ -207,6 +207,29 @@ def test_go_to_cursor_position(create_outlineexplorer, qtbot):
     assert outlineexplorer.treewidget.currentItem().text(0) == 'method1'
 
 
+def test_outlineexplorer_updates(create_outlineexplorer, qtbot):
+    """
+    Test that the cursor is followed
+    """
+    outlineexplorer = create_outlineexplorer(TEXT, 'test.py',
+                                             follow_cursor=True)
+    # Move the mouse cursor in the editor to line 5 :
+    editor = outlineexplorer.treewidget.current_editor
+    editor._editor.go_to_line(4)
+    assert editor._editor.get_text_line(4) == ""
+    # Go to cursor to open the cursor
+    qtbot.mouseClick(outlineexplorer.fromcursor_btn, Qt.LeftButton)
+
+    newcell_txt = "# %% newcell"
+    with qtbot.waitSignal(editor.sig_outline_explorer_data_changed):
+        qtbot.keyClicks(editor._editor, newcell_txt)
+
+    # editor._editor.go_to_line(3)
+    assert editor._editor.get_text_line(3) == newcell_txt
+    # check the outline explorer is up to date
+    assert outlineexplorer.treewidget.currentItem().text(0) == 'newcell'
+
+
 def test_go_to_cursor_position_with_new_file(create_outlineexplorer, qtbot):
     """
     Test that clicking on the 'Go to cursor position' button located in the

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -174,11 +174,27 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         self.editor_tree_cache = {}
         self.editor_ids = {}
         self.ordered_editor_ids = []
-        self.current_editor = None
+        self._current_editor = None
         title = _("Outline")
         self.set_title(title)
         self.setWindowTitle(title)
         self.setUniformRowHeights(True)
+
+    @property
+    def current_editor(self):
+        """Get current editor."""
+        return self._current_editor
+
+    @current_editor.setter
+    def current_editor(self, value):
+        """Set current editor and connect the necessary signals."""
+        if self._current_editor == value:
+            return
+        # Disconnect previous editor
+        self.connect_current_editor(False)
+        self._current_editor = value
+        # Connect new editor
+        self.connect_current_editor(True)
 
     def get_actions_from_items(self, items):
         """Reimplemented OneColumnTree method"""
@@ -258,7 +274,20 @@ class OutlineExplorerTreeWidget(OneColumnTree):
             item = item_at_line(root_item, line)
             self.setCurrentItem(item)
             self.scrollToItem(item)
-                
+
+
+    def connect_current_editor(self, state):
+        """Connect or disconnect the editor from signals."""
+        editor = self.current_editor
+        if editor is None:
+            return
+
+        # Connect syntax highlighter
+        sig_update = editor.sig_outline_explorer_data_changed
+        if state:
+            sig_update.connect(self.update_all)
+        else:
+            sig_update.disconnect(self.update_all)
     def clear(self):
         """Reimplemented Qt method"""
         self.set_title('')
@@ -305,7 +334,8 @@ class OutlineExplorerTreeWidget(OneColumnTree):
             root_item = self.editor_items[editor_id]
             root_item.set_path(new_filename, fullpath=self.show_fullpath)
             self.__sort_toplevel_items()
-        
+
+    @Slot()
     def update_all(self):
         self.save_expanded_state()
         for editor, editor_id in list(self.editor_ids.items()):
@@ -605,7 +635,7 @@ class OutlineExplorerWidget(QWidget):
     edit_goto = Signal(str, int, str)
     edit = Signal(str)
     is_visible = Signal()
-    
+
     def __init__(self, parent=None, show_fullpath=True, show_all_files=True,
                  group_cells=True, show_comments=True,
                  sort_files_alphabetically=False,
@@ -685,7 +715,7 @@ class OutlineExplorerWidget(QWidget):
                 self.treewidget.sort_files_alphabetically),
             expanded_state=self.treewidget.get_expanded_state(),
             scrollbar_position=self.treewidget.get_scrollbar_position(),
-            visibility=self.isVisible()
+            visibility=self.isVisible(),
             )
 
     def update(self):

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -21,7 +21,7 @@ from pygments.lexer import RegexLexer, bygroups
 from pygments.lexers import get_lexer_by_name
 from pygments.token import (Text, Other, Keyword, Name, String, Number,
                             Comment, Generic, Token)
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, QTimer, Signal, Slot
 from qtpy.QtGui import (QColor, QCursor, QFont, QSyntaxHighlighter,
                         QTextCharFormat, QTextOption)
 from qtpy.QtWidgets import QApplication
@@ -113,6 +113,8 @@ class BaseSH(QSyntaxHighlighter):
     NORMAL = 0
     # Syntax highlighting parameters.
     BLANK_ALPHA_FACTOR = 0.31
+
+    sig_outline_explorer_data_changed = Signal()
 
     def __init__(self, parent, font=None, color_scheme='Spyder'):
         QSyntaxHighlighter.__init__(self, parent)
@@ -426,6 +428,11 @@ class PythonSH(BaseSH):
         self.import_statements = {}
         self.found_cell_separators = False
         self.cell_separators = CELL_LANGUAGES['Python']
+        # Avoid updating the outline explorer with every single letter typed
+        self.outline_explorer_data_update_timer = QTimer()
+        self.outline_explorer_data_update_timer.setSingleShot(True)
+        self.outline_explorer_data_update_timer.timeout.connect(
+            self.sig_outline_explorer_data_changed)
 
     def highlight_block(self, text):
         """Implement specific highlight for Python."""
@@ -556,6 +563,7 @@ class PythonSH(BaseSH):
             block_nb = self.currentBlock().blockNumber()
             self.outlineexplorer_data[block_nb] = oedata
             self.outlineexplorer_data['found_cell_separators'] = self.found_cell_separators
+            self.outline_explorer_data_update_timer.start(500)
         if import_stmt is not None:
             block_nb = self.currentBlock().blockNumber()
             self.import_statements[block_nb] = import_stmt


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot (if affecting the UI)

![follow](https://user-images.githubusercontent.com/6740194/56855771-f0ca6780-6944-11e9-9a71-41480d9104b7.gif)
<!--- Explain what you've done and why --->
Add the possibility to follow the cursor in the outline explorer, so the user knows where (s)he is.

Updates automatically the cell name when the syntax highlighter sees a change

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #885.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
impact27
<!--- Thanks for your help making Spyder better for everyone! --->
