### PR TITLE
PR: Mark test_update_warnings_after_delete_line as slow and second

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -348,7 +348,8 @@ def test_filter_numpy_warning(main_window, qtbot):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
-@pytest.mark.skipif(PY2, reason="Times out in PY2")
+@pytest.mark.skipif(PY2 or sys.platform.startswith('linux'),
+                    reason="Times out in PY2 and fails on second run on Linux")
 def test_get_help_combo(main_window, qtbot):
     """
     Test that Help can display docstrings for names typed in its combobox.

--- a/spyder/plugins/editor/widgets/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/tests/test_warnings.py
@@ -146,6 +146,8 @@ def test_get_warnings(qtbot, lsp_codeeditor):
     assert warnings == expected
 
 
+@pytest.mark.slow
+@pytest.mark.second
 def test_update_warnings_after_delete_line(qtbot, lsp_codeeditor):
     """
     Test that code style warnings are correctly updated after deleting a line


### PR DESCRIPTION
I forgot to suggest this to @jnsebgosselin in PR #9300, but it's pretty important.