### PR TITLE
PR: Restrict PyLS version to be less than 0.25

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,7 @@ install_requires = [
     # pyqtwebengine module
     'pyqtwebengine<5.13',
     # Pyls with all its dependencies
-    'python-language-server[all]>=0.19.0',
+    'python-language-server[all]>=0.19.0,<0.25',
     # Required to get SSH connections to remote kernels
     'pexpect;platform_system!="Windows"',
     'paramiko;platform_system=="Windows"'

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 
 
 # Dependencies
-PYLS_REQVER = '>=0.19.0'
+PYLS_REQVER = '>=0.19.0;<0.25'
 dependencies.add('pyls',
                  _("Editor's code completion, go-to-definition, help and "
                    "real-time code analysis"),


### PR DESCRIPTION
That's because 0.25 added support for Pylint as a linter but now it it's not possible to turn it off.

Pinging @stonebig about it.