### PR TITLE
PR: Improvements to the cmd used to start external terminals on Windows

### DIFF
--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -291,8 +291,10 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
     p_args += get_python_args(fname, python_args, interact, debug, args)
 
     if os.name == 'nt':
-        cmd = ('start cmd.exe /K "cd %s && ' % wdir + ' '.join(p_args) +
-               '"' + ' ^&^& exit')
+        cmd = 'start cmd.exe /K "'
+        if wdir:
+            cmd += 'cd ' + wdir + ' && '
+        cmd += ' '.join(p_args) + '"' + ' ^&^& exit'
         # Command line and cwd have to be converted to the filesystem
         # encoding before passing them to subprocess, but only for
         # Python 2.

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -303,7 +303,10 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
             cmd = encoding.to_fs_from_unicode(cmd)
             wdir = encoding.to_fs_from_unicode(wdir)
         try:
-            run_shell_command(cmd, cwd=wdir)
+            if wdir:
+                run_shell_command(cmd, cwd=wdir)
+            else:
+                run_shell_command(cmd)
         except WindowsError:
             from qtpy.QtWidgets import QMessageBox
             from spyder.config.base import _

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -291,7 +291,8 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
     p_args += get_python_args(fname, python_args, interact, debug, args)
 
     if os.name == 'nt':
-        cmd = 'start cmd.exe /c "cd %s && ' % wdir + ' '.join(p_args) + '"'
+        cmd = ('start cmd.exe /K "cd %s && ' % wdir + ' '.join(p_args) +
+               '"' + ' ^&^& exit')
         # Command line and cwd have to be converted to the filesystem
         # encoding before passing them to subprocess, but only for
         # Python 2.

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -41,6 +41,7 @@ else:
 # =============================================================================
 @pytest.fixture
 def scriptpath(tmpdir):
+    """Save a basic Python script in a file."""
     script = ("with open('out.txt', 'w') as f:\n"
               "    f.write('done')\n")
     scriptpath = tmpdir.join('write-done.py')
@@ -64,6 +65,10 @@ def test_is_valid_w_interpreter():
     os.environ.get('CI', None) is None or sys.platform == 'darwin',
     reason='fails in macOS and sometimes locally')
 def test_run_python_script_in_terminal(scriptpath, qtbot):
+    """
+    Test running a Python script in an external terminal when specifying
+    explicitely the working directory.
+    """
     # Run the script.
     outfilepath = osp.join(scriptpath.dirname, 'out.txt')
     run_python_script_in_terminal(
@@ -81,6 +86,10 @@ def test_run_python_script_in_terminal(scriptpath, qtbot):
     os.environ.get('CI', None) is None or sys.platform == 'darwin',
     reason='fails in macOS and sometimes locally')
 def test_run_python_script_in_terminal_with_wdir_empty(scriptpath, qtbot):
+    """
+    Test running a Python script in an external terminal without specifying
+    the working directory.
+    """
     # Run the script.
     outfilepath = osp.join(os.getcwd(), 'out.txt')
     run_python_script_in_terminal(scriptpath.strpath, '', '', False, False, '')

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -36,6 +36,21 @@ else:
     INVALID_INTERPRETER = os.path.join(home_dir, 'miniconda', 'bin', 'ipython')
 
 
+# =============================================================================
+# ---- Fixtures
+# =============================================================================
+@pytest.fixture
+def scriptpath(tmpdir):
+    script = ("with open('out.txt', 'w') as f:\n"
+              "    f.write('done')\n")
+    scriptpath = tmpdir.join('write-done.py')
+    scriptpath.write(script)
+    return scriptpath
+
+
+# =============================================================================
+# ---- Tests
+# =============================================================================
 @pytest.mark.skipif((sys.platform.startswith('linux') or
                      os.environ.get('CI', None) is None),
                     reason='It only runs in CI services and '
@@ -48,17 +63,11 @@ def test_is_valid_w_interpreter():
 @pytest.mark.skipif(
     os.environ.get('CI', None) is None or sys.platform == 'darwin',
     reason='fails in macOS and sometimes locally')
-def test_run_python_script_in_terminal(tmpdir, qtbot):
-    # Create the Python script file.
-    script = ("with open('out.txt', 'w') as f:\n"
-              "    f.write('done')\n")
-    scriptpath = tmpdir.join('write-done.py')
-    scriptpath.write(script)
-
+def test_run_python_script_in_terminal(scriptpath, qtbot):
     # Run the script.
-    outfilepath = osp.join(tmpdir.strpath, 'out.txt')
+    outfilepath = osp.join(scriptpath.dirname, 'out.txt')
     run_python_script_in_terminal(
-        scriptpath.strpath, tmpdir.strpath, '', False, False, '')
+        scriptpath.strpath, scriptpath.dirname, '', False, False, '')
     qtbot.waitUntil(lambda: osp.exists(outfilepath), timeout=1000)
 
     # Assert the result.
@@ -71,13 +80,7 @@ def test_run_python_script_in_terminal(tmpdir, qtbot):
 @pytest.mark.skipif(
     os.environ.get('CI', None) is None or sys.platform == 'darwin',
     reason='fails in macOS and sometimes locally')
-def test_run_python_script_in_terminal_with_wdir_empty(tmpdir, qtbot):
-    # Create the Python script file.
-    script = ("with open('out.txt', 'w') as f:\n"
-              "    f.write('done')\n")
-    scriptpath = tmpdir.join('write-done.py')
-    scriptpath.write(script)
-
+def test_run_python_script_in_terminal_with_wdir_empty(scriptpath, qtbot):
     # Run the script.
     outfilepath = osp.join(os.getcwd(), 'out.txt')
     run_python_script_in_terminal(scriptpath.strpath, '', '', False, False, '')

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -44,9 +44,9 @@ def test_is_valid_w_interpreter():
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif((os.name == 'nt' or os.environ.get('CI', None) is None or
-                     sys.platform == 'darwin'),
-                    reason='gets stuck on Windows and fails in macOS and sometimes locally') # FIXME
+@pytest.mark.skipif(
+    os.environ.get('CI', None) is None or sys.platform == 'darwin',
+    reason='fails in macOS and sometimes locally')
 def test_run_python_script_in_terminal(tmpdir, qtbot):
     scriptpath = tmpdir.join('write-done.py')
     outfilepath = tmpdir.join('out.txt')

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -61,9 +61,9 @@ def test_run_python_script_in_terminal(tmpdir, qtbot):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif((os.name == 'nt' or os.environ.get('CI', None) is None or
-                     sys.platform == 'darwin'),
-                    reason='gets stuck on Windows and fails in macOS and sometimes locally') # FIXME
+@pytest.mark.skipif(
+    os.environ.get('CI', None) is None or sys.platform == 'darwin',
+    reason='fails in macOS and sometimes locally')
 def test_run_python_script_in_terminal_with_wdir_empty(tmpdir, qtbot):
     scriptpath = tmpdir.join('write-done.py')
     outfilepath = tmpdir.join('out.txt')

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -49,15 +49,21 @@ def test_is_valid_w_interpreter():
     os.environ.get('CI', None) is None or sys.platform == 'darwin',
     reason='fails in macOS and sometimes locally')
 def test_run_python_script_in_terminal(tmpdir, qtbot):
-    scriptpath = tmpdir.join('write-done.py')
-    outfilepath = tmpdir.join('out.txt')
+    # Create the Python script file.
     script = ("with open('out.txt', 'w') as f:\n"
               "    f.write('done')\n")
+    scriptpath = tmpdir.join('write-done.py')
     scriptpath.write(script)
-    run_python_script_in_terminal(scriptpath.strpath, tmpdir.strpath, '',
-                                  False, False, '')
-    qtbot.wait(1000) # wait for script to finish
-    res = outfilepath.read()
+
+    # Run the script.
+    outfilepath = osp.join(tmpdir.strpath, 'out.txt')
+    run_python_script_in_terminal(
+        scriptpath.strpath, tmpdir.strpath, '', False, False, '')
+    qtbot.waitUntil(lambda: osp.exists(outfilepath), timeout=1000)
+
+    # Assert the result.
+    with open(outfilepath, 'r') as txtfile:
+        res = txtfile.read()
     assert res == 'done'
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)

You can test this change with this script :

```python
import sys
from PyQt5.QtWidgets import QPushButton, QWidget, QApplication, QGridLayout


class SomeClass(QWidget):
    def __init__(self):
        super().__init__()
        layout = QGridLayout(self)
        btn_crash = QPushButton('Crash')
        btn_crash.clicked.connect(self.crash)
        btn_crash2 = QPushButton('Crash2')
        btn_crash2.clicked.connect(self.crash2)
        btn_close = QPushButton('Close')
        btn_close.clicked.connect(self.close)
        layout.addWidget(btn_crash)
        layout.addWidget(btn_crash2)
        layout.addWidget(btn_close)

    def show(self):
        super().show()

    def crash(self):
        raise ValueError

    def crash2(self):
        return self.crash2()


if __name__ == '__main__':
    app = QApplication(sys.argv)
    window = SomeClass()
    window.show()
    sys.exit(app.exec_())
``` 

![image](https://user-images.githubusercontent.com/10170372/56962727-40678980-6b25-11e9-80ee-a9cd5044821f.png)

With the proposed changes, executing the script above in an external terminal with the option `Interact with the python console after execution` **unchecked** will do the following:

1. The terminal is automatically closed when clicking on the `Close` button (like before).
2. The Python console crash and exit, but the terminal remains open showing the traceback of the error when clicking either one of the `Crash` buttons (while previously the terminal would close automatically).

With the proposed changes, executing this script in an external terminal with the option `Interact with the python console after execution` **checked** will do the following:

1. The terminal does not close and the Python console remains open to interact with when clicking on the close button (like before).
2. Same as point 2 above when clicking either one of the `Crash` buttons

![image](https://user-images.githubusercontent.com/10170372/57458902-2bcf7380-7240-11e9-918c-03845dd634d2.png)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9240


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
