### PR TITLE
PR: Remove autosaves on successful file close to partially mitigate spurious creation bugs

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -354,7 +354,7 @@ class Editor(SpyderPluginWidget):
 
         active_project_path = None
         if self.projects is not None:
-             active_project_path = self.projects.get_active_project_path()
+            active_project_path = self.projects.get_active_project_path()
         if not active_project_path:
             self.set_open_filenames()
         else:
@@ -377,6 +377,14 @@ class Editor(SpyderPluginWidget):
             else:
                 for win in self.editorwindows[:]:
                     win.close()
+                # Remove autosave on successful close to avoid issue #9265.
+                # Probably a good idea anyway to mitigate autosave issues.
+                # Ignore errors resulting from file being open in > 2
+                # editorstacks or another Spyder being closed first and
+                # removing the spurious files.
+                for editorstack_split in self.editorstacks:
+                    editorstack_split.autosave.remove_all_autosave_files(
+                        errors="ignore")
                 return True
         except IndexError:
             return True

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -56,6 +56,6 @@ def test_autosave_remove_autosave_file(mocker, exception):
     fileinfo.filename = 'orig'
     addon = AutosaveForStack(mock_stack)
     addon.name_mapping = {'orig': 'autosave'}
-    addon.remove_autosave_file(fileinfo)
+    addon.remove_autosave_file(fileinfo.filename)
     mock_remove.assert_called_with('autosave')
     assert mock_dialog.called == exception

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -13,7 +13,7 @@ from spyder.plugins.editor.utils.autosave import (AutosaveForStack,
                                                   AutosaveForPlugin)
 
 
-def test_autosave_component_set_interval(qtbot, mocker):
+def test_autosave_component_set_interval(mocker):
     """Test that setting the interval does indeed change it and calls
     do_autosave if enabled."""
     mocker.patch.object(AutosaveForPlugin, 'do_autosave')
@@ -43,7 +43,8 @@ def test_autosave_component_timer_if_enabled(qtbot, mocker, enabled):
 
 
 @pytest.mark.parametrize('exception', [False, True])
-def test_autosave_remove_autosave_file(mocker, exception):
+@pytest.mark.parametrize('errors', ['raise', 'ignore'])
+def test_autosave_remove_autosave_file(mocker, exception, errors):
     """Test that AutosaveForStack.remove_autosave_file removes the autosave
     file and that an error dialog is displayed if an exception is raised."""
     mock_remove = mocker.patch('os.remove')
@@ -56,6 +57,40 @@ def test_autosave_remove_autosave_file(mocker, exception):
     fileinfo.filename = 'orig'
     addon = AutosaveForStack(mock_stack)
     addon.name_mapping = {'orig': 'autosave'}
-    addon.remove_autosave_file(fileinfo.filename)
+
+    addon.remove_autosave_file(fileinfo.filename, errors=errors)
+    assert addon.name_mapping == {}
     mock_remove.assert_called_with('autosave')
-    assert mock_dialog.called == exception
+    assert mock_dialog.called == (exception and errors == 'raise')
+
+
+@pytest.mark.parametrize('exception', [False, True])
+@pytest.mark.parametrize('errors', ['raise', 'ignore'])
+def test_autosave_remove_all_autosave_files(mocker, exception, errors):
+    """
+    Test that ``remove_all_autosave_files`` succeeds and handles errors.
+
+    Check that AutosaveForStack.remove_all_autosave_files removes all
+    autosaves and that an error dialog is displayed if an exception is raised.
+    """
+    mock_remove = mocker.patch('os.remove')
+    if exception:
+        mock_remove.side_effect = EnvironmentError()
+    mock_dialog = mocker.patch(
+        'spyder.plugins.editor.utils.autosave.AutosaveErrorDialog')
+    mock_stack = mocker.Mock()
+    addon = AutosaveForStack(mock_stack)
+    addon.name_mapping = {}
+    for idx in range(3):
+        addon.name_mapping['orig_' + str(idx)] = 'autosave_' + str(idx)
+
+    addon.remove_all_autosave_files(errors=errors)
+    assert addon.name_mapping == {}
+    assert mock_remove.call_count == 3
+    assert mock_remove.call_args_list == [
+        (('autosave_' + str(idx),),) for idx in range(3)]
+    assert mock_dialog.called == (exception and errors == 'raise')
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1505,6 +1505,10 @@ class EditorStack(QWidget):
 
             self.add_last_closed_file(finfo.filename)
 
+            # Remove autosave on successful close to work around issue #9265.
+            # Probably a good idea in general to mitigate any other bugs.
+            self.autosave.remove_autosave_file(finfo)
+
         if self.get_stack_count() == 0 and self.create_new_file_if_empty:
             self.sig_new_file[()].emit()
             return False

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1507,7 +1507,7 @@ class EditorStack(QWidget):
 
             # Remove autosave on successful close to work around issue #9265.
             # Probably a good idea in general to mitigate any other bugs.
-            self.autosave.remove_autosave_file(finfo)
+            self.autosave.remove_autosave_file(finfo.filename)
 
         if self.get_stack_count() == 0 and self.create_new_file_if_empty:
             self.sig_new_file[()].emit()
@@ -1620,7 +1620,7 @@ class EditorStack(QWidget):
                 if not self.save(index):
                     return False
             elif no_all:
-                self.autosave.remove_autosave_file(finfo)
+                self.autosave.remove_autosave_file(finfo.filename)
             elif (finfo.editor.document().isModified() and
                   self.save_dialog_on_tests):
 
@@ -1638,13 +1638,13 @@ class EditorStack(QWidget):
                     if not self.save(index):
                         return False
                 elif answer == QMessageBox.No:
-                    self.autosave.remove_autosave_file(finfo)
+                    self.autosave.remove_autosave_file(finfo.filename)
                 elif answer == QMessageBox.YesToAll:
                     if not self.save(index):
                         return False
                     yes_all = True
                 elif answer == QMessageBox.NoToAll:
-                    self.autosave.remove_autosave_file(finfo)
+                    self.autosave.remove_autosave_file(finfo.filename)
                     no_all = True
                 elif answer == QMessageBox.Cancel:
                     return False
@@ -1703,7 +1703,7 @@ class EditorStack(QWidget):
             self.set_os_eol_chars(osname=osname)
         try:
             self._write_to_file(finfo, finfo.filename)
-            self.autosave.remove_autosave_file(finfo)
+            self.autosave.remove_autosave_file(finfo.filename)
             finfo.newly_created = False
             self.encoding_changed.emit(finfo.encoding)
             finfo.lastmodified = QFileInfo(finfo.filename).lastModified()

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -722,7 +722,7 @@ def test_remove_autosave_file(editor_bot, mocker, qtbot):
     assert autosave.name_mapping == expected
     assert blocker.args == ['autosave_mapping', expected]
     with qtbot.wait_signal(editor_stack.sig_option_changed) as blocker:
-        autosave.remove_autosave_file(editor_stack.data[0])
+        autosave.remove_autosave_file(editor_stack.data[0].filename)
     assert not os.access(autosave_filename, os.R_OK)
     assert autosave.name_mapping == {}
     assert blocker.args == ['autosave_mapping', {}]

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -58,6 +58,26 @@ def editor_bot(base_editor_bot, qtbot):
 
 
 @pytest.fixture
+def editor_multifile_bot(base_editor_bot, qtbot):
+    """
+    Like `editor_bot`, but open multiple files with procedural content.
+    """
+    editor_stack = base_editor_bot
+    finfo_list = []
+    for idx in range(3):
+        text = ('sample_var_{idx} = 1 + {idx}\n'
+                'print(sample_var_{idx})\n'
+                '\n'
+                'x = {idx}').format(idx=idx)
+        finfo = editor_stack.new('spam_{idx}.py'.format(idx=idx),
+                                 'utf-8', text)
+        finfo.newly_created = False
+        finfo_list.append(finfo)
+    qtbot.addWidget(editor_stack)
+    return editor_stack, finfo_list
+
+
+@pytest.fixture
 def editor_find_replace_bot(base_editor_bot, qtbot):
     editor_stack = base_editor_bot
     text = ('spam bacon\n'
@@ -730,6 +750,39 @@ def test_remove_autosave_file(editor_bot, mocker, qtbot):
         autosave.autosave(0)
     assert not os.access(autosave_filename, os.R_OK)
     assert autosave.name_mapping == {}
+
+
+def test_remove_all_autosave_files(editor_multifile_bot, mocker, qtbot):
+    """
+    Test that remove_all_autosave_files() removes all autosave files.
+
+    Also, test that it updates `name_mapping`.
+    """
+    editor_stack, finfo_list = editor_multifile_bot
+    autosave = editor_stack.autosave
+    autosave_basenames = []
+    autosave_filenames = []
+    expected_mapping = {}
+    with qtbot.wait_signal(editor_stack.sig_option_changed) as blocker:
+        for idx, finfo in enumerate(finfo_list):
+            autosave.autosave(idx)
+            autosave_basenames.append(os.path.basename(finfo.filename))
+            autosave_filenames.append(os.path.join(
+                get_conf_path('autosave'), autosave_basenames[idx]))
+            assert os.access(autosave_filenames[idx], os.R_OK)
+            expected_mapping[autosave_basenames[idx]] = autosave_filenames[idx]
+    assert autosave.name_mapping == expected_mapping
+    assert blocker.args == ['autosave_mapping', expected_mapping]
+    with qtbot.wait_signal(editor_stack.sig_option_changed) as blocker:
+        autosave.remove_all_autosave_files(errors='raise')
+    assert autosave.name_mapping == {}
+    assert blocker.args == ['autosave_mapping', {}]
+    for idx, autosave_filename in enumerate(autosave_filenames):
+        assert not os.access(autosave_filename, os.R_OK)
+        with qtbot.assert_not_emitted(editor_stack.sig_option_changed):
+            autosave.autosave(idx)
+        assert not os.access(autosave_filename, os.R_OK)
+        assert autosave.name_mapping == {}
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -708,7 +708,7 @@ def test_autosave_handles_error(editor_bot, mocker):
 
 def test_remove_autosave_file(editor_bot, mocker, qtbot):
     """
-    Test that remove_autosave_file() removes the autosave file
+    Test that remove_autosave_file() removes the autosave file.
 
     Also, test that it updates `name_mapping`.
     """

--- a/spyder/plugins/editor/widgets/tests/test_save.py
+++ b/spyder/plugins/editor/widgets/tests/test_save.py
@@ -191,7 +191,7 @@ def test_save(editor_bot, mocker):
     editor_stack.file_saved.emit.assert_called_with(
         str(id(editor_stack)), 'foo.py', 'foo.py')
     editor_stack.autosave.remove_autosave_file.assert_called_with(
-        editor_stack.data[0])
+        editor_stack.data[0].filename)
 
     editor_stack.file_saved = save_file_saved
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

Partially mitigates the impact of #9265 .

It was much more complex than initially anticipated, but with this PR Spyder now removes autosave files after successfully closing them (either choosing not to save, or with no changes present) if an autosave exists, either when closing individual files or when closing the editor entirely. In order to do the latter, since the action is not already synchronized between panes like closing files and the autosaves are not in the ``name_mapping`` dict of the first split pane, I just iterate through all the EditorStacks, ignoring errors (which will occur if there are more than two, or if another Spyder instance removes them first), to make sure all autosaves are removed.

I also added both unit (autosave) and functional (editor) tests of the ``remove_all_autosave_files()`` function I added, as well as improved the existing tests of the ``remove_autosave_file()`` function, and refactored the latter to take a filename directly rather than an finfo object to greatly simplify the former and because only the filename was ever actually used.

Note: This should *not* close the linked issue, because it doesn't resolve the root of the problem and there are other, less serious side effects this mitigation is inherently not able to address directly.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM_Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
