### PR TITLE
PR: Remove CodeEditor instances from LSP client when split editor is closed

### DIFF
--- a/spyder/plugins/editor/lsp/providers/document.py
+++ b/spyder/plugins/editor/lsp/providers/document.py
@@ -246,6 +246,8 @@ class DocumentProvider:
             params[ClientConstants.CANCEL] = True
         else:
             editors = self.watched_files[filename]
+            if len(editors) > 1:
+                params[ClientConstants.CANCEL] = True
             idx = -1
             for i, editor in enumerate(editors):
                 if id(codeeditor) == id(editor):
@@ -256,4 +258,5 @@ class DocumentProvider:
 
             if len(editors) == 0:
                 self.watched_files.pop(filename)
+
         return params

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2649,7 +2649,7 @@ class EditorSplitter(QSplitter):
             self.unregister_editorstack_cb(self.editorstack)
             self.editorstack = None
             close_splitter = self.count() == 1
-        except RuntimeError:
+        except (RuntimeError, AttributeError):
             # editorsplitter has been destroyed (happens when closing a
             # EditorMainWindow instance)
             return

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -819,6 +819,8 @@ class EditorStack(QWidget):
             for finfo in self.data:
                 self.outlineexplorer.remove_editor(finfo.editor.oe_proxy)
 
+        for finfo in self.data:
+            finfo.editor.notify_close()
         QWidget.closeEvent(self, event)
 
     def clone_editor_from(self, other_finfo, set_current):

--- a/spyder/plugins/editor/widgets/tests/fixtures.py
+++ b/spyder/plugins/editor/widgets/tests/fixtures.py
@@ -25,7 +25,7 @@ from spyder.widgets.findreplace import FindReplace
 
 
 @pytest.fixture
-def setup_editor(qtbot_module, request):
+def setup_editor(qtbot):
     """
     Set up EditorStack with CodeEditor containing some Python code.
     The cursor is at the empty line below the code.
@@ -39,7 +39,7 @@ def setup_editor(qtbot_module, request):
     editorStack.set_find_widget(FindReplace(editorStack))
     editorStack.set_io_actions(Mock(), Mock(), Mock(), Mock())
     finfo = editorStack.new('foo.py', 'utf-8', text)
-    qtbot_module.addWidget(editorStack)
+    qtbot.addWidget(editorStack)
     return editorStack, finfo.editor
 
 

--- a/spyder/plugins/editor/widgets/tests/fixtures.py
+++ b/spyder/plugins/editor/widgets/tests/fixtures.py
@@ -25,7 +25,7 @@ from spyder.widgets.findreplace import FindReplace
 
 
 @pytest.fixture
-def setup_editor(qtbot):
+def setup_editor(qtbot_module, request):
     """
     Set up EditorStack with CodeEditor containing some Python code.
     The cursor is at the empty line below the code.
@@ -39,7 +39,7 @@ def setup_editor(qtbot):
     editorStack.set_find_widget(FindReplace(editorStack))
     editorStack.set_io_actions(Mock(), Mock(), Mock(), Mock())
     finfo = editorStack.new('foo.py', 'utf-8', text)
-    qtbot.addWidget(editorStack)
+    qtbot_module.addWidget(editorStack)
     return editorStack, finfo.editor
 
 

--- a/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
+++ b/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
@@ -11,10 +11,11 @@ Tests for EditorSplitter class in editor.py
 # Standard library imports
 try:
     from unittest.mock import Mock
+    import pathlib
 except ImportError:
     from mock import Mock  # Python 2
+    import pathlib2 as pathlib
 
-import pathlib
 import os.path as osp
 from functools import partial
 
@@ -392,7 +393,7 @@ def test_set_layout_settings_goto(editor_splitter_layout_bot):
 def test_lsp_splitter_close(editor_splitter_lsp):
     """Test for issue #9341"""
     editorsplitter, lsp_manager = editor_splitter_lsp
-    # assert False
+
     editorsplitter.split()
     lsp_files = lsp_manager.clients['python']['instance'].watched_files
     editor = editorsplitter.editorstack.get_current_editor()

--- a/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
+++ b/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
@@ -122,7 +122,6 @@ def editor_splitter_layout_bot(editor_splitter_bot):
 
 
 # ---- Tests
-
 def test_init(editor_splitter_bot):
     """"Test __init__."""
     es = editor_splitter_bot
@@ -390,6 +389,8 @@ def test_set_layout_settings_goto(editor_splitter_layout_bot):
                                              (False, 'foo.py', [1, 1, 1])]
 
 
+@pytest.mark.slow
+@pytest.mark.first
 def test_lsp_splitter_close(editor_splitter_lsp):
     """Test for issue #9341"""
     editorsplitter, lsp_manager = editor_splitter_lsp

--- a/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
+++ b/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
@@ -16,6 +16,7 @@ except ImportError:
     from mock import Mock  # Python 2
     import pathlib2 as pathlib
 
+import os
 import os.path as osp
 from functools import partial
 
@@ -392,6 +393,8 @@ def test_set_layout_settings_goto(editor_splitter_layout_bot):
 
 @pytest.mark.slow
 @pytest.mark.first
+@pytest.mark.skipif(os.name == 'nt',
+                    reason="Makes other tests fail on Windows")
 def test_lsp_splitter_close(editor_splitter_lsp):
     """Test for issue #9341"""
     editorsplitter, lsp_manager = editor_splitter_lsp

--- a/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
+++ b/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
@@ -93,6 +93,7 @@ def editor_splitter_lsp(qtbot_module, lsp_manager, request):
 
     def teardown():
         editorsplitter.hide()
+        editorsplitter.close()
 
     request.addfinalizer(teardown)
     return editorsplitter, lsp_manager


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Send ```textDocument/didClose``` notification on all codeeditor instances that belong to a split tab that is closed.

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9341 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@andfoy
<!--- Thanks for your help making Spyder better for everyone! --->
