### PR TITLE
PR: Fix code editor background color

### DIFF
--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -446,7 +446,7 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
                 (self.objectName(), background.name(), foreground.name())
         self.setStyleSheet(style)
 
-    #------Extra selections
+    # ---- Extra selections
     def get_extra_selections(self, key):
         """Return editor extra selections.
 

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -435,19 +435,16 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         Set text editor palette colors:
         background color and caret (text cursor) color
         """
-        palette = QPalette()
-        palette.setColor(QPalette.Base, background)
-        palette.setColor(QPalette.Text, foreground)
-        self.setPalette(palette)
-
-        # Set the right background color when changing color schemes
-        # or creating new Editor windows. This seems to be a Qt bug.
-        # Fixes Issue 2028 and 8069
-        if self.objectName():
-            style = "QPlainTextEdit#%s {background: %s; color: %s;}" % \
-                    (self.objectName(), background.name(), foreground.name())
-            self.setStyleSheet(style)
-
+        # Because QtStylsheet overrides QPalette and because some style do not
+        # use the palette for all drawing (e.g. macOS styles), the background
+        # and foreground color of each TextEditBaseWidget instance must be set
+        # with a stylesheet extended with an ID Selector.
+        # Fixes Issue 2028, 8069 and 9248.
+        if not self.objectName():
+            self.setObjectName(self.__class__.__name__ + str(id(self)))
+        style = "QPlainTextEdit#%s {background: %s; color: %s;}" % \
+                (self.objectName(), background.name(), foreground.name())
+        self.setStyleSheet(style)
 
     #------Extra selections
     def get_extra_selections(self, key):

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -289,22 +289,6 @@ class CodeEditor(TextEditBaseWidget):
 
         self.setFocusPolicy(Qt.StrongFocus)
 
-        # We use these object names to set the right background
-        # color when changing color schemes or creating new
-        # Editor windows. This seems to be a Qt bug.
-        # Fixes issues 2028 and 8069
-        plugin_name = repr(parent)
-        if 'editor' in plugin_name.lower():
-            self.setObjectName('editor')
-        elif 'help' in plugin_name.lower():
-            self.setObjectName('help')
-        elif 'historylog' in plugin_name.lower():
-            self.setObjectName('historylog')
-        elif 'configdialog' in plugin_name.lower():
-            self.setObjectName('configdialog')
-        elif 'errordialog' in plugin_name.lower():
-            self.setObjectName('errordialog')
-
         # Caret (text cursor)
         self.setCursorWidth( CONF.get('main', 'cursor/width') )
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

![image](https://user-images.githubusercontent.com/10170372/57819215-775cb280-7755-11e9-8dc1-5d72db480086.png)


<!--- Explain what you've done and why --->

From Qt documentation, it is said that `QPalette` should not be used in conjunction with `QtStyleSheets`, because the later override the former.

Since custom stylesheet are propagated to the children when applied to the parent, this means that the background and foreground color of the `TextEditBaseWidget` need to be set with a stylesheet extended with an ID Selector if we want this to be robust instead of doing it by setting a new a color palette.

Moreover, some styles do not use the palette for all drawing such as the Windows Vista and macOS styles.

https://doc.qt.io/qt-5/qapplication.html#setPalette
https://doc.qt.io/archives/qt-5.8/stylesheet-syntax.html#selector-types

![image](https://user-images.githubusercontent.com/10170372/57819786-f357fa00-7757-11e9-99b8-6b1974f7c263.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9248


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
