### PR TITLE
help spyder registery integration on windows

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -324,6 +324,9 @@ class MainWindow(QMainWindow):
         self.default_style = str(qapp.style().objectName())
         self.dialog_manager = DialogManager()
 
+        # help Windows registry shortcuts integration
+        if os.name == "nt" and options.working_directory[-1] == r'\':
+            options.working_directory = options.working_directory[:-1]    
         self.init_workdir = options.working_directory
         self.profile = options.profile
         self.multithreaded = options.multithreaded


### PR DESCRIPTION
see https://github.com/spyder-ide/spyder/issues/9354

## Description of Changes

removes the un-needed trailing r"\" present in a windows path returned per "~ps1", when calling spyder via a registery shortcut  