### PR TITLE
PR: Move test_calltip to test_hints_and_calltips.py

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -202,50 +202,6 @@ def main_window(request):
 # =============================================================================
 # ---- Tests
 # =============================================================================
-# IMPORTANT NOTE: Please leave this test to be the first one here to
-# avoid possible timeouts in Appveyor
-@pytest.mark.slow
-@pytest.mark.use_introspection
-@flaky(max_runs=3)
-@pytest.mark.skipif(os.name == 'nt' or not PY2,
-                    reason="Times out on AppVeyor and fails on PY3/PyQt 5.6")
-def test_calltip(main_window, qtbot):
-    """Test that the calltip in editor is hidden when matching ')' is found."""
-    # Load test file
-    text = 'a = [1,2,3]\n(max'
-    lsp_client = main_window.lspmanager.clients['python']['instance']
-    with qtbot.waitSignal(lsp_client.sig_initialize, timeout=30000):
-        main_window.editor.new(fname="test.py", text=text)
-    code_editor = main_window.editor.get_focus_widget()
-
-    # Set text to start
-    # with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-    #     code_editor.set_text(text)
-    #     code_editor.document_did_change()
-    code_editor.set_text(text)
-    code_editor.go_to_line(2)
-    code_editor.move_cursor(4)
-    calltip = code_editor.calltip_widget
-    assert not calltip.isVisible()
-
-    with qtbot.waitSignal(code_editor.sig_signature_invoked, timeout=30000):
-        qtbot.keyPress(code_editor, Qt.Key_ParenLeft, delay=3000)
-        # qtbot.keyPress(code_editor, Qt.Key_A, delay=1000)
-
-    # qtbot.wait(1000)
-    # print(calltip.isVisible())
-    qtbot.waitUntil(lambda: calltip.isVisible(), timeout=3000)
-
-    qtbot.keyPress(code_editor, Qt.Key_ParenRight, delay=1000)
-    qtbot.keyPress(code_editor, Qt.Key_Space)
-    qtbot.waitUntil(lambda: not calltip.isVisible(), timeout=3000)
-    assert not QToolTip.isVisible()
-    qtbot.keyPress(code_editor, Qt.Key_ParenRight, delay=1000)
-    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=1000)
-
-    main_window.editor.close_file()
-
-
 @pytest.mark.slow
 def test_lock_action(main_window):
     """Test the lock interface action."""

--- a/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
+++ b/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
@@ -25,6 +25,29 @@ def {SIG}:
 some_function""".format(SIG=TEST_SIG, DOC=TEST_DOCSTRING)
 
 
+def test_hide_calltip(lsp_codeeditor, qtbot):
+    """Test that calltips are hidden when a matching ')' is found."""
+    code_editor, _ = lsp_codeeditor
+
+    text = 'a = [1,2,3]\n(max'
+    # Set text to start
+    code_editor.set_text(text)
+    code_editor.go_to_line(2)
+    code_editor.move_cursor(4)
+    calltip = code_editor.calltip_widget
+    assert not calltip.isVisible()
+
+    with qtbot.waitSignal(code_editor.sig_signature_invoked, timeout=30000):
+        qtbot.keyPress(code_editor, Qt.Key_ParenLeft, delay=3000)
+
+    qtbot.waitUntil(lambda: calltip.isVisible(), timeout=3000)
+    qtbot.keyPress(code_editor, Qt.Key_ParenRight, delay=1000)
+    qtbot.keyPress(code_editor, Qt.Key_Space)
+    qtbot.waitUntil(lambda: not calltip.isVisible(), timeout=3000)
+    qtbot.keyPress(code_editor, Qt.Key_ParenRight, delay=1000)
+    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=1000)
+
+
 @pytest.mark.slow
 @pytest.mark.second
 @pytest.mark.parametrize('params', [

--- a/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
+++ b/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
@@ -24,7 +24,17 @@ def {SIG}:
 
 some_function""".format(SIG=TEST_SIG, DOC=TEST_DOCSTRING)
 
-
+@pytest.mark.slow
+@pytest.mark.second
+@pytest.mark.parametrize('params', [
+            # Parameter, Expected Output
+            ('dict', '' if PY2 else 'dict'),
+            ('type', 'type'),
+            ('"".format', '-> str'),
+            ('import math', 'module'),
+            (TEST_TEXT, TEST_DOCSTRING)
+        ]
+    )
 def test_hide_calltip(lsp_codeeditor, qtbot):
     """Test that calltips are hidden when a matching ')' is found."""
     code_editor, _ = lsp_codeeditor

--- a/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
+++ b/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
@@ -24,17 +24,9 @@ def {SIG}:
 
 some_function""".format(SIG=TEST_SIG, DOC=TEST_DOCSTRING)
 
+
 @pytest.mark.slow
 @pytest.mark.second
-@pytest.mark.parametrize('params', [
-            # Parameter, Expected Output
-            ('dict', '' if PY2 else 'dict'),
-            ('type', 'type'),
-            ('"".format', '-> str'),
-            ('import math', 'module'),
-            (TEST_TEXT, TEST_DOCSTRING)
-        ]
-    )
 def test_hide_calltip(lsp_codeeditor, qtbot):
     """Test that calltips are hidden when a matching ')' is found."""
     code_editor, _ = lsp_codeeditor

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -28,35 +28,6 @@ LOCATION = osp.realpath(osp.join(os.getcwd(), osp.dirname(__file__)))
 
 
 @pytest.mark.slow
-@pytest.mark.use_introspection
-@flaky(max_runs=3)
-@pytest.mark.skipif(os.name == 'nt' or not PY2,
-                    reason="Times out on AppVeyor and fails on PY3/PyQt 5.6")
-def test_calltip(lsp_codeeditor, qtbot):
-    """Test that the calltip in editor is hidden when matching ')' is found."""
-    code_editor, _ = lsp_codeeditor
-
-    text = 'a = [1,2,3]\n(max'
-    # Set text to start
-    code_editor.set_text(text)
-    code_editor.go_to_line(2)
-    code_editor.move_cursor(4)
-    calltip = code_editor.calltip_widget
-    assert not calltip.isVisible()
-
-    with qtbot.waitSignal(code_editor.sig_signature_invoked, timeout=30000):
-        qtbot.keyPress(code_editor, Qt.Key_ParenLeft, delay=3000)
-
-    qtbot.waitUntil(lambda: calltip.isVisible(), timeout=3000)
-    qtbot.keyPress(code_editor, Qt.Key_ParenRight, delay=1000)
-    qtbot.keyPress(code_editor, Qt.Key_Space)
-    qtbot.waitUntil(lambda: not calltip.isVisible(), timeout=3000)
-    assert not QToolTip.isVisible()
-    qtbot.keyPress(code_editor, Qt.Key_ParenRight, delay=1000)
-    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=1000)
-
-
-@pytest.mark.slow
 @pytest.mark.first
 def test_space_completion(lsp_codeeditor, qtbot):
     """Validate completion's space character handling."""

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -14,10 +14,8 @@ import random
 # Third party imports
 import pytest
 import pytestqt
-from flaky import flaky
 
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QToolTip
 
 # Local imports
 from spyder.py3compat import PY2

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -14,8 +14,10 @@ import random
 # Third party imports
 import pytest
 import pytestqt
+from flaky import flaky
 
 from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QToolTip
 
 # Local imports
 from spyder.py3compat import PY2
@@ -23,6 +25,35 @@ from spyder.py3compat import PY2
 
 # Location of this file
 LOCATION = osp.realpath(osp.join(os.getcwd(), osp.dirname(__file__)))
+
+
+@pytest.mark.slow
+@pytest.mark.use_introspection
+@flaky(max_runs=3)
+@pytest.mark.skipif(os.name == 'nt' or not PY2,
+                    reason="Times out on AppVeyor and fails on PY3/PyQt 5.6")
+def test_calltip(lsp_codeeditor, qtbot):
+    """Test that the calltip in editor is hidden when matching ')' is found."""
+    code_editor, _ = lsp_codeeditor
+
+    text = 'a = [1,2,3]\n(max'
+    # Set text to start
+    code_editor.set_text(text)
+    code_editor.go_to_line(2)
+    code_editor.move_cursor(4)
+    calltip = code_editor.calltip_widget
+    assert not calltip.isVisible()
+
+    with qtbot.waitSignal(code_editor.sig_signature_invoked, timeout=30000):
+        qtbot.keyPress(code_editor, Qt.Key_ParenLeft, delay=3000)
+
+    qtbot.waitUntil(lambda: calltip.isVisible(), timeout=3000)
+    qtbot.keyPress(code_editor, Qt.Key_ParenRight, delay=1000)
+    qtbot.keyPress(code_editor, Qt.Key_Space)
+    qtbot.waitUntil(lambda: not calltip.isVisible(), timeout=3000)
+    assert not QToolTip.isVisible()
+    qtbot.keyPress(code_editor, Qt.Key_ParenRight, delay=1000)
+    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=1000)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Move test_calltip to test_introspection, even though I wasn't able to remove `sig_signature_invoked` to detect the visibility of the calltip.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

This PR is part of the issue #7724


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Steff456
<!--- Thanks for your help making Spyder better for everyone! --->
