### PR TITLE
PR: Fix Ctrl+Tab to cycle files on the editor

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -465,7 +465,6 @@ class MainWindow(QMainWindow):
         # otherwise the external tools menu is lost after leaving setup method
         self.external_tools_menu_actions = []
         self.view_menu = None
-        self.hidden_menu = None
         self.plugins_menu = None
         self.plugins_menu_actions = []
         self.toolbars_menu = None
@@ -744,10 +743,6 @@ class MainWindow(QMainWindow):
         # Help menu
         self.help_menu = self.menuBar().addMenu(_("&Help"))
 
-        # Hidden menu
-        if sys.platform == 'darwin':
-            self.hidden_menu = self.menuBar().addMenu(_(""))
-
         # Status bar
         status = self.statusBar()
         status.setObjectName("StatusBar")
@@ -934,9 +929,16 @@ class MainWindow(QMainWindow):
                                        context=Qt.ApplicationShortcut)
         self.register_shortcut(restart_action, "_", "Restart")
 
-        self.file_menu_actions += [self.file_switcher_action,
-                                   self.symbol_finder_action, None,
-                                   restart_action, quit_action]
+        file_actions = [
+            self.file_switcher_action,
+            self.symbol_finder_action,
+            None,
+        ]
+        if sys.platform == 'darwin':
+            file_actions.extend(self.editor.tab_navigation_actions + [None])
+
+        file_actions.extend([restart_action, quit_action])
+        self.file_menu_actions += file_actions
         self.set_splash("")
 
         # Namespace browser

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -465,6 +465,7 @@ class MainWindow(QMainWindow):
         # otherwise the external tools menu is lost after leaving setup method
         self.external_tools_menu_actions = []
         self.view_menu = None
+        self.hidden_menu = None
         self.plugins_menu = None
         self.plugins_menu_actions = []
         self.toolbars_menu = None
@@ -742,6 +743,10 @@ class MainWindow(QMainWindow):
 
         # Help menu
         self.help_menu = self.menuBar().addMenu(_("&Help"))
+
+        # Hidden menu
+        if sys.platform == 'darwin':
+            self.hidden_menu = self.menuBar().addMenu(_(""))
 
         # Status bar
         status = self.statusBar()

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -405,8 +405,8 @@ DEFAULTS = [
               'editor/conditional breakpoint': 'Shift+F12',
               'editor/run selection': "F9",
               'editor/go to line': 'Ctrl+L',
-              'editor/go to previous file': 'Ctrl+Shift+Tab',
-              'editor/go to next file': 'Ctrl+Tab',
+              'editor/go to previous file': CTRL + '+Shift+Tab',
+              'editor/go to next file': CTRL + '+Tab',
               'editor/cycle to previous file': 'Ctrl+PgUp',
               'editor/cycle to next file': 'Ctrl+PgDown',
               'editor/new file': "Ctrl+N",
@@ -716,7 +716,7 @@ DEFAULTS = [
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '50.0.0'
+CONF_VERSION = '50.1.0'
 
 
 # Main configuration instance

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -807,6 +807,7 @@ class Editor(SpyderPluginWidget):
 
         # Fixes issue 6055
         # See: https://bugreports.qt.io/browse/QTBUG-8596
+        self.tab_navigation_actions = []
         if sys.platform == 'darwin':
             self.go_to_next_file_action = create_action(
                 self,
@@ -830,32 +831,37 @@ class Editor(SpyderPluginWidget):
                 context="Editor",
                 name="Go to previous file",
             )
-            self.main.hidden_menu.addAction(self.go_to_next_file_action)
-            self.main.hidden_menu.addAction(self.go_to_previous_file_action)
+            self.tab_navigation_actions = [
+                MENU_SEPARATOR,
+                self.go_to_previous_file_action,
+                self.go_to_next_file_action,
+            ]
 
         # ---- File menu/toolbar construction ----
         self.recent_file_menu = QMenu(_("Open &recent"), self)
         self.recent_file_menu.aboutToShow.connect(self.update_recent_file_menu)
 
-        file_menu_actions = [self.new_action,
-                             MENU_SEPARATOR,
-                             self.open_action,
-                             self.open_last_closed_action,
-                             self.recent_file_menu,
-                             MENU_SEPARATOR,
-                             MENU_SEPARATOR,
-                             self.save_action,
-                             self.save_all_action,
-                             save_as_action,
-                             save_copy_as_action,
-                             self.revert_action,
-                             MENU_SEPARATOR,
-                             print_preview_action,
-                             self.print_action,
-                             MENU_SEPARATOR,
-                             self.close_action,
-                             self.close_all_action,
-                             MENU_SEPARATOR]
+        file_menu_actions = [
+            self.new_action,
+            MENU_SEPARATOR,
+            self.open_action,
+            self.open_last_closed_action,
+            self.recent_file_menu,
+            MENU_SEPARATOR,
+            MENU_SEPARATOR,
+            self.save_action,
+            self.save_all_action,
+            save_as_action,
+            save_copy_as_action,
+            self.revert_action,
+            MENU_SEPARATOR,
+            print_preview_action,
+            self.print_action,
+            MENU_SEPARATOR,
+            self.close_action,
+            self.close_all_action,
+            MENU_SEPARATOR,
+        ]
 
         self.main.file_menu_actions += file_menu_actions
         file_toolbar_actions = ([self.new_action, self.open_action,
@@ -2748,7 +2754,7 @@ class Editor(SpyderPluginWidget):
         for editorstack in self.editorstacks:
             editorstack.create_new_file_if_empty = value
 
-    # --- Hidden actions
+    # --- File Menu actions (Mac only)
     @Slot()
     def go_to_next_file(self):
         """Switch to next file tab on the current editor stack."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

![shortcuts](https://user-images.githubusercontent.com/3627835/58228426-4a2f7780-7cf4-11e9-8707-10eacf7578d8.gif)


<!--- Explain what you've done and why --->

As per https://bugreports.qt.io/browse/QTBUG-8596, the action needs to be added to a menu for this to work on OSX. Created a "hidden" menu to try this out and it is working :-). now... where should we add these actions? We cannot disable or hide them or this will cease to work

<img width="1439" alt="Screen Shot 2019-05-23 at 00 44 53" src="https://user-images.githubusercontent.com/3627835/58228358-0dfc1700-7cf4-11e9-9396-08e8a3ac0f0c.png">

This PR now updates the default shortcut on MAC to use the `control` key as chrome firefox and similar applications do on OSX.

There is a separate issue on the `Spyder Preferences` related to setting shortcuts on OSX that use `tab` and `control`, which currently do not seem to work.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #6055

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
