### PR TITLE
PR: Fix signature format for dict kwargs

### DIFF
--- a/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
+++ b/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
@@ -15,7 +15,7 @@ import pytest
 
 # Constants
 PY2 = sys.version[0] == '2'
-TEST_SIG = 'some_function(hello=None)'
+TEST_SIG = 'some_function(foo={}, hello=None)'
 TEST_DOCSTRING = "This is the test docstring."
 TEST_TEXT = """'''Testing something'''
 def {SIG}:

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -359,6 +359,11 @@ class BaseEditMixin(object):
         has_multisignature = False
         language = getattr(self, 'language', '').lower()
         signature_or_text = signature_or_text.replace('\\*', '*')
+
+        # Remove special symbols that could itefere with ''.format
+        signature_or_text = signature_or_text.replace('{', '&#123;')
+        signature_or_text = signature_or_text.replace('}', '&#125;')
+
         lines = signature_or_text.split('\n')
         inspect_word = None
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Signatures that included `kwargs` with default values using `dicts` were interfering with the `''.format`

![soup](https://user-images.githubusercontent.com/3627835/58231767-5ff56a80-7cfd-11e9-8c0e-50f8462c7d2e.gif)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9395

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
