### PR TITLE
PR: Disable zooming and update displayed scaling percent when "Fits plot to window" is checked

### DIFF
--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -439,7 +439,7 @@ class FigureViewer(QScrollArea):
         """A filter to control the zooming and panning of the figure canvas."""
 
         # ---- Zooming
-        if event.type() == QEvent.Wheel:
+        if event.type() == QEvent.Wheel and not self.auto_fit_plotting:
             modifiers = QApplication.keyboardModifiers()
             if modifiers == Qt.ControlModifier:
                 if event.angleDelta().y() > 0:

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -120,15 +120,19 @@ class FigureBrowser(QWidget):
                                      "}")
         self.thumbnails_sb = ThumbnailScrollBar(
             self.figviewer, background_color=self.background_color)
+        
+        toolbar = self.setup_toolbar()
+        self.setup_option_actions(mute_inline_plotting,
+                                  show_plot_outline,
+                                  auto_fit_plotting)
 
-        # Create the layout :
+        # Create the layout.
         main_widget = QSplitter()
         main_widget.addWidget(self.figviewer)
         main_widget.addWidget(self.thumbnails_sb)
         main_widget.setFrameStyle(QScrollArea().frameStyle())
 
         self.tools_layout = QHBoxLayout()
-        toolbar = self.setup_toolbar()
         for widget in toolbar:
             self.tools_layout.addWidget(widget)
         self.tools_layout.addStretch()
@@ -136,11 +140,6 @@ class FigureBrowser(QWidget):
 
         layout = create_plugin_layout(self.tools_layout, main_widget)
         self.setLayout(layout)
-
-        # Option actions :
-        self.setup_option_actions(mute_inline_plotting,
-                                  show_plot_outline,
-                                  auto_fit_plotting)
 
     def setup_toolbar(self):
         """Setup the toolbar"""

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -17,7 +17,7 @@ import os.path as osp
 # ---- Third library imports
 from qtconsole.svg import svg_to_image, svg_to_clipboard
 from qtpy.compat import getsavefilename, getexistingdirectory
-from qtpy.QtCore import Qt, Signal, QRect, QEvent, QPoint, QTimer, Slot
+from qtpy.QtCore import Qt, Signal, QRect, QEvent, QPoint, QSize, QTimer, Slot
 from qtpy.QtGui import QPixmap, QPainter, QKeySequence
 from qtpy.QtWidgets import (QApplication, QHBoxLayout, QMenu,
                             QVBoxLayout, QWidget, QGridLayout, QFrame,
@@ -121,11 +121,6 @@ class FigureBrowser(QWidget):
         self.thumbnails_sb = ThumbnailScrollBar(
             self.figviewer, background_color=self.background_color)
 
-        # Option actions :
-        self.setup_option_actions(mute_inline_plotting,
-                                  show_plot_outline,
-                                  auto_fit_plotting)
-
         # Create the layout :
         main_widget = QSplitter()
         main_widget.addWidget(self.figviewer)
@@ -141,6 +136,11 @@ class FigureBrowser(QWidget):
 
         layout = create_plugin_layout(self.tools_layout, main_widget)
         self.setLayout(layout)
+
+        # Option actions :
+        self.setup_option_actions(mute_inline_plotting,
+                                  show_plot_outline,
+                                  auto_fit_plotting)
 
     def setup_toolbar(self):
         """Setup the toolbar"""
@@ -188,12 +188,12 @@ class FigureBrowser(QWidget):
         vsep2 = QFrame()
         vsep2.setFrameStyle(53)
 
-        zoom_out_btn = create_toolbutton(
+        self.zoom_out_btn = create_toolbutton(
                 self, icon=ima.icon('zoom_out'),
                 tip=_("Zoom out (Ctrl + mouse-wheel-down)"),
                 triggered=self.zoom_out)
 
-        zoom_in_btn = create_toolbutton(
+        self.zoom_in_btn = create_toolbutton(
                 self, icon=ima.icon('zoom_in'),
                 tip=_("Zoom in (Ctrl + mouse-wheel-up)"),
                 triggered=self.zoom_in)
@@ -211,8 +211,8 @@ class FigureBrowser(QWidget):
         layout = QHBoxLayout(zoom_pan)
         layout.setSpacing(0)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(zoom_out_btn)
-        layout.addWidget(zoom_in_btn)
+        layout.addWidget(self.zoom_out_btn)
+        layout.addWidget(self.zoom_in_btn)
         layout.addWidget(self.zoom_disp)
 
         return [savefig_btn, saveall_btn, copyfig_btn, closefig_btn,
@@ -311,6 +311,8 @@ class FigureBrowser(QWidget):
         """Change the auto_fit_plotting option and scale images."""
         self.option_changed('auto_fit_plotting', state)
         self.figviewer.auto_fit_plotting = state
+        self.zoom_out_btn.setEnabled(not state)
+        self.zoom_in_btn.setEnabled(not state)
 
     def set_shellwidget(self, shellwidget):
         """Bind the shellwidget instance to the figure browser"""

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -529,7 +529,9 @@ class FigureViewer(QScrollArea):
             else:
                 new_height = int(height)
                 new_width = int(height / fheight * fwidth)
-        self.figcanvas.setFixedSize(new_width, new_height)
+
+        if self.figcanvas.size() != QSize(new_width, new_height):
+            self.figcanvas.setFixedSize(new_width, new_height)
 
     def get_scaling(self):
         """Get the current scaling of the figure in percent."""

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -120,7 +120,7 @@ class FigureBrowser(QWidget):
                                      "}")
         self.thumbnails_sb = ThumbnailScrollBar(
             self.figviewer, background_color=self.background_color)
-        
+
         toolbar = self.setup_toolbar()
         self.setup_option_actions(mute_inline_plotting,
                                   show_plot_outline,

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -535,7 +535,7 @@ class FigureViewer(QScrollArea):
 
     def get_scaling(self):
         """Get the current scaling of the figure in percent."""
-        return self.figcanvas.size().width() / self.figcanvas.fwidth * 100
+        return self.figcanvas.width() / self.figcanvas.fwidth * 100
 
     def reset_original_image(self):
         """Reset the image to its original size."""

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -311,7 +311,6 @@ class FigureBrowser(QWidget):
         """Change the auto_fit_plotting option and scale images."""
         self.option_changed('auto_fit_plotting', state)
         self.figviewer.auto_fit_plotting = state
-        self.figviewer.scale_image()
 
     def set_shellwidget(self, shellwidget):
         """Bind the shellwidget instance to the figure browser"""
@@ -422,6 +421,7 @@ class FigureViewer(QScrollArea):
         else:
             self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
             self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self.scale_image()
 
     def setup_figcanvas(self):
         """Setup the FigureCanvas."""

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -536,7 +536,7 @@ class FigureViewer(QScrollArea):
 
     def get_scaling(self):
         """Get the current scaling of the figure in percent."""
-        return self._scalestep**self._scalefactor*100
+        return self.figcanvas.size().width() / self.figcanvas.fwidth * 100
 
     def reset_original_image(self):
         """Reset the image to its original size."""

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -492,7 +492,6 @@ class FigureViewer(QScrollArea):
             self._scalefactor += 1
             self.scale_image()
             self._adjust_scrollbar(self._scalestep)
-            self.sig_zoom_changed.emit(self.get_scaling())
 
     def zoom_out(self):
         """Scale the image down by one scale step."""
@@ -500,7 +499,6 @@ class FigureViewer(QScrollArea):
             self._scalefactor -= 1
             self.scale_image()
             self._adjust_scrollbar(1/self._scalestep)
-            self.sig_zoom_changed.emit(self.get_scaling())
 
     def scale_image(self):
         """Scale the image size."""
@@ -532,6 +530,7 @@ class FigureViewer(QScrollArea):
 
         if self.figcanvas.size() != QSize(new_width, new_height):
             self.figcanvas.setFixedSize(new_width, new_height)
+            self.sig_zoom_changed.emit(self.get_scaling())
 
     def get_scaling(self):
         """Get the current scaling of the figure in percent."""

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -418,7 +418,9 @@ def test_autofit_figure_viewer(figbrowser, tmpdir, fmt):
     else:
         new_height = int(height)
         new_width = int(height / fheight * fwidth)
-
+    
+    assert (figbrowser.zoom_disp.value() ==
+            np.floor(figcanvas.width() / fwidth * 100))
     assert figcanvas.width() == new_width
     assert figcanvas.height() == new_height
 

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -380,9 +380,10 @@ def test_zoom_figure_viewer(figbrowser, tmpdir, fmt):
         scaling_factor += zoom_step
         scale = scaling_step**scaling_factor
 
-        assert figbrowser.zoom_disp.value() == np.floor(scale * 100)
-        assert figcanvas.width() == np.floor(fwidth * scale)
-        assert figcanvas.height() == np.floor(fheight * scale)
+        assert (figbrowser.zoom_disp.value() ==
+                np.floor(int(fwidth * scale) / fwidth * 100))
+        assert figcanvas.width() == int(fwidth * scale)
+        assert figcanvas.height() == int(fheight * scale)
 
 
 @pytest.mark.parametrize("fmt", ['image/png', 'image/svg+xml'])

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -418,7 +418,7 @@ def test_autofit_figure_viewer(figbrowser, tmpdir, fmt):
     else:
         new_height = int(height)
         new_width = int(height / fheight * fwidth)
-    
+
     assert (figbrowser.zoom_disp.value() ==
             np.floor(figcanvas.width() / fwidth * 100))
     assert figcanvas.width() == new_width


### PR DESCRIPTION
## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

![disable_zoom_and_upd_scaling](https://user-images.githubusercontent.com/10170372/58256376-e8473000-7d3c-11e9-86e3-32a1da1f4b6f.gif)

### Issue(s) Resolved

Fixes #9405

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin