### PR TITLE
PR: Fix code cells that fill the whole screen lose their background highlight

### DIFF
--- a/spyder/plugins/outlineexplorer/editor.py
+++ b/spyder/plugins/outlineexplorer/editor.py
@@ -36,7 +36,7 @@ class OutlineExplorerProxyEditor(OutlineExplorerProxy):
 
     def get_outlineexplorer_data(self):
         oe_data = self._editor.get_outlineexplorer_data()
-        self._editor.has_cell_separators = oe_data.pop(
+        self._editor.has_cell_separators = oe_data.get(
             'found_cell_separators', False)
         return oe_data
 

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -470,6 +470,7 @@ class PythonSH(BaseSH):
     def highlight_block(self, text):
         """Implement specific highlight for Python."""
         text = to_text_string(text)
+        self.found_cell_separators = False
         prev_state = tbh.get_state(self.currentBlock().previous())
         if prev_state == self.INSIDE_DQ3STRING:
             offset = -4


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

This error shouldn't currently happen in the highlighting code logic but at some point `has_cell_separators` is returning false when there are cell separators in the code.

It looks like `found_cell_separators` is being popped then subsequent calls  `get_outlineexplorer_data` return false.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9443


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: bcolsen

<!--- Thanks for your help making Spyder better for everyone! --->
