### PR TITLE
PR: Autocomplete only left part of selected word.

### DIFF
--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -192,6 +192,26 @@ def test_completions(lsp_codeeditor, qtbot):
     assert "asin(x)" in [x['label'] for x in sig.args[0]]
     qtbot.keyPress(completion, Qt.Key_Enter, delay=300)
 
+    # enter for new line
+    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)
+
+    # Complete math.a|angle <tab> s ...<enter> to math.asin|angle
+    qtbot.keyClicks(code_editor, 'math.aangle')
+    for i in range(len('angle')):
+        qtbot.keyClick(code_editor, Qt.Key_Left)
+
+    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
+        code_editor.document_did_change()
+
+    with qtbot.waitSignal(completion.sig_show_completions,
+                          timeout=10000) as sig:
+        qtbot.keyPress(code_editor, Qt.Key_Tab)
+        qtbot.keyPress(code_editor, 's')
+    assert "asin(x)" in [x['label'] for x in sig.args[0]]
+    qtbot.keyPress(completion, Qt.Key_Enter, delay=300)
+    for i in range(len('angle')):
+        qtbot.keyClick(code_editor, Qt.Key_Right)
+
     # Check math.a <tab> <backspace> doesn't emit sig_show_completions
     qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)
     qtbot.keyClicks(code_editor, 'math.a')
@@ -218,7 +238,9 @@ def test_completions(lsp_codeeditor, qtbot):
 
     assert code_editor.toPlainText() == 'import math\nmath.degrees\n'\
                                         'math.degrees()\nmath.asin\n'\
-                                        'math.c\nmath.asin\nmath.\n'
+                                        'math.c\nmath.asin\n'\
+                                        'math.asinangle\n'\
+                                        'math.\n'
 
 
 if __name__ == '__main__':

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -768,6 +768,7 @@ class BaseEditMixin(object):
         """Return current word, i.e. word at cursor position,
             and the start position"""
         cursor = self.textCursor()
+        cursor_pos = cursor.position()
 
         if cursor.hasSelection():
             # Removes the selection and moves the cursor to the left side
@@ -809,7 +810,10 @@ class BaseEditMixin(object):
         # find a valid python variable name
         match = re.findall(r'([^\d\W]\w*)', text, re.UNICODE)
         if match:
-            return match[0], cursor.selectionStart()
+            text, startpos = match[0], cursor.selectionStart()
+            if completion:
+                text = text[:cursor_pos - startpos]
+            return text, startpos
 
     def get_current_word(self, completion=False):
         """Return current word, i.e. word at cursor position"""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Sometimes I want to autocomplete a word while I have something on the right of it:
```
import math

value = angle / 2
```
In this example, I want to take the `sin` of this angle:
```
import math

value = math.s|angle / 2
```
If I press `<tab>`, nothing will happen. But I want ` math.sin|angle`.




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
