### PR TITLE
PR: Disable LSP services on CodeEditors before restarting LSP client

### DIFF
--- a/spyder/plugins/editor/lsp/manager.py
+++ b/spyder/plugins/editor/lsp/manager.py
@@ -208,6 +208,7 @@ class LSPManager(QObject):
                     if self.clients[language]['status'] == self.STOPPED:
                         self.clients[language] = config
                     elif self.clients[language]['status'] == self.RUNNING:
+                        self.main.editor.stop_lsp_services(language)
                         self.close_client(language)
                         self.clients[language] = config
                         self.start_client(language)

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -299,6 +299,11 @@ class Editor(SpyderPluginWidget):
             language, settings))
         self.lsp_server_ready(language, self.lsp_editor_settings[language])
 
+    def stop_lsp_services(self, language):
+        """Notify all editorstacks about LSP server unavailability."""
+        for editorstack in self.editorstacks:
+            editorstack.notify_server_down(language)
+
     def lsp_server_ready(self, language, configuration):
         """Notify all stackeditors about LSP server availability."""
         for editorstack in self.editorstacks:

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -850,6 +850,9 @@ class CodeEditor(TextEditBaseWidget):
             self.lsp_ready = True
             self.document_did_open()
 
+    def stop_lsp_services(self):
+        self.lsp_ready = False
+
     def parse_lsp_config(self, config):
         """Parse and load LSP server editor capabilities."""
         sync_options = config['textDocumentSync']

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1541,6 +1541,13 @@ class EditorStack(QWidget):
             if editor.language.lower() == language:
                 editor.start_lsp_services(config)
 
+    def notify_server_down(self, language):
+        """Notify language server unavailability to code editors."""
+        for index in range(self.get_stack_count()):
+            editor = self.tabs.widget(index)
+            if editor.language.lower() == language:
+                editor.stop_lsp_services()
+
     def close_all_files(self):
         """Close all opened scripts"""
         while self.close_file():


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Disable LSP availability on codeeditors that have opened files of a particular language, whose LSP server requires a restart.

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9425


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@andfoy
<!--- Thanks for your help making Spyder better for everyone! --->
