### PR TITLE
PR: Use file contents to decide when to autosave

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -179,6 +179,14 @@ class Editor(SpyderPluginWidget):
                                           lambda vs: self.rehighlight_cells())
         self.register_widget_shortcuts(self.find_widget)
 
+        # Start autosave component
+        # (needs to be done before EditorSplitter)
+        self.autosave = AutosaveForPlugin(self)
+        self.autosave.try_recover_from_autosave()
+        # Multiply by 1000 to convert seconds to milliseconds
+        self.autosave.interval = self.get_option('autosave_interval') * 1000
+        self.autosave.enabled = self.get_option('autosave_enabled')
+
         # Tabbed editor widget + Find/Replace widget
         editor_widgets = QWidget(self)
         editor_layout = QVBoxLayout()
@@ -188,13 +196,6 @@ class Editor(SpyderPluginWidget):
                                          self.stack_menu_actions, first=True)
         editor_layout.addWidget(self.editorsplitter)
         editor_layout.addWidget(self.find_widget)
-
-        # Start autosave component
-        self.autosave = AutosaveForPlugin(self)
-        self.autosave.try_recover_from_autosave()
-        # Multiply by 1000 to convert seconds to milliseconds
-        self.autosave.interval = self.get_option('autosave_interval') * 1000
-        self.autosave.enabled = self.get_option('autosave_enabled')
 
         # Splitter: editor widgets (see above) + outline explorer
         self.splitter = QSplitter(self)
@@ -1109,19 +1110,6 @@ class Editor(SpyderPluginWidget):
                 CONF.set('lsp-server', 'pydocstyle', checked)
             self.main.lspmanager.update_server_list()
 
-    def received_sig_option_changed(self, option, value):
-        """
-        Called when sig_option_changed is received.
-
-        If option being changed is autosave_mapping, then synchronize new
-        mapping with all editor stacks except the sender.
-        """
-        if option == 'autosave_mapping':
-            for editorstack in self.editorstacks:
-                if editorstack != self.sender():
-                    editorstack.autosave_mapping = value
-        self.sig_option_changed.emit(option, value)
-
     #------ Focus tabwidget
     def __get_focus_editorstack(self):
         fwidget = QApplication.focusWidget()
@@ -1186,8 +1174,6 @@ class Editor(SpyderPluginWidget):
             editorstack.file_saved.connect(
                 self.vcs_status.update_vcs_state)
 
-        editorstack.autosave_mapping \
-            = CONF.get('editor', 'autosave_mapping', {})
         editorstack.set_help(self.help)
         editorstack.set_io_actions(self.new_action, self.open_action,
                                    self.save_action, self.revert_action)
@@ -1234,8 +1220,7 @@ class Editor(SpyderPluginWidget):
         editorstack.ending_long_process.connect(self.ending_long_process)
 
         # Redirect signals
-        editorstack.sig_option_changed.connect(
-                self.received_sig_option_changed)
+        editorstack.sig_option_changed.connect(self.sig_option_changed)
         editorstack.redirect_stdio.connect(
                                  lambda state: self.redirect_stdio.emit(state))
         editorstack.exec_in_extconsole.connect(
@@ -1292,6 +1277,10 @@ class Editor(SpyderPluginWidget):
         editorstack.sig_save_bookmark.connect(self.save_bookmark)
         editorstack.sig_load_bookmark.connect(self.load_bookmark)
         editorstack.sig_save_bookmarks.connect(self.save_bookmarks)
+
+        # Register editorstack's autosave component with plugin's autosave
+        # component
+        self.autosave.register_autosave_for_stack(editorstack.autosave)
 
     def unregister_editorstack(self, editorstack):
         """Removing editorstack only if it's not the last remaining"""

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -387,14 +387,6 @@ class Editor(SpyderPluginWidget):
             else:
                 for win in self.editorwindows[:]:
                     win.close()
-                # Remove autosave on successful close to avoid issue #9265.
-                # Probably a good idea anyway to mitigate autosave issues.
-                # Ignore errors resulting from file being open in > 2
-                # editorstacks or another Spyder being closed first and
-                # removing the spurious files.
-                for editorstack_split in self.editorstacks:
-                    editorstack_split.autosave.remove_all_autosave_files(
-                        errors="ignore")
                 return True
         except IndexError:
             return True

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -146,31 +146,16 @@ def test_editor_transmits_sig_option_changed(editor_plugin, qtbot):
     assert blocker.args == ['autosave_mapping', {1: 2}]
 
 
-def test_editor_sets_autosave_mapping_on_first_editorstack(editor_plugin):
-    """Check that first editor stack gets autosave mapping from config."""
-    editor = editor_plugin
-    editorStack = editor.get_current_editorstack()
-    assert editorStack.autosave_mapping == {}
 
-
-def test_editor_syncs_autosave_mapping_among_editorstacks(editor_plugin, qtbot):
-    """Check that when an editorstack emits a sig_option_changed for
-    autosave_mapping, the autosave mapping of all other editorstacks is
-    updated."""
+def test_editorstacks_share_autosave_data(editor_plugin, qtbot):
+    """Check that two EditorStacks share the same autosave data."""
     editor = editor_plugin
     editor.editorsplitter.split()
     assert len(editor.editorstacks) == 2
-    old_mapping = {}
-    for editorstack in editor.editorstacks:
-        assert editorstack.autosave_mapping == old_mapping
-    new_mapping = {'ham': 'spam'}
-    editor.get_current_editorstack().sig_option_changed.emit(
-            'autosave_mapping', new_mapping)
-    for editorstack in editor.editorstacks:
-        if editorstack == editor.get_current_editorstack():
-            assert editorstack.autosave_mapping == old_mapping
-        else:
-            assert editorstack.autosave_mapping == new_mapping
+    autosave1 = editor.editorstacks[0].autosave
+    autosave2 = editor.editorstacks[1].autosave
+    assert autosave1.name_mapping is autosave2.name_mapping
+    assert autosave1.file_hashes is autosave2.file_hashes
 
 
 # The mock_RecoveryDialog fixture needs to be called before setup_editor, so

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -146,7 +146,6 @@ def test_editor_transmits_sig_option_changed(editor_plugin, qtbot):
     assert blocker.args == ['autosave_mapping', {1: 2}]
 
 
-
 def test_editorstacks_share_autosave_data(editor_plugin, qtbot):
     """Check that two EditorStacks share the same autosave data."""
     editor = editor_plugin

--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -159,8 +159,7 @@ class AutosaveForStack(object):
         """
         Remove autosave file for specified file.
 
-        This function also updates `self.autosave_mapping` and clears the
-        `changed_since_autosave` flag.
+        This function also updates `self.name_mapping` and `self.file_hashes`.
         """
         if filename not in self.name_mapping:
             return
@@ -235,9 +234,9 @@ class AutosaveForStack(object):
         file.
 
         In all other cases, save a copy in a file with the name given by
-        `self.get_autosave_filename()` and clear the `changed_since_autosave`
-        flag and update the cached hash of the autosave file. An error dialog
-        notifies the user of any errors raised when saving.
+        `self.get_autosave_filename()` and update the cached hash of the
+        autosave file. An error dialog notifies the user of any errors raised
+        when saving.
 
         Args:
             index (int): index into self.stack.data
@@ -263,7 +262,6 @@ class AutosaveForStack(object):
         logger.debug('Autosaving %s to %s', finfo.filename, autosave_filename)
         try:
             self.stack._write_to_file(finfo, autosave_filename)
-            finfo.editor.document().changed_since_autosave = False
             autosave_hash = self.stack.compute_hash(finfo)
             self.file_hashes[autosave_filename] = autosave_hash
         except EnvironmentError as error:

--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -231,12 +231,7 @@ class AutosaveForStack(object):
         (if it exists) or the original file (if no autosave filee exists),
         then do nothing. If the current contents are the same as the file on
         disc, but the autosave file is different, then remove the autosave
-        file.
-
-        In all other cases, save a copy in a file with the name given by
-        `self.get_autosave_filename()` and update the cached hash of the
-        autosave file. An error dialog notifies the user of any errors raised
-        when saving.
+        file. In all other cases, autosave the file.
 
         Args:
             index (int): index into self.stack.data
@@ -258,6 +253,19 @@ class AutosaveForStack(object):
         else:
             if new_hash == orig_hash:
                 return
+        self.autosave(finfo)
+
+    def autosave(self, finfo):
+        """
+        Autosave a file.
+
+        Save a copy in a file with name `self.get_autosave_filename()` and
+        update the cached hash of the autosave file. An error dialog notifies
+        the user of any errors raised when saving.
+
+        Args:
+            fileinfo (FileInfo): file that is to be autosaved.
+        """
         autosave_filename = self.get_autosave_filename(finfo.filename)
         logger.debug('Autosaving %s to %s', finfo.filename, autosave_filename)
         try:

--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -176,6 +176,7 @@ class AutosaveForStack(object):
                 msgbox = AutosaveErrorDialog(error_message, error)
                 msgbox.exec_if_enabled()
         del self.name_mapping[filename]
+        del self.file_hashes[autosave_filename]
         self.stack.sig_option_changed.emit(
             'autosave_mapping', self.name_mapping)
         logger.debug('Removed autosave file %s', autosave_filename)

--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -245,15 +245,14 @@ class AutosaveForStack(object):
         if orig_filename in self.name_mapping:
             autosave_filename = self.name_mapping[orig_filename]
             autosave_hash = self.file_hashes[autosave_filename]
-            if new_hash == autosave_hash:
-                return
-            elif new_hash == orig_hash:
-                self.remove_autosave_file(orig_filename)
-                return
+            if new_hash != autosave_hash:
+                if new_hash == orig_hash:
+                    self.remove_autosave_file(orig_filename)
+                else:
+                    self.autosave(finfo)
         else:
-            if new_hash == orig_hash:
-                return
-        self.autosave(finfo)
+            if new_hash != orig_hash:
+                self.autosave(finfo)
 
     def autosave(self, finfo):
         """

--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -180,7 +180,7 @@ class AutosaveForStack(object):
                 autosave_filename = osp.join(autosave_dir, autosave_basename)
         return autosave_filename
 
-    def remove_autosave_file(self, filename, errors='raise'):
+    def remove_autosave_file(self, filename):
         """
         Remove autosave file for specified file.
 
@@ -192,30 +192,15 @@ class AutosaveForStack(object):
         try:
             os.remove(autosave_filename)
         except EnvironmentError as error:
-            error_message = (_('{} while removing autosave file {}')
-                             .format(type(error), autosave_filename))
-            if errors == 'ignore':
-                logger.debug('%s : %s', error_message, str(error))
-            else:
-                msgbox = AutosaveErrorDialog(error_message, error)
-                msgbox.exec_if_enabled()
+            action = (_('Error while removing autosave file {}')
+                      .format(autosave_filename))
+            msgbox = AutosaveErrorDialog(action, error)
+            msgbox.exec_if_enabled()
         del self.name_mapping[filename]
         del self.file_hashes[autosave_filename]
         self.stack.sig_option_changed.emit(
-            'autosave_mapping', self.name_mapping)
-        logger.debug('Removed autosave file %s', autosave_filename)
-
-    def remove_all_autosave_files(self, errors='raise'):
-        """
-        Remove all autosave files stored in this componet's mapping.
-
-        Args:
-            errors (str, optional): "raise" (default) or "ignore" errors.
-        """
-        if not self.name_mapping:
-            return
-        for filename in list(self.name_mapping):
-            self.remove_autosave_file(filename, errors=errors)
+                'autosave_mapping', self.name_mapping)
+        logger.debug('Removing autosave file %s', autosave_filename)
 
     def get_autosave_filename(self, filename):
         """

--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -25,7 +25,15 @@ logger = logging.getLogger(__name__)
 
 
 class AutosaveForPlugin(object):
-    """Component of editor plugin implementing autosave functionality."""
+    """
+    Component of editor plugin implementing autosave functionality.
+
+    Attributes:
+        name_mapping (dict): map between names of opened and autosave files.
+        file_hashes (dict): map between file names and hash of their contents.
+            This is used for both files opened in the editor and their
+            corresponding autosave files.
+    """
 
     # Interval (in ms) between two autosaves
     DEFAULT_AUTOSAVE_INTERVAL = 60 * 1000
@@ -41,6 +49,8 @@ class AutosaveForPlugin(object):
             editor (Editor): editor plugin.
         """
         self.editor = editor
+        self.name_mapping = {}
+        self.file_hashes = {}
         self.timer = QTimer(self.editor)
         self.timer.setSingleShot(True)
         self.timer.timeout.connect(self.do_autosave)
@@ -112,10 +122,25 @@ class AutosaveForPlugin(object):
         dialog.exec_if_nonempty()
         self.recover_files_to_open = dialog.files_to_open[:]
 
+    def register_autosave_for_stack(self, autosave_for_stack):
+        """
+        Register an AutosaveForStack object.
+
+        This replaces the `name_mapping` and `file_hashes` attributes
+        in `autosave_for_stack` with references to the corresponding
+        attributes of `self`, so that all AutosaveForStack objects
+        share the same data.
+        """
+        autosave_for_stack.name_mapping = self.name_mapping
+        autosave_for_stack.file_hashes = self.file_hashes
+
 
 class AutosaveForStack(object):
     """
     Component of EditorStack implementing autosave functionality.
+
+    In Spyder, the `name_mapping` and `file_hashes` are set to references to
+    the corresponding variables in `AutosaveForPlugin`.
 
     Attributes:
         stack (EditorStack): editor stack this component belongs to.

--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -222,9 +222,9 @@ class AutosaveForStack(object):
             logger.debug('New autosave file name')
         return autosave_filename
 
-    def autosave(self, index):
+    def maybe_autosave(self, index):
         """
-        Autosave a file.
+        Autosave a file if necessary.
 
         If the file is newly created (and thus not named by the user), do
         nothing.  If the current contents are the same as the autosave file
@@ -271,6 +271,6 @@ class AutosaveForStack(object):
             msgbox.exec_if_enabled()
 
     def autosave_all(self):
-        """Autosave all opened files."""
+        """Autosave all opened files where necessary."""
         for index in range(self.stack.get_stack_count()):
-            self.autosave(index)
+            self.maybe_autosave(index)

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -64,8 +64,7 @@ def test_autosave(mocker):
 
 
 @pytest.mark.parametrize('exception', [False, True])
-@pytest.mark.parametrize('errors', ['raise', 'ignore'])
-def test_autosave_remove_autosave_file(mocker, exception, errors):
+def test_autosave_remove_autosave_file(mocker, exception):
     """Test that AutosaveForStack.remove_autosave_file removes the autosave
     file, that an error dialog is displayed if an exception is raised,
     and that the autosave file is removed from `name_mapping` and
@@ -82,40 +81,11 @@ def test_autosave_remove_autosave_file(mocker, exception, errors):
     addon.name_mapping = {'orig': 'autosave'}
     addon.file_hashes = {'autosave': 42}
 
-    addon.remove_autosave_file(fileinfo.filename, errors=errors)
+    addon.remove_autosave_file(fileinfo.filename)
     assert addon.name_mapping == {}
     assert addon.file_hashes == {}
     mock_remove.assert_called_with('autosave')
-    assert mock_dialog.called == (exception and errors == 'raise')
-
-
-@pytest.mark.parametrize('exception', [False, True])
-@pytest.mark.parametrize('errors', ['raise', 'ignore'])
-def test_autosave_remove_all_autosave_files(mocker, exception, errors):
-    """
-    Test that ``remove_all_autosave_files`` succeeds and handles errors.
-
-    Check that AutosaveForStack.remove_all_autosave_files removes all
-    autosaves and that an error dialog is displayed if an exception is raised.
-    """
-    mock_remove = mocker.patch('os.remove')
-    if exception:
-        mock_remove.side_effect = EnvironmentError()
-    mock_dialog = mocker.patch(
-        'spyder.plugins.editor.utils.autosave.AutosaveErrorDialog')
-    mock_stack = mocker.Mock()
-    addon = AutosaveForStack(mock_stack)
-    addon.name_mapping = {}
-    for idx in range(3):
-        addon.name_mapping['orig_' + str(idx)] = 'autosave_' + str(idx)
-    addon.file_hashes = mocker.MagicMock()
-
-    addon.remove_all_autosave_files(errors=errors)
-    assert addon.name_mapping == {}
-    assert mock_remove.call_count == 3
-    assert mock_remove.call_args_list == [
-        (('autosave_' + str(idx),),) for idx in range(3)]
-    assert mock_dialog.called == (exception and errors == 'raise')
+    assert mock_dialog.called == exception
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -48,7 +48,7 @@ def test_autosave(mocker):
     mock_editor = mocker.Mock()
     mock_fileinfo = mocker.Mock(editor=mock_editor, filename='orig',
                                 newly_created=False)
-    mock_document = mocker.Mock(changed_since_autosave=True)
+    mock_document = mocker.Mock()
     mock_fileinfo.editor.document.return_value = mock_document
     mock_stack = mocker.Mock(data=[mock_fileinfo])
     addon = AutosaveForStack(mock_stack)

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -64,7 +64,9 @@ def test_autosave(mocker):
 @pytest.mark.parametrize('errors', ['raise', 'ignore'])
 def test_autosave_remove_autosave_file(mocker, exception, errors):
     """Test that AutosaveForStack.remove_autosave_file removes the autosave
-    file and that an error dialog is displayed if an exception is raised."""
+    file, that an error dialog is displayed if an exception is raised,
+    and that the autosave file is removed from `name_mapping` and
+    `file_hashes`."""
     mock_remove = mocker.patch('os.remove')
     if exception:
         mock_remove.side_effect = EnvironmentError()
@@ -75,9 +77,11 @@ def test_autosave_remove_autosave_file(mocker, exception, errors):
     fileinfo.filename = 'orig'
     addon = AutosaveForStack(mock_stack)
     addon.name_mapping = {'orig': 'autosave'}
+    addon.file_hashes = {'autosave': 42}
 
     addon.remove_autosave_file(fileinfo.filename, errors=errors)
     assert addon.name_mapping == {}
+    assert addon.file_hashes == {}
     mock_remove.assert_called_with('autosave')
     assert mock_dialog.called == (exception and errors == 'raise')
 
@@ -101,6 +105,7 @@ def test_autosave_remove_all_autosave_files(mocker, exception, errors):
     addon.name_mapping = {}
     for idx in range(3):
         addon.name_mapping['orig_' + str(idx)] = 'autosave_' + str(idx)
+    addon.file_hashes = mocker.MagicMock()
 
     addon.remove_all_autosave_files(errors=errors)
     assert addon.name_mapping == {}

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -43,8 +43,8 @@ def test_autosave_component_timer_if_enabled(qtbot, mocker, enabled):
 
 
 def test_autosave(mocker):
-    """Test that AutosaveForStack.autosave writes the contents to the autosave
-    file and updates the file_hashes."""
+    """Test that AutosaveForStack.maybe_autosave writes the contents to the
+    autosave file and updates the file_hashes."""
     mock_editor = mocker.Mock()
     mock_fileinfo = mocker.Mock(editor=mock_editor, filename='orig',
                                 newly_created=False)
@@ -56,7 +56,7 @@ def test_autosave(mocker):
     addon.file_hashes = {'orig': 1, 'autosave': 2}
     mock_stack.compute_hash.return_value = 3
 
-    addon.autosave(0)
+    addon.maybe_autosave(0)
 
     mock_stack._write_to_file.assert_called_with(mock_fileinfo, 'autosave')
     mock_stack.compute_hash.assert_called_with(mock_fileinfo)

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -42,6 +42,24 @@ def test_autosave_component_timer_if_enabled(qtbot, mocker, enabled):
         addon.do_autosave.assert_not_called()
 
 
+def test_autosave(mocker):
+    """Test that AutosaveForStack.autosave writes the contents to the autosave
+    file and updates the file_hashes."""
+    mock_editor = mocker.Mock()
+    mock_fileinfo = mocker.Mock(editor=mock_editor, filename='orig',
+                                newly_created=False)
+    mock_document = mocker.Mock(changed_since_autosave=True)
+    mock_fileinfo.editor.document.return_value = mock_document
+    mock_stack = mocker.Mock(data=[mock_fileinfo])
+    addon = AutosaveForStack(mock_stack)
+    addon.name_mapping = {'orig': 'autosave'}
+
+    addon.autosave(0)
+    mock_stack.compute_hash.assert_called_with(mock_fileinfo)
+    mock_hash = mock_stack.compute_hash.return_value
+    assert addon.file_hashes == {'autosave': mock_hash}
+
+
 @pytest.mark.parametrize('exception', [False, True])
 @pytest.mark.parametrize('errors', ['raise', 'ignore'])
 def test_autosave_remove_autosave_file(mocker, exception, errors):

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -53,11 +53,14 @@ def test_autosave(mocker):
     mock_stack = mocker.Mock(data=[mock_fileinfo])
     addon = AutosaveForStack(mock_stack)
     addon.name_mapping = {'orig': 'autosave'}
+    addon.file_hashes = {'orig': 1, 'autosave': 2}
+    mock_stack.compute_hash.return_value = 3
 
     addon.autosave(0)
+
+    mock_stack._write_to_file.assert_called_with(mock_fileinfo, 'autosave')
     mock_stack.compute_hash.assert_called_with(mock_fileinfo)
-    mock_hash = mock_stack.compute_hash.return_value
-    assert addon.file_hashes == {'autosave': mock_hash}
+    assert addon.file_hashes == {'orig': 1, 'autosave': 3}
 
 
 @pytest.mark.parametrize('exception', [False, True])

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -199,7 +199,6 @@ class FileInfo(QObject):
     def text_changed(self):
         """Editor's text has changed"""
         self.default = False
-        self.editor.document().changed_since_autosave = True
         self.text_changed_at.emit(self.filename,
                                   self.editor.get_position('cursor'))
 
@@ -1753,7 +1752,6 @@ class EditorStack(QWidget):
                                  finfo.filename, finfo.filename)
 
             finfo.editor.document().setModified(False)
-            finfo.editor.document().changed_since_autosave = False
             self.modification_changed(index=index)
             self.analyze_script(index)
 
@@ -2238,7 +2236,6 @@ class EditorStack(QWidget):
         position = finfo.editor.get_position('cursor')
         finfo.editor.set_text(txt)
         finfo.editor.document().setModified(False)
-        finfo.editor.document().changed_since_autosave = False
         self.autosave.file_hashes[finfo.filename] = hash(txt)
         finfo.editor.set_cursor_position(position)
 
@@ -2330,7 +2327,6 @@ class EditorStack(QWidget):
         if cloned_from is None:
             editor.set_text(txt)
             editor.document().setModified(False)
-            editor.document().changed_since_autosave = False
         finfo.text_changed_at.connect(
             lambda fname, position:
             self.text_changed_at.emit(fname, position))

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1514,7 +1514,7 @@ class EditorStack(QWidget):
                 self.set_stack_index(new_index)
 
             self.add_last_closed_file(finfo.filename)
- 
+
             if finfo.filename in self.autosave.file_hashes:
                 del self.autosave.file_hashes[finfo.filename]
 

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1514,10 +1514,7 @@ class EditorStack(QWidget):
                 self.set_stack_index(new_index)
 
             self.add_last_closed_file(finfo.filename)
-
-            # Remove autosave on successful close to work around issue #9265.
-            # Probably a good idea in general to mitigate any other bugs.
-            self.autosave.remove_autosave_file(finfo.filename)
+ 
             if finfo.filename in self.autosave.file_hashes:
                 del self.autosave.file_hashes[finfo.filename]
 
@@ -1639,7 +1636,7 @@ class EditorStack(QWidget):
                 if not self.save(index):
                     return False
             elif no_all:
-                self.autosave.remove_autosave_file(finfo.filename)
+                self.autosave.remove_autosave_file(finfo)
             elif (finfo.editor.document().isModified() and
                   self.save_dialog_on_tests):
 

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1519,6 +1519,8 @@ class EditorStack(QWidget):
             # Remove autosave on successful close to work around issue #9265.
             # Probably a good idea in general to mitigate any other bugs.
             self.autosave.remove_autosave_file(finfo.filename)
+            if finfo.filename in self.autosave.file_hashes:
+                del self.autosave.file_hashes[finfo.filename]
 
         if self.get_stack_count() == 0 and self.create_new_file_if_empty:
             self.sig_new_file[()].emit()
@@ -1734,6 +1736,8 @@ class EditorStack(QWidget):
             self.set_os_eol_chars(osname=osname)
         try:
             self._write_to_file(finfo, finfo.filename)
+            file_hash = self.compute_hash(finfo)
+            self.autosave.file_hashes[finfo.filename] = file_hash
             self.autosave.remove_autosave_file(finfo.filename)
             finfo.newly_created = False
             self.encoding_changed.emit(finfo.encoding)
@@ -2235,6 +2239,7 @@ class EditorStack(QWidget):
         finfo.editor.set_text(txt)
         finfo.editor.document().setModified(False)
         finfo.editor.document().changed_since_autosave = False
+        self.autosave.file_hashes[finfo.filename] = hash(txt)
         finfo.editor.set_cursor_position(position)
 
         #XXX CodeEditor-only: re-scan the whole text to rebuild outline

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1676,7 +1676,7 @@ class EditorStack(QWidget):
         Returns:
             int: computed hash.
         """
-        txt = to_text_string(fileinfo.editor.get_text_with_eol())
+        txt = fileinfo.editor.get_text_with_eol()
         return hash(txt)
 
     def _write_to_file(self, fileinfo, filename):
@@ -1689,7 +1689,7 @@ class EditorStack(QWidget):
         This is a low-level function that only saves the text to file in the
         correct encoding without doing any error handling.
         """
-        txt = to_text_string(fileinfo.editor.get_text_with_eol())
+        txt = fileinfo.editor.get_text_with_eol()
         fileinfo.encoding = encoding.write(txt, filename, fileinfo.encoding)
 
     def save(self, index=None, force=False):

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1668,6 +1668,18 @@ class EditorStack(QWidget):
                     return False
         return True
 
+    def compute_hash(self, fileinfo):
+        """Compute hash of contents of editor.
+
+        Args:
+            fileinfo: FileInfo object associated to editor to be saved
+
+        Returns:
+            int: computed hash.
+        """
+        txt = to_text_string(fileinfo.editor.get_text_with_eol())
+        return hash(txt)
+
     def _write_to_file(self, fileinfo, filename):
         """Low-level function for writing text of editor to file.
 

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1672,7 +1672,8 @@ class EditorStack(QWidget):
         """Compute hash of contents of editor.
 
         Args:
-            fileinfo: FileInfo object associated to editor to be saved
+            fileinfo: FileInfo object associated to editor whose hash needs
+                to be computed.
 
         Returns:
             int: computed hash.
@@ -2407,6 +2408,9 @@ class EditorStack(QWidget):
     def load(self, filename, set_current=True, add_where='end'):
         """
         Load filename, create an editor instance and return it
+
+        This also sets the hash of the loaded file in the autosave component.
+
         *Warning* This is loading file, creating editor but not executing
         the source code analysis -- the analysis must be done by the editor
         plugin (in case multiple editorstack instances are handled)
@@ -2414,6 +2418,7 @@ class EditorStack(QWidget):
         filename = osp.abspath(to_text_string(filename))
         self.starting_long_process.emit(_("Loading %s...") % filename)
         text, enc = encoding.read(filename)
+        self.autosave.file_hashes[filename] = hash(text)
         finfo = self.create_new_editor(filename, enc, text, set_current,
                                        add_where=add_where)
         index = self.data.index(finfo)

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -10,6 +10,7 @@ Tests for editor.py
 
 # Standard library imports
 import os
+import os.path as osp
 from sys import platform
 try:
     from unittest.mock import Mock, MagicMock
@@ -674,8 +675,9 @@ def test_opening_sets_file_hash(base_editor_bot, mocker):
     editor_stack = base_editor_bot
     mocker.patch('spyder.plugins.editor.widgets.editor.encoding.read',
                  return_value=('my text', 42))
-    editor_stack.load('/mock-filename')
-    expected = {'/mock-filename': hash('my text')}
+    filename = osp.realpath('/mock-filename')
+    editor_stack.load(filename)
+    expected = {filename: hash('my text')}
     assert editor_stack.autosave.file_hashes == expected
 
 
@@ -684,10 +686,11 @@ def test_reloading_updates_file_hash(base_editor_bot, mocker):
     editor_stack = base_editor_bot
     mocker.patch('spyder.plugins.editor.widgets.editor.encoding.read',
                  side_effect=[('my text', 42), ('new text', 42)])
-    finfo = editor_stack.load('/mock-filename')
+    filename = osp.realpath('/mock-filename')
+    finfo = editor_stack.load(filename)
     index = editor_stack.data.index(finfo)
     editor_stack.reload(index)
-    expected = {'/mock-filename': hash('new text')}
+    expected = {filename: hash('new text')}
     assert editor_stack.autosave.file_hashes == expected
 
 
@@ -696,7 +699,8 @@ def test_closing_removes_file_hash(base_editor_bot, mocker):
     editor_stack = base_editor_bot
     mocker.patch('spyder.plugins.editor.widgets.editor.encoding.read',
                  return_value=('my text', 42))
-    finfo = editor_stack.load('/mock-filename')
+    filename = osp.realpath('/mock-filename')
+    finfo = editor_stack.load(filename)
     index = editor_stack.data.index(finfo)
     editor_stack.close_file(index)
     assert editor_stack.autosave.file_hashes == {}

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -661,6 +661,16 @@ def test_autosave_does_not_save_new_files(editor_bot, mocker):
     editor_stack._write_to_file.assert_not_called()
 
 
+def test_opening_sets_file_hash(editor_bot, mocker):
+    """Test that opening a file sets the file hash."""
+    editor_stack, editor = editor_bot
+    mocker.patch('spyder.plugins.editor.widgets.editor.encoding.read',
+                 return_value=('my text', 42))
+    editor_stack.load('/mock-filename')
+    expected = {'/mock-filename': hash('my text')}
+    assert editor_stack.autosave.file_hashes == expected
+
+
 @pytest.mark.parametrize('filename', ['ham.py', 'ham.txt'])
 def test_autosave_does_not_save_after_open(base_editor_bot, mocker, qtbot,
                                            filename):

--- a/spyder/plugins/editor/widgets/tests/test_save.py
+++ b/spyder/plugins/editor/widgets/tests/test_save.py
@@ -172,6 +172,7 @@ def test_save(editor_bot, mocker):
     assert save(index=0) is True
     assert not editor.encoding.write.called
     assert not editor_stack.autosave.remove_autosave_file.called
+    assert editor_stack.autosave.file_hashes == {}
 
     # File modified.
     editor_stack.data[0].editor.document().setModified(True)
@@ -183,6 +184,7 @@ def test_save(editor_bot, mocker):
     editor_stack.save_as.assert_called_with(index=0)
     assert not editor.encoding.write.called
     assert not editor_stack.autosave.remove_autosave_file.called
+    assert editor_stack.autosave.file_hashes == {}
 
     # Force save.
     editor.os.path.isfile.return_value = True
@@ -192,6 +194,8 @@ def test_save(editor_bot, mocker):
         str(id(editor_stack)), 'foo.py', 'foo.py')
     editor_stack.autosave.remove_autosave_file.assert_called_with(
         editor_stack.data[0].filename)
+    expected = {'foo.py': hash('a = 1\nprint(a)\n\nx = 2\n')}
+    assert editor_stack.autosave.file_hashes == expected
 
     editor_stack.file_saved = save_file_saved
 

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -317,11 +317,7 @@ class BaseSH(QSyntaxHighlighter):
 
     def rehighlight(self):
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
-        # rehighlight() triggers the textChanged signal, which in our editor
-        # switches changed_since_autosave to True; we need to prevent this.
-        old_changed = getattr(self.document(), 'changed_since_autosave', False)
         QSyntaxHighlighter.rehighlight(self)
-        self.document().changed_since_autosave = old_changed
         QApplication.restoreOverrideCursor()
 
 


### PR DESCRIPTION

## Description of Changes

This PR changes the autosave system so that it uses the file contents to decide whether to autosave or not. Currently, we use Qt's `textChanged` to see whether the user made any changes since the last autosave, and if yes, we autosave. It turns out that this leads to a lot of false positives. Running the highlighter emits `textChanged`, as does splitting the editor window. This leads to files being autosaved needlessly and possibly to user confusion when the user is asked whether to recover from these unnecessary autosave files. We can guard against this, but I think the design is quite fragile. In particular, if a user makes an edit and then undoes the edit, it will count as a change for the autosave system and I don't see a good way to detect this.

Here, I try a different approach: Spyder compares the contents of the editor against the contents of the file on disk and autosaves if they are different. The logic is in commit a079e6b. Spyder stores the hash of the file contents on disk so that they don't need to be read in again. A disadvantage of this approach is that we have to compute the hash of the contents of the editor whenever the autosave system fires (by default, once a minute). This may take some time when editing large files (I did not test this, but I guess it may be noticeable for files of 100 MB or more). However, I guess that other parts of Spyder are also problematic for such large files.

Additionally, this PR moves ownership of the autosave data from EditorStack level to plugin level (commit 
9c31c23). This ensures that when the user splits the editor pane, the autosave data in the EditorStacks are synchronized.

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/)) **N/A**


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9265


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
