### PR TITLE
PR: Remove cell seporator detection from syntax highlighting and use oedata instead

### DIFF
--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -538,7 +538,12 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         if whole_file_selected:
             self.clear_extra_selections('current_cell')
         elif whole_screen_selected:
-            if self.highlighter.found_cell_separators:
+            has_cell_separators = False
+            for oedata in self.outlineexplorer_data_list():
+                if oedata.def_type == oedata.CELL:
+                    has_cell_separators = True
+                    break
+            if has_cell_separators:
                 self.set_extra_selections('current_cell', [selection])
                 self.update_extra_selections()
             else:

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -156,9 +156,6 @@ class BaseSH(QSyntaxHighlighter):
         self.fold_detector = None
         self.editor = None
 
-        # Cell separator could be there in any language
-        self.found_cell_separators = False
-        
     def get_background_color(self):
         return QColor(self.background_color)
 
@@ -467,7 +464,6 @@ class PythonSH(BaseSH):
     def highlight_block(self, text):
         """Implement specific highlight for Python."""
         text = to_text_string(text)
-        self.found_cell_separators = False
         prev_state = tbh.get_state(self.currentBlock().previous())
         if prev_state == self.INSIDE_DQ3STRING:
             offset = -4
@@ -522,7 +518,6 @@ class PythonSH(BaseSH):
                         self.setFormat(start, end-start, self.formats[key])
                         if key == "comment":
                             if text.lstrip().startswith(self.cell_separators):
-                                self.found_cell_separators = True
                                 oedata = OutlineExplorerData(
                                     self.currentBlock())
                                 oedata.text = to_text_string(text).strip()
@@ -643,7 +638,6 @@ class PythonSH(BaseSH):
         return statments
             
     def rehighlight(self):
-        self.found_cell_separators = False
         BaseSH.rehighlight(self)
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Syntax highlighting is not reliable for cell detection, but now we can use our updated oedata.

Running a loop when ever you scroll probably isn't the best solution but I don't see any performance impacts. 

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9443


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: bcolsen

<!--- Thanks for your help making Spyder better for everyone! --->
