### PR TITLE
PR: Prevent indentation/unindentation in the CodeEditor when Ctrl+Tab or Ctrl+Shift+Tab is pressed

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -3272,7 +3272,7 @@ class CodeEditor(TextEditBaseWidget):
                 if ind(leading_text) == ind(prevtxt):
                     self.unindent(force=True)
             TextEditBaseWidget.keyPressEvent(self, event)
-        elif key == Qt.Key_Tab:
+        elif key == Qt.Key_Tab and not ctrl:
             # Important note: <TAB> can't be called with a QShortcut because
             # of its singular role with respect to widget focus management
             if not has_selection and not self.tab_mode:
@@ -3280,7 +3280,7 @@ class CodeEditor(TextEditBaseWidget):
             else:
                 # indent the selected text
                 self.indent_or_replace()
-        elif key == Qt.Key_Backtab:
+        elif key == Qt.Key_Backtab and not ctrl:
             # Backtab, i.e. Shift+<TAB>, could be treated as a QShortcut but
             # there is no point since <TAB> can't (see above)
             if not has_selection and not self.tab_mode:


### PR DESCRIPTION
## Description of Changes

When the `Ctrl + Tab` and `Ctrl + Shift + Tab` key sequences are not assigned to any shortcut, pressing these keys will be handled in the `keyPressEvent` of the `CodeEditor`.

This PR adds conditions so that the current line is not indented or unintended when these shortcuts are pressed and so that the event is passed to the parent instead, resulting in a cycling forward or backward of the tabs of the Editorstack.

Note that in Windows, when the `Ctrl + Tab` and `Ctrl + Shift + Tab` key sequences  are assigned to a shortcut, the event related to the pressing of these keys is handled by the corresponding shortcut, not by the `keyPressEvent` of the `CodeEditor`. By default, these two key sequences are assigned to the `go to next file` and `go to previous file` shortcut, which trigger the tabs switcher with a mru behaviour.

## Issue(s) Resolved

Fixes #9515


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
