### PR TITLE
PR: Preserve file permissions when saving in the editor

### DIFF
--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -239,12 +239,8 @@ def write(text, filename, encoding='utf-8', mode='wb'):
         # Needed to fix file permissions overwritting
         # See spyder-ide/spyder#9381
         try:
-            FileNotFoundError
-        except NameError:  # Python 2
-            FileNotFoundError = OSError
-        try:
             original_mode = os.stat(filename).st_mode
-        except FileNotFoundError:
+        except OSError:
             # Creating a new file, emulate what os.open() does
             umask = os.umask(0)
             os.umask(umask)

--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -239,6 +239,10 @@ def write(text, filename, encoding='utf-8', mode='wb'):
         # Needed to fix file permissions overwritting
         # See spyder-ide/spyder#9381
         try:
+            FileNotFoundError
+        except NameError:  # Python 2
+            FileNotFoundError = OSError
+        try:
             original_mode = os.stat(filename).st_mode
         except FileNotFoundError:
             # Creating a new file, emulate what os.open() does

--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -235,12 +235,12 @@ def write(text, filename, encoding='utf-8', mode='wb'):
         with open(filename, mode) as textfile:
             textfile.write(text)
     else:
-        mode = os.stat(filename).st_mode
+        original_mode = os.stat(filename).st_mode
         with atomic_write(filename,
                           overwrite=True,
                           mode=mode) as textfile:
             textfile.write(text)
-        os.chmod(filename, mode)
+        os.chmod(filename, original_mode)
     return encoding
 
 

--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -240,7 +240,7 @@ def write(text, filename, encoding='utf-8', mode='wb'):
         # See spyder-ide/spyder#9381
         try:
             original_mode = os.stat(filename).st_mode
-        except OSError:
+        except OSError:  # Change to FileNotFoundError for PY3
             # Creating a new file, emulate what os.open() does
             umask = os.umask(0)
             os.umask(umask)

--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -235,10 +235,12 @@ def write(text, filename, encoding='utf-8', mode='wb'):
         with open(filename, mode) as textfile:
             textfile.write(text)
     else:
+        mode = os.stat(filename).st_mode
         with atomic_write(filename,
                           overwrite=True,
                           mode=mode) as textfile:
             textfile.write(text)
+        os.chmod(filename, mode)
     return encoding
 
 

--- a/spyder/utils/tests/test_encoding.py
+++ b/spyder/utils/tests/test_encoding.py
@@ -10,6 +10,7 @@ import os
 import stat
 
 from spyder.utils.encoding import is_text_file, get_coding, write
+from spyder.py3compat import to_text_string
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(),
                                              os.path.dirname(__file__)))
@@ -18,9 +19,10 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(),
 def test_permissions(tmpdir):
     """Check that file permissions are preserved."""
     p_file = tmpdir.mkdir("permissions").join("permissions_text.txt")
+    p_file = to_text_string(p_file)
 
     # Write file and define execution permissions
-    write("Some text", str(p_file))
+    write("Some text", p_file)
     st = os.stat(p_file)
     mode = st.st_mode | stat.S_IEXEC
     os.chmod(p_file, mode)
@@ -28,7 +30,7 @@ def test_permissions(tmpdir):
     old_mode = os.stat(p_file).st_mode
 
     # Write the file and check permissions
-    write("Some text and more", str(p_file))
+    write("Some text and more", p_file)
     new_mode = os.stat(p_file).st_mode
 
     assert old_mode == new_mode

--- a/spyder/utils/tests/test_encoding.py
+++ b/spyder/utils/tests/test_encoding.py
@@ -7,11 +7,31 @@
 
 import pytest
 import os
+import stat
 
-from spyder.utils.encoding import is_text_file, get_coding
+from spyder.utils.encoding import is_text_file, get_coding, write
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(),
                                              os.path.dirname(__file__)))
+
+
+def test_permissions(tmpdir):
+    """Check that file permissions are preserved."""
+    p_file = tmpdir.mkdir("permissions").join("permissions_text.txt")
+
+    # Write file and define execution permissions
+    write("Some text", str(p_file))
+    st = os.stat(p_file)
+    mode = st.st_mode | stat.S_IEXEC
+    os.chmod(p_file, mode)
+
+    old_mode = os.stat(p_file).st_mode
+
+    # Write the file and check permissions
+    write("Some text and more", str(p_file))
+    new_mode = os.stat(p_file).st_mode
+
+    assert old_mode == new_mode
 
 
 def test_is_text_file(tmpdir):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Preserve file permission when saving with `atomic_writes`


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9381 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
