### PR TITLE
PR: Remove extra padding around plots and variable explorer plugins

### DIFF
--- a/spyder/plugins/plots/plugin.py
+++ b/spyder/plugins/plots/plugin.py
@@ -35,6 +35,7 @@ class Plots(SpyderPluginWidget):
 
         # Widgets
         self.stack = QStackedWidget(self)
+        self.stack.setStyleSheet("QStackedWidget{padding: 0px; border: 0px}")
         self.shellwidgets = {}
 
         # Layout

--- a/spyder/plugins/variableexplorer/plugin.py
+++ b/spyder/plugins/variableexplorer/plugin.py
@@ -45,6 +45,7 @@ class VariableExplorer(SpyderPluginWidget):
 
         # Widgets
         self.stack = QStackedWidget(self)
+        self.stack.setStyleSheet("QStackedWidget{padding: 0px; border: 0px}")
         self.shellwidgets = {}
 
         # Layout


### PR DESCRIPTION
## Description of Changes

As noticed in PR https://github.com/spyder-ide/spyder/pull/9452#issuecomment-497460070, there is some extra padding around the `Plots` and `Variable Explorer` plugin under the dark theme.

This PR fixes this by setting the padding and margin of the stack widget used in the layout of both of these plugins to 0 px. I think there is no need to add this under a `is_darkmode` condition because we don't want to have any padding or margin for the stack widget in these plugins under any theme.

This was initially part of PR #9452, but I believe that this change should have its own PR because it is not really related to the size of the icons.

### Before the changes:

![extra_padding_before](https://user-images.githubusercontent.com/10170372/59314217-5919a200-8c82-11e9-848c-86c59429f490.gif)

### After the changes:

![extra_padding_after](https://user-images.githubusercontent.com/10170372/59314214-55861b00-8c82-11e9-8c38-29169c7c3617.gif)

### Issue(s) Resolved

Fixes the issue reported in PR https://github.com/spyder-ide/spyder/pull/9452#issuecomment-497460070


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin




