### PR TITLE
PR: Add desktop.ini file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist/
 bin/
 spyder.egg-info/
 Thumbs.db
+desktop.ini
 .DS_Store/
 spyder_crash.log
 .DS_Store


### PR DESCRIPTION
This PR is simply to add `desktop.ini` file to our `.gitignore`

> A Desktop.ini file is a file that determines the way a folder is displayed by Windows. These files can be found in any folder, anywhere on your computer, as long as that folder has a custom appearance set for it. Desktop.ini files control things like the icon used for that folder and its localized name.
