### PR TITLE
PR: Style improvement to the wait spinner used in the Find plugin

### DIFF
--- a/spyder/plugins/findinfiles/widgets.py
+++ b/spyder/plugins/findinfiles/widgets.py
@@ -41,9 +41,8 @@ from spyder.utils.misc import getcwd_or_home
 from spyder.widgets.comboboxes import PatternComboBox
 from spyder.widgets.onecolumntree import OneColumnTree
 from spyder.utils.misc import regexp_error_msg
-from spyder.utils.qthelpers import create_toolbutton
+from spyder.utils.qthelpers import create_toolbutton, create_waitspinner
 from spyder.config.gui import get_font
-from spyder.widgets.waitingspinner import QWaitingSpinner
 
 
 ON = 'on'
@@ -911,9 +910,7 @@ class FileProgressBar(QWidget):
         QWidget.__init__(self, parent)
 
         self.status_text = QLabel(self)
-        self.spinner = QWaitingSpinner(self, centerOnParent=False)
-        self.spinner.setNumberOfLines(12)
-        self.spinner.setInnerRadius(2)
+        self.spinner = create_waitspinner(parent=self)
         layout = QHBoxLayout()
         layout.addWidget(self.spinner)
         layout.addWidget(self.status_text)

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -7,6 +7,7 @@
 """Qt utilities"""
 
 # Standard library imports
+from math import pi
 import os
 import os.path as osp
 import re
@@ -24,11 +25,12 @@ from qtpy.QtWidgets import (QAction, QApplication, QHBoxLayout, QLabel,
 
 # Local imports
 from spyder.config.base import get_image_path, running_in_mac_app
-from spyder.config.gui import get_shortcut
+from spyder.config.gui import get_shortcut, is_dark_interface
 from spyder.utils import programs
 from spyder.utils import icon_manager as ima
 from spyder.utils.icon_manager import get_icon, get_std_icon
 from spyder.py3compat import is_text_string, to_text_string
+from spyder.widgets.waitingspinner import QWaitingSpinner
 
 # Note: How to redirect a signal from widget *a* to widget *b* ?
 # ----
@@ -212,6 +214,30 @@ def create_toolbutton(parent, text=None, shortcut=None, icon=None, tip=None,
     if shortcut is not None:
         button.setShortcut(shortcut)
     return button
+
+
+def create_waitspinner(size=32, n=11, parent=None):
+    """
+    Create a wait spinner with the specified size built with n circling dots.
+    """
+    dot_padding = 1
+
+    # To calculate the size of the dots, we need to solve the following
+    # system of two equations in two variables.
+    # (1) middle_circumference = pi * (size - dot_size)
+    # (2) middle_circumference = n * (dot_size + dot_padding)
+    dot_size = (pi * size - n * dot_padding) / (n + pi)
+    inner_radius = (size - 2 * dot_size) / 2
+
+    spinner = QWaitingSpinner(parent, centerOnParent=False)
+    spinner.setTrailSizeDecreasing(True)
+    spinner.setNumberOfLines(n)
+    spinner.setLineLength(dot_size)
+    spinner.setLineWidth(dot_size)
+    spinner.setInnerRadius(inner_radius)
+    spinner.setColor(Qt.white if is_dark_interface() else Qt.black)
+
+    return spinner
 
 
 def action2button(action, autoraise=True, text_beside_icon=False, parent=None):

--- a/spyder/widgets/waitingspinner.py
+++ b/spyder/widgets/waitingspinner.py
@@ -55,6 +55,7 @@ class QWaitingSpinner(QWidget):
         self._roundness = 100.0
         self._minimumTrailOpacity = 3.14159265358979323846
         self._trailFadePercentage = 80.0
+        self._trailSizeDecreasing = False
         self._revolutionsPerSecond = 1.57079632679489661923
         self._numberOfLines = 20
         self._lineLength = 10
@@ -92,9 +93,19 @@ class QWaitingSpinner(QWidget):
             distance = self.lineCountDistanceFromPrimary(i, self._currentCounter, self._numberOfLines)
             color = self.currentLineColor(distance, self._numberOfLines, self._trailFadePercentage,
                                           self._minimumTrailOpacity, self._color)
+
+            # Calcul the scaling factor to apply to the size and thickness
+            # of the lines in the trail.
+            if self._trailSizeDecreasing:
+                sf = (self._numberOfLines - distance) / self._numberOfLines
+            else:
+                sf = 1
+
             painter.setBrush(color)
-            painter.drawRoundedRect(QRect(0, -self._lineWidth / 2, self._lineLength, self._lineWidth), self._roundness,
-                                    self._roundness, Qt.RelativeSize)
+            rect = QRect(0, -self._lineWidth / 2,
+                         sf * self._lineLength, sf * self._lineWidth)
+            painter.drawRoundedRect(
+                rect, self._roundness, self._roundness, Qt.RelativeSize)
             painter.restore()
 
     def start(self):
@@ -158,6 +169,13 @@ class QWaitingSpinner(QWidget):
     def lineLength(self):
         return self._lineLength
 
+    def isTrailSizeDecreasing(self):
+        """
+        Return whether the length and thickness of the trailing lines
+        are decreasing.
+        """
+        return self._trailSizeDecreasing
+
     def lineWidth(self):
         return self._lineWidth
 
@@ -179,6 +197,13 @@ class QWaitingSpinner(QWidget):
 
     def setTrailFadePercentage(self, trail):
         self._trailFadePercentage = trail
+
+    def setTrailSizeDecreasing(self, value):
+        """
+        Set whether the length and thickness of the trailing lines
+        are decreasing.
+        """
+        self._trailSizeDecreasing = value
 
     def setMinimumTrailOpacity(self, minimumTrailOpacity):
         self._minimumTrailOpacity = minimumTrailOpacity

--- a/spyder/widgets/waitingspinner.py
+++ b/spyder/widgets/waitingspinner.py
@@ -36,9 +36,9 @@ A port of `QtWaitingSpinner <https://github.com/snowwlex/QtWaitingSpinner>`_.
 
 import math
 
-from qtpy.QtCore import *
-from qtpy.QtGui import *
-from qtpy.QtWidgets import *
+from qtpy.QtCore import QRect, Qt, QTimer
+from qtpy.QtGui import QColor, QPainter
+from qtpy.QtWidgets import QWidget
 
 
 class QWaitingSpinner(QWidget):

--- a/spyder/widgets/waitingspinner.py
+++ b/spyder/widgets/waitingspinner.py
@@ -94,7 +94,7 @@ class QWaitingSpinner(QWidget):
             color = self.currentLineColor(distance, self._numberOfLines, self._trailFadePercentage,
                                           self._minimumTrailOpacity, self._color)
 
-            # Calcul the scaling factor to apply to the size and thickness
+            # Compute the scaling factor to apply to the size and thickness
             # of the lines in the trail.
             if self._trailSizeDecreasing:
                 sf = (self._numberOfLines - distance) / self._numberOfLines


### PR DESCRIPTION
## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

- I fixed the color of the spinner when under the dark mode.
- I created a qthelper function to make the creation of the wait spinner easier if we have to use it somewhere else in the future.
- I added the option to decrease the size of the trail in the spinner class
- I changed the look of the spinner so that plain dots are used instead of lines for the animation.

Here are animations that show the wait spinner after this PR under the dark and WindowsVista theme :

![waitspinner_light](https://user-images.githubusercontent.com/10170372/59551708-dfb4d480-8f4b-11e9-8c6a-78d6f6b62eee.gif)

![waitspinner_dark](https://user-images.githubusercontent.com/10170372/59551725-125ecd00-8f4c-11e9-9802-8512df5067de.gif)

<br>For comparison, here is an animation that shows the wait spinner before this PR :

![waitspinner_light_old](https://user-images.githubusercontent.com/10170372/59551822-3ff84600-8f4d-11e9-9f3b-39acea783739.gif)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9578


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin
