### PR TITLE
PR: Send fallback completions to the end of the completion widget

### DIFF
--- a/spyder/plugins/editor/fallback/actor.py
+++ b/spyder/plugins/editor/fallback/actor.py
@@ -65,7 +65,7 @@ class FallbackActor(QObject):
         keyword_set = set(keywords)
         keywords = [{'kind': CompletionItemKind.KEYWORD,
                      'insertText': keyword,
-                     'sortText': 'z{0}'.format(keyword[0].lower()),
+                     'sortText': 'zz{0}'.format(keyword[0].lower()),
                      'filterText': keyword, 'documentation': ''}
                     for keyword in keywords]
         # logger.debug(keywords)
@@ -73,7 +73,7 @@ class FallbackActor(QObject):
         # logger.debug(tokens)
         tokens = get_words(text, language)
         tokens = [{'kind': CompletionItemKind.TEXT, 'insertText': token,
-                   'sortText': 'z{0}'.format(token[0].lower()),
+                   'sortText': 'zz{0}'.format(token[0].lower()),
                    'filterText': token, 'documentation': ''}
                   for token in tokens]
         for token in tokens:

--- a/spyder/plugins/editor/fallback/actor.py
+++ b/spyder/plugins/editor/fallback/actor.py
@@ -60,7 +60,7 @@ class FallbackActor(QThread):
         keyword_set = set(keywords)
         keywords = [{'kind': CompletionItemKind.KEYWORD,
                      'insertText': keyword,
-                     'sortText': keyword[0].lower(),
+                     'sortText': 'z{0}'.format(keyword[0].lower()),
                      'filterText': keyword, 'documentation': ''}
                     for keyword in keywords]
         # logger.debug(keywords)
@@ -68,7 +68,7 @@ class FallbackActor(QThread):
         # logger.debug(tokens)
         tokens = get_words(text, language)
         tokens = [{'kind': CompletionItemKind.TEXT, 'insertText': token,
-                   'sortText': token[0].lower(),
+                   'sortText': 'z{0}'.format(token[0].lower()),
                    'filterText': token, 'documentation': ''}
                   for token in tokens]
         for token in tokens:

--- a/spyder/plugins/editor/fallback/actor.py
+++ b/spyder/plugins/editor/fallback/actor.py
@@ -65,7 +65,7 @@ class FallbackActor(QObject):
         keyword_set = set(keywords)
         keywords = [{'kind': CompletionItemKind.KEYWORD,
                      'insertText': keyword,
-                     'sortText': 'zz{0}'.format(keyword[0].lower()),
+                     'sortText': u'zz{0}'.format(keyword[0].lower()),
                      'filterText': keyword, 'documentation': ''}
                     for keyword in keywords]
         # logger.debug(keywords)
@@ -73,7 +73,7 @@ class FallbackActor(QObject):
         # logger.debug(tokens)
         tokens = get_words(text, language)
         tokens = [{'kind': CompletionItemKind.TEXT, 'insertText': token,
-                   'sortText': 'zz{0}'.format(token[0].lower()),
+                   'sortText': u'zz{0}'.format(token[0].lower()),
                    'filterText': token, 'documentation': ''}
                   for token in tokens]
         for token in tokens:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
A character 'z' is prepended to the sortText response of the ``FallbackActor``, such that LSP completions are presented first, and then the fallback ones. If LSP is not available, then the fallback ones are displayed sorted.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
![ezgif com-gif-maker](https://user-images.githubusercontent.com/1878982/59617580-335e2400-90ec-11e9-916f-51768d2d80cf.gif)



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@andfoy
<!--- Thanks for your help making Spyder better for everyone! --->
