### PR TITLE
PR: Restore underlining errors and warnings in the Editor

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1952,8 +1952,7 @@ class CodeEditor(TextEditBaseWidget):
             block.selection = QTextCursor(cursor)
             block.color = color
             self.__highlight_selection('code_analysis', block.selection,
-                                       underline_color=block.color,
-                                       underline_style=QTextCharFormat.WaveUnderline)
+                                       underline_color=block.color)
 
         self.sig_process_code_analysis.emit()
         self.update_extra_selections()

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1470,7 +1470,7 @@ class CodeEditor(TextEditBaseWidget):
     def __highlight_selection(self, key, cursor, foreground_color=None,
                         background_color=None, underline_color=None,
                         outline_color=None,
-                        underline_style=QTextCharFormat.WaveUnderline,
+                        underline_style=QTextCharFormat.SingleUnderline,
                         update=False):
         if cursor is None:
             return

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1941,7 +1941,7 @@ class CodeEditor(TextEditBaseWidget):
                 QTextCursor.NextCharacter, n=end['character'],
                 mode=QTextCursor.KeepAnchor)
             color = QColor(color)
-            color.setAlpha(50)
+            color.setAlpha(255)
 
             data = block.userData()
             if not data:
@@ -1951,6 +1951,9 @@ class CodeEditor(TextEditBaseWidget):
             block.setUserData(data)
             block.selection = QTextCursor(cursor)
             block.color = color
+            self.__highlight_selection('code_analysis', block.selection,
+                                       underline_color=block.color,
+                                       underline_style=QTextCharFormat.WaveUnderline)
 
         self.sig_process_code_analysis.emit()
         self.update_extra_selections()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

Restore underlining errors and warning in the editor from PyLS 

I'm not sure if we should use wave underline, it is not showing as much as expected.
![image](https://user-images.githubusercontent.com/20992645/59654951-15c9a280-915e-11e9-9338-f95eaa2aa676.png)

However the single line underline is more visible,
![image](https://user-images.githubusercontent.com/20992645/59654964-28dc7280-915e-11e9-9d84-7df7347fb44c.png)

<!--- Explain what you've done and why --->


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9472 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: steff456

<!--- Thanks for your help making Spyder better for everyone! --->
