### PR TITLE
PR: Add an option to turn on/off the underlining of errors and warnings in the Editor. 

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -206,6 +206,7 @@ DEFAULTS = [
               'convert_eol_on_save_to': 'LF',
               'tab_always_indent': False,
               'intelligent_backspace': True,
+              'underline_errors': False,
               'highlight_current_line': True,
               'highlight_current_cell': True,
               'occurrence_highlighting': True,

--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -40,6 +40,8 @@ class EditorConfigPage(PluginConfigPage):
                                      'indent_guides')
         linenumbers_box = newcb(_("Show line numbers"), 'line_numbers')
         blanks_box = newcb(_("Show blank spaces"), 'blank_spaces')
+        underline_errors_box = newcb(_("Underline errors and warnings"),
+                                     'underline_errors')
         currentline_box = newcb(_("Highlight current line"),
                                 'highlight_current_line')
         currentcell_box = newcb(_("Highlight current cell"),
@@ -92,6 +94,7 @@ class EditorConfigPage(PluginConfigPage):
         display_layout.addWidget(showindentguides_box)
         display_layout.addWidget(linenumbers_box)
         display_layout.addWidget(blanks_box)
+        display_layout.addWidget(underline_errors_box)
         display_layout.addWidget(currentline_box)
         display_layout.addWidget(currentcell_box)
         display_layout.addWidget(wrap_mode_box)

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -794,13 +794,18 @@ class Editor(SpyderPluginWidget):
         show_docstring_warnings_action = self._create_checkable_action(
             _("Show docstring style warnings"), 'pydocstyle')
 
+        underline_errors = self._create_checkable_action(
+            _("Underline errors and warnings"),
+            'underline_errors', 'set_underline_errors_enabled')
+
         self.checkable_actions = {
                 'blank_spaces': showblanks_action,
                 'scroll_past_end': scrollpastend_action,
                 'indent_guides': showindentguides_action,
                 'show_class_func_dropdown': show_classfunc_dropdown_action,
                 'pycodestyle': show_codestyle_warnings_action,
-                'pydocstyle': show_docstring_warnings_action}
+                'pydocstyle': show_docstring_warnings_action,
+                'underline_errors': underline_errors}
 
         fixindentation_action = create_action(self, _("Fix indentation"),
                       tip=_("Replace tab characters by space characters"),
@@ -966,6 +971,7 @@ class Editor(SpyderPluginWidget):
             show_classfunc_dropdown_action,
             show_codestyle_warnings_action,
             show_docstring_warnings_action,
+            underline_errors,
             MENU_SEPARATOR,
             self.todo_list_action,
             self.warning_list_action,
@@ -1197,6 +1203,7 @@ class Editor(SpyderPluginWidget):
         settings = (
             ('set_todolist_enabled',                'todo_list'),
             ('set_blanks_enabled',                  'blank_spaces'),
+            ('set_underline_errors_enabled',        'underline_errors'),
             ('set_scrollpastend_enabled',           'scroll_past_end'),
             ('set_linenumbers_enabled',             'line_numbers'),
             ('set_edgeline_enabled',                'edge_line'),

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -338,7 +338,7 @@ class CodeEditor(TextEditBaseWidget):
         self.blanks_enabled = False
 
         # Underline errors and warnings
-        self.underline_enabled = False
+        self.underline_errors_enabled = False
 
         # Scrolling past the end of the document
         self.scrollpastend_enabled = False
@@ -1244,7 +1244,7 @@ class CodeEditor(TextEditBaseWidget):
 
     def set_underline_errors_enabled(self, state):
         """Toggle the underlining of errors and warnings."""
-        self.underline_errors = state
+        self.underline_errors_enabled = state
         self.document_did_change()
 
     def set_highlight_current_line(self, enable):
@@ -1965,7 +1965,7 @@ class CodeEditor(TextEditBaseWidget):
             block.setUserData(data)
             block.selection = QTextCursor(cursor)
             block.color = color
-            if self.underline_errors:
+            if self.underline_errors_enabled:
                 self.__highlight_selection('code_analysis', block.selection,
                                            underline_color=block.color)
 

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -337,6 +337,9 @@ class CodeEditor(TextEditBaseWidget):
         # Blanks enabled
         self.blanks_enabled = False
 
+        # Underline errors and warnings
+        self.underline_enabled = False
+
         # Scrolling past the end of the document
         self.scrollpastend_enabled = False
 
@@ -722,6 +725,7 @@ class CodeEditor(TextEditBaseWidget):
                      edge_line=True,
                      edge_line_columns=(79,),
                      show_blanks=False,
+                     underline_errors=False,
                      close_parentheses=True,
                      close_quotes=False,
                      add_colons=True,
@@ -780,6 +784,9 @@ class CodeEditor(TextEditBaseWidget):
         # Lexer
         self.filename = filename
         self.set_language(language, filename)
+
+        # Underline errors and warnings
+        self.set_underline_errors_enabled(underline_errors)
 
         # Highlight current cell
         self.set_highlight_current_cell(highlight_current_cell)
@@ -1234,6 +1241,11 @@ class CodeEditor(TextEditBaseWidget):
     def set_occurrence_timeout(self, timeout):
         """Set occurrence highlighting timeout (ms)"""
         self.occurrence_timer.setInterval(timeout)
+
+    def set_underline_errors_enabled(self, state):
+        """Toggle the underlining of errors and warnings."""
+        self.underline_errors = state
+        self.document_did_change()
 
     def set_highlight_current_line(self, enable):
         """Enable/disable current line highlighting"""
@@ -1953,8 +1965,9 @@ class CodeEditor(TextEditBaseWidget):
             block.setUserData(data)
             block.selection = QTextCursor(cursor)
             block.color = color
-            self.__highlight_selection('code_analysis', block.selection,
-                                       underline_color=block.color)
+            if self.underline_errors:
+                self.__highlight_selection('code_analysis', block.selection,
+                                           underline_color=block.color)
 
         self.sig_process_code_analysis.emit()
         self.update_extra_selections()

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -542,6 +542,7 @@ class EditorStack(QWidget):
         self.tabmode_enabled = False
         self.stripmode_enabled = False
         self.intelligent_backspace_enabled = True
+        self.underline_errors_enabled = False
         self.highlight_current_line_enabled = False
         self.highlight_current_cell_enabled = False
         self.occurrence_highlighting_enabled = True

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1136,6 +1136,12 @@ class EditorStack(QWidget):
             for finfo in self.data:
                 finfo.editor.set_occurrence_timeout(timeout)
 
+    def set_underline_errors_enabled(self, state):
+        self.underline_errors_enabled = state
+        if self.data:
+            for finfo in self.data:
+                finfo.editor.set_underline_errors_enabled(state)
+
     def set_highlight_current_line_enabled(self, state):
         self.highlight_current_line_enabled = state
         if self.data:
@@ -2312,6 +2318,7 @@ class EditorStack(QWidget):
         editor.setup_editor(
             linenumbers=self.linenumbers_enabled,
             show_blanks=self.blanks_enabled,
+            underline_errors=self.underline_errors_enabled,
             scroll_past_end=self.scrollpastend_enabled,
             edge_line=self.edgeline_enabled,
             edge_line_columns=self.edgeline_columns, language=language,

--- a/spyder/preferences/appearance.py
+++ b/spyder/preferences/appearance.py
@@ -317,6 +317,7 @@ class AppearanceConfigPage(GeneralConfigPage):
                 )
         show_blanks = CONF.get('editor', 'blank_spaces')
         update_scrollbar = CONF.get('editor', 'scroll_past_end')
+        underline_errors = CONF.get('editor', 'underline_errors')
         if scheme_name is None:
             scheme_name = self.current_scheme
         self.preview_editor.setup_editor(linenumbers=True,
@@ -324,6 +325,7 @@ class AppearanceConfigPage(GeneralConfigPage):
                                          tab_mode=False,
                                          font=get_font(),
                                          show_blanks=show_blanks,
+                                         underline_errors=underline_errors,
                                          color_scheme=scheme_name,
                                          scroll_past_end=update_scrollbar)
         self.preview_editor.set_text(text)


### PR DESCRIPTION
## Description of Changes

- Added the `Underline errors and warnings` option to the `Source` menu and to the `Editor\Display` preferences.

![image](https://user-images.githubusercontent.com/10170372/59894259-e90bca00-93ad-11e9-90d3-f251fc98b182.png)

![image](https://user-images.githubusercontent.com/10170372/59894285-02147b00-93ae-11e9-83c9-87f1c8da0c95.png)

### Issue(s) Resolved

Fixes #9627


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin
