### PR TITLE
PR: Fix and improvement to the highlighting and underlining of errors and warnings in the Editor

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2043,6 +2043,7 @@ class CodeEditor(TextEditBaseWidget):
             self.highlight_line_warning(block_data)
 
     def highlight_line_warning(self, block_data):
+        """Highlight errors and warnings in this editor."""
         self.clear_extra_selections('code_analysis_highlight')
         self.__highlight_selection('code_analysis_highlight',
                                    block_data.selection,

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1912,7 +1912,8 @@ class CodeEditor(TextEditBaseWidget):
     def cleanup_code_analysis(self):
         """Remove all code analysis markers"""
         self.setUpdatesEnabled(False)
-        self.clear_extra_selections('code_analysis')
+        self.clear_extra_selections('code_analysis_highlight')
+        self.clear_extra_selections('code_analysis_underline')
         for data in self.blockuserdata_list():
             data.code_analysis = []
 
@@ -1965,8 +1966,11 @@ class CodeEditor(TextEditBaseWidget):
             block.setUserData(data)
             block.selection = QTextCursor(cursor)
             block.color = color
+
+            # Underline errors and warnings in this editor.
             if self.underline_errors_enabled:
-                self.__highlight_selection('code_analysis', block.selection,
+                self.__highlight_selection('code_analysis_underline',
+                                           block.selection,
                                            underline_color=block.color)
 
         self.sig_process_code_analysis.emit()
@@ -2039,13 +2043,14 @@ class CodeEditor(TextEditBaseWidget):
             self.highlight_line_warning(block_data)
 
     def highlight_line_warning(self, block_data):
-        self.clear_extra_selections('code_analysis')
-        self.__highlight_selection('code_analysis', block_data.selection,
+        self.clear_extra_selections('code_analysis_highlight')
+        self.__highlight_selection('code_analysis_highlight',
+                                   block_data.selection,
                                    background_color=block_data.color)
         self.update_extra_selections()
         self.linenumberarea.update()
         QTimer.singleShot(
-            5000, lambda: self.clear_extra_selections('code_analysis'))
+            5000, lambda: self.clear_extra_selections('code_analysis_highlight'))
 
     def get_current_warnings(self):
         """

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1245,7 +1245,10 @@ class CodeEditor(TextEditBaseWidget):
     def set_underline_errors_enabled(self, state):
         """Toggle the underlining of errors and warnings."""
         self.underline_errors_enabled = state
-        self.document_did_change()
+        if state:
+            self.document_did_change()
+        else:
+            self.clear_extra_selections('code_analysis_underline')
 
     def set_highlight_current_line(self, enable):
         """Enable/disable current line highlighting"""

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1990,6 +1990,7 @@ class CodeEditor(TextEditBaseWidget):
         """
         self._last_hover_word = None
         self.tooltip_widget.hide()
+        self.clear_extra_selections('code_analysis_highlight')
 
     def show_code_analysis_results(self, line_number, block_data):
         """Show warning/error messages."""
@@ -2050,8 +2051,6 @@ class CodeEditor(TextEditBaseWidget):
                                    background_color=block_data.color)
         self.update_extra_selections()
         self.linenumberarea.update()
-        QTimer.singleShot(
-            5000, lambda: self.clear_extra_selections('code_analysis_highlight'))
 
     def get_current_warnings(self):
         """


### PR DESCRIPTION
## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

- I removed the timer for clearing the errors and warnings highlight. Now it is cleared instantly when the errors and warnings tooltip is hidden.
- I have split the logging of the errors and warnings highlight and underline in the extra selections so that we can clear one without affecting the other.

![highlight_underline_improvements](https://user-images.githubusercontent.com/10170372/59925064-3ebf9100-9405-11e9-89e1-0dbccbcc3707.gif)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9635
Fixes #9631

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
