### PR TITLE
PR: Fix test_set_get_project_filenames* functions so the test matches actual spyder behaviour

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1006,6 +1006,50 @@ Files covered:
 spyder/plugins/variableexplorer/widgets/dataframeeditor.py
 
 
+-------------------------------------------------------------------------------
+
+
+
+Classes from objbrowser 1.2.1
+-----------------------------
+
+
+Copyright (c) 2016 Pepijn Kenter
+
+
+Author: Pepijn Kenter | titusjan@gmail.com | https://github.com/titusjan
+Site/Source: https://github.com/titusjan/objbrowser
+License: MIT (Expat) License | https://opensource.org/licenses/MIT
+
+Modifications made to each class to adapt them to Spyder's needs.
+
+
+objbrowser is distributed under the MIT license.
+
+
+Use the core functionality of the project, mainly changing the code to use
+the upstream version of qtpy project (since it is already a dependency of
+Spyder).
+
+See below for the full text of the MIT (Expat) license.
+
+The current objbrowser license can be viewed at:
+https://github.com/titusjan/objbrowser/blob/master/LICENSE.txt
+
+The current version of the original files can be viewed at:
+https://github.com/titusjan/objbrowser/tree/master/objbrowser
+
+
+Files covered:
+
+spyder/plugins/variableexplorer/widgets/objectexplorer/attribute_model.py
+spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
+spyder/plugins/variableexplorer/widgets/objectexplorer/tree_item.py
+spyder/plugins/variableexplorer/widgets/objectexplorerr/tree_model.py
+spyder/plugins/variableexplorer/widgets/objectexplorer/utils.py
+
+
 ===============================================================================
 
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ a Python version greater than 2.7 or 3.4 (Python <=3.3 is no longer supported).
 * **Chardet**: Character encoding auto-detection in Python.
 * **Numpydoc**: Used by Jedi to get function return types from Numpydocstrings.
 * **Cloudpickle**: Serialize variables in the IPython kernel to send to Spyder.
-* **spyder-kernels** 1.2.0+: Jupyter kernels for the Spyder console.
+* **spyder-kernels** 1.4.0+: Jupyter kernels for the Spyder console.
 * **keyring**: Save Github credentials to report errors securely.
 * **QDarkStyle** 2.6.4+: A dark stylesheet for Qt applications, used for Spyder's dark theme.
 * **atomicwrites**: Atomic file writes.

--- a/continuous_integration/circle/modules_test.sh
+++ b/continuous_integration/circle/modules_test.sh
@@ -112,6 +112,9 @@ for f in spyder/*/*/*/*/*.py; do
     if [[ $f == spyder/plugins/editor/lsp/*/*.py ]]; then
         continue
     fi
+    if [[ $f == spyder/plugins/variableexplorer/widgets/objectexplorer/__init__.py ]]; then
+        continue
+    fi
     python "$f"
     if [ $? -ne 0 ]; then
         exit 1

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -13,7 +13,7 @@ chardet >=2.0.0
 numpydoc
 pyqt <5.10
 keyring
-spyder-kernels >=1.2
+spyder-kernels >=1.4
 python-language-server >=0.19
 qdarkstyle >=2.6.4
 atomicwrites

--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,7 @@ install_requires = [
     'pyzmq',
     'chardet>=2.0.0',
     'numpydoc',
-    'spyder-kernels>=1.2',
+    'spyder-kernels>=1.4',
     'qdarkstyle>=2.6.4',
     'atomicwrites',
     'diff-match-patch',

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -168,7 +168,9 @@ DEFAULTS = [
               'exclude_capitalized': False,
               'exclude_unsupported': True,
               'truncate': True,
-              'minmax': False
+              'minmax': False,
+              'show_callable_attributes': True,
+              'show_special_attributes': False
              }),
             ('plots',
              {

--- a/spyder/plugins/breakpoints/widgets/breakpointsgui.py
+++ b/spyder/plugins/breakpoints/widgets/breakpointsgui.py
@@ -19,8 +19,7 @@ import sys
 # Third party imports
 from qtpy import API
 from qtpy.compat import to_qvariant
-from qtpy.QtCore import (QAbstractTableModel, QModelIndex, QTextCodec, Qt,
-                         Signal)
+from qtpy.QtCore import QAbstractTableModel, QModelIndex, Qt, Signal
 from qtpy.QtWidgets import (QItemDelegate, QMenu, QTableView, QHBoxLayout,
                             QVBoxLayout, QWidget)
 
@@ -36,9 +35,6 @@ try:
 except KeyError as error:
     import gettext
     _ = gettext.gettext
-
-
-locale_codec = QTextCodec.codecForLocale()
 
 
 class BreakpointTableModel(QAbstractTableModel):

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -1327,7 +1327,11 @@ class IPythonConsole(SpyderPluginWidget):
             if ("<ipython-input-" in fname and
                     self.run_cell_filename is not None):
                 fname = self.run_cell_filename
-            self.edit_goto.emit(osp.abspath(fname), int(lnb), '')
+            # This is needed to fix issue spyder-ide/spyder#9217
+            try:
+                self.edit_goto.emit(osp.abspath(fname), int(lnb), '')
+            except ValueError:
+                pass
 
     @Slot()
     def show_intro(self):

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -1461,7 +1461,17 @@ class IPythonConsole(SpyderPluginWidget):
 
         # Create kernel client
         kernel_client = QtKernelClient(connection_file=connection_file)
-        kernel_client.load_connection_file()
+
+        # This is needed for issue spyder-ide/spyder#9304
+        try:
+            kernel_client.load_connection_file()
+        except Exception as e:
+            QMessageBox.critical(self, _('Connection error'),
+                                 _("An error occurred while trying to load "
+                                   "the kernel connection file. The error "
+                                   "was:\n\n") + to_text_string(e))
+            return
+
         if hostname is not None:
             try:
                 connection_info = dict(ip = kernel_client.ip,

--- a/spyder/plugins/profiler/widgets/profilergui.py
+++ b/spyder/plugins/profiler/widgets/profilergui.py
@@ -25,8 +25,7 @@ import logging
 
 # Third party imports
 from qtpy.compat import getopenfilename, getsavefilename
-from qtpy.QtCore import (QByteArray, QProcess, QProcessEnvironment, QTextCodec,
-                         Qt, Signal)
+from qtpy.QtCore import QByteArray, QProcess, QProcessEnvironment, Qt, Signal
 from qtpy.QtGui import QColor
 from qtpy.QtWidgets import (QApplication, QHBoxLayout, QLabel, QMessageBox,
                             QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget)
@@ -50,10 +49,7 @@ except KeyError as error:
     _ = gettext.gettext
 
 
-locale_codec = QTextCodec.codecForLocale()
 logger = logging.getLogger(__name__)
-
-
 def is_profiler_installed():
     from spyder.utils.programs import is_module_installed
     return is_module_installed('cProfile') and is_module_installed('pstats')
@@ -327,7 +323,7 @@ class ProfilerWidget(QWidget):
                 qba += self.process.readAllStandardError()
             else:
                 qba += self.process.readAllStandardOutput()
-        text = to_text_string( locale_codec.toUnicode(qba.data()) )
+        text = to_text_string(qba.data(), encoding='utf-8')
         if error:
             self.error_output += text
         else:

--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -188,8 +188,9 @@ def test_set_get_project_filenames_when_closing(create_projects, tmpdir):
 
     Regression test for Issue #8375
     """
-    opened_files = ['file1', 'file2', 'file3']
+
     path = to_text_string(tmpdir.mkdir('project1'))
+    opened_files = [os.path.join(path, file) for file in ['file1', 'file2', 'file3']]
 
     # Create the projects plugin.
     projects = create_projects(path, opened_files)
@@ -206,9 +207,9 @@ def test_set_get_project_filenames_when_switching(create_projects, tmpdir):
     Test that files in the Editor are loaded and saved correctly when
     switching projects.
     """
-    opened_files = ['file1', 'file2', 'file3']
     path1 = to_text_string(tmpdir.mkdir('project1'))
     path2 = to_text_string(tmpdir.mkdir('project2'))
+    opened_files = [os.path.join(path1, file) for file in ['file1', 'file2', 'file3']]
 
     # Create the projects plugin.
     projects = create_projects(path1, opened_files)

--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -190,7 +190,8 @@ def test_set_get_project_filenames_when_closing(create_projects, tmpdir):
     """
 
     path = to_text_string(tmpdir.mkdir('project1'))
-    opened_files = [os.path.join(path, file) for file in ['file1', 'file2', 'file3']]
+    opened_files = [os.path.join(path, file)
+                    for file in ['file1', 'file2', 'file3']]
 
     # Create the projects plugin.
     projects = create_projects(path, opened_files)
@@ -209,7 +210,8 @@ def test_set_get_project_filenames_when_switching(create_projects, tmpdir):
     """
     path1 = to_text_string(tmpdir.mkdir('project1'))
     path2 = to_text_string(tmpdir.mkdir('project2'))
-    opened_files = [os.path.join(path1, file) for file in ['file1', 'file2', 'file3']]
+    opened_files = [os.path.join(path1, file)
+                    for file in ['file1', 'file2', 'file3']]
 
     # Create the projects plugin.
     projects = create_projects(path1, opened_files)

--- a/spyder/plugins/pylint/widgets/pylintgui.py
+++ b/spyder/plugins/pylint/widgets/pylintgui.py
@@ -21,7 +21,7 @@ import time
 # Third party imports
 import pylint
 from qtpy.compat import getopenfilename
-from qtpy.QtCore import QByteArray, QProcess, QTextCodec, Signal, Slot
+from qtpy.QtCore import QByteArray, QProcess, Signal, Slot
 from qtpy.QtWidgets import (QHBoxLayout, QLabel, QMessageBox, QTreeWidgetItem,
                             QVBoxLayout, QWidget)
 
@@ -46,7 +46,6 @@ except KeyError as error:
     import gettext
     _ = gettext.gettext
 
-locale_codec = QTextCodec.codecForLocale()
 PYLINT_REQVER = '>=0.25'
 PYLINT_VER = pylint.__version__
 dependencies.add("pylint", _("Static code analysis"),
@@ -358,7 +357,7 @@ class PylintWidget(QWidget):
                 qba += self.process.readAllStandardError()
             else:
                 qba += self.process.readAllStandardOutput()
-        text = to_text_string( locale_codec.toUnicode(qba.data()) )
+        text = to_text_string(qba.data(), encoding='utf-8')
         if error:
             self.error_output += text
         else:

--- a/spyder/plugins/variableexplorer/tests/test_variableexplorer.py
+++ b/spyder/plugins/variableexplorer/tests/test_variableexplorer.py
@@ -33,8 +33,9 @@ def test_get_settings(monkeypatch):
 
     app = qapplication()
     settings = VariableExplorer(None).get_settings()
-    expected = {'remote1': 'remote1val', 'remote2': 'remote2val',
-                'dataframe_format': '%3d'}
+    expected = {'dataframe_format': '%3d',
+                'remote1': 'remote1val',
+                'remote2': 'remote2val'}
     assert settings == expected
 
 

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -64,9 +64,11 @@ class NamespaceBrowser(QWidget):
         self.exclude_unsupported = None
         self.excluded_names = None
         self.minmax = None
-        
+
         # Other setting
         self.dataframe_format = None
+        self.show_callable_attributes = None
+        self.show_special_attributes = None
 
         self.editor = None
         self.exclude_private_action = None
@@ -82,7 +84,9 @@ class NamespaceBrowser(QWidget):
     def setup(self, check_all=None, exclude_private=None,
               exclude_uppercase=None, exclude_capitalized=None,
               exclude_unsupported=None, excluded_names=None,
-              minmax=None, dataframe_format=None):
+              minmax=None, dataframe_format=None,
+              show_callable_attributes=None,
+              show_special_attributes=None):
         """
         Setup the namespace browser with provided settings.
 
@@ -100,7 +104,9 @@ class NamespaceBrowser(QWidget):
         self.excluded_names = excluded_names
         self.minmax = minmax
         self.dataframe_format = dataframe_format
-        
+        self.show_callable_attributes = show_callable_attributes
+        self.show_special_attributes = show_special_attributes
+
         if self.editor is not None:
             self.editor.setup_menu(minmax)
             self.editor.set_dataframe_format(dataframe_format)
@@ -112,11 +118,14 @@ class NamespaceBrowser(QWidget):
             return
 
         self.editor = RemoteCollectionsEditorTableView(
-                        self,
-                        data=None,
-                        minmax=minmax,
-                        shellwidget=self.shellwidget,
-                        dataframe_format=dataframe_format)
+            self,
+            data=None,
+            minmax=minmax,
+            shellwidget=self.shellwidget,
+            dataframe_format=dataframe_format,
+            show_callable_attributes=show_callable_attributes,
+            show_special_attributes=show_special_attributes
+        )
 
         self.editor.sig_option_changed.connect(self.sig_option_changed.emit)
         self.editor.sig_files_dropped.connect(self.import_data)

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/__init__.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2016 Pepijn Kenter.
+# Copyright (c) 2019- Spyder Project Contributors
+#
+# Components of objectbrowser originally distributed under
+# the MIT (Expat) license. Licensed under the terms of the MIT License;
+# see NOTICE.txt in the Spyder root directory for details
+# -----------------------------------------------------------------------------
+
+
+"""
+spyder.plugins.variableexplorer.widgets.objectexplorer
+======================================================
+
+Object explorer widget.
+"""
+
+from .attribute_model import DEFAULT_ATTR_COLS, DEFAULT_ATTR_DETAILS
+from .tree_model import TreeModel, TreeProxyModel
+from .toggle_column_mixin import ToggleColumnTreeView
+from .objectexplorer import ObjectExplorer

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/attribute_model.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/attribute_model.py
@@ -1,0 +1,483 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2016 Pepijn Kenter.
+# Copyright (c) 2019- Spyder Project Contributors
+#
+# Components of objectbrowser originally distributed under
+# the MIT (Expat) license. Licensed under the terms of the MIT License;
+# see NOTICE.txt in the Spyder root directory for details
+# -----------------------------------------------------------------------------
+
+# Standard library imports
+import inspect
+import logging
+import pprint
+import string
+
+# Third-party imports
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QTextOption
+from spyder_kernels.utils.nsview import value_to_display
+
+# Local imports
+from spyder.config.base import _
+from spyder.py3compat import TEXT_TYPES, to_text_string
+
+# Attribute models constants
+try:
+    import numpy as np
+except ImportError:
+    _NUMPY_INSTALLED = False
+else:
+    _NUMPY_INSTALLED = True
+
+SMALL_COL_WIDTH = 120
+MEDIUM_COL_WIDTH = 200
+
+_PRETTY_PRINTER = pprint.PrettyPrinter(indent=4)
+
+_ALL_PREDICATES = (inspect.ismodule, inspect.isclass, inspect.ismethod,
+                   inspect.isfunction, inspect.isgeneratorfunction,
+                   inspect.isgenerator,
+                   inspect.istraceback, inspect.isframe, inspect.iscode,
+                   inspect.isbuiltin, inspect.isroutine, inspect.isabstract,
+                   inspect.ismethoddescriptor, inspect.isdatadescriptor,
+                   inspect.isgetsetdescriptor, inspect.ismemberdescriptor)
+
+# The cast to int is necessary to avoid a bug in PySide, See:
+# https://bugreports.qt-project.org/browse/PYSIDE-20
+ALIGN_LEFT = int(Qt.AlignVCenter | Qt.AlignLeft)
+ALIGN_RIGHT = int(Qt.AlignVCenter | Qt.AlignRight)
+
+logger = logging.getLogger(__name__)
+
+
+###################
+# Data functions ##
+###################
+def tio_call(obj_fn, tree_item):
+    """Calls obj_fn(tree_item.obj)."""
+    return obj_fn(tree_item.obj)
+
+
+def safe_tio_call(obj_fn, tree_item, log_exceptions=False):
+    """
+    Call the obj_fn(tree_item.obj).
+    Returns empty string in case of an error.
+    """
+    tio = tree_item.obj
+    try:
+        return str(obj_fn(tio))
+    except Exception as ex:
+        if log_exceptions:
+            logger.exception(ex)
+        return ""
+
+
+def safe_data_fn(obj_fn, log_exceptions=False):
+    """
+    Creates a function that returns an empty string in case of an exception.
+
+    :param fnobj_fn: function that will be wrapped
+    :type obj_fn: object to basestring function
+    :returns: function that can be used as AttributeModel data_fn attribute
+    :rtype: objbrowser.treeitem.TreeItem to string function
+    """
+    def data_fn(tree_item):
+        """
+        Call the obj_fn(tree_item.obj).
+        Returns empty string in case of an error.
+        """
+        return safe_tio_call(obj_fn, tree_item, log_exceptions=log_exceptions)
+
+    return data_fn
+
+
+def tio_predicates(tree_item):
+    """Returns the inspect module predicates that are true for this object."""
+    tio = tree_item.obj
+    predicates = [pred.__name__ for pred in _ALL_PREDICATES if pred(tio)]
+    return ", ".join(predicates)
+
+
+def tio_summary(tree_item):
+    """
+    Returns a small summary of regular objects.
+    For callables and modules an empty string is returned.
+    """
+    tio = tree_item.obj
+    if isinstance(tio, TEXT_TYPES):
+        return tio
+    elif isinstance(tio, (list, tuple, set, frozenset, dict)):
+        n_items = len(tio)
+        if n_items == 0:
+            return _("empty {}").format(type(tio).__name__)
+        if n_items == 1:
+            return _("{} of {} item").format(type(tio).__name__, n_items)
+        else:
+            return _("{} of {} items").format(type(tio).__name__, n_items)
+    elif _NUMPY_INSTALLED and isinstance(tio, np.ndarray):
+        return _("array of {}, shape: {}").format(tio.dtype, tio.shape)
+    elif callable(tio) or inspect.ismodule(tio):
+        return ""
+    else:
+        return str(tio)
+
+
+def tio_is_attribute(tree_item):
+    """
+    Returns 'True' if the tree item object is an attribute of the parent
+    opposed to e.g. a list element.
+    """
+    if tree_item.is_attribute is None:
+        return ''
+    else:
+        return str(tree_item.is_attribute)
+
+
+def tio_is_callable(tree_item):
+    """Returns 'True' if the tree item object is callable."""
+    return str(callable(tree_item.obj))  # Python 2
+    # return str(hasattr(tree_item.obj, "__call__")) # Python 3?
+
+
+def tio_doc_str(tree_item):
+    """Returns the doc string of an object."""
+    tio = tree_item.obj
+    try:
+        return tio.__doc__
+    except AttributeError:
+        return _('<no doc string found>')
+
+
+# Attributes models
+class AttributeModel(object):
+    """
+    Determines how an object attribute is rendered
+    in a table column or details pane.
+    """
+    def __init__(self,
+                 name,
+                 doc=_("<no help available>"),
+                 data_fn=None,
+                 col_visible=True,
+                 width=SMALL_COL_WIDTH,
+                 alignment=ALIGN_LEFT,
+                 line_wrap=QTextOption.NoWrap):
+        """
+        Constructor
+
+        :param name: name used to describe the attribute
+        :type name: string
+        :param doc: short string documenting the attribute
+        :type doc: string
+        :param data_fn: function that calculates the value shown in the UI
+        :type  data_fn: function(TreeItem_ to string.
+        :param col_visible: if True, the attribute is col_visible by default
+                            in the table
+        :type col_visible: bool
+        :param width: default width in the attribute table
+        :type with: int
+        :param alignment: alignment of the value in the table
+        :type alignment: Qt.AlignmentFlag
+        :param line_wrap: Line wrap mode of the attribute in the details pane
+        :type line_wrap: QtGui.QPlainTextEdit
+        """
+
+        if not callable(data_fn):
+            raise ValueError("data_fn must be function(TreeItem)->string")
+
+        self.name = name
+        self.doc = doc
+        self.data_fn = data_fn
+        self.col_visible = col_visible
+        self.width = width
+        self.alignment = alignment
+        self.line_wrap = line_wrap
+
+    def __repr__(self):
+        """String representation."""
+        return _("<AttributeModel for {!r}>").format(self.name)
+
+    @property
+    def settings_name(self):
+        """The name where spaces are replaced by underscores."""
+        sname = self.name.replace(' ', '_')
+        return sname.translate(None,
+                               string.punctuation).translate(None,
+                                                             string.whitespace)
+
+
+#######################
+# Column definitions ##
+#######################
+ATTR_MODEL_VALUE = AttributeModel(
+    'Value',
+    doc=_("The value of the object."),
+    data_fn=lambda tree_item: value_to_display(tree_item.obj),
+    col_visible=True,
+    width=SMALL_COL_WIDTH)
+
+ATTR_MODEL_NAME = AttributeModel(
+    'Name',
+    doc=_("The name of the object."),
+    data_fn=lambda tree_item: tree_item.obj_name
+    if tree_item.obj_name else _('<root>'),
+    col_visible=True,
+    width=SMALL_COL_WIDTH)
+
+
+ATTR_MODEL_PATH = AttributeModel(
+    'Path',
+    doc=_("A path to the data: e.g. var[1]['a'].item"),
+    data_fn=lambda tree_item: tree_item.obj_path
+    if tree_item.obj_path else _('<root>'),
+    col_visible=True,
+    width=MEDIUM_COL_WIDTH)
+
+
+ATTR_MODEL_SUMMARY = AttributeModel(
+    'summary',
+    doc=_("A summary of the object for regular "
+          "objects (is empty for non-regular objects"
+          "such as callables or modules)."),
+    data_fn=tio_summary,
+    col_visible=True,
+    alignment=ALIGN_LEFT,
+    width=MEDIUM_COL_WIDTH)
+
+
+ATTR_MODEL_UNICODE = AttributeModel(
+    'unicode',
+    doc=_("The unicode representation "
+          "of the object. In Python 2 it uses unicode()"
+          "In Python 3 the str() function is used."),
+    data_fn=lambda tree_item: to_text_string(tree_item.obj),
+    col_visible=False,
+    width=MEDIUM_COL_WIDTH,
+    line_wrap=QTextOption.WrapAtWordBoundaryOrAnywhere)
+
+
+ATTR_MODEL_STR = AttributeModel(
+    'str',
+    doc=_("The string representation of the object using the str() function."
+          "In Python 3 there is no difference with the 'unicode' column."),
+    data_fn=lambda tree_item: str(tree_item.obj),
+    col_visible=False,
+    width=MEDIUM_COL_WIDTH,
+    line_wrap=QTextOption.WrapAtWordBoundaryOrAnywhere)
+
+
+ATTR_MODEL_REPR = AttributeModel(
+    'repr (*)',
+    doc=_("The string representation of the "
+          "object using the repr() function."),
+    data_fn=lambda tree_item: repr(tree_item.obj),
+    col_visible=True,
+    width=MEDIUM_COL_WIDTH,
+    line_wrap=QTextOption.WrapAtWordBoundaryOrAnywhere)
+
+
+ATTR_MODEL_TYPE = AttributeModel(
+    'type function',
+    doc=_("Type of the object determined using the builtin type() function"),
+    data_fn=lambda tree_item: str(type(tree_item.obj)),
+    col_visible=False,
+    width=MEDIUM_COL_WIDTH)
+
+
+ATTR_MODEL_CLASS = AttributeModel(
+    'Type',
+    doc="The name of the class of the object via obj.__class__.__name__",
+    data_fn=lambda tree_item: type(tree_item.obj).__name__,
+    col_visible=True,
+    width=MEDIUM_COL_WIDTH)
+
+
+ATTR_MODEL_LENGTH = AttributeModel(
+    'Size',
+    doc=_("The length of the object using the len() function"),
+    # data_fn     = tio_length,
+    data_fn=safe_data_fn(len),
+    col_visible=True,
+    alignment=ALIGN_RIGHT,
+    width=SMALL_COL_WIDTH)
+
+
+ATTR_MODEL_ID = AttributeModel(
+    'Id',
+    doc=_("The identifier of the object with "
+          "calculated using the id() function"),
+    data_fn=lambda tree_item: "0x{:X}".format(id(tree_item.obj)),
+    col_visible=False,
+    alignment=ALIGN_RIGHT,
+    width=SMALL_COL_WIDTH)
+
+
+ATTR_MODEL_IS_ATTRIBUTE = AttributeModel(
+    'Attribute',
+    doc=_("The object is an attribute of the parent "
+          "(opposed to e.g. a list element)."
+          "Attributes are displayed in italics in the table."),
+    data_fn=tio_is_attribute,
+    col_visible=False,
+    width=SMALL_COL_WIDTH)
+
+
+ATTR_MODEL_CALLABLE = AttributeModel(
+    'Callable',
+    doc=_("True if the object is callable."
+          "Determined with the `callable` built-in function."
+          "Callable objects are displayed in blue in the table."),
+    data_fn=tio_is_callable,
+    col_visible=True,
+    width=SMALL_COL_WIDTH)
+
+
+ATTR_MODEL_IS_ROUTINE = AttributeModel(
+    'Routine',
+    doc=_("True if the object is a user-defined or "
+          "built-in function or method."
+          "Determined with the inspect.isroutine() method."),
+    data_fn=lambda tree_item: str(inspect.isroutine(tree_item.obj)),
+    col_visible=False,
+    width=SMALL_COL_WIDTH)
+
+
+ATTR_MODEL_PRED = AttributeModel(
+    'inspect predicates',
+    doc=_("Predicates from the inspect module"),
+    data_fn=tio_predicates,
+    col_visible=False,
+    width=MEDIUM_COL_WIDTH)
+
+
+ATTR_MODEL_PRETTY_PRINT = AttributeModel(
+    'pretty print',
+    doc=_("Pretty printed representation of "
+          "the object using the pprint module."),
+    data_fn=lambda tree_item: _PRETTY_PRINTER.pformat(tree_item.obj),
+    col_visible=False,
+    width=MEDIUM_COL_WIDTH)
+
+
+ATTR_MODEL_DOC_STRING = AttributeModel(
+    'doc string',
+    doc=_("The object's doc string"),
+    data_fn=tio_doc_str,
+    col_visible=False,
+    width=MEDIUM_COL_WIDTH)
+
+
+ATTR_MODEL_GET_DOC = AttributeModel(
+    'Documentation',
+    doc=_("The object's doc string, leaned up by inspect.getdoc()"),
+    data_fn=safe_data_fn(inspect.getdoc),
+    col_visible=False,
+    width=MEDIUM_COL_WIDTH)
+
+
+ATTR_MODEL_GET_COMMENTS = AttributeModel(
+    'inspect.getcomments',
+    doc=_("Comments above the object's definition. "
+          "Retrieved using inspect.getcomments()"),
+    data_fn=lambda tree_item: inspect.getcomments(tree_item.obj),
+    col_visible=False,
+    width=MEDIUM_COL_WIDTH)
+
+
+ATTR_MODEL_GET_MODULE = AttributeModel(
+    'inspect.getmodule',
+    doc=_("The object's module. Retrieved using inspect.module"),
+    data_fn=safe_data_fn(inspect.getmodule),
+    col_visible=False,
+    width=MEDIUM_COL_WIDTH)
+
+
+ATTR_MODEL_GET_FILE = AttributeModel(
+    'File',
+    doc=_("The object's file. Retrieved using inspect.getfile"),
+    data_fn=safe_data_fn(inspect.getfile),
+    col_visible=False,
+    width=MEDIUM_COL_WIDTH)
+
+
+ATTR_MODEL_GET_SOURCE_FILE = AttributeModel(
+    'Source file',  # calls inspect.getfile()
+    doc=_("The object's file. Retrieved using inspect.getsourcefile"),
+    data_fn=safe_data_fn(inspect.getsourcefile),
+    col_visible=False,
+    width=MEDIUM_COL_WIDTH)
+
+
+ATTR_MODEL_GET_SOURCE_LINES = AttributeModel(
+    'inspect.getsourcelines',
+    doc=_("Uses inspect.getsourcelines() "
+          "to get a list of source lines for the object"),
+    data_fn=safe_data_fn(inspect.getsourcelines),
+    col_visible=False,
+    width=MEDIUM_COL_WIDTH)
+
+
+ATTR_MODEL_GET_SOURCE = AttributeModel(
+    'Source code',
+    doc=_("The source code of an object retrieved using inspect.getsource"),
+    data_fn=safe_data_fn(inspect.getsource),
+    col_visible=False,
+    width=MEDIUM_COL_WIDTH)
+
+
+ALL_ATTR_MODELS = (
+    ATTR_MODEL_NAME,
+    ATTR_MODEL_PATH,
+    ATTR_MODEL_SUMMARY,
+    ATTR_MODEL_UNICODE,
+    ATTR_MODEL_STR,
+    ATTR_MODEL_REPR,
+    ATTR_MODEL_TYPE,
+    ATTR_MODEL_CLASS,
+    ATTR_MODEL_LENGTH,
+    ATTR_MODEL_ID,
+    ATTR_MODEL_IS_ATTRIBUTE,
+    ATTR_MODEL_CALLABLE,
+    ATTR_MODEL_IS_ROUTINE,
+    ATTR_MODEL_PRED,
+    ATTR_MODEL_PRETTY_PRINT,
+    ATTR_MODEL_DOC_STRING,
+    ATTR_MODEL_GET_DOC,
+    ATTR_MODEL_GET_COMMENTS,
+    ATTR_MODEL_GET_MODULE,
+    ATTR_MODEL_GET_FILE,
+    ATTR_MODEL_GET_SOURCE_FILE,
+    ATTR_MODEL_GET_SOURCE_LINES,
+    ATTR_MODEL_GET_SOURCE)
+
+DEFAULT_ATTR_COLS = (
+    ATTR_MODEL_NAME,
+    ATTR_MODEL_CLASS,
+    ATTR_MODEL_LENGTH,
+    ATTR_MODEL_VALUE,
+    ATTR_MODEL_CALLABLE,
+    ATTR_MODEL_PATH,
+    ATTR_MODEL_ID,
+    ATTR_MODEL_IS_ATTRIBUTE,
+    ATTR_MODEL_IS_ROUTINE,
+    ATTR_MODEL_GET_FILE,
+    ATTR_MODEL_GET_SOURCE_FILE)
+
+DEFAULT_ATTR_DETAILS = (
+    # ATTR_MODEL_STR, # Too similar to unicode column
+    ATTR_MODEL_GET_DOC,
+    ATTR_MODEL_GET_SOURCE,
+    ATTR_MODEL_GET_FILE,
+    ATTR_MODEL_REPR,
+    # ATTR_MODEL_DOC_STRING, # not used, too similar to ATTR_MODEL_GET_DOC
+    # ATTR_MODEL_GET_MODULE, # not used, already in table
+    # ATTR_MODEL_GET_SOURCE_FILE,  # not used, already in table
+    # ATTR_MODEL_GET_SOURCE_LINES, # not used, ATTR_MODEL_GET_SOURCE is better
+)
+
+# Sanity check for duplicates
+assert len(ALL_ATTR_MODELS) == len(set(ALL_ATTR_MODELS))
+assert len(DEFAULT_ATTR_COLS) == len(set(DEFAULT_ATTR_COLS))
+assert len(DEFAULT_ATTR_DETAILS) == len(set(DEFAULT_ATTR_DETAILS))

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -1,0 +1,499 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2016 Pepijn Kenter.
+# Copyright (c) 2019- Spyder Project Contributors
+#
+# Components of objectbrowser originally distributed under
+# the MIT (Expat) license. Licensed under the terms of the MIT License;
+# see NOTICE.txt in the Spyder root directory for details
+# -----------------------------------------------------------------------------
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+# Standard library imports
+import logging
+import traceback
+
+# Third-party imports
+from qtpy.QtCore import Slot, Signal, QModelIndex, QPoint, QSize, Qt
+from qtpy.QtGui import QKeySequence, QTextOption
+from qtpy.QtWidgets import (QAbstractItemView, QAction, QButtonGroup,
+                            QDialog, QGroupBox, QHBoxLayout, QHeaderView,
+                            QLabel, QMenu, QRadioButton, QSplitter,
+                            QToolButton, QVBoxLayout, QWidget)
+
+# Local imports
+from spyder.config.base import _
+from spyder.config.gui import get_font, is_dark_interface
+from spyder.config.main import CONF
+from spyder.utils.qthelpers import (add_actions, create_plugin_layout,
+                                    create_toolbutton, qapplication)
+from spyder.plugins.editor.widgets.codeeditor import CodeEditor
+from spyder.plugins.variableexplorer.widgets.objectexplorer import (
+    DEFAULT_ATTR_COLS, DEFAULT_ATTR_DETAILS, ToggleColumnTreeView,
+    TreeModel, TreeProxyModel)
+from spyder.utils import icon_manager as ima
+
+
+logger = logging.getLogger(__name__)
+
+
+# About message
+EDITOR_NAME = 'Object'
+
+
+class ObjectExplorer(QDialog):
+    """Object explorer main widget window."""
+    # TODO: Use signal to trigger update of configs
+    sig_option_changed = Signal(str, object)
+
+    _browsers = []  # Keep lists of browser windows.
+
+    def __init__(self,
+                 obj,
+                 name='',
+                 expanded=False,
+                 resize_to_contents=True,
+                 parent=None,
+                 attribute_columns=DEFAULT_ATTR_COLS,
+                 attribute_details=DEFAULT_ATTR_DETAILS,
+                 show_callable_attributes=False,
+                 show_special_attributes=False,
+                 reset=False):
+        """
+        Constructor
+
+        :param name: name of the object as it will appear in the root node
+        :param expanded: show the first visible root element expanded
+        :param resize_to_contents: resize columns to contents ignoring width
+            of the attributes
+        :param obj: any Python object or variable
+        :param attribute_columns: list of AttributeColumn objects that
+            define which columns are present in the table and their defaults
+        :param attribute_details: list of AttributeDetails objects that define
+            which attributes can be selected in the details pane.
+        :param show_callable_attributes: if True rows where the 'is attribute'
+            and 'is callable' columns are both True, are displayed.
+            Otherwise they are hidden.
+        :param show_special_attributes: if True rows where the 'is attribute'
+            is True and the object name starts and ends with two underscores,
+            are displayed. Otherwise they are hidden.
+        :param reset: If true the persistent settings, such as column widths,
+            are reset.
+        """
+        QDialog.__init__(self, parent=parent)
+
+        self._instance_nr = self._add_instance()
+
+        # Model
+        self._attr_cols = attribute_columns
+        self._attr_details = attribute_details
+
+        self._tree_model = TreeModel(obj, obj_name=name,
+                                     attr_cols=self._attr_cols)
+
+        self._proxy_tree_model = TreeProxyModel(
+            show_callable_attributes=show_callable_attributes,
+            show_special_attributes=show_special_attributes)
+
+        self._proxy_tree_model.setSourceModel(self._tree_model)
+        # self._proxy_tree_model.setSortRole(RegistryTableModel.SORT_ROLE)
+        self._proxy_tree_model.setDynamicSortFilter(True)
+        # self._proxy_tree_model.setSortCaseSensitivity(Qt.CaseInsensitive)
+
+        # Views
+        self._setup_actions()
+        self._setup_menu(show_callable_attributes=show_callable_attributes,
+                         show_special_attributes=show_special_attributes)
+        self._setup_views()
+        if name:
+            name = "{} -".format(name)
+        self.setWindowTitle("{} {}".format(name, EDITOR_NAME))
+        self.setWindowFlags(Qt.Window)
+
+        self._resize_to_contents = resize_to_contents
+        self._readViewSettings(reset=reset)
+
+        # Update views with model
+        self.toggle_show_special_attribute_action.setChecked(
+            show_special_attributes)
+        self.toggle_show_callable_action.setChecked(show_callable_attributes)
+
+        # Select first row so that a hidden root node will not be selected.
+        first_row_index = self._proxy_tree_model.firstItemIndex()
+        self.obj_tree.setCurrentIndex(first_row_index)
+        if self._tree_model.inspectedNodeIsVisible or expanded:
+            self.obj_tree.expand(first_row_index)
+
+    def _add_instance(self):
+        """
+        Adds the browser window to the list of browser references.
+        If a None is present in the list it is inserted at that position,
+        otherwise it is appended to the list. The index number is returned.
+
+        This mechanism is used so that repeatedly creating and closing windows
+        does not increase the instance number, which is used in writing
+        the persistent settings.
+        """
+        try:
+            idx = self._browsers.index(None)
+        except ValueError:
+            self._browsers.append(self)
+            idx = len(self._browsers) - 1
+        else:
+            self._browsers[idx] = self
+
+        return idx
+
+    def _remove_instance(self):
+        """Sets the reference in the browser list to None."""
+        idx = self._browsers.index(self)
+        self._browsers[idx] = None
+
+    def _make_show_column_function(self, column_idx):
+        """Creates a function that shows or hides a column."""
+        show_column = lambda checked: self.obj_tree.setColumnHidden(
+            column_idx, not checked)
+        return show_column
+
+    def _setup_actions(self):
+        """Creates the main window actions."""
+        # Show/hide callable objects
+        self.toggle_show_callable_action = \
+            QAction(_("Show callable attributes"), self, checkable=True,
+                    shortcut=QKeySequence("Alt+C"),
+                    statusTip=_("Shows/hides attributes "
+                                "that are callable (functions, methods, etc)"))
+        self.toggle_show_callable_action.toggled.connect(
+            self._proxy_tree_model.setShowCallables)
+
+        # Show/hide special attributes
+        self.toggle_show_special_attribute_action = \
+            QAction(_("Show __special__ attributes"), self, checkable=True,
+                    shortcut=QKeySequence("Alt+S"),
+                    statusTip=_("Shows or hides __special__ attributes"))
+        self.toggle_show_special_attribute_action.toggled.connect(
+            self._proxy_tree_model.setShowSpecialAttributes)
+
+    def _setup_menu(self, show_callable_attributes=False,
+                    show_special_attributes=False):
+        """Sets up the main menu."""
+        self.tools_layout = QHBoxLayout()
+
+        callable_attributes = create_toolbutton(
+            self, text=_("Show callable attributes"),
+            icon=ima.icon("class"),
+            toggled=self._toggle_show_callable_attributes_action)
+        callable_attributes.setCheckable(True)
+        callable_attributes.setChecked(show_callable_attributes)
+        self.tools_layout.addWidget(callable_attributes)
+
+        special_attributes = create_toolbutton(
+            self, text=_("Show __special__ attributes"),
+            icon=ima.icon("private2"),
+            toggled=self._toggle_show_special_attributes_action)
+        special_attributes.setCheckable(True)
+        special_attributes.setChecked(show_special_attributes)
+        self.tools_layout.addWidget(special_attributes)
+
+        self.tools_layout.addStretch()
+
+        self.options_button = create_toolbutton(
+                self, text=_('Options'), icon=ima.icon('tooloptions'))
+        self.options_button.setPopupMode(QToolButton.InstantPopup)
+
+        self.show_cols_submenu = QMenu(self)
+        self.options_button.setMenu(self.show_cols_submenu)
+        # Don't show menu arrow and remove padding
+        if is_dark_interface():
+            self.options_button.setStyleSheet(
+                ("QToolButton::menu-indicator{image: none;}\n"
+                 "QToolButton{padding: 3px;}"))
+        else:
+            self.options_button.setStyleSheet(
+                "QToolButton::menu-indicator{image: none;}")
+        self.tools_layout.addWidget(self.options_button)
+
+    @Slot()
+    def _toggle_show_callable_attributes_action(self):
+        """Toggle show callable atributes action."""
+        action_checked = not self.toggle_show_callable_action.isChecked()
+        self.toggle_show_callable_action.setChecked(action_checked)
+        self.sig_option_changed.emit('show_callable_attributes',
+                                     action_checked)
+
+    @Slot()
+    def _toggle_show_special_attributes_action(self):
+        """Toggle show special attributes action."""
+        action_checked = (
+            not self.toggle_show_special_attribute_action.isChecked())
+        self.toggle_show_special_attribute_action.setChecked(action_checked)
+        self.sig_option_changed.emit('show_special_attributes', action_checked)
+
+    def _setup_views(self):
+        """Creates the UI widgets."""
+        self.central_splitter = QSplitter(self, orientation=Qt.Vertical)
+        layout = create_plugin_layout(self.tools_layout,
+                                      self.central_splitter)
+        self.setLayout(layout)
+
+        # Tree widget
+        self.obj_tree = ToggleColumnTreeView()
+        self.obj_tree.setAlternatingRowColors(True)
+        self.obj_tree.setModel(self._proxy_tree_model)
+        self.obj_tree.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.obj_tree.setUniformRowHeights(True)
+        self.obj_tree.setAnimated(True)
+        self.obj_tree.add_header_context_menu()
+
+        # Stretch last column?
+        # It doesn't play nice when columns are hidden and then shown again.
+        obj_tree_header = self.obj_tree.header()
+        obj_tree_header.setSectionsMovable(True)
+        obj_tree_header.setStretchLastSection(False)
+        add_actions(self.show_cols_submenu,
+                    self.obj_tree.toggle_column_actions_group.actions())
+
+        self.central_splitter.addWidget(self.obj_tree)
+
+        # Bottom pane
+        bottom_pane_widget = QWidget()
+        bottom_layout = QHBoxLayout()
+        bottom_layout.setSpacing(0)
+        bottom_layout.setContentsMargins(5, 5, 5, 5)  # left top right bottom
+        bottom_pane_widget.setLayout(bottom_layout)
+        self.central_splitter.addWidget(bottom_pane_widget)
+
+        group_box = QGroupBox(_("Details"))
+        bottom_layout.addWidget(group_box)
+
+        v_group_layout = QVBoxLayout()
+        h_group_layout = QHBoxLayout()
+        h_group_layout.setContentsMargins(2, 2, 2, 2)  # left top right bottom
+        group_box.setLayout(v_group_layout)
+        v_group_layout.addLayout(h_group_layout)
+
+        # Radio buttons
+        radio_widget = QWidget()
+        radio_layout = QVBoxLayout()
+        radio_layout.setContentsMargins(0, 0, 0, 0)  # left top right bottom
+        radio_widget.setLayout(radio_layout)
+
+        self.button_group = QButtonGroup(self)
+        for button_id, attr_detail in enumerate(self._attr_details):
+            radio_button = QRadioButton(attr_detail.name)
+            radio_layout.addWidget(radio_button)
+            self.button_group.addButton(radio_button, button_id)
+
+        self.button_group.buttonClicked[int].connect(
+            self._change_details_field)
+        self.button_group.button(0).setChecked(True)
+
+        radio_layout.addStretch(1)
+        h_group_layout.addWidget(radio_widget)
+
+        # Editor widget
+        self.editor = CodeEditor(self)
+        self.editor.setReadOnly(True)
+        h_group_layout.addWidget(self.editor)
+
+        # Warining label about repr
+        repr_label = QLabel(_("(*) Some objects have very large repr's, "
+                              "which can freeze Spyder. Please use this "
+                              "with care."))
+        v_group_layout.addWidget(repr_label)
+
+        # Splitter parameters
+        self.central_splitter.setCollapsible(0, False)
+        self.central_splitter.setCollapsible(1, True)
+        self.central_splitter.setSizes([500, 320])
+        self.central_splitter.setStretchFactor(0, 10)
+        self.central_splitter.setStretchFactor(1, 0)
+
+        # Connect signals
+        # Keep a temporary reference of the selection_model to prevent
+        # segfault in PySide.
+        # See http://permalink.gmane.org/gmane.comp.lib.qt.pyside.devel/222
+        selection_model = self.obj_tree.selectionModel()
+        selection_model.currentChanged.connect(self._update_details)
+
+    # End of setup_methods
+    def _readViewSettings(self, reset=False):
+        """
+        Reads the persistent program settings.
+
+        :param reset: If True, the program resets to its default settings.
+        """
+        pos = QPoint(20 * self._instance_nr, 20 * self._instance_nr)
+        window_size = QSize(825, 650)
+        details_button_idx = 0
+
+        header = self.obj_tree.header()
+        header_restored = False
+
+        if reset:
+            logger.debug("Resetting persistent view settings")
+        else:
+            pos = pos
+            window_size = window_size
+            details_button_idx = details_button_idx
+#            splitter_state = settings.value("central_splitter/state")
+            splitter_state = None
+            if splitter_state:
+                self.central_splitter.restoreState(splitter_state)
+#            header_restored = self.obj_tree.read_view_settings(
+#                'table/header_state',
+#                settings, reset)
+            header_restored = False
+
+        if not header_restored:
+            column_sizes = [col.width for col in self._attr_cols]
+            column_visible = [col.col_visible for col in self._attr_cols]
+
+            for idx, size in enumerate(column_sizes):
+                if not self._resize_to_contents and size > 0:  # Just in case
+                    header.resizeSection(idx, size)
+                else:
+                    header.setSectionResizeMode(QHeaderView.ResizeToContents)
+
+            for idx, visible in enumerate(column_visible):
+                elem = self.obj_tree.toggle_column_actions_group.actions()[idx]
+                elem.setChecked(visible)
+
+        self.resize(window_size)
+
+        button = self.button_group.button(details_button_idx)
+        if button is not None:
+            button.setChecked(True)
+
+    @Slot(QModelIndex, QModelIndex)
+    def _update_details(self, current_index, _previous_index):
+        """Shows the object details in the editor given an index."""
+        tree_item = self._proxy_tree_model.treeItem(current_index)
+        self._update_details_for_item(tree_item)
+
+    def _change_details_field(self, _button_id=None):
+        """Changes the field that is displayed in the details pane."""
+        # logger.debug("_change_details_field: {}".format(_button_id))
+        current_index = self.obj_tree.selectionModel().currentIndex()
+        tree_item = self._proxy_tree_model.treeItem(current_index)
+        self._update_details_for_item(tree_item)
+
+    def _update_details_for_item(self, tree_item):
+        """Shows the object details in the editor given an tree_item."""
+        try:
+            # obj = tree_item.obj
+            button_id = self.button_group.checkedId()
+            assert button_id >= 0, ("No radio button selected. "
+                                    "Please report this bug.")
+            attr_details = self._attr_details[button_id]
+            data = attr_details.data_fn(tree_item)
+            self.editor.setPlainText(data)
+            self.editor.setWordWrapMode(attr_details.line_wrap)
+            show_blanks = CONF.get('editor', 'blank_spaces')
+            update_scrollbar = CONF.get('editor', 'scroll_past_end')
+            scheme_name = CONF.get('appearance', 'selected')
+            self.editor.setup_editor(tab_mode=False,
+                                     font=get_font(),
+                                     show_blanks=show_blanks,
+                                     color_scheme=scheme_name,
+                                     scroll_past_end=update_scrollbar)
+            self.editor.set_text(data)
+            if attr_details.name == 'Source code':
+                self.editor.set_language('Python')
+            else:
+                self.editor.set_language('Rst')
+        except Exception as ex:
+            self.editor.setStyleSheet("color: red;")
+            stack_trace = traceback.format_exc()
+            self.editor.setPlainText("{}\n\n{}".format(ex, stack_trace))
+            self.editor.setWordWrapMode(
+                QTextOption.WrapAtWordBoundaryOrAnywhere)
+
+    def _finalize(self):
+        """
+        Cleans up resources when this window is closed.
+        Disconnects all signals for this window.
+        """
+        self.toggle_show_callable_action.toggled.disconnect(
+            self._proxy_tree_model.setShowCallables)
+        self.toggle_show_special_attribute_action.toggled.disconnect(
+            self._proxy_tree_model.setShowSpecialAttributes)
+        self.button_group.buttonClicked[int].disconnect(
+            self._change_details_field)
+        selection_model = self.obj_tree.selectionModel()
+        selection_model.currentChanged.disconnect(self._update_details)
+
+    def closeEvent(self, event):
+        """Called when the window is closed."""
+        logger.debug("closeEvent")
+        self._finalize()
+        self.close()
+        event.accept()
+        self._remove_instance()
+        self.about_to_quit()
+        logger.debug("Closed {} window {}".format(EDITOR_NAME,
+                                                  self._instance_nr))
+
+    def about_to_quit(self):
+        """Called when application is about to quit."""
+        # Sanity check
+        for idx, bw in enumerate(self._browsers):
+            if bw is not None:
+                raise AssertionError("Reference not"
+                                     " cleaned up: {}".format(idx))
+
+    @classmethod
+    def create_explorer(cls, *args, **kwargs):
+        """
+        Creates and shows and ObjectExplorer window.
+
+        The *args and **kwargs will be passed to the ObjectExplorer constructor
+
+        A (class attribute) reference to the browser window is kept to prevent
+        it from being garbage-collected.
+        """
+        object_explorer = cls(*args, **kwargs)
+        object_explorer.exec_()
+        return object_explorer
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+def test():
+    """Run object editor test"""
+    import datetime
+    import numpy as np
+    from spyder.pil_patch import Image
+
+    app = qapplication()
+
+    data = np.random.random_integers(255, size=(100, 100)).astype('uint8')
+    image = Image.fromarray(data)
+
+    class Foobar(object):
+        def __init__(self):
+            self.text = "toto"
+
+        def get_text(self):
+            return self.text
+    foobar = Foobar()
+    example = {'str': 'kjkj kj k j j kj k jkj',
+               'list': [1, 3, 4, 'kjkj', None],
+               'set': {1, 2, 1, 3, None, 'A', 'B', 'C', True, False},
+               'dict': {'d': 1, 'a': np.random.rand(10, 10), 'b': [1, 2]},
+               'float': 1.2233,
+               'array': np.random.rand(10, 10),
+               'image': image,
+               'date': datetime.date(1945, 5, 8),
+               'datetime': datetime.datetime(1945, 5, 8),
+               'foobar': foobar}
+    ObjectExplorer.create_explorer(example, 'Example',
+                                   show_callable_attributes=True,
+                                   show_special_attributes=True)
+
+
+if __name__ == "__main__":
+    test()

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/__init__.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019- Spyder Project Contributors
+#
+# Released under the terms of the MIT License
+# (see LICENSE.txt in the Spyder root directory for details)
+# -----------------------------------------------------------------------------
+
+"""Object Explorer Tests."""

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/test_objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/test_objectexplorer.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019- Spyder Project Contributors
+#
+# Released under the terms of the MIT License
+# (see LICENSE.txt in the Spyder root directory for details)
+# -----------------------------------------------------------------------------
+
+"""
+Tests for the array editor.
+"""
+
+# Standard library imports
+import datetime
+
+# Third party imports
+from qtpy.QtCore import Qt
+import numpy as np
+import pytest
+
+# Local imports
+from spyder.plugins.variableexplorer.widgets.objectexplorer import (
+        ObjectExplorer)
+from spyder.py3compat import PY2
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+@pytest.fixture
+def objectexplorer(qtbot):
+    """Set up ObjectExplorer."""
+    def create_objectexplorer(obj, **kwargs):
+        editor = ObjectExplorer(obj, **kwargs)
+        qtbot.addWidget(editor)
+        return editor
+    return create_objectexplorer
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+def test_objectexplorer(objectexplorer):
+    """Test to validate proper creation of the editor."""
+    class Foobar(object):
+        def __init__(self):
+            self.text = "toto"
+
+        def get_text(self):
+            return self.text
+    foobar = Foobar()
+    editor = objectexplorer(foobar,
+                            name='foobar',
+                            show_callable_attributes=False,
+                            show_special_attributes=False)
+    # Editor was created
+    assert editor
+
+    # Check header data and default hidden sections
+    header = editor.obj_tree.header()
+    header_model = header.model()
+    assert not header.isSectionHidden(0)
+    assert header_model.headerData(0, Qt.Horizontal,
+                                   Qt.DisplayRole) == "Name"
+    assert not header.isSectionHidden(1)
+    assert header_model.headerData(1, Qt.Horizontal,
+                                   Qt.DisplayRole) == "Type"
+    assert not header.isSectionHidden(2)
+    assert header_model.headerData(2, Qt.Horizontal,
+                                   Qt.DisplayRole) == "Size"
+    assert not header.isSectionHidden(3)
+    assert header_model.headerData(3, Qt.Horizontal,
+                                   Qt.DisplayRole) == "Value"
+    assert not header.isSectionHidden(4)
+    assert header_model.headerData(4, Qt.Horizontal,
+                                   Qt.DisplayRole) == "Callable"
+    assert not header.isSectionHidden(5)
+    assert header_model.headerData(5, Qt.Horizontal,
+                                   Qt.DisplayRole) == "Path"
+    assert header.isSectionHidden(6)
+    assert header_model.headerData(6, Qt.Horizontal,
+                                   Qt.DisplayRole) == "Id"
+    assert header.isSectionHidden(7)
+    assert header_model.headerData(7, Qt.Horizontal,
+                                   Qt.DisplayRole) == "Attribute"
+    assert header.isSectionHidden(8)
+    assert header_model.headerData(8, Qt.Horizontal,
+                                   Qt.DisplayRole) == "Routine"
+    assert header.isSectionHidden(9)
+    assert header_model.headerData(9, Qt.Horizontal,
+                                   Qt.DisplayRole) == "File"
+    assert header.isSectionHidden(10)
+    assert header_model.headerData(10, Qt.Horizontal,
+                                   Qt.DisplayRole) == "Source file"
+
+    model = editor.obj_tree.model()
+
+    # Check number of rows
+    assert model.rowCount() == 1
+    assert model.columnCount() == 11
+
+
+@pytest.mark.skipif(PY2, reason="Number of rows is different in PY2")
+def test_objectexplorer_types(objectexplorer):
+    """Test to validate proper handling of multiple data types."""
+    test = {'str': 'kjkj kj k j j kj k jkj',
+            'list': [1, 3, 4, 'kjkj', None],
+            'set': {1, 2, 1, 3, None, 'A', 'B', 'C', True, False},
+            'dict': {'d': 1, 'a': np.random.rand(10, 10), 'b': [1, 2]},
+            'float': 1.2233,
+            'array': np.random.rand(10, 10),
+            'date': datetime.date(1945, 5, 8),
+            'datetime': datetime.datetime(1945, 5, 8)}
+    editor = objectexplorer(test,
+                            expanded=True,
+                            show_callable_attributes=True,
+                            show_special_attributes=True)
+    # Editor was created
+    assert editor
+
+    # Check number of rows
+    model = editor.obj_tree.model()
+    assert model.rowCount() == 48
+    assert model.columnCount() == 11
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2016 Pepijn Kenter.
+# Copyright (c) 2019- Spyder Project Contributors
+#
+# Components of objectbrowser originally distributed under
+# the MIT (Expat) license. Licensed under the terms of the MIT License;
+# see NOTICE.txt in the Spyder root directory for details
+# -----------------------------------------------------------------------------
+
+# Standard library imports
+import logging
+
+# Third-party imports
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (QAction, QActionGroup, QTableWidget, QTreeView,
+                            QTreeWidget)
+
+# Local imports
+from spyder.config.base import _
+
+logger = logging.getLogger(__name__)
+
+
+# Toggle mixin
+class ToggleColumnMixIn(object):
+    """
+    Adds actions to a QTableView that can show/hide columns
+    by right clicking on the header
+    """
+    def add_header_context_menu(self, checked=None, checkable=None,
+                                enabled=None):
+        """
+        Adds the context menu from using header information
+
+        checked can be a header_name -> boolean dictionary. If given, headers
+        with the key name will get the checked value from the dictionary.
+        The corresponding column will be hidden if checked is False.
+
+        checkable can be a header_name -> boolean dictionary. If given, headers
+        with the key name will get the checkable value from the dictionary.
+
+        enabled can be a header_name -> boolean dictionary. If given, headers
+        with the key name will get the enabled value from the dictionary.
+        """
+        checked = checked if checked is not None else {}
+        checkable = checkable if checkable is not None else {}
+        enabled = enabled if enabled is not None else {}
+
+        horizontal_header = self._horizontal_header()
+        horizontal_header.setContextMenuPolicy(Qt.ActionsContextMenu)
+
+        self.toggle_column_actions_group = QActionGroup(self)
+        self.toggle_column_actions_group.setExclusive(False)
+        self.__toggle_functions = []  # for keeping references
+
+        for col in range(horizontal_header.count()):
+            column_label = self.model().headerData(col, Qt.Horizontal,
+                                                   Qt.DisplayRole)
+            logger.debug("Adding: col {}: {}".format(col, column_label))
+            action = QAction(str(column_label),
+                             self.toggle_column_actions_group,
+                             checkable=checkable.get(column_label, True),
+                             enabled=enabled.get(column_label, True),
+                             toolTip=_("Shows or hides "
+                                       "the {} column").format(column_label))
+            func = self.__make_show_column_function(col)
+            self.__toggle_functions.append(func)  # keep reference
+            horizontal_header.addAction(action)
+            is_checked = checked.get(
+                column_label,
+                not horizontal_header.isSectionHidden(col))
+            horizontal_header.setSectionHidden(col, not is_checked)
+            action.setChecked(is_checked)
+            action.toggled.connect(func)
+
+    def get_header_context_menu_actions(self):
+        """Returns the actions of the context menu of the header."""
+        return self._horizontal_header().actions()
+
+    def _horizontal_header(self):
+        """
+        Returns the horizontal header (of type QHeaderView).
+
+        Override this if the horizontalHeader() function does not exist.
+        """
+        return self.horizontalHeader()
+
+    def __make_show_column_function(self, column_idx):
+        """Creates a function that shows or hides a column."""
+        show_column = lambda checked: self.setColumnHidden(column_idx,
+                                                           not checked)
+        return show_column
+
+    def read_view_settings(self, key, settings=None, reset=False):
+        """
+        Reads the persistent program settings
+
+        :param reset: If True, the program resets to its default settings
+        :returns: True if the header state was restored, otherwise returns
+                  False
+        """
+        logger.debug("Reading view settings for: {}".format(key))
+        header_restored = False
+        # TODO: Implement settings management
+#        if not reset:
+#            if settings is None:
+#                settings = get_qsettings()
+#            horizontal_header = self._horizontal_header()
+#            header_data = settings.value(key)
+#            if header_data:
+#                header_restored = horizontal_header.restoreState(header_data)
+#
+#            # update actions
+#            for col, action in enumerate(horizontal_header.actions()):
+#                is_checked = not horizontal_header.isSectionHidden(col)
+#                action.setChecked(is_checked)
+
+        return header_restored
+
+    def write_view_settings(self, key, settings=None):
+        """Writes the view settings to the persistent store."""
+        logger.debug("Writing view settings for: {}".format(key))
+#       TODO: Settings management
+#        if settings is None:
+#            settings = get_qsettings()
+#        settings.setValue(key, self._horizontal_header().saveState())
+
+
+class ToggleColumnTableWidget(QTableWidget, ToggleColumnMixIn):
+    """
+    A QTableWidget where right clicking on the header allows the user
+    to show/hide columns.
+    """
+    pass
+
+
+class ToggleColumnTreeWidget(QTreeWidget, ToggleColumnMixIn):
+    """
+    A QTreeWidget where right clicking on the header allows the user to
+    show/hide columns.
+    """
+    def _horizontal_header(self):
+        """
+        Returns the horizontal header (of type QHeaderView).
+
+        Override this if the horizontalHeader() function does not exist.
+        """
+        return self.header()
+
+
+class ToggleColumnTreeView(QTreeView, ToggleColumnMixIn):
+    """
+    A QTreeView where right clicking on the header allows the user to
+    show/hide columns.
+    """
+    def _horizontal_header(self):
+        """
+        Returns the horizontal header (of type QHeaderView).
+
+        Override this if the horizontalHeader() function does not exist.
+        """
+        return self.header()

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/tree_item.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/tree_item.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2016 Pepijn Kenter.
+# Copyright (c) 2019- Spyder Project Contributors
+#
+# Based on: PySide examples/itemviews/simpletreemodel
+# See: http://harmattan-dev.nokia.com/docs/library/html/qt4/
+# itemviews-simpletreemodel.html
+#
+# Components of objectbrowser originally distributed under
+# the MIT (Expat) license. Licensed under the terms of the MIT License;
+# see NOTICE.txt in the Spyder root directory for details
+# -----------------------------------------------------------------------------
+
+# Standard library imports
+import logging
+
+# Local imports
+from spyder.config.base import _
+from spyder.plugins.variableexplorer.widgets.objectexplorer.utils import (
+    cut_off_str)
+
+logger = logging.getLogger(__name__)
+
+# Maximum number of characters used in the __str__ method to
+# represent the underlying object
+MAX_OBJ_STR_LEN = 50
+
+
+# Utility functions
+def name_is_special(method_name):
+    """Returns true if the method name starts and ends with two underscores."""
+    return method_name.startswith('__') and method_name.endswith('__')
+
+
+# TreeWidget Elements
+class TreeItem(object):
+    """Tree node class that can be used to build trees of objects."""
+    def __init__(self, obj, name, obj_path, is_attribute, parent=None):
+        self.parent_item = parent
+        self.obj = obj
+        self.obj_name = str(name)
+        self.obj_path = str(obj_path)
+        self.is_attribute = is_attribute
+        self.child_items = []
+        self.has_children = True
+        self.children_fetched = False
+
+    def __str__(self):
+        n_children = len(self.child_items)
+        if n_children == 0:
+            return _("<TreeItem(0x{:x}): {} = {}>").format(
+                id(self.obj),
+                self.obj_path,
+                cut_off_str(self.obj, MAX_OBJ_STR_LEN))
+        else:
+            return _("<TreeItem(0x{:x}): {} ({:d} children)>").format(
+                id(self.obj),
+                self.obj_path,
+                len(self.child_items))
+
+    def __repr__(self):
+        n_children = len(self.child_items)
+        return _("<TreeItem(0x{:x}): {} ({:d} children)>") \
+            .format(id(self.obj), self.obj_path, n_children)
+
+    @property
+    def is_special_attribute(self):
+        """
+        Return true if the items is an attribute and its
+        name begins and end with 2 underscores.
+        """
+        return self.is_attribute and name_is_special(self.obj_name)
+
+    @property
+    def is_callable_attribute(self):
+        """Return true if the items is an attribute and it is callable."""
+        return self.is_attribute and self.is_callable
+
+    @property
+    def is_callable(self):
+        """Return true if the underlying object is callable."""
+        return callable(self.obj)
+
+    def append_child(self, item):
+        item.parent_item = self
+        self.child_items.append(item)
+
+    def insert_children(self, idx, items):
+        self.child_items[idx:idx] = items
+        for item in items:
+            item.parent_item = self
+
+    def child(self, row):
+        return self.child_items[row]
+
+    def child_count(self):
+        return len(self.child_items)
+
+    def parent(self):
+        return self.parent_item
+
+    def row(self):
+        if self.parent_item:
+            return self.parent_item.child_items.index(self)
+        else:
+            return 0
+
+    def pretty_print(self, indent=0):
+        if 0:
+            logger.debug(indent * "    " + str(self))
+        else:
+            logger.debug(indent * "    " + str(self))
+        for child_item in self.child_items:
+            child_item.pretty_print(indent + 1)

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/tree_model.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/tree_model.py
@@ -1,0 +1,593 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2016 Pepijn Kenter.
+# Copyright (c) 2019- Spyder Project Contributors
+#
+# Based on: PySide examples/itemviews/simpletreemodel
+# See: http://harmattan-dev.nokia.com/docs/library/html/qt4/
+# itemviews-simpletreemodel.html
+#
+# Components of objectbrowser originally distributed under
+# the MIT (Expat) license. Licensed under the terms of the MIT License;
+# see NOTICE.txt in the Spyder root directory for details
+# -----------------------------------------------------------------------------
+
+# Standard library imports
+import logging
+import inspect
+from difflib import SequenceMatcher
+from collections import OrderedDict
+
+# Third-party imports
+from qtpy.QtCore import (QAbstractItemModel, QModelIndex, Qt,
+                         QSortFilterProxyModel)
+from qtpy.QtGui import QFont, QBrush, QColor
+
+# Local imports
+from spyder.config.base import _
+from spyder.plugins.variableexplorer.widgets.objectexplorer.utils import (
+    cut_off_str)
+from spyder.plugins.variableexplorer.widgets.objectexplorer.tree_item import (
+    TreeItem)
+from spyder.py3compat import to_unichr
+from spyder.utils import icon_manager as ima
+
+logger = logging.getLogger(__name__)
+
+
+# TODO: a lot of methods (e.g. rowCount) test if parent.column() > 0.
+# This should probably be replaced with an assert.
+
+# Keep the method names camelCase since it inherits from a Qt object.
+# Disabled need for docstrings. For a good explanation of the methods,
+# take a look at the Qt simple tree model example.
+# See: http://harmattan-dev.nokia.com/docs/
+# library/html/qt4/itemviews-simpletreemodel.html
+
+# The main window inherits from a Qt class, therefore it has many
+# ancestors public methods and attributes.
+class TreeModel(QAbstractItemModel):
+    """
+    Model that provides an interface to an objectree
+    that is build of TreeItems.
+    """
+    def __init__(self,
+                 obj,
+                 obj_name='',
+                 attr_cols=None,
+                 parent=None):
+        """
+        Constructor
+
+        :param obj: any Python object or variable
+        :param obj_name: name of the object as it will appear in the root node
+                         If empty, no root node will be drawn.
+        :param attr_cols: list of AttributeColumn definitions
+        :param parent: the parent widget
+        """
+        super(TreeModel, self).__init__(parent)
+        self._attr_cols = attr_cols
+
+        self.regular_font = QFont()  # Font for members (non-functions)
+        # Font for __special_attributes__
+        self.special_attribute_font = QFont()
+        self.special_attribute_font.setItalic(False)
+
+        self.regular_color = QBrush(QColor(ima.MAIN_FG_COLOR))
+        self.callable_color = QBrush(
+            QColor(ima.MAIN_FG_COLOR))  # for functions, methods, etc.
+
+        # The following members will be initialized by populateTree
+        # The rootItem is always invisible. If the obj_name
+        # is the empty string, the inspectedItem
+        # will be the rootItem (and therefore be invisible).
+        # If the obj_name is given, an
+        # invisible root item will be added and the
+        # inspectedItem will be its only child.
+        # In that case the inspected item will be visible.
+        self._inspected_node_is_visible = None
+        self._inspected_item = None
+        self._root_item = None
+        self.populateTree(obj, obj_name=obj_name)
+
+    @property
+    def inspectedNodeIsVisible(self):
+        """
+        Returns True if the inspected node is visible.
+        In that case an invisible root node has been added.
+        """
+        return self._inspected_node_is_visible
+
+    @property
+    def rootItem(self):
+        """ The root TreeItem.
+        """
+        return self._root_item
+
+    @property
+    def inspectedItem(self):  # TODO: needed?
+        """The TreeItem that contains the item under inspection."""
+        return self._inspected_item
+
+    def rootIndex(self):  # TODO: needed?
+        """
+        The index that returns the root element
+        (same as an invalid index).
+        """
+        return QModelIndex()
+
+    def inspectedIndex(self):
+        """The model index that point to the inspectedItem."""
+        if self.inspectedNodeIsVisible:
+            return self.createIndex(0, 0, self._inspected_item)
+        else:
+            return self.rootIndex()
+
+    def columnCount(self, _parent=None):
+        """ Returns the number of columns in the tree """
+        return len(self._attr_cols)
+
+    def data(self, index, role):
+        """Returns the tree item at the given index and role."""
+        if not index.isValid():
+            return None
+
+        col = index.column()
+        tree_item = index.internalPointer()
+        obj = tree_item.obj
+
+        if role == Qt.DisplayRole:
+            try:
+                attr = self._attr_cols[col].data_fn(tree_item)
+                # Replace carriage returns and line feeds with unicode glyphs
+                # so that all table rows fit on one line.
+                # return attr.replace('\n',
+                #                     unichr(0x240A)).replace('\r',
+                #                     unichr(0x240D))
+                return (attr.replace('\r\n', to_unichr(0x21B5))
+                            .replace('\n', to_unichr(0x21B5))
+                            .replace('\r', to_unichr(0x21B5)))
+            except Exception as ex:
+                # logger.exception(ex)
+                return "**ERROR**: {}".format(ex)
+
+        elif role == Qt.TextAlignmentRole:
+            return self._attr_cols[col].alignment
+
+        elif role == Qt.ForegroundRole:
+            if tree_item.is_callable:
+                return self.callable_color
+            else:
+                return self.regular_color
+
+        elif role == Qt.FontRole:
+            if tree_item.is_attribute:
+                return self.special_attribute_font
+            else:
+                return self.regular_font
+        else:
+            return None
+
+    def flags(self, index):
+        if not index.isValid():
+            return Qt.NoItemFlags
+
+        return Qt.ItemIsEnabled | Qt.ItemIsSelectable
+
+    def headerData(self, section, orientation, role):
+        if orientation == Qt.Horizontal and role == Qt.DisplayRole:
+            return self._attr_cols[section].name
+        else:
+            return None
+
+    def treeItem(self, index):
+        if not index.isValid():
+            return self.rootItem
+        else:
+            return index.internalPointer()
+
+    def index(self, row, column, parent=None):
+
+        if parent is None:
+            logger.debug("parent is None")
+            parent = QModelIndex()
+
+        parentItem = self.treeItem(parent)
+
+        if not self.hasIndex(row, column, parent):
+            logger.debug("hasIndex "
+                         "is False: ({}, {}) {!r}".format(row,
+                                                          column, parentItem))
+            # logger.warn("Parent index model"
+            #             ": {!r} != {!r}".format(parent.model(), self))
+
+            return QModelIndex()
+
+        childItem = parentItem.child(row)
+        # logger.debug("  {}".format(childItem.obj_path))
+        if childItem:
+            return self.createIndex(row, column, childItem)
+        else:
+            logger.warn("no childItem")
+            return QModelIndex()
+
+    def parent(self, index):
+        if not index.isValid():
+            return QModelIndex()
+
+        child_item = index.internalPointer()
+        parent_item = child_item.parent()
+
+        if parent_item is None or parent_item == self.rootItem:
+            return QModelIndex()
+
+        return self.createIndex(parent_item.row(), 0, parent_item)
+
+    def rowCount(self, parent=None):
+        parent = QModelIndex() if parent is None else parent
+
+        if parent.column() > 0:
+            # This is taken from the PyQt simpletreemodel example.
+            return 0
+        else:
+            return self.treeItem(parent).child_count()
+
+    def hasChildren(self, parent=None):
+        parent = QModelIndex() if parent is None else parent
+        if parent.column() > 0:
+            return 0
+        else:
+            return self.treeItem(parent).has_children
+
+    def canFetchMore(self, parent=None):
+        parent = QModelIndex() if parent is None else parent
+        if parent.column() > 0:
+            return 0
+        else:
+            result = not self.treeItem(parent).children_fetched
+            # logger.debug("canFetchMore: {} = {}".format(parent, result))
+            return result
+
+    def fetchMore(self, parent=None):
+        """
+        Fetches the children given the model index of a parent node.
+        Adds the children to the parent.
+        """
+        parent = QModelIndex() if parent is None else parent
+        if parent.column() > 0:
+            return
+
+        parent_item = self.treeItem(parent)
+        if parent_item.children_fetched:
+            return
+
+        tree_items = self._fetchObjectChildren(parent_item.obj,
+                                               parent_item.obj_path)
+
+        self.beginInsertRows(parent, 0, len(tree_items) - 1)
+        for tree_item in tree_items:
+            parent_item.append_child(tree_item)
+
+        parent_item.children_fetched = True
+        self.endInsertRows()
+
+    def _fetchObjectChildren(self, obj, obj_path):
+        """
+        Fetches the children of a Python object.
+        Returns: list of TreeItems
+        """
+        obj_children = []
+        path_strings = []
+
+        if isinstance(obj, (list, tuple)):
+            obj_children = sorted(enumerate(obj))
+            path_strings = ['{}[{}]'.format(obj_path,
+                            item[0]) if obj_path else item[0]
+                            for item in obj_children]
+        elif isinstance(obj, (set, frozenset)):
+            obj_children = [('pop()', elem) for elem in obj]
+            path_strings = ['{0}.pop()'.format(obj_path,
+                            item[0]) if obj_path else item[0]
+                            for item in obj_children]
+        elif hasattr(obj, 'items'):  # dictionaries and the likes.
+            try:
+                obj_children = list(obj.items())
+            except Exception as ex:
+                # Can happen if the items method expects an argument,
+                # for instance the types.DictType.items
+                # method expects a dictionary.
+                logger.warn("No items expanded. "
+                            "Objects items() call failed: {}".format(ex))
+                obj_children = []
+
+            # Sort keys, except when the object is an OrderedDict.
+            if not isinstance(obj, OrderedDict):
+                try:
+                    obj_children = sorted(obj.items())
+                except Exception as ex:
+                    logger.debug("Unable to sort "
+                                 "dictionary keys: {}".format(ex))
+
+            path_strings = ['{}[{!r}]'.format(obj_path,
+                            item[0]) if obj_path else item[0]
+                            for item in obj_children]
+
+        assert len(obj_children) == len(path_strings), "sanity check"
+        is_attr_list = [False] * len(obj_children)
+
+        # Object attributes
+        for attr_name, attr_value in sorted(inspect.getmembers(obj)):
+            obj_children.append((attr_name, attr_value))
+            path_strings.append('{}.{}'.format(obj_path,
+                                attr_name) if obj_path else attr_name)
+            is_attr_list.append(True)
+
+        assert len(obj_children) == len(path_strings), "sanity check"
+        tree_items = []
+        for item, path_str, is_attr in zip(obj_children, path_strings,
+                                           is_attr_list):
+            name, child_obj = item
+            tree_items.append(TreeItem(child_obj, name, path_str, is_attr))
+
+        return tree_items
+
+    def populateTree(self, obj, obj_name='', inspected_node_is_visible=None):
+        """Fills the tree using a python object. Sets the rootItem."""
+        logger.debug("populateTree with object id = 0x{:x}".format(id(obj)))
+        if inspected_node_is_visible is None:
+            inspected_node_is_visible = (obj_name != '')
+        self._inspected_node_is_visible = inspected_node_is_visible
+
+        if self._inspected_node_is_visible:
+            self._root_item = TreeItem(None, _('<invisible_root>'),
+                                       _('<invisible_root>'), None)
+            self._root_item.children_fetched = True
+            self._inspected_item = TreeItem(obj, obj_name,
+                                            obj_name, is_attribute=None)
+            self._root_item.append_child(self._inspected_item)
+        else:
+            # The root itself will be invisible
+            self._root_item = TreeItem(obj, obj_name,
+                                       obj_name, is_attribute=None)
+            self._inspected_item = self._root_item
+
+            # Fetch all items of the root so we can
+            # select the first row in the constructor.
+            root_index = self.index(0, 0)
+            self.fetchMore(root_index)
+
+    def _auxRefreshTree(self, tree_index):
+        """
+        Auxiliary function for refreshTree that recursively refreshes the
+        tree nodes.
+
+        If the underlying Python object has been changed, we don't want to
+        delete the old tree model and create a new one from scratch because
+        this loses all information about which nodes are fetched and expanded.
+        Instead the old tree model is updated. Using the difflib from the
+        standard library it is determined for a parent node which child nodes
+        should be added or removed. This is done based on the node names only,
+        not on the node contents (the underlying Python objects). Testing the
+        underlying nodes for equality is potentially slow. It is faster to
+        let the refreshNode function emit the dataChanged signal for all cells.
+        """
+        tree_item = self.treeItem(tree_index)
+        logger.debug("_auxRefreshTree({}): {}{}".format(
+            tree_index, tree_item.obj_path,
+            "*" if tree_item.children_fetched else ""))
+
+        if tree_item.children_fetched:
+
+            old_items = tree_item.child_items
+            new_items = self._fetchObjectChildren(tree_item.obj,
+                                                  tree_item.obj_path)
+
+            old_item_names = [(item.obj_name,
+                               item.is_attribute) for item in old_items]
+            new_item_names = [(item.obj_name,
+                               item.is_attribute) for item in new_items]
+            seqMatcher = SequenceMatcher(isjunk=None, a=old_item_names,
+                                         b=new_item_names,
+                                         autojunk=False)
+            opcodes = seqMatcher.get_opcodes()
+
+            logger.debug("(reversed) "
+                         "opcodes: {}".format(list(reversed(opcodes))))
+
+            for tag, i1, i2, j1, j2 in reversed(opcodes):
+
+                if 1 or tag != 'equal':
+                    logger.debug("  {:7s}, a[{}:{}] ({}), b[{}:{}] ({})"
+                                 .format(tag, i1, i2,
+                                         old_item_names[i1:i2], j1, j2,
+                                         new_item_names[j1:j2]))
+
+                if tag == 'equal':
+                    # Only when node names are equal is _auxRefreshTree
+                    # called recursively.
+                    assert i2-i1 == j2-j1, ("equal sanity "
+                                            "check failed "
+                                            "{} != {}".format(i2-i1, j2-j1))
+                    for old_row, new_row in zip(range(i1, i2), range(j1, j2)):
+                        old_items[old_row].obj = new_items[new_row].obj
+                        child_index = self.index(old_row, 0, parent=tree_index)
+                        self._auxRefreshTree(child_index)
+
+                elif tag == 'replace':
+                    # Explicitly remove the old item and insert the new.
+                    # The old item may have child nodes which indices must be
+                    # removed by Qt, otherwise it crashes.
+                    assert i2-i1 == j2-j1, ("replace sanity "
+                                            "check failed "
+                                            "{} != {}").format(i2-i1, j2-j1)
+
+                    # row number of first removed
+                    first = i1
+                    # row number of last element after insertion
+                    last = i1 + i2 - 1
+                    logger.debug("     calling "
+                                 "beginRemoveRows({}, {}, {})".format(
+                                    tree_index, first, last))
+                    self.beginRemoveRows(tree_index, first, last)
+                    del tree_item.child_items[i1:i2]
+                    self.endRemoveRows()
+
+                    # row number of first element after insertion
+                    first = i1
+                    # row number of last element after insertion
+                    last = i1 + j2 - j1 - 1
+                    logger.debug("     calling "
+                                 "beginInsertRows({}, {}, {})".format(
+                                    tree_index, first, last))
+                    self.beginInsertRows(tree_index, first, last)
+                    tree_item.insert_children(i1, new_items[j1:j2])
+                    self.endInsertRows()
+
+                elif tag == 'delete':
+                    assert j1 == j2, ("delete"
+                                      " sanity check "
+                                      "failed. {} != {}".format(j1, j2))
+                    # row number of first that will be removed
+                    first = i1
+                    # row number of last element after insertion
+                    last = i1 + i2 - 1
+                    logger.debug("     calling "
+                                 "beginRemoveRows"
+                                 "({}, {}, {})".format(tree_index,
+                                                       first, last))
+                    self.beginRemoveRows(tree_index, first, last)
+                    del tree_item.child_items[i1:i2]
+                    self.endRemoveRows()
+
+                elif tag == 'insert':
+                    assert i1 == i2, ("insert "
+                                      "sanity check "
+                                      "failed. {} != {}".format(i1, i2))
+                    # row number of first element after insertion
+                    first = i1
+                    # row number of last element after insertion
+                    last = i1 + j2 - j1 - 1
+                    logger.debug("     "
+                                 "calling beginInsertRows"
+                                 "({}, {}, {})".format(tree_index,
+                                                       first, last))
+                    self.beginInsertRows(tree_index, first, last)
+                    tree_item.insert_children(i1, new_items[j1:j2])
+                    self.endInsertRows()
+                else:
+                    raise ValueError("Invalid tag: {}".format(tag))
+
+    def refreshTree(self):
+        """
+        Refreshes the tree model from the underlying root object
+        (which may have been changed).
+        """
+        logger.info("")
+        logger.info("refreshTree: {}".format(self.rootItem))
+
+        root_item = self.treeItem(self.rootIndex())
+        logger.info("  root_item:      {} (idx={})".format(root_item,
+                                                           self.rootIndex()))
+        inspected_item = self.treeItem(self.inspectedIndex())
+        logger.info("  inspected_item: {} (idx={})".format(
+            inspected_item,
+            self.inspectedIndex()))
+
+        assert (root_item is inspected_item) != self.inspectedNodeIsVisible, \
+            "sanity check"
+
+        self._auxRefreshTree(self.inspectedIndex())
+
+        root_obj = self.rootItem.obj
+        logger.debug("After _auxRefreshTree, "
+                     "root_obj: {}".format(cut_off_str(root_obj, 80)))
+        self.rootItem.pretty_print()
+
+        # Emit the dataChanged signal for all cells.
+        # This is faster than checking which nodes
+        # have changed, which may be slow for some underlying Python objects.
+        n_rows = self.rowCount()
+        n_cols = self.columnCount()
+        top_left = self.index(0, 0)
+        bottom_right = self.index(n_rows-1, n_cols-1)
+
+        logger.debug("bottom_right: ({}, {})".format(bottom_right.row(),
+                                                     bottom_right.column()))
+        self.dataChanged.emit(top_left, bottom_right)
+
+
+class TreeProxyModel(QSortFilterProxyModel):
+    """Proxy model that overrides the sorting and can filter out items."""
+    def __init__(self,
+                 show_callable_attributes=True,
+                 show_special_attributes=True,
+                 parent=None):
+        """
+        Constructor
+
+        :param show_callable_attributes: if True the callables objects,
+            i.e. objects (such as function) that  a __call__ method,
+            will be displayed (in brown). If False they are hidden.
+        :param show_special_attributes: if True the objects special attributes,
+            i.e. methods with a name that starts and ends with two underscores,
+            will be displayed (in italics). If False they are hidden.
+        :param parent: the parent widget
+        """
+        super(TreeProxyModel, self).__init__(parent)
+
+        self._show_callables = show_callable_attributes
+        self._show_special_attributes = show_special_attributes
+
+    def treeItem(self, proxy_index):
+        index = self.mapToSource(proxy_index)
+        return self.sourceModel().treeItem(index)
+
+    def firstItemIndex(self):
+        """Returns the first child of the root item."""
+        # We cannot just call the same function of the source model
+        # because the first node there may be hidden.
+        source_root_index = self.sourceModel().rootIndex()
+        proxy_root_index = self.mapFromSource(source_root_index)
+        first_item_index = self.index(0, 0, proxy_root_index)
+        return first_item_index
+
+    def filterAcceptsRow(self, sourceRow, sourceParentIndex):
+        """
+        Returns true if the item in the row indicated by the given source_row
+        and source_parent should be included in the model.
+        """
+        parent_item = self.sourceModel().treeItem(sourceParentIndex)
+        tree_item = parent_item.child(sourceRow)
+
+        accept = ((self._show_special_attributes or
+                   not tree_item.is_special_attribute) and
+                  (self._show_callables or
+                   not tree_item.is_callable_attribute))
+
+        # logger.debug("filterAcceptsRow = {}: {}".format(accept, tree_item))
+        return accept
+
+    def getShowCallables(self):
+        return self._show_callables
+
+    def setShowCallables(self, show_callables):
+        """
+        Shows/hides show_callables, which have a __call__ attribute.
+        Repopulates the tree.
+        """
+        logger.debug("setShowCallables: {}".format(show_callables))
+        self._show_callables = show_callables
+        self.invalidateFilter()
+
+    def getShowSpecialAttributes(self):
+        return self._show_special_attributes
+
+    def setShowSpecialAttributes(self, show_special_attributes):
+        """
+        Shows/hides special attributes, which begin with an underscore.
+        Repopulates the tree.
+        """
+        logger.debug("setShowSpecialAttributes:"
+                     " {}".format(show_special_attributes))
+        self._show_special_attributes = show_special_attributes
+        self.invalidateFilter()

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/utils.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/utils.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2016 Pepijn Kenter.
+# Copyright (c) 2019- Spyder Project Contributors
+#
+# Components of objectbrowser originally distributed under
+# the MIT (Expat) license.
+# Licensed under the terms of the MIT License; see NOTICE.txt in the Spyder
+# root directory for details
+# -----------------------------------------------------------------------------
+
+# Standard library imports
+import logging
+
+
+def cut_off_str(obj, max_len):
+    """
+    Creates a string representation of an object, no longer than
+    max_len characters
+
+    Uses repr(obj) to create the string representation.
+    If this is longer than max_len -3 characters, the last three will
+    be replaced with elipsis.
+    """
+    s = repr(obj)
+    if len(s) > max_len - 3:
+        s = s[:max_len - 3] + '...'
+    return s

--- a/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
@@ -362,22 +362,27 @@ def test_editor_parent_set(monkeypatch):
                               'collectionseditor.TextEditor')
     monkeypatch.setattr(attr_to_patch_textedit, MockTextEditor)
 
+    MockObjectExplorer = Mock()
+    attr_to_patch_objectexplorer = ('spyder.plugins.variableexplorer.widgets.'
+                                    + 'collectionseditor.ObjectExplorer')
+    monkeypatch.setattr(attr_to_patch_objectexplorer, MockObjectExplorer)
+
     editor_data = [[0, 1, 2, 3, 4],
                    numpy.array([1.0, 42.0, 1337.0]),
                    pandas.DataFrame([[1, 2, 3], [20, 30, 40]]),
-                   "012345678901234567890123456789012345678901234567890123456",
-                   os]
+                   os,
+                   "012345678901234567890123456789012345678901234567890123456"]
     col_editor = CollectionsEditorTableView(test_parent, editor_data)
     assert col_editor.parent() is test_parent
 
     for idx, mock_class in enumerate([MockCollectionsEditor,
                                       MockArrayEditor,
                                       MockDataFrameEditor,
-                                      MockTextEditor,
-                                      MockCollectionsEditor]):
+                                      MockObjectExplorer,
+                                      MockTextEditor]):
         col_editor.delegate.createEditor(col_editor.parent(), None,
                                          col_editor.model.createIndex(idx, 3))
-        assert mock_class.call_count == 1 + (idx // 3)
+        assert mock_class.call_count == 1 + (idx // 4)
         assert mock_class.call_args[1]["parent"] is test_parent
 
 

--- a/spyder/py3compat.py
+++ b/spyder/py3compat.py
@@ -84,6 +84,15 @@ else:
 #==============================================================================
 # Strings
 #==============================================================================
+def to_unichr(character_code):
+    """
+    Return the Unicode string of the character with the given Unicode code.
+    """
+    if PY2:
+        return unichr(character_code)
+    else:
+        return chr(character_code)
+
 def is_type_text_string(obj):
     """Return True if `obj` is type text string, False if it is anything else,
     like an instance of a class that extends the basestring class."""

--- a/spyder/widgets/calltip.py
+++ b/spyder/widgets/calltip.py
@@ -319,8 +319,12 @@ class CallTipWidget(QLabel):
         """ Reimplemented to disconnect signal handlers and event filter.
         """
         super(CallTipWidget, self).hideEvent(event)
-        self._text_edit.cursorPositionChanged.disconnect(
-            self._cursor_position_changed)
+        # This is needed for issue spyder-ide/spyder#9221
+        try:
+            self._text_edit.cursorPositionChanged.disconnect(
+                self._cursor_position_changed)
+        except TypeError:
+            pass
         self._text_edit.removeEventFilter(self)
 
     def leaveEvent(self, event):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* Changed the arbitrarily defined lists of test files to be absolute paths rather than relative

These tests use a mocker function to return files open in the editor without actually having to create and open any files. The problem is that the mocker function was returning a list of relative paths, while the actual function (main.editor.get_open_filenames) returns a list of absolute paths.

This change means the mocker function in the test is correctly replicating the actual function now, while still achieving the goal of not having to create and open files during the test.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Shannon Keough

<!--- Thanks for your help making Spyder better for everyone! --->
