### PR TITLE
PR: Disable autosave if not running in single instance mode

### DIFF
--- a/spyder/plugins/editor/tests/conftest.py
+++ b/spyder/plugins/editor/tests/conftest.py
@@ -48,6 +48,8 @@ def editor_plugin(qtbot, monkeypatch):
                 projects = Mock()
                 projects.get_active_project.return_value = None
                 return projects
+            elif attr == 'new_instance':
+                return False  # otherwise autosave is disabled
             else:
                 return Mock()
 

--- a/spyder/plugins/editor/tests/conftest.py
+++ b/spyder/plugins/editor/tests/conftest.py
@@ -120,3 +120,19 @@ def editor_plugin_open_files(request, editor_plugin, python_files):
         return editor, expected_filenames, expected_current_filename
 
     return _get_editor_open_files
+
+
+@pytest.fixture
+def conf(request):
+    """
+    Fixture yielding the Spyder config and resetting it after the test.
+
+    You can use conf.set() to change the Spyder config in your test function.
+    If you want to change the config at setup time, then use
+    @pytest.mark.parametrize('conf', [(section, label, value)], indirect=True)
+    in front of your test function
+    """
+    if hasattr(request, 'param'):
+        CONF.set(*request.param)
+    yield CONF
+    CONF.reset_to_defaults()

--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -106,8 +106,17 @@ class AutosaveForPlugin(object):
         """Stop the autosave timer."""
         self.timer.stop()
 
+    def single_instance(self):
+        """Return whether Spyder is running in single instance mode."""
+        single_instance = CONF.get('main', 'single_instance')
+        new_instance = self.editor.main.new_instance
+        return single_instance and not new_instance
+
     def do_autosave(self):
         """Instruct current editorstack to autosave files where necessary."""
+        if not self.single_instance():
+            logger.debug('Autosave disabled because not single instance')
+            return
         logger.debug('Autosave triggered')
         stack = self.editor.get_current_editorstack()
         stack.autosave.autosave_all()
@@ -115,6 +124,9 @@ class AutosaveForPlugin(object):
 
     def try_recover_from_autosave(self):
         """Offer to recover files from autosave."""
+        if not self.single_instance():
+            self.recover_files_to_open = []
+            return
         autosave_dir = get_conf_path('autosave')
         autosave_mapping = CONF.get('editor', 'autosave_mapping', {})
         dialog = RecoveryDialog(autosave_dir, autosave_mapping,


### PR DESCRIPTION
This is a temporary stop gap to work around bugs in the autosave system like #9420 when multiple Spyder instances are running simultaneously. Once a more permanent fix is developed, this can be reverted.

<s>I did not include a test, because the code is already run by existing tests and it seems a bit too much effort to write a test for what is meant to be a temporary change, </s>

### Issue(s) Resolved

This does not truly resolve the issue, so no "Fixes #..."

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
