### PR TITLE
PR: Fix test_set_get_project_filenames* functions so the test matches actual spyder behaviour

### DIFF
--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -188,8 +188,9 @@ def test_set_get_project_filenames_when_closing(create_projects, tmpdir):
 
     Regression test for Issue #8375
     """
-    opened_files = ['file1', 'file2', 'file3']
     path = to_text_string(tmpdir.mkdir('project1'))
+    opened_files = [os.path.join(path, file)
+                    for file in ['file1', 'file2', 'file3']]
 
     # Create the projects plugin.
     projects = create_projects(path, opened_files)
@@ -206,9 +207,10 @@ def test_set_get_project_filenames_when_switching(create_projects, tmpdir):
     Test that files in the Editor are loaded and saved correctly when
     switching projects.
     """
-    opened_files = ['file1', 'file2', 'file3']
     path1 = to_text_string(tmpdir.mkdir('project1'))
     path2 = to_text_string(tmpdir.mkdir('project2'))
+    opened_files = [os.path.join(path1, file)
+                    for file in ['file1', 'file2', 'file3']]
 
     # Create the projects plugin.
     projects = create_projects(path1, opened_files)


### PR DESCRIPTION

## Description of Changes

* Changed the arbitrarily defined lists of test files to be absolute paths rather than relative

These tests use a mocker function to return files open in the editor without actually having to create and open any files. The problem is that the mocker function was returning a list of relative paths, while the actual function (main.editor.get_open_filenames) returns a list of absolute paths.

This change means the mocker function in the test is correctly replicating the actual function now, while still achieving the goal of not having to create and open files during the test.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Shannon Keough

<!--- Thanks for your help making Spyder better for everyone! --->