### PR TITLE
PR: Save project recent files as relative paths in workspace.ini

### DIFF
--- a/spyder/plugins/projects/api.py
+++ b/spyder/plugins/projects/api.py
@@ -87,8 +87,8 @@ class BaseProject(object):
             return []
 
         recent_files = [recent_file if os.path.isabs(recent_file)
-	                        else os.path.join(self.root_path, recent_file)
-	                        for recent_file in recent_files]
+                        else os.path.join(self.root_path, recent_file)
+                        for recent_file in recent_files]
         for recent_file in recent_files[:]:
             if not os.path.isfile(recent_file):
                 recent_files.remove(recent_file)

--- a/spyder/plugins/projects/api.py
+++ b/spyder/plugins/projects/api.py
@@ -86,6 +86,9 @@ class BaseProject(object):
         except EnvironmentError:
             return []
 
+        recent_files = [recent_file if os.path.isabs(recent_file)
+	                        else os.path.join(self.root_path, recent_file)
+	                        for recent_file in recent_files]
         for recent_file in recent_files[:]:
             if not os.path.isfile(recent_file):
                 recent_files.remove(recent_file)

--- a/spyder/plugins/projects/api.py
+++ b/spyder/plugins/projects/api.py
@@ -70,6 +70,8 @@ class BaseProject(object):
         for recent_file in recent_files[:]:
             if not os.path.isfile(recent_file):
                 recent_files.remove(recent_file)
+        recent_files = [os.path.relpath(recent_file, self.root_path)
+                        for recent_file in recent_files]
         try:
             self.CONF[WORKSPACE].set('main', 'recent_files',
                                      list(OrderedDict.fromkeys(recent_files)))

--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -199,8 +199,8 @@ def test_set_get_project_filenames_when_closing(create_projects, tmpdir):
     # Close and reopen the project.
     projects.close_project()
     projects.open_project(path=path)
-    assert projects.get_project_filenames() == [os.path.relpath(file, path)
-                                                for file in opened_files]
+    assert projects.get_project_filenames() == opened_files
+
 
 
 def test_set_get_project_filenames_when_switching(create_projects, tmpdir):
@@ -224,8 +224,8 @@ def test_set_get_project_filenames_when_switching(create_projects, tmpdir):
     # Switch back to the first project.
     projects.close_project()
     projects.open_project(path=path1)
-    assert projects.get_project_filenames() == [os.path.relpath(file, path1)
-                                                for file in opened_files]
+    assert projects.get_project_filenames() == opened_files
+
 
 
 def test_recent_projects_menu_action(projects, tmpdir):

--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -198,7 +198,8 @@ def test_set_get_project_filenames_when_closing(create_projects, tmpdir):
     # Close and reopen the project.
     projects.close_project()
     projects.open_project(path=path)
-    assert projects.get_project_filenames() == [os.path.relpath(file, path) for file in opened_files]
+    assert projects.get_project_filenames() == [os.path.relpath(file, path)
+                                                for file in opened_files]
 
 
 def test_set_get_project_filenames_when_switching(create_projects, tmpdir):
@@ -221,7 +222,8 @@ def test_set_get_project_filenames_when_switching(create_projects, tmpdir):
     # Switch back to the first project.
     projects.close_project()
     projects.open_project(path=path1)
-    assert projects.get_project_filenames() == [os.path.relpath(file, path1) for file in opened_files]
+    assert projects.get_project_filenames() == [os.path.relpath(file, path1)
+                                                for file in opened_files]
 
 
 def test_recent_projects_menu_action(projects, tmpdir):

--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -202,7 +202,6 @@ def test_set_get_project_filenames_when_closing(create_projects, tmpdir):
     assert projects.get_project_filenames() == opened_files
 
 
-
 def test_set_get_project_filenames_when_switching(create_projects, tmpdir):
     """
     Test that files in the Editor are loaded and saved correctly when
@@ -225,7 +224,6 @@ def test_set_get_project_filenames_when_switching(create_projects, tmpdir):
     projects.close_project()
     projects.open_project(path=path1)
     assert projects.get_project_filenames() == opened_files
-
 
 
 def test_recent_projects_menu_action(projects, tmpdir):

--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -198,7 +198,7 @@ def test_set_get_project_filenames_when_closing(create_projects, tmpdir):
     # Close and reopen the project.
     projects.close_project()
     projects.open_project(path=path)
-    assert projects.get_project_filenames() == opened_files
+    assert projects.get_project_filenames() == [os.path.relpath(file, path) for file in opened_files]
 
 
 def test_set_get_project_filenames_when_switching(create_projects, tmpdir):
@@ -221,7 +221,7 @@ def test_set_get_project_filenames_when_switching(create_projects, tmpdir):
     # Switch back to the first project.
     projects.close_project()
     projects.open_project(path=path1)
-    assert projects.get_project_filenames() == opened_files
+    assert projects.get_project_filenames() == [os.path.relpath(file, path1) for file in opened_files]
 
 
 def test_recent_projects_menu_action(projects, tmpdir):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* When closing a project, recent_files are written to workspace.ini relative to project root_path
* Relevant tests changed to expect the recent files fetched from workspace.ini to be relative paths from project root


This allows better portability of projects. Project directories can be moved, or stored in different locations on different systems, and opening the project will still successfully open all the recent files into tabs.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #5491


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Shannon Keough

<!--- Thanks for your help making Spyder better for everyone! --->