### PR TITLE
PR: Restored selection after replaced in selection

### DIFF
--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -419,8 +419,10 @@ def test_selection_escape_characters(editor_find_replace_bot, qtbot):
     cursor.select(QTextCursor.LineUnderCursor)
     assert cursor.selection().toPlainText() == "\\n \\t escape characters"
 
-    #replace
+    # Replace
     finder.replace_find_selection()
+    # Test that selection is correct
+    assert cursor.selection().toPlainText() == "\\n \\t some escape characters"
     assert editor.toPlainText() == expected_new_text
 
 

--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -571,12 +571,20 @@ class FindReplace(QWidget):
             replacement = re_pattern.sub(replace_text, selected_text)
             if replacement != selected_text:
                 cursor = self.editor.textCursor()
+                start_pos = cursor.selectionStart()
                 cursor.beginEditBlock()
                 cursor.removeSelectedText()
                 if not self.re_button.isChecked():
                     replacement = re.sub(r'\\(?![nrtf])(.)', r'\1', replacement)
                 cursor.insertText(replacement)
+                # Restore selection
+                self.editor.set_cursor_position(start_pos)
+                newl_cnt = replacement.count(self.editor.get_line_separator())
+                sel_len = len(replacement) - newl_cnt
+                for c in range(sel_len):
+                    self.editor.extend_selection_to_next('character', 'right')
                 cursor.endEditBlock()
+
             if focus_replace_text:
                 self.replace_text.setFocus()
             else:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
After performing "Replace selection", the selection used to go away. With this PR it is restored after replacement.

![afterreplaceselection](https://user-images.githubusercontent.com/8114497/60178591-32c83a80-981c-11e9-9632-dff5dbc908d0.gif)

As far as I can tell there are not tests for the findreplace widget, so it is not straightforward to add a test for it.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9685


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Oscar Gustafsson/oscargus

<!--- Thanks for your help making Spyder better for everyone! --->
