### PR TITLE
PR: Fix replace in selection with backslashes

### DIFF
--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -424,6 +424,30 @@ def test_selection_escape_characters(editor_find_replace_bot, qtbot):
     assert editor.toPlainText() == expected_new_text
 
 
+def test_selection_backslash(editor_find_replace_bot, qtbot):
+    editor_stack, editor, finder = editor_find_replace_bot
+    expected_new_text = ('spam bacon\n'
+                         'spam sausage\n'
+                         'spam egg\n'
+                         r'a = r"\left\{" + "\\}\\right\n"')
+    text_to_add = 'a = r"\\leeft\\{" + "\\\\}\\\\right\\n"'
+    qtbot.keyClicks(editor, text_to_add)
+
+    finder.show()
+    finder.show_replace()
+    qtbot.keyClicks(finder.search_text, 'leeft')
+    qtbot.keyClicks(finder.replace_text, 'left')
+
+    # Select last line
+    cursor = editor.textCursor()
+    cursor.select(QTextCursor.LineUnderCursor)
+    assert cursor.selection().toPlainText() == text_to_add
+
+    # Replace
+    finder.replace_find_selection()
+    assert editor.toPlainText() == expected_new_text
+
+
 def test_advance_cell(editor_cells_bot):
     editor_stack, editor = editor_cells_bot
 

--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -553,7 +553,7 @@ class FindReplace(QWidget):
                 pattern = search_text
             else:
                 pattern = re.escape(search_text)
-                replace_text = re.escape(replace_text)
+                replace_text = replace_text.replace('\\', r'\\')
             if words:  # match whole words only
                 pattern = r'\b{pattern}\b'.format(pattern=pattern)
 
@@ -573,8 +573,6 @@ class FindReplace(QWidget):
                 cursor = self.editor.textCursor()
                 cursor.beginEditBlock()
                 cursor.removeSelectedText()
-                if not self.re_button.isChecked():
-                    replacement = re.sub(r'\\(?![nrtf])(.)', r'\1', replacement)
                 cursor.insertText(replacement)
                 cursor.endEditBlock()
             if focus_replace_text:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Earlier backslashes were mishandled in "Replace selection", see #6416 and comments. Basically, most backslashes were removed except before certain characters.

* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->


<!--- Explain what you've done and why --->
This line 
"This functions must not be used for the replacement string in sub() and subn(), only backslashes should be escaped."
from https://docs.python.org/3/library/re.html#re.escape gave the solution. Earlier, the replace text had been escaped using `re.escape`, now it is only a simple replace as `replace_text.replace('\\', r'\\')`

A test has been added to show that it can handle any type of combination of backslashes in the code, not only the control character combinations \n etc as the previous fix was for.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #6416


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Oscar Gustafsson/oscargus

<!--- Thanks for your help making Spyder better for everyone! --->
