### PR TITLE
Right justify keyboard shortcuts in menus

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -105,7 +105,7 @@ if hasattr(Qt, 'AA_EnableHighDpiScaling'):
 # Create our QApplication instance here because it's needed to render the
 # splash screen created below
 #==============================================================================
-from spyder.utils.qthelpers import qapplication, MENU_SEPARATOR
+from spyder.utils.qthelpers import qapplication, MENU_SEPARATOR, MenuProxyStyle
 from spyder.config.base import get_image_path
 MAIN_APP = qapplication()
 
@@ -1267,11 +1267,19 @@ class MainWindow(QMainWindow):
         # Menu about to show
         for child in self.menuBar().children():
             if isinstance(child, QMenu):
+                # Next 2 lines used to right justify keyboard shortcuts.
+                self._proxy = MenuProxyStyle(child.style())
+                child.setStyle(self._proxy)
                 try:
                     child.aboutToShow.connect(self.update_edit_menu)
                     child.aboutToShow.connect(self.update_search_menu)
                 except TypeError:
                     pass
+
+        # Right justify shortcuts.
+        for menu_keyb_shortcut in [self.plugins_menu, self.quick_layout_menu]:
+            self._proxy = MenuProxyStyle(menu_keyb_shortcut.style())
+            menu_keyb_shortcut.setStyle(self._proxy)
 
         logger.info("*** End of MainWindow setup ***")
         self.is_starting_up = False
@@ -2261,6 +2269,9 @@ class MainWindow(QMainWindow):
 
     def createPopupMenu(self):
         menu = QMenu('', self)
+        # Next 2 lines used to right justify keyboard shortcuts.
+        self._proxy = MenuProxyStyle(menu.style())
+        menu.setStyle(self._proxy)
         actions = self.help_menu_actions[:3] + \
                     [None, self.help_menu_actions[-1]]
         add_actions(menu, actions)

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1267,24 +1267,23 @@ class MainWindow(QMainWindow):
         # Menu about to show
         for child in self.menuBar().children():
             if isinstance(child, QMenu):
-                # Right justify keyboard shortcuts in this/these menus.
-                # Apply only for none dark themes. Otherwise tests fail.
-                if not is_dark_interface():
-                    self._proxy = MenuProxyStyle(child.style())
-                    child.setStyle(self._proxy)
                 try:
                     child.aboutToShow.connect(self.update_edit_menu)
                     child.aboutToShow.connect(self.update_search_menu)
                 except TypeError:
                     pass
 
-        # Right justify keyboard shortcuts in this/these menus.
-        # Apply only for none dark themes. Otherwise tests fail.
+        # Right justify keyboard shortcuts.
+        # Apply only for none dark themes, otherwise tests fail.
         if not is_dark_interface():
-            for menu_keyb_shortcut in [self.plugins_menu,
-                                       self.quick_layout_menu]:
-                self._proxy = MenuProxyStyle(menu_keyb_shortcut.style())
-                menu_keyb_shortcut.setStyle(self._proxy)
+            sub_menus = [self.plugins_menu, self.quick_layout_menu,
+                         self.explorer.fileexplorer.treewidget.menu,
+                         self.projects.explorer.treewidget.menu]
+            sub_menus += [child for child in self.menuBar().children()]
+            for sub_menu in sub_menus:
+                if isinstance(sub_menu, QMenu):
+                    self._proxy = MenuProxyStyle(sub_menu.style())
+                    sub_menu.setStyle(self._proxy)
 
         logger.info("*** End of MainWindow setup ***")
         self.is_starting_up = False
@@ -2274,8 +2273,8 @@ class MainWindow(QMainWindow):
 
     def createPopupMenu(self):
         menu = QMenu('', self)
-        # Right justify keyboard shortcuts in this/these menus.
-        # Apply only for none dark themes. Otherwise tests fail.
+        # Right justify keyboard shortcuts in the menu.
+        # Apply only for none dark themes, otherwise tests fail.
         if not is_dark_interface():
             self._proxy = MenuProxyStyle(menu.style())
             menu.setStyle(self._proxy)

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -153,7 +153,7 @@ from spyder.utils import icon_manager as ima
 from spyder.utils.programs import is_module_installed
 from spyder.utils.misc import select_port, getcwd_or_home, get_python_executable
 from spyder.plugins.help.utils.sphinxify import CSS_PATH, DARK_CSS_PATH
-from spyder.config.gui import is_dark_font_color
+from spyder.config.gui import is_dark_font_color, is_dark_interface
 
 #==============================================================================
 # Local gui imports
@@ -1267,19 +1267,24 @@ class MainWindow(QMainWindow):
         # Menu about to show
         for child in self.menuBar().children():
             if isinstance(child, QMenu):
-                # Next 2 lines used to right justify keyboard shortcuts.
-                self._proxy = MenuProxyStyle(child.style())
-                child.setStyle(self._proxy)
+                # Right justify keyboard shortcuts in this/these menus.
+                # Apply only for none dark themes. Otherwise tests fail.
+                if not is_dark_interface():
+                    self._proxy = MenuProxyStyle(child.style())
+                    child.setStyle(self._proxy)
                 try:
                     child.aboutToShow.connect(self.update_edit_menu)
                     child.aboutToShow.connect(self.update_search_menu)
                 except TypeError:
                     pass
 
-        # Right justify shortcuts.
-        for menu_keyb_shortcut in [self.plugins_menu, self.quick_layout_menu]:
-            self._proxy = MenuProxyStyle(menu_keyb_shortcut.style())
-            menu_keyb_shortcut.setStyle(self._proxy)
+        # Right justify keyboard shortcuts in this/these menus.
+        # Apply only for none dark themes. Otherwise tests fail.
+        if not is_dark_interface():
+            for menu_keyb_shortcut in [self.plugins_menu,
+                                       self.quick_layout_menu]:
+                self._proxy = MenuProxyStyle(menu_keyb_shortcut.style())
+                menu_keyb_shortcut.setStyle(self._proxy)
 
         logger.info("*** End of MainWindow setup ***")
         self.is_starting_up = False
@@ -2269,9 +2274,11 @@ class MainWindow(QMainWindow):
 
     def createPopupMenu(self):
         menu = QMenu('', self)
-        # Next 2 lines used to right justify keyboard shortcuts.
-        self._proxy = MenuProxyStyle(menu.style())
-        menu.setStyle(self._proxy)
+        # Right justify keyboard shortcuts in this/these menus.
+        # Apply only for none dark themes. Otherwise tests fail.
+        if not is_dark_interface():
+            self._proxy = MenuProxyStyle(menu.style())
+            menu.setStyle(self._proxy)
         actions = self.help_menu_actions[:3] + \
                     [None, self.help_menu_actions[-1]]
         add_actions(menu, actions)
@@ -2623,7 +2630,6 @@ class MainWindow(QMainWindow):
         msgBox.setWindowTitle(_("About %s") % "Spyder")
         msgBox.setStandardButtons(QMessageBox.Ok)
 
-        from spyder.config.gui import is_dark_interface
         if PYQT5:
             if is_dark_interface():
                 icon_filename = "spyder.svg"

--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -163,8 +163,8 @@ class BasePluginWidgetMixin(object):
 
         # Options menu
         self._options_menu = QMenu(self)
-        # Right justify keyboard shortcuts in this/these menus.
-        # Apply only for none dark themes. Otherwise tests fail.
+        # Right justify keyboard shortcuts in the menu.
+        # Apply only for none dark themes, otherwise tests fail.
         if not is_dark_interface():
             self._proxy = MenuProxyStyle(self._options_menu.style())
             self._options_menu.setStyle(self._proxy)

--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -163,9 +163,11 @@ class BasePluginWidgetMixin(object):
 
         # Options menu
         self._options_menu = QMenu(self)
-        # Next 2 lines used to right justify keyboard shortcuts.
-        self._proxy = MenuProxyStyle(self._options_menu.style())
-        self._options_menu.setStyle(self._proxy)
+        # Right justify keyboard shortcuts in this/these menus.
+        # Apply only for none dark themes. Otherwise tests fail.
+        if not is_dark_interface():
+            self._proxy = MenuProxyStyle(self._options_menu.style())
+            self._options_menu.setStyle(self._proxy)
 
         # NOTE: Don't use the default option of CONF.get to assign a
         # None shortcut to plugins that don't have one. That will mess

--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -28,7 +28,7 @@ from spyder.py3compat import configparser, is_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import (
     add_actions, create_action, create_toolbutton, MENU_SEPARATOR,
-    toggle_actions)
+    toggle_actions, MenuProxyStyle)
 from spyder.widgets.dock import SpyderDockWidget
 
 
@@ -163,6 +163,9 @@ class BasePluginWidgetMixin(object):
 
         # Options menu
         self._options_menu = QMenu(self)
+        # Next 2 lines used to right justify keyboard shortcuts.
+        self._proxy = MenuProxyStyle(self._options_menu.style())
+        self._options_menu.setStyle(self._proxy)
 
         # NOTE: Don't use the default option of CONF.get to assign a
         # None shortcut to plugins that don't have one. That will mess

--- a/spyder/plugins/console/widgets/shell.py
+++ b/spyder/plugins/console/widgets/shell.py
@@ -121,8 +121,8 @@ class ShellBaseWidget(ConsoleBaseWidget, SaveHistoryMixin,
     def setup_context_menu(self):
         """Setup shell context menu"""
         self.menu = QMenu(self)
-        # Right justify keyboard shortcuts in this/these menus.
-        # Apply only for none dark themes. Otherwise tests fail.
+        # Right justify keyboard shortcuts in the menus.
+        # Apply only for none dark themes, otherwise tests fail.
         if is_dark_interface():
             self._proxy = MenuProxyStyle(self.menu.style())
             self.menu.setStyle(self._proxy)

--- a/spyder/plugins/console/widgets/shell.py
+++ b/spyder/plugins/console/widgets/shell.py
@@ -28,7 +28,7 @@ from qtpy.QtWidgets import QApplication, QMenu, QToolTip
 
 # Local import
 from spyder.config.base import _, get_conf_path, get_debug_level, STDERR
-from spyder.config.gui import config_shortcut, get_shortcut
+from spyder.config.gui import config_shortcut, get_shortcut, is_dark_interface
 from spyder.config.main import CONF
 from spyder.py3compat import (builtins, is_string, is_text_string,
                               PY3, str_lower, to_text_string)
@@ -121,9 +121,11 @@ class ShellBaseWidget(ConsoleBaseWidget, SaveHistoryMixin,
     def setup_context_menu(self):
         """Setup shell context menu"""
         self.menu = QMenu(self)
-        # Next 2 lines used to right justify keyboard shortcuts.
-        self._proxy = MenuProxyStyle(self.menu.style())
-        self.menu.setStyle(self._proxy)
+        # Right justify keyboard shortcuts in this/these menus.
+        # Apply only for none dark themes. Otherwise tests fail.
+        if is_dark_interface():
+            self._proxy = MenuProxyStyle(self.menu.style())
+            self.menu.setStyle(self._proxy)
         self.cut_action = create_action(self, _("Cut"),
                                         shortcut=keybinding('Cut'),
                                         icon=ima.icon('editcut'),

--- a/spyder/plugins/console/widgets/shell.py
+++ b/spyder/plugins/console/widgets/shell.py
@@ -35,7 +35,7 @@ from spyder.py3compat import (builtins, is_string, is_text_string,
 from spyder.utils import encoding
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import (add_actions, create_action, keybinding,
-                                    restore_keyevent)
+                                    restore_keyevent, MenuProxyStyle)
 from spyder.widgets.mixins import (GetHelpMixin, SaveHistoryMixin,
                                    TracebackLinksMixin, BrowseHistoryMixin)
 from spyder.plugins.console.widgets.console import ConsoleBaseWidget
@@ -121,6 +121,9 @@ class ShellBaseWidget(ConsoleBaseWidget, SaveHistoryMixin,
     def setup_context_menu(self):
         """Setup shell context menu"""
         self.menu = QMenu(self)
+        # Next 2 lines used to right justify keyboard shortcuts.
+        self._proxy = MenuProxyStyle(self.menu.style())
+        self.menu.setStyle(self._proxy)
         self.cut_action = create_action(self, _("Cut"),
                                         shortcut=keybinding('Cut'),
                                         icon=ima.icon('editcut'),

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -79,7 +79,7 @@ from spyder.utils import encoding, programs, sourcecode
 from spyder.utils import icon_manager as ima
 from spyder.utils import syntaxhighlighters as sh
 from spyder.utils.qthelpers import (add_actions, create_action, file_uri,
-                                    mimedata2url)
+                                    mimedata2url, MenuProxyStyle)
 from spyder.utils.vcs import get_git_remotes, remote_to_url
 
 
@@ -3170,6 +3170,9 @@ class CodeEditor(TextEditBaseWidget):
 
         # Build menu
         self.menu = QMenu(self)
+        # Next 2 lines used to right justify keyboard shortcuts.
+        self._proxy1 = MenuProxyStyle(self.menu.style())
+        self.menu.setStyle(self._proxy1)
         actions_1 = [self.run_cell_action, self.run_cell_and_advance_action,
                      self.re_run_last_cell_action, self.run_selection_action,
                      self.gotodef_action, None, self.undo_action,
@@ -3188,6 +3191,9 @@ class CodeEditor(TextEditBaseWidget):
 
         # Read-only context-menu
         self.readonly_menu = QMenu(self)
+        # Next 2 lines used to right justify keyboard shortcuts.
+        self._proxy2 = MenuProxyStyle(self.readonly_menu.style())
+        self.readonly_menu.setStyle(self._proxy2)
         add_actions(self.readonly_menu,
                     (self.copy_action, None, selectall_action,
                      self.gotodef_action))

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -49,7 +49,7 @@ from spyder_kernels.utils.dochelpers import getobj
 # Local imports
 from spyder.api.panel import Panel
 from spyder.config.base import _, get_debug_level, running_under_pytest
-from spyder.config.gui import get_shortcut, config_shortcut
+from spyder.config.gui import get_shortcut, config_shortcut, is_dark_interface
 from spyder.config.main import CONF
 from spyder.plugins.editor.api.decoration import TextDecoration
 from spyder.plugins.editor.extensions import (CloseBracketsExtension,
@@ -3170,9 +3170,11 @@ class CodeEditor(TextEditBaseWidget):
 
         # Build menu
         self.menu = QMenu(self)
-        # Next 2 lines used to right justify keyboard shortcuts.
-        self._proxy1 = MenuProxyStyle(self.menu.style())
-        self.menu.setStyle(self._proxy1)
+        # Right justify keyboard shortcuts in this/these menus.
+        # Apply only for none dark themes. Otherwise tests fail.
+        if not is_dark_interface():
+            self._proxy1 = MenuProxyStyle(self.menu.style())
+            self.menu.setStyle(self._proxy1)
         actions_1 = [self.run_cell_action, self.run_cell_and_advance_action,
                      self.re_run_last_cell_action, self.run_selection_action,
                      self.gotodef_action, None, self.undo_action,
@@ -3191,9 +3193,11 @@ class CodeEditor(TextEditBaseWidget):
 
         # Read-only context-menu
         self.readonly_menu = QMenu(self)
-        # Next 2 lines used to right justify keyboard shortcuts.
-        self._proxy2 = MenuProxyStyle(self.readonly_menu.style())
-        self.readonly_menu.setStyle(self._proxy2)
+        # Right justify keyboard shortcuts in this/these menus.
+        # Apply only for none dark themes. Otherwise tests fail.
+        if not is_dark_interface():
+            self._proxy2 = MenuProxyStyle(self.readonly_menu.style())
+            self.readonly_menu.setStyle(self._proxy2)
         add_actions(self.readonly_menu,
                     (self.copy_action, None, selectall_action,
                      self.gotodef_action))

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -3170,8 +3170,8 @@ class CodeEditor(TextEditBaseWidget):
 
         # Build menu
         self.menu = QMenu(self)
-        # Right justify keyboard shortcuts in this/these menus.
-        # Apply only for none dark themes. Otherwise tests fail.
+        # Right justify keyboard shortcuts.
+        # Apply only for none dark themes, otherwise tests fail.
         if not is_dark_interface():
             self._proxy1 = MenuProxyStyle(self.menu.style())
             self.menu.setStyle(self._proxy1)
@@ -3193,8 +3193,8 @@ class CodeEditor(TextEditBaseWidget):
 
         # Read-only context-menu
         self.readonly_menu = QMenu(self)
-        # Right justify keyboard shortcuts in this/these menus.
-        # Apply only for none dark themes. Otherwise tests fail.
+        # Right justify keyboard shortcuts.
+        # Apply only for none dark themes, otherwise tests fail.
         if not is_dark_interface():
             self._proxy2 = MenuProxyStyle(self.readonly_menu.style())
             self.readonly_menu.setStyle(self._proxy2)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -762,9 +762,11 @@ class EditorStack(QWidget):
             menu_btn.setStyleSheet(
                 "QToolButton::menu-indicator{image: none;}")
         self.menu = QMenu(self)
-        # Next 2 lines used to right justify keyboard shortcuts.
-        self._proxy = MenuProxyStyle(self.menu.style())
-        self.menu.setStyle(self._proxy)
+        # Right justify keyboard shortcuts in this/these menus.
+        # Apply only for none dark themes. Otherwise tests fail.
+        if not is_dark_interface():
+            self._proxy = MenuProxyStyle(self.menu.style())
+            self.menu.setStyle(self._proxy)
         menu_btn.setMenu(self.menu)
         menu_btn.setPopupMode(menu_btn.InstantPopup)
         self.menu.aboutToShow.connect(self.__setup_menu)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -41,7 +41,7 @@ from spyder.utils import icon_manager as ima
 from spyder.utils import encoding, sourcecode, syntaxhighlighters
 from spyder.utils.qthelpers import (add_actions, create_action,
                                     create_toolbutton, MENU_SEPARATOR,
-                                    mimedata2url)
+                                    mimedata2url, MenuProxyStyle)
 from spyder.plugins.outlineexplorer.widgets import OutlineExplorerWidget
 from spyder.plugins.outlineexplorer.editor import OutlineExplorerProxyEditor
 from spyder.widgets.fileswitcher import FileSwitcher
@@ -762,6 +762,9 @@ class EditorStack(QWidget):
             menu_btn.setStyleSheet(
                 "QToolButton::menu-indicator{image: none;}")
         self.menu = QMenu(self)
+        # Next 2 lines used to right justify keyboard shortcuts.
+        self._proxy = MenuProxyStyle(self.menu.style())
+        self.menu.setStyle(self._proxy)
         menu_btn.setMenu(self.menu)
         menu_btn.setPopupMode(menu_btn.InstantPopup)
         self.menu.aboutToShow.connect(self.__setup_menu)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -762,8 +762,8 @@ class EditorStack(QWidget):
             menu_btn.setStyleSheet(
                 "QToolButton::menu-indicator{image: none;}")
         self.menu = QMenu(self)
-        # Right justify keyboard shortcuts in this/these menus.
-        # Apply only for none dark themes. Otherwise tests fail.
+        # Right justify keyboard shortcuts in thr menus.
+        # Apply only for none dark themes, otherwise tests fail.
         if not is_dark_interface():
             self._proxy = MenuProxyStyle(self.menu.style())
             self.menu.setStyle(self._proxy)

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -41,7 +41,8 @@ from spyder.utils import icon_manager as ima
 from spyder.utils import misc, programs, vcs
 from spyder.utils.misc import getcwd_or_home
 from spyder.utils.qthelpers import (add_actions, create_action,
-                                    create_plugin_layout, file_uri)
+                                    create_plugin_layout, file_uri,
+                                    MenuProxyStyle)
 
 try:
     from nbconvert import PythonExporter as nbexporter
@@ -537,6 +538,9 @@ class DirView(QTreeView):
 
     def update_menu(self):
         """Update context menu"""
+        # Next 2 lines used to right justify keyboard shortcuts.
+        self._proxy = MenuProxyStyle(self.menu.style())
+        self.menu.setStyle(self._proxy)
         self.menu.clear()
         add_actions(self.menu, self.create_context_menu_actions())
 

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -41,8 +41,7 @@ from spyder.utils import icon_manager as ima
 from spyder.utils import misc, programs, vcs
 from spyder.utils.misc import getcwd_or_home
 from spyder.utils.qthelpers import (add_actions, create_action,
-                                    create_plugin_layout, file_uri,
-                                    MenuProxyStyle)
+                                    create_plugin_layout, file_uri)
 
 try:
     from nbconvert import PythonExporter as nbexporter
@@ -538,11 +537,6 @@ class DirView(QTreeView):
 
     def update_menu(self):
         """Update context menu"""
-        # Right justify keyboard shortcuts in this/these menus.
-        # Apply only for none dark themes. Otherwise tests fail.
-        if not is_dark_interface():
-            self._proxy = MenuProxyStyle(self.menu.style())
-            self.menu.setStyle(self._proxy)
         self.menu.clear()
         add_actions(self.menu, self.create_context_menu_actions())
 

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -538,9 +538,11 @@ class DirView(QTreeView):
 
     def update_menu(self):
         """Update context menu"""
-        # Next 2 lines used to right justify keyboard shortcuts.
-        self._proxy = MenuProxyStyle(self.menu.style())
-        self.menu.setStyle(self._proxy)
+        # Right justify keyboard shortcuts in this/these menus.
+        # Apply only for none dark themes. Otherwise tests fail.
+        if not is_dark_interface():
+            self._proxy = MenuProxyStyle(self.menu.style())
+            self.menu.setStyle(self._proxy)
         self.menu.clear()
         add_actions(self.menu, self.create_context_menu_actions())
 

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -27,6 +27,7 @@ from spyder.widgets.helperwidgets import MessageCheckBox
 from spyder.plugins.ipythonconsole.widgets import (
         ControlWidget, DebuggingWidget, FigureBrowserWidget,
         HelpWidget, NamepaceBrowserWidget, PageControlWidget)
+from spyder.utils.qthelpers import MenuProxyStyle
 
 
 class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
@@ -479,6 +480,9 @@ the sympy module (e.g. plot)
     def _context_menu_make(self, pos):
         """Reimplement the IPython context menu"""
         menu = super(ShellWidget, self)._context_menu_make(pos)
+        # Next 2 lines used to right justify keyboard shortcuts.
+        self._proxy = MenuProxyStyle(menu.style())
+        menu.setStyle(self._proxy)
         return self.ipyclient.add_actions_to_context_menu(menu)
 
     def _banner_default(self):

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -17,7 +17,7 @@ from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QMessageBox
 from spyder.config.main import CONF
 from spyder.config.base import _
-from spyder.config.gui import config_shortcut
+from spyder.config.gui import config_shortcut, is_dark_interface
 from spyder.py3compat import PY2, to_text_string
 from spyder.utils import encoding
 from spyder.utils import programs
@@ -480,9 +480,11 @@ the sympy module (e.g. plot)
     def _context_menu_make(self, pos):
         """Reimplement the IPython context menu"""
         menu = super(ShellWidget, self)._context_menu_make(pos)
-        # Next 2 lines used to right justify keyboard shortcuts.
-        self._proxy = MenuProxyStyle(menu.style())
-        menu.setStyle(self._proxy)
+        # Right justify keyboard shortcuts in this/these menus.
+        # Apply only for none dark themes. Otherwise tests fail.
+        if not is_dark_interface():
+            self._proxy = MenuProxyStyle(menu.style())
+            menu.setStyle(self._proxy)
         return self.ipyclient.add_actions_to_context_menu(menu)
 
     def _banner_default(self):

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -480,8 +480,8 @@ the sympy module (e.g. plot)
     def _context_menu_make(self, pos):
         """Reimplement the IPython context menu"""
         menu = super(ShellWidget, self)._context_menu_make(pos)
-        # Right justify keyboard shortcuts in this/these menus.
-        # Apply only for none dark themes. Otherwise tests fail.
+        # Right justify keyboard shortcuts in the menu.
+        # Apply only for none dark themes, otherwise tests fail.
         if not is_dark_interface():
             self._proxy = MenuProxyStyle(menu.style())
             menu.setStyle(self._proxy)

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -18,10 +18,10 @@ import logging
 from qtpy.compat import to_qvariant, from_qvariant
 from qtpy.QtCore import (QEvent, QLibraryInfo, QLocale, QObject, Qt, QTimer,
                          QTranslator, Signal, Slot)
-from qtpy.QtGui import QIcon, QKeyEvent, QKeySequence, QPixmap
+from qtpy.QtGui import QIcon, QKeyEvent, QKeySequence, QPixmap, QPalette
 from qtpy.QtWidgets import (QAction, QApplication, QHBoxLayout, QLabel,
                             QLineEdit, QMenu, QStyle, QToolBar, QToolButton,
-                            QVBoxLayout, QWidget)
+                            QVBoxLayout, QWidget, QStyle, QProxyStyle)
 
 # Local imports
 from spyder.config.base import get_image_path, running_in_mac_app
@@ -596,6 +596,31 @@ def create_plugin_layout(tools_layout, main_widget=None):
     if main_widget is not None:
         layout.addWidget(main_widget)
     return layout
+
+
+class MenuProxyStyle(QProxyStyle):
+    """Menu proxy class to right justify shortcuts in QMenu"""
+
+    def drawControl(self, element, option, painter, widget=None):
+        shortcut = ""
+
+        if element == QStyle.CE_MenuItem:
+            vals = option.text.split("\t")
+
+            if len(vals) == 2:
+                text, shortcut = vals
+                option.text = text
+        super(MenuProxyStyle, self).drawControl(element, option, painter,
+                                                widget)
+        if shortcut:
+            margin = 10  # Margin from the right of menu column to shortcuts.
+            self.proxy().drawItemText(painter,
+                                      option.rect.adjusted(margin, 0, -margin,
+                                                           0),
+                                      Qt.AlignRight | Qt.AlignVCenter,
+                                      option.palette,
+                                      option.state & QStyle.State_Enabled,
+                                      shortcut, QPalette.Text)
 
 
 MENU_SEPARATOR = None

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -599,11 +599,11 @@ def create_plugin_layout(tools_layout, main_widget=None):
 
 
 class MenuProxyStyle(QProxyStyle):
-    """Menu proxy class to right justify shortcuts in QMenu"""
+    """Menu proxy class to right justify shortcuts in QMenu."""
 
     def drawControl(self, element, option, painter, widget=None):
+        """Reimplement Qt method."""
         shortcut = ""
-
         if element == QStyle.CE_MenuItem:
             vals = option.text.split("\t")
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

![shortcuts_right_justify](https://user-images.githubusercontent.com/22060413/60432732-e6ee0a80-9bfa-11e9-9e20-e6aab5d04b51.gif)

<!--- Explain what you've done and why --->
This PR right justify all keyboard shortcuts found in all menus and context menus in Spyder. Unfortunately it does not work when dark theme is used. The reason is probably related to the fact that Qt style sheets are currently not supported for custom QStyle subclasses as described [here](https://doc.qt.io/archives/qt-4.8/stylesheet.html). I could not find another simple way to make the same changes except using QStyle subclasses.

This is a very minor change and probably might not be necessary one. However, I am just submitting it for your review. 



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @Khalilsqu

<!--- Thanks for your help making Spyder better for everyone! --->
