### PR TITLE
PR: Keep preferences on top and give focus if the shortcut is called

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -750,9 +750,9 @@ class MainWindow(QMainWindow):
         logger.info("Creating Tools menu...")
         # Tools + External Tools
         prefs_action = create_action(self, _("Pre&ferences"),
-                                        icon=ima.icon('configure'),
-                                        triggered=self.edit_preferences,
-                                        context=Qt.ApplicationShortcut)
+                                     icon=ima.icon('configure'),
+                                     triggered=self.show_preferences,
+                                     context=Qt.ApplicationShortcut)
         self.register_shortcut(prefs_action, "_", "Preferences",
                                add_shortcut_to_tip=True)
         spyder_path_action = create_action(self,
@@ -2912,7 +2912,7 @@ class MainWindow(QMainWindow):
             return
 
     @Slot()
-    def edit_preferences(self):
+    def show_preferences(self):
         """Edit Spyder preferences"""
         from spyder.preferences.configdialog import ConfigDialog
 
@@ -2961,6 +2961,11 @@ class MainWindow(QMainWindow):
             dlg.show()
             dlg.check_all_settings()
             dlg.exec_()
+        else:
+            self.prefs_dialog_instance.show()
+            self.prefs_dialog_instance.activateWindow()
+            self.prefs_dialog_instance.raise_()
+            self.prefs_dialog_instance.setFocus()
 
     def __preference_page_changed(self, index):
         """Preference page index has changed"""

--- a/spyder/preferences/configdialog.py
+++ b/spyder/preferences/configdialog.py
@@ -148,6 +148,7 @@ class ConfigDialog(QDialog):
         # (e.g. the editor's analysis thread in Spyder), thus leading to
         # a segmentation fault on UNIX or an application crash on Windows
         self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setWindowFlags(Qt.Dialog | Qt.WindowStaysOnTopHint)
         self.setWindowTitle(_('Preferences'))
         self.setWindowIcon(ima.icon('configure'))
         self.contents_widget.setMovement(QListView.Static)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Preferences now stay on top, before if you clicked the Spyder main window the preferences would go to the background. Also if the preferences looses focus, calling the dialog (by shortcut) or toolbutton will give focus to the current open preferences dialog.
![pref](https://user-images.githubusercontent.com/3627835/60630261-0d5ca300-9dbf-11e9-968f-9ce5b2bf8e15.gif)

Also changed the name of the method as show is more telling that the thing is a dialog


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->




### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca

<!--- Thanks for your help making Spyder better for everyone! --->
