### PR TITLE
PR: Fix stripping on return for strings

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -3656,6 +3656,7 @@ class CodeEditor(TextEditBaseWidget):
             self.document_did_change()
             # Correct last change position
             self.last_change_position = line_range[1]
+            self.last_position = self.textCursor().position()
             return line_range[1] - (line_range[0] + len(strip))
         return 0
 

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -3621,7 +3621,12 @@ class CodeEditor(TextEditBaseWidget):
             # Check if still on the line
             return 0
 
-        if not self.strip_trailing_spaces_on_modify:
+        # Check if end of line in string
+        cursor = self.textCursor()
+        cursor.setPosition(line_range[1])
+
+        if (not self.strip_trailing_spaces_on_modify
+                or self.in_string(cursor=cursor)):
             if self.last_auto_indent is None:
                 return 0
             elif (self.last_auto_indent !=
@@ -3633,12 +3638,6 @@ class CodeEditor(TextEditBaseWidget):
             self.last_auto_indent = None
         elif not pos_in_line(self.last_change_position):
             # Should process if pressed return or made a change on the line:
-            return 0
-
-        # Check if end of line in string
-        cursor = self.textCursor()
-        cursor.setPosition(line_range[1])
-        if self.in_string(cursor=cursor):
             return 0
 
         cursor.setPosition(line_range[0])

--- a/spyder/plugins/editor/widgets/tests/test_codeeditor.py
+++ b/spyder/plugins/editor/widgets/tests/test_codeeditor.py
@@ -133,6 +133,10 @@ def test_editor_log_lsp_handle_errors(editorbot, capsys):
          'def fun():\n    """fun\n\n    ',
          [Qt.Key_Enter, Qt.Key_Enter],
          True),
+        ('def fun():\n    """fun',
+         'def fun():\n    """fun\n\n    ',
+         [Qt.Key_Enter, Qt.Key_Enter],
+         False),
     ])
 def test_editor_rstrip_keypress(
         editorbot, input_text, expected_text, keys, strip_all):

--- a/spyder/plugins/editor/widgets/tests/test_codeeditor.py
+++ b/spyder/plugins/editor/widgets/tests/test_codeeditor.py
@@ -129,6 +129,10 @@ def test_editor_log_lsp_handle_errors(editorbot, capsys):
          'a=1\na=2 \na=3',
          [(Qt.LeftButton, 6), Qt.Key_Up],
          True),
+        ('def fun():\n    """fun',
+         'def fun():\n    """fun\n\n    ',
+         [Qt.Key_Enter, Qt.Key_Enter],
+         True),
     ])
 def test_editor_rstrip_keypress(
         editorbot, input_text, expected_text, keys, strip_all):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Strip tabs added by spyder in strings as well.

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

When line stripping is disabled, it will still remove spaces added by spyder. This adds this behaviour in strings for any state of line stripping.


Before:
![before](https://user-images.githubusercontent.com/6740194/60672447-47847e00-9e6d-11e9-8b78-e4ee85d9fceb.gif)
After
![after](https://user-images.githubusercontent.com/6740194/60672446-47847e00-9e6d-11e9-919e-4d5176471217.gif)


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
