### PR TITLE
PR: Add different icon color for style warninngs

### DIFF
--- a/spyder/plugins/editor/panels/linenumber.py
+++ b/spyder/plugins/editor/panels/linenumber.py
@@ -45,6 +45,7 @@ class LineNumberArea(Panel):
         self.info_icon = ima.icon('information')
         self.hint_icon = ima.icon('hint')
         self.todo_icon = ima.icon('todo')
+        self.style_warning_icon = ima.icon('style-warning')
 
         # Line number area management
         self._margin = True
@@ -67,7 +68,7 @@ class LineNumberArea(Panel):
         # See spyder-ide/spyder#2296 and spyder-ide/spyder#4811.
         font = self.editor.font()
         font_height = self.editor.fontMetrics().height()
-
+        style_sources = self.editor.get_style_warning_sources()
         active_block = self.editor.textCursor().block()
         active_line_number = active_block.blockNumber() + 1
 
@@ -104,11 +105,16 @@ class LineNumberArea(Panel):
                 if data.code_analysis:
                     errors = 0
                     warnings = 0
+                    style_warnings = 0
                     infos = 0
                     hints = 0
-                    for _, _, sev, _ in data.code_analysis:
+                    for src, _, sev, _ in data.code_analysis:
                         errors += sev == DiagnosticSeverity.ERROR
-                        warnings += sev == DiagnosticSeverity.WARNING
+                        if sev == DiagnosticSeverity.WARNING:
+                            if src in style_sources:
+                                style_warnings += 1
+                            else:
+                                warnings += sev == DiagnosticSeverity.WARNING
                         infos += sev == DiagnosticSeverity.INFORMATION
                         hints += sev == DiagnosticSeverity.HINT
 
@@ -116,6 +122,9 @@ class LineNumberArea(Panel):
                         draw_pixmap(1, top, self.error_icon.pixmap(icon_size))
                     elif warnings:
                         draw_pixmap(1, top, self.warning_icon.pixmap(icon_size))
+                    elif style_warnings:
+                        draw_pixmap(1, top, 
+                                    self.style_warning_icon.pixmap(icon_size))
                     elif infos:
                         draw_pixmap(1, top, self.info_icon.pixmap(icon_size))
                     elif hints:

--- a/spyder/plugins/editor/panels/linenumber.py
+++ b/spyder/plugins/editor/panels/linenumber.py
@@ -123,7 +123,7 @@ class LineNumberArea(Panel):
                     elif warnings:
                         draw_pixmap(1, top, self.warning_icon.pixmap(icon_size))
                     elif style_warnings:
-                        draw_pixmap(1, top, 
+                        draw_pixmap(1, top,
                                     self.style_warning_icon.pixmap(icon_size))
                     elif infos:
                         draw_pixmap(1, top, self.info_icon.pixmap(icon_size))

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2000,6 +2000,16 @@ class CodeEditor(TextEditBaseWidget):
         self.tooltip_widget.hide()
         self.clear_extra_selections('code_analysis_highlight')
 
+    def get_style_warning_sources(self):
+        """
+        Return sources to take into account for checking style warninigs.
+        """
+        if self.language.lower() == 'python':
+            style_warning_sources = ['pycodestyle', 'pydocstyle']
+        else:
+            style_warning_sources = []
+        return style_warning_sources
+
     def show_code_analysis_results(self, line_number, block_data):
         """Show warning/error messages."""
         from spyder.config.base import get_image_path
@@ -2010,7 +2020,8 @@ class CodeEditor(TextEditBaseWidget):
             DiagnosticSeverity.INFORMATION: 'information',
             DiagnosticSeverity.HINT: 'hint',
         }
-
+        style_icon = 'style-warning'
+        style_sources = self.get_style_warning_sources()
         code_analysis = block_data.code_analysis
 
         # Size must be adapted from font
@@ -2071,7 +2082,11 @@ class CodeEditor(TextEditBaseWidget):
             else:
                 msg = '<br>'.join(new_paragraphs)
 
-            base_64 = ima.base64_from_icon(icons[sev], size, size)
+            if src in style_sources:
+                icon = style_icon
+            else:
+                icon = icons[sev]
+            base_64 = ima.base64_from_icon(icon, size, size)
             if max_lines_msglist >= 0:
                 msglist.append(template.format(base_64, msg, src,
                                                code, size=size))

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -160,6 +160,7 @@ _qtaargs = {
     'gotoline':                [('fa.sort-numeric-asc',), {'color': MAIN_FG_COLOR}],
     'error':                   [('fa.times-circle',), {'color': 'darkred'}],
     'warning':                 [('fa.warning',), {'color': 'orange'}],
+    'style-warning':           [('fa.warning',), {'color': '#3775a9'}],
     'information':             [('fa.info-circle',), {'color': '#3775a9'}],
     'hint':                    [('fa.lightbulb-o',), {'color': 'yellow'}],
     'todo':                    [('fa.exclamation',), {'color': '#3775a9'}],


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Style warnings are now treated as another type of warning (with lesser severity) and a different icon.

![warnings](https://user-images.githubusercontent.com/3627835/60848031-9c483180-a1aa-11e9-8963-29e2b979945e.gif)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #5489


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
