### PR TITLE
PR: Use text instead of key in the editor close bracket extension

### DIFF
--- a/spyder/plugins/editor/extensions/closebrackets.py
+++ b/spyder/plugins/editor/extensions/closebrackets.py
@@ -5,24 +5,18 @@
 # (see spyder/__init__.py for details)
 """This module contains the close quotes editor extension."""
 
-from qtpy.QtCore import Qt
 from qtpy.QtGui import QTextCursor
-
 from spyder.api.editorextension import EditorExtension
 
 
 class CloseBracketsExtension(EditorExtension):
     """Editor Extension for insert brackets automatically."""
-    BRACKETS_LIST = ["(", ")", "{", "}", "[", "]"]
-    BRACKETS_KEYS = [Qt.Key_ParenLeft, Qt.Key_ParenRight,
-                     Qt.Key_BraceLeft, Qt.Key_BraceRight,
-                     Qt.Key_BracketLeft, Qt.Key_BracketRight]
-    BRACKETS_CHAR = dict(zip(BRACKETS_KEYS, BRACKETS_LIST))
-    BRACKETS_LEFT = dict(zip(BRACKETS_KEYS[::2], BRACKETS_LIST[::2]))
-    BRACKETS_RIGHT = dict(zip(BRACKETS_KEYS[1::2], BRACKETS_LIST[1::2]))
-    BRACKETS_PAIR = {Qt.Key_ParenLeft: "()", Qt.Key_ParenRight: "()",
-                     Qt.Key_BraceLeft: "{}", Qt.Key_BraceRight: "{}",
-                     Qt.Key_BracketLeft: "[]", Qt.Key_BracketRight: "[]"}
+    BRACKETS_CHAR = ["(", ")", "{", "}", "[", "]"]
+    BRACKETS_LEFT = BRACKETS_CHAR[::2]
+    BRACKETS_RIGHT = BRACKETS_CHAR[1::2]
+    BRACKETS_PAIR = {"(": "()", ")": "()",
+                     "{": "{}", "}": "{}",
+                     "[": "[]", "]": "[]"}
 
     def on_state_changed(self, state):
         """Connect/disconnect sig_key_pressed signal."""
@@ -35,10 +29,10 @@ class CloseBracketsExtension(EditorExtension):
         if event.isAccepted():
             return
 
-        key = event.key()
-        if key in self.BRACKETS_CHAR and self.enabled:
+        char = event.text()
+        if char in self.BRACKETS_CHAR and self.enabled:
             self.editor.completion_widget.hide()
-            self._autoinsert_brackets(key)
+            self._autoinsert_brackets(char)
             self.editor.document_did_change()
             event.accept()
 
@@ -50,8 +44,8 @@ class CloseBracketsExtension(EditorExtension):
         (')', ']' or '}')
         """
         if closing_brackets_type is None:
-            opening_brackets = self.BRACKETS_LEFT.values()
-            closing_brackets = self.BRACKETS_RIGHT.values()
+            opening_brackets = self.BRACKETS_LEFT
+            closing_brackets = self.BRACKETS_RIGHT
         else:
             closing_brackets = [closing_brackets_type]
             opening_brackets = [{')': '(', '}': '{',
@@ -71,10 +65,9 @@ class CloseBracketsExtension(EditorExtension):
                     return True
         return False
 
-    def _autoinsert_brackets(self, key):
+    def _autoinsert_brackets(self, char):
         """Control automatic insertation of brackets in various situations."""
-        char = self.BRACKETS_CHAR[key]
-        pair = self.BRACKETS_PAIR[key]
+        pair = self.BRACKETS_PAIR[char]
 
         line_text = self.editor.get_text('sol', 'eol')
         line_to_cursor = self.editor.get_text('sol', 'cursor')
@@ -89,9 +82,9 @@ class CloseBracketsExtension(EditorExtension):
             cursor.movePosition(QTextCursor.Left, QTextCursor.KeepAnchor,
                                 len(text))
             self.editor.setTextCursor(cursor)
-        elif key in self.BRACKETS_LEFT:
+        elif char in self.BRACKETS_LEFT:
             if (not trailing_text or
-                    trailing_text[0] in self.BRACKETS_RIGHT.values() or
+                    trailing_text[0] in self.BRACKETS_RIGHT or
                     trailing_text[0] in [',', ':', ';']):
                 # Automatic insertion of brackets
                 self.editor.insert_text(pair)
@@ -101,7 +94,7 @@ class CloseBracketsExtension(EditorExtension):
                 self.editor.insert_text(char)
             if char in self.editor.signature_completion_characters:
                 self.editor.request_signature()
-        elif key in self.BRACKETS_RIGHT:
+        elif char in self.BRACKETS_RIGHT:
             if (self.editor.next_char() == char and
                     not self.editor.textCursor().atBlockEnd() and
                     not self.unmatched_brackets_in_line(

--- a/spyder/plugins/editor/extensions/closebrackets.py
+++ b/spyder/plugins/editor/extensions/closebrackets.py
@@ -29,6 +29,9 @@ class CloseBracketsExtension(EditorExtension):
         if event.isAccepted():
             return
 
+        # It is necessary to use here the text of the event and not the key
+        # to avoid issues with international keyboards.
+        # See spyder-ide/spyder#9749
         char = event.text()
         if char in self.BRACKETS_CHAR and self.enabled:
             self.editor.completion_widget.hide()


### PR DESCRIPTION
## Description of Changes

* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

![curly](https://user-images.githubusercontent.com/20992645/61065478-60d77e00-a3c9-11e9-91db-702371354b3d.gif)

Automatic insertion of parentheses, brackets and braces should be done against the text of the key press event instead of the key in the `CloseBracketsExtension`.

This is because on some international keyboards, the key that was pressed does not always correspond to the text when some key modifiers are used.

For example, on the macOS with a french keyboard, the key combination `Alt + (` results in the key press event text `{`, while the key would be `Qt.Key_ParenLeft`.

PS: I have no mean to test that this is actually fixing #9749, so please review carefully :)

### Issue(s) Resolved

Fixes #9749
