### PR TITLE
PR: Use text instead of key in the editor close quotes extension

### DIFF
--- a/spyder/plugins/editor/extensions/closequotes.py
+++ b/spyder/plugins/editor/extensions/closequotes.py
@@ -52,6 +52,9 @@ class CloseQuotesExtension(EditorExtension):
         if event.isAccepted():
             return
 
+        # It is necessary to use here the text of the event and not the key
+        # to avoid issues with international keyboards.
+        # See spyder-ide/spyder#9814
         char = event.text()
         if char in ('"', '\'') and self.enabled:
             self.editor.completion_widget.hide()

--- a/spyder/plugins/editor/extensions/closequotes.py
+++ b/spyder/plugins/editor/extensions/closequotes.py
@@ -52,17 +52,15 @@ class CloseQuotesExtension(EditorExtension):
         if event.isAccepted():
             return
 
-        key = event.key()
-        if key in (Qt.Key_QuoteDbl, Qt.Key_Apostrophe) and self.enabled:
+        char = event.text()
+        if char in ('"', '\'') and self.enabled:
             self.editor.completion_widget.hide()
-            self._autoinsert_quotes(key)
+            self._autoinsert_quotes(char)
             self.editor.document_did_change()
             event.accept()
 
-    def _autoinsert_quotes(self, key):
+    def _autoinsert_quotes(self, char):
         """Control how to automatically insert quotes in various situations."""
-        char = {Qt.Key_QuoteDbl: '"', Qt.Key_Apostrophe: '\''}[key]
-
         line_text = self.editor.get_text('sol', 'eol')
         line_to_cursor = self.editor.get_text('sol', 'cursor')
         cursor = self.editor.textCursor()


### PR DESCRIPTION
## Description of Changes

After working on PR #9813, I realized that we needed to use the text of the key press event instead of the key in the `CloseQuotesExtension` too.

This is because on some international keyboards, the key that was pressed does not always correspond to the text when some key modifiers are used.

For example, on my keyboard, I need to press `Qt.Key_Apostrophe` followed by the `Spacebar` to type a single quote character. So, this feature was not working on my own computer and I never realized it until now!