### PR TITLE
PR: Add millisecond editing capabilities to variable explorer

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -536,6 +536,7 @@ class CollectionsDelegate(QItemDelegate):
             else:
                 if isinstance(value, datetime.datetime):
                     editor = QDateTimeEdit(value, parent=parent)
+                    editor.setDisplayFormat('dd/MM/yyyy HH:mm:ss.zzz')
                 else:
                     editor = QDateEdit(value, parent=parent)
                 editor.setCalendarPopup(True)
@@ -698,14 +699,15 @@ class CollectionsDelegate(QItemDelegate):
                 return
         elif isinstance(editor, QDateEdit):
             qdate = editor.date()
-            value = datetime.date( qdate.year(), qdate.month(), qdate.day() )
+            value = datetime.date(qdate.year(), qdate.month(), qdate.day())
         elif isinstance(editor, QDateTimeEdit):
             qdatetime = editor.dateTime()
             qdate = qdatetime.date()
             qtime = qdatetime.time()
-            value = datetime.datetime( qdate.year(), qdate.month(),
-                                       qdate.day(), qtime.hour(),
-                                       qtime.minute(), qtime.second() )
+            # datetime uses microseconds, QDateTime returns milliseconds
+            value = datetime.datetime(qdate.year(), qdate.month(), qdate.day(),
+                                      qtime.hour(), qtime.minute(),
+                                      qtime.second(), qtime.msec()*1000)
         else:
             # Should not happen...
             raise RuntimeError("Unsupported editor widget")


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->

Added milliseconds (and seconds) editing capabilities to variable explorer. Small problem is that QDateTime only supports milliseconds, while timeedit uses microseconds. Hence, any fractional milliseconds will be lost.

![datetime](https://user-images.githubusercontent.com/8114497/61408757-11b9ad80-a8e1-11e9-9d1d-0802a108e78f.gif)

No idea how to test this though.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9451


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Oscar Gustafsson/@oscargus

<!--- Thanks for your help making Spyder better for everyone! --->
