### PR TITLE
PR: Set encoding to unicode for Profiler and Pylint processes

### DIFF
--- a/spyder/plugins/profiler/widgets/profilergui.py
+++ b/spyder/plugins/profiler/widgets/profilergui.py
@@ -275,6 +275,7 @@ class ProfilerWidget(QWidget):
             for envItem in env:
                 envName, separator, envValue = envItem.partition('=')
                 processEnvironment.insert(envName, envValue)
+            processEnvironment.insert("PYTHONIOENCODING", "utf8")
             self.process.setProcessEnvironment(processEnvironment)
 
         self.output = ''

--- a/spyder/plugins/pylint/widgets/pylintgui.py
+++ b/spyder/plugins/pylint/widgets/pylintgui.py
@@ -21,7 +21,7 @@ import time
 # Third party imports
 import pylint
 from qtpy.compat import getopenfilename
-from qtpy.QtCore import QByteArray, QProcess, Signal, Slot
+from qtpy.QtCore import QByteArray, QProcess, Signal, Slot, QProcessEnvironment
 from qtpy.QtWidgets import (QHBoxLayout, QLabel, QMessageBox, QTreeWidgetItem,
                             QVBoxLayout, QWidget)
 
@@ -340,6 +340,10 @@ class PylintWidget(QWidget):
             p_args += [osp.basename(filename)]
         else:
             p_args = [osp.basename(filename)]
+        processEnvironment = QProcessEnvironment()
+        processEnvironment.insert("PYTHONIOENCODING", "utf8")
+        self.process.setProcessEnvironment(processEnvironment)
+
         self.process.start(sys.executable, p_args)
 
         running = self.process.waitForStarted()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
#7031 and #9536 are both caused by the profiler and code analysis running in a QProcess, which uses the default system encoding. This PR fixes this by setting the encoding, currently to utf8, but ideally to the encoding used by the file in question.

This is rather straightforward if the file is opened in the editor, but not that straightforward otherwise. Any ideas how to do that in these cases? Or is utf8 a good enough guess in general?

I'll try to figure out some tests. Probably code analysis is easiest (as there were no results earlier). For profiling one will have to check that no error dialog shows up.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #7031
Fixes #9356


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Oscar Gustafsson/@oscargus

<!--- Thanks for your help making Spyder better for everyone! --->
