### PR TITLE
PR: Made Analyze button respect "save before" setting

### DIFF
--- a/spyder/plugins/pylint/plugin.py
+++ b/spyder/plugins/pylint/plugin.py
@@ -67,6 +67,10 @@ class Pylint(SpyderPluginWidget):
         # Follow editorstacks tab change
         self.main.editor.sig_editor_focus_changed.connect(self.set_filename)
 
+        # Used by Analyze button to check if file should be saved and start
+        # analysis
+        self.pylint.start_analysis.connect(self.run_pylint_from_analyze_button)
+
     #------ SpyderPluginWidget API --------------------------------------------
     def get_plugin_title(self):
         """Return widget title"""
@@ -142,6 +146,9 @@ class Pylint(SpyderPluginWidget):
     @Slot()
     def run_pylint(self):
         """Run pylint code analysis"""
+        if (self.get_option('save_before', True)
+                and not self.main.editor.save()):
+            return
         self.switch_to_plugin()
         self.analyze(self.main.editor.get_current_filename())
 
@@ -150,3 +157,16 @@ class Pylint(SpyderPluginWidget):
         if self.dockwidget:
             self.switch_to_plugin()
         self.pylint.analyze(filename)
+
+    @Slot()
+    def run_pylint_from_analyze_button(self):
+        """
+        See if file should and can be saved and run pylint code analysis.
+
+        Does not check that file name is valid etc, so should only be used for
+        Analyze button.
+        """
+        if (self.get_option('save_before', True)
+                and not self.main.editor.save()):
+            return
+        self.pylint.start()

--- a/spyder/plugins/pylint/plugin.py
+++ b/spyder/plugins/pylint/plugin.py
@@ -142,9 +142,6 @@ class Pylint(SpyderPluginWidget):
     @Slot()
     def run_pylint(self):
         """Run pylint code analysis"""
-        if (self.get_option('save_before', True)
-                and not self.main.editor.save()):
-            return
         self.switch_to_plugin()
         self.analyze(self.main.editor.get_current_filename())
 

--- a/spyder/plugins/pylint/widgets/pylintgui.py
+++ b/spyder/plugins/pylint/widgets/pylintgui.py
@@ -148,13 +148,14 @@ class PylintWidget(QWidget):
     DATAPATH = get_conf_path('pylint.results')
     VERSION = '1.1.0'
     redirect_stdio = Signal(bool)
+    start_analysis = Signal()
 
     def __init__(self, parent, max_entries=100, options_button=None,
                  text_color=None, prevrate_color=None):
         QWidget.__init__(self, parent)
 
         self.setWindowTitle("Pylint")
-        self.parent = parent
+
         self.output = None
         self.error_output = None
         self.filename = None
@@ -176,7 +177,8 @@ class PylintWidget(QWidget):
         self.start_button = create_toolbutton(self, icon=ima.icon('run'),
                                     text=_("Analyze"),
                                     tip=_("Run analysis"),
-                                    triggered=self.start, text_beside_icon=True)
+                                    triggered=self.analyze_button_handler,
+                                    text_beside_icon=True)
         self.stop_button = create_toolbutton(self,
                                              icon=ima.icon('stop'),
                                              text=_("Stop"),
@@ -311,14 +313,14 @@ class PylintWidget(QWidget):
                        readonly=True, size=(700, 500)).exec_()
 
     @Slot()
+    def analyze_button_handler(self):
+        """ Try to start code analysis when Analyze button pressed."""
+
+        self.start_analysis.emit()
+
+    @Slot()
     def start(self):
         """ Start the code analysis. """
-        # Check if the file should be automatically saved before analysis
-        if self.parent and self.parent.get_option('save_before', True):
-            # Try saving it
-            if not self.parent.main.editor.save():
-                # Saving failed for some reason, do not analyze
-                return
 
         filename = to_text_string(self.filecombo.currentText())
 

--- a/spyder/plugins/pylint/widgets/pylintgui.py
+++ b/spyder/plugins/pylint/widgets/pylintgui.py
@@ -154,7 +154,7 @@ class PylintWidget(QWidget):
         QWidget.__init__(self, parent)
 
         self.setWindowTitle("Pylint")
-
+        self.parent = parent
         self.output = None
         self.error_output = None
         self.filename = None
@@ -312,6 +312,14 @@ class PylintWidget(QWidget):
 
     @Slot()
     def start(self):
+        """ Start the code analysis. """
+        # Check if the file should be automatically saved before analysis
+        if self.parent and self.parent.get_option('save_before', True):
+            # Try saving it
+            if not self.parent.main.editor.save():
+                # Saving failed for some reason, do not analyze
+                return
+
         filename = to_text_string(self.filecombo.currentText())
 
         self.process = QProcess(self)

--- a/spyder/plugins/pylint/widgets/pylintgui.py
+++ b/spyder/plugins/pylint/widgets/pylintgui.py
@@ -314,14 +314,12 @@ class PylintWidget(QWidget):
 
     @Slot()
     def analyze_button_handler(self):
-        """ Try to start code analysis when Analyze button pressed."""
-
+        """Try to start code analysis when Analyze button pressed."""
         self.start_analysis.emit()
 
     @Slot()
     def start(self):
-        """ Start the code analysis. """
-
+        """Start the code analysis."""
         filename = to_text_string(self.filecombo.currentText())
 
         self.process = QProcess(self)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Earlier, pressing the Analyze button in Code Analysis did not save the file even if the setting requested it (Pressing the shortcut or selecting the menu option did it though.) This is fixed here.

![pylintsave](https://user-images.githubusercontent.com/8114497/61568734-c0e2ba00-aa84-11e9-8e06-d7292ccb5d54.gif)

A small change of behavior comes with this PR. Earlier, the code analysis pane was not activated if the automatic save. Now, it is activated, but the analysis is not executed.

Didn't find any suitable tests to base a possibly new test on.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9604


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Oscar Gustafsson/@oscargus

<!--- Thanks for your help making Spyder better for everyone! --->
