### PR TITLE
PR: Reenable sorting of keyboard shortcuts table after clearing filter text

### DIFF
--- a/spyder/preferences/shortcuts.py
+++ b/spyder/preferences/shortcuts.py
@@ -659,7 +659,7 @@ class CustomSortFilterProxy(QSortFilterProxyModel):
     def set_filter(self, text):
         """Set regular expression for filter."""
         self.pattern = get_search_regex(text)
-        if self.pattern:
+        if self.pattern and text:
             self._parent.setSortingEnabled(False)
         else:
             self._parent.setSortingEnabled(True)

--- a/spyder/preferences/tests/test_shorcuts.py
+++ b/spyder/preferences/tests/test_shorcuts.py
@@ -24,36 +24,73 @@ from spyder.preferences.shortcuts import (
 
 # ---- Qt Test Fixtures
 @pytest.fixture
-def shorcut_table(qtbot):
+def shortcut_table(qtbot):
     """Set up shortcuts."""
-    shorcut_table = ShortcutsTable()
-    qtbot.addWidget(shorcut_table)
-    return shorcut_table
+    shortcut_table = ShortcutsTable()
+    qtbot.addWidget(shortcut_table)
+    return shortcut_table
 
 
 @pytest.fixture
-def create_shortcut_editor(shorcut_table, qtbot):
-    shortcuts = shorcut_table.source_model.shortcuts
+def create_shortcut_editor(shortcut_table, qtbot):
+    shortcuts = shortcut_table.source_model.shortcuts
 
     def _create_bot(context, name):
         sequence = CONF.get('shortcuts', "{}/{}".format(context, name))
         shortcut_editor = ShortcutEditor(
-            shorcut_table, context, name, sequence, shortcuts)
+            shortcut_table, context, name, sequence, shortcuts)
         qtbot.addWidget(shortcut_editor)
         shortcut_editor.show()
         return shortcut_editor
     return _create_bot
 
 
+# ---- Filter text mock
+class FilterTextMock():
+    def __init__(self, text):
+        self.txt = text
+
+    def text(self):
+        return self.txt
+
+
 # ---- Tests ShortcutsTable
 @pytest.mark.skipif(
     sys.platform.startswith('linux') and os.environ.get('CI') is not None,
     reason="It fails on Linux due to the lack of a proper X server.")
-def test_shortcuts(shorcut_table):
+def test_shortcuts(shortcut_table):
     """Run shortcuts table."""
-    shorcut_table.show()
-    shorcut_table.check_shortcuts()
-    assert shorcut_table
+    shortcut_table.show()
+    shortcut_table.check_shortcuts()
+    assert shortcut_table
+
+
+def test_shortcuts_filtering(shortcut_table):
+    """Run shortcuts table."""
+    # Store original row count
+    row_count = shortcut_table.model().rowCount()
+    # Filter for "debug"
+    shortcut_table.finder = FilterTextMock('debug')
+    shortcut_table.set_regex()
+    # Sorting should be disabled
+    assert not shortcut_table.isSortingEnabled()
+    # Six hits (causes a bit of an issue to hardcode it like this if new
+    # shortcuts are added...)
+    assert shortcut_table.model().rowCount() == 6
+    # Remove filter text
+    shortcut_table.finder = FilterTextMock('')
+    shortcut_table.set_regex()
+    # Should be sortable again
+    assert shortcut_table.isSortingEnabled()
+    # All entries restored
+    assert shortcut_table.model().rowCount() == row_count
+
+    # Same thing, but using reset instead
+    shortcut_table.finder = FilterTextMock('debug')
+    shortcut_table.set_regex()
+    shortcut_table.set_regex(reset=True)
+    assert shortcut_table.isSortingEnabled()
+    assert shortcut_table.model().rowCount() == row_count
 
 
 # ---- Tests ShortcutEditor


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->
Earlier, the sorting capabilities of the keyboard shortcut table was not re-enabled after the filter text was cleared. Now it is.

Also added a bit of testing for the filtering (including the thing I fixed). Not ideal to hard code the number of names containing "debug", but I selected a string that is probably quite stable...

Finally, renamed `shorcut_table` to `shortcut_table` leading to more changed lines than the actual contribution.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Oscar Gustafsson/@oscargus

<!--- Thanks for your help making Spyder better for everyone! --->
