### PR TITLE
PR: Improve unindent behavior

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2643,7 +2643,21 @@ class CodeEditor(TextEditBaseWidget):
         force=True: unindent even if cursor is not a the beginning of the line
         """
         if self.has_selected_text():
-            self.remove_prefix(self.indent_chars)
+            if self.indent_chars == "\t":
+                # Tabs, remove one tab
+                self.remove_prefix(self.indent_chars)
+            else:
+                # Spaces
+                space_count = len(self.indent_chars)
+                leading_spaces = self.__spaces_for_prefix()
+                remainder = leading_spaces % space_count
+                if remainder:
+                    # Get block on "space multiple grid".
+                    # See spyder-ide/spyder#5734.
+                    self.remove_prefix(" "*remainder)
+                else:
+                    # Unindent one space multiple
+                    self.remove_prefix(self.indent_chars)
         else:
             leading_text = self.get_text('sol', 'cursor')
             if force or not leading_text.strip() \

--- a/spyder/plugins/editor/widgets/tests/test_indentation.py
+++ b/spyder/plugins/editor/widgets/tests/test_indentation.py
@@ -29,6 +29,15 @@ def make_indent(editor, single_line=True, start_line=1):
     return to_text_string(text)
 
 
+def make_unindent(editor, single_line=True, start_line=1):
+    """Unindent and return code."""
+    editor.go_to_line(start_line)
+    if not single_line:
+        editor.moveCursor(QTextCursor.End, mode=QTextCursor.KeepAnchor)
+    editor.unindent()
+    text = editor.toPlainText()
+    return to_text_string(text)
+
 # --- Fixtures
 # -----------------------------------------------------------------------------
 @pytest.fixture
@@ -56,14 +65,15 @@ def test_single_line_indent(code_editor_indent_bot):
             "print(self.b)\n"
             "\n"
             )
+    expected = ("class a():\n"
+                "  self.b = 1\n"
+                "print(self.b)\n"
+                "\n"
+                )
     editor.set_text(text)
     # Indent line without spaces
-    text = make_indent(editor, start_line=2)
-    assert text == ("class a():\n"
-                    "  self.b = 1\n"
-                    "print(self.b)\n"
-                    "\n"
-                    )
+    new_text = make_indent(editor, start_line=2)
+    assert new_text == expected
 
 
 def test_selection_indent(code_editor_indent_bot):
@@ -74,14 +84,16 @@ def test_selection_indent(code_editor_indent_bot):
             "print(self.b)\n"
             "\n"
             )
+    expected = ("class a():\n"
+                "  self.b = 1\n"
+                "  print(self.b)\n"
+                "  \n"
+                )
+
     editor.set_text(text)
     # Toggle manually commented code
-    text = make_indent(editor, single_line=False, start_line=2)
-    assert text == ("class a():\n"
-                    "  self.b = 1\n"
-                    "  print(self.b)\n"
-                    "  \n"
-                    )
+    new_text = make_indent(editor, single_line=False, start_line=2)
+    assert new_text == expected
 
 
 def test_fix_indentation(code_editor_indent_bot):
@@ -112,6 +124,98 @@ def test_fix_indentation(code_editor_indent_bot):
     editor.redo()
     assert to_text_string(editor.toPlainText()) == fixed
     assert editor.document().isModified()
+
+
+def test_single_line_unindent(code_editor_indent_bot):
+    """Test unindentation in a single line."""
+    editor, qtbot = code_editor_indent_bot
+    text = ("class a():\n"
+            "  self.b = 1\n"
+            "print(self.b)\n"
+            "\n"
+            )
+    expected = ("class a():\n"
+                "self.b = 1\n"
+                "print(self.b)\n"
+                "\n"
+                )
+    editor.set_text(text)
+    # Indent line without spaces
+    new_text = make_unindent(editor, start_line=2)
+    assert new_text == expected
+
+
+def test_selection_unindent(code_editor_indent_bot):
+    """Test unindentation with selection of more than one line."""
+    editor, qtbot = code_editor_indent_bot
+    text = ("class a():\n"
+            "  self.b = 1\n"
+            "  print(self.b)\n"
+            "  \n"
+            )
+    expected = ("class a():\n"
+                "self.b = 1\n"
+                "print(self.b)\n"
+                "\n"
+                )
+    editor.set_text(text)
+    # Toggle manually commented code
+    new_text = make_unindent(editor, single_line=False, start_line=2)
+    assert new_text == expected
+
+
+def test_single_line_unindent_to_grid(code_editor_indent_bot):
+    """Test unindentation in a single line."""
+    editor, qtbot = code_editor_indent_bot
+    text = ("class a():\n"
+            "   self.b = 1\n"
+            "print(self.b)\n"
+            "\n"
+            )
+    expected = ("class a():\n"
+                "  self.b = 1\n"
+                "print(self.b)\n"
+                "\n"
+                )
+    editor.set_text(text)
+    # Indent line without spaces
+    new_text = make_unindent(editor, start_line=2)
+    assert new_text == expected
+
+    expected2 = ("class a():\n"
+                 "self.b = 1\n"
+                 "print(self.b)\n"
+                 "\n"
+                 )
+    new_text2 = make_unindent(editor, start_line=2)
+    assert new_text2 == expected2
+
+
+def test_selection_unindent_to_grid(code_editor_indent_bot):
+    """Test unindentation with selection of more than one line."""
+    editor, qtbot = code_editor_indent_bot
+    text = ("class a():\n"
+            "   self.b = 1\n"
+            "   print(self.b)\n"
+            "\n"
+            )
+    expected = ("class a():\n"
+                "  self.b = 1\n"
+                "  print(self.b)\n"
+                "\n"
+                )
+    editor.set_text(text)
+    # Toggle manually commented code
+    new_text = make_unindent(editor, single_line=False, start_line=2)
+    assert new_text == expected
+
+    expected2 = ("class a():\n"
+                 "self.b = 1\n"
+                 "print(self.b)\n"
+                 "\n"
+                 )
+    new_text2 = make_unindent(editor, single_line=False, start_line=2)
+    assert new_text2 == expected2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Improved the unindent behavior as suggested in https://github.com/spyder-ide/spyder/issues/5734#issuecomment-346209380

For a multiline selection, the lowest number of spaces is used

So assuming four spaces indentation level:
```
5 spaces
9 spaces
```

becomes:
```
4 spaces
8 spaces
```

Also,
```
5 spaces 
6 spaces
```

becomes:
```
4 spaces 
5 spaces
```

which next time becomes:
```
0 space
1 space
```

and stays as
```
0 space
1 space
```

Not sure what the actually expected behavior is here. One may consider first time aligning all rows to the next lower spacing multiple, so 
```
5 spaces
6 spaces
```

becomes
```
4 spaces
4 spaces
```

That require a bit more work though and I do not know if there are any obvious drawbacks with it.

Also added tests for unindent in general, which I do not think was there before. (Which lead to the question if tab and shift+tab are always reciprocal, I think not.) And rewrote the indent test code for easier copy-and-paste...

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #5734


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Oscar Gustafsson/@oscargus

<!--- Thanks for your help making Spyder better for everyone! --->
