### PR TITLE
PR: Add unambiguous file names to Breakpoints pane

### DIFF
--- a/spyder/plugins/breakpoints/plugin.py
+++ b/spyder/plugins/breakpoints/plugin.py
@@ -49,12 +49,12 @@ class Breakpoints(SpyderPluginWidget):
 
         path = osp.join(self.PLUGIN_PATH, self.IMG_PATH)
         self.icon = ima.icon('breakpoints', icon_path=path)
-    
+
     #------ SpyderPluginWidget API --------------------------------------------
     def get_plugin_title(self):
         """Return widget title"""
         return _("Breakpoints")
-    
+
     def get_plugin_icon(self):
         """Return widget icon"""
         return self.icon
@@ -85,7 +85,7 @@ class Breakpoints(SpyderPluginWidget):
         self.add_dockwidget()
 
         list_action = create_action(self, _("List breakpoints"),
-                                   triggered=self.show, icon=self.icon)
+                                    triggered=self.show, icon=self.icon)
         list_action.setEnabled(True)
         pos = self.main.debug_menu_actions.index('list_breakpoints')
         self.main.debug_menu_actions.insert(pos, list_action)

--- a/spyder/plugins/breakpoints/plugin.py
+++ b/spyder/plugins/breakpoints/plugin.py
@@ -46,6 +46,9 @@ class Breakpoints(SpyderPluginWidget):
         self.setLayout(layout)
 
         self.breakpoints.set_data()
+
+        path = osp.join(self.PLUGIN_PATH, self.IMG_PATH)
+        self.icon = ima.icon('breakpoints', icon_path=path)
     
     #------ SpyderPluginWidget API --------------------------------------------
     def get_plugin_title(self):
@@ -54,9 +57,8 @@ class Breakpoints(SpyderPluginWidget):
     
     def get_plugin_icon(self):
         """Return widget icon"""
-        path = osp.join(self.PLUGIN_PATH, self.IMG_PATH)
-        return ima.icon('profiler', icon_path=path)
-    
+        return self.icon
+
     def get_focus_widget(self):
         """
         Return the widget to give focus to when
@@ -83,7 +85,7 @@ class Breakpoints(SpyderPluginWidget):
         self.add_dockwidget()
 
         list_action = create_action(self, _("List breakpoints"),
-                                   triggered=self.show)
+                                   triggered=self.show, icon=self.icon)
         list_action.setEnabled(True)
         pos = self.main.debug_menu_actions.index('list_breakpoints')
         self.main.debug_menu_actions.insert(pos, list_action)

--- a/spyder/plugins/breakpoints/widgets/breakpointsgui.py
+++ b/spyder/plugins/breakpoints/widgets/breakpointsgui.py
@@ -33,7 +33,7 @@ from spyder.utils.sourcecode import disambiguate_fname
 # This is needed for testing this module as a stand alone script
 try:
     _ = get_translation("breakpoints", "spyder_breakpoints")
-except KeyError as error:
+except KeyError:
     import gettext
     _ = gettext.gettext
 
@@ -43,11 +43,12 @@ COL_FILE, COL_LINE, COL_CONDITION, COL_BLANK, COL_FULL = range(COLUMN_COUNT +
                                                                EXTRA_COLUMNS)
 COLUMN_HEADERS = (_("File"), _("Line"), _("Condition"), (""))
 
+
 class BreakpointTableModel(QAbstractTableModel):
     """
     Table model for breakpoints dictionary
-
     """
+
     def __init__(self, parent, data):
         QAbstractTableModel.__init__(self, parent)
         if data is None:
@@ -59,15 +60,18 @@ class BreakpointTableModel(QAbstractTableModel):
     def set_data(self, data):
         """Set model data"""
         self._data = data
-        keys = list(data.keys())
         self.breakpoints = []
-        for key in keys:
-            bp_list = data[key]
-            if bp_list:
-                for item in data[key]:
-                    # Store full file name in last position, which is not shown
-                    self.breakpoints.append((disambiguate_fname(keys, key),
-                                             item[0], item[1], "", key))
+        files = []
+        # Generate list of filenames with active breakpoints
+        for key in data.keys():
+            if data[key] and key not in files:
+                files.append(key)
+        # Insert items
+        for key in files:
+            for item in data[key]:
+                # Store full file name in last position, which is not shown
+                self.breakpoints.append((disambiguate_fname(files, key),
+                                         item[0], item[1], "", key))
         self.reset()
 
     def rowCount(self, qindex=QModelIndex()):
@@ -162,7 +166,7 @@ class BreakpointTableView(QTableView):
 
     def adjust_columns(self):
         """Resize three first columns to contents"""
-        for col in range(3):
+        for col in range(COLUMN_COUNT-1):
             self.resizeColumnToContents(col)
 
     def mouseDoubleClickEvent(self, event):

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -131,7 +131,7 @@ _qtaargs = {
     'breakpoint_transparent':  [('fa.circle',), {'color': 'darkred', 'opacity': 0.75, 'scale_factor': 0.9}],
     'breakpoint_big':          [('fa.circle',), {'color': '#cc0000', 'scale_factor': 0.9} ],
     'breakpoint_cond_big':     [('fa.question-circle',), {'color': '#cc0000', 'scale_factor': 0.9},],
-    'breakpoints':             [('fa.list-ul',), {'color': MAIN_FG_COLOR}],
+    'breakpoints':             [('mdi.dots-vertical',), {'color': MAIN_FG_COLOR}],
     'arrow_debugger':          [('mdi.arrow-right-bold',), {'color': '#3775a9', 'scale_factor': 2.0}],
     'debug':                   [('spyder.debug',), {'color': '#3775a9'}],
     'arrow-step-over':         [('spyder.step-forward',), {'color': '#3775a9'}],

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -131,6 +131,7 @@ _qtaargs = {
     'breakpoint_transparent':  [('fa.circle',), {'color': 'darkred', 'opacity': 0.75, 'scale_factor': 0.9}],
     'breakpoint_big':          [('fa.circle',), {'color': '#cc0000', 'scale_factor': 0.9} ],
     'breakpoint_cond_big':     [('fa.question-circle',), {'color': '#cc0000', 'scale_factor': 0.9},],
+    'breakpoints':             [('fa.list-ul',), {'color': MAIN_FG_COLOR}],
     'arrow_debugger':          [('mdi.arrow-right-bold',), {'color': '#3775a9', 'scale_factor': 2.0}],
     'debug':                   [('spyder.debug',), {'color': '#3775a9'}],
     'arrow-step-over':         [('spyder.step-forward',), {'color': '#3775a9'}],


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

When having breakpoints in files with the same name, it was hard to tell the difference. (Although I realized at a rather later stage that there was a tooltip hover on the file name with the full path.) This PR adds unambiguous file names to the Breakpoints pane.

![breakpoints](https://user-images.githubusercontent.com/8114497/62072064-1e71c600-b23e-11e9-94ee-978922e67f6b.png)

It should also be slightly more efficient as the name is only computed once per data update.

I also added/corrected an icon for the Breakpoints pane. After some deliberation, I thought that mdi-dots-vertical probably was the best I could find. Three stacked dots.

Earlier, it was the profiler icon, although it wasn't shown in the menu.

In addition, I right-aligned the line numbers (not shown in the screen shot), and refactored the code a bit, using constants for the different columns.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Oscar Gustafsson/@oscargus

<!--- Thanks for your help making Spyder better for everyone! --->
