### PR TITLE
PR: Enable edition only with double click (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -338,13 +338,14 @@ class CollectionsDelegate(QItemDelegate):
 
     def updateEditorGeometry(self, editor, option, index):
         """
-        Overriding method updateEditorGeometry
+        Overriding method updateEditorGeometry.
+
+        This is necessary to set the correct position of the QLineEdit
+        editor since option.rect doesn't have values -> QRect() and
+        makes the editor to be invisible (i.e. it has 0 as x, y, width
+        and height) when doing double click over a cell.
+        See spyder-ide/spyder#9945
         """
-        # Needed to set in the correct position the QLineEdit editor
-        # since option.rect doesn't have values -> QRect() and makes the editor
-        # to being invisible (has 0 as x, y, width and height)
-        # when doing double click over a cell
-        # See spyder-ide/spyder#9945
         table_view = editor.parent().parent()
         if isinstance(table_view, QTableView):
             row = index.row()

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -15,7 +15,7 @@ import datetime
 from qtpy.compat import to_qvariant
 from qtpy.QtCore import QDateTime, Qt, Signal, Slot
 from qtpy.QtWidgets import (QAbstractItemDelegate, QDateEdit, QDateTimeEdit,
-                            QItemDelegate, QLineEdit, QMessageBox)
+                            QItemDelegate, QLineEdit, QMessageBox, QTableView)
 
 # Local imports
 from spyder.config.base import _
@@ -345,14 +345,18 @@ class CollectionsDelegate(QItemDelegate):
         # to being invisible (has 0 as x, y, width and height)
         # when doing double click over a cell
         # See spyder-ide/spyder#9945
-        row = index.row()
-        column = index.column()
         table_view = editor.parent().parent()
-        y0 = table_view.rowViewportPosition(row)
-        x0 = table_view.columnViewportPosition(column)
-        width = table_view.columnWidth(column)
-        height = table_view.rowHeight(row)
-        editor.setGeometry(x0, y0, width, height)
+        if isinstance(table_view, QTableView):
+            row = index.row()
+            column = index.column()
+            y0 = table_view.rowViewportPosition(row)
+            x0 = table_view.columnViewportPosition(column)
+            width = table_view.columnWidth(column)
+            height = table_view.rowHeight(row)
+            editor.setGeometry(x0, y0, width, height)
+        else:
+            super(CollectionsDelegate, self).updateEditorGeometry(
+                editor, option, index)
 
 
 class ToggleColumnDelegate(CollectionsDelegate):

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -336,6 +336,24 @@ class CollectionsDelegate(QItemDelegate):
             raise RuntimeError("Unsupported editor widget")
         self.set_value(index, value)
 
+    def updateEditorGeometry(self, editor, option, index):
+        """
+        Overriding method updateEditorGeometry
+        """
+        # Needed to set in the correct position the QLineEdit editor
+        # since option.rect doesn't have values -> QRect() and makes the editor
+        # to being invisible (has 0 as x, y, width and height)
+        # when doing double click over a cell
+        # See spyder-ide/spyder#9945
+        row = index.row()
+        column = index.column()
+        table_view = editor.parent().parent()
+        y0 = table_view.rowViewportPosition(row)
+        x0 = table_view.columnViewportPosition(column)
+        width = table_view.columnWidth(column)
+        height = table_view.rowHeight(row)
+        editor.setGeometry(x0, y0, width, height)
+
 
 class ToggleColumnDelegate(CollectionsDelegate):
     """ToggleColumn Item Delegate"""

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -1115,10 +1115,6 @@ class CollectionsEditorTableView(BaseTableView):
 
         self.delegate = CollectionsDelegate(self)
         self.setItemDelegate(self.delegate)
-        self.setSelectionBehavior(QAbstractItemView.SelectItems)
-        self.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.setEditTriggers(QAbstractItemView.AllEditTriggers)
-        self.setSortingEnabled(True)
 
         self.setup_table()
         self.menu = self.setup_menu(minmax)
@@ -1422,10 +1418,6 @@ class RemoteCollectionsEditorTableView(BaseTableView):
         self.delegate = RemoteCollectionsDelegate(self)
         self.delegate.sig_free_memory.connect(self.sig_free_memory.emit)
         self.setItemDelegate(self.delegate)
-        self.setSelectionBehavior(QAbstractItemView.SelectItems)
-        self.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.setEditTriggers(QAbstractItemView.AllEditTriggers)
-        self.setSortingEnabled(True)
 
         self.setup_table()
         self.menu = self.setup_menu(minmax)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Set the edition of items in the Variable Explorer only with double click


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9945 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
