### PR TITLE
PR: Improve support for Kite on macOS

### DIFF
--- a/spyder/plugins/completion/kite/plugin.py
+++ b/spyder/plugins/completion/kite/plugin.py
@@ -85,16 +85,17 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
         is checked first and if nothing is found or an error occurs, the
         default path is used.
         """
-        path = '/Applications/Kite.app'
+        default_path = '/Applications/Kite.app'
+        path = None
         try:
             out = subprocess.check_output(
                 ['mdfind', 'kMDItemCFBundleIdentifier="com.kite.Kite"'])
             installed = len(out) > 0
             path = (out.decode('utf-8', 'replace').strip().split('\n')[0]
-                    if installed else None)
+                    if installed else default_path)
         except (subprocess.CalledProcessError, UnicodeDecodeError) as ex:
             # Use the default path
-            path = '/Applications/Kite.app'
+            path = default_path
         finally:
             return path
 

--- a/spyder/plugins/completion/kite/plugin.py
+++ b/spyder/plugins/completion/kite/plugin.py
@@ -80,7 +80,12 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
         return osp.exists(osp.realpath(path)), path
 
     def _locate_kite_darwin(self):
-        path = ''
+        """
+        Looks up where Kite.app is installed on macOS systems. The bundle ID
+        is checked first and if nothing is found or an error occurs, the
+        default path is used.
+        """
+        path = '/Applications/Kite.app'
         try:
             out = subprocess.check_output(
                 ['mdfind', 'kMDItemCFBundleIdentifier="com.kite.Kite"'])

--- a/spyder/plugins/completion/kite/plugin.py
+++ b/spyder/plugins/completion/kite/plugin.py
@@ -9,6 +9,7 @@
 # Standard library imports
 import os
 import os.path as osp
+import subprocess
 import sys
 import logging
 import functools
@@ -75,15 +76,35 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
         elif sys.platform.startswith('linux'):
             path = osp.expanduser('~/.local/share/kite/kited')
         elif sys.platform == 'darwin':
-            path = '/opt/kite/kited'
+            path = self._locate_kite_darwin()
         return osp.exists(osp.realpath(path)), path
+
+    def _locate_kite_darwin(self):
+        path = ''
+        try:
+            out = subprocess.check_output(
+                ['mdfind', 'kMDItemCFBundleIdentifier="com.kite.Kite"'])
+            installed = len(out) > 0
+            path = (out.decode('utf-8', 'replace').strip().split('\n')[0]
+                    if installed else None)
+        except (subprocess.CalledProcessError, UnicodeDecodeError) as ex:
+            # Use the default path
+            path = '/Applications/Kite.app'
+        finally:
+            return path
 
     def _check_if_kite_running(self):
         running = False
         for proc in psutil.process_iter(attrs=['pid', 'name', 'username']):
-            if 'kited' in proc.name():
+            if self._is_proc_kite(proc):
                 logger.debug('Kite process already '
                              'running with PID {0}'.format(proc.pid))
                 running = True
                 break
         return running
+
+    def _is_proc_kite(self, proc):
+        if os.name == 'nt' or sys.platform.startswith('linux'):
+            return 'kited' in proc.name()
+        else:
+            return proc.name() == 'Kite'

--- a/spyder/plugins/completion/kite/plugin.py
+++ b/spyder/plugins/completion/kite/plugin.py
@@ -79,7 +79,18 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
             path = self._locate_kite_darwin()
         return osp.exists(osp.realpath(path)), path
 
-    def _locate_kite_darwin(self):
+    def _check_if_kite_running(self):
+        running = False
+        for proc in psutil.process_iter(attrs=['pid', 'name', 'username']):
+            if self._is_proc_kite(proc):
+                logger.debug('Kite process already '
+                             'running with PID {0}'.format(proc.pid))
+                running = True
+                break
+        return running
+
+    @staticmethod
+    def _locate_kite_darwin():
         """
         Looks up where Kite.app is installed on macOS systems. The bundle ID
         is checked first and if nothing is found or an error occurs, the
@@ -99,17 +110,8 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
         finally:
             return path
 
-    def _check_if_kite_running(self):
-        running = False
-        for proc in psutil.process_iter(attrs=['pid', 'name', 'username']):
-            if self._is_proc_kite(proc):
-                logger.debug('Kite process already '
-                             'running with PID {0}'.format(proc.pid))
-                running = True
-                break
-        return running
-
-    def _is_proc_kite(self, proc):
+    @staticmethod
+    def _is_proc_kite(proc):
         if os.name == 'nt' or sys.platform.startswith('linux'):
             return 'kited' in proc.name()
         else:

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -65,7 +65,14 @@ def is_program_installed(basename):
     Return program absolute path if installed in PATH.
 
     Otherwise, return None
+
+    On macOS systems, a .app is considered installed if
+    it exists.
     """
+    if (sys.platform == 'darwin' and basename.endswith('.app') and
+            osp.exists(basename)):
+        return basename
+
     for path in os.environ["PATH"].split(os.pathsep):
         abspath = osp.join(path, basename)
         if osp.isfile(abspath):
@@ -89,6 +96,24 @@ def find_program(basename):
         path = is_program_installed(name)
         if path:
             return path
+
+
+def get_full_command_for_program(path):
+    """
+    Return the list of tokens necessary to open the program
+    at a given path.
+
+    On macOS systems, this function prefixes .app paths with
+    'open -a', which is necessary to run the application.
+
+    On all other OS's, this function has no effect.
+
+    :str path: The path of the program to run.
+    :return: The list of tokens necessary to run the program.
+    """
+    if sys.platform == 'darwin' and path.endswith('.app'):
+        return ['open', '-a', path]
+    return [path]
 
 
 def alter_subprocess_kwargs_by_platform(**kwargs):
@@ -178,7 +203,7 @@ def run_program(program, args=None, **subprocess_kwargs):
     if not fullcmd:
         raise ProgramError("Program %s was not found" % program)
     # As per subprocess, we make a complete list of prog+args
-    fullcmd = [fullcmd] + (args or [])
+    fullcmd = get_full_command_for_program(fullcmd) + (args or [])
     for stream in ['stdin', 'stdout', 'stderr']:
         subprocess_kwargs.setdefault(stream, subprocess.PIPE)
     subprocess_kwargs = alter_subprocess_kwargs_by_platform(


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

This PR handles Kite on macOS systems properly. Specifically, it fixes the lookup for the Kite application and it also adds the functionality to open `.app` applications properly (which is then used to run Kite).

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->

* Modify `KiteCompletionPlugin` to properly check for the Kite app on macOS
* Implement support to open `.app` applications in `spyder.util.programs`

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
@its-dhung
<!--- Thanks for your help making Spyder better for everyone! --->
