### PR TITLE
PR: Fix tests in Travis

### DIFF
--- a/continuous_integration/azure/install.bat
+++ b/continuous_integration/azure/install.bat
@@ -23,10 +23,6 @@ if %USE_CONDA% == yes (
     :: Install qtconsole from Github
     pip install git+https://github.com/jupyter/qtconsole.git
     if errorlevel 1 exit 1
-
-    :: Downgrade Jedi because 0.14 broke the PyLS
-    pip install jedi==0.13.3
-    if errorlevel 1 exit 1
 )
 
 :: Install spyder-kernels from master

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -29,6 +29,12 @@ if [ "$USE_CONDA" = "yes" ]; then
     # Install spyder-kernels from Github with no deps
     pip install -q --no-deps git+https://github.com/spyder-ide/spyder-kernels
 else
+    # Downgrade to Python 3.7.3 because 3.7.4 is not pulling
+    # wheels for all packages
+    if [ "$PYTHON_VERSION" = "3.7" ]; then
+        conda install -q -y python=3.7.3
+    fi
+
     # Install Spyder and its dependencies from our setup.py
     pip install -e .[test]
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -33,7 +33,7 @@ else
     pip install -e .[test]
 
     # Downgrade PyQt5 to 5.11 in Circle.
-    # Else our tests gives segfaults
+    # Else our tests give segfaults
     if [ "$CIRCLECI" = "true" ]; then
         pip install pyqt5==5.11.*
     fi
@@ -49,9 +49,6 @@ else
 
     # Install spyder-kernels from Github
     pip install -q git+https://github.com/spyder-ide/spyder-kernels
-
-    # Downgrade Jedi because 0.14 broke the PyLS
-    pip install jedi==0.13.3
 
     # Install coveralls
     pip install -q coveralls


### PR DESCRIPTION
Tests started to fail with a new version of Python 3.7 released by Anaconda (pip is not pulling wheels on Linux for all packages with Python 3.7.4).

The fix was to downgrade to 3.7.3 in the meantime.