### PR TITLE
PR: Drop support for Python 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,11 @@ to install them separately in those cases.
 ### Build dependencies
 
 When installing Spyder from its source package, the only requirement is to have
-a Python version greater than 2.7 or 3.4 (Python <=3.3 is no longer supported).
+a Python version equal or greater than 3.5 or 2.7.
 
 ### Runtime dependencies
 
-* **Python** 2.7 or 3.4+: The core language Spyder is written in and for.
+* **Python** 3.5+ or 2.7: The core language Spyder is written in and for.
 * **PyQt5** 5.6+: Python bindings for Qt, used for Spyder's GUI.
 * **qtconsole** 4.5.0+: Enhanced Python interpreter.
 * **Python-language-server**: Editor code completion, calltips

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ PY3 = sys.version_info[0] == 3
 # Taken from the notebook setup.py -- Modified BSD License
 #==============================================================================
 v = sys.version_info
-if v[:2] < (2, 7) or (v[0] >= 3 and v[:2] < (3, 4)):
-    error = "ERROR: Spyder requires Python version 2.7 or 3.4 and above."
+if v[:2] < (2, 7) or (v[0] >= 3 and v[:2] < (3, 5)):
+    error = "ERROR: Spyder requires Python version 2.7 or 3.5 and above."
     print(error, file=sys.stderr)
     sys.exit(1)
 


### PR DESCRIPTION
Python 3.4 reached end of life several months ago, so there's no need to keep supporting it.