### PR TITLE
PR: Fix "Projects > Recent" menu entries

### DIFF
--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -209,6 +209,12 @@ class Projects(SpyderPluginWidget):
                 self._toggle_view_action.setChecked(True)
             self._visibility_changed(True)
 
+    def build_opener(self, project):
+        """Build function opening passed project"""
+        def opener(*args, **kwargs):
+            self.open_project(path=project)
+        return opener
+
     # ------ Public API -------------------------------------------------------
     def setup_menu_actions(self):
         """Setup and update the menu actions."""
@@ -222,14 +228,15 @@ class Projects(SpyderPluginWidget):
                         self,
                         name,
                         icon=ima.icon('project'),
-                        triggered=(
-                            lambda _, p=project: self.open_project(path=p))
-                        )
+                        triggered=self.build_opener(project),
+                    )
                     self.recent_projects_actions.append(action)
                 else:
                     self.recent_projects.remove(project)
-            self.recent_projects_actions += [None,
-                                             self.clear_recent_projects_action]
+            self.recent_projects_actions += [
+                None,
+                self.clear_recent_projects_action,
+            ]
         else:
             self.recent_projects_actions = [self.clear_recent_projects_action]
         add_actions(self.recent_project_menu, self.recent_projects_actions)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Fixed opening any recent project except 1st

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
The root of problem was incorrect work with closures. On each iteration lambda was created, but it used `project` variable reference defined outside lambda. So, all lambda store the same reference to variable which changes each iteration. After stopping iteration it stores last iteration value



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10014


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
