### PR TITLE
PR: Solve some issues with QString compatibility with emojis

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -75,7 +75,7 @@ from spyder.plugins.completion.decorators import (
     request, handles, class_register)
 from spyder.plugins.editor.widgets.base import TextEditBaseWidget
 from spyder.plugins.outlineexplorer.languages import PythonCFM
-from spyder.py3compat import PY2, to_text_string
+from spyder.py3compat import PY2, to_text_string, is_string, QString_len
 from spyder.utils import encoding, programs, sourcecode
 from spyder.utils import icon_manager as ima
 from spyder.utils import syntaxhighlighters as sh
@@ -1536,7 +1536,7 @@ class CodeEditor(TextEditBaseWidget):
         extra_selections = []
         self.found_results = []
         for match in regobj.finditer(text):
-            pos1, pos2 = match.span()
+            pos1, pos2 = sh.get_span(match)
             selection = TextDecoration(self.textCursor())
             selection.format.setBackground(self.found_results_color)
             selection.cursor.setPosition(pos1)
@@ -2255,7 +2255,7 @@ class CodeEditor(TextEditBaseWidget):
         Remove suffix from current line (there should not be any selection)
         """
         cursor = self.textCursor()
-        cursor.setPosition(cursor.position()-len(suffix),
+        cursor.setPosition(cursor.position() - QString_len(suffix),
                            QTextCursor.KeepAnchor)
         if to_text_string(cursor.selectedText()) == suffix:
             cursor.removeSelectedText()
@@ -3412,7 +3412,7 @@ class CodeEditor(TextEditBaseWidget):
         while match:
             for key, value in list(match.groupdict().items()):
                 if value:
-                    start, end = match.span()
+                    start, end = sh.get_span(match)
 
                     # Get cursor selection if pattern found
                     cursor = self.cursorForPosition(coordinates)
@@ -3636,7 +3636,7 @@ class CodeEditor(TextEditBaseWidget):
         strip = text.rstrip()
         # I think all the characters we can strip are in a single QChar.
         # Therefore there shouldn't be any length problems.
-        N_strip = len(text) - len(strip)
+        N_strip = QString_len(text[len(strip):])
 
         if N_strip > 0:
             # Select text to remove

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -3634,10 +3634,13 @@ class CodeEditor(TextEditBaseWidget):
         # remove spaces on the right
         text = cursor.selectedText()
         strip = text.rstrip()
+        # I think all the characters we can strip are in a single QChar.
+        # Therefore there shouldn't be any length problems.
+        N_strip = len(text) - len(strip)
 
-        if line_range[0] + len(strip) < line_range[1]:
+        if N_strip > 0:
             # Select text to remove
-            cursor.setPosition(line_range[0] + len(strip))
+            cursor.setPosition(line_range[1] - N_strip)
             cursor.setPosition(line_range[1],
                                QTextCursor.KeepAnchor)
             cursor.removeSelectedText()
@@ -3645,7 +3648,7 @@ class CodeEditor(TextEditBaseWidget):
             # Correct last change position
             self.last_change_position = line_range[1]
             self.last_position = self.textCursor().position()
-            return line_range[1] - (line_range[0] + len(strip))
+            return N_strip
         return 0
 
     def mouseMoveEvent(self, event):

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -75,13 +75,14 @@ from spyder.plugins.completion.decorators import (
     request, handles, class_register)
 from spyder.plugins.editor.widgets.base import TextEditBaseWidget
 from spyder.plugins.outlineexplorer.languages import PythonCFM
-from spyder.py3compat import PY2, to_text_string, is_string, QString_len
+from spyder.py3compat import PY2, to_text_string, is_string
 from spyder.utils import encoding, programs, sourcecode
 from spyder.utils import icon_manager as ima
 from spyder.utils import syntaxhighlighters as sh
 from spyder.utils.qthelpers import (add_actions, create_action, file_uri,
                                     mimedata2url)
 from spyder.utils.vcs import get_git_remotes, remote_to_url
+from spyder.utils.qstringhelpers import qstring_length
 
 
 try:
@@ -2255,7 +2256,7 @@ class CodeEditor(TextEditBaseWidget):
         Remove suffix from current line (there should not be any selection)
         """
         cursor = self.textCursor()
-        cursor.setPosition(cursor.position() - QString_len(suffix),
+        cursor.setPosition(cursor.position() - qstring_length(suffix),
                            QTextCursor.KeepAnchor)
         if to_text_string(cursor.selectedText()) == suffix:
             cursor.removeSelectedText()
@@ -3636,7 +3637,7 @@ class CodeEditor(TextEditBaseWidget):
         strip = text.rstrip()
         # I think all the characters we can strip are in a single QChar.
         # Therefore there shouldn't be any length problems.
-        N_strip = QString_len(text[len(strip):])
+        N_strip = qstring_length(text[len(strip):])
 
         if N_strip > 0:
             # Select text to remove

--- a/spyder/plugins/editor/widgets/tests/test_codeeditor.py
+++ b/spyder/plugins/editor/widgets/tests/test_codeeditor.py
@@ -137,6 +137,10 @@ def test_editor_log_lsp_handle_errors(editorbot, capsys):
          'def fun():\n    """fun\n\n    ',
          [Qt.Key_Enter, Qt.Key_Enter],
          False),
+        ("('🚫')",
+         "('🚫')\n",
+         [Qt.Key_Enter],
+         True),
     ])
 def test_editor_rstrip_keypress(
         editorbot, input_text, expected_text, keys, strip_all):

--- a/spyder/plugins/editor/widgets/tests/test_codeeditor.py
+++ b/spyder/plugins/editor/widgets/tests/test_codeeditor.py
@@ -12,7 +12,7 @@ import pytest
 
 # Local imports
 from spyder.plugins.editor.widgets.editor import codeeditor
-from spyder.py3compat import PY3
+from spyder.py3compat import PY2, PY3
 
 
 # --- Fixtures
@@ -86,6 +86,7 @@ def test_editor_log_lsp_handle_errors(editorbot, capsys):
     assert test_1 or test_2
 
 
+@pytest.mark.skipif(PY2, reason="Python 2 strings don't have attached encoding.")
 @pytest.mark.parametrize(
     "input_text, expected_text, keys, strip_all",
     [

--- a/spyder/py3compat.py
+++ b/spyder/py3compat.py
@@ -306,21 +306,5 @@ else:
     TimeoutError = TimeoutError
 
 
-def QString_len(text):
-    """
-    Tries to compute what the length of an utf16-encoded QString would be.
-    """
-    if PY2:
-        # I don't know what this is encoded in, so there in nothing I can do.
-        return len(text)
-    utf16_text = text.encode('utf16')
-    length = len(utf16_text) // 2
-    # Remove Byte order mark.
-    # TODO: All unicode Non-characters should be removed
-    if utf16_text[:2] in [b'\xff\xfe', b'\xff\xff', b'\xfe\xff']:
-        length -= 1
-    return length
-
-
 if __name__ == '__main__':
     pass

--- a/spyder/py3compat.py
+++ b/spyder/py3compat.py
@@ -305,5 +305,22 @@ if PY2:
 else:
     TimeoutError = TimeoutError
 
+
+def QString_len(text):
+    """
+    Tries to compute what the length of an utf16-encoded QString would be.
+    """
+    if PY2:
+        # I don't know what this is encoded in, so there in nothing I can do.
+        return len(text)
+    utf16_text = text.encode('utf16')
+    length = len(utf16_text) // 2
+    # Remove Byte order mark.
+    # TODO: All unicode Non-characters should be removed
+    if utf16_text[:2] in [b'\xff\xfe', b'\xff\xff', b'\xfe\xff']:
+        length -= 1
+    return length
+
+
 if __name__ == '__main__':
     pass

--- a/spyder/utils/qstringhelpers.py
+++ b/spyder/utils/qstringhelpers.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""QString compatibility."""
+
+from spyder.py3compat import PY2
+
+
+def qstring_length(text):
+    """
+    Tries to compute what the length of an utf16-encoded QString would be.
+    """
+    if PY2:
+        # I don't know what this is encoded in, so there is nothing I can do.
+        return len(text)
+    utf16_text = text.encode('utf16')
+    length = len(utf16_text) // 2
+    # Remove Byte order mark.
+    # TODO: All unicode Non-characters should be removed
+    if utf16_text[:2] in [b'\xff\xfe', b'\xff\xff', b'\xfe\xff']:
+        length -= 1
+    return length

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -511,7 +511,7 @@ class PythonSH(BaseSH):
         self.outline_explorer_data_update_timer.timeout.connect(
             self.sig_outline_explorer_data_changed)
 
-    def highlight_match(self, text, match, key, offset,
+    def highlight_match(self, text, match, key, value, offset,
                         state, import_stmt, oedata):
         """Highlight a single match."""
         start, end = get_span(match, key)
@@ -619,14 +619,17 @@ class PythonSH(BaseSH):
 
         oedata = None
         import_stmt = None
-        state = self.NORMAL
+
         self.setFormat(0, QString_len(text), self.formats["normal"])
+
+        state = self.NORMAL
         match = self.PROG.search(text)
         while match:
             for key, value in list(match.groupdict().items()):
                 if value:
                     state, import_stmt, oedata = self.highlight_match(
-                        text, match, key, offset, state, import_stmt, oedata)
+                        text, match, key, value, offset,
+                        state, import_stmt, oedata)
 
             match = self.PROG.search(text, match.end())
 

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -102,6 +102,15 @@ for key, value in CUSTOM_EXTENSION_LEXER.items():
 #==============================================================================
 # Auxiliary functions
 #==============================================================================
+def get_span(match, key=None):
+    if key is not None:
+        start, end = match.span(key)
+    else:
+        start, end = match.span()
+    start = QString_len(match.string[:start])
+    end = QString_len(match.string[:end])
+    return start, end
+
 def get_color_scheme(name):
     """Get a color scheme from config using its name"""
     name = name.lower()
@@ -311,7 +320,7 @@ class BaseSH(QSyntaxHighlighter):
         while match:
             for __, value in list(match.groupdict().items()):
                 if value:
-                    start, end = match.span()
+                    start, end = get_span(match)
                     start = max([0, start + offset])
                     end = max([0, end + offset])
                     font = self.format(start)
@@ -331,20 +340,20 @@ class BaseSH(QSyntaxHighlighter):
             format_trailing = self.formats.get("trailing", None)
             match = self.BLANKPROG.search(text, offset)
             while match:
-                start, end = match.span()
+                start, end = get_span(match)
                 start = max([0, start+offset])
                 end = max([0, end+offset])
                 # Format trailing spaces at the end of the line.
-                if end == len(text) and format_trailing is not None:
-                    self.setFormat(start, end, format_trailing)
+                if end == QString_len(text) and format_trailing is not None:
+                    self.setFormat(start, end - start, format_trailing)
                 # Format leading spaces, e.g. indentation.
                 if start == 0 and format_leading is not None:
-                    self.setFormat(start, end, format_leading)
+                    self.setFormat(start, end - start, format_leading)
                 format = self.format(start)
                 color_foreground = format.foreground().color()
                 alpha_new = self.BLANK_ALPHA_FACTOR * color_foreground.alphaF()
                 color_foreground.setAlphaF(alpha_new)
-                self.setFormat(start, end-start, color_foreground)
+                self.setFormat(start, end - start, color_foreground)
                 match = self.BLANKPROG.search(text, match.end())
 
     def highlight_extras(self, text, offset=0):
@@ -378,14 +387,14 @@ class GenericSH(BaseSH):
     def highlight_block(self, text):
         """Implement highlight using regex defined in children classes."""
         text = to_text_string(text)
-        self.setFormat(0, len(text), self.formats["normal"])
+        self.setFormat(0, QString_len(text), self.formats["normal"])
 
         match = self.PROG.search(text)
         index = 0
         while match:
             for key, value in list(match.groupdict().items()):
                 if value:
-                    start, end = match.span(key)
+                    start, end = get_span(match, key)
                     index += end-start
                     self.setFormat(start, end-start, self.formats[key])
 
@@ -532,7 +541,7 @@ class PythonSH(BaseSH):
         while match:
             for key, value in list(match.groupdict().items()):
                 if value:
-                    start, end = match.span(key)
+                    start, end = get_span(match, key)
                     start = max([0, start+offset])
                     end = max([0, end+offset])
                     length = QString_len(value)
@@ -570,7 +579,7 @@ class PythonSH(BaseSH):
                                 if cell_head == '':
                                     oedata.cell_level = 0
                                 else:
-                                    oedata.cell_level = len(cell_head) - 2
+                                    oedata.cell_level = QString_len(cell_head) - 2
                                 oedata.fold_level = start
                                 oedata.def_type = OutlineExplorerData.CELL
                                 def_name = get_code_cell_name(text)
@@ -586,14 +595,14 @@ class PythonSH(BaseSH):
                             if value in ("def", "class"):
                                 match1 = self.IDPROG.match(text, end)
                                 if match1:
-                                    start1, end1 = match1.span(1)
+                                    start1, end1 = get_span(match1, 1)
                                     self.setFormat(start1, end1-start1,
                                                    self.formats["definition"])
                                     oedata = OutlineExplorerData(
                                         self.currentBlock())
                                     oedata.text = to_text_string(text)
-                                    oedata.fold_level = (len(text)
-                                                         - len(text.lstrip()))
+                                    oedata.fold_level = (QString_len(text)
+                                                         - QString_len(text.lstrip()))
                                     oedata.def_type = self.DEF_TYPES[
                                                         to_text_string(value)]
                                     oedata.def_name = text[start1:end1]
@@ -615,15 +624,15 @@ class PythonSH(BaseSH):
                                 # if in a comment; cheap approximation to the
                                 # truth
                                 if '#' in text:
-                                    endpos = text.index('#')
+                                    endpos = QString_len(text[:text.index('#')])
                                 else:
-                                    endpos = len(text)
+                                    endpos = QString_len(text)
                                 while True:
                                     match1 = self.ASPROG.match(text, end,
                                                                endpos)
                                     if not match1:
                                         break
-                                    start, end = match1.span(1)
+                                    start, end = get_span(match1, 1)
                                     self.setFormat(start, length,
                                                    self.formats["keyword"])
 
@@ -763,7 +772,7 @@ class CppSH(BaseSH):
         """Implement highlight specific for C/C++."""
         text = to_text_string(text)
         inside_comment = tbh.get_state(self.currentBlock().previous()) == self.INSIDE_COMMENT
-        self.setFormat(0, len(text),
+        self.setFormat(0, QString_len(text),
                        self.formats["comment" if inside_comment else "normal"])
 
         match = self.PROG.search(text)
@@ -771,11 +780,11 @@ class CppSH(BaseSH):
         while match:
             for key, value in list(match.groupdict().items()):
                 if value:
-                    start, end = match.span(key)
+                    start, end = get_span(match, key)
                     index += end-start
                     if key == "comment_start":
                         inside_comment = True
-                        self.setFormat(start, len(text)-start,
+                        self.setFormat(start, QString_len(text)-start,
                                        self.formats["comment"])
                     elif key == "comment_end":
                         inside_comment = False
@@ -850,20 +859,20 @@ class FortranSH(BaseSH):
     def highlight_block(self, text):
         """Implement highlight specific for Fortran."""
         text = to_text_string(text)
-        self.setFormat(0, len(text), self.formats["normal"])
+        self.setFormat(0, QString_len(text), self.formats["normal"])
 
         match = self.PROG.search(text)
         index = 0
         while match:
             for key, value in list(match.groupdict().items()):
                 if value:
-                    start, end = match.span(key)
+                    start, end = get_span(match, key)
                     index += end-start
                     self.setFormat(start, end-start, self.formats[key])
                     if value.lower() in ("subroutine", "module", "function"):
                         match1 = self.IDPROG.match(text, end)
                         if match1:
-                            start1, end1 = match1.span(1)
+                            start1, end1 = get_span(match1, 1)
                             self.setFormat(start1, end1-start1,
                                            self.formats["definition"])
 
@@ -877,12 +886,12 @@ class Fortran77SH(FortranSH):
         """Implement highlight specific for Fortran77."""
         text = to_text_string(text)
         if text.startswith(("c", "C")):
-            self.setFormat(0, len(text), self.formats["comment"])
+            self.setFormat(0, QString_len(text), self.formats["comment"])
             self.highlight_extras(text)
         else:
             FortranSH.highlight_block(self, text)
             self.setFormat(0, 5, self.formats["comment"])
-            self.setFormat(73, max([73, len(text)]),
+            self.setFormat(73, max([73, QString_len(text)]),
                            self.formats["comment"])
 
 
@@ -925,15 +934,15 @@ class DiffSH(BaseSH):
         """Implement highlight specific Diff/Patch files."""
         text = to_text_string(text)
         if text.startswith("+++"):
-            self.setFormat(0, len(text), self.formats["keyword"])
+            self.setFormat(0, QString_len(text), self.formats["keyword"])
         elif text.startswith("---"):
-            self.setFormat(0, len(text), self.formats["keyword"])
+            self.setFormat(0, QString_len(text), self.formats["keyword"])
         elif text.startswith("+"):
-            self.setFormat(0, len(text), self.formats["string"])
+            self.setFormat(0, QString_len(text), self.formats["string"])
         elif text.startswith("-"):
-            self.setFormat(0, len(text), self.formats["number"])
+            self.setFormat(0, QString_len(text), self.formats["number"])
         elif text.startswith("@"):
-            self.setFormat(0, len(text), self.formats["builtin"])
+            self.setFormat(0, QString_len(text), self.formats["builtin"])
 
         self.highlight_extras(text)
 
@@ -1025,35 +1034,35 @@ class BaseWebSH(BaseSH):
         previous_state = tbh.get_state(self.currentBlock().previous())
 
         if previous_state == self.COMMENT:
-            self.setFormat(0, len(text), self.formats["comment"])
+            self.setFormat(0, QString_len(text), self.formats["comment"])
         else:
             previous_state = self.NORMAL
-            self.setFormat(0, len(text), self.formats["normal"])
+            self.setFormat(0, QString_len(text), self.formats["normal"])
 
         tbh.set_state(self.currentBlock(), previous_state)
         match = self.PROG.search(text)
 
         match_count = 0
-        n_characters = len(text)
+        n_characters = QString_len(text)
         # There should never be more matches than characters in the text.
         while match and match_count < n_characters:
             match_dict = match.groupdict()
             for key, value in list(match_dict.items()):
                 if value:
-                    start, end = match.span(key)
+                    start, end = get_span(match, key)
                     if previous_state == self.COMMENT:
                         if key == "multiline_comment_end":
                             tbh.set_state(self.currentBlock(), self.NORMAL)
-                            self.setFormat(end, len(text),
+                            self.setFormat(end, QString_len(text),
                                            self.formats["normal"])
                         else:
                             tbh.set_state(self.currentBlock(), self.COMMENT)
-                            self.setFormat(0, len(text),
+                            self.setFormat(0, QString_len(text),
                                            self.formats["comment"])
                     else:
                         if key == "multiline_comment_start":
                             tbh.set_state(self.currentBlock(), self.COMMENT)
-                            self.setFormat(start, len(text),
+                            self.setFormat(start, QString_len(text),
                                            self.formats["comment"])
                         else:
                             tbh.set_state(self.currentBlock(), self.NORMAL)
@@ -1148,20 +1157,20 @@ class MarkdownSH(BaseSH):
         previous_state = self.previousBlockState()
 
         if previous_state == self.CODE:
-            self.setFormat(0, len(text), self.formats["code"])
+            self.setFormat(0, QString_len(text), self.formats["code"])
         else:
             previous_state = self.NORMAL
-            self.setFormat(0, len(text), self.formats["normal"])
+            self.setFormat(0, QString_len(text), self.formats["normal"])
 
         self.setCurrentBlockState(previous_state)
 
         match = self.PROG.search(text)
         match_count = 0
-        n_characters = len(text)
+        n_characters = QString_len(text)
 
         while match and match_count< n_characters:
             for key, value in list(match.groupdict().items()):
-                start, end = match.span(key)
+                start, end = get_span(match, key)
 
                 if value:
                     previous_state = self.previousBlockState()
@@ -1169,7 +1178,7 @@ class MarkdownSH(BaseSH):
                     if previous_state == self.CODE:
                         if key == "code":
                             # Change to normal
-                            self.setFormat(0, len(text),
+                            self.setFormat(0, QString_len(text),
                                            self.formats["normal"])
                             self.setCurrentBlockState(self.NORMAL)
                         else:
@@ -1177,7 +1186,7 @@ class MarkdownSH(BaseSH):
                     else:
                         if key == "code":
                             # Change to code
-                            self.setFormat(0, len(text), self.formats["code"])
+                            self.setFormat(0, QString_len(text), self.formats["code"])
                             self.setCurrentBlockState(self.CODE)
                             continue
 
@@ -1327,7 +1336,7 @@ class PygmentsSH(BaseSH):
         # will have the correct behaviour of starting at 0.
         if self._allow_highlight:
             start = self.previousBlockState() + 1
-            end = start + len(text)
+            end = start + QString_len(text)
             for i, (fmt, letter) in enumerate(self._charlist[start:end]):
                 self.setFormat(i, 1, fmt)
             self.setCurrentBlockState(end)

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -31,7 +31,7 @@ from spyder import dependencies
 from spyder.config.base import _
 from spyder.config.manager import CONF
 from spyder.py3compat import (builtins, is_text_string, to_text_string, PY3,
-                              PY36_OR_MORE)
+                              PY36_OR_MORE, QString_len)
 from spyder.plugins.editor.utils.languages import CELL_LANGUAGES
 from spyder.plugins.editor.utils.editor import TextBlockHelper as tbh
 from spyder.plugins.editor.utils.editor import BlockUserData
@@ -525,7 +525,7 @@ class PythonSH(BaseSH):
         oedata = None
         import_stmt = None
 
-        self.setFormat(0, len(text), self.formats["normal"])
+        self.setFormat(0, QString_len(text), self.formats["normal"])
 
         state = self.NORMAL
         match = self.PROG.search(text)
@@ -535,28 +535,29 @@ class PythonSH(BaseSH):
                     start, end = match.span(key)
                     start = max([0, start+offset])
                     end = max([0, end+offset])
+                    length = QString_len(value)
                     if key == "uf_sq3string":
-                        self.setFormat(start, end-start,
+                        self.setFormat(start, length,
                                        self.formats["string"])
                         state = self.INSIDE_SQ3STRING
                     elif key == "uf_dq3string":
-                        self.setFormat(start, end-start,
+                        self.setFormat(start, length,
                                        self.formats["string"])
                         state = self.INSIDE_DQ3STRING
                     elif key == "uf_sqstring":
-                        self.setFormat(start, end-start,
+                        self.setFormat(start, length,
                                        self.formats["string"])
                         state = self.INSIDE_SQSTRING
                     elif key == "uf_dqstring":
-                        self.setFormat(start, end-start,
+                        self.setFormat(start, length,
                                        self.formats["string"])
                         state = self.INSIDE_DQSTRING
                     elif key in ["ufe_sqstring", "ufe_dqstring"]:
-                        self.setFormat(start, end-start,
+                        self.setFormat(start, length,
                                        self.formats["string"])
                         state = self.INSIDE_NON_MULTILINE_STRING
                     else:
-                        self.setFormat(start, end-start, self.formats[key])
+                        self.setFormat(start, length, self.formats[key])
                         if key == "comment":
                             if text.lstrip().startswith(self.cell_separators):
                                 oedata = OutlineExplorerData(
@@ -623,7 +624,7 @@ class PythonSH(BaseSH):
                                     if not match1:
                                         break
                                     start, end = match1.span(1)
-                                    self.setFormat(start, end-start,
+                                    self.setFormat(start, length,
                                                    self.formats["keyword"])
 
             match = self.PROG.search(text, match.end())

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -34,6 +34,7 @@ from spyder.config.gui import is_dark_interface
 from spyder.config.manager import CONF
 from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils import encoding, sourcecode, programs
+from spyder.utils import syntaxhighlighters as sh
 from spyder.utils.misc import get_error_match
 from spyder.widgets.arraybuilder import ArrayBuilderDialog
 
@@ -1019,7 +1020,7 @@ class BaseEditMixin(object):
             offset = max([cursor.selectionEnd(), cursor.selectionStart()])
             match = regobj.search(text, offset)
         if match:
-            pos1, pos2 = match.span()
+            pos1, pos2 = sh.get_span(match)
             fcursor = self.textCursor()
             fcursor.setPosition(pos1)
             fcursor.setPosition(pos2, QTextCursor.KeepAnchor)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Attempt to correct some of the problems that arise from the string length difference between `QString` and Python3 `str`

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Searching for `🚫`:
Before
![Screenshot 2019-08-19 at 18 19 37](https://user-images.githubusercontent.com/6740194/63286137-37a2eb00-c2af-11e9-9ac6-68c5047e8d88.png)
After
![Screenshot 2019-08-19 at 18 25 42](https://user-images.githubusercontent.com/6740194/63286138-37a2eb00-c2af-11e9-8e2f-0564c429026c.png)




### Issue(s) Resolved

Fixes #10039 almost completely

a = '💆🏽‍♂️' still gives:
![Screenshot 2019-08-19 at 18 31 13](https://user-images.githubusercontent.com/6740194/63286306-9d8f7280-c2af-11e9-80dd-df1eafa31e55.png) (Which I believe is a Qt bug and therefore can't be fixed here.)

And highlighting is broken in qtconsole.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
