### PR TITLE
PR: Avoid discarding file open event in macOS app

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3455,7 +3455,7 @@ def run_spyder(app, options, args):
         app.sig_open_external_file.connect(main.open_external_file)
         app._has_started = True
         if hasattr(app, '_pending_file_open'):
-            args = [*app._pending_file_open, *args]
+            args = app._pending_file_open + args
 
     # Open external files passed as args
     if args:

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3446,11 +3446,6 @@ def run_spyder(app, options, args):
         main.console.shell.interpreter.namespace['spy'] = \
                                                     Spy(app=app, window=main)
 
-    # Open external files passed as args
-    if args:
-        for a in args:
-            main.open_external_file(a)
-
     # Don't show icons in menus for Mac
     if sys.platform == 'darwin':
         QCoreApplication.setAttribute(Qt.AA_DontShowIconsInMenus, True)
@@ -3458,6 +3453,14 @@ def run_spyder(app, options, args):
     # Open external files with our Mac app
     if running_in_mac_app():
         app.sig_open_external_file.connect(main.open_external_file)
+        app._has_started = True
+        if hasattr(app, '_pending_file_open'):
+            args = [*app._pending_file_open, *args]
+
+    # Open external files passed as args
+    if args:
+        for a in args:
+            main.open_external_file(a)
 
     # To give focus again to the last focused widget after restoring
     # the window

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -24,7 +24,7 @@ from qtpy.QtWidgets import (QAction, QApplication, QHBoxLayout, QLabel,
                             QToolButton, QVBoxLayout, QWidget)
 
 # Local imports
-from spyder.config.base import get_image_path, running_in_mac_app
+from spyder.config.base import get_image_path, running_in_mac_app, MAC_APP_NAME
 from spyder.config.gui import get_shortcut, is_dark_interface
 from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils import icon_manager as ima
@@ -59,11 +59,16 @@ class MacApplication(QApplication):
 
     def __init__(self, *args):
         QApplication.__init__(self, *args)
+        self._has_started = False
+        self._pending_file_open = []
 
     def event(self, event):
         if event.type() == QEvent.FileOpen:
             fname = str(event.file())
-            self.sig_open_external_file.emit(fname)
+            if self._has_started:
+                self.sig_open_external_file.emit(fname)
+            elif MAC_APP_NAME not in fname:
+                self._pending_file_open.append(fname)
         return QApplication.event(self, event)
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Keep track of file open events that appen before the app is fully up. This is useful when the app is opened by clicking on a python file. The current behaviour is to open the app but not display the opened file.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
