### PR TITLE
PR: Prevent Kite error at startup if Kite is closed on macOS

### DIFF
--- a/spyder/plugins/completion/kite/plugin.py
+++ b/spyder/plugins/completion/kite/plugin.py
@@ -112,7 +112,16 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
 
     @staticmethod
     def _is_proc_kite(proc):
+        try:
+            # This is raising `ZombieProcess: psutil.ZombieProcess` on OSX
+            # if kite is not running.
+            name = proc.name()
+        except Exception:
+            name = ''
+
         if os.name == 'nt' or sys.platform.startswith('linux'):
-            return 'kited' in proc.name()
+            is_kite = 'kited' in name
         else:
-            return proc.name() == 'Kite'
+            is_kite = 'Kite' == name
+
+        return is_kite


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

If I close Kite on OSX and start spyder I was getting a `psutil.ZombieProcess` error.


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
