### PR TITLE
PR: Hide size/type columns and add show/hide actions to header (right click) and plugin opts.

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1655,14 +1655,14 @@ class MainWindow(QMainWindow):
         s_layout = {
             'widgets': [
                 # Column 0
-                [[explorer_file, explorer_project]],
+                [[explorer_project]],
                 # Column 1
                 [[editor]],
                 # Column 2
                 [[outline]],
                 # Column 3
                 [[help_plugin, explorer_variable, plots,     # Row 0
-                  helper, finder] + plugins,
+                  helper, explorer_file, finder] + plugins,
                  [console_int, console_ipy, history]]        # Row 1
                 ],
             'width fraction': [15,            # Column 0 width

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1655,18 +1655,18 @@ class MainWindow(QMainWindow):
         s_layout = {
             'widgets': [
                 # Column 0
-                [[explorer_project]],
+                [[explorer_file, explorer_project]],
                 # Column 1
                 [[editor]],
                 # Column 2
                 [[outline]],
                 # Column 3
                 [[help_plugin, explorer_variable, plots,     # Row 0
-                  helper, explorer_file, finder] + plugins,
+                  helper, finder] + plugins,
                  [console_int, console_ipy, history]]        # Row 1
                 ],
-            'width fraction': [ 5,            # Column 0 width
-                               55,            # Column 1 width
+            'width fraction': [15,            # Column 0 width
+                               45,            # Column 1 width
                                 5,            # Column 2 width
                                45],           # Column 3 width
             'height fraction': [[100],          # Column 0, row heights

--- a/spyder/plugins/explorer/plugin.py
+++ b/spyder/plugins/explorer/plugin.py
@@ -119,7 +119,7 @@ class Explorer(SpyderPluginWidget):
 
     def on_first_registration(self):
         """Action to be performed on first plugin registration"""
-        self.tabify(self.main.variableexplorer)
+        self.tabify(self.main.projects)
 
     def apply_plugin_settings(self, options):
         """Handle preference options update."""

--- a/spyder/plugins/explorer/plugin.py
+++ b/spyder/plugins/explorer/plugin.py
@@ -117,9 +117,11 @@ class Explorer(SpyderPluginWidget):
         self.fileexplorer.treewidget.refresh(new_path,
                                              force_current=force_current)
 
-    # def on_first_registration(self):
-    #     """Action to be performed on first plugin registration"""
-    #     self.tabify(self.main.projects)
+    def on_first_registration(self):
+        """Action to be performed on first plugin registration."""
+        # TODO: Remove this for spyder 5
+        # self.tabify(self.main.projects)
+        self.tabify(self.main.variableexplorer)
 
     def apply_plugin_settings(self, options):
         """Handle preference options update."""

--- a/spyder/plugins/explorer/plugin.py
+++ b/spyder/plugins/explorer/plugin.py
@@ -35,6 +35,8 @@ class Explorer(SpyderPluginWidget):
         """Initialization."""
         SpyderPluginWidget.__init__(self, parent)
 
+        visible_columns = self.get_option('visible_columns',
+                                          default=[0, 3])  # Name & Last Mod
         self.fileexplorer = ExplorerWidget(
             self,
             name_filters=self.get_option('name_filters'),
@@ -44,12 +46,11 @@ class Explorer(SpyderPluginWidget):
             single_click_to_open=self.get_option('single_click_to_open'),
             file_associations=self.get_option('file_associations',
                                               default={}),
+            visible_columns=visible_columns,
         )
-
         layout = QVBoxLayout()
         layout.addWidget(self.fileexplorer)
         self.setLayout(layout)
-
         self.fileexplorer.sig_option_changed.connect(
             self._update_config_options)
 

--- a/spyder/plugins/explorer/plugin.py
+++ b/spyder/plugins/explorer/plugin.py
@@ -117,9 +117,9 @@ class Explorer(SpyderPluginWidget):
         self.fileexplorer.treewidget.refresh(new_path,
                                              force_current=force_current)
 
-    def on_first_registration(self):
-        """Action to be performed on first plugin registration"""
-        self.tabify(self.main.projects)
+    # def on_first_registration(self):
+    #     """Action to be performed on first plugin registration"""
+    #     self.tabify(self.main.projects)
 
     def apply_plugin_settings(self, options):
         """Handle preference options update."""

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -1556,6 +1556,11 @@ class ExplorerWidget(QWidget):
         self.treewidget.chdir(getcwd_or_home())
         self.treewidget.common_actions += [None, icontext_action]
 
+        for i in [1, 2, 3]:
+            self.treewidget.hideColumn(i)
+        # self.treewidget.setHeaderHidden(True)
+
+
         button_previous.setDefaultAction(previous_action)
         previous_action.setEnabled(False)
 

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -1256,6 +1256,36 @@ class DirView(QTreeView):
             self.setRowHidden(index.row(), index.parent(), True)
 
 
+class DirNameProxyModel(QSortFilterProxyModel):
+    """
+    https://stackoverflow.com/a/20715646
+    """
+
+    def lessThan(self, left, right):
+        """"""
+        # If sorting by file names column
+        if self.sortColumn() == 0:
+            fsm = self.sourceModel()
+            asc = self.sortOrder() == Qt.AscendingOrder
+
+            leftFileInfo = fsm.fileInfo(left)
+            rightFileInfo = fsm.fileInfo(right)
+
+            # If DotAndDot move in the beginning
+            if fsm.data(left).toString() == '..':
+                return asc
+            if fsm.data(right).toString() == '..':
+                return not asc
+
+            # Move dirs upper
+            if not leftFileInfo.isDir() and rightFileInfo.isDir():
+                return not asc
+            if leftFileInfo.isDir() and not rightFileInfo.isDir():
+                return asc
+
+        return QSortFilterProxyModel.lessThan(self, left, right)
+
+
 class ProxyModel(QSortFilterProxyModel):
     """Proxy model: filters tree view"""
     def __init__(self, parent):
@@ -1298,6 +1328,7 @@ class ProxyModel(QSortFilterProxyModel):
             if index.data() == root_dir:
                 return osp.join(self.root_path, root_dir)
         return QSortFilterProxyModel.data(self, index, role)
+
 
 class FilteredDirView(DirView):
     """Filtered file/directory tree view"""

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -1409,6 +1409,7 @@ class ExplorerTreeWidget(DirView):
     set_previous_enabled = Signal(bool)
     set_next_enabled = Signal(bool)
     sig_open_dir = Signal(str)
+    sig_column_visibility_changed = Signal(int)
 
     def __init__(self, parent=None, show_cd_only=None):
         DirView.__init__(self, parent)
@@ -1593,6 +1594,13 @@ class ExplorerWidget(QWidget):
                             icon=ima.icon('ArrowUp'),
                             triggered=self.treewidget.go_to_parent_directory)
 
+        toggle_size_column_action = create_action(self, text=_('Size'),
+                                                  toggled=lambda: self.toggle_columns(1))
+        toggle_kind_column_action = create_action(self, text=_('Kind'),
+                                                  toggled=lambda: self.toggle_columns(2))
+        toggle_last_column_action = create_action(
+            self, text=_('Last modified'), toggled=lambda: self.toggle_columns(3))
+
         # Setup widgets
         self.treewidget.setup(
             name_filters=name_filters,
@@ -1600,11 +1608,13 @@ class ExplorerWidget(QWidget):
             single_click_to_open=single_click_to_open,
             file_associations=file_associations,
         )
-        self.treewidget.chdir(getcwd_or_home())
-        self.treewidget.common_actions += [None, icontext_action]
-
         for i in [1, 2]:
             self.treewidget.hideColumn(i)
+
+        self.treewidget.chdir(getcwd_or_home())
+        self.treewidget.common_actions += [None, icontext_action, None,
+            toggle_size_column_action, toggle_kind_column_action,
+            toggle_last_column_action]
 
         button_previous.setDefaultAction(previous_action)
         previous_action.setEnabled(False)
@@ -1636,6 +1646,10 @@ class ExplorerWidget(QWidget):
         self.treewidget.set_previous_enabled.connect(
                                                previous_action.setEnabled)
         self.treewidget.set_next_enabled.connect(next_action.setEnabled)
+
+    def toggle_columns(self, column):
+        """"""
+
 
     @Slot(bool)
     def toggle_icontext(self, state):

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -175,7 +175,7 @@ class DirView(QTreeView):
 
         # Signals
         header.customContextMenuRequested.connect(self.show_header_menu)
-        header.sectionClicked.connect(lambda x: self.sort_by_column())
+        # header.sectionClicked.connect(lambda x: self.sort_by_column())
 
     #---- Model
     def setup_fs_model(self):
@@ -197,7 +197,7 @@ class DirView(QTreeView):
         self.setAnimated(False)
         self.setSortingEnabled(True)
         self.sortByColumn(0, Qt.AscendingOrder)
-        self.setSortingEnabled(False)
+        # self.setSortingEnabled(False)
         self.fsmodel.modelReset.connect(self.reset_icon_provider)
         self.reset_icon_provider()
         # Disable the view of .spyproject.

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -219,9 +219,10 @@ class DirView(QTreeView):
                  _("Sort by last modified")]
         header_actions = []
         for column, item in enumerate(items):
+            order = int(not self._last_order)
             action = create_action(
                 self, item, None, None,
-                triggered=lambda __, col=column, order=int(not self._last_order):
+                triggered=lambda x, col=column, order=order:
                     self.sortByColumn(col, order),
             )
             if column == self._last_column:
@@ -229,7 +230,7 @@ class DirView(QTreeView):
                 action.setCheckable(True)
                 action.setChecked(True)
                 action.setDisabled(False)
-            
+
             header_actions.append(action)
 
         add_actions(self.menu_header, header_actions)

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -1300,36 +1300,6 @@ class DirView(QTreeView):
             self.setRowHidden(index.row(), index.parent(), True)
 
 
-class DirNameProxyModel(QSortFilterProxyModel):
-    """
-    https://stackoverflow.com/a/20715646
-    """
-
-    def lessThan(self, left, right):
-        """"""
-        # If sorting by file names column
-        if self.sortColumn() == 0:
-            fsm = self.sourceModel()
-            asc = self.sortOrder() == Qt.AscendingOrder
-
-            leftFileInfo = fsm.fileInfo(left)
-            rightFileInfo = fsm.fileInfo(right)
-
-            # If DotAndDot move in the beginning
-            if fsm.data(left).toString() == '..':
-                return asc
-            if fsm.data(right).toString() == '..':
-                return not asc
-
-            # Move dirs upper
-            if not leftFileInfo.isDir() and rightFileInfo.isDir():
-                return not asc
-            if leftFileInfo.isDir() and not rightFileInfo.isDir():
-                return asc
-
-        return QSortFilterProxyModel.lessThan(self, left, right)
-
-
 class ProxyModel(QSortFilterProxyModel):
     """Proxy model: filters tree view"""
     def __init__(self, parent):
@@ -1631,9 +1601,8 @@ class ExplorerWidget(QWidget):
         self.treewidget.chdir(getcwd_or_home())
         self.treewidget.common_actions += [None, icontext_action]
 
-        for i in [1, 2, 3]:
+        for i in [1, 2]:
             self.treewidget.hideColumn(i)
-        # self.treewidget.setHeaderHidden(True)
 
         button_previous.setDefaultAction(previous_action)
         previous_action.setEnabled(False)

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -175,7 +175,6 @@ class DirView(QTreeView):
 
         # Signals
         header.customContextMenuRequested.connect(self.show_header_menu)
-        # header.sectionClicked.connect(lambda x: self.sort_by_column())
 
     #---- Model
     def setup_fs_model(self):
@@ -213,28 +212,31 @@ class DirView(QTreeView):
         self._last_order = not self._last_order
 
     def show_header_menu(self, pos):
-        """"""
+        """Display header menu"""
         self.menu_header.clear()
-        items = [_('Sort by name'), _('Sort by size'), _("Sort by kind"),
-                 _("Sort by last modified")]
+        items = [_('Size'), _('Kind'), _("Last modified")]
         header_actions = []
-        for column, item in enumerate(items):
-            order = int(not self._last_order)
+        for idx, item in enumerate(items):
+            column = idx + 1
             action = create_action(
-                self, item, None, None,
-                triggered=lambda x, col=column, order=order:
-                    self.sortByColumn(col, order),
+                self,
+                item,
+                None,
+                None,
+                toggled=lambda x, c=column: self._toggle_column(c),
             )
-            if column == self._last_column:
-                action.setDisabled(True)
-                action.setCheckable(True)
-                action.setChecked(True)
-                action.setDisabled(False)
-
+            action.blockSignals(True)
+            action.setChecked(not self.isColumnHidden(column))
+            action.blockSignals(False)
             header_actions.append(action)
 
         add_actions(self.menu_header, header_actions)
         self.menu_header.popup(self.mapToGlobal(pos))
+
+    def _toggle_column(self, column):
+        """Toggle hidden status of column."""
+        is_hidden = self.isColumnHidden(column)
+        self.setColumnHidden(column, not is_hidden)
 
     def set_single_click_to_open(self, value):
         """Set single click to open items."""

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -219,7 +219,8 @@ class Projects(SpyderPluginWidget):
     # ------ Public API -------------------------------------------------------
     def on_first_registration(self):
         """Action to be performed on first plugin registration"""
-        self.tabify(self.main.explorer)
+        # TODO: Uncomment for Spyder 5
+        # self.tabify(self.main.explorer)
 
     def setup_menu_actions(self):
         """Setup and update the menu actions."""

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -217,6 +217,10 @@ class Projects(SpyderPluginWidget):
         return opener
 
     # ------ Public API -------------------------------------------------------
+    def on_first_registration(self):
+        """Action to be performed on first plugin registration"""
+        self.tabify(self.main.explorer)
+
     def setup_menu_actions(self):
         """Setup and update the menu actions."""
         self.recent_project_menu.clear()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

Hide size/type (or kind on mac) columns on file explorer and a add show/hide actions to header with right click (context menu) and plugin options.

![filexplorer](https://user-images.githubusercontent.com/3627835/64806196-42703900-d558-11e9-957a-46bd419e2b8d.gif)


<!--- Explain what you've done and why --->

- Explorer is now on the left and tabbed with the project explorer
- Size/Modified/Kind Columns have been removed
- Sorting by these columns is still possible via Context menu

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
