### PR TITLE
PR: Fix getting blocks by numbers in the editor

### DIFF
--- a/spyder/plugins/editor/extensions/docstring.py
+++ b/spyder/plugins/editor/extensions/docstring.py
@@ -71,7 +71,7 @@ class DocstringWriterExtension(object):
         """Get func def when the cursor is located on the first def line."""
         document = self.code_editor.document()
         cursor = QTextCursor(
-            document.findBlockByLineNumber(self.line_number_cursor - 1))
+            document.findBlockByNumber(self.line_number_cursor - 1))
 
         func_text = ''
         func_indent = ''

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -218,7 +218,7 @@ class ScrollFlagArea(Panel):
             # When the vertical scrollbar is not visible, the flags are
             # vertically aligned with the center of their corresponding
             # text block with no scaling.
-            block = self.editor.document().findBlockByLineNumber(value)
+            block = self.editor.document().findBlockByNumber(value)
             top = self.editor.blockBoundingGeometry(block).translated(
                       self.editor.contentOffset()).top()
             bottom = top + self.editor.blockBoundingRect(block).height()

--- a/spyder/plugins/editor/utils/editor.py
+++ b/spyder/plugins/editor/utils/editor.py
@@ -200,9 +200,13 @@ class TextHelper(object):
         except KeyError:
             pass
         else:
+            if block.isVisible():
+                return
             from spyder.plugins.editor.utils.folding import FoldScope
-            if not block.isVisible():
-                block = FoldScope.find_parent_scope(block)
+
+            while not block.isVisible():
+                # Find first uncolapsed block
+                block = FoldScope.find_parent_scope(block.previous())
                 if TextBlockHelper.is_collapsed(block):
                     folding_panel.toggle_fold_trigger(block)
 

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1605,10 +1605,10 @@ class CodeEditor(TextEditBaseWidget):
 
     def select_lines(self, linenumber_pressed, linenumber_released):
         """Select line(s) after a mouse press/mouse press drag event"""
-        find_block_by_line_number = self.document().findBlockByLineNumber
+        find_block_by_number = self.document().findBlockByNumber
         move_n_blocks = (linenumber_released - linenumber_pressed)
         start_line = linenumber_pressed
-        start_block = find_block_by_line_number(start_line - 1)
+        start_block = find_block_by_number(start_line - 1)
 
         cursor = self.textCursor()
         cursor.setPosition(start_block.position())
@@ -2475,7 +2475,7 @@ class CodeEditor(TextEditBaseWidget):
         """
         cursor = self.textCursor()
         block_nb = cursor.blockNumber()
-        prev_block = self.document().findBlockByLineNumber(block_nb-1)
+        prev_block = self.document().findBlockByNumber(block_nb-1)
         prevline = to_text_string(prev_block.text())
 
         indentation = re.match(r"\s*", prevline).group()

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2619,7 +2619,7 @@ class EditorStack(QWidget):
             else:
                 cell_name = oe_data.oedata.cell_index()
         else:
-            if block.firstLineNumber() == 0:
+            if block.blockNumber() == 0:
                 # There is no name for the first cell, refer by cell number
                 cell_name = 0
             else:

--- a/spyder/plugins/editor/widgets/tests/test_breakpoints.py
+++ b/spyder/plugins/editor/widgets/tests/test_breakpoints.py
@@ -126,7 +126,7 @@ def test_add_remove_breakpoint(code_editor_bot, mocker):
 
     # Test adding condition on line containing code.
     reset_emits(editor)
-    block = editor.document().findBlockByLineNumber(3)  # Block is one less.
+    block = editor.document().findBlockByNumber(3)  # Block is one less.
     arb(line_number=4, condition='a > 50')
     editor_assert_helper(editor, block, bp=True, bpc='a > 50', emits=True)
 
@@ -153,7 +153,7 @@ def test_add_remove_breakpoint_with_edit_condition(code_editor_bot, mocker):
     mocker.patch.object(debugger.QInputDialog, 'getText')
 
     linenumber = 5
-    block = editor.document().findBlockByLineNumber(linenumber - 1)
+    block = editor.document().findBlockByNumber(linenumber - 1)
 
     # Call with edit_breakpoint on line that has never had a breakpoint set.
     # Once a line has a breakpoint set, it remains in userData(), which results

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -102,7 +102,10 @@ def editor_folding_bot(base_editor_bot, qtbot):
             'class a():\n'  # fold-block level-0
             '    self.b = 1\n'
             '    print(self.b)\n'
-            '    \n'
+            '    def c():\n'
+            '        print(1)\n'
+            '        return\n'
+            '        \n'
             )
     finfo = editor_stack.new('foo.py', 'utf-8', text)
 
@@ -521,7 +524,7 @@ def test_unfold_when_searching(editor_folding_bot, qtbot):
 def test_unfold_goto(editor_folding_bot):
     editor_stack, editor, finder = editor_folding_bot
     folding_panel = editor.panels.get('FoldingPanel')
-    line_goto = editor.document().findBlockByLineNumber(3)
+    line_goto = editor.document().findBlockByLineNumber(5)
 
     # fold region
     block = editor.document().findBlockByLineNumber(1)
@@ -529,7 +532,7 @@ def test_unfold_goto(editor_folding_bot):
     assert not line_goto.isVisible()
 
     # unfolded when goto
-    editor.go_to_line(4)
+    editor.go_to_line(6)
     assert line_goto.isVisible()
 
 
@@ -838,4 +841,4 @@ def test_remove_autosave_file(editor_bot, mocker, qtbot):
 
 
 if __name__ == "__main__":
-    pytest.main()
+    pytest.main(['test_editor.py'])

--- a/spyder/plugins/outlineexplorer/tests/test_outline_explorer.py
+++ b/spyder/plugins/outlineexplorer/tests/test_outline_explorer.py
@@ -37,7 +37,7 @@ class testBlock():
     def __init__(self, line_number):
         self._line = line_number - 1
 
-    def firstLineNumber(self):
+    def blockNumber(self):
         return self._line
 
 

--- a/spyder/plugins/outlineexplorer/tests/test_outline_explorer_editor.py
+++ b/spyder/plugins/outlineexplorer/tests/test_outline_explorer_editor.py
@@ -22,7 +22,7 @@ class testBlock():
     def __init__(self, line_number):
         self._line = line_number - 1
 
-    def firstLineNumber(self):
+    def blockNumber(self):
         return self._line
 
 
@@ -83,7 +83,7 @@ def test_editor_outline_explorer(editor_outline_explorer_bot):
         a = right.__dict__
         b = left.__dict__
         b['color'] = None
-        assert a['block'].firstLineNumber() == b['block'].firstLineNumber()
+        assert a['block'].blockNumber() == b['block'].blockNumber()
         a['block'] = None
         b['block'] = None
         assert a == b

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -81,7 +81,7 @@ class TreeItem(QTreeWidgetItem):
     @property
     def line(self):
         """Get line number."""
-        return self.oedata.block.firstLineNumber() + 1
+        return self.oedata.block.blockNumber() + 1
 
     def update(self):
         """Update the tree element."""
@@ -498,7 +498,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
 
         for data in editor.outlineexplorer_data_list():
             try:
-                line_nb = data.block.firstLineNumber() + 1
+                line_nb = data.block.blockNumber() + 1
             except AttributeError:
                 continue
             level = None if data is None else data.fold_level

--- a/spyder/widgets/fileswitcher.py
+++ b/spyder/widgets/fileswitcher.py
@@ -648,7 +648,7 @@ class FileSwitcher(QDialog):
         for oedata in self.get_widget().outlineexplorer_data_list():
             if oedata.is_class_or_function():
                 symbol_list.append((
-                    oedata.block.firstLineNumber(),
+                    oedata.block.blockNumber(),
                     oedata.def_name, oedata.fold_level,
                     oedata.get_token()))
         return sorted(symbol_list)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Replaced `block.firstLineNumber` by` block.blockNumber`, which is what is meant by line number:
<img width="197" alt="Screenshot 2019-08-25 at 10 13 44" src="https://user-images.githubusercontent.com/6740194/63648223-617f6600-c724-11e9-89fa-b66c21c20b40.png">

Here `class C():` is on `firstLineNumber` 14 and on `blockNumber` 18

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10073


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->