### PR TITLE
PR: Store autosave information in separate files instead of the Spyder config

### DIFF
--- a/spyder/plugins/editor/tests/conftest.py
+++ b/spyder/plugins/editor/tests/conftest.py
@@ -48,8 +48,6 @@ def editor_plugin(qtbot, monkeypatch):
                 projects = Mock()
                 projects.get_active_project.return_value = None
                 return projects
-            elif attr == 'new_instance':
-                return False  # otherwise autosave is disabled
             else:
                 return Mock()
 
@@ -120,19 +118,3 @@ def editor_plugin_open_files(request, editor_plugin, python_files):
         return editor, expected_filenames, expected_current_filename
 
     return _get_editor_open_files
-
-
-@pytest.fixture
-def conf(request):
-    """
-    Fixture yielding the Spyder config and resetting it after the test.
-
-    You can use conf.set() to change the Spyder config in your test function.
-    If you want to change the config at setup time, then use
-    @pytest.mark.parametrize('conf', [(section, label, value)], indirect=True)
-    in front of your test function
-    """
-    if hasattr(request, 'param'):
-        CONF.set(*request.param)
-    yield CONF
-    CONF.reset_to_defaults()

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -128,27 +128,14 @@ def test_editor_has_autosave_component(editor_plugin):
     assert isinstance(editor.autosave, AutosaveForPlugin)
 
 
-def test_autosave_component_do_autosave(conf, editor_plugin, mocker):
+def test_autosave_component_do_autosave(editor_plugin, mocker):
     """Test that AutosaveForPlugin's do_autosave() calls the current editor
     stack's autosave_all()."""
     editor = editor_plugin
     editorStack = editor.get_current_editorstack()
     mocker.patch.object(editorStack.autosave, 'autosave_all')
-    conf.set('main', 'single_instance', True)
     editor.autosave.do_autosave()
     assert editorStack.autosave.autosave_all.called
-
-
-def test_autosave_component_when_not_single_instance(
-        conf, editor_plugin, mocker):
-    """Test that AutosaveForPlugin's do_autosave() does not calls the current
-    editor stack's autosave_all() when not run in single-instance mode."""
-    editor = editor_plugin
-    editorStack = editor.get_current_editorstack()
-    mocker.patch.object(editorStack.autosave, 'autosave_all')
-    conf.set('main', 'single_instance', False)
-    editor.autosave.do_autosave()
-    assert not editorStack.autosave.autosave_all.called
 
 
 def test_editor_transmits_sig_option_changed(editor_plugin, qtbot):
@@ -170,12 +157,10 @@ def test_editorstacks_share_autosave_data(editor_plugin, qtbot):
     assert autosave1.file_hashes is autosave2.file_hashes
 
 
-# The conf and mock_RecoveryDialog fixtures need to be called
-# before editor_plugin, so they need to be mentioned first
-@pytest.mark.parametrize('conf', [('main', 'single_instance', True)],
-                         indirect=True)
+# The mock_RecoveryDialog fixture needs to be called before setup_editor, so
+# it needs to be mentioned first
 def test_editor_calls_recoverydialog_exec_if_nonempty(
-        conf, mock_RecoveryDialog, editor_plugin):
+        mock_RecoveryDialog, editor_plugin):
     """Check that editor tries to exec a recovery dialog on construction."""
     assert mock_RecoveryDialog.return_value.exec_if_nonempty.called
 

--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -140,7 +140,7 @@ class AutosaveForPlugin(object):
         # In Python 3, easier to use os.scandir()
         for name in os.listdir(autosave_dir):
             full_name = osp.join(autosave_dir, name)
-            match = re.fullmatch(r'pid([0-9]*)\.txt', name)
+            match = re.match(r'pid([0-9]*)\.txt\Z', name)
             if match:
                 pid_files.append(full_name)
                 logger.debug('Reading pid file: {}'.format(full_name))

--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -126,9 +126,11 @@ class AutosaveForPlugin(object):
         """
         Get a list of files to recover from the Spyder config file.
 
-        This returns a dict mapping original file names to autosave file names.
+        This returns a list of tuples containing the original file names and
+        the corresponding autosave file names.
         """
-        return CONF.get('editor', 'autosave_mapping', {})
+        result_as_dict = CONF.get('editor', 'autosave_mapping', {})
+        return list(result_as_dict.items())
 
     def try_recover_from_autosave(self):
         """Offer to recover files from autosave."""

--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -157,7 +157,8 @@ class AutosaveForPlugin(object):
             else:
                 non_pid_files.append(full_name)
 
-        # Add all files not mentioned in any pid file
+        # Add all files not mentioned in any pid file. This can only happen if
+        # the pid file somehow got corrupted.
         for filename in set(non_pid_files) - set(files_mentioned):
             files_to_recover.append((None, filename))
             logger.debug('Added unmentioned file: {}'.format(filename))
@@ -179,7 +180,7 @@ class AutosaveForPlugin(object):
         for pidfile in pidfiles:
             try:
                 os.remove(pidfile)
-            except OSError:
+            except (IOError, OSError):
                 pass
 
     def register_autosave_for_stack(self, autosave_for_stack):
@@ -257,7 +258,7 @@ class AutosaveForStack(object):
         else:
             try:
                 os.remove(pidfile_name)
-            except OSError:
+            except (IOError, OSError):
                 pass
 
     def remove_autosave_file(self, filename):

--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -106,17 +106,8 @@ class AutosaveForPlugin(object):
         """Stop the autosave timer."""
         self.timer.stop()
 
-    def single_instance(self):
-        """Return whether Spyder is running in single instance mode."""
-        single_instance = CONF.get('main', 'single_instance')
-        new_instance = self.editor.main.new_instance
-        return single_instance and not new_instance
-
     def do_autosave(self):
         """Instruct current editorstack to autosave files where necessary."""
-        if not self.single_instance():
-            logger.debug('Autosave disabled because not single instance')
-            return
         logger.debug('Autosave triggered')
         stack = self.editor.get_current_editorstack()
         stack.autosave.autosave_all()
@@ -154,9 +145,6 @@ class AutosaveForPlugin(object):
 
     def try_recover_from_autosave(self):
         """Offer to recover files from autosave."""
-        if not self.single_instance():
-            self.recover_files_to_open = []
-            return
         autosave_mapping = self.get_files_to_recover()
         dialog = RecoveryDialog(autosave_mapping, parent=self.editor)
         dialog.exec_if_nonempty()

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -171,7 +171,8 @@ def test_save_autosave_mapping_with_nonempty_mapping(mocker, tmpdir):
 
 
 @pytest.mark.parametrize('pidfile_exists', [False, True])
-def test_save_autosave_mapping_with_empty_mapping(mocker, tmpdir, pidfile_exists):
+def test_save_autosave_mapping_with_empty_mapping(mocker, tmpdir,
+                                                  pidfile_exists):
     """Test that save_autosave_mapping() does not write the pidfile if the
     mapping is empty, and that is removes the pidfile if it exists."""
     mocker.patch('os.getpid', return_value=42)

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -5,6 +5,9 @@
 #
 """Tests for autosave.py"""
 
+# Standard library imports
+import ast
+
 # Third party imports
 import pytest
 
@@ -42,6 +45,90 @@ def test_autosave_component_timer_if_enabled(qtbot, mocker, enabled):
         addon.do_autosave.assert_not_called()
 
 
+def test_get_files_to_recover_with_empty_autosave_dir(mocker, tmpdir):
+    """Test that get_files_to_recover() does not break if there is no autosave
+    directory."""
+    mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
+                 return_value=tmpdir)
+    addon = AutosaveForPlugin(None)
+
+    result = addon.get_files_to_recover()
+
+    assert result == ([], [])
+
+
+def test_get_files_to_recover_with_one_pid_file(mocker, tmpdir):
+    """Test get_files_to_recover() if autosave dir contains one pid file with
+    one autosave file."""
+    mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
+                 return_value=tmpdir)
+    pidfile = tmpdir.join('pid42.txt')
+    autosavefile = tmpdir.join('foo.py')
+    pidfile.write('{"original": ' + repr(str(autosavefile)) + '}')
+    autosavefile.write('bar = 1')
+    addon = AutosaveForPlugin(None)
+
+    result = addon.get_files_to_recover()
+
+    expected = ([('original', str(autosavefile))], [str(pidfile)])
+    assert result == expected
+
+
+def test_get_files_to_recover_with_non_pid_file(mocker, tmpdir):
+    """Test get_files_to_recover() if autosave dir contains no pid file, but
+    one Python file."""
+    mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
+                 return_value=tmpdir)
+    pythonfile = tmpdir.join('foo.py')
+    pythonfile.write('bar = 1')
+    addon = AutosaveForPlugin(None)
+
+    result = addon.get_files_to_recover()
+
+    expected = ([(None, str(pythonfile))], [])
+    assert result == expected
+
+
+def test_get_files_to_recover_without_autosave_dir(mocker):
+    """Test that get_files_to_recover() does not break if there is no autosave
+    directory."""
+    mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
+                 return_value='non-existing-directory')
+    addon = AutosaveForPlugin(None)
+
+    result = addon.get_files_to_recover()
+
+    assert result == ([], [])
+
+
+@pytest.mark.parametrize('error_on_remove', [False, True])
+def test_try_recover(mocker, tmpdir, error_on_remove):
+    """Test that try_recover_from_autosave() displays a RecoveryDialog, that
+    it stores the files that the user wants to open as reported by the dialog,
+    and that it removes the pid file. If error_on_remove is set, then
+    removing the pid file will raise an OSError; this should be ignored."""
+    mock_RecoveryDialog = mocker.patch(
+            'spyder.plugins.editor.utils.autosave.RecoveryDialog')
+    mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
+                 return_value=tmpdir)
+    pidfile = tmpdir.join('pid42.txt')
+    autosavefile = tmpdir.join('foo.py')
+    pidfile.write('{"original": ' + repr(str(autosavefile)) + '}')
+    autosavefile.write('bar = 1')
+    addon = AutosaveForPlugin(None)
+    if error_on_remove:
+        mocker.patch('os.remove', side_effect=OSError)
+
+    addon.try_recover_from_autosave()
+
+    expected_mapping = [('original', str(autosavefile))]
+    mock_RecoveryDialog.assert_called_with(expected_mapping, parent=None)
+    expected_files_to_open = mock_RecoveryDialog().files_to_open[:]
+    assert addon.recover_files_to_open == expected_files_to_open
+    if not error_on_remove:
+        assert not pidfile.check()
+
+
 def test_autosave(mocker):
     """Test that AutosaveForStack.maybe_autosave writes the contents to the
     autosave file and updates the file_hashes."""
@@ -61,6 +148,39 @@ def test_autosave(mocker):
     mock_stack._write_to_file.assert_called_with(mock_fileinfo, 'autosave')
     mock_stack.compute_hash.assert_called_with(mock_fileinfo)
     assert addon.file_hashes == {'orig': 1, 'autosave': 3}
+
+
+def test_save_autosave_mapping_with_nonempty_mapping(mocker, tmpdir):
+    """Test that save_autosave_mapping() writes the current autosave mapping
+    to the correct file if the mapping is not empty."""
+    mocker.patch('os.getpid', return_value=42)
+    mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
+                 return_value=tmpdir)
+    addon = AutosaveForStack(None)
+    addon.name_mapping = {'orig': 'autosave'}
+
+    addon.save_autosave_mapping()
+
+    pidfile = tmpdir.join('pid42.txt')
+    assert ast.literal_eval(pidfile.read()) == addon.name_mapping
+
+
+@pytest.mark.parametrize('pidfile_exists', [False, True])
+def test_save_autosave_mapping_with_empty_mapping(mocker, tmpdir, pidfile_exists):
+    """Test that save_autosave_mapping() does not write the pidfile if the
+    mapping is empty, and that is removes the pidfile if it exists."""
+    mocker.patch('os.getpid', return_value=42)
+    mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
+                 return_value=tmpdir)
+    addon = AutosaveForStack(None)
+    addon.name_mapping = {}
+    pidfile = tmpdir.join('pid42.txt')
+    if pidfile_exists:
+        pidfile.write('This is an ex-parrot!')
+
+    addon.save_autosave_mapping()
+
+    assert not pidfile.check()
 
 
 @pytest.mark.parametrize('exception', [False, True])
@@ -84,7 +204,7 @@ def test_autosave_remove_autosave_file(mocker, exception):
     addon.remove_autosave_file(fileinfo.filename)
     assert addon.name_mapping == {}
     assert addon.file_hashes == {}
-    mock_remove.assert_called_with('autosave')
+    mock_remove.assert_any_call('autosave')
     assert mock_dialog.called == exception
 
 

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -48,7 +48,7 @@ def test_autosave_component_timer_if_enabled(qtbot, mocker, enabled):
 def test_get_files_to_recover_with_empty_autosave_dir(mocker, tmpdir):
     """Test get_files_to_recover() when autosave dir contains no files."""
     mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
-                 return_value=tmpdir)
+                 return_value=str(tmpdir))
     addon = AutosaveForPlugin(None)
 
     result = addon.get_files_to_recover()
@@ -61,7 +61,7 @@ def test_get_files_to_recover_with_one_pid_file(mocker, tmpdir, running):
     """Test get_files_to_recover() if autosave dir contains one pid file with
     one autosave file. Depending on the value of running, """
     mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
-                 return_value=tmpdir)
+                 return_value=str(tmpdir))
     mock_is_spyder_process = mocker.patch(
             'spyder.plugins.editor.utils.autosave.is_spyder_process',
             return_value=running)
@@ -83,7 +83,7 @@ def test_get_files_to_recover_with_non_pid_file(mocker, tmpdir):
     """Test get_files_to_recover() if autosave dir contains no pid file, but
     one Python file."""
     mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
-                 return_value=tmpdir)
+                 return_value=str(tmpdir))
     pythonfile = tmpdir.join('foo.py')
     pythonfile.write('bar = 1')
     addon = AutosaveForPlugin(None)
@@ -115,7 +115,7 @@ def test_try_recover(mocker, tmpdir, error_on_remove):
     mock_RecoveryDialog = mocker.patch(
             'spyder.plugins.editor.utils.autosave.RecoveryDialog')
     mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
-                 return_value=tmpdir)
+                 return_value=str(tmpdir))
     pidfile = tmpdir.join('pid42.txt')
     autosavefile = tmpdir.join('foo.py')
     pidfile.write('{"original": ' + repr(str(autosavefile)) + '}')
@@ -160,7 +160,7 @@ def test_save_autosave_mapping_with_nonempty_mapping(mocker, tmpdir):
     to the correct file if the mapping is not empty."""
     mocker.patch('os.getpid', return_value=42)
     mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
-                 return_value=tmpdir)
+                 return_value=str(tmpdir))
     addon = AutosaveForStack(None)
     addon.name_mapping = {'orig': 'autosave'}
 
@@ -177,7 +177,7 @@ def test_save_autosave_mapping_with_empty_mapping(mocker, tmpdir,
     mapping is empty, and that is removes the pidfile if it exists."""
     mocker.patch('os.getpid', return_value=42)
     mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
-                 return_value=tmpdir)
+                 return_value=str(tmpdir))
     addon = AutosaveForStack(None)
     addon.name_mapping = {}
     pidfile = tmpdir.join('pid42.txt')
@@ -197,7 +197,7 @@ def test_autosave_remove_autosave_file(mocker, exception):
     `file_hashes`."""
     mock_remove = mocker.patch('os.remove')
     if exception:
-        mock_remove.side_effect = EnvironmentError()
+        mock_remove.side_effect = OSError()
     mock_dialog = mocker.patch(
         'spyder.plugins.editor.utils.autosave.AutosaveErrorDialog')
     mock_stack = mocker.Mock()

--- a/spyder/plugins/editor/widgets/recover.py
+++ b/spyder/plugins/editor/widgets/recover.py
@@ -116,7 +116,7 @@ class RecoveryDialog(QDialog):
             else:
                 orig_dict = None
             autosave_dict = gather_file_data(autosave)
-            if 'mtime' not in autosave_dict: # autosave file does not exist
+            if 'mtime' not in autosave_dict:  # autosave file does not exist
                 continue
             self.data.append((orig_dict, autosave_dict))
         self.data.sort(key=recovery_data_key_function)

--- a/spyder/plugins/editor/widgets/recover.py
+++ b/spyder/plugins/editor/widgets/recover.py
@@ -108,7 +108,7 @@ class RecoveryDialog(QDialog):
                 full_name = osp.join(self.autosave_dir, name)
                 if osp.isdir(full_name):
                     continue
-                for orig, autosave in self.autosave_mapping.items():
+                for orig, autosave in self.autosave_mapping:
                     if autosave == full_name:
                         orig_dict = gather_file_data(orig)
                         break
@@ -297,21 +297,21 @@ def make_temporary_files(tempdir):
     autosave_file = osp.join(autosave_dir, 'ham.py')
     with open(autosave_file, 'w') as f:
         f.write('ham = "autosave"\n')
-    autosave_mapping[orig_file] = autosave_file
+    autosave_mapping = [(orig_file, autosave_file)]
 
     # spam.py: Only autosave file exists, mentioned in mapping
     orig_file = osp.join(orig_dir, 'spam.py')
     autosave_file = osp.join(autosave_dir, 'spam.py')
     with open(autosave_file, 'w') as f:
         f.write('spam = "autosave"\n')
-    autosave_mapping[orig_file] = autosave_file
+    autosave_mapping += [(orig_file, autosave_file)]
 
     # eggs.py: Only original files exists, mentioned in mapping
     orig_file = osp.join(orig_dir, 'eggs.py')
     with open(orig_file, 'w') as f:
         f.write('eggs = "original"\n')
     autosave_file = osp.join(autosave_dir, 'eggs.py')
-    autosave_mapping[orig_file] = autosave_file
+    autosave_mapping += [(orig_file, autosave_file)]
 
     # cheese.py: Only autosave file exists, not mentioned in mapping
     autosave_file = osp.join(autosave_dir, 'cheese.py')

--- a/spyder/plugins/editor/widgets/recover.py
+++ b/spyder/plugins/editor/widgets/recover.py
@@ -331,8 +331,8 @@ def test():  # pragma: no cover
 
     app = qapplication()
     tempdir = tempfile.mkdtemp()
-    _, autosave_dir, autosave_mapping = make_temporary_files(tempdir)
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    unused, unused, autosave_mapping = make_temporary_files(tempdir)
+    dialog = RecoveryDialog(autosave_mapping)
     dialog.exec_()
     print('files_to_open =', dialog.files_to_open)  # spyder: test-skip
     shutil.rmtree(tempdir)

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -792,11 +792,9 @@ def test_autosave_updates_name_mapping(editor_bot, mocker, qtbot):
     assert editor_stack.autosave.name_mapping == {}
     mocker.patch.object(editor_stack, '_write_to_file')
     editor.set_text('spam\n')
-    with qtbot.wait_signal(editor_stack.sig_option_changed) as blocker:
-        editor_stack.autosave.maybe_autosave(0)
+    editor_stack.autosave.maybe_autosave(0)
     expected = {'foo.py': os.path.join(get_conf_path('autosave'), 'foo.py')}
     assert editor_stack.autosave.name_mapping == expected
-    assert blocker.args == ['autosave_mapping', expected]
 
 
 def test_maybe_autosave_handles_error(editor_bot, mocker):
@@ -823,18 +821,18 @@ def test_remove_autosave_file(editor_bot, mocker, qtbot):
     editor_stack, editor = editor_bot
     autosave = editor_stack.autosave
     editor.set_text('spam\n')
-    with qtbot.wait_signal(editor_stack.sig_option_changed) as blocker:
-        autosave.maybe_autosave(0)
+
+    autosave.maybe_autosave(0)
+
     autosave_filename = os.path.join(get_conf_path('autosave'), 'foo.py')
     assert os.access(autosave_filename, os.R_OK)
     expected = {'foo.py': autosave_filename}
     assert autosave.name_mapping == expected
-    assert blocker.args == ['autosave_mapping', expected]
-    with qtbot.wait_signal(editor_stack.sig_option_changed) as blocker:
-        autosave.remove_autosave_file(editor_stack.data[0].filename)
+
+    autosave.remove_autosave_file(editor_stack.data[0].filename)
+
     assert not os.access(autosave_filename, os.R_OK)
     assert autosave.name_mapping == {}
-    assert blocker.args == ['autosave_mapping', {}]
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/editor/widgets/tests/test_recover.py
+++ b/spyder/plugins/editor/widgets/tests/test_recover.py
@@ -34,7 +34,7 @@ def test_recoverydialog_has_cancel_button(qtbot, tmpdir):
     Test that a RecoveryDialog has a button in a dialog button box and that
     this button cancels the dialog window.
     """
-    dialog = RecoveryDialog(str(tmpdir), {})
+    dialog = RecoveryDialog([])
     qtbot.addWidget(dialog)
     button = dialog.findChild(QDialogButtonBox).findChild(QPushButton)
     with qtbot.waitSignal(dialog.rejected):
@@ -44,7 +44,7 @@ def test_recoverydialog_has_cancel_button(qtbot, tmpdir):
 def test_recoverydialog_table_labels(qtbot, recovery_env):
     """Test that table in RecoveryDialog has the correct labels."""
     orig_dir, autosave_dir, autosave_mapping = recovery_env
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    dialog = RecoveryDialog(autosave_mapping)
     table = dialog.findChild(QTableWidget)
 
     def text(i, j):
@@ -72,11 +72,11 @@ def test_recoverydialog_table_labels(qtbot, recovery_env):
 
 def test_recoverydialog_exec_if_nonempty_when_empty(qtbot, tmpdir, mocker):
     """
-    Test that exec_if_nonempty does nothing if autosave dir is empty.
+    Test that exec_if_nonempty does nothing if autosave files do not exist.
 
     Specifically, test that it does not `exec_()` the dialog.
     """
-    dialog = RecoveryDialog(str(tmpdir), {'ham': 'spam'})
+    dialog = RecoveryDialog([('ham', 'spam')])
     mocker.patch.object(dialog, 'exec_')
     assert dialog.exec_if_nonempty() == dialog.Accepted
     dialog.exec_.assert_not_called()
@@ -86,7 +86,7 @@ def test_recoverydialog_exec_if_nonempty_when_nonempty(
         qtbot, recovery_env, mocker):
     """Test that exec_if_nonempty executes dialog if autosave dir not empty."""
     orig_dir, autosave_dir, autosave_mapping = recovery_env
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    dialog = RecoveryDialog(autosave_mapping)
     mocker.patch.object(dialog, 'exec_', return_value='eggs')
     assert dialog.exec_if_nonempty() == 'eggs'
     assert dialog.exec_.called
@@ -101,7 +101,7 @@ def test_recoverydialog_exec_if_nonempty_when_no_autosave_dir(
     """
     orig_dir, autosave_dir, autosave_mapping = recovery_env
     shutil.rmtree(autosave_dir)
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    dialog = RecoveryDialog(autosave_mapping)
     mocker.patch.object(dialog, 'exec_')
     assert dialog.exec_if_nonempty() == dialog.Accepted
     dialog.exec_.assert_not_called()
@@ -116,7 +116,7 @@ def test_recoverydialog_restore_button(qtbot, recovery_env):
     grid is deactivated.
     """
     orig_dir, autosave_dir, autosave_mapping = recovery_env
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    dialog = RecoveryDialog(autosave_mapping)
     table = dialog.findChild(QTableWidget)
     button = table.cellWidget(0, 2).findChildren(QPushButton)[0]
     button.click()
@@ -137,7 +137,7 @@ def test_recoverydialog_restore_when_original_does_not_exist(
     deactivated.
     """
     orig_dir, autosave_dir, autosave_mapping = recovery_env
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    dialog = RecoveryDialog(autosave_mapping)
     table = dialog.findChild(QTableWidget)
     button = table.cellWidget(1, 2).findChildren(QPushButton)[0]
     button.click()
@@ -160,7 +160,7 @@ def test_recoverydialog_restore_when_original_not_recorded(
     new_name = osp.join(orig_dir, 'monty.py')
     mocker.patch('spyder.plugins.editor.widgets.recover.getsavefilename',
                  return_value=(new_name, 'ignored'))
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    dialog = RecoveryDialog(autosave_mapping)
     table = dialog.findChild(QTableWidget)
     button = table.cellWidget(2, 2).findChildren(QPushButton)[0]
     button.click()
@@ -183,7 +183,7 @@ def test_recoverydialog_restore_fallback(qtbot, recovery_env, mocker):
     if not PY2:
         mocker.patch('spyder.plugins.editor.widgets.recover.os.replace',
                      side_effect=OSError)
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    dialog = RecoveryDialog(autosave_mapping)
     table = dialog.findChild(QTableWidget)
     button = table.cellWidget(0, 2).findChildren(QPushButton)[0]
     button.click()
@@ -210,7 +210,7 @@ def test_recoverydialog_restore_when_error(qtbot, recovery_env, mocker):
                  side_effect=IOError)
     mock_QMessageBox = mocker.patch(
                 'spyder.plugins.editor.widgets.recover.QMessageBox')
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    dialog = RecoveryDialog(autosave_mapping)
     table = dialog.findChild(QTableWidget)
     button = table.cellWidget(0, 2).findChildren(QPushButton)[0]
     button.click()
@@ -235,7 +235,7 @@ def test_recoverydialog_accepted_after_all_restored(
     new_name = osp.join(orig_dir, 'monty.py')
     mocker.patch('spyder.plugins.editor.widgets.recover.getsavefilename',
                  return_value=(new_name, 'ignored'))
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    dialog = RecoveryDialog(autosave_mapping)
     table = dialog.findChild(QTableWidget)
     with qtbot.assertNotEmitted(dialog.accepted):
         for row in range(table.rowCount() - 1):
@@ -254,7 +254,7 @@ def test_recoverydialog_discard_button(qtbot, recovery_env):
     deactivated.
     """
     orig_dir, autosave_dir, autosave_mapping = recovery_env
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    dialog = RecoveryDialog(autosave_mapping)
     table = dialog.findChild(QTableWidget)
     button = table.cellWidget(0, 2).findChildren(QPushButton)[1]
     button.click()
@@ -278,7 +278,7 @@ def test_recoverydialog_discard_when_error(qtbot, recovery_env, mocker):
                  side_effect=OSError)
     mock_QMessageBox = mocker.patch(
                 'spyder.plugins.editor.widgets.recover.QMessageBox')
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    dialog = RecoveryDialog(autosave_mapping)
     table = dialog.findChild(QTableWidget)
     button = table.cellWidget(0, 2).findChildren(QPushButton)[1]
     button.click()
@@ -300,7 +300,7 @@ def test_recoverydialog_open_button(qtbot, recovery_env):
     deactivated.
     """
     orig_dir, autosave_dir, autosave_mapping = recovery_env
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    dialog = RecoveryDialog(autosave_mapping)
     table = dialog.findChild(QTableWidget)
     button = table.cellWidget(0, 2).findChildren(QPushButton)[2]
     button.click()
@@ -319,7 +319,7 @@ def test_recoverydialog_open_when_no_original(qtbot, recovery_env):
     file.
     """
     orig_dir, autosave_dir, autosave_mapping = recovery_env
-    dialog = RecoveryDialog(autosave_dir, autosave_mapping)
+    dialog = RecoveryDialog(autosave_mapping)
     table = dialog.findChild(QTableWidget)
     button = table.cellWidget(2, 2).findChildren(QPushButton)[2]
     button.click()

--- a/spyder/utils/external/lockfile.py
+++ b/spyder/utils/external/lockfile.py
@@ -27,9 +27,8 @@ __metaclass__ = type
 import errno, os
 from time import time as _uniquefloat
 
-import psutil
-from spyder.config.base import running_under_pytest
 from spyder.py3compat import PY2, to_binary_string
+from spyder.utils.programs import is_spyder_process
 
 def unique():
     if PY2:
@@ -190,22 +189,7 @@ class FilesystemLock:
                     try:
                         if kill is not None:
                             kill(int(pid), 0)
-                        # Verify that the running process corresponds to
-                        # a Spyder one
-                        p = psutil.Process(int(pid))
-
-                        # Valid names for main script
-                        names = set(['spyder', 'spyder3', 'spyder.exe',
-                                     'spyder3.exe', 'bootstrap.py',
-                                     'spyder-script.py'])
-                        if running_under_pytest():
-                            names.add('runtests.py')
-
-                        # Check the first three command line arguments
-                        arguments = set(os.path.basename(arg)
-                                        for arg in p.cmdline()[:3])
-                        conditions = [names & arguments]
-                        if not any(conditions):
+                        if not is_spyder_process(int(pid)):
                             raise(OSError(errno.ESRCH, 'No such process'))
                     except OSError as e:
                         if e.errno == errno.ESRCH:

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -986,6 +986,5 @@ def is_spyder_process(pid):
         arguments = set(os.path.basename(arg) for arg in p.cmdline()[:3])
         conditions = [names & arguments]
         return any(conditions)
-
     except (psutil.NoSuchProcess, psutil.AccessDenied):
         return False


### PR DESCRIPTION
## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/)) **N/A** 

This PR stores which files are autosaved and where in a separate file called `pidNNN.txt` in the autosave directory, where `NNN` is the pid of the Spyder process. This information is used when the files are recovered after a crash. Before this information was stored in the Spyder config file.

The new approach has two advantages. Firstly, if the user is running multiple Spyder instances simultaneously, then one instance overwrites the changes the other instance makes to the config file, so the autosave info got muddled in the old system, while now each instance has its own location to write its data to. Secondly, by also recording the pid of the Spyder process that created the autosave file, we can check whether that process is still running. and not change the autosave file if it is.

### Issue(s) Resolved

Fixes #9420

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
