### PR TITLE
PR: Always enable Kite completions

### DIFF
--- a/spyder/plugins/completion/kite/__init__.py
+++ b/spyder/plugins/completion/kite/__init__.py
@@ -14,7 +14,6 @@ class _KiteEndpoints(type):
     KITE_PORT = 46624
     KITE_URL = 'http://localhost:{0}'.format(KITE_PORT)
 
-    ALIVE_ENDPOINT = ('GET', '/clientapi/ping')
     LANGUAGES_ENDPOINT = ('GET', '/clientapi/languages')
     EVENT_ENDPOINT = ('POST', '/clientapi/editor/event')
     HOVER_ENDPOINT = (

--- a/spyder/plugins/completion/kite/client.py
+++ b/spyder/plugins/completion/kite/client.py
@@ -31,47 +31,22 @@ class KiteClient(QObject, KiteMethodProviderMixIn):
     sig_client_not_responding = Signal()
     sig_perform_request = Signal(int, str, object)
 
-    MAX_SERVER_CONTACT_RETRIES = 40
-
     def __init__(self, parent):
         QObject.__init__(self, parent)
-        self.contact_retries = 0
         self.endpoint = None
         self.requests = {}
         self.languages = []
         self.mutex = QMutex()
         self.opened_files = {}
-        self.alive = False
         self.thread_started = False
         self.thread = QThread()
         self.moveToThread(self.thread)
         self.thread.started.connect(self.started)
         self.sig_perform_request.connect(self.perform_request)
 
-    def __wait_http_session_to_start(self):
-        logger.debug('Waiting Kite HTTP endpoint to be available...')
-        _, url = KITE_ENDPOINTS.ALIVE_ENDPOINT
-        try:
-            code = requests.get(url).status_code
-        except Exception:
-            code = 500
-
-        if self.contact_retries == self.MAX_SERVER_CONTACT_RETRIES:
-            logger.debug('Kite server is not answering')
-            self.sig_client_not_responding.emit()
-        elif code != 200:
-            self.contact_retries += 1
-            QTimer.singleShot(250, self.__wait_http_session_to_start)
-        elif code == 200:
-            self.alive = True
-            self.start_client()
-
     def start(self):
         if not self.thread_started:
             self.thread.start()
-        self.__wait_http_session_to_start()
-
-    def start_client(self):
         logger.debug('Starting Kite HTTP session...')
         self.endpoint = requests.Session()
         self.languages = self.get_languages()
@@ -108,18 +83,13 @@ class KiteClient(QObject, KiteMethodProviderMixIn):
     def send(self, method, params, url_params):
         response = None
         if self.endpoint is not None and method in KITE_REQUEST_MAPPING:
-            if self.alive:
-                http_verb, path = KITE_REQUEST_MAPPING[method]
-                path = path.format(**url_params)
-                try:
-                    success, response = self.perform_http_request(
-                        http_verb, path, params)
-                except (ConnectionRefusedError, ConnectionError):
-                    self.alive = False
-                    self.endpoint = None
-                    self.contact_retries = 0
-                    self.__wait_http_session_to_start()
-                    return response
+            http_verb, path = KITE_REQUEST_MAPPING[method]
+            path = path.format(**url_params)
+            try:
+                success, response = self.perform_http_request(
+                    http_verb, path, params)
+            except (ConnectionRefusedError, ConnectionError):
+                return response
         return response
 
     def perform_request(self, req_id, method, params):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Previously, we were using logic to ping Kite up to 40 times before considering Kite unreachable, and permanently disabling the Kite completions plugin.

It is much more robust to always make Kite completions requests, and let the connection error out. The `ConnectionError` happens very quickly, so this has no noticeable performance impact. There are many other types of I/O happening per-keystroke that are much slower.

In order for the user experience to be pleasant, this depends on completely ignoring `ConnectionError`s: #10029. This PR does not address that issue.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@metalogical

<!--- Thanks for your help making Spyder better for everyone! --->
