### PR TITLE
PR: Fix code editor freeze when searching for next/previous warnings

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2083,39 +2083,44 @@ class CodeEditor(TextEditBaseWidget):
         return warnings
 
     def go_to_next_warning(self):
-        """Go to next code analysis warning message
-        and return new cursor position"""
+        """
+        Go to next code warning message and return new cursor position.
+        """
         block = self.textCursor().block()
         line_count = self.document().blockCount()
-        while True:
-            if block.blockNumber()+1 < line_count:
+        for _ in range(line_count):
+            line_number = block.blockNumber() + 1
+            if line_number < line_count:
                 block = block.next()
             else:
                 block = self.document().firstBlock()
+
             data = block.userData()
             if data and data.code_analysis:
-                break
-        line_number = block.blockNumber()+1
-        self.go_to_line(line_number)
-        self.show_code_analysis_results(line_number, data)
-        return self.get_position('cursor')
+                line_number = block.blockNumber() + 1
+                self.go_to_line(line_number)
+                self.show_code_analysis_results(line_number, data)
+                return self.get_position('cursor')
 
     def go_to_previous_warning(self):
-        """Go to previous code analysis warning message
-        and return new cursor position"""
+        """
+        Go to previous code warning message and return new cursor position.
+        """
         block = self.textCursor().block()
-        while True:
-            if block.blockNumber() > 0:
+        line_count = self.document().blockCount()
+        for _ in range(line_count):
+            line_number = block.blockNumber() + 1
+            if line_number > 1:
                 block = block.previous()
             else:
                 block = self.document().lastBlock()
+
             data = block.userData()
             if data and data.code_analysis:
-                break
-        line_number = block.blockNumber()+1
-        self.go_to_line(line_number)
-        self.show_code_analysis_results(line_number, data)
-        return self.get_position('cursor')
+                line_number = block.blockNumber() + 1
+                self.go_to_line(line_number)
+                self.show_code_analysis_results(line_number, data)
+                return self.get_position('cursor')
 
     def cell_list(self):
         """Get the outline explorer data for all cells."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->

Changed code to find next/previous warnings use a for loop instead of a while as in this case we know the max amount of possible iterations. Also refactored the code a bit.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Related to #10024


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca

<!--- Thanks for your help making Spyder better for everyone! --->
