### PR TITLE
PR: Hide tooltips if switching editor in stack

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2219,6 +2219,10 @@ class Editor(SpyderPluginWidget):
     def current_file_changed(self, filename, position):
         self.add_cursor_position_to_history(to_text_string(filename), position,
                                             fc=True)
+        # Hide any open tooltips
+        current_stack = self.get_current_editorstack()
+        if current_stack is not None:
+            current_stack.hide_tooltip()
 
     @Slot()
     def go_to_last_edit_location(self):

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -807,6 +807,11 @@ class EditorStack(QWidget):
                 lambda menu=self.menu:
                 set_menu_icons(menu, False))
 
+    def hide_tooltip(self):
+        """Hide any open tooltips."""
+        for finfo in self.data:
+            finfo.editor.hide_tooltip()
+
     @Slot()
     def update_fname_label(self):
         """Upadte file name label."""
@@ -923,7 +928,11 @@ class EditorStack(QWidget):
         offset = editor.get_position('cursor')
         if pos:
             cursor = editor.get_last_hover_cursor()
-            offset = cursor.position()
+            if cursor:
+                offset = cursor.position()
+            else:
+                return
+
         line, col = editor.get_cursor_line_column(cursor)
         editor.request_hover(line, col, offset,
                              show_hint=False, clicked=bool(pos))


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

If a tooltip is displayed and the file was siwtched, the tootlip of the previous file remained on top. Now tooltips are hidden on file change.

See animation

## Before
![before](https://user-images.githubusercontent.com/3627835/63909841-f070d480-c9e9-11e9-9bbf-ad1363448ebb.gif)

## After
![after](https://user-images.githubusercontent.com/3627835/63909846-f8307900-c9e9-11e9-8bc4-12fe70ad4e84.gif)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
