### PR TITLE
PR: Fix completion order for lower/upper case entries

### DIFF
--- a/spyder/plugins/completion/kite/providers/document.py
+++ b/spyder/plugins/completion/kite/providers/document.py
@@ -91,7 +91,7 @@ class DocumentProvider:
                             completion['hint'], CompletionItemKind.TEXT),
                         'insertText': completion['snippet']['text'],
                         'filterText': completion['display'],
-                        'sortText': completion['display'][0],
+                        'sortText': completion['display'],
                         'documentation': completion['documentation']['text']
                     }
                     spyder_completions.append(entry)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -989,7 +989,8 @@ class CodeEditor(TextEditBaseWidget):
             first_letter = text[0] if len(text) > 0 else ''
             is_upper_word = first_letter.isupper()
             completions = [] if completions is None else completions
-            available_completions = {x['insertText']: x for x in completions}
+            available_completions = {x['insertText'].strip():
+                                     x for x in completions[::-1]}
             available_completions.pop(text, False)
             completions = list(available_completions.values())
 

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -986,12 +986,27 @@ class CodeEditor(TextEditBaseWidget):
             cursor = self.textCursor()
             cursor.select(QTextCursor.WordUnderCursor)
             text = to_text_string(cursor.selectedText())
+            first_letter = text[0] if len(text) > 0 else ''
+            is_upper_word = first_letter.isupper()
             completions = [] if completions is None else completions
             available_completions = {x['insertText']: x for x in completions}
             available_completions.pop(text, False)
             completions = list(available_completions.values())
 
             if completions is not None and len(completions) > 0:
+                for completion in completions:
+                    sort_text = completion['sortText']
+                    if is_upper_word:
+                        first_sort_letter = sort_text[1]
+                        if first_sort_letter.islower():
+                            if first_sort_letter.upper() == first_letter:
+                                completion['sortText'] = 'z' + sort_text
+                    else:
+                        first_sort_letter = sort_text[1]
+                        if first_sort_letter.isupper():
+                            if first_sort_letter.lower() == first_letter:
+                                completion['sortText'] = 'z' + sort_text
+
                 completion_list = sorted(completions,
                                          key=lambda x: x['sortText'])
                 self.completion_widget.show_list(


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Fixed completion entries order depending on the first letter of the word to complete.

![ezgif com-video-to-gif(10)](https://user-images.githubusercontent.com/1878982/63988700-27ef8780-caa3-11e9-8484-bb0d8f367d9c.gif)




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10109


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@andfoy 
<!--- Thanks for your help making Spyder better for everyone! --->
