### PR TITLE
PR: Avoid RuntimeError when handling completion responses

### DIFF
--- a/spyder/plugins/completion/fallback/plugin.py
+++ b/spyder/plugins/completion/fallback/plugin.py
@@ -16,7 +16,6 @@ import logging
 # Local imports
 from spyder.api.completion import SpyderCompletionPlugin
 from spyder.plugins.completion.fallback.actor import FallbackActor
-# from spyder.plugins.completion.languageserver import LSPRequestTypes
 
 
 logger = logging.getLogger(__name__)

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -329,6 +329,10 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
                                 self.req_status.pop(req_id)
                                 if req_id in self.req_reply:
                                     self.req_reply.pop(req_id)
+            except RuntimeError:
+                # This is triggered when a codeeditor instance has been
+                # removed before the response can be processed.
+                pass
             except zmq.ZMQError:
                 self.notifier.setEnabled(True)
                 return

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -145,11 +145,12 @@ class CompletionManager(SpyderCompletionPlugin):
                 break
         return {'params': response}
 
-    def gather_and_send(self,
-                        principal_source, response_instance, req_type, req_id):
+    def gather_and_send(self, principal_source, response_instance, req_type,
+                        req_id):
         logger.debug('Gather responses for {0}'.format(req_type))
         responses = []
         req_id_responses = self.requests[req_id]['sources']
+
         if req_type == LSPRequestTypes.DOCUMENT_COMPLETION:
             # principal_source = self.plugin_priority[req_type]
             responses = self.gather_completions(
@@ -161,7 +162,13 @@ class CompletionManager(SpyderCompletionPlugin):
         else:
             principal_source = self.plugin_priority['all']
             responses = req_id_responses[principal_source]
-        response_instance.handle_response(req_type, responses)
+
+        try:
+            response_instance.handle_response(req_type, responses)
+        except RuntimeError:
+            # This is triggered when a codeeditor instance has been
+            # removed before the response can be processed.
+            pass
 
     def send_request(self, language, req_type, req, req_id=None):
         req_id = self.req_id

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -973,6 +973,10 @@ class CodeEditor(TextEditBaseWidget):
         """Handle linting response."""
         try:
             self.process_code_analysis(params['params'])
+        except RuntimeError:
+            # This is triggered when a codeeditor instance has been
+            # removed before the response can be processed.
+            return
         except Exception:
             self.log_lsp_handle_errors("Error when processing linting")
 
@@ -1031,6 +1035,10 @@ class CodeEditor(TextEditBaseWidget):
                                          key=lambda x: x['sortText'])
                 self.completion_widget.show_list(
                         completion_list, position, automatic)
+        except RuntimeError:
+            # This is triggered when a codeeditor instance has been
+            # removed before the response can be processed.
+            return
         except Exception:
             self.log_lsp_handle_errors('Error when processing completions')
 
@@ -1078,6 +1086,10 @@ class CodeEditor(TextEditBaseWidget):
                     language=self.language,
                     documentation=documentation,
                 )
+        except RuntimeError:
+            # This is triggered when a codeeditor instance has been
+            # removed before the response can be processed.
+            return
         except Exception:
             self.log_lsp_handle_errors("Error when processing signature")
 
@@ -1110,7 +1122,10 @@ class CodeEditor(TextEditBaseWidget):
                     self.show_hint(content, inspect_word=word,
                                    at_point=self._last_point)
                     self._last_point = None
-
+        except RuntimeError:
+            # This is triggered when a codeeditor instance has been
+            # removed before the response can be processed.
+            return
         except Exception:
             self.log_lsp_handle_errors("Error when processing hover")
 
@@ -1158,6 +1173,10 @@ class CodeEditor(TextEditBaseWidget):
                     self.go_to_definition.emit(position['file'],
                                                start['line'] + 1,
                                                start['character'])
+        except RuntimeError:
+            # This is triggered when a codeeditor instance has been
+            # removed before the response can be processed.
+            return
         except Exception:
             self.log_lsp_handle_errors(
                 "Error when processing go to definition")


### PR DESCRIPTION
These errors were triggered when a CodeEditor instance was removed before responses can be processed by it.