### PR TITLE
PR: Don't call MainWindow's apply_settings method when no needed

### DIFF
--- a/spyder/plugins/projects/confpage.py
+++ b/spyder/plugins/projects/confpage.py
@@ -102,7 +102,6 @@ class WorkspaceConfigPage(ProjectConfigPage):
     def apply_settings(self, options):
         """ """
         pass  # TODO:
-        #self.main.apply_settings()
 
 
 class CodeConfigPage(ProjectConfigPage):
@@ -139,7 +138,6 @@ class CodeConfigPage(ProjectConfigPage):
     def apply_settings(self, options):
         """ """
         print('applied')  # spyder: test-skip
-        #self.main.apply_settings()
 
 
 class VersionConfigPage(ProjectConfigPage):
@@ -174,7 +172,6 @@ class VersionConfigPage(ProjectConfigPage):
     def apply_settings(self, options):
         """ """
         print('applied')  # spyder: test-skip
-        #self.main.apply_settings()
 
 
 if __name__ == "__main__":

--- a/spyder/preferences/maininterpreter.py
+++ b/spyder/preferences/maininterpreter.py
@@ -261,4 +261,3 @@ class MainInterpreterConfigPage(GeneralConfigPage):
                 self.set_option('custom_interpreter', executable)
         if not self.pyexec_edit.text():
             self.set_option('custom_interpreter', '')
-        self.main.apply_settings()


### PR DESCRIPTION
This helps to reduce the time necessary to change the main Python interpreter in our preferences by a significant amount.