### PR TITLE
PR: Fix PyLS options not being updated correctly when a previous server was running

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -490,7 +490,7 @@ DEFAULTS = [
               'pydocstyle/ignore': '',
               'pydocstyle/match': '(?!test_).*\\.py',
               'pydocstyle/match_dir': '[^\\.].*',
-              'advanced/command_launch': 'pyls',
+              'advanced/module': 'pyls',
               'advanced/host': '127.0.0.1',
               'advanced/port': 2087,
               'advanced/external': False,
@@ -590,4 +590,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '52.1.0'
+CONF_VERSION = '53.0.0'

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -36,7 +36,7 @@ from spyder.plugins.completion.languageserver.decorators import (
 from spyder.plugins.completion.languageserver.transport import MessageKind
 from spyder.plugins.completion.languageserver.providers import (
     LSPMethodProviderMixIn)
-from spyder.utils.misc import getcwd_or_home
+from spyder.utils.misc import getcwd_or_home, select_port
 
 # Conditional imports
 if PY2:
@@ -66,16 +66,11 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
     #  facilities.
     sig_server_error = Signal(str)
 
-    # Constants
-    external_server_fmt = ('--server-host %(host)s '
-                           '--server-port %(port)s ')
-
     def __init__(self, parent,
                  server_settings={},
                  folder=getcwd_or_home(),
                  language='python'):
         QObject.__init__(self)
-        # LSPMethodProviderMixIn.__init__(self)
         self.manager = parent
         self.zmq_in_socket = None
         self.zmq_out_socket = None
@@ -91,6 +86,15 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         self.watched_files = {}
         self.watched_folders = {}
         self.req_reply = {}
+
+        # Select a free port to start the server.
+        # NOTE: Don't use the new value to set server_setttings['port']!!
+        # That's not required because this doesn't really correspond to a
+        # change in the config settings of the server. Else a server
+        # restart would be generated when doing a
+        # workspace/didChangeConfiguration request.
+        if not server_settings['external']:
+            server_port = select_port(default_port=server_settings['port'])
 
         self.transport_args = [sys.executable, '-u',
                                osp.join(LOCATION, 'transport', 'main.py')]
@@ -110,8 +114,13 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         self.context = zmq.Context()
 
         server_args_fmt = server_settings.get('args', '')
-        server_args = server_args_fmt.format(**server_settings)
-        transport_args = self.external_server_fmt % (server_settings)
+        server_args = server_args_fmt.format(
+            host=server_settings['host'],
+            port=server_port)
+        transport_args_fmt = '--server-host {host} --server-port {port} '
+        transport_args = transport_args_fmt.format(
+            host=server_settings['host'],
+            port=server_port)
 
         self.server_args = []
         if language == 'python':

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -936,9 +936,9 @@ class LanguageServerConfigPage(GeneralConfigPage):
         advanced_label.setAlignment(Qt.AlignJustify)
 
         # Advanced options
-        self.advanced_command_launch = self.create_lineedit(
-            _("Command to launch the Python language server: "),
-            'advanced/command_launch', alignment=Qt.Horizontal,
+        self.advanced_module = self.create_lineedit(
+            _("Module for the Python language server: "),
+            'advanced/module', alignment=Qt.Horizontal,
             word_wrap=False)
         self.advanced_host = self.create_lineedit(
             _("IP Address and port to bind the server to: "),
@@ -957,8 +957,8 @@ class LanguageServerConfigPage(GeneralConfigPage):
 
         # Advanced layout
         advanced_g_layout = QGridLayout()
-        advanced_g_layout.addWidget(self.advanced_command_launch.label, 1, 0)
-        advanced_g_layout.addWidget(self.advanced_command_launch.textbox, 1, 1)
+        advanced_g_layout.addWidget(self.advanced_module.label, 1, 0)
+        advanced_g_layout.addWidget(self.advanced_module.textbox, 1, 1)
         advanced_g_layout.addWidget(self.advanced_host.label, 2, 0)
 
         advanced_host_port_g_layout = QGridLayout()
@@ -1045,14 +1045,12 @@ class LanguageServerConfigPage(GeneralConfigPage):
 
     def disable_tcp(self, state):
         if state == Qt.Checked:
-            # self.advanced_command_launch.textbox.setEnabled(False)
             self.advanced_host.textbox.setEnabled(False)
             self.advanced_port.spinbox.setEnabled(False)
             self.external_server.stateChanged.disconnect()
             self.external_server.setChecked(False)
             self.external_server.setEnabled(False)
         else:
-            # self.advanced_command_launch.textbox.setEnabled(True)
             self.advanced_host.textbox.setEnabled(True)
             self.advanced_port.spinbox.setEnabled(True)
             self.external_server.setChecked(False)
@@ -1061,18 +1059,16 @@ class LanguageServerConfigPage(GeneralConfigPage):
 
     def disable_stdio(self, state):
         if state == Qt.Checked:
-            # self.advanced_command_launch.textbox.setEnabled(False)
             self.advanced_host.textbox.setEnabled(True)
             self.advanced_port.spinbox.setEnabled(True)
-            self.advanced_command_launch.textbox.setEnabled(False)
+            self.advanced_module.textbox.setEnabled(False)
             self.use_stdio.stateChanged.disconnect()
             self.use_stdio.setChecked(False)
             self.use_stdio.setEnabled(False)
         else:
-            # self.advanced_command_launch.textbox.setEnabled(True)
             self.advanced_host.textbox.setEnabled(True)
             self.advanced_port.spinbox.setEnabled(True)
-            self.advanced_command_launch.textbox.setEnabled(True)
+            self.advanced_module.textbox.setEnabled(True)
             self.use_stdio.setChecked(False)
             self.use_stdio.setEnabled(True)
             self.use_stdio.stateChanged.connect(self.disable_tcp)

--- a/spyder/plugins/completion/languageserver/plugin.py
+++ b/spyder/plugins/completion/languageserver/plugin.py
@@ -23,7 +23,7 @@ from spyder.config.base import get_conf_path, running_under_pytest
 from spyder.config.lsp import PYTHON_CONFIG
 from spyder.config.manager import CONF
 from spyder.api.completion import SpyderCompletionPlugin
-from spyder.utils.misc import select_port, getcwd_or_home
+from spyder.utils.misc import getcwd_or_home
 from spyder.plugins.completion.languageserver import LSP_LANGUAGES
 from spyder.plugins.completion.languageserver.client import LSPClient
 from spyder.plugins.completion.languageserver.confpage import (
@@ -154,10 +154,6 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
             started = language_client['status'] == self.RUNNING
             if language_client['status'] == self.STOPPED:
                 config = language_client['config']
-
-                if not config['external']:
-                    port = select_port(default_port=config['port'])
-                    config['port'] = port
 
                 language_client['instance'] = LSPClient(
                     parent=self,

--- a/spyder/plugins/completion/languageserver/plugin.py
+++ b/spyder/plugins/completion/languageserver/plugin.py
@@ -202,8 +202,6 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
                 self.clients[language] = config
                 self.register_queue[language] = []
             else:
-                logger.debug(
-                    self.clients[language]['config'] != config['config'])
                 current_config = self.clients[language]['config']
                 new_config = config['config']
                 restart_diff = ['cmd', 'args', 'host',
@@ -211,6 +209,8 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
                 restart = any([current_config[x] != new_config[x]
                                for x in restart_diff])
                 if restart:
+                    logger.debug("Restart required for {} client!".format(
+                        language))
                     if self.clients[language]['status'] == self.STOPPED:
                         self.clients[language] = config
                     elif self.clients[language]['status'] == self.RUNNING:

--- a/spyder/plugins/completion/languageserver/plugin.py
+++ b/spyder/plugins/completion/languageserver/plugin.py
@@ -280,7 +280,7 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
         python_config = PYTHON_CONFIG.copy()
 
         # Server options
-        cmd = self.get_option('advanced/command_launch')
+        cmd = self.get_option('advanced/module')
         host = self.get_option('advanced/host')
         port = self.get_option('advanced/port')
 

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -892,7 +892,6 @@ class CodeEditor(TextEditBaseWidget):
                 logger.error('%', 1, stack_info=True)
 
     # ------------- LSP: Configuration and protocol start/end ----------------
-
     def start_completion_services(self):
         logger.debug("Completions services available for: {0}".format(
             self.filename))
@@ -903,6 +902,7 @@ class CodeEditor(TextEditBaseWidget):
         """Start LSP integration if it wasn't done before."""
         logger.debug("LSP available for: %s" % self.filename)
         self.parse_lsp_config(config)
+        self.completions_available = True
         self.document_did_open()
 
     def stop_completion_services(self):

--- a/spyder/preferences/general.py
+++ b/spyder/preferences/general.py
@@ -224,8 +224,8 @@ class MainConfigPage(GeneralConfigPage):
             "",
             'high_dpi_custom_scale_factors',
             tip=_("Enter values for different screens "
-                  "separated by semicolons ';', "
-                  "float values are supported"),
+                  "separated by semicolons ';'.\n"
+                  "Float values are supported"),
             alignment=Qt.Horizontal,
             regex=r"[0-9]+(?:\.[0-9]*)(;[0-9]+(?:\.[0-9]*))*",
             restart=True)


### PR DESCRIPTION
This PR avoids touching LSP server configurations when selecting a free port for the server. That was triggering a server restart, which (due to another bug, fixed here too) was stopping LSP services for the current open files.

This PR also renamed the PyLS option about the "command" we use to start it. Since we really use `sys.executable -m <command>`, that option doesn't correspond to a command (or executable) in your system, but to a Python module that implements the server.

Fixes #9933