### PR TITLE
PR: Detect zombie process and add python as default Kite client available language 

### DIFF
--- a/spyder/plugins/completion/kite/client.py
+++ b/spyder/plugins/completion/kite/client.py
@@ -65,7 +65,7 @@ class KiteClient(QObject, KiteMethodProviderMixIn):
         verb, url = KITE_ENDPOINTS.LANGUAGES_ENDPOINT
         success, response = self.perform_http_request(verb, url)
         if response is None:
-            response = []
+            response = ['python']
         return response
 
     def perform_http_request(self, verb, url, params=None):
@@ -74,7 +74,8 @@ class KiteClient(QObject, KiteMethodProviderMixIn):
         http_method = getattr(self.endpoint, verb)
         try:
             http_response = http_method(url, json=params)
-        except Exception:
+        except Exception as error:
+            logger.debug('Kite request error: {0}'.format(error))
             return False, None
         success = http_response.status_code == 200
         if success:

--- a/spyder/plugins/completion/kite/plugin.py
+++ b/spyder/plugins/completion/kite/plugin.py
@@ -87,7 +87,8 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
 
     def _check_if_kite_running(self):
         running = False
-        for proc in psutil.process_iter(attrs=['pid', 'name', 'username']):
+        for proc in psutil.process_iter(attrs=['pid', 'name', 'username',
+                                               'status']):
             if self._is_proc_kite(proc):
                 logger.debug('Kite process already '
                              'running with PID {0}'.format(proc.pid))
@@ -126,7 +127,7 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
             name = ''
 
         if os.name == 'nt' or sys.platform.startswith('linux'):
-            is_kite = 'kited' in name
+            is_kite = 'kited' in name and proc.status() != 'zombie'
         else:
             is_kite = 'Kite' == name
 


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

- Verify name and process status to check if kite is running to prevent zombie processes interfering with the check.
- Default available languages for the Kite client to `python` to ensure initial registration of the client even when a connection error raise.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
