### PR TITLE
PR: Catch errors when sending messages to tcp sockets that reject a connection from our LSP client

### DIFF
--- a/spyder/plugins/completion/languageserver/transport/tcp/producer.py
+++ b/spyder/plugins/completion/languageserver/transport/tcp/producer.py
@@ -72,8 +72,7 @@ class TCPLanguageServerClient(LanguageServerClient):
         except (BrokenPipeError, ConnectionError) as e:
             # This avoids a total freeze at startup
             # when we're trying to connect to a TCP
-            # (but not LSP) server that rejects our
-            # connection
+            # socket that rejects our connection
             logger.error(e)
 
     def is_server_alive(self):

--- a/spyder/plugins/completion/languageserver/transport/tcp/producer.py
+++ b/spyder/plugins/completion/languageserver/transport/tcp/producer.py
@@ -70,6 +70,10 @@ class TCPLanguageServerClient(LanguageServerClient):
             self.socket.send(content_length)
             self.socket.send(body)
         except (BrokenPipeError, ConnectionError) as e:
+            # This avoids a total freeze at startup
+            # when we're trying to connect to a TCP
+            # (but not LSP) server that rejects our
+            # connection
             logger.error(e)
 
     def is_server_alive(self):

--- a/spyder/plugins/completion/languageserver/transport/tcp/producer.py
+++ b/spyder/plugins/completion/languageserver/transport/tcp/producer.py
@@ -25,6 +25,8 @@ from spyder.plugins.completion.languageserver.transport.tcp.consumer import (
     TCPIncomingMessageThread)
 from spyder.plugins.completion.languageserver.transport.common.producer import (
     LanguageServerClient)
+from spyder.py3compat import ConnectionError, BrokenPipeError
+
 
 logger = logging.getLogger(__name__)
 
@@ -64,8 +66,11 @@ class TCPLanguageServerClient(LanguageServerClient):
 
     def transport_send(self, content_length, body):
         logger.debug('Sending message via TCP')
-        self.socket.send(content_length)
-        self.socket.send(body)
+        try:
+            self.socket.send(content_length)
+            self.socket.send(body)
+        except (BrokenPipeError, ConnectionError) as e:
+            logger.error(e)
 
     def is_server_alive(self):
         connected = False

--- a/spyder/py3compat.py
+++ b/spyder/py3compat.py
@@ -305,12 +305,13 @@ else:
 # Exceptions
 # ============================================================================
 if PY2:
-    ConnectionRefusedError = ConnectionError = OSError
+    ConnectionRefusedError = ConnectionError = BrokenPipeError = OSError
     TimeoutError = RuntimeError
 else:
     ConnectionError = ConnectionError
     ConnectionRefusedError = ConnectionRefusedError
     TimeoutError = TimeoutError
+    BrokenPipeError = BrokenPipeError
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This avoids a total freeze at startup when there's a TCP socket listening at `host:port` (as defined in our preferences), which rejects our connection.

I also tested things with a simple ping/pong server and (fortunately) in that case Spyder doesn't freeze, but this fix is not really needed.