### PR TITLE
PR: Send current cursor position to Kite to enable autosearch in Kite Copilot

### DIFF
--- a/spyder/plugins/completion/kite/providers/document.py
+++ b/spyder/plugins/completion/kite/providers/document.py
@@ -62,7 +62,9 @@ class DocumentProvider:
             'filename': osp.realpath(params['file']),
             'text': params['text'],
             'action': 'focus',
-            'selections': []
+            'selections': [
+                {'start': params['offset'], 'end': params['offset']}
+            ]
         }
 
         default_info = {'text': '', 'count': 0}
@@ -80,7 +82,9 @@ class DocumentProvider:
             'filename': osp.realpath(params['file']),
             'text': params['text'],
             'action': 'edit',
-            'selections': []
+            'selections': [
+                {'start': params['offset'], 'end': params['offset']}
+            ]
         }
         with QMutexLocker(self.mutex):
             file_info = self.opened_files[params['file']]

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -972,7 +972,8 @@ class CodeEditor(TextEditBaseWidget):
             'language': self.language,
             'version': self.text_version,
             'text': self.toPlainText(),
-            'codeeditor': self
+            'codeeditor': self,
+            'offset': self.get_position('cursor')
         }
         return params
 
@@ -989,7 +990,8 @@ class CodeEditor(TextEditBaseWidget):
             'file': self.filename,
             'version': self.text_version,
             'text': text,
-            'diff': patch
+            'diff': patch,
+            'offset': self.get_position('cursor')
         }
         return params
 


### PR DESCRIPTION
## Description of Changes
* [ ] Wrote at least one-line docstrings (--> new new functions)
* [ ] Added unit test(s) covering the changes
* [ ] Included a screenshot or animation 


<!--- Explain what you've done and why --->
The kited application needs the current cursor position to find out about the currently edited token. This token is then used to show the documentation in Kite Copilot.

This pull request adds the missing properties to the event requests which are send to Kite on localhost.


### Issue(s) Resolved

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: jansorg

<!--- Thanks for your help making Spyder better for everyone! --->
