### PR TITLE
PR: Fix OSError when saving files on Linux

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1774,7 +1774,14 @@ class EditorStack(QWidget):
         correct encoding without doing any error handling.
         """
         txt = fileinfo.editor.get_text_with_eol()
-        fileinfo.encoding = encoding.write(txt, filename, fileinfo.encoding)
+        try:
+            fileinfo.encoding = encoding.write(txt, filename,
+                                               fileinfo.encoding)
+        except OSError:
+            # Some filesystems don't support the option to sync directories
+            # issue untitaker/python-atomicwrites#17
+            with open(filename, 'w') as f:
+                f.write(txt)
 
     def save(self, index=None, force=False):
         """Write text of editor to a file.

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1776,19 +1776,7 @@ class EditorStack(QWidget):
         correct encoding without doing any error handling.
         """
         txt = fileinfo.editor.get_text_with_eol()
-        try:
-            fileinfo.encoding = encoding.write(txt, filename,
-                                               fileinfo.encoding)
-        except OSError:
-            # Some filesystems don't support the option to sync directories
-            # issue untitaker/python-atomicwrites#17
-            if PY2:
-                with codecs.open(filename, 'w',
-                                 encoding=fileinfo.encoding) as f:
-                    f.write(txt)
-            else:
-                with open(filename, 'w', encoding=fileinfo.encoding) as f:
-                    f.write(txt)
+        fileinfo.encoding = encoding.write(txt, filename, fileinfo.encoding)
 
     def save(self, index=None, force=False):
         """Write text of editor to a file.

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -18,6 +18,7 @@ import os
 import os.path as osp
 import sys
 import unicodedata
+import codecs
 
 # Third party imports
 import qdarkstyle
@@ -35,7 +36,8 @@ from spyder.config.base import _, running_under_pytest
 from spyder.config.gui import config_shortcut, is_dark_interface, get_shortcut
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
                                  get_filter, is_kde_desktop, is_anaconda)
-from spyder.py3compat import qbytearray_to_str, to_text_string, MutableSequence
+from spyder.py3compat import (qbytearray_to_str, to_text_string,
+                              MutableSequence, PY2)
 from spyder.utils import icon_manager as ima
 from spyder.utils import encoding, sourcecode, syntaxhighlighters
 from spyder.utils.qthelpers import (add_actions, create_action,
@@ -1780,8 +1782,13 @@ class EditorStack(QWidget):
         except OSError:
             # Some filesystems don't support the option to sync directories
             # issue untitaker/python-atomicwrites#17
-            with open(filename, 'w') as f:
-                f.write(txt)
+            if PY2:
+                with codecs.open(filename, 'w',
+                                 encoding=fileinfo.encoding) as f:
+                    f.write(txt)
+            else:
+                with open(filename, 'w', encoding=fileinfo.encoding) as f:
+                    f.write(txt)
 
     def save(self, index=None, force=False):
         """Write text of editor to a file.

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -18,7 +18,6 @@ import os
 import os.path as osp
 import sys
 import unicodedata
-import codecs
 
 # Third party imports
 import qdarkstyle
@@ -37,7 +36,7 @@ from spyder.config.gui import config_shortcut, is_dark_interface, get_shortcut
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
                                  get_filter, is_kde_desktop, is_anaconda)
 from spyder.py3compat import (qbytearray_to_str, to_text_string,
-                              MutableSequence, PY2)
+                              MutableSequence)
 from spyder.utils import icon_manager as ima
 from spyder.utils import encoding, sourcecode, syntaxhighlighters
 from spyder.utils.qthelpers import (add_actions, create_action,

--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -253,12 +253,8 @@ def write(text, filename, encoding='utf-8', mode='wb'):
         except OSError:
             # Some filesystems don't support the option to sync directories
             # issue untitaker/python-atomicwrites#17
-            if PY2:
-                with codecs.open(filename, 'w', encoding=encoding) as f:
-                    f.write(text)
-            else:
-                with open(filename, 'w', encoding=encoding) as f:
-                    f.write(text)
+            with open(filename, mode) as textfile:
+                textfile.write(text)
         os.chmod(filename, original_mode)
     return encoding
 

--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -238,7 +238,7 @@ def write(text, filename, encoding='utf-8', mode='wb'):
     else:
         # Based in the solution at untitaker/python-atomicwrites#42.
         # Needed to fix file permissions overwritting.
-        # See untitaker/python-atomicwrites#17
+        # See spyder-ide/spyder#9381.
         try:
             original_mode = os.stat(filename).st_mode
         except OSError:  # Change to FileNotFoundError for PY3
@@ -252,7 +252,7 @@ def write(text, filename, encoding='utf-8', mode='wb'):
                 textfile.write(text)
         except OSError as error:
             # Some filesystems don't support the option to sync directories
-            # issue untitaker/python-atomicwrites#17
+            # See untitaker/python-atomicwrites#17
             if error.errno != errno.EINVAL:
                 with open(filename, mode) as textfile:
                     textfile.write(text)

--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -17,7 +17,6 @@ import locale
 import re
 import os
 import sys
-import codecs
 
 # Third-party imports
 from chardet.universaldetector import UniversalDetector

--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -17,6 +17,7 @@ import locale
 import re
 import os
 import sys
+import codecs
 
 # Third-party imports
 from chardet.universaldetector import UniversalDetector
@@ -24,7 +25,7 @@ from atomicwrites import atomic_write
 
 # Local imports
 from spyder.py3compat import (is_string, to_text_string, is_binary_string,
-                              is_unicode)
+                              is_unicode, PY2)
 from spyder.utils.external.binaryornot.check import is_binary
 
 
@@ -245,10 +246,19 @@ def write(text, filename, encoding='utf-8', mode='wb'):
             umask = os.umask(0)
             os.umask(umask)
             original_mode = 0o777 & ~umask
-        with atomic_write(filename,
-                          overwrite=True,
-                          mode=mode) as textfile:
-            textfile.write(text)
+        try:
+            with atomic_write(filename, overwrite=True,
+                              mode=mode) as textfile:
+                textfile.write(text)
+        except OSError:
+            # Some filesystems don't support the option to sync directories
+            # issue untitaker/python-atomicwrites#17
+            if PY2:
+                with codecs.open(filename, 'w', encoding=encoding) as f:
+                    f.write(text)
+            else:
+                with open(filename, 'w', encoding=encoding) as f:
+                    f.write(text)
         os.chmod(filename, original_mode)
     return encoding
 


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Catch a system error and write the file normally. This happens because some systems doesn't support the option to sync directories.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10208 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
