### PR TITLE
PR: Avoid stripping if the event comes from another editor

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -3811,6 +3811,9 @@ class CodeEditor(TextEditBaseWidget):
         Remove trailing whitespace on leaving a non-string line containing it.
         Return the number of removed spaces.
         """
+        if not self.hasFocus():
+            # Avoid problem when using split editor
+            return 0
         # Update current position
         current_position = self.textCursor().position()
         last_position = self.last_position

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -3811,9 +3811,10 @@ class CodeEditor(TextEditBaseWidget):
         Remove trailing whitespace on leaving a non-string line containing it.
         Return the number of removed spaces.
         """
-        if not self.hasFocus():
-            # Avoid problem when using split editor
-            return 0
+        if not running_under_pytest():
+            if not self.hasFocus():
+                # Avoid problem when using split editor
+                return 0
         # Update current position
         current_position = self.textCursor().position()
         last_position = self.last_position

--- a/spyder/plugins/editor/widgets/tests/test_codeeditor.py
+++ b/spyder/plugins/editor/widgets/tests/test_codeeditor.py
@@ -154,6 +154,8 @@ def test_editor_rstrip_keypress(
     cursor = widget.textCursor()
     cursor.movePosition(QTextCursor.End)
     widget.setTextCursor(cursor)
+    widget.setFocus()
+    assert widget.hasFocus()
     for key in keys:
         if isinstance(key, tuple):
             # Mouse event

--- a/spyder/plugins/editor/widgets/tests/test_codeeditor.py
+++ b/spyder/plugins/editor/widgets/tests/test_codeeditor.py
@@ -154,8 +154,6 @@ def test_editor_rstrip_keypress(
     cursor = widget.textCursor()
     cursor.movePosition(QTextCursor.End)
     widget.setTextCursor(cursor)
-    widget.setFocus()
-    assert widget.hasFocus()
     for key in keys:
         if isinstance(key, tuple):
             # Mouse event


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
When the editor is split, a change in one editor should not trigger a strip in the other editor. Here, the focus is checked before stripping.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
