### PR TITLE
PR: Add ability to modify other plugin options

### DIFF
--- a/spyder/api/plugins.py
+++ b/spyder/api/plugins.py
@@ -71,7 +71,7 @@ class BasePlugin(BasePluginMixin):
         super(BasePlugin, self)._show_status_message(message, timeout)
 
     @Slot(str, object)
-    def set_option(self, option, value):
+    def set_option(self, option, value, section=None):
         """
         Set an option in Spyder configuration file.
 
@@ -89,9 +89,9 @@ class BasePlugin(BasePluginMixin):
           same or another plugin.
         * CONF_SECTION needs to be defined for this to work.
         """
-        super(BasePlugin, self)._set_option(option, value)
+        super(BasePlugin, self)._set_option(option, value, section=section)
 
-    def get_option(self, option, default=NoDefault):
+    def get_option(self, option, default=NoDefault, section=None):
         """
         Get an option from Spyder configuration file.
 
@@ -105,7 +105,8 @@ class BasePlugin(BasePluginMixin):
         bool, int, str, tuple, list, dict
             Value associated with `option`.
         """
-        return super(BasePlugin, self)._get_option(option, default)
+        return super(BasePlugin, self)._get_option(option, default,
+                                                   section=section)
 
     def starting_long_process(self, message):
         """

--- a/spyder/api/preferences.py
+++ b/spyder/api/preferences.py
@@ -13,7 +13,8 @@ given plugin.
 from spyder.preferences.configdialog import SpyderConfigPage
 
 class PluginConfigPage(SpyderConfigPage):
-    """Plugin configuration dialog box page widget"""
+    """Plugin configuration dialog box page widget."""
+
     def __init__(self, plugin, parent):
         self.plugin = plugin
         self.get_option = plugin.get_option

--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -58,13 +58,15 @@ class BasePluginMixin(object):
         """Register plugin configuration."""
         CONF.register_plugin(self)
 
-    def _set_option(self, option, value):
+    def _set_option(self, option, value, section=None):
         """Set option in spyder.ini"""
-        CONF.set(self.CONF_SECTION, str(option), value)
+        section = self.CONF_SECTION if section is None else section
+        CONF.set(section, str(option), value)
 
-    def _get_option(self, option, default=NoDefault):
+    def _get_option(self, option, default=NoDefault, section=None):
         """Get option from spyder.ini."""
-        return CONF.get(self.CONF_SECTION, option, default)
+        section = self.CONF_SECTION if section is None else section
+        return CONF.get(section, option, default)
 
     def _show_status_message(self, message, timeout=0):
         """Show message in main window's status bar."""

--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -161,7 +161,7 @@ class EditorConfigPage(PluginConfigPage):
             _("Tab stop width:"),
             _("spaces"),
             'tab_stop_width_spaces',
-            4, 1, 8, 1)
+            default=4, min_=1, max_=8, step=1)
 
         def enable_tabwidth_spin(index):
             if index == 7:  # Tabulations

--- a/spyder/preferences/general.py
+++ b/spyder/preferences/general.py
@@ -105,7 +105,7 @@ class MainConfigPage(GeneralConfigPage):
         margin_box = newcb(_("Custom margin for panes:"),
                            'use_custom_margin')
         margin_spin = self.create_spinbox("", _("pixels"), 'custom_margin',
-                                          0, 0, 30)
+                                          default=0, min_=0, max_=30)
         margin_box.toggled.connect(margin_spin.spinbox.setEnabled)
         margin_box.toggled.connect(margin_spin.slabel.setEnabled)
         margin_spin.spinbox.setEnabled(self.get_option('use_custom_margin'))


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)


<!--- Explain what you've done and why --->

Other plugins can now change other plugin options. This is needed to group some settings that are better displayed on a different configuration page of the config dialog. Should be used with care and sparingly!


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
