### PR TITLE
PR: Only remove trailing spaces when option is turned on in Preferences

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -222,7 +222,7 @@ DEFAULTS = [
               'autosave_enabled': True,
               'autosave_interval': 60,
               'docstring_type': 'Numpydoc',
-              'strip_trailing_spaces_on_modify': True,
+              'strip_trailing_spaces_on_modify': False,
               }),
             ('historylog',
              {
@@ -592,4 +592,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '53.0.0'
+CONF_VERSION = '53.1.0'

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1282,7 +1282,7 @@ class CodeEditor(TextEditBaseWidget):
 
     def set_strip_mode(self, enable):
         """
-        Strip all trailing spaces if enabled, else only strip on auto-indents.
+        Strip all trailing spaces if enabled.
         """
         self.strip_trailing_spaces_on_modify = enable
 
@@ -3475,7 +3475,10 @@ class CodeEditor(TextEditBaseWidget):
                   self.autoinsert_colons():
                     self.textCursor().beginEditBlock()
                     self.insert_text(':' + self.get_line_separator())
-                    self.fix_and_strip_indent()
+                    if self.strip_trailing_spaces_on_modify:
+                        self.fix_and_strip_indent()
+                    else:
+                        self.fix_indent()
                     self.textCursor().endEditBlock()
                 elif self.is_completion_widget_visible():
                     self.select_completion_list()
@@ -3496,7 +3499,11 @@ class CodeEditor(TextEditBaseWidget):
 
                     self.textCursor().beginEditBlock()
                     insert_text(event)
-                    self.fix_and_strip_indent(comment_or_string=cmt_or_str)
+                    if self.strip_trailing_spaces_on_modify:
+                        self.fix_and_strip_indent(
+                            comment_or_string=cmt_or_str)
+                    else:
+                        self.fix_indent()
                     self.textCursor().endEditBlock()
         elif key == Qt.Key_Insert and not shift and not ctrl:
             self.setOverwriteMode(not self.overwriteMode())

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -3503,7 +3503,7 @@ class CodeEditor(TextEditBaseWidget):
                         self.fix_and_strip_indent(
                             comment_or_string=cmt_or_str)
                     else:
-                        self.fix_indent()
+                        self.fix_indent(comment_or_string=cmt_or_str)
                     self.textCursor().endEditBlock()
         elif key == Qt.Key_Insert and not shift and not ctrl:
             self.setOverwriteMode(not self.overwriteMode())

--- a/spyder/plugins/editor/widgets/tests/test_codeeditor.py
+++ b/spyder/plugins/editor/widgets/tests/test_codeeditor.py
@@ -91,7 +91,7 @@ def test_editor_log_lsp_handle_errors(editorbot, capsys):
     "input_text, expected_text, keys, strip_all",
     [
         ("for i in range(2): ",
-         "for i in range(2): \n\n     \n    ",
+         "for i in range(2): \n    \n     \n    ",
          [Qt.Key_Enter, Qt.Key_Enter, ' ', Qt.Key_Enter],
          False),
         ('for i in range(2): ',
@@ -135,7 +135,7 @@ def test_editor_log_lsp_handle_errors(editorbot, capsys):
          [Qt.Key_Enter, Qt.Key_Enter],
          True),
         ('def fun():\n    """fun',
-         'def fun():\n    """fun\n\n    ',
+         'def fun():\n    """fun\n    \n    ',
          [Qt.Key_Enter, Qt.Key_Enter],
          False),
         ("('🚫')",


### PR DESCRIPTION
This also turns off that option by default because it's really more for power users.

Fixes #10248.