### PR TITLE
PR: Add several validations for external LSP servers

### DIFF
--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -82,6 +82,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         self.zmq_in_port = None
         self.zmq_out_port = None
         self.transport_client = None
+        self.notifier = None
         self.language = language
 
         self.initialized = False
@@ -109,6 +110,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
                                osp.join(LOCATION, 'transport', 'main.py')]
         self.external_server = server_settings.get('external', False)
         self.stdio = server_settings.get('stdio', False)
+
         # Setting stdio on implies that external_server is off
         if self.stdio and self.external_server:
             error = ('If server is set to use stdio communication, '
@@ -270,17 +272,13 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         logger.debug('LSP {} client started!'.format(self.language))
 
     def stop(self):
-        # self.shutdown()
-        # self.exit()
         logger.info('Stopping {} client...'.format(self.language))
         if self.notifier is not None:
             self.notifier.activated.disconnect(self.on_msg_received)
             self.notifier.setEnabled(False)
             self.notifier = None
-        # if os.name == 'nt':
-        #     self.transport_client.send_signal(signal.CTRL_BREAK_EVENT)
-        # else:
-        self.transport_client.kill()
+        if self.transport_client is not None:
+            self.transport_client.kill()
         self.context.destroy()
         if not self.external_server:
             self.lsp_server.kill()

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -36,8 +36,7 @@ from spyder.plugins.completion.languageserver.decorators import (
 from spyder.plugins.completion.languageserver.transport import MessageKind
 from spyder.plugins.completion.languageserver.providers import (
     LSPMethodProviderMixIn)
-from spyder.utils.misc import (getcwd_or_home, select_port,
-                               check_connection_port)
+from spyder.utils.misc import getcwd_or_home, select_port
 
 # Conditional imports
 if PY2:

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -36,7 +36,8 @@ from spyder.plugins.completion.languageserver.decorators import (
 from spyder.plugins.completion.languageserver.transport import MessageKind
 from spyder.plugins.completion.languageserver.providers import (
     LSPMethodProviderMixIn)
-from spyder.utils.misc import getcwd_or_home, select_port
+from spyder.utils.misc import (getcwd_or_home, select_port,
+                               check_connection_port)
 
 # Conditional imports
 if PY2:
@@ -123,6 +124,8 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         transport_args = transport_args_fmt.format(
             host=server_settings['host'],
             port=server_port)
+        self.server_host = server_settings['host']
+        self.server_port = server_port
 
         self.server_args = []
         if language == 'python':
@@ -206,6 +209,13 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
                 stdin=server_stdin,
                 stderr=server_stderr,
                 creationflags=creation_flags)
+        else:
+            # Check connection to lsp server using a TCP socket
+            response = check_connection_port(self.server_host,
+                                             self.server_port)
+            if not response:
+                # TODO: start a new server
+                pass
 
         client_log = subprocess.PIPE
         if get_debug_level() > 0:

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -67,10 +67,6 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
     #  facilities.
     sig_server_error = Signal(str)
 
-    #: Signal to report that no connection could be established
-    #  with an external server.
-    sig_no_external_server = Signal(str, int, str)
-
     def __init__(self, parent,
                  server_settings={},
                  folder=getcwd_or_home(),
@@ -215,17 +211,6 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
                 stdin=server_stdin,
                 stderr=server_stderr,
                 creationflags=creation_flags)
-        else:
-            # Check connection to lsp server using a TCP socket
-            response = check_connection_port(self.server_host,
-                                             self.server_port)
-            if not response:
-                self.sig_no_external_server.emit(
-                    self.server_host,
-                    self.server_port,
-                    self.language
-                )
-                return
 
         client_log = subprocess.PIPE
         if get_debug_level() > 0:

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -303,6 +303,10 @@ class LSPServerEditor(QDialog):
         host_text = self.host_input.text()
         cmd_text = self.cmd_input.text()
 
+        if host_text not in ['127.0.0.1', 'localhost']:
+            self.external = True
+            self.external_cb.setChecked(True)
+
         if not self.HOST_REGEX.match(host_text):
             self.button_ok.setEnabled(False)
             self.host_input.setStyleSheet(self.INVALID_CSS)
@@ -1227,8 +1231,8 @@ class LanguageServerConfigPage(GeneralConfigPage):
         QMessageBox.critical(
             self,
             _("Error"),
-            _("It appears there is no {language} language server listening at "
-              "address:"
+            _("It appears there is no {language} language server listening "
+              "at address:"
               "<br><br>"
               "<tt>{host}:{port}</tt>"
               "<br><br>"
@@ -1239,16 +1243,23 @@ class LanguageServerConfigPage(GeneralConfigPage):
 
     def is_valid(self):
         """Check if config options are valid."""
+        host = self.advanced_host.textbox.text()
+
+        # If host is not local, the server must be external
+        # and we need to automatically check the corresponding
+        # option
+        if host not in ['127.0.0.1', 'localhost']:
+            self.external_server.setChecked(True)
+
         # Check connection to LSP server using a TCP socket
         if self.external_server.isChecked():
-            host = self.advanced_host.textbox.text()
             port = int(self.advanced_port.spinbox.text())
             response = check_connection_port(host, port)
             if not response:
                 self.report_no_external_server(host, port, 'python')
                 return False
             else:
-                return True
+                return super(GeneralConfigPage, self).is_valid()
         else:
             return super(GeneralConfigPage, self).is_valid()
 

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -1273,8 +1273,7 @@ class LanguageServerConfigPage(GeneralConfigPage):
             # Check that host and port of the current server are
             # different from the new ones provided to connect to
             # an external server.
-            cm = self.main.completions
-            lsp = cm.get_client('lsp')
+            lsp = self.main.completions.get_client('lsp')
             pyclient = lsp.clients.get('python')
             if pyclient is not None:
                 instance = pyclient['instance']

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -1277,7 +1277,8 @@ class LanguageServerConfigPage(GeneralConfigPage):
             pyclient = lsp.clients.get('python')
             if pyclient is not None:
                 instance = pyclient['instance']
-                if not pyclient['config']['external']:
+                if (instance is not None and
+                        not pyclient['config']['external']):
                     if (instance.server_host == host and
                             instance.server_port == port):
                         self.report_no_address_change()

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -1247,6 +1247,8 @@ class LanguageServerConfigPage(GeneralConfigPage):
             if not response:
                 self.report_no_external_server(host, port, 'python')
                 return False
+            else:
+                return True
         else:
             return super(GeneralConfigPage, self).is_valid()
 

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -1177,6 +1177,13 @@ class LanguageServerConfigPage(GeneralConfigPage):
         Show a warning when trying to modify the PyLS advanced
         settings.
         """
+        # Don't show warning if the option is already enabled.
+        # This avoids showing it when the Preferences dialog
+        # is created.
+        if self.get_option('advanced/enabled'):
+            return
+
+        # Show warning when toggling the button state
         if state:
             QMessageBox.warning(
                 self,

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -300,7 +300,7 @@ def regexp_error_msg(pattern):
 
 
 def check_connection_port(address, port):
-    """Verify if a port is available given the address given."""
+    """Verify if `port` is available in `address`."""
     # Create a TCP socket
     s = socket.socket()
     logger.debug("Attempting to connect to {} on port {}".format(

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -307,7 +307,7 @@ def check_connection_port(address, port):
                  address, port))
     try:
         s.connect((address, port))
-        logger.debug("Connected to {} on port {}").format(address, port)
+        logger.debug("Connected to {} on port {}".format(address, port))
         return True
     except socket.error as e:
         logger.debug("Connection to {} on port {} failed: {}".format(

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -13,6 +13,7 @@ import os.path as osp
 import re
 import sys
 import stat
+import socket
 
 from spyder.py3compat import is_text_string, getcwd
 from spyder.config.base import get_home_dir
@@ -296,3 +297,21 @@ def regexp_error_msg(pattern):
     except re.error as e:
         return str(e)
     return None
+
+
+def check_connection_port(address, port):
+    """Verify if a port is available given the address given."""
+    # Create a TCP socket
+    s = socket.socket()
+    logger.debug("Attempting to connect to {} on port {}".format(
+                 address, port))
+    try:
+        s.connect((address, port))
+        logger.debug("Connected to {} on port {}").format(address, port)
+        return True
+    except socket.error as e:
+        logger.debug("Connection to {} on port {} failed: {}".format(
+                     address, port, e))
+        return False
+    finally:
+        s.close()

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -303,6 +303,7 @@ def check_connection_port(address, port):
     """Verify if `port` is available in `address`."""
     # Create a TCP socket
     s = socket.socket()
+    s.settimeout(2)
     logger.debug("Attempting to connect to {} on port {}".format(
                  address, port))
     try:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Add several validations to avoid problems with external servers

1. Don't allow to activate the external server option when the address of external server is not different from the one of current one (this avoids issue #9992).

    ![Selección_021](https://user-images.githubusercontent.com/365293/65386382-5297cd80-dd3b-11e9-9204-e10d7e687194.png)

2. Don't allow to activate the external server option when there's no external server listening at `host:port`:

    ![Selección_022](https://user-images.githubusercontent.com/365293/65386450-15800b00-dd3c-11e9-9e76-e181871ddc6f.png)

3. Don't create an LSP client to an external server at startup if that server is not listening at `host:port` (this should avoid issue #10209):

    ![Selección_024](https://user-images.githubusercontent.com/365293/65386492-b66ec600-dd3c-11e9-9065-5c2c3edb5730.png)

4. Allow to start an internal server if the session started with a non-working external server. 


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10209 
Fixes #9992.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
