### PR TITLE
PR: Show exact match completions

### DIFF
--- a/spyder/plugins/completion/fallback/actor.py
+++ b/spyder/plugins/completion/fallback/actor.py
@@ -53,7 +53,7 @@ class FallbackActor(QObject):
         self.thread.started.connect(self.started)
         self.sig_mailbox.connect(self.handle_msg)
 
-    def tokenize(self, text, language):
+    def tokenize(self, text, offset, language):
         """
         Return all tokens in `text` and all keywords associated by
         Pygments to `language`.
@@ -74,7 +74,7 @@ class FallbackActor(QObject):
         # logger.debug(keywords)
         # tokens = list(lexer.get_tokens(text))
         # logger.debug(tokens)
-        tokens = get_words(text, language)
+        tokens = get_words(text, offset, language)
         tokens = [{'kind': CompletionItemKind.TEXT, 'insertText': token,
                    'label': token,
                    'sortText': u'zz{0}'.format(token[0].lower()),
@@ -110,13 +110,20 @@ class FallbackActor(QObject):
             _id, msg_type, file))
         if msg_type == LSPRequestTypes.DOCUMENT_DID_OPEN:
             self.file_tokens[file] = {
-                'text': msg['text'], 'language': msg['language']}
+                'text': msg['text'],
+                'offset': msg['offset'],
+                'language': msg['language'],
+            }
         elif msg_type == LSPRequestTypes.DOCUMENT_DID_CHANGE:
             if file not in self.file_tokens:
                 self.file_tokens[file] = {
-                    'text': '', 'language': msg['language']}
+                    'text': '',
+                    'offset': msg['offset'],
+                    'language': msg['language'],
+                }
             diff = msg['diff']
             text = self.file_tokens[file]
+            text['offset'] = msg['offset']
             text, _ = self.diff_patch.patch_apply(
                 diff, text['text'])
             self.file_tokens[file]['text'] = text
@@ -127,6 +134,8 @@ class FallbackActor(QObject):
             if file in self.file_tokens:
                 text_info = self.file_tokens[file]
                 tokens = self.tokenize(
-                    text_info['text'], text_info['language'])
+                    text_info['text'],
+                    text_info['offset'],
+                    text_info['language'])
             tokens = {'params': tokens}
             self.sig_set_tokens.emit(_id, tokens)

--- a/spyder/plugins/completion/fallback/tests/test_fallback.py
+++ b/spyder/plugins/completion/fallback/tests/test_fallback.py
@@ -10,6 +10,7 @@ import os.path as osp
 import pytest
 from diff_match_patch import diff_match_patch
 from spyder.plugins.completion.languageserver import LSPRequestTypes
+from spyder.plugins.completion.fallback.utils import get_words
 
 
 DATA_PATH = osp.join(osp.dirname(osp.abspath(__file__)), "data")
@@ -67,7 +68,8 @@ def test_file_open_close(qtbot_module, fallback_fixture):
 
     open_request = {
         'file': 'test.py',
-        'text': TEST_FILE
+        'text': TEST_FILE,
+        'offset': -1,
     }
     fallback.send_request(
         'python', LSPRequestTypes.DOCUMENT_DID_OPEN, open_request)
@@ -83,6 +85,12 @@ def test_file_open_close(qtbot_module, fallback_fixture):
     assert 'test.py' not in fallback.fallback_actor.file_tokens
 
 
+def test_get_words():
+    source = 'foo bar123 baz car456'
+    tokens = get_words(source, 5, 'python')
+    assert set(tokens) == {'foo', 'baz', 'car456'}
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize('file_fixture', language_list, indirect=True)
 def test_tokenize(qtbot_module, fallback_fixture, file_fixture):
@@ -93,7 +101,8 @@ def test_tokenize(qtbot_module, fallback_fixture, file_fixture):
     # diff = diff_match.patch_make('', contents)
     open_request = {
         'file': filename,
-        'text': contents
+        'text': contents,
+        'offset': -1,
     }
     fallback.send_request(
         language, LSPRequestTypes.DOCUMENT_DID_OPEN, open_request)
@@ -118,7 +127,8 @@ def test_token_update(qtbot_module, fallback_fixture):
     # diff = diff_match.patch_make('', TEST_FILE)
     open_request = {
         'file': 'test.py',
-        'text': TEST_FILE
+        'text': TEST_FILE,
+        'offset': -1,
     }
     fallback.send_request(
         'python', LSPRequestTypes.DOCUMENT_DID_OPEN, open_request)
@@ -138,7 +148,8 @@ def test_token_update(qtbot_module, fallback_fixture):
     diff = diff_match.patch_make(TEST_FILE, TEST_FILE_UPDATE)
     update_request = {
         'file': 'test.py',
-        'diff': diff
+        'diff': diff,
+        'offset': -1,
     }
     fallback.send_request(
         'python', LSPRequestTypes.DOCUMENT_DID_CHANGE, update_request)

--- a/spyder/plugins/completion/fallback/utils.py
+++ b/spyder/plugins/completion/fallback/utils.py
@@ -95,7 +95,7 @@ def get_keywords(lexer):
     return keywords
 
 
-def get_words(text, language=None):
+def get_words(text, exclude_offset=None, language=None):
     """
     Extract all words from a source code file to be used in code completion.
 
@@ -103,7 +103,13 @@ def get_words(text, language=None):
     to carry out the inline completion similar to VSCode.
     """
     regex = LANGUAGE_REGEX.get(language.lower(), all_regex)
-    tokens = list({x for x in regex.findall(text) if x != ''})
+    tokens = [x
+              for x in (m.group()
+                        for m in regex.finditer(text)
+                        if exclude_offset is None or
+                        exclude_offset < m.start() or
+                        m.end() < exclude_offset)
+              if x != '']
     return tokens
 
 

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1066,29 +1066,6 @@ class CodeEditor(TextEditBaseWidget):
             first_letter = text1[0] if len(text1) > 0 else ''
             is_upper_word = first_letter.isupper()
             completions = [] if completions is None else completions
-            comparison_key = 'label'
-            if self.code_snippets:
-                available_completions = {x['label'].strip():
-                                         x for x in completions}
-                t1 = available_completions.pop(text1, None)
-                t2 = available_completions.pop(text2, None)
-
-                if t1 is not None:
-                    if t1['insertText'] != t1[comparison_key]:
-                        available_completions[t1[comparison_key]] = t1
-
-                if t2 is not None:
-                    t1_label = t1[comparison_key] if t1 else None
-                    if t2[comparison_key] != t1_label:
-                        if t2['insertText'] != t2[comparison_key]:
-                            available_completions[t2[comparison_key]] = t2
-            else:
-                comparison_key = 'insertText'
-                available_completions = {x['insertText'].strip(): x
-                                         for x in completions[::-1]}
-                available_completions.pop(text1, None)
-
-            completions = list(available_completions.values())
 
             if completions is not None and len(completions) > 0:
                 for completion in completions:


### PR DESCRIPTION
## Description of Changes

This is a proposal to change the completions filtering behavior to show completions that exactly match what the user has typed under the cursor.

As far as I can tell, the main reason to have the filtering was that the fallback plugin would generate "identity" completions via tokenization, so I filter out tokens that are under the cursor there.

The advantage to showing exact matches is primarily if there are many other completions, and exact matches are not shown, then if I hit enter, the wrong completion will be inserted:

![Screen Shot 2019-09-27 at 11 47 39 AM](https://user-images.githubusercontent.com/1977419/65794301-ada33900-e11c-11e9-9e0e-80997568caf5.png)

Please let me know if you disagree with this change. Also, I'm sure tests will fail, so I'll fix those.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @metalogical 

<!--- Thanks for your help making Spyder better for everyone! --->
