### PR TITLE
PR: Remove extraneous Kite config option

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -510,7 +510,6 @@ DEFAULTS = [
               'call_to_action': True,
               # Enable the installation dialog
               'show_installation_dialog': True,
-              'call_to_action': True,
              }),
             ]
 


### PR DESCRIPTION
It was introduced because I had the option in two PRs that both got merged. It doesn't actually break anything, since if you duplicate keys in a dict literal, the latter one is taken. But we should fix it.

@ccordoba12 