### PR TITLE
PR: Don't use PyLS 0.29 for now in our tests

### DIFF
--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -12,7 +12,7 @@ pygments >=2.0
 pylint
 pympler
 pyqt <5.13
-python-language-server >=0.28.2
+python-language-server >=0.28.2,<0.29.0
 pyxdg
 pyzmq
 qdarkstyle >=2.7


### PR DESCRIPTION
That version brings Jedi 0.15, which has several errors.