### PR TITLE
PR: Editor plugin is raised after selecting file in the switcher

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1055,6 +1055,7 @@ class Editor(SpyderPluginWidget):
 
         # Add modes to switcher
         self.switcher_manager = EditorSwitcherManager(
+            self,
             self.main.switcher,
             lambda: self.get_current_editor(),
             lambda: self.get_current_editorstack(),

--- a/spyder/plugins/editor/utils/switcher.py
+++ b/spyder/plugins/editor/utils/switcher.py
@@ -99,8 +99,8 @@ class EditorSwitcherManager(object):
     LINE_MODE = ':'
     FILES_MODE = ''
 
-    def __init__(self, switcher_instance, get_codeeditor, get_editorstack,
-                 section=_("Editor")):
+    def __init__(self, plugin, switcher_instance, get_codeeditor,
+                 get_editorstack, section=_("Editor")):
         """
         'get_codeeditor' and 'get_editorstack' params should be callables
         to get the current CodeEditor or EditorStack instance as needed.
@@ -108,6 +108,7 @@ class EditorSwitcherManager(object):
             current_codeeditor = get_codeditor()
             current_editorstack = get_editorstack()
         """
+        self._plugin = plugin
         self._switcher = switcher_instance
         self._editor = get_codeeditor
         self._editorstack = get_editorstack
@@ -231,6 +232,7 @@ class EditorSwitcherManager(object):
             # Each plugin that wants to attach to the switcher should do this?
             if item.get_section() == self._section:
                 self.editor_switcher_handler(data)
+                self._plugin.switch_to_plugin()
 
     def handle_switcher_text(self, search_text):
         """Handle switcher search text for line mode."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Add a switch to plugin to the editor widget for raising when there's another plugin over the editor.

![fix](https://user-images.githubusercontent.com/20992645/66865153-3d8a1500-ef5c-11e9-98d4-9c7632303ee9.gif)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10335 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
