### PR TITLE
PR: Check length of parameters when trying to parse signatures

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1130,7 +1130,7 @@ class CodeEditor(TextEditBaseWidget):
                 parameter_idx = signature_params['activeParameter']
                 parameters = signature_data['parameters']
                 parameter = None
-                if parameter_idx < len(parameters):
+                if len(parameters) > 0 and parameter_idx < len(parameters):
                     parameter_data = parameters[parameter_idx]
                     parameter = parameter_data['label']
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
The issue  #10453 occured because parameter_idx = -1 and len(parameters)=0.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10453 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ok97465

<!--- Thanks for your help making Spyder better for everyone! --->
