### PR TITLE
PR: Send correct Unicode offset encoding to Kite

### DIFF
--- a/spyder/plugins/completion/kite/providers/document.py
+++ b/spyder/plugins/completion/kite/providers/document.py
@@ -70,9 +70,11 @@ class DocumentProvider:
             'filename': osp.realpath(params['file']),
             'text': params['text'],
             'action': 'focus',
-            'selections': [
-                {'start': params['offset'], 'end': params['offset']}
-            ]
+            'selections': [{
+                'start': params['offset'],
+                'end': params['offset'],
+                'encoding': 'utf-16',
+            }],
         }
 
         with QMutexLocker(self.mutex):
@@ -87,9 +89,11 @@ class DocumentProvider:
             'filename': osp.realpath(params['file']),
             'text': params['text'],
             'action': 'edit',
-            'selections': [
-                {'start': params['offset'], 'end': params['offset']}
-            ]
+            'selections': [{
+                'start': params['offset'],
+                'end': params['offset'],
+                'encoding': 'utf-16',
+            }],
         }
         with QMutexLocker(self.mutex):
             self.opened_files[params['file']] = params['text']
@@ -106,7 +110,7 @@ class DocumentProvider:
             'position': {
                 'begin': params['offset']
             },
-            'placeholders': []
+            'offset_encoding': 'utf-16',
         }
         return request
 
@@ -164,7 +168,8 @@ class DocumentProvider:
         request = {
             'filename': path,
             'hash': md5,
-            'cursor_runes': params['offset']
+            'cursor_runes': params['offset'],
+            'offset_encoding': 'utf-16',
         }
         return None, request
 
@@ -191,7 +196,7 @@ class DocumentProvider:
             'filename': request['file'],
             'text': text,
             'cursor_runes': request['offset'],
-            'offset_encoding': 'utf-32'
+            'offset_encoding': 'utf-16',
         }
         return response
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

LSP and Qt both "talk about" UTF-16 code units (i.e. UTF-16 16-byte chunks, of which 1 or 2 may be used for a single code point):
- https://doc.qt.io/qt-5/qtextcursor.html#position
- https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#text-documents

So Qt / LSP should be compatible by default. Kite, on the other hand, allows the client to specify an encoding, but uses UTF-32 (i.e. Unicode code points) as the default.

So we need to tell Kite that we're using UTF-16.

Let me know if you have suggestions for test cases here.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->
fixes #10401 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @metalogical 

<!--- Thanks for your help making Spyder better for everyone! --->
