### PR TITLE
PR: Reduce flakyness of tests

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,6 +4,7 @@ pytest-cov
 pytest-qt
 pytest-ordering
 pytest-lazy-fixture
+pytest-faulthandler
 mock
 pandas
 scipy

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,7 +4,7 @@ pytest-cov
 pytest-qt
 pytest-ordering
 pytest-lazy-fixture
-pytest-faulthandler
+pytest-faulthandler <2.0
 mock
 pandas
 scipy

--- a/runtests.py
+++ b/runtests.py
@@ -37,11 +37,6 @@ def main(run_slow=False, extra_args=None):
                    '-rw',
                    '--durations=10']
 
-    if sys.version[0] == '3':
-        # Print stack if segmentation fault
-        import faulthandler
-        faulthandler.enable()
-
     if RUN_CI:
         pytest_args += ['-x', '--cov=spyder', '--no-cov-on-fail',
                         '--run-slow']

--- a/setup.py
+++ b/setup.py
@@ -247,6 +247,7 @@ extras_require = {
              'pytest-xvfb;platform_system=="Linux"',
              'pytest-ordering',
              'pytest-lazy-fixture',
+             'pytest-faulthandler',
              'mock',
              'flaky',
              'pandas',

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1147,7 +1147,9 @@ def test_run_cell_copy(main_window, qtbot, tmpdir):
     shell = main_window.ipyconsole.get_current_shellwidget()
     qtbot.waitUntil(lambda: shell._prompt_html is not None,
                     timeout=SHELL_TIMEOUT)
-
+    # Make sure run_cell_copy is properly set
+    for editorstack in main_window.editor.editorstacks:
+        editorstack.set_run_cell_copy(True)
     # Load test file
     main_window.editor.load(filepath)
 

--- a/spyder/plugins/completion/kite/utils/tests/test_install.py
+++ b/spyder/plugins/completion/kite/utils/tests/test_install.py
@@ -60,7 +60,7 @@ def test_kite_install(qtbot):
                 FINISHED]
 
         # This status can be obtained the second time our tests are run
-        if not installation_statuses == ['Install finished']:
+        if not installation_statuses == ['Installation finished']:
             assert installation_statuses == expected_installation_status
 
     install_manager.sig_installation_status.connect(installation_status)

--- a/spyder/plugins/ipythonconsole/tests/conftest.py
+++ b/spyder/plugins/ipythonconsole/tests/conftest.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright © Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# ----------------------------------------------------------------------------
+
+import pytest
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    # execute all other hooks to obtain the report object
+    outcome = yield
+    rep = outcome.get_result()
+
+    # set a report attribute for each phase of a call, which can
+    # be "setup", "call", "teardown"
+    setattr(item, "rep_" + rep.when, rep)

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -173,7 +173,14 @@ def ipyconsole(qtbot, request):
 
     qtbot.addWidget(window)
     window.show()
-    return console
+
+    yield console
+
+    # Print shell content if failed
+    if request.node.rep_setup.passed:
+        if request.node.rep_call.failed:
+            # Print content of shellwidget and close window
+            print(console.get_current_shellwidget()._control.toPlainText())
 
 
 # =============================================================================


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

 1. Kite test issue:  'Install finished' has been renamed 'Installation finished'?
 2. Since we reuse the same window, the cleanup of the window must be improved to avoid test failure (the tests are marked flaky but they still fail once.)
 3. Close all open clients when finishing a test
 4. Add pytest-faulthandler to print traceback for segmentation faults
 5. Remove `print(control.toPlainText())` as it is now duplicated in `def main_window`
 6. Print `control.toPlainText()` upon ipythonconsole test failure

* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: impact27

<!--- Thanks for your help making Spyder better for everyone! --->
