### PR TITLE
Cooperative completions

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -207,6 +207,7 @@ DEFAULTS = [
               'automatic_completions': True,
               'automatic_completions_after_chars': 3,
               'automatic_completions_after_ms': 300,
+              'completions_max_request_ms': 200,
               'completions_hint': True,
               'underline_errors': False,
               'highlight_current_line': True,

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -723,6 +723,10 @@ class LanguageServerConfigPage(GeneralConfigPage):
             _("Show automatic completions after keyboard idle (ms):"), None,
             'automatic_completions_after_ms', min_=0, max_=5000, step=10,
             tip=_("Default is 300"), section='editor')
+        self.completions_max_request_ms = self.create_spinbox(
+            _("Time to wait for completions to return (ms):"), None,
+            'completions_max_request_ms', min_=10, max_=5000, step=10,
+            tip=_("Default is 200"), section='editor')
         code_snippets_box = newcb(_("Enable code snippets"), 'code_snippets')
 
         completion_layout = QGridLayout()
@@ -735,7 +739,11 @@ class LanguageServerConfigPage(GeneralConfigPage):
                                     3, 1)
         completion_layout.addWidget(self.completions_after_ms.plabel, 4, 0)
         completion_layout.addWidget(self.completions_after_ms.spinbox, 4, 1)
-        completion_layout.addWidget(code_snippets_box, 5, 0)
+        completion_layout.addWidget(self.completions_max_request_ms.plabel,
+                                    5, 0)
+        completion_layout.addWidget(self.completions_max_request_ms.spinbox,
+                                    5, 1)
+        completion_layout.addWidget(code_snippets_box, 6, 0)
         completion_layout.setColumnStretch(2, 5)
         completion_widget = QWidget()
         completion_widget.setLayout(completion_layout)
@@ -1164,6 +1172,8 @@ class LanguageServerConfigPage(GeneralConfigPage):
         self.completions_after_characters.plabel.setEnabled(state)
         self.completions_after_ms.spinbox.setEnabled(state)
         self.completions_after_ms.plabel.setEnabled(state)
+        self.completions_max_request_ms.spinbox.setEnabled(state)
+        self.completions_max_request_ms.plabel.setEnabled(state)
 
     def disable_tcp(self, state):
         if state == Qt.Checked:
@@ -1388,6 +1398,8 @@ class LanguageServerConfigPage(GeneralConfigPage):
                 'editor', 'automatic_completions_after_chars'),
             'set_automatic_completions_after_ms': (
                 'editor', 'automatic_completions_after_ms'),
+            'set_completions_max_request_ms': (
+                'editor', 'completions_max_request_ms'),
         }
         for editorstack in editor.editorstacks:
             for method_name, (sec, opt) in editor_method_sec_opts.items():

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -725,8 +725,8 @@ class LanguageServerConfigPage(GeneralConfigPage):
             tip=_("Default is 300"), section='editor')
         self.completions_max_request_ms = self.create_spinbox(
             _("Time to wait for completions to return (ms):"), None,
-            'completions_max_request_ms', min_=10, max_=5000, step=10,
-            tip=_("Default is 200"), section='editor')
+            'completions_max_request_ms', min_=0, max_=5000, step=10,
+            tip=_("Default is 200 / 0 to disable"), section='editor')
         code_snippets_box = newcb(_("Enable code snippets"), 'code_snippets')
 
         completion_layout = QGridLayout()

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -221,7 +221,9 @@ class CompletionManager(SpyderCompletionPlugin):
                 language, req_type, req, req_id)
 
         # Start the timer on this request
-        QTimer.singleShot(200, lambda: self.receive_timeout(req_id))
+        max_ms = self.get_option('completions_max_request_ms',
+                                 default=200, section='editor')
+        QTimer.singleShot(max_ms, lambda: self.receive_timeout(req_id))
 
     def send_notification(self, language, notification_type, notification):
         for client_name in self.clients:

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -213,7 +213,6 @@ class CompletionManager(SpyderCompletionPlugin):
             'req_type': req_type,
             'response_instance': req['response_instance'],
             'sources': {},
-            'timed_out': False,
         }
         for client_name in self.clients:
             client_info = self.clients[client_name]

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -116,20 +116,12 @@ class CompletionManager(SpyderCompletionPlugin):
             request_responses['sources'][completion_source] = resp
 
             wait_for = self.WAIT_FOR_SOURCE[request_responses['req_type']]
-            if not resp:
-                # Any response is better than no response
-                keep_waiting = any(
-                    self._is_client_running(source) and
-                    source not in request_responses['sources']
-                    for source in self.clients)
-            elif completion_source not in wait_for:
-                # A wait_for response is better than non-wait_for
-                keep_waiting = any(
-                    self._is_client_running(source) and
-                    source not in request_responses['sources']
-                    for source in wait_for)
-            else:
-                keep_waiting = False
+
+            # Wait for all providers to finish
+            keep_waiting = any(
+                self._is_client_running(source) and
+                source not in request_responses['sources']
+                for source in wait_for)
 
             if keep_waiting:
                 return

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -223,7 +223,8 @@ class CompletionManager(SpyderCompletionPlugin):
         # Start the timer on this request
         max_ms = self.get_option('completions_max_request_ms',
                                  default=200, section='editor')
-        QTimer.singleShot(max_ms, lambda: self.receive_timeout(req_id))
+        if max_ms > 0:
+            QTimer.singleShot(max_ms, lambda: self.receive_timeout(req_id))
 
     def send_notification(self, language, notification_type, notification):
         for client_name in self.clients:

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -131,6 +131,7 @@ class CompletionManager(SpyderCompletionPlugin):
 
     @Slot(int)
     def receive_timeout(self, req_id):
+        # On timeout, collect all completions and return to the user
         logger.debug("Completion plugin: Request {} timed out".format(req_id))
 
         if req_id not in self.requests:
@@ -219,6 +220,7 @@ class CompletionManager(SpyderCompletionPlugin):
             client_info['plugin'].send_request(
                 language, req_type, req, req_id)
 
+        # Start the timer on this request
         QTimer.singleShot(200, lambda: self.receive_timeout(req_id))
 
     def send_notification(self, language, notification_type, notification):

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -132,10 +132,10 @@ class CompletionManager(SpyderCompletionPlugin):
     @Slot(int)
     def receive_timeout(self, req_id):
         # On timeout, collect all completions and return to the user
-        logger.debug("Completion plugin: Request {} timed out".format(req_id))
-
         if req_id not in self.requests:
             return
+
+        logger.debug("Completion plugin: Request {} timed out".format(req_id))
 
         with QMutexLocker(self.collection_mutex):
             request_responses = self.requests[req_id]

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1224,6 +1224,8 @@ class Editor(SpyderPluginWidget):
              'automatic_completions_after_chars'),
             ('set_automatic_completions_after_ms',
              'automatic_completions_after_ms'),
+            ('set_completions_max_request_ms',
+             'completions_max_request_ms'),
             ('set_completions_hint_enabled',        'completions_hint'),
             ('set_highlight_current_line_enabled',  'highlight_current_line'),
             ('set_highlight_current_cell_enabled',  'highlight_current_cell'),

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -512,6 +512,9 @@ class CodeEditor(TextEditBaseWidget):
         self.automatic_completions_after_chars = 3
         self.automatic_completions_after_ms = 300
 
+        # Completions timeout
+        self.completions_max_request_ms = 200
+
         # Completions hint
         self.completions_hint = True
 
@@ -781,6 +784,7 @@ class CodeEditor(TextEditBaseWidget):
                      automatic_completions=True,
                      automatic_completions_after_chars=3,
                      automatic_completions_after_ms=300,
+                     completions_max_request_ms=200,
                      completions_hint=True,
                      hover_hints=True,
                      code_snippets=True,
@@ -876,6 +880,9 @@ class CodeEditor(TextEditBaseWidget):
             automatic_completions_after_chars)
         self.set_automatic_completions_after_ms(
             automatic_completions_after_ms)
+
+        # Completions timeout
+        self.set_completions_max_request_ms(completions_max_request_ms)
 
         # Completions hint
         self.toggle_completions_hint(completions_hint)
@@ -1313,6 +1320,12 @@ class CodeEditor(TextEditBaseWidget):
         Set the amount of time in ms after which auto completion is fired.
         """
         self.automatic_completions_after_ms = ms
+
+    def set_completions_max_request_ms(self, ms):
+        """
+        Set the amount of time to wait for completions to return.
+        """
+        self.completions_max_request_ms = ms
 
     def set_close_parentheses_enabled(self, enable):
         """Enable/disable automatic parentheses insertion feature"""

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -554,6 +554,7 @@ class EditorStack(QWidget):
         self.automatic_completions_enabled = True
         self.automatic_completion_chars = 3
         self.automatic_completion_ms = 300
+        self.completions_max_request_ms = 200
         self.completions_hint_enabled = True
         self.hover_hints_enabled = True
         self.code_snippets_enabled = True
@@ -1192,6 +1193,12 @@ class EditorStack(QWidget):
         if self.data:
             for finfo in self.data:
                 finfo.editor.set_automatic_completions_after_ms(ms)
+
+    def set_completions_max_request_ms(self, ms):
+        self.completions_max_request_ms = ms
+        if self.data:
+            for finfo in self.data:
+                finfo.editor.set_completions_max_request_ms(ms)
 
     def set_completions_hint_enabled(self, state):
         self.completions_hint_enabled = state
@@ -2424,6 +2431,7 @@ class EditorStack(QWidget):
             automatic_completions=self.automatic_completions_enabled,
             automatic_completions_after_chars=self.automatic_completion_chars,
             automatic_completions_after_ms=self.automatic_completion_ms,
+            completions_max_request_ms=self.completions_max_request_ms,
             code_snippets=self.code_snippets_enabled,
             completions_hint=self.completions_hint_enabled,
             hover_hints=self.hover_hints_enabled,

--- a/spyder/plugins/editor/widgets/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/tests/conftest.py
@@ -43,7 +43,8 @@ def codeeditor_factory():
                         font=QFont("Monospace", 10),
                         automatic_completions=True,
                         automatic_completions_after_chars=1,
-                        automatic_completions_after_ms=200)
+                        automatic_completions_after_ms=200,
+                        completions_max_request_ms=200)
     editor.resize(640, 480)
     return editor
 

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -43,7 +43,6 @@ def test_space_completion(lsp_codeeditor, qtbot):
     code_editor, _ = lsp_codeeditor
     code_editor.toggle_automatic_completions(False)
     code_editor.toggle_code_snippets(False)
-    code_editor.set_completions_max_request_ms(9000)
 
     completion = code_editor.completion_widget
 

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -43,7 +43,7 @@ def test_space_completion(lsp_codeeditor, qtbot):
     code_editor, _ = lsp_codeeditor
     code_editor.toggle_automatic_completions(False)
     code_editor.toggle_code_snippets(False)
-    code_editor.set_completions_max_request_ms(0)
+    code_editor.set_completions_max_request_ms(9000)
 
     completion = code_editor.completion_widget
 

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -43,6 +43,7 @@ def test_space_completion(lsp_codeeditor, qtbot):
     code_editor, _ = lsp_codeeditor
     code_editor.toggle_automatic_completions(False)
     code_editor.toggle_code_snippets(False)
+    CONF.set('editor', 'completions_max_request_ms', 0)
 
     completion = code_editor.completion_widget
 

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -43,6 +43,7 @@ def test_space_completion(lsp_codeeditor, qtbot):
     code_editor, _ = lsp_codeeditor
     code_editor.toggle_automatic_completions(False)
     code_editor.toggle_code_snippets(False)
+    code_editor.set_completions_max_request_ms(0)
 
     completion = code_editor.completion_widget
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

This PR changes the completions logic to allow multiple completions providers to return completions for any given request.

Previously, completions providers would "race" against one another such that only one was allowed to return completions to the user. There are a couple of downsides to this methodology.

1. In some cases, if the "wrong" completions provider returns first, the user is left with completions that are semantically incorrect. In the video below, notice how the LSP provider returns first but the completions it provides are semantically incorrect and would result in a bug.
![lsp](https://user-images.githubusercontent.com/3752225/67342045-16948b80-f4e6-11e9-90b6-fe93b8eac747.gif)
2. The design does not allow for a future where there could be multiple completions providers that are used for different reasons. This inflexibility therefore greatly reduces the value users can get from their completions experience.

With this PR, the `CompletionManager` class now waits for all completions providers to return before returning them back to the user. In the video below, notice how both Kite and LSP completions are returned (though the LSP completions are semantically wrong).

![kite+lsp](https://user-images.githubusercontent.com/3752225/67341800-62930080-f4e5-11e9-9d3d-836bd78dbc65.gif)

To prevent slow completions providers from keeping the user waiting, the `CompletionManager` institutes a timeout per completions request at which point, all available completions are gathered and sent back. This is controlled through a setting:

![image](https://user-images.githubusercontent.com/3752225/67341910-bef62000-f4e5-11e9-8e23-3a0002cc3b70.png)



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10447 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @its-dhung 

<!--- Thanks for your help making Spyder better for everyone! --->
