### PR TITLE
PR: Remove pytest-faulthandler from our requirements

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,7 +4,6 @@ pytest-cov
 pytest-qt
 pytest-ordering
 pytest-lazy-fixture
-pytest-faulthandler <2.0
 mock
 pandas
 scipy

--- a/setup.py
+++ b/setup.py
@@ -247,7 +247,6 @@ extras_require = {
              'pytest-xvfb;platform_system=="Linux"',
              'pytest-ordering',
              'pytest-lazy-fixture',
-             'pytest-faulthandler',
              'mock',
              'flaky',
              'pandas',


### PR DESCRIPTION
Let's see if this removes the problems we're seeing today with our IPython console tests.