### PR TITLE
PR: Completions performance improvements

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -208,7 +208,7 @@ DEFAULTS = [
               'automatic_completions_after_chars': 3,
               'automatic_completions_after_ms': 300,
               'completions_hint': True,
-              'completions_hint_after_ms': 1000,
+              'completions_hint_after_ms': 500,
               'underline_errors': False,
               'highlight_current_line': True,
               'highlight_current_cell': True,

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -208,6 +208,7 @@ DEFAULTS = [
               'automatic_completions_after_chars': 3,
               'automatic_completions_after_ms': 300,
               'completions_hint': True,
+              'completions_hint_after_ms': 1000,
               'underline_errors': False,
               'highlight_current_line': True,
               'highlight_current_cell': True,

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -711,6 +711,10 @@ class LanguageServerConfigPage(GeneralConfigPage):
             _("Show completion details"),
             'completions_hint',
             section='editor')
+        self.completions_hint_after_ms = self.create_spinbox(
+            _("Show completion detail after keyboard idle (ms):"), None,
+            'completions_hint_after_ms', min_=0, max_=5000, step=10,
+            tip=_("Default is 1000"), section='editor')
         self.automatic_completion_box = newcb(
             _("Show completions on the fly"),
             'automatic_completions',
@@ -728,15 +732,19 @@ class LanguageServerConfigPage(GeneralConfigPage):
         completion_layout = QGridLayout()
         completion_layout.addWidget(self.completion_box, 0, 0)
         completion_layout.addWidget(self.completion_hint_box, 1, 0)
-        completion_layout.addWidget(self.automatic_completion_box, 2, 0)
+        completion_layout.addWidget(self.completions_hint_after_ms.plabel,
+                                    2, 0)
+        completion_layout.addWidget(self.completions_hint_after_ms.spinbox,
+                                    2, 1)
+        completion_layout.addWidget(self.automatic_completion_box, 3, 0)
         completion_layout.addWidget(self.completions_after_characters.plabel,
-                                    3, 0)
+                                    4, 0)
         completion_layout.addWidget(self.completions_after_characters.spinbox,
-                                    3, 1)
-        completion_layout.addWidget(self.completions_after_ms.plabel, 4, 0)
-        completion_layout.addWidget(self.completions_after_ms.spinbox, 4, 1)
-        completion_layout.addWidget(code_snippets_box, 5, 0)
-        completion_layout.setColumnStretch(2, 5)
+                                    4, 1)
+        completion_layout.addWidget(self.completions_after_ms.plabel, 5, 0)
+        completion_layout.addWidget(self.completions_after_ms.spinbox, 5, 1)
+        completion_layout.addWidget(code_snippets_box, 6, 0)
+        completion_layout.setColumnStretch(2, 6)
         completion_widget = QWidget()
         completion_widget.setLayout(completion_layout)
 
@@ -1383,6 +1391,8 @@ class LanguageServerConfigPage(GeneralConfigPage):
             'set_automatic_completions_enabled': ('editor',
                                                   'automatic_completions'),
             'set_completions_hint_enabled': ('editor', 'completions_hint'),
+            'set_completions_hint_after_ms': ('editor',
+                                              'completions_hint_after_ms'),
             'set_underline_errors_enabled': ('editor', 'underline_errors'),
             'set_automatic_completions_after_chars': (
                 'editor', 'automatic_completions_after_chars'),

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -714,7 +714,7 @@ class LanguageServerConfigPage(GeneralConfigPage):
         self.completions_hint_after_ms = self.create_spinbox(
             _("Show completion detail after keyboard idle (ms):"), None,
             'completions_hint_after_ms', min_=0, max_=5000, step=10,
-            tip=_("Default is 1000"), section='editor')
+            tip=_("Default is 500"), section='editor')
         self.automatic_completion_box = newcb(
             _("Show completions on the fly"),
             'automatic_completions',

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1225,6 +1225,8 @@ class Editor(SpyderPluginWidget):
             ('set_automatic_completions_after_ms',
              'automatic_completions_after_ms'),
             ('set_completions_hint_enabled',        'completions_hint'),
+            ('set_completions_hint_after_ms',
+             'completions_hint_after_ms'),
             ('set_highlight_current_line_enabled',  'highlight_current_line'),
             ('set_highlight_current_cell_enabled',  'highlight_current_cell'),
             ('set_occurrence_highlighting_enabled',  'occurrence_highlighting'),

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2128,7 +2128,6 @@ class CodeEditor(TextEditBaseWidget):
     # --- Hint for completions
     def show_hint_for_completion(self, word, documentation, at_point):
         """Show hint for completion element."""
-        self.hide_tooltip()
         if self.completions_hint:
             completion_doc = {'name': word,
                               'signature': documentation}
@@ -2142,8 +2141,8 @@ class CodeEditor(TextEditBaseWidget):
                     max_lines=self._DEFAULT_MAX_LINES,
                     max_width=self._DEFAULT_COMPLETION_HINT_MAX_WIDTH)
                 self.tooltip_widget.move(at_point)
-            else:
-                self.hide_tooltip()
+                return
+        self.hide_tooltip()
 
     def show_code_analysis_results(self, line_number, block_data):
         """Show warning/error messages."""
@@ -3479,9 +3478,6 @@ class CodeEditor(TextEditBaseWidget):
                      '&', '|', '^', '~', '<', '>', '<=', '>=', '==', '!='}
         delimiters = {',', ':', ';', '@', '=', '->', '+=', '-=', '*=', '/=',
                       '//=', '%=', '@=', '&=', '|=', '^=', '>>=', '<<=', '**='}
-
-        if not shift and not ctrl:
-            self.hide_tooltip()
 
         if text not in self.auto_completion_characters:
             if text in operators or text in delimiters:

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -358,9 +358,18 @@ class CodeEditor(TextEditBaseWidget):
         # Typing keys / handling on the fly completions
         # See: keyPressEvent
         self._last_key_pressed_text = ''
-        self._timer_key_press = QTimer(self)
-        self._timer_key_press.setSingleShot(True)
-        self._timer_key_press.timeout.connect(self._handle_completions)
+        self._timer_autocomplete = QTimer(self)
+        self._timer_autocomplete.setSingleShot(True)
+        self._timer_autocomplete.timeout.connect(self._handle_completions)
+
+        # Handle completions hints
+        self._completions_hint_idle = False
+        self._timer_completions_hint = QTimer(self)
+        self._timer_completions_hint.setSingleShot(True)
+        self._timer_completions_hint.timeout.connect(
+            self._set_completions_hint_idle)
+        self.completion_widget.sig_completion_hint.connect(
+            self.show_hint_for_completion)
 
         # Goto uri
         self._last_hover_pattern_key = None
@@ -514,6 +523,7 @@ class CodeEditor(TextEditBaseWidget):
 
         # Completions hint
         self.completions_hint = True
+        self.completions_hint_after_ms = 1000
 
         self.close_parentheses_enabled = True
         self.close_quotes_enabled = False
@@ -584,10 +594,6 @@ class CodeEditor(TextEditBaseWidget):
         self.previous_text = ''
         self.word_tokens = []
         self.patch = []
-
-        # Handle completions hints
-        self.completion_widget.sig_completion_hint.connect(
-            self.show_hint_for_completion)
 
         # re-use parent of completion_widget (usually the main window)
         compl_parent = self.completion_widget.parent()
@@ -782,6 +788,7 @@ class CodeEditor(TextEditBaseWidget):
                      automatic_completions_after_chars=3,
                      automatic_completions_after_ms=300,
                      completions_hint=True,
+                     completions_hint_after_ms=1000,
                      hover_hints=True,
                      code_snippets=True,
                      highlight_current_line=True,
@@ -874,11 +881,11 @@ class CodeEditor(TextEditBaseWidget):
         self.toggle_automatic_completions(automatic_completions)
         self.set_automatic_completions_after_chars(
             automatic_completions_after_chars)
-        self.set_automatic_completions_after_ms(
-            automatic_completions_after_ms)
+        self.set_automatic_completions_after_ms(automatic_completions_after_ms)
 
         # Completions hint
         self.toggle_completions_hint(completions_hint)
+        self.set_completions_hint_after_ms(completions_hint_after_ms)
 
         # Hover hints
         self.toggle_hover_hints(hover_hints)
@@ -1313,6 +1320,12 @@ class CodeEditor(TextEditBaseWidget):
         Set the amount of time in ms after which auto completion is fired.
         """
         self.automatic_completions_after_ms = ms
+
+    def set_completions_hint_after_ms(self, ms):
+        """
+        Set the amount of time in ms after which the completions hint is shown.
+        """
+        self.completions_hint_after_ms = ms
 
     def set_close_parentheses_enabled(self, enable):
         """Enable/disable automatic parentheses insertion feature"""
@@ -2125,10 +2138,14 @@ class CodeEditor(TextEditBaseWidget):
         self.tooltip_widget.hide()
         self.clear_extra_selections('code_analysis_highlight')
 
+    def _set_completions_hint_idle(self):
+        self._completions_hint_idle = True
+        self.completion_widget.trigger_completion_hint()
+
     # --- Hint for completions
     def show_hint_for_completion(self, word, documentation, at_point):
         """Show hint for completion element."""
-        if self.completions_hint:
+        if self.completions_hint and self._completions_hint_idle:
             completion_doc = {'name': word,
                               'signature': documentation}
 
@@ -3430,7 +3447,13 @@ class CodeEditor(TextEditBaseWidget):
     def keyPressEvent(self, event):
         """Reimplement Qt method."""
         if self.automatic_completions_after_ms > 0:
-            self._timer_key_press.start(self.automatic_completions_after_ms)
+            self._timer_autocomplete.start(self.automatic_completions_after_ms)
+
+        if self.completions_hint_after_ms > 0:
+            self._completions_hint_idle = False
+            self._timer_completions_hint.start(self.completions_hint_after_ms)
+        else:
+            self._set_completions_hint_idle()
 
         def insert_text(event):
             TextEditBaseWidget.keyPressEvent(self, event)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -523,7 +523,7 @@ class CodeEditor(TextEditBaseWidget):
 
         # Completions hint
         self.completions_hint = True
-        self.completions_hint_after_ms = 1000
+        self.completions_hint_after_ms = 500
 
         self.close_parentheses_enabled = True
         self.close_quotes_enabled = False
@@ -788,7 +788,7 @@ class CodeEditor(TextEditBaseWidget):
                      automatic_completions_after_chars=3,
                      automatic_completions_after_ms=300,
                      completions_hint=True,
-                     completions_hint_after_ms=1000,
+                     completions_hint_after_ms=500,
                      hover_hints=True,
                      code_snippets=True,
                      highlight_current_line=True,

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -49,9 +49,7 @@ class CompletionWidget(QListWidget):
                      CompletionItemKind.FILE: 'filenew',
                      CompletionItemKind.REFERENCE: 'reference',
                      }
-
-    ICON_MAP = {typ: ima.icon(typ) for typ in set(ITEM_TYPE_MAP.values())}
-    ICON_MAP['no_match'] = ima.icon('no_match')
+    ICON_MAP = {}
 
     sig_show_completions = Signal(object)
 
@@ -198,6 +196,11 @@ class CompletionWidget(QListWidget):
         if self.count() == 0:
             self.hide()
 
+    def _get_cached_icon(self, name):
+        if name not in self.ICON_MAP:
+            self.ICON_MAP[name] = ima.icon(name)
+        return self.ICON_MAP[name]
+
     def set_item_display(self, item_widget, item_info, height, width):
         """Set item text & icons using the info available."""
         item_provider = item_info['provider']
@@ -221,8 +224,7 @@ class CompletionWidget(QListWidget):
             width=width)
 
         item_widget.setText(item_text)
-        if item_type in self.ICON_MAP:
-            item_widget.setIcon(self.ICON_MAP[item_type])
+        item_widget.setIcon(self._get_cached_icon(item_type))
 
     def get_html_item_representation(self, item_completion, item_type,
                                      icon_provider=None,

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -236,6 +236,12 @@ class CompletionWidget(QListWidget):
         height = to_text_string(height)
         width = to_text_string(width)
 
+        # Unfortunately, both old- and new-style Python string formatting
+        # have poor performance due to being implemented as functions that
+        # parse the format string.
+        # f-strings in new versions of Python are fast due to Python
+        # compiling them into efficient string operations, but to be
+        # compatible with old versions of Python, we manually join strings.
         parts = [
             '<table width="', width, '" height="', height, '">', '<tr>',
 

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -309,8 +309,8 @@ class CompletionWidget(QListWidget):
             self.hide()
             self.textedit.keyPressEvent(event)
         elif key in (Qt.Key_Up, Qt.Key_Down, Qt.Key_PageUp, Qt.Key_PageDown,
-                     Qt.Key_Home, Qt.Key_End,
-                     Qt.Key_CapsLock) and not modifier:
+                     Qt.Key_Home, Qt.Key_End) and not modifier:
+            self.textedit._completions_hint_idle = True
             if key == Qt.Key_Up and self.currentRow() == 0:
                 self.setCurrentRow(self.count() - 1)
             elif key == Qt.Key_Down and self.currentRow() == self.count()-1:

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -555,13 +555,14 @@ class EditorStack(QWidget):
         self.automatic_completion_chars = 3
         self.automatic_completion_ms = 300
         self.completions_hint_enabled = True
+        self.completions_hint_after_ms = 1000
         self.hover_hints_enabled = True
         self.code_snippets_enabled = True
         self.underline_errors_enabled = False
         self.highlight_current_line_enabled = False
         self.highlight_current_cell_enabled = False
         self.occurrence_highlighting_enabled = True
-        self.occurrence_highlighting_timeout=1500
+        self.occurrence_highlighting_timeout = 1500
         self.checkeolchars_enabled = True
         self.always_remove_trailing_spaces = False
         self.convert_eol_on_save = False
@@ -1198,6 +1199,12 @@ class EditorStack(QWidget):
         if self.data:
             for finfo in self.data:
                 finfo.editor.toggle_completions_hint(state)
+
+    def set_completions_hint_after_ms(self, ms):
+        self.completions_hint_after_ms = ms
+        if self.data:
+            for finfo in self.data:
+                finfo.editor.set_completions_hint_after_ms(ms)
 
     def set_hover_hints_enabled(self, state):
         self.hover_hints_enabled = state
@@ -2426,6 +2433,7 @@ class EditorStack(QWidget):
             automatic_completions_after_ms=self.automatic_completion_ms,
             code_snippets=self.code_snippets_enabled,
             completions_hint=self.completions_hint_enabled,
+            completions_hint_after_ms=self.completions_hint_after_ms,
             hover_hints=self.hover_hints_enabled,
             highlight_current_line=self.highlight_current_line_enabled,
             highlight_current_cell=self.highlight_current_cell_enabled,

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -555,7 +555,7 @@ class EditorStack(QWidget):
         self.automatic_completion_chars = 3
         self.automatic_completion_ms = 300
         self.completions_hint_enabled = True
-        self.completions_hint_after_ms = 1000
+        self.completions_hint_after_ms = 500
         self.hover_hints_enabled = True
         self.code_snippets_enabled = True
         self.underline_errors_enabled = False

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -22,6 +22,7 @@ from spyder.config.gui import is_dark_interface
 from spyder.utils.encoding import is_text_file
 import qtawesome as qta
 
+
 if is_dark_interface():
     MAIN_FG_COLOR = 'white'
 else:

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -22,7 +22,6 @@ from spyder.config.gui import is_dark_interface
 from spyder.utils.encoding import is_text_file
 import qtawesome as qta
 
-
 if is_dark_interface():
     MAIN_FG_COLOR = 'white'
 else:

--- a/spyder/widgets/calltip.py
+++ b/spyder/widgets/calltip.py
@@ -129,11 +129,10 @@ class ToolTipWidget(QLabel):
         """
         # Don't attempt to show it if it's already visible and the text
         # to be displayed is the same as the one displayed before.
-        if self.isVisible():
-            if self.tip == tip:
-                return True
-            else:
-                self.hide()
+        if self.tip == tip:
+            if not self.isVisible():
+                self.show()
+            return
 
         # Set the text and resize the widget accordingly.
         self.tip = tip
@@ -197,7 +196,8 @@ class ToolTipWidget(QLabel):
             point.setX(adjusted_point.x() - tip_width - padding)
 
         self.move(point)
-        self.show()
+        if not self.isVisible():
+            self.show()
         return True
 
     def mousePressEvent(self, event):

--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -152,9 +152,14 @@ class HTMLDelegate(QStyledItemDelegate):
         painter.restore()
 
     def sizeHint(self, option, index):
-        # use a fixed size instead of computing an "ideal width"
-        # because it's more performant, and this is a reasonable size
-        return QSize(621, 22)
+        options = QStyleOptionViewItem(option)
+        self.initStyleOption(options, index)
+
+        doc = QTextDocument()
+        doc.setDocumentMargin(self._margin)
+        doc.setHtml(options.text)
+
+        return QSize(round(doc.idealWidth()), round(doc.size().height() - 2))
 
 
 class ItemDelegate(QStyledItemDelegate):

--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -114,16 +114,21 @@ class HTMLDelegate(QStyledItemDelegate):
         super(HTMLDelegate, self).__init__(parent)
         self._margin = margin
 
-    def paint(self, painter, option, index):
+    def _prepare_text_document(self, option, index):
+        # This logic must be shared between paint and sizeHint for consitency
         options = QStyleOptionViewItem(option)
         self.initStyleOption(options, index)
-
-        style = (QApplication.style() if options.widget is None
-                 else options.widget.style())
 
         doc = QTextDocument()
         doc.setDocumentMargin(self._margin)
         doc.setHtml(options.text)
+        return options, doc
+
+    def paint(self, painter, option, index):
+        options, doc = self._prepare_text_document(option, index)
+
+        style = (QApplication.style() if options.widget is None
+                 else options.widget.style())
 
         options.text = ""
         style.drawControl(QStyle.CE_ItemViewItem, options, painter)
@@ -152,13 +157,7 @@ class HTMLDelegate(QStyledItemDelegate):
         painter.restore()
 
     def sizeHint(self, option, index):
-        options = QStyleOptionViewItem(option)
-        self.initStyleOption(options, index)
-
-        doc = QTextDocument()
-        doc.setDocumentMargin(self._margin)
-        doc.setHtml(options.text)
-
+        __, doc = self._prepare_text_document(option, index)
         return QSize(round(doc.idealWidth()), round(doc.size().height() - 2))
 
 

--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -152,13 +152,9 @@ class HTMLDelegate(QStyledItemDelegate):
         painter.restore()
 
     def sizeHint(self, option, index):
-        options = QStyleOptionViewItem(option)
-        self.initStyleOption(options, index)
-
-        doc = QTextDocument()
-        doc.setHtml(options.text)
-
-        return QSize(round(doc.idealWidth()), round(doc.size().height() - 2))
+        # use a fixed size instead of computing an "ideal width"
+        # because it's more performant, and this is a reasonable size
+        return QSize(621, 22)
 
 
 class ItemDelegate(QStyledItemDelegate):

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -64,6 +64,8 @@ class BaseEditMixin(object):
     sig_will_remove_selection = None
     sig_text_was_inserted = None
 
+    _styled_widgets = set()
+
     def __init__(self):
         self.eol_chars = None
         self.calltip_size = 600
@@ -122,14 +124,14 @@ class BaseEditMixin(object):
 
         return point
 
-    def _update_stylesheet(self, widget, _updated=set()):
+    def _update_stylesheet(self, widget):
+        """Update the background stylesheet to make it lighter."""
         # Update the stylesheet for a given widget at most once
         # because Qt is slow to repeatedly parse & apply CSS
-        if id(widget) in _updated:
+        if id(widget) in self._styled_widgets:
             return
-        _updated.add(id(widget))
+        self._styled_widgets.add(id(widget))
 
-        """Update the background stylesheet to make it lighter."""
         if is_dark_interface():
             css = qdarkstyle.load_stylesheet_from_environment()
             widget.setStyleSheet(css)

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -122,7 +122,13 @@ class BaseEditMixin(object):
 
         return point
 
-    def _update_stylesheet(self, widget):
+    def _update_stylesheet(self, widget, _updated=set()):
+        # Update the stylesheet for a given widget at most once
+        # because Qt is slow to repeatedly parse & apply CSS
+        if id(widget) in _updated:
+            return
+        _updated.add(id(widget))
+
         """Update the background stylesheet to make it lighter."""
         if is_dark_interface():
             css = qdarkstyle.load_stylesheet_from_environment()


### PR DESCRIPTION
## Description of Changes

I used cProfile & the [profilehooks](https://mg.pov.lt/profilehooks/) library to profile completions-related logic. The reason for the lag was all in the rendering logic, so I focused on reducing wasted work there. In particular some Qt functions are slow, so we should avoid calling them when necessary.

1. reduce calls to `hide_tooltip()`
2. reduce calls to `icon_manager.icon()`
3. use `''.join()` instead of string formatting with `str.format`
4. reduce calls to `setStylesheet`
5. use a fixed size hint for completions list items, because creating a `QTextDocument` and calling `idealWidth` every time is very slow.
    - I tested it on various screen sizes, and it seems to scale very well.
    - I used the size that I was seeing the old behavior typically return (it always returned the same size in my testing).
6. Add a separate delay on showing completion detail so that the user can configure them separately. This is important since rendering the completion hint widget is slow.

As a result, the lag is much less perceptible, but not entirely eliminated. I may have more ideas on how to improve this in the future, but this is definitely an incremental effort, so we can start with these low-hanging fruit.

![Screen Shot 2019-10-25 at 2 40 06 PM](https://user-images.githubusercontent.com/1977419/67606322-ddeaf100-f735-11e9-8715-30bcb2dff6f3.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

fixes #10457 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @metalogical 

<!--- Thanks for your help making Spyder better for everyone! --->
