### PR TITLE
PR: Correctly handle Kite replacement range, fixing dict completions

### DIFF
--- a/spyder/plugins/completion/kite/providers/document.py
+++ b/spyder/plugins/completion/kite/providers/document.py
@@ -127,8 +127,14 @@ class DocumentProvider:
                     'kind': KITE_DOCUMENT_TYPES.get(
                         completion['hint'], CompletionItemKind.TEXT),
                     'label': completion['display'],
-                    'insertText': convert_text_snippet(completion['snippet']),
-                    'filterText': completion['display'],
+                    'textEdit': {
+                        'newText': convert_text_snippet(completion['snippet']),
+                        'range': {
+                            'start': completion['replace']['begin'],
+                            'end': completion['replace']['end'],
+                        },
+                    },
+                    'filterText': '',
                     # Use the returned ordering
                     'sortText': (i, 0),
                     'documentation': completion['documentation']['text'],
@@ -137,15 +143,22 @@ class DocumentProvider:
                 spyder_completions.append(entry)
 
                 if 'children' in completion:
-                    children_snippets = completion['children']
-                    for j, child in enumerate(children_snippets):
+                    for j, child in enumerate(completion['children']):
                         child_entry = {
                             'kind': KITE_DOCUMENT_TYPES.get(
                                 child['hint'], CompletionItemKind.TEXT),
                             'label': ' '*2 + child['display'],
+                            'textEdit': {
+                                'newText': convert_text_snippet(
+                                    child['snippet']),
+                                'range': {
+                                    'start': child['replace']['begin'],
+                                    'end': child['replace']['end'],
+                                },
+                            },
                             'insertText': convert_text_snippet(
                                 child['snippet']),
-                            'filterText': child['snippet']['text'],
+                            'filterText': '',
                             # Use the returned ordering
                             'sortText': (i, j+1),
                             'documentation': child['documentation']['text'],

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -854,11 +854,20 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         """Completion list is active, Enter was just pressed"""
         self.completion_widget.item_selected()
 
-    def insert_completion(self, text, completion_position):
-        if text:
+    def insert_completion(self, completion, completion_position):
+        if not completion:
+            return
+        cursor = self.textCursor()
+        if isinstance(completion, dict):
+            cursor.setPosition(completion['textEdit']['range']['start'])
+            cursor.setPosition(completion['textEdit']['range']['end'],
+                               QTextCursor.KeepAnchor)
+            text = to_text_string(completion['textEdit']['newText'])
+        else:
+            text = to_text_string(completion)
+
             # Get word on the left of the cursor.
             result = self.get_current_word_and_position(completion=True)
-            cursor = self.textCursor()
             if result is not None:
                 current_text, start_position = result
                 end_position = start_position + len(current_text)
@@ -869,18 +878,20 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
                 # Remove the word under the cursor
                 cursor.setPosition(end_position,
                                    QTextCursor.KeepAnchor)
-                cursor.removeSelectedText()
-                self.setTextCursor(cursor)
             else:
                 # Check if we are in the correct position
                 if cursor.position() != completion_position:
                     return
-            # Add text
-            if self.code_snippets:
-                self.sig_insert_completion.emit(text)
-            else:
-                self.insert_text(text)
-                self.document_did_change()
+
+        cursor.removeSelectedText()
+        self.setTextCursor(cursor)
+
+        # Add text
+        if self.code_snippets:
+            self.sig_insert_completion.emit(text)
+        else:
+            self.insert_text(text)
+        self.document_did_change()
 
     def is_completion_widget_visible(self):
         """Return True is completion list widget is visible"""

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -855,6 +855,14 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         self.completion_widget.item_selected()
 
     def insert_completion(self, completion, completion_position):
+        """Insert a completion into the editor.
+
+        completion_position is where the completion was generated.
+
+        The replacement range is computed using the (LSP) completion's
+        textEdit field if it exists. Otherwise, we replace from the
+        start of the word under the cursor.
+        """
         if not completion:
             return
         cursor = self.textCursor()

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -858,13 +858,16 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         if not completion:
             return
         cursor = self.textCursor()
-        if isinstance(completion, dict):
+        if isinstance(completion, dict) and 'textEdit' in completion:
             cursor.setPosition(completion['textEdit']['range']['start'])
             cursor.setPosition(completion['textEdit']['range']['end'],
                                QTextCursor.KeepAnchor)
             text = to_text_string(completion['textEdit']['newText'])
         else:
-            text = to_text_string(completion)
+            text = completion
+            if isinstance(completion, dict):
+                text = completion['insertText']
+            text = to_text_string(text)
 
             # Get word on the left of the cursor.
             result = self.get_current_word_and_position(completion=True)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1064,34 +1064,20 @@ class CodeEditor(TextEditBaseWidget):
             completions = params['params']
             completions = [] if completions is None else completions
 
-            # Compute default replace_start, replace_end for completions
-            # that don't specify a textEdit.
-            replace_end = self.textCursor().position()
-            under_cursor = self.get_current_word_and_position(
-                completion=True)
+            under_cursor = self.get_current_word_and_position(completion=True)
             if under_cursor:
-                word, replace_start = under_cursor
+                word, _ = under_cursor
             else:
                 word = ''
-                replace_start = replace_end
-
-            # Normalize all completions to contain a textEdit
-            for completion in completions:
-                if 'textEdit' not in completion:
-                    completion['textEdit'] = {
-                        'range': {
-                            'start': replace_start,
-                            'end': replace_end,
-                        },
-                        'newText': completion['insertText'],
-                    }
-
             first_letter = ''
             if len(word) > 0:
                 first_letter = word[0]
 
             def sort_key(completion):
-                first_insert_letter = completion['textEdit']['newText'][0]
+                if 'textEdit' in completion:
+                    first_insert_letter = completion['textEdit']['newText'][0]
+                else:
+                    first_insert_letter = completion['insertText'][0]
                 case_mismatch = (
                     (first_letter.isupper() and first_insert_letter.islower())
                     or

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1064,11 +1064,13 @@ class CodeEditor(TextEditBaseWidget):
             completions = params['params']
             completions = [] if completions is None else completions
 
+            replace_end = self.textCursor().position()
             under_cursor = self.get_current_word_and_position(completion=True)
             if under_cursor:
-                word, _ = under_cursor
+                word, replace_start = under_cursor
             else:
                 word = ''
+                replace_start = replace_end
             first_letter = ''
             if len(word) > 0:
                 first_letter = word[0]
@@ -1087,6 +1089,21 @@ class CodeEditor(TextEditBaseWidget):
                 return (case_mismatch, completion['sortText'])
 
             completion_list = sorted(completions, key=sort_key)
+
+            # Allow for textEdit completions to be filtered by Spyder
+            # if on-the-fly completions are disabled, only if the
+            # textEdit range matches the word under the cursor.
+            for completion in completion_list:
+                if 'textEdit' in completion:
+                    c_replace_start = completion['textEdit']['range']['start']
+                    c_replace_end = completion['textEdit']['range']['end']
+                    if (c_replace_start == replace_start
+                            and c_replace_end == replace_end):
+                        insert_text = completion['textEdit']['newText']
+                        completion['filterText'] = insert_text
+                        completion['insertText'] = insert_text
+                        del completion['textEdit']
+
             if len(completion_list) > 0:
                 self.completion_widget.show_list(
                         completion_list, position, automatic)

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -340,7 +340,7 @@ class CompletionWidget(QListWidget):
         if item is None:
             item = self.currentItem()
         current_word = self.textedit.get_current_word(completion=True)
-        completion = self.currentItem().data(Qt.UserRole)
+        completion = item.data(Qt.UserRole)
         if isinstance(completion, dict):
             filter_text = completion['filterText']
         else:

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -172,7 +172,12 @@ class CompletionWidget(QListWidget):
 
     def update_list(self, current_word, new=True):
         """
-        Update the displayed list by filtering self.completion_list.
+        Update the displayed list by filtering self.completion_list based on
+        the current_word under the cursor (see check_can_complete).
+
+        If we're not updating the list with new completions, we filter out
+        textEdit completions, since it's difficult to apply them correctly
+        after the user makes edits.
 
         If no items are left on the list the autocompletion should stop
         """

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -270,6 +270,8 @@ def test_completions(lsp_codeeditor, qtbot):
     qtbot.keyPress(code_editor, Qt.Key_Right, delay=300)
     qtbot.keyPress(code_editor, Qt.Key_Right, delay=300)
     qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)
+    assert code_editor.toPlainText() == 'import math\nmath.hypot\n'\
+                                        'math.hypot()\n'
 
     # Complete math.a <tab> ... s <enter> to math.asin
     qtbot.keyClicks(code_editor, 'math.a')
@@ -284,11 +286,13 @@ def test_completions(lsp_codeeditor, qtbot):
     assert "acos(x)" == completion.completion_list[0]['label']
     qtbot.keyClicks(completion, 's')
     data = completion.item(0).data(Qt.UserRole)
-    assert "asin" == data['textEdit']['newText']
+    assert "asin" == data['insertText']
     qtbot.keyPress(completion, Qt.Key_Enter, delay=300)
 
     # enter for new line
     qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)
+    assert code_editor.toPlainText() == 'import math\nmath.hypot\n'\
+                                        'math.hypot()\nmath.asin\n'
 
     # Check can get list back
     qtbot.keyClicks(code_editor, 'math.f')
@@ -307,6 +311,9 @@ def test_completions(lsp_codeeditor, qtbot):
 
     # enter for new line
     qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)
+    assert code_editor.toPlainText() == 'import math\nmath.hypot\n'\
+                                        'math.hypot()\nmath.asin\n'\
+                                        'math.f\n'
 
     # Complete math.a <tab> s ...<enter> to math.asin
     qtbot.keyClicks(code_editor, 'math.a')
@@ -322,6 +329,9 @@ def test_completions(lsp_codeeditor, qtbot):
 
     # enter for new line
     qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)
+    assert code_editor.toPlainText() == 'import math\nmath.hypot\n'\
+                                        'math.hypot()\nmath.asin\n'\
+                                        'math.f\nmath.asin\n'
 
     # Complete math.a|angle <tab> s ...<enter> to math.asin|angle
     qtbot.keyClicks(code_editor, 'math.aangle')
@@ -340,8 +350,13 @@ def test_completions(lsp_codeeditor, qtbot):
     for i in range(len('angle')):
         qtbot.keyClick(code_editor, Qt.Key_Right)
 
-    # Check math.a <tab> <backspace> doesn't emit sig_show_completions
     qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)
+    assert code_editor.toPlainText() == 'import math\nmath.hypot\n'\
+                                        'math.hypot()\nmath.asin\n'\
+                                        'math.f\nmath.asin\n'\
+                                        'math.asinangle\n'
+
+    # Check math.a <tab> <backspace> doesn't emit sig_show_completions
     qtbot.keyClicks(code_editor, 'math.a')
     with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
         code_editor.document_did_change()

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -283,7 +283,8 @@ def test_completions(lsp_codeeditor, qtbot):
     # Test if the list is updated
     assert "acos(x)" == completion.completion_list[0]['label']
     qtbot.keyClicks(completion, 's')
-    assert "asin" == completion.item(0).data(Qt.UserRole)
+    data = completion.item(0).data(Qt.UserRole)
+    assert "asin" == data['textEdit']['newText']
     qtbot.keyPress(completion, Qt.Key_Enter, delay=300)
 
     # enter for new line


### PR DESCRIPTION
## Description of Changes

* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

Kite returns a replacement range with each completion indicating where to insert the completion within the buffer. This is particularly useful for more non-traditional completions, such as Kite's dict completions, where simply matching the preceding identifier is not enough. Kite's dict completions were previously broken in Spyder, but this change fixes them.

1. Support the `textEdit` functionality of the [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_completion)
2. Properly respect the `filterText` when deciding whether completions are still valid.
3. Update the Kite provider to specify a `textEdit` instead of `insertText`, and also not use `filterText`, since Kite filters internally (and will always do so -- it is part of the API spec).


![2019-10-23 19 00 31](https://user-images.githubusercontent.com/1977419/67447024-6dbe5d00-f5c7-11e9-889a-d372a17fb6e0.gif)

Should I add any unit tests for this? @andfoy @ccordoba12 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @metalogical 

<!--- Thanks for your help making Spyder better for everyone! --->
