### PR TITLE
PR: Add a "wait_for" timeout for completions

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -207,6 +207,7 @@ DEFAULTS = [
               'automatic_completions': True,
               'automatic_completions_after_chars': 3,
               'automatic_completions_after_ms': 300,
+              'completions_wait_for_ms': 200,
               'completions_hint': True,
               'underline_errors': False,
               'highlight_current_line': True,

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -994,10 +994,17 @@ class LanguageServerConfigPage(GeneralConfigPage):
         self.fallback_enabled = newcb(_("Enable fallback completions"),
                                       'enable',
                                       section='fallback-completions')
+        self.completions_wait_for_ms = self.create_spinbox(
+            _("Time to wait for all providers to return (ms):"), None,
+            'completions_wait_for_ms', min_=0, max_=5000, step=10,
+            tip=_("Beyond this timeout, "
+                  "the first available provider will be returned"),
+            section='editor')
 
         clients_layout = QVBoxLayout()
         clients_layout.addWidget(self.kite_enabled)
         clients_layout.addWidget(self.fallback_enabled)
+        clients_layout.addWidget(self.completions_wait_for_ms)
         clients_group.setLayout(clients_layout)
 
         kite_layout = QVBoxLayout()

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -43,6 +43,7 @@ def test_space_completion(lsp_codeeditor, qtbot):
     code_editor, _ = lsp_codeeditor
     code_editor.toggle_automatic_completions(False)
     code_editor.toggle_code_snippets(False)
+    CONF.set('editor', 'completions_wait_for_ms', 0)
 
     completion = code_editor.completion_widget
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

This is an update of https://github.com/spyder-ide/spyder/pull/10493, based on the feedback provided there: https://github.com/spyder-ide/spyder/pull/10493#discussion_r337796602


<!--- Explain what you've done and why --->

1. Before the timeout, we continue waiting until all "`wait_for`" providers have returned.
    - this behavior is new
2. After the timeout, we wait until any "`wait_for`" provider has returned a non-empty response (or until all "`wait_for`" providers have returned empty responses).
    - this is the same as the current default behavior

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10447


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @metalogical 

<!--- Thanks for your help making Spyder better for everyone! --->
