### PR TITLE
PR: Fix blocknumber segfault

### DIFF
--- a/spyder/plugins/editor/utils/switcher.py
+++ b/spyder/plugins/editor/utils/switcher.py
@@ -29,11 +29,13 @@ def get_symbol_list(outlineexplorer_data_list):
     symbol_list = []
     for oedata in outlineexplorer_data_list:
         if oedata.is_class_or_function():
-            symbol_list.append((
-                oedata.firstLineNumber(),
-                oedata.def_name,
-                oedata.fold_level,
-                oedata.get_token()))
+            line_number = oedata.firstLineNumber()
+            if line_number is not None:
+                symbol_list.append((
+                    line_number,
+                    oedata.def_name,
+                    oedata.fold_level,
+                    oedata.get_token()))
     return sorted(symbol_list)
 
 

--- a/spyder/plugins/editor/utils/switcher.py
+++ b/spyder/plugins/editor/utils/switcher.py
@@ -30,7 +30,7 @@ def get_symbol_list(outlineexplorer_data_list):
     for oedata in outlineexplorer_data_list:
         if oedata.is_class_or_function():
             symbol_list.append((
-                oedata.block.firstLineNumber(),
+                oedata.firstLineNumber(),
                 oedata.def_name,
                 oedata.fold_level,
                 oedata.get_token()))

--- a/spyder/plugins/editor/utils/switcher.py
+++ b/spyder/plugins/editor/utils/switcher.py
@@ -29,10 +29,10 @@ def get_symbol_list(outlineexplorer_data_list):
     symbol_list = []
     for oedata in outlineexplorer_data_list:
         if oedata.is_class_or_function():
-            line_number = oedata.firstLineNumber()
+            line_number = oedata.get_block_number()
             if line_number is not None:
                 symbol_list.append((
-                    line_number,
+                    line_number + 1,
                     oedata.def_name,
                     oedata.fold_level,
                     oedata.get_token()))

--- a/spyder/plugins/outlineexplorer/api.py
+++ b/spyder/plugins/outlineexplorer/api.py
@@ -25,6 +25,7 @@ outlineexplorer.edit_goto.connect(handle_go_to)
 import re
 
 from qtpy.QtCore import Signal, QObject
+from qtpy.QtGui import QTextBlock
 from spyder.config.base import _
 
 
@@ -94,7 +95,8 @@ class OutlineExplorerData(QObject):
         self.def_type = def_type
         self.def_name = def_name
         self.color = color
-        self.block = block
+        # Copy the text block to make sure it is not deleted
+        self.block = QTextBlock(block)
 
     def is_not_class_nor_function(self):
         return self.def_type not in (self.CLASS, self.FUNCTION)
@@ -188,6 +190,10 @@ class OutlineExplorerData(QObject):
         forward : bool, optional
             Whether to iterate forward or backward from the current block.
         """
+        if not self.is_valid():
+            # Avoid calling blockNumber if not a valid block
+            return
+
         if forward:
             block = self.block.next()
         else:
@@ -243,3 +249,17 @@ class OutlineExplorerData(QObject):
             return True
         else:
             return False
+
+    def blockNumber(self):
+        """Get the block number."""
+        if not self.is_valid():
+            # Avoid calling blockNumber if not a valid block
+            return
+        return self.block.blockNumber()
+
+    def firstLineNumber(self):
+        """Get the first line number."""
+        if not self.is_valid():
+            # Avoid calling firstLineNumber if not a valid block
+            return
+        return self.block.firstLineNumber()

--- a/spyder/plugins/outlineexplorer/api.py
+++ b/spyder/plugins/outlineexplorer/api.py
@@ -256,16 +256,9 @@ class OutlineExplorerData(QObject):
         else:
             return False
 
-    def blockNumber(self):
+    def get_block_number(self):
         """Get the block number."""
         if not self.is_valid():
             # Avoid calling blockNumber if not a valid block
             return None
         return self.block.blockNumber()
-
-    def firstLineNumber(self):
-        """Get the first line number."""
-        if not self.is_valid():
-            # Avoid calling firstLineNumber if not a valid block
-            return None
-        return self.block.firstLineNumber()

--- a/spyder/plugins/outlineexplorer/api.py
+++ b/spyder/plugins/outlineexplorer/api.py
@@ -260,12 +260,12 @@ class OutlineExplorerData(QObject):
         """Get the block number."""
         if not self.is_valid():
             # Avoid calling blockNumber if not a valid block
-            return
+            return None
         return self.block.blockNumber()
 
     def firstLineNumber(self):
         """Get the first line number."""
         if not self.is_valid():
             # Avoid calling firstLineNumber if not a valid block
-            return
+            return None
         return self.block.firstLineNumber()

--- a/spyder/plugins/outlineexplorer/api.py
+++ b/spyder/plugins/outlineexplorer/api.py
@@ -233,6 +233,7 @@ class OutlineExplorerData(QObject):
         return (block
                 and block.isValid()
                 and block.userData()
+                and hasattr(block.userData(), 'oedata')
                 and block.userData().oedata == self
                 )
 

--- a/spyder/plugins/outlineexplorer/api.py
+++ b/spyder/plugins/outlineexplorer/api.py
@@ -27,6 +27,7 @@ import re
 from qtpy.QtCore import Signal, QObject
 from qtpy.QtGui import QTextBlock
 from spyder.config.base import _
+from spyder.config.base import running_under_pytest
 
 
 class OutlineExplorerProxy(QObject):
@@ -95,8 +96,12 @@ class OutlineExplorerData(QObject):
         self.def_type = def_type
         self.def_name = def_name
         self.color = color
-        # Copy the text block to make sure it is not deleted
-        self.block = QTextBlock(block)
+        if running_under_pytest():
+            # block might be a dummy
+            self.block = block
+        else:
+            # Copy the text block to make sure it is not deleted
+            self.block = QTextBlock(block)
 
     def is_not_class_nor_function(self):
         return self.def_type not in (self.CLASS, self.FUNCTION)

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -81,7 +81,7 @@ class TreeItem(QTreeWidgetItem):
     @property
     def line(self):
         """Get line number."""
-        return self.oedata.block.blockNumber() + 1
+        return self.oedata.blockNumber() + 1
 
     def update(self):
         """Update the tree element."""
@@ -498,7 +498,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
 
         for data in editor.outlineexplorer_data_list():
             try:
-                line_nb = data.block.blockNumber() + 1
+                line_nb = data.blockNumber() + 1
             except AttributeError:
                 continue
             level = None if data is None else data.fold_level

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -81,7 +81,9 @@ class TreeItem(QTreeWidgetItem):
     @property
     def line(self):
         """Get line number."""
-        return self.oedata.blockNumber() + 1
+        block_number = self.oedata.blockNumber()
+        if block_number is not None:
+            return block_number + 1
 
     def update(self):
         """Update the tree element."""
@@ -498,7 +500,10 @@ class OutlineExplorerTreeWidget(OneColumnTree):
 
         for data in editor.outlineexplorer_data_list():
             try:
-                line_nb = data.blockNumber() + 1
+                line_nb = data.blockNumber()
+                if line_nb is None:
+                    continue
+                line_nb += 1
             except AttributeError:
                 continue
             level = None if data is None else data.fold_level

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -84,6 +84,7 @@ class TreeItem(QTreeWidgetItem):
         block_number = self.oedata.blockNumber()
         if block_number is not None:
             return block_number + 1
+        return None
 
     def update(self):
         """Update the tree element."""

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -81,7 +81,7 @@ class TreeItem(QTreeWidgetItem):
     @property
     def line(self):
         """Get line number."""
-        block_number = self.oedata.blockNumber()
+        block_number = self.oedata.get_block_number()
         if block_number is not None:
             return block_number + 1
         return None
@@ -501,7 +501,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
 
         for data in editor.outlineexplorer_data_list():
             try:
-                line_nb = data.blockNumber()
+                line_nb = data.get_block_number()
                 if line_nb is None:
                     continue
                 line_nb += 1


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

When a file is shortened outside of spyder (Like checkout something with git), this file is reloaded in spyder. If the line the cursor was on doesn't exist anymore, a segfault takes place because the block no longer exists: see traceback:
```
Fatal Python error: Segmentation fault

Current thread 0x0000000117862d40 (most recent call first):
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/outlineexplorer/widgets.py", line 84 in line
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/outlineexplorer/widgets.py", line 154 in <lambda>
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/outlineexplorer/widgets.py", line 154 in get_item_children
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/outlineexplorer/widgets.py", line 164 in item_at_line
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/outlineexplorer/widgets.py", line 304 in go_to_cursor_position
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/outlineexplorer/widgets.py", line 319 in do_follow_cursor
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/editor/widgets/codeeditor.py", line 1569 in __cursor_position_changed
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/editor/widgets/codeeditor.py", line 3975 in setPlainText
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/editor/widgets/codeeditor.py", line 1913 in set_text
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/editor/widgets/editor.py", line 2347 in reload
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/editor/widgets/editor.py", line 2271 in __check_file_status
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/editor/widgets/editor.py", line 2295 in refresh
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/editor/widgets/editor.py", line 2159 in focus_changed
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/editor/widgets/base.py", line 983 in focusInEvent
  File "/Users/quentinpeter/pyscripts/spyder/spyder/plugins/editor/widgets/codeeditor.py", line 3429 in event
  File "/Users/quentinpeter/pyscripts/spyder/spyder/app/mainwindow.py", line 3529 in run_spyder
  File "/Users/quentinpeter/pyscripts/spyder/spyder/app/mainwindow.py", line 3646 in main
  File "/Users/quentinpeter/pyscripts/spyder/spyder/app/start.py", line 209 in main
  File "/Applications/Spyder.app/Contents/MacOS/Spyder", line 7 in <module>
```

Top of the system trace:
```
Thread 0 Crashed:: ZMQbg/273  Dispatch queue: com.apple.main-thread
0   QtGui                         	0x000000012bd6fdf1 QTextBlock::blockNumber() const + 81
1   QtGui.so                      	0x000000012c205d4b meth_QTextBlock_blockNumber(_object*, _object*) + 75
2   org.python.python             	0x000000010e4f342b _PyMethodDef_RawFastCallKeywords + 235
3   org.python.python             	0x000000010e4f2ab2 _PyCFunction_FastCallKeywords + 44
4   org.python.python             	0x000000010e587e82 call_function + 636
```

top from another crash:
```
Thread 0 Crashed:: ZMQbg/5  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fff6f0e747a __pthread_kill + 10
1   libsystem_pthread.dylib       	0x00007fff6f1a4707 pthread_kill + 384
2   libsystem_c.dylib             	0x00007fff6efff31e raise + 26
3   libsystem_platform.dylib      	0x00007fff6f199b1d _sigtramp + 29
4   ???                           	000000000000000000 0 + 0
5   QtGui.so                      	0x000000012afa7d4b meth_QTextBlock_blockNumber(_object*, _object*) + 75
6   org.python.python             	0x000000010d2ac42b _PyMethodDef_RawFastCallKeywords + 235
7   org.python.python             	0x000000010d2abab2 _PyCFunction_FastCallKeywords + 44
8   org.python.python             	0x000000010d340e82 call_function + 636
```
This PR copies the block to avoid this segfault.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
