### PR TITLE
PR: Retrieve Kite copilot documentation on click

### DIFF
--- a/spyder/plugins/completion/kite/providers/document.py
+++ b/spyder/plugins/completion/kite/providers/document.py
@@ -158,8 +158,6 @@ class DocumentProvider:
     @send_request(method=LSPRequestTypes.DOCUMENT_HOVER)
     def request_hover(self, params):
         text = self.opened_files.get(params['file'], "")
-        params['text'] = text
-        self.document_did_change(params)
         md5 = hashlib.md5(text.encode('utf-8')).hexdigest()
         path = params['file']
         path = path.replace(osp.sep, ':')

--- a/spyder/plugins/completion/kite/providers/document.py
+++ b/spyder/plugins/completion/kite/providers/document.py
@@ -158,6 +158,8 @@ class DocumentProvider:
     @send_request(method=LSPRequestTypes.DOCUMENT_HOVER)
     def request_hover(self, params):
         text = self.opened_files.get(params['file'], "")
+        params['text'] = text
+        self.document_did_change(params)
         md5 = hashlib.md5(text.encode('utf-8')).hexdigest()
         path = params['file']
         path = path.replace(osp.sep, ':')

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1580,6 +1580,7 @@ class CodeEditor(TextEditBaseWidget):
         """Cursor position has changed"""
         line, column = self.get_cursor_line_column()
         self.sig_cursor_position_changed.emit(line, column)
+
         if self.highlight_current_cell_enabled:
             self.highlight_current_cell()
         else:
@@ -4034,6 +4035,11 @@ class CodeEditor(TextEditBaseWidget):
             self.sig_alt_left_mouse_pressed.emit(event)
         else:
             TextEditBaseWidget.mousePressEvent(self, event)
+
+    def mouseReleaseEvent(self, event):
+        """Override Qt method."""
+        self.document_did_change()
+        TextEditBaseWidget.mouseReleaseEvent(self, event)
 
     def contextMenuEvent(self, event):
         """Reimplement Qt method"""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR enables Kite copilot to display documentation whenever the cursor is moved on click.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

![ezgif com-video-to-gif(15)](https://user-images.githubusercontent.com/1878982/67827858-39531100-fa9f-11e9-8e48-80cdd67f5982.gif)
<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10349


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@andfoy
<!--- Thanks for your help making Spyder better for everyone! --->
