### PR TITLE
PR: Add methods to handle external plugins shortcuts

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3187,7 +3187,8 @@ class MainWindow(QMainWindow):
         toberemoved = []
         for index, (qobject, context, name, add_shortcut_to_tip,
                     plugin_name) in enumerate(self.shortcut_data):
-            keyseq = QKeySequence(CONF.get_shortcut(context, name, plugin_name))
+            keyseq = QKeySequence(CONF.get_shortcut(context, name,
+                                                    plugin_name))
             try:
                 if isinstance(qobject, QAction):
                     if sys.platform == 'darwin' and \

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3174,20 +3174,20 @@ class MainWindow(QMainWindow):
 
     #---- Shortcuts
     def register_shortcut(self, qaction_or_qshortcut, context, name,
-                          add_shortcut_to_tip=False):
+                          add_shortcut_to_tip=False, plugin_name=None):
         """
         Register QAction or QShortcut to Spyder main application,
         with shortcut (context, name, default)
         """
         self.shortcut_data.append((qaction_or_qshortcut, context,
-                                   name, add_shortcut_to_tip))
+                                   name, add_shortcut_to_tip, plugin_name))
 
     def apply_shortcuts(self):
         """Apply shortcuts settings to all widgets/plugins"""
         toberemoved = []
-        for index, (qobject, context, name,
-                    add_shortcut_to_tip) in enumerate(self.shortcut_data):
-            keyseq = QKeySequence(CONF.get_shortcut(context, name))
+        for index, (qobject, context, name, add_shortcut_to_tip,
+                    plugin_name) in enumerate(self.shortcut_data):
+            keyseq = QKeySequence(CONF.get_shortcut(context, name, plugin_name))
             try:
                 if isinstance(qobject, QAction):
                     if sys.platform == 'darwin' and \

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -176,7 +176,6 @@ from spyder.utils.qthelpers import (create_action, add_actions, get_icon,
                                     create_program_action, DialogManager,
                                     create_python_script_action, file_uri,
                                     MENU_SEPARATOR, set_menu_icons)
-from spyder.config.gui import get_shortcut
 from spyder.otherplugins import get_spyderplugins_mods
 from spyder.app import tour
 
@@ -3131,7 +3130,7 @@ class MainWindow(QMainWindow):
         toberemoved = []
         for index, (qobject, context, name,
                     add_shortcut_to_tip) in enumerate(self.shortcut_data):
-            keyseq = QKeySequence( get_shortcut(context, name) )
+            keyseq = QKeySequence(CONF.get_shortcut(context, name))
             try:
                 if isinstance(qobject, QAction):
                     if sys.platform == 'darwin' and \
@@ -3143,7 +3142,7 @@ class MainWindow(QMainWindow):
                         add_shortcut_to_tooltip(qobject, context, name)
                 elif isinstance(qobject, QShortcut):
                     qobject.setKey(keyseq)
-            except RuntimeError:
+            except RuntimeError as e:
                 # Object has been deleted
                 toberemoved.append(index)
         for index in sorted(toberemoved, reverse=True):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3142,7 +3142,7 @@ class MainWindow(QMainWindow):
                         add_shortcut_to_tooltip(qobject, context, name)
                 elif isinstance(qobject, QShortcut):
                     qobject.setKey(keyseq)
-            except RuntimeError as e:
+            except RuntimeError:
                 # Object has been deleted
                 toberemoved.append(index)
         for index in sorted(toberemoved, reverse=True):

--- a/spyder/config/gui.py
+++ b/spyder/config/gui.py
@@ -91,51 +91,17 @@ def set_font(font, section='appearance', option='font'):
     FONT_CACHE[(section, option)] = font
 
 
-def get_shortcut(context, name):
-    """Get keyboard shortcut (key sequence string)"""
-    return CONF.get('shortcuts', '%s/%s' % (context, name))
-
-
-def set_shortcut(context, name, keystr):
-    """Set keyboard shortcut (key sequence string)"""
-    CONF.set('shortcuts', '%s/%s' % (context, name), keystr)
-
-
-def fixed_shortcut(keystr, parent, action):
+def _config_shortcut(action, context, name, keystr, parent):
     """
-    DEPRECATED: This function will be removed in Spyder 4.0
+    Create a Shortcut namedtuple for a widget.
 
-    Define a fixed shortcut according to a keysequence string
+    The data contained in this tuple will be registered in our shortcuts
+    preferences page.
     """
-    sc = QShortcut(QKeySequence(keystr), parent, action)
-    sc.setContext(Qt.WidgetWithChildrenShortcut)
-    return sc
-
-
-def config_shortcut(action, context, name, parent):
-    """
-    Create a Shortcut namedtuple for a widget
-
-    The data contained in this tuple will be registered in
-    our shortcuts preferences page
-    """
-    keystr = get_shortcut(context, name)
     qsc = QShortcut(QKeySequence(keystr), parent, action)
     qsc.setContext(Qt.WidgetWithChildrenShortcut)
     sc = Shortcut(data=(qsc, context, name))
     return sc
-
-
-def iter_shortcuts():
-    """Iterate over keyboard shortcuts."""
-    for context_name, keystr in CONF.items('shortcuts'):
-        context, name = context_name.split("/", 1)
-        yield context, name, keystr
-
-
-def reset_shortcuts():
-    """Reset keyboard shortcuts to default values"""
-    CONF.reset_to_defaults(section='shortcuts')
 
 
 def get_color_scheme(name):

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -230,7 +230,11 @@ class ConfigurationManager(object):
     # Shortcut configuration management
     # ------------------------------------------------------------------------
     def _get_shortcut_config(self, context):
-        """Return the shortcut configuration for global or plugin configs."""
+        """
+        Return the shortcut configuration for global or plugin configs.
+
+        Context must be either '_' for global or the name of a plugin.
+        """
         config = self._user_config
         if context in self._plugin_configs:
             plugin_class, config = self._plugin_configs[context]

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -295,10 +295,12 @@ class ConfigurationManager(object):
             context, name = context_name.split('/', 1)
             yield context, name, keystr
 
-        for plugin_config in self._plugin_configs:
-            for context_name, keystr in plugin_config.items('shortcuts'):
-                context, name = context_name.split('/', 1)
-                yield context, name, keystr
+        for p_section, (p_class, p_config) in self._plugin_configs.items():
+            items = p_config.items('shortcuts')
+            if items:
+                for context_name, keystr in items:
+                    context, name = context_name.split('/', 1)
+                    yield context, name, keystr
 
     def reset_shortcuts(self):
         """Reset keyboard shortcuts to default values."""

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -13,7 +13,7 @@ import os
 import os.path as osp
 
 # Local imports
-from spyder.config.base import get_conf_paths, get_conf_path, get_home_dir
+from spyder.config.base import _, get_conf_paths, get_conf_path, get_home_dir
 from spyder.config.main import CONF_VERSION, DEFAULTS, NAME_MAP
 from spyder.config.user import UserConfig, MultiUserConfig, NoDefault
 
@@ -235,17 +235,21 @@ class ConfigurationManager(object):
 
         Context must be either '_' for global or the name of a plugin.
         """
+        context = context.lower()
+        extra_valid_contexts = ['_', 'array_builder', 'console',
+                                'find_replace']
         config = self._user_config
+
         if context in self._plugin_configs:
             plugin_class, config = self._plugin_configs[context]
             # Check if plugin has a separate file
             if not plugin_class.CONF_FILE:
                 config = self._user_config
-        elif context == '_':
+        elif context in self._user_config.sections() + extra_valid_contexts:
             config = self._user_config
         else:
-            # Raise error?
-            pass
+            raise ValueError(_("Shortcut context must match '_' or plugin "
+                               "`CONF_SECTION`!"))
 
         return config
 
@@ -274,6 +278,7 @@ class ConfigurationManager(object):
         The data contained in this tuple will be registered in our shortcuts
         preferences page.
         """
+        # We only import on demand to avoid loading Qt modules
         from spyder.config.gui import _config_shortcut
 
         keystr = self.get_shortcut(context, name)

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -264,8 +264,8 @@ class ConfigurationManager(object):
                          + EXTRA_VALID_SHORTCUT_CONTEXTS):
             config = self._user_config
         else:
-            raise ValueError(_("Shortcut context must match '_' or plugin "
-                               "`CONF_SECTION`!"))
+            raise ValueError(_("Shortcut context must match '_' or the "
+                               "plugin `CONF_SECTION`!"))
 
         return config
 

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -236,8 +236,12 @@ class ConfigurationManager(object):
         Context must be either '_' for global or the name of a plugin.
         """
         context = context.lower()
-        extra_valid_contexts = ['_', 'array_builder', 'console',
-                                'find_replace']
+        extra_valid_contexts = [
+            '_',
+            'array_builder',
+            'console',
+            'find_replace',
+        ]
         config = self._user_config
 
         if context in self._plugin_configs:

--- a/spyder/config/user.py
+++ b/spyder/config/user.py
@@ -907,6 +907,15 @@ class MultiUserConfig(object):
         """Return the UserConfig class to use."""
         return SpyderUserConfig
 
+    def sections(self):
+        """Return all sections of the configuration file."""
+        sections = set()
+        for _, config in self._configs_map.items():
+            for section in config.sections(): 
+                sections.add(section)
+
+        return list(sorted(sections))
+
     def items(self, section):
         """Return all the items option/values for the given section."""
         config = self._get_config(section, None)

--- a/spyder/config/user.py
+++ b/spyder/config/user.py
@@ -911,7 +911,7 @@ class MultiUserConfig(object):
         """Return all sections of the configuration file."""
         sections = set()
         for _, config in self._configs_map.items():
-            for section in config.sections(): 
+            for section in config.sections():
                 sections.add(section)
 
         return list(sorted(sections))
@@ -922,7 +922,10 @@ class MultiUserConfig(object):
         if config is None:
             config = self._configs_map[self.DEFAULT_FILE_NAME]
 
-        return config.items(section=section)
+        if config.has_section(section):
+            return config.items(section=section)
+        else:
+            return None
 
     def options(self, section):
         """Return all the options for the given section."""

--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -161,6 +161,8 @@ class BasePluginWidgetMixin(object):
         self._default_margins = None
         self._isvisible = False
 
+        self.shortcut = None
+
         # Options buttons
         self.options_button = create_toolbutton(self, text=_('Options'),
                                                 icon=ima.icon('tooloptions'))
@@ -177,15 +179,6 @@ class BasePluginWidgetMixin(object):
 
         # Options menu
         self._options_menu = QMenu(self)
-
-        # NOTE: Don't use the default option of CONF.get to assign a
-        # None shortcut to plugins that don't have one. That will mess
-        # the creation of our Keyboard Shortcuts prefs page
-        try:
-            self.shortcut = CONF.get('shortcuts', '_/switch to %s' %
-                                     self.CONF_SECTION)
-        except configparser.NoOptionError:
-            pass
 
         # We decided to create our own toggle action instead of using
         # the one that comes with dockwidget because it's not possible
@@ -265,10 +258,23 @@ class BasePluginWidgetMixin(object):
         dock.topLevelChanged.connect(self._on_top_level_changed)
         dock.sig_plugin_closed.connect(self._plugin_closed)
         self.dockwidget = dock
+
+        # NOTE: Don't use the default option of CONF.get to assign a
+        # None shortcut to plugins that don't have one. That will mess
+        # the creation of our Keyboard Shortcuts prefs page
+        try:
+            context = '_'
+            name = 'switch to {}'.format(self.CONF_SECTION)
+            self.shortcut = CONF.get_shortcut(context, name,
+                                              plugin_name=self.CONF_SECTION)
+        except configparser.NoOptionError:
+            pass
+
         if self.shortcut is not None:
             sc = QShortcut(QKeySequence(self.shortcut), self.main,
-                            self.switch_to_plugin)
-            self.register_shortcut(sc, "_", "Switch to %s" % self.CONF_SECTION)
+                           self.switch_to_plugin)
+            self.register_shortcut(sc, "_", "Switch to {}".format(
+                self.CONF_SECTION))
         return (dock, self._LOCATION)
 
     def _switch_to_plugin(self):
@@ -425,8 +431,12 @@ class BasePluginWidgetMixin(object):
     def _register_shortcut(self, qaction_or_qshortcut, context, name,
                            add_shortcut_to_tip=False):
         """Register a shortcut associated to a QAction or QShortcut."""
-        self.main.register_shortcut(qaction_or_qshortcut, context,
-                                    name, add_shortcut_to_tip)
+        self.main.register_shortcut(
+            qaction_or_qshortcut,
+            context,
+            name,
+            add_shortcut_to_tip,
+            self.CONF_SECTION)
 
     def _get_color_scheme(self):
         """Get the current color scheme."""

--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -270,11 +270,12 @@ class BasePluginWidgetMixin(object):
         except configparser.NoOptionError:
             pass
 
-        if self.shortcut is not None:
+        if self.shortcut is not None and self.main is not None:
             sc = QShortcut(QKeySequence(self.shortcut), self.main,
                            self.switch_to_plugin)
             self.register_shortcut(sc, "_", "Switch to {}".format(
                 self.CONF_SECTION))
+
         return (dock, self._LOCATION)
 
     def _switch_to_plugin(self):

--- a/spyder/plugins/console/widgets/shell.py
+++ b/spyder/plugins/console/widgets/shell.py
@@ -28,7 +28,6 @@ from qtpy.QtWidgets import QApplication, QMenu, QToolTip
 
 # Local import
 from spyder.config.base import _, get_conf_path, get_debug_level, STDERR
-from spyder.config.gui import config_shortcut, get_shortcut
 from spyder.config.manager import CONF
 from spyder.py3compat import (builtins, is_string, is_text_string,
                               PY3, str_lower, to_text_string)
@@ -647,16 +646,22 @@ class PythonShellWidget(TracebackLinksMixin, ShellBaseWidget,
         self.shortcuts = self.create_shortcuts()
 
     def create_shortcuts(self):
-        array_inline = config_shortcut(lambda: self.enter_array_inline(),
-                                       context='array_builder',
-                                       name='enter array inline', parent=self)
-        array_table = config_shortcut(lambda: self.enter_array_table(),
-                                      context='array_builder',
-                                      name='enter array table', parent=self)
-        inspectsc = config_shortcut(self.inspect_current_object,
-                                    context='Console',
-                                    name='Inspect current object',
-                                    parent=self)
+        array_inline = CONF.config_shortcut(
+            lambda: self.enter_array_inline(),
+            context='array_builder',
+            name='enter array inline',
+            parent=self)
+        array_table = CONF.config_shortcut(
+            lambda: self.enter_array_table(),
+            context='array_builder',
+            name='enter array table',
+            parent=self)
+        inspectsc = CONF.config_shortcut(
+            self.inspect_current_object,
+            context='Console',
+            name='Inspect current object',
+            parent=self)
+
         return [inspectsc, array_inline, array_table]
 
     def get_shortcut_data(self):
@@ -677,13 +682,13 @@ class PythonShellWidget(TracebackLinksMixin, ShellBaseWidget,
                                      icon=ima.icon('copywop'),
                                      triggered=self.copy_without_prompts)
         clear_line_action = create_action(self, _("Clear line"),
-                                     QKeySequence(get_shortcut('console',
+                                     QKeySequence(CONF.get_shortcut('console',
                                                                'Clear line')),
                                      icon=ima.icon('editdelete'),
                                      tip=_("Clear line"),
                                      triggered=self.clear_line)
         clear_action = create_action(self, _("Clear shell"),
-                                     QKeySequence(get_shortcut('console',
+                                     QKeySequence(CONF.get_shortcut('console',
                                                                'Clear shell')),
                                      icon=ima.icon('editclear'),
                                      tip=_("Clear shell contents "

--- a/spyder/plugins/console/widgets/shell.py
+++ b/spyder/plugins/console/widgets/shell.py
@@ -677,23 +677,28 @@ class PythonShellWidget(TracebackLinksMixin, ShellBaseWidget,
     def setup_context_menu(self):
         """Reimplements ShellBaseWidget method"""
         ShellBaseWidget.setup_context_menu(self)
-        self.copy_without_prompts_action = create_action(self,
-                                     _("Copy without prompts"),
-                                     icon=ima.icon('copywop'),
-                                     triggered=self.copy_without_prompts)
-        clear_line_action = create_action(self, _("Clear line"),
-                                     QKeySequence(CONF.get_shortcut('console',
-                                                               'Clear line')),
-                                     icon=ima.icon('editdelete'),
-                                     tip=_("Clear line"),
-                                     triggered=self.clear_line)
-        clear_action = create_action(self, _("Clear shell"),
-                                     QKeySequence(CONF.get_shortcut('console',
-                                                               'Clear shell')),
-                                     icon=ima.icon('editclear'),
-                                     tip=_("Clear shell contents "
-                                           "('cls' command)"),
-                                     triggered=self.clear_terminal)
+        self.copy_without_prompts_action = create_action(
+            self,
+            _("Copy without prompts"),
+            icon=ima.icon('copywop'),
+            triggered=self.copy_without_prompts)
+
+        clear_line_action = create_action(
+            self,
+            _("Clear line"),
+            QKeySequence(CONF.get_shortcut('console', 'Clear line')),
+            icon=ima.icon('editdelete'),
+            tip=_("Clear line"),
+            triggered=self.clear_line)
+
+        clear_action = create_action(
+            self,
+            _("Clear shell"),
+            QKeySequence(CONF.get_shortcut('console', 'Clear shell')),
+            icon=ima.icon('editclear'),
+            tip=_("Clear shell contents ('cls' command)"),
+            triggered=self.clear_terminal)
+
         add_actions(self.menu, (self.copy_without_prompts_action,
                     clear_line_action, clear_action))
 

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -29,7 +29,6 @@ from qtpy.QtWidgets import (QAction, QActionGroup, QApplication, QDialog,
 
 # Local imports
 from spyder.config.base import _, get_conf_path, running_under_pytest
-from spyder.config.gui import get_shortcut
 from spyder.config.manager import CONF
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
                                  get_filter)
@@ -570,11 +569,14 @@ class Editor(SpyderPluginWidget):
         self.register_shortcut(run_action, context="_", name="Run",
                                add_shortcut_to_tip=True)
 
-        configure_action = create_action(self, _("&Configuration per file..."),
-                                         icon=ima.icon('run_settings'),
-                               tip=_("Run settings"),
-                               menurole=QAction.NoRole,
-                               triggered=self.edit_run_configurations)
+        configure_action = create_action(
+            self,
+            _("&Configuration per file..."),
+            icon=ima.icon('run_settings'),
+            tip=_("Run settings"),
+            menurole=QAction.NoRole,
+            triggered=self.edit_run_configurations)
+
         self.register_shortcut(configure_action, context="_",
                                name="Configure", add_shortcut_to_tip=True)
 
@@ -599,25 +601,26 @@ class Editor(SpyderPluginWidget):
         run_cell_action = create_action(self,
                             _("Run cell"),
                             icon=ima.icon('run_cell'),
-                            shortcut=get_shortcut('editor', 'run cell'),
+                            shortcut=CONF.get_shortcut('editor', 'run cell'),
                             tip=_("Run current cell \n"
                                   "[Use #%% to create cells]"),
                             triggered=self.run_cell,
                             context=Qt.WidgetShortcut)
 
-        run_cell_advance_action = create_action(self,
-                   _("Run cell and advance"),
-                   icon=ima.icon('run_cell_advance'),
-                   shortcut=get_shortcut('editor', 'run cell and advance'),
-                   tip=_("Run current cell and go to the next one "),
-                   triggered=self.run_cell_and_advance,
-                   context=Qt.WidgetShortcut)
+        run_cell_advance_action = create_action(
+            self,
+            _("Run cell and advance"),
+            icon=ima.icon('run_cell_advance'),
+            shortcut=CONF.get_shortcut('editor', 'run cell and advance'),
+            tip=_("Run current cell and go to the next one "),
+            triggered=self.run_cell_and_advance,
+            context=Qt.WidgetShortcut)
 
         debug_cell_action = create_action(
             self,
             _("Debug cell"),
             icon=ima.icon('debug_cell'),
-            shortcut=get_shortcut('editor', 'debug cell'),
+            shortcut=CONF.get_shortcut('editor', 'debug cell'),
             tip=_("Debug current cell "
                   "(Alt+Shift+Enter)"),
             triggered=self.debug_cell,
@@ -835,13 +838,13 @@ class Editor(SpyderPluginWidget):
             self.go_to_next_file_action = create_action(
                 self,
                 _("Go to next file"),
-                shortcut=get_shortcut('editor', 'go to previous file'),
+                shortcut=CONF.get_shortcut('editor', 'go to previous file'),
                 triggered=self.go_to_next_file,
             )
             self.go_to_previous_file_action = create_action(
                 self,
                 _("Go to previous file"),
-                shortcut=get_shortcut('editor', 'go to next file'),
+                shortcut=CONF.get_shortcut('editor', 'go to next file'),
                 triggered=self.go_to_previous_file,
             )
             self.register_shortcut(

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -50,7 +50,6 @@ from spyder_kernels.utils.dochelpers import getobj
 # Local imports
 from spyder.api.panel import Panel
 from spyder.config.base import _, get_debug_level, running_under_pytest
-from spyder.config.gui import get_shortcut, config_shortcut
 from spyder.config.manager import CONF
 from spyder.plugins.editor.api.decoration import TextDecoration
 from spyder.plugins.editor.extensions import (CloseBracketsExtension,
@@ -729,7 +728,7 @@ class CodeEditor(TextEditBaseWidget):
         shortcuts = []
         for context, name, callback in shortcut_context_name_callbacks:
             shortcuts.append(
-                config_shortcut(
+                CONF.config_shortcut(
                     callback, context=context, name=name, parent=self))
         return shortcuts
 
@@ -3360,26 +3359,26 @@ class CodeEditor(TextEditBaseWidget):
         """Setup context menu"""
         self.undo_action = create_action(
             self, _("Undo"), icon=ima.icon('undo'),
-            shortcut=get_shortcut('editor', 'undo'), triggered=self.undo)
+            shortcut=CONF.get_shortcut('editor', 'undo'), triggered=self.undo)
         self.redo_action = create_action(
             self, _("Redo"), icon=ima.icon('redo'),
-            shortcut=get_shortcut('editor', 'redo'), triggered=self.redo)
+            shortcut=CONF.get_shortcut('editor', 'redo'), triggered=self.redo)
         self.cut_action = create_action(
             self, _("Cut"), icon=ima.icon('editcut'),
-            shortcut=get_shortcut('editor', 'cut'), triggered=self.cut)
+            shortcut=CONF.get_shortcut('editor', 'cut'), triggered=self.cut)
         self.copy_action = create_action(
             self, _("Copy"), icon=ima.icon('editcopy'),
-            shortcut=get_shortcut('editor', 'copy'), triggered=self.copy)
+            shortcut=CONF.get_shortcut('editor', 'copy'), triggered=self.copy)
         self.paste_action = create_action(
             self, _("Paste"), icon=ima.icon('editpaste'),
-            shortcut=get_shortcut('editor', 'paste'), triggered=self.paste)
+            shortcut=CONF.get_shortcut('editor', 'paste'), triggered=self.paste)
         selectall_action = create_action(
             self, _("Select All"), icon=ima.icon('selectall'),
-            shortcut=get_shortcut('editor', 'select all'),
+            shortcut=CONF.get_shortcut('editor', 'select all'),
             triggered=self.selectAll)
         toggle_comment_action = create_action(
             self, _("Comment")+"/"+_("Uncomment"), icon=ima.icon('comment'),
-            shortcut=get_shortcut('editor', 'toggle comment'),
+            shortcut=CONF.get_shortcut('editor', 'toggle comment'),
             triggered=self.toggle_comment)
         self.clear_all_output_action = create_action(
             self, _("Clear all ouput"), icon=ima.icon('ipython_console'),
@@ -3389,31 +3388,31 @@ class CodeEditor(TextEditBaseWidget):
             triggered=self.convert_notebook)
         self.gotodef_action = create_action(
             self, _("Go to definition"),
-            shortcut=get_shortcut('editor', 'go to definition'),
+            shortcut=CONF.get_shortcut('editor', 'go to definition'),
             triggered=self.go_to_definition_from_cursor)
 
         # Run actions
         self.run_cell_action = create_action(
             self, _("Run cell"), icon=ima.icon('run_cell'),
-            shortcut=get_shortcut('editor', 'run cell'),
+            shortcut=CONF.get_shortcut('editor', 'run cell'),
             triggered=self.sig_run_cell.emit)
         self.run_cell_and_advance_action = create_action(
             self, _("Run cell and advance"), icon=ima.icon('run_cell'),
-            shortcut=get_shortcut('editor', 'run cell and advance'),
+            shortcut=CONF.get_shortcut('editor', 'run cell and advance'),
             triggered=self.sig_run_cell_and_advance.emit)
         self.re_run_last_cell_action = create_action(
             self, _("Re-run last cell"), icon=ima.icon('run_cell'),
-            shortcut=get_shortcut('editor', 're-run last cell'),
+            shortcut=CONF.get_shortcut('editor', 're-run last cell'),
             triggered=self.sig_re_run_last_cell.emit)
         self.run_selection_action = create_action(
             self, _("Run &selection or current line"),
             icon=ima.icon('run_selection'),
-            shortcut=get_shortcut('editor', 'run selection'),
+            shortcut=CONF.get_shortcut('editor', 'run selection'),
             triggered=self.sig_run_selection.emit)
 
         self.debug_cell_action = create_action(
             self, _("Debug cell"), icon=ima.icon('debug_cell'),
-            shortcut=get_shortcut('editor', 'debug cell'),
+            shortcut=CONF.get_shortcut('editor', 'debug cell'),
             triggered=self.sig_debug_cell.emit)
 
         # Zoom actions
@@ -3433,7 +3432,7 @@ class CodeEditor(TextEditBaseWidget):
         writer = self.writer_docstring
         self.docstring_action = create_action(
             self, _("Generate docstring"),
-            shortcut=get_shortcut('editor', 'docstring'),
+            shortcut=CONF.get_shortcut('editor', 'docstring'),
             triggered=writer.write_docstring_at_first_line_of_function)
 
         # Build menu
@@ -4066,8 +4065,8 @@ class CodeEditor(TextEditBaseWidget):
             self.sig_alt_left_mouse_pressed.emit(event)
         else:
             TextEditBaseWidget.mousePressEvent(self, event)
-
     def mouseReleaseEvent(self, event):
+
         """Override Qt method."""
         self.document_did_change()
         TextEditBaseWidget.mouseReleaseEvent(self, event)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -3371,7 +3371,8 @@ class CodeEditor(TextEditBaseWidget):
             shortcut=CONF.get_shortcut('editor', 'copy'), triggered=self.copy)
         self.paste_action = create_action(
             self, _("Paste"), icon=ima.icon('editpaste'),
-            shortcut=CONF.get_shortcut('editor', 'paste'), triggered=self.paste)
+            shortcut=CONF.get_shortcut('editor', 'paste'),
+            triggered=self.paste)
         selectall_action = create_action(
             self, _("Select All"), icon=ima.icon('selectall'),
             shortcut=CONF.get_shortcut('editor', 'select all'),

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -32,7 +32,8 @@ from qtpy.QtWidgets import (QAction, QApplication, QFileDialog, QHBoxLayout,
 
 # Local imports
 from spyder.config.base import _, running_under_pytest
-from spyder.config.gui import config_shortcut, is_dark_interface, get_shortcut
+from spyder.config.gui import is_dark_interface
+from spyder.config.manager import CONF
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
                                  get_filter, is_kde_desktop, is_anaconda)
 from spyder.py3compat import (qbytearray_to_str, to_text_string,
@@ -324,10 +325,10 @@ class TabSwitcherWidget(QListWidget):
         self.set_dialog_position()
         self.setCurrentRow(0)
 
-        config_shortcut(lambda: self.select_row(-1), context='Editor',
-                        name='Go to previous file', parent=self)
-        config_shortcut(lambda: self.select_row(1), context='Editor',
-                        name='Go to next file', parent=self)
+        CONF.config_shortcut(lambda: self.select_row(-1), context='Editor',
+                             name='Go to previous file', parent=self)
+        CONF.config_shortcut(lambda: self.select_row(1), context='Editor',
+                             name='Go to next file', parent=self)
 
     def load_data(self):
         """Fill ListWidget with the tabs texts.
@@ -379,7 +380,7 @@ class TabSwitcherWidget(QListWidget):
         When ctrl is released and tab_switcher is visible, tab will be changed.
         """
         if self.isVisible():
-            qsc = get_shortcut(context='Editor', name='Go to next file')
+            qsc = CONF.get_shortcut(context='Editor', name='Go to next file')
 
             for key in qsc.split('+'):
                 key = key.lower()
@@ -621,128 +622,215 @@ class EditorStack(QWidget):
     def create_shortcuts(self):
         """Create local shortcuts"""
         # --- Configurable shortcuts
-        inspect = config_shortcut(self.inspect_current_object, context='Editor',
+        inspect = CONF.config_shortcut(self.inspect_current_object, context='Editor',
                                   name='Inspect current object', parent=self)
         # TODO: Cleaner way to do this?
+        # This should be called from the plugin and not the widgets
         app = QCoreApplication.instance()
-        set_breakpoint = config_shortcut(self.set_or_clear_breakpoint,
-                                         context='Editor', name='Breakpoint',
-                                         parent=self)
-        set_cond_breakpoint = config_shortcut(
-                                    self.set_or_edit_conditional_breakpoint,
-                                    context='Editor',
-                                    name='Conditional breakpoint',
-                                    parent=self)
-        gotoline = config_shortcut(self.go_to_line, context='Editor',
-                                   name='Go to line', parent=self)
-        tab = config_shortcut(lambda: self.tab_navigation_mru(forward=False),
-                              context='Editor',
-                              name='Go to previous file', parent=self)
-        tabshift = config_shortcut(self.tab_navigation_mru, context='Editor',
-                                   name='Go to next file', parent=self)
-        prevtab = config_shortcut(lambda: self.tabs.tab_navigate(-1),
-                                  context='Editor',
-                                  name='Cycle to previous file', parent=self)
-        nexttab = config_shortcut(lambda: self.tabs.tab_navigate(1),
-                                  context='Editor',
-                                  name='Cycle to next file', parent=self)
-        run_selection = config_shortcut(self.run_selection, context='Editor',
-                                        name='Run selection', parent=self)
-        new_file = config_shortcut(lambda : self.sig_new_file[()].emit(),
-                                   context='Editor', name='New file',
-                                   parent=self)
-        open_file = config_shortcut(lambda : self.plugin_load[()].emit(),
-                                    context='Editor', name='Open file',
-                                    parent=self)
-        save_file = config_shortcut(self.save, context='Editor',
-                                    name='Save file', parent=self)
-        save_all = config_shortcut(self.save_all, context='Editor',
-                                   name='Save all', parent=self)
-        save_as = config_shortcut(lambda : self.sig_save_as.emit(),
-                                  context='Editor', name='Save As',
-                                  parent=self)
-        close_all = config_shortcut(self.close_all_files, context='Editor',
-                                    name='Close all', parent=self)
-        prev_edit_pos = config_shortcut(lambda : self.sig_prev_edit_pos.emit(),
-                                        context="Editor",
-                                        name="Last edit location",
-                                        parent=self)
-        prev_cursor = config_shortcut(lambda : self.sig_prev_cursor.emit(),
-                                      context="Editor",
-                                      name="Previous cursor position",
-                                      parent=self)
-        next_cursor = config_shortcut(lambda : self.sig_next_cursor.emit(),
-                                      context="Editor",
-                                      name="Next cursor position",
-                                      parent=self)
-        zoom_in_1 = config_shortcut(lambda : self.zoom_in.emit(),
-                                      context="Editor",
-                                      name="zoom in 1",
-                                      parent=self)
-        zoom_in_2 = config_shortcut(lambda : self.zoom_in.emit(),
-                                      context="Editor",
-                                      name="zoom in 2",
-                                      parent=self)
-        zoom_out = config_shortcut(lambda : self.zoom_out.emit(),
-                                      context="Editor",
-                                      name="zoom out",
-                                      parent=self)
-        zoom_reset = config_shortcut(lambda: self.zoom_reset.emit(),
-                                      context="Editor",
-                                      name="zoom reset",
-                                      parent=self)
-        close_file_1 = config_shortcut(self.close_file,
-                                      context="Editor",
-                                      name="close file 1",
-                                      parent=self)
-        close_file_2 = config_shortcut(self.close_file,
-                                      context="Editor",
-                                      name="close file 2",
-                                      parent=self)
-        run_cell = config_shortcut(self.run_cell,
-                                      context="Editor",
-                                      name="run cell",
-                                      parent=self)
-        debug_cell = config_shortcut(self.debug_cell,
-                                     context="Editor",
-                                     name="debug cell",
-                                     parent=self)
-        run_cell_and_advance = config_shortcut(self.run_cell_and_advance,
-                                      context="Editor",
-                                      name="run cell and advance",
-                                      parent=self)
-        go_to_next_cell = config_shortcut(self.advance_cell,
-                                          context="Editor",
-                                          name="go to next cell",
-                                          parent=self)
-        go_to_previous_cell = config_shortcut(lambda: self.advance_cell(reverse=True),
-                                              context="Editor",
-                                              name="go to previous cell",
-                                              parent=self)
-        re_run_last_cell = config_shortcut(self.re_run_last_cell,
-                                      context="Editor",
-                                      name="re-run last cell",
-                                      parent=self)
-        prev_warning = config_shortcut(lambda: self.sig_prev_warning.emit(),
-                                       context="Editor",
-                                       name="Previous warning",
-                                       parent=self)
-        next_warning = config_shortcut(lambda: self.sig_next_warning.emit(),
-                                       context="Editor",
-                                       name="Next warning",
-                                       parent=self)
-        split_vertically = config_shortcut(lambda: self.sig_split_vertically.emit(),
-                                           context="Editor",
-                                           name="split vertically",
-                                           parent=self)
-        split_horizontally = config_shortcut(lambda: self.sig_split_horizontally.emit(),
-                                             context="Editor",
-                                             name="split horizontally",
-                                             parent=self)
-        close_split = config_shortcut(self.close_split,
-                                      context="Editor",
-                                      name="close split panel",
-                                      parent=self)
+
+        set_breakpoint = CONF.config_shortcut(
+            self.set_or_clear_breakpoint,
+            context='Editor',
+            name='Breakpoint',
+            parent=self)
+
+        set_cond_breakpoint = CONF.config_shortcut(
+            self.set_or_edit_conditional_breakpoint,
+            context='Editor',
+            name='Conditional breakpoint',
+            parent=self)
+
+        gotoline = CONF.config_shortcut(
+            self.go_to_line,
+            context='Editor',
+            name='Go to line',
+            parent=self)
+
+        tab = CONF.config_shortcut(
+            lambda: self.tab_navigation_mru(forward=False),
+            context='Editor',
+            name='Go to previous file',
+            parent=self)
+
+        tabshift = CONF.config_shortcut(
+            self.tab_navigation_mru,
+            context='Editor',
+            name='Go to next file',
+            parent=self)
+
+        prevtab = CONF.config_shortcut(
+            lambda: self.tabs.tab_navigate(-1),
+            context='Editor',
+            name='Cycle to previous file',
+            parent=self)
+
+        nexttab = CONF.config_shortcut(
+            lambda: self.tabs.tab_navigate(1),
+            context='Editor',
+            name='Cycle to next file',
+            parent=self)
+
+        run_selection = CONF.config_shortcut(
+            self.run_selection,
+            context='Editor',
+            name='Run selection',
+            parent=self)
+
+        new_file = CONF.config_shortcut(
+            lambda: self.sig_new_file[()].emit(),
+            context='Editor',
+            name='New file',
+            parent=self)
+
+        open_file = CONF.config_shortcut(
+            lambda: self.plugin_load[()].emit(),
+            context='Editor',
+            name='Open file',
+            parent=self)
+
+        save_file = CONF.config_shortcut(
+            self.save,
+            context='Editor',
+            name='Save file',
+            parent=self)
+
+        save_all = CONF.config_shortcut(
+            self.save_all,
+            context='Editor',
+            name='Save all',
+            parent=self)
+
+        save_as = CONF.config_shortcut(
+            lambda: self.sig_save_as.emit(),
+            context='Editor',
+            name='Save As',
+            parent=self)
+
+        close_all = CONF.config_shortcut(
+            self.close_all_files,
+            context='Editor',
+            name='Close all',
+            parent=self)
+
+        prev_edit_pos = CONF.config_shortcut(
+            lambda: self.sig_prev_edit_pos.emit(),
+            context="Editor",
+            name="Last edit location",
+            parent=self)
+
+        prev_cursor = CONF.config_shortcut(
+            lambda: self.sig_prev_cursor.emit(),
+            context="Editor",
+            name="Previous cursor position",
+            parent=self)
+
+        next_cursor = CONF.config_shortcut(
+            lambda: self.sig_next_cursor.emit(),
+            context="Editor",
+            name="Next cursor position",
+            parent=self)
+
+        zoom_in_1 = CONF.config_shortcut(
+            lambda: self.zoom_in.emit(),
+            context="Editor",
+            name="zoom in 1",
+            parent=self)
+
+        zoom_in_2 = CONF.config_shortcut(
+            lambda: self.zoom_in.emit(),
+            context="Editor",
+            name="zoom in 2",
+            parent=self)
+
+        zoom_out = CONF.config_shortcut(
+            lambda: self.zoom_out.emit(),
+            context="Editor",
+            name="zoom out",
+            parent=self)
+
+        zoom_reset = CONF.config_shortcut(
+            lambda: self.zoom_reset.emit(),
+            context="Editor",
+            name="zoom reset",
+            parent=self)
+
+        close_file_1 = CONF.config_shortcut(
+            self.close_file,
+            context="Editor",
+            name="close file 1",
+            parent=self)
+
+        close_file_2 = CONF.config_shortcut(
+            self.close_file,
+            context="Editor",
+            name="close file 2",
+            parent=self)
+
+        run_cell = CONF.config_shortcut(
+            self.run_cell,
+            context="Editor",
+            name="run cell",
+            parent=self)
+
+        debug_cell = CONF.config_shortcut(
+            self.debug_cell,
+            context="Editor",
+            name="debug cell",
+            parent=self)
+
+        run_cell_and_advance = CONF.config_shortcut(
+            self.run_cell_and_advance,
+            context="Editor",
+            name="run cell and advance",
+            parent=self)
+
+        go_to_next_cell = CONF.config_shortcut(
+            self.advance_cell,
+            context="Editor",
+            name="go to next cell",
+            parent=self)
+
+        go_to_previous_cell = CONF.config_shortcut(
+            lambda: self.advance_cell(reverse=True),
+            context="Editor",
+            name="go to previous cell",
+            parent=self)
+
+        re_run_last_cell = CONF.config_shortcut(
+            self.re_run_last_cell,
+            context="Editor",
+            name="re-run last cell",
+            parent=self)
+
+        prev_warning = CONF.config_shortcut(
+            lambda: self.sig_prev_warning.emit(),
+            context="Editor",
+            name="Previous warning",
+            parent=self)
+
+        next_warning = CONF.config_shortcut(
+            lambda: self.sig_next_warning.emit(),
+            context="Editor",
+            name="Next warning",
+            parent=self)
+
+        split_vertically = CONF.config_shortcut(
+            lambda: self.sig_split_vertically.emit(),
+            context="Editor",
+            name="split vertically",
+            parent=self)
+
+        split_horizontally = CONF.config_shortcut(
+            lambda: self.sig_split_horizontally.emit(),
+            context="Editor",
+            name="split horizontally",
+            parent=self)
+
+        close_split = CONF.config_shortcut(
+            self.close_split,
+            context="Editor",
+            name="close split panel",
+            parent=self)
 
         # Return configurable ones
         return [inspect, set_breakpoint, set_cond_breakpoint, gotoline, tab,
@@ -1427,18 +1515,18 @@ class EditorStack(QWidget):
                 icon=ima.icon('versplit'),
                 tip=_("Split vertically this editor window"),
                 triggered=lambda: self.sig_split_vertically.emit(),
-                shortcut=get_shortcut(context='Editor', name='split vertically'),
+                shortcut=CONF.get_shortcut(context='Editor', name='split vertically'),
                 context=Qt.WidgetShortcut)
         self.horsplit_action = create_action(self, _("Split horizontally"),
                 icon=ima.icon('horsplit'),
                 tip=_("Split horizontally this editor window"),
                 triggered=lambda: self.sig_split_horizontally.emit(),
-                shortcut=get_shortcut(context='Editor', name='split horizontally'),
+                shortcut=CONF.get_shortcut(context='Editor', name='split horizontally'),
                 context=Qt.WidgetShortcut)
         self.close_action = create_action(self, _("Close this panel"),
                 icon=ima.icon('close_panel'),
                 triggered=self.close_split,
-                shortcut=get_shortcut(context='Editor', name='close split panel'),
+                shortcut=CONF.get_shortcut(context='Editor', name='close split panel'),
                 context=Qt.WidgetShortcut)
 
         # Regular actions

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -622,8 +622,11 @@ class EditorStack(QWidget):
     def create_shortcuts(self):
         """Create local shortcuts"""
         # --- Configurable shortcuts
-        inspect = CONF.config_shortcut(self.inspect_current_object, context='Editor',
-                                  name='Inspect current object', parent=self)
+        inspect = CONF.config_shortcut(
+            self.inspect_current_object,
+            context='Editor',
+            name='Inspect current object',
+            parent=self)
         # TODO: Cleaner way to do this?
         # This should be called from the plugin and not the widgets
         app = QCoreApplication.instance()
@@ -1511,23 +1514,34 @@ class EditorStack(QWidget):
                 triggered=plugin.create_new_window)
 
         # Splitting
-        self.versplit_action = create_action(self, _("Split vertically"),
-                icon=ima.icon('versplit'),
-                tip=_("Split vertically this editor window"),
-                triggered=lambda: self.sig_split_vertically.emit(),
-                shortcut=CONF.get_shortcut(context='Editor', name='split vertically'),
-                context=Qt.WidgetShortcut)
-        self.horsplit_action = create_action(self, _("Split horizontally"),
-                icon=ima.icon('horsplit'),
-                tip=_("Split horizontally this editor window"),
-                triggered=lambda: self.sig_split_horizontally.emit(),
-                shortcut=CONF.get_shortcut(context='Editor', name='split horizontally'),
-                context=Qt.WidgetShortcut)
-        self.close_action = create_action(self, _("Close this panel"),
-                icon=ima.icon('close_panel'),
-                triggered=self.close_split,
-                shortcut=CONF.get_shortcut(context='Editor', name='close split panel'),
-                context=Qt.WidgetShortcut)
+        self.versplit_action = create_action(
+            self,
+            _("Split vertically"),
+            icon=ima.icon('versplit'),
+            tip=_("Split vertically this editor window"),
+            triggered=lambda: self.sig_split_vertically.emit(),
+            shortcut=CONF.get_shortcut(context='Editor',
+                                       name='split vertically'),
+            context=Qt.WidgetShortcut)
+
+        self.horsplit_action = create_action(
+            self,
+            _("Split horizontally"),
+            icon=ima.icon('horsplit'),
+            tip=_("Split horizontally this editor window"),
+            triggered=lambda: self.sig_split_horizontally.emit(),
+            shortcut=CONF.get_shortcut(context='Editor',
+                                       name='split horizontally'),
+            context=Qt.WidgetShortcut)
+
+        self.close_action = create_action(
+            self,
+            _("Close this panel"),
+            icon=ima.icon('close_panel'),
+            triggered=self.close_split,
+            shortcut=CONF.get_shortcut(context='Editor',
+                                       name='close split panel'),
+            context=Qt.WidgetShortcut)
 
         # Regular actions
         actions = [MENU_SEPARATOR, self.versplit_action,

--- a/spyder/plugins/editor/widgets/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/tests/test_shortcuts.py
@@ -68,7 +68,8 @@ def test_default_keybinding_values():
     assert CONF.get_shortcut('editor', 'select all') == 'Ctrl+A'
     assert CONF.get_shortcut('editor', 'delete line') == 'Ctrl+D'
     assert CONF.get_shortcut('editor', 'transform to lowercase') == 'Ctrl+U'
-    assert CONF.get_shortcut('editor', 'transform to uppercase') == 'Ctrl+Shift+U'
+    assert CONF.get_shortcut('editor',
+                             'transform to uppercase') == 'Ctrl+Shift+U'
     assert CONF.get_shortcut('editor', 'go to line') == 'Ctrl+L'
     assert CONF.get_shortcut('editor', 'next word') == 'Ctrl+Right'
     assert CONF.get_shortcut('editor', 'previous word') == 'Ctrl+Left'

--- a/spyder/plugins/editor/widgets/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/tests/test_shortcuts.py
@@ -22,9 +22,9 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication
 
 # Local imports
-from spyder.plugins.editor.widgets.editor import EditorStack
-from spyder.config.gui import get_shortcut
 from spyder.plugins.editor.widgets.codeeditor import GoToLineDialog
+from spyder.plugins.editor.widgets.editor import EditorStack
+from spyder.config.manager import CONF
 
 
 # ---- Qt Test Fixtures
@@ -57,21 +57,21 @@ def test_default_keybinding_values():
     of key strings to qtbot.keyClicks.
     """
     # Assert default keybindings.
-    assert get_shortcut('editor', 'start of document') == 'Ctrl+Home'
-    assert get_shortcut('editor', 'end of document') == 'Ctrl+End'
-    assert get_shortcut('editor', 'delete') == 'Del'
-    assert get_shortcut('editor', 'undo') == 'Ctrl+Z'
-    assert get_shortcut('editor', 'redo') == 'Ctrl+Shift+Z'
-    assert get_shortcut('editor', 'copy') == 'Ctrl+C'
-    assert get_shortcut('editor', 'paste') == 'Ctrl+V'
-    assert get_shortcut('editor', 'cut') == 'Ctrl+X'
-    assert get_shortcut('editor', 'select all') == 'Ctrl+A'
-    assert get_shortcut('editor', 'delete line') == 'Ctrl+D'
-    assert get_shortcut('editor', 'transform to lowercase') == 'Ctrl+U'
-    assert get_shortcut('editor', 'transform to uppercase') == 'Ctrl+Shift+U'
-    assert get_shortcut('editor', 'go to line') == 'Ctrl+L'
-    assert get_shortcut('editor', 'next word') == 'Ctrl+Right'
-    assert get_shortcut('editor', 'previous word') == 'Ctrl+Left'
+    assert CONF.get_shortcut('editor', 'start of document') == 'Ctrl+Home'
+    assert CONF.get_shortcut('editor', 'end of document') == 'Ctrl+End'
+    assert CONF.get_shortcut('editor', 'delete') == 'Del'
+    assert CONF.get_shortcut('editor', 'undo') == 'Ctrl+Z'
+    assert CONF.get_shortcut('editor', 'redo') == 'Ctrl+Shift+Z'
+    assert CONF.get_shortcut('editor', 'copy') == 'Ctrl+C'
+    assert CONF.get_shortcut('editor', 'paste') == 'Ctrl+V'
+    assert CONF.get_shortcut('editor', 'cut') == 'Ctrl+X'
+    assert CONF.get_shortcut('editor', 'select all') == 'Ctrl+A'
+    assert CONF.get_shortcut('editor', 'delete line') == 'Ctrl+D'
+    assert CONF.get_shortcut('editor', 'transform to lowercase') == 'Ctrl+U'
+    assert CONF.get_shortcut('editor', 'transform to uppercase') == 'Ctrl+Shift+U'
+    assert CONF.get_shortcut('editor', 'go to line') == 'Ctrl+L'
+    assert CONF.get_shortcut('editor', 'next word') == 'Ctrl+Right'
+    assert CONF.get_shortcut('editor', 'previous word') == 'Ctrl+Left'
 
 
 @pytest.mark.skipif(

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -33,7 +33,7 @@ from qtpy.QtWidgets import (QApplication, QFileIconProvider, QFileSystemModel,
 
 # Local imports
 from spyder.config.base import _, get_home_dir
-from spyder.config.gui import config_shortcut, get_shortcut
+from spyder.config.manager import CONF
 from spyder.py3compat import str_lower, to_binary_string, to_text_string
 from spyder.utils import encoding
 from spyder.utils import icon_manager as ima
@@ -451,21 +451,21 @@ class DirView(QTreeView):
                                              triggered=self.convert_notebooks)
         copy_file_clipboard_action = (
             create_action(self, _("Copy"),
-                          QKeySequence(get_shortcut('explorer', 'copy file')),
+                          QKeySequence(CONF.get_shortcut('explorer', 'copy file')),
                           icon=ima.icon('editcopy'),
                           triggered=self.copy_file_clipboard))
         save_file_clipboard_action = (
             create_action(self, _("Paste"),
-                          QKeySequence(get_shortcut('explorer', 'paste file')),
+                          QKeySequence(CONF.get_shortcut('explorer', 'paste file')),
                           icon=ima.icon('editpaste'),
                           triggered=self.save_file_clipboard))
         copy_absolute_path_action = (
             create_action(self, _("Copy Absolute Path"), QKeySequence(
-                get_shortcut('explorer', 'copy absolute path')),
+                CONF.get_shortcut('explorer', 'copy absolute path')),
                           triggered=self.copy_absolute_path))
         copy_relative_path_action = (
             create_action(self, _("Copy Relative Path"), QKeySequence(
-                get_shortcut('explorer', 'copy relative path')),
+                CONF.get_shortcut('explorer', 'copy relative path')),
                           triggered=self.copy_relative_path))
 
         actions = []
@@ -1181,20 +1181,30 @@ class DirView(QTreeView):
     def create_shortcuts(self):
         """Create shortcuts for this file explorer."""
         # Configurable
-        copy_clipboard_file = config_shortcut(self.copy_file_clipboard,
-                                              context='explorer',
-                                              name='copy file', parent=self)
-        paste_clipboard_file = config_shortcut(self.save_file_clipboard,
-                                               context='explorer',
-                                               name='paste file', parent=self)
-        copy_absolute_path = config_shortcut(self.copy_absolute_path,
-                                             context='explorer',
-                                             name='copy absolute path',
-                                             parent=self)
-        copy_relative_path = config_shortcut(self.copy_relative_path,
-                                             context='explorer',
-                                             name='copy relative path',
-                                             parent=self)
+        copy_clipboard_file = CONF.config_shortcut(
+            self.copy_file_clipboard,
+            context='explorer',
+            name='copy file',
+            parent=self)
+
+        paste_clipboard_file = CONF.config_shortcut(
+            self.save_file_clipboard,
+            context='explorer',
+            name='paste file',
+            parent=self)
+
+        copy_absolute_path = CONF.config_shortcut(
+            self.copy_absolute_path,
+            context='explorer',
+            name='copy absolute path',
+            parent=self)
+
+        copy_relative_path = CONF.config_shortcut(
+            self.copy_relative_path,
+            context='explorer',
+            name='copy relative path',
+            parent=self)
+
         return [copy_clipboard_file, paste_clipboard_file, copy_absolute_path,
                 copy_relative_path]
 

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -434,39 +434,61 @@ class DirView(QTreeView):
             self, _("Open in Spyder"), icon=ima.icon('edit'),
             triggered=self.open)
         open_with_menu = QMenu(_('Open with'), self)
+
         open_external_action = create_action(
-            self, _("Open externally"),
+            self,
+            _("Open externally"),
             triggered=self.open_external)
-        move_action = create_action(self, _("Move..."),
-                                    icon="move.png",
-                                    triggered=self.move)
-        delete_action = create_action(self, _("Delete..."),
-                                      icon=ima.icon('editdelete'),
-                                      triggered=self.delete)
-        rename_action = create_action(self, _("Rename..."),
-                                      icon=ima.icon('rename'),
-                                      triggered=self.rename)
-        ipynb_convert_action = create_action(self, _("Convert to Python script"),
-                                             icon=ima.icon('python'),
-                                             triggered=self.convert_notebooks)
-        copy_file_clipboard_action = (
-            create_action(self, _("Copy"),
-                          QKeySequence(CONF.get_shortcut('explorer', 'copy file')),
-                          icon=ima.icon('editcopy'),
-                          triggered=self.copy_file_clipboard))
-        save_file_clipboard_action = (
-            create_action(self, _("Paste"),
-                          QKeySequence(CONF.get_shortcut('explorer', 'paste file')),
-                          icon=ima.icon('editpaste'),
-                          triggered=self.save_file_clipboard))
-        copy_absolute_path_action = (
-            create_action(self, _("Copy Absolute Path"), QKeySequence(
-                CONF.get_shortcut('explorer', 'copy absolute path')),
-                          triggered=self.copy_absolute_path))
-        copy_relative_path_action = (
-            create_action(self, _("Copy Relative Path"), QKeySequence(
-                CONF.get_shortcut('explorer', 'copy relative path')),
-                          triggered=self.copy_relative_path))
+
+        move_action = create_action(
+            self,
+            _("Move..."),
+            icon="move.png",
+            triggered=self.move)
+
+        delete_action = create_action(
+            self,
+            _("Delete..."),
+            icon=ima.icon('editdelete'),
+            triggered=self.delete)
+
+        rename_action = create_action(
+            self,
+            _("Rename..."),
+            icon=ima.icon('rename'),
+            triggered=self.rename)
+
+        ipynb_convert_action = create_action(
+            self,
+            _("Convert to Python script"),
+            icon=ima.icon('python'),
+            triggered=self.convert_notebooks)
+
+        copy_file_clipboard_action = create_action(
+            self,
+            _("Copy"),
+            QKeySequence(CONF.get_shortcut('explorer', 'copy file')),
+            icon=ima.icon('editcopy'),
+            triggered=self.copy_file_clipboard)
+
+        save_file_clipboard_action = create_action(
+            self,
+            _("Paste"),
+            QKeySequence(CONF.get_shortcut('explorer', 'paste file')),
+            icon=ima.icon('editpaste'),
+            triggered=self.save_file_clipboard)
+
+        copy_absolute_path_action = create_action(
+            self,
+            _("Copy Absolute Path"),
+            QKeySequence(CONF.get_shortcut('explorer', 'copy absolute path')),
+            triggered=self.copy_absolute_path)
+
+        copy_relative_path_action = create_action(
+            self,
+            _("Copy Relative Path"),
+            QKeySequence(CONF.get_shortcut('explorer', 'copy relative path')),
+            triggered=self.copy_relative_path)
 
         actions = []
         if only_modules:

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -34,7 +34,8 @@ from qtpy.QtWidgets import (QHBoxLayout, QLabel, QMenu, QMessageBox,
 # Local imports
 from spyder.config.base import (_, get_image_path, get_module_source_path,
                                 running_under_pytest)
-from spyder.config.gui import get_shortcut, is_dark_interface
+from spyder.config.gui import is_dark_interface
+from spyder.config.manager import CONF
 from spyder.utils import icon_manager as ima
 from spyder.utils import sourcecode
 from spyder.utils.encoding import get_coding
@@ -434,32 +435,39 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
     def add_actions_to_context_menu(self, menu):
         """Add actions to IPython widget context menu"""
-        inspect_action = create_action(self, _("Inspect current object"),
-                                    QKeySequence(get_shortcut('console',
-                                                    'inspect current object')),
-                                    icon=ima.icon('MessageBoxInformation'),
-                                    triggered=self.inspect_object)
+        inspect_action = create_action(
+            self,
+            _("Inspect current object"),
+            QKeySequence(CONF.get_shortcut('console',
+                                           'inspect current object')),
+            icon=ima.icon('MessageBoxInformation'),
+            triggered=self.inspect_object)
 
-        clear_line_action = create_action(self, _("Clear line or block"),
-                                          QKeySequence(get_shortcut(
-                                                  'console',
-                                                  'clear line')),
-                                          triggered=self.clear_line)
+        clear_line_action = create_action(
+            self,
+            _("Clear line or block"),
+            QKeySequence(CONF.get_shortcut('console', 'clear line')),
+            triggered=self.clear_line)
 
-        reset_namespace_action = create_action(self, _("Remove all variables"),
-                                               QKeySequence(get_shortcut(
-                                                       'ipython_console',
-                                                       'reset namespace')),
-                                               icon=ima.icon('editdelete'),
-                                               triggered=self.reset_namespace)
+        reset_namespace_action = create_action(
+            self,
+            _("Remove all variables"),
+            QKeySequence(CONF.get_shortcut('ipython_console',
+                                           'reset namespace')),
+            icon=ima.icon('editdelete'),
+            triggered=self.reset_namespace)
 
-        clear_console_action = create_action(self, _("Clear console"),
-                                             QKeySequence(get_shortcut('console',
-                                                               'clear shell')),
-                                             triggered=self.clear_console)
+        clear_console_action = create_action(
+            self,
+            _("Clear console"),
+            QKeySequence(CONF.get_shortcut('console', 'clear shell')),
+            triggered=self.clear_console)
 
-        quit_action = create_action(self, _("&Quit"), icon=ima.icon('exit'),
-                                    triggered=self.exit_callback)
+        quit_action = create_action(
+            self,
+            _("&Quit"),
+            icon=ima.icon('exit'),
+            triggered=self.exit_callback)
 
         add_actions(menu, (None, inspect_action, clear_line_action,
                            clear_console_action, reset_namespace_action,

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -18,9 +18,8 @@ from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports
-from spyder.config.manager import CONF
 from spyder.config.base import _
-from spyder.config.gui import config_shortcut
+from spyder.config.manager import CONF
 from spyder.py3compat import to_text_string
 from spyder.utils import programs, encoding
 from spyder.utils import syntaxhighlighters as sh
@@ -338,29 +337,53 @@ the sympy module (e.g. plot)
 
     def create_shortcuts(self):
         """Create shortcuts for ipyconsole."""
-        inspect = config_shortcut(self._control.inspect_current_object,
-                                  context='Console',
-                                  name='Inspect current object', parent=self)
-        clear_console = config_shortcut(self.clear_console, context='Console',
-                                        name='Clear shell', parent=self)
-        restart_kernel = config_shortcut(self.ipyclient.restart_kernel,
-                                         context='ipython_console',
-                                         name='Restart kernel', parent=self)
-        new_tab = config_shortcut(lambda: self.new_client.emit(),
-                                  context='ipython_console', name='new tab',
-                                  parent=self)
-        reset_namespace = config_shortcut(lambda: self._reset_namespace(),
-                                          context='ipython_console',
-                                          name='reset namespace', parent=self)
-        array_inline = config_shortcut(self._control.enter_array_inline,
-                                       context='array_builder',
-                                       name='enter array inline', parent=self)
-        array_table = config_shortcut(self._control.enter_array_table,
-                                      context='array_builder',
-                                      name='enter array table', parent=self)
-        clear_line = config_shortcut(self.ipyclient.clear_line,
-                                     context='console', name='clear line',
-                                     parent=self)
+        inspect = CONF.config_shortcut(
+            self._control.inspect_current_object,
+            context='Console',
+            name='Inspect current object',
+            parent=self)
+
+        clear_console = CONF.config_shortcut(
+            self.clear_console,
+            context='Console',
+            name='Clear shell',
+            parent=self)
+
+        restart_kernel = CONF.config_shortcut(
+            self.ipyclient.restart_kernel,
+            context='ipython_console',
+            name='Restart kernel',
+            parent=self)
+
+        new_tab = CONF.config_shortcut(
+            lambda: self.new_client.emit(),
+            context='ipython_console',
+            name='new tab',
+            parent=self)
+
+        reset_namespace = CONF.config_shortcut(
+            lambda: self._reset_namespace(),
+            context='ipython_console',
+            name='reset namespace',
+            parent=self)
+
+        array_inline = CONF.config_shortcut(
+            self._control.enter_array_inline,
+            context='array_builder',
+            name='enter array inline',
+            parent=self)
+
+        array_table = CONF.config_shortcut(
+            self._control.enter_array_table,
+            context='array_builder',
+            name='enter array table',
+            parent=self)
+
+        clear_line = CONF.config_shortcut(
+            self.ipyclient.clear_line,
+            context='console',
+            name='clear line',
+            parent=self)
 
         return [inspect, clear_console, restart_kernel, new_tab,
                 reset_namespace, array_inline, array_table, clear_line]

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -286,7 +286,7 @@ class FigureBrowser(QWidget):
             parent=self)
 
         nextfig = CONF.config_shortcut(
-            self.go_next_thumbnail, 
+            self.go_next_thumbnail,
             context='plots',
             name='next figure',
             parent=self)

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -27,13 +27,14 @@ from qtpy.QtWidgets import (QApplication, QHBoxLayout, QMenu,
 
 # ---- Local library imports
 from spyder.config.base import _
+from spyder.config.manager import CONF
 from spyder.py3compat import is_unicode, to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import (add_actions, create_action,
                                     create_toolbutton, create_plugin_layout,
                                     MENU_SEPARATOR)
 from spyder.utils.misc import getcwd_or_home
-from spyder.config.gui import config_shortcut, get_shortcut, is_dark_interface
+from spyder.config.gui import is_dark_interface
 
 
 def save_figure_tofile(fig, fmt, fname):
@@ -157,7 +158,7 @@ class FigureBrowser(QWidget):
         copyfig_btn = create_toolbutton(
             self, icon=ima.icon('editcopy'),
             tip=_("Copy plot to clipboard as image (%s)" %
-                  get_shortcut('plots', 'copy')),
+                  CONF.get_shortcut('plots', 'copy')),
             triggered=self.copy_figure)
 
         closefig_btn = create_toolbutton(
@@ -176,13 +177,13 @@ class FigureBrowser(QWidget):
         goback_btn = create_toolbutton(
                 self, icon=ima.icon('ArrowBack'),
                 tip=_("Previous Figure ({})".format(
-                      get_shortcut('plots', 'previous figure'))),
+                      CONF.get_shortcut('plots', 'previous figure'))),
                 triggered=self.go_previous_thumbnail)
 
         gonext_btn = create_toolbutton(
                 self, icon=ima.icon('ArrowForward'),
                 tip=_("Next Figure ({})".format(
-                      get_shortcut('plots', 'next figure'))),
+                      CONF.get_shortcut('plots', 'next figure'))),
                 triggered=self.go_next_thumbnail)
 
         vsep2 = QFrame()
@@ -272,12 +273,23 @@ class FigureBrowser(QWidget):
     def create_shortcuts(self):
         """Create shortcuts for this widget."""
         # Configurable
-        copyfig = config_shortcut(self.copy_figure, context='plots',
-                                  name='copy', parent=self)
-        prevfig = config_shortcut(self.go_previous_thumbnail, context='plots',
-                                  name='previous figure', parent=self)
-        nextfig = config_shortcut(self.go_next_thumbnail, context='plots',
-                                  name='next figure', parent=self)
+        copyfig = CONF.config_shortcut(
+            self.copy_figure,
+            context='plots',
+            name='copy',
+            parent=self)
+
+        prevfig = CONF.config_shortcut(
+            self.go_previous_thumbnail,
+            context='plots',
+            name='previous figure',
+            parent=self)
+
+        nextfig = CONF.config_shortcut(
+            self.go_next_thumbnail, 
+            context='plots',
+            name='next figure',
+            parent=self)
 
         return [copyfig, prevfig, nextfig]
 
@@ -989,10 +1001,11 @@ class FigureCanvas(QFrame):
         if self.fig:
             pos = QPoint(event.x(), event.y())
             context_menu = QMenu(self)
-            context_menu.addAction(ima.icon('editcopy'), "Copy Image",
-                                   self.copy_figure,
-                                   QKeySequence(
-                                       get_shortcut('plots', 'copy')))
+            context_menu.addAction(
+                ima.icon('editcopy'),
+                "Copy Image",
+                self.copy_figure,
+                QKeySequence(CONF.get_shortcut('plots', 'copy')))
             context_menu.popup(self.mapToGlobal(pos))
 
     @Slot()

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -33,7 +33,8 @@ from spyder_kernels.utils.nsview import value_to_display
 # Local imports
 from spyder.config.base import _
 from spyder.config.fonts import DEFAULT_SMALL_DELTA
-from spyder.config.gui import get_font, config_shortcut
+from spyder.config.gui import get_font
+from spyder.config.manager import CONF
 from spyder.py3compat import (io, is_binary_string, is_string,
                               is_text_string, PY3, to_binary_string,
                               to_text_string)
@@ -426,8 +427,11 @@ class ArrayView(QTableView):
         self.viewport().resize(min(total_width, 1024), self.height())
         self.shape = shape
         self.menu = self.setup_menu()
-        config_shortcut(self.copy, context='variable_explorer', name='copy',
-                        parent=self)
+        CONF.config_shortcut(
+            self.copy,
+            context='variable_explorer',
+            name='copy',
+            parent=self)
         self.horizontalScrollBar().valueChanged.connect(
                             lambda val: self.load_more_data(val, columns=True))
         self.verticalScrollBar().valueChanged.connect(

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -54,7 +54,8 @@ import numpy as np
 # Local imports
 from spyder.config.base import _
 from spyder.config.fonts import DEFAULT_SMALL_DELTA
-from spyder.config.gui import get_font, config_shortcut
+from spyder.config.gui import get_font
+from spyder.config.manager import CONF
 from spyder.py3compat import (io, is_text_string, is_type_text_string, PY2,
                               to_text_string, perf_counter)
 from spyder.utils import icon_manager as ima
@@ -515,8 +516,11 @@ class DataFrameView(QTableView):
         self.header_class = header
         self.header_class.sectionClicked.connect(self.sortByColumn)
         self.menu = self.setup_menu()
-        config_shortcut(self.copy, context='variable_explorer', name='copy',
-                        parent=self)
+        CONF.config_shortcut(
+            self.copy,
+            context='variable_explorer',
+            name='copy',
+            parent=self)
         self.horizontalScrollBar().valueChanged.connect(
                         lambda val: self.load_more_data(val, columns=True))
         self.verticalScrollBar().valueChanged.connect(

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -27,7 +27,6 @@ from spyder_kernels.utils.nsview import get_supported_types, REMOTE_SETTINGS
 
 # Local imports
 from spyder.config.base import _
-from spyder.config.gui import config_shortcut
 from spyder.config.manager import CONF
 from spyder.py3compat import PY2, is_text_string, to_text_string
 from spyder.utils import encoding
@@ -209,9 +208,11 @@ class NamespaceBrowser(QWidget):
             self, text=_("Search variable names and types"),
             icon=ima.icon('find'),
             toggled=self.show_finder)
-        config_shortcut(lambda: self.show_finder(set_visible=True),
-                        context='variable_explorer',
-                        name='search', parent=self)
+        CONF.config_shortcut(
+            lambda: self.show_finder(set_visible=True),
+            context='variable_explorer',
+            name='search',
+            parent=self)
 
         self.refresh_button = create_toolbutton(
             self, text=_("Refresh variables"),

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -208,6 +208,7 @@ class NamespaceBrowser(QWidget):
             self, text=_("Search variable names and types"),
             icon=ima.icon('find'),
             toggled=self.show_finder)
+
         CONF.config_shortcut(
             lambda: self.show_finder(set_visible=True),
             context='variable_explorer',
@@ -218,7 +219,8 @@ class NamespaceBrowser(QWidget):
             self, text=_("Refresh variables"),
             icon=ima.icon('refresh'),
             triggered=self.refresh_table)
-        config_shortcut(self.refresh_table,
+
+        CONF.config_shortcut(self.refresh_table,
                         context='variable_explorer',
                         name='refresh', parent=self)
 

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -189,23 +189,33 @@ class NamespaceBrowser(QWidget):
 
     def setup_toolbar(self):
         """Setup toolbar"""
-        load_button = create_toolbutton(self, text=_('Import data'),
-                                        icon=ima.icon('fileimport'),
-                                        triggered=lambda: self.import_data())
-        self.save_button = create_toolbutton(self, text=_("Save data"),
-                            icon=ima.icon('filesave'),
-                            triggered=lambda: self.save_data(self.filename))
+        load_button = create_toolbutton(
+            self,
+            text=_('Import data'),
+            icon=ima.icon('fileimport'),
+            triggered=lambda: self.import_data())
+
+        self.save_button = create_toolbutton(
+            self, text=_("Save data"),
+            icon=ima.icon('filesave'),
+            triggered=lambda: self.save_data(self.filename))
+
         self.save_button.setEnabled(False)
-        save_as_button = create_toolbutton(self,
-                                           text=_("Save data as..."),
-                                           icon=ima.icon('filesaveas'),
-                                           triggered=self.save_data)
+
+        save_as_button = create_toolbutton(
+            self,
+            text=_("Save data as..."),
+            icon=ima.icon('filesaveas'),
+            triggered=self.save_data)
+
         reset_namespace_button = create_toolbutton(
-                self, text=_("Remove all variables"),
-                icon=ima.icon('editdelete'), triggered=self.reset_namespace)
+            self, text=_("Remove all variables"),
+            icon=ima.icon('editdelete'),
+            triggered=self.reset_namespace)
 
         self.search_button = create_toolbutton(
-            self, text=_("Search variable names and types"),
+            self,
+            text=_("Search variable names and types"),
             icon=ima.icon('find'),
             toggled=self.show_finder)
 
@@ -216,13 +226,16 @@ class NamespaceBrowser(QWidget):
             parent=self)
 
         self.refresh_button = create_toolbutton(
-            self, text=_("Refresh variables"),
+            self,
+            text=_("Refresh variables"),
             icon=ima.icon('refresh'),
             triggered=self.refresh_table)
 
-        CONF.config_shortcut(self.refresh_table,
-                        context='variable_explorer',
-                        name='refresh', parent=self)
+        CONF.config_shortcut(
+            self.refresh_table,
+            context='variable_explorer',
+            name='refresh',
+            parent=self)
 
         return [load_button, self.save_button, save_as_button,
                 reset_namespace_button, self.search_button,

--- a/spyder/preferences/shortcuts.py
+++ b/spyder/preferences/shortcuts.py
@@ -23,8 +23,6 @@ from qtpy.QtWidgets import (QAbstractItemView, QApplication, QDialog,
 # Local imports
 from spyder.config.base import _
 from spyder.config.manager import CONF
-from spyder.config.gui import (get_shortcut, iter_shortcuts,
-                               reset_shortcuts, set_shortcut)
 from spyder.preferences.configdialog import GeneralConfigPage
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import get_std_icon, create_toolbutton
@@ -476,10 +474,10 @@ class Shortcut(object):
         return "{0}/{1}: {2}".format(self.context, self.name, self.key)
 
     def load(self):
-        self.key = get_shortcut(self.context, self.name)
+        self.key = CONF.get_shortcut(self.context, self.name)
 
     def save(self):
-        set_shortcut(self.context, self.name, self.key)
+        CONF.set_shortcut(self.context, self.name, self.key)
 
 
 CONTEXT, NAME, SEQUENCE, SEARCH_SCORE = [0, 1, 2, 3]
@@ -682,7 +680,7 @@ class ShortcutsTable(QTableView):
     def load_shortcuts(self):
         """Load shortcuts and assign to table model."""
         shortcuts = []
-        for context, name, keystr in iter_shortcuts():
+        for context, name, keystr in CONF.iter_shortcuts():
             shortcut = Shortcut(context, name, keystr)
             shortcuts.append(shortcut)
         shortcuts = sorted(shortcuts, key=lambda x: x.context+x.name)
@@ -854,7 +852,7 @@ class ShortcutsConfigPage(GeneralConfigPage):
                                     QMessageBox.Yes | QMessageBox.No)
         if reset == QMessageBox.No:
             return
-        reset_shortcuts()
+        CONF.reset_shortcuts()
         self.main.apply_shortcuts()
         self.table.load_shortcuts()
         self.load_from_conf()

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -22,8 +22,6 @@ from qtpy.QtGui import QIcon, QKeyEvent, QKeySequence, QPixmap
 from qtpy.QtWidgets import (QAction, QApplication, QHBoxLayout, QLabel,
                             QLineEdit, QMenu, QProxyStyle, QStyle, QToolBar,
                             QToolButton, QVBoxLayout, QWidget)
-if sys.platform == "darwin":
-    import applaunchservices as als
 
 # Local imports
 from spyder.config.base import get_image_path, MAC_APP_NAME
@@ -36,6 +34,11 @@ from spyder.utils.icon_manager import get_icon, get_kite_icon, get_std_icon
 from spyder.widgets.waitingspinner import QWaitingSpinner
 from spyder.config.manager import CONF
 
+# Third party imports
+if sys.platform == "darwin":
+    import applaunchservices as als
+
+
 # Note: How to redirect a signal from widget *a* to widget *b* ?
 # ----
 # It has to be done manually:
@@ -45,7 +48,6 @@ from spyder.config.manager import CONF
 # (self.listwidget is widget *a* and self is widget *b*)
 #    self.connect(self.listwidget, SIGNAL('option_changed'),
 #                 lambda *args: self.emit(SIGNAL('option_changed'), *args))
-
 logger = logging.getLogger(__name__)
 MENU_SEPARATOR = None
 

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -27,7 +27,8 @@ if sys.platform == "darwin":
 
 # Local imports
 from spyder.config.base import get_image_path, MAC_APP_NAME
-from spyder.config.gui import get_shortcut, is_dark_interface
+from spyder.config.manager import CONF
+from spyder.config.gui import is_dark_interface
 from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils import programs
@@ -313,7 +314,7 @@ def create_action(parent, text, shortcut=None, icon=None, tip=None,
 def add_shortcut_to_tooltip(action, context, name):
     """Add the shortcut associated with a given action to its tooltip"""
     action.setToolTip(action.toolTip() + ' (%s)' %
-                      get_shortcut(context=context, name=name))
+                      CONF.get_shortcut(context=context, name=name))
 
 
 def add_actions(target, actions, insert_before=None):

--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -214,21 +214,25 @@ class FindReplace(QWidget):
             context='find_replace',
             name='Find next',
             parent=parent)
+
         findprev = CONF.config_shortcut(
             self.find_previous,
             context='find_replace',
             name='Find previous',
             parent=parent)
+
         togglefind = CONF.config_shortcut(
             self.show,
             context='find_replace',
             name='Find text',
             parent=parent)
+
         togglereplace = CONF.config_shortcut(
             self.show_replace,
             context='find_replace',
             name='Replace text',
             parent=parent)
+
         hide = CONF.config_shortcut(
             self.hide,
             context='find_replace',

--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -22,7 +22,7 @@ from qtpy.QtWidgets import (QGridLayout, QHBoxLayout, QLabel,
 
 # Local imports
 from spyder.config.base import _
-from spyder.config.gui import config_shortcut
+from spyder.config.manager import CONF
 from spyder.py3compat import to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.misc import regexp_error_msg
@@ -209,18 +209,31 @@ class FindReplace(QWidget):
     def create_shortcuts(self, parent):
         """Create shortcuts for this widget"""
         # Configurable
-        findnext = config_shortcut(self.find_next, context='find_replace',
-                                   name='Find next', parent=parent)
-        findprev = config_shortcut(self.find_previous, context='find_replace',
-                                   name='Find previous', parent=parent)
-        togglefind = config_shortcut(self.show, context='find_replace',
-                                     name='Find text', parent=parent)
-        togglereplace = config_shortcut(self.show_replace,
-                                        context='find_replace',
-                                        name='Replace text',
-                                        parent=parent)
-        hide = config_shortcut(self.hide, context='find_replace',
-                               name='hide find and replace', parent=self)
+        findnext = CONF.config_shortcut(
+            self.find_next,
+            context='find_replace',
+            name='Find next',
+            parent=parent)
+        findprev = CONF.config_shortcut(
+            self.find_previous,
+            context='find_replace',
+            name='Find previous',
+            parent=parent)
+        togglefind = CONF.config_shortcut(
+            self.show,
+            context='find_replace',
+            name='Find text',
+            parent=parent)
+        togglereplace = CONF.config_shortcut(
+            self.show_replace,
+            context='find_replace',
+            name='Replace text',
+            parent=parent)
+        hide = CONF.config_shortcut(
+            self.hide,
+            context='find_replace',
+            name='hide find and replace',
+            parent=self)
 
         return [findnext, findprev, togglefind, togglereplace, hide]
 

--- a/spyder/widgets/shortcutssummary.py
+++ b/spyder/widgets/shortcutssummary.py
@@ -20,7 +20,7 @@ from qtpy.QtWidgets import (QDialog, QLabel, QGridLayout, QGroupBox,
 
 # Local imports
 from spyder.config.base import _
-from spyder.config.gui import iter_shortcuts
+from spyder.config.manager import CONF
 
 # Constants
 MAX_FONT_SIZE = 16
@@ -78,7 +78,7 @@ class ShortcutsSummaryDialog(QDialog):
         added_shortcuts = 0
         group = None
         # group shortcuts by context
-        shortcuts = groupby(sorted(iter_shortcuts()), key=itemgetter(0))
+        shortcuts = groupby(sorted(CONF.iter_shortcuts()), key=itemgetter(0))
 
         for context, group_shortcuts in shortcuts:
             for i, (context, name, keystr) in enumerate(group_shortcuts):

--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -23,7 +23,7 @@ from qtpy.QtWidgets import (QHBoxLayout, QMenu, QTabBar,
 
 # Local imports
 from spyder.config.base import _
-from spyder.config.gui import config_shortcut
+from spyder.config.manager import CONF
 from spyder.py3compat import to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.misc import get_common_path
@@ -421,7 +421,7 @@ class BaseTabs(QTabWidget):
 
 
 class Tabs(BaseTabs):
-    """BaseTabs widget with movable tabs and tab navigation shortcuts"""
+    """BaseTabs widget with movable tabs and tab navigation shortcuts."""
     # Signals
     move_data = Signal(int, int)
     move_tab_finished = Signal()
@@ -442,14 +442,26 @@ class Tabs(BaseTabs):
                                           self.move_tab_from_another_tabwidget)
         self.setTabBar(tab_bar)
 
-        config_shortcut(lambda: self.tab_navigate(1), context='editor',
-                        name='go to next file', parent=parent)
-        config_shortcut(lambda: self.tab_navigate(-1), context='editor',
-                        name='go to previous file', parent=parent)
-        config_shortcut(lambda: self.sig_close_tab.emit(self.currentIndex()),
-                        context='editor', name='close file 1', parent=parent)
-        config_shortcut(lambda: self.sig_close_tab.emit(self.currentIndex()),
-                        context='editor', name='close file 2', parent=parent)
+        CONF.config_shortcut(
+            lambda: self.tab_navigate(1),
+            context='editor',
+            name='go to next file',
+            parent=parent)
+        CONF.config_shortcut(
+            lambda: self.tab_navigate(-1),
+            context='editor',
+            name='go to previous file',
+            parent=parent)
+        CONF.config_shortcut(
+            lambda: self.sig_close_tab.emit(self.currentIndex()),
+            context='editor',
+            name='close file 1',
+            parent=parent)
+        CONF.config_shortcut(
+            lambda: self.sig_close_tab.emit(self.currentIndex()),
+            context='editor',
+            name='close file 2',
+            parent=parent)
 
     @Slot(int, int)
     def move_tab(self, index_from, index_to):

--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -447,16 +447,19 @@ class Tabs(BaseTabs):
             context='editor',
             name='go to next file',
             parent=parent)
+
         CONF.config_shortcut(
             lambda: self.tab_navigate(-1),
             context='editor',
             name='go to previous file',
             parent=parent)
+
         CONF.config_shortcut(
             lambda: self.sig_close_tab.emit(self.currentIndex()),
             context='editor',
             name='close file 1',
             parent=parent)
+
         CONF.config_shortcut(
             lambda: self.sig_close_tab.emit(self.currentIndex()),
             context='editor',


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

Moved shortcut management from `config/gui.py` to `config/manager.py`

Now the shortcut handling is used via `CONF` which will correctly parse external plugin configuration.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #3254 
Fixes #3321 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
