### PR TITLE
PR: Add button and keyboard shortcut to refresh the variable explorer during execution

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -460,6 +460,7 @@ DEFAULTS = [
               'variable_explorer/copy': 'Ctrl+C',
               # ---- In widgets/variableexplorer/namespacebrowser.py ----
               'variable_explorer/search': 'Ctrl+F',
+              'variable_explorer/refresh': 'Ctrl+R',
               # ---- In widgets/plots/figurebrowser.py ----
               'plots/copy': 'Ctrl+C',
               'plots/previous figure': 'Ctrl+PgUp',

--- a/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
@@ -56,10 +56,10 @@ class NamepaceBrowserWidget(RichJupyterWidget):
         if self.kernel_client is None:
             return
         if self.namespacebrowser:
-            self.call_kernel(
-                callback=self.set_namespace_view).get_namespace_view()
-            self.call_kernel(
-                callback=self.set_var_properties).get_var_properties()
+            self.call_kernel(interrupt=True, callback=self.set_namespace_view
+                             ).get_namespace_view()
+            self.call_kernel(interrupt=True, callback=self.set_var_properties
+                             ).get_var_properties()
 
     def set_namespace_view(self, view):
         """Set the current namespace view."""

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -215,7 +215,7 @@ class NamespaceBrowser(QWidget):
 
         self.refresh_button = create_toolbutton(
             self, text=_("Refresh variables"),
-            icon=ima.icon('redo'),
+            icon=ima.icon('refresh'),
             triggered=self.refresh_table)
         config_shortcut(self.refresh_table,
                         context='variable_explorer',

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -216,7 +216,7 @@ class NamespaceBrowser(QWidget):
         self.refresh_button = create_toolbutton(
             self, text=_("Refresh variables"),
             icon=ima.icon('redo'),
-            toggled=self.refresh_table)
+            triggered=self.refresh_table)
         config_shortcut(self.refresh_table,
                         context='variable_explorer',
                         name='refresh', parent=self)

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -213,7 +213,6 @@ class NamespaceBrowser(QWidget):
                         context='variable_explorer',
                         name='search', parent=self)
 
-
         self.refresh_button = create_toolbutton(
             self, text=_("Refresh variables"),
             icon=ima.icon('redo'),

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -213,8 +213,18 @@ class NamespaceBrowser(QWidget):
                         context='variable_explorer',
                         name='search', parent=self)
 
+
+        self.refresh_button = create_toolbutton(
+            self, text=_("Refresh variables"),
+            icon=ima.icon('redo'),
+            toggled=self.refresh_table)
+        config_shortcut(self.refresh_table,
+                        context='variable_explorer',
+                        name='refresh', parent=self)
+
         return [load_button, self.save_button, save_as_button,
-                reset_namespace_button, self.search_button]
+                reset_namespace_button, self.search_button,
+                self.refresh_button]
 
     def setup_option_actions(self, exclude_private, exclude_uppercase,
                              exclude_capitalized, exclude_unsupported):

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -187,6 +187,7 @@ _qtaargs = {
     'replace':                 [('fa.exchange',), {'color': MAIN_FG_COLOR}],
     'undo':                    [('fa.undo',), {'color': MAIN_FG_COLOR}],
     'redo':                    [('fa.repeat',), {'color': MAIN_FG_COLOR}],
+    'refresh':                 [('mdi.refresh',), {'color': MAIN_FG_COLOR}],
     'restart':                 [('fa.repeat',), {'color': MAIN_FG_COLOR}],
     'editcopy':                [('fa.copy',), {'color': MAIN_FG_COLOR}],
     'editcut':                 [('fa.scissors',), {'color': MAIN_FG_COLOR}],


### PR DESCRIPTION
![refresh](https://user-images.githubusercontent.com/6740194/68029292-37639a80-fcb7-11e9-9506-294c534367cf.gif)
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #4398


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
impact27
<!--- Thanks for your help making Spyder better for everyone! --->
