### PR TITLE
PR: Filter completions with an empty value for the 'insertText' key

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1069,7 +1069,9 @@ class CodeEditor(TextEditBaseWidget):
         position, automatic = args
         try:
             completions = params['params']
-            completions = [] if completions is None else completions
+            completions = ([] if completions is None else
+                           [completion for completion in completions
+                            if completion['insertText']])
 
             replace_end = self.textCursor().position()
             under_cursor = self.get_current_word_and_position(completion=True)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Filter completion list to prevent completions with an empty 'insertText' value.

Seems like the LSP is returning this as a completion:

```python
{'label': '',
'kind': 9,
'detail': 'cv2.cv2',
'documentation': 'cv2.cv2()\n\nPython wrapper for OpenCV.',
'sortText': (1, 'a'),
'insertText': '',
'filterText': '',
'insertTextFormat': 1,
'provider': 'LSP'}
```

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10593 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
