### PR TITLE
WIP: Add option to increase/decrease icon size in toolbars

### DIFF
--- a/spyder/api/panes.py
+++ b/spyder/api/panes.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+spyder.api.panes
+==================
+
+Here, 'panes' are Qt main windows that should be used to encapsulate the
+main interface of Spyder plugins.
+"""
+
+# ---- Standard library imports
+import uuid
+
+# ---- Third party imports
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QMainWindow, QToolBar
+
+# ---- Local imports
+from spyder.config.gui import is_dark_interface
+from spyder.utils.qthelpers import create_toolbar_stretcher
+
+
+class SpyderPaneToolbar(QToolBar):
+    """
+    Spyder pane toolbar class.
+
+    A toolbar class that is used by the spyder pane widget class.
+    """
+
+    def __init__(self, parent=None, areas=Qt.TopToolBarArea,
+                 corner_widget=None):
+        super().__init__(parent)
+        self._set_corner_widget(corner_widget)
+        self.setObjectName("pane_toolbar_{}".format(str(uuid.uuid4())[:8]))
+        self.setFloatable(False)
+        self.setMovable(False)
+        self.setAllowedAreas(areas)
+        self.setContextMenuPolicy(Qt.PreventContextMenu)
+        self._set_style()
+
+    def addWidget(self, widget):
+        """
+        Override Qt method to take into account the existence of a corner
+        widget when adding a new widget in this toolbar.
+        """
+        if self._corner_widget is not None:
+            super().insertWidget(self._corner_separator_action, widget)
+        else:
+            super().addWidget(widget)
+
+    def addAction(self, action):
+        """
+        Override Qt method to take into account the existence of a corner
+        widget when adding a new action in this toolbar.
+        """
+        if self._corner_widget is not None:
+            super().insertAction(self._corner_separator_action, action)
+        else:
+            super().addAction(action)
+
+    def _set_corner_widget(self, corner_widget):
+        """
+        Add the given corner widget to this toolbar.
+
+        A stretcher widget is added before the corner widget so that
+        its position is forced to the right side of the toolbar when the
+        toolbar is resized.
+        """
+        self._corner_widget = corner_widget
+        if corner_widget is not None:
+            self._corner_separator_action = super().addWidget(
+                create_toolbar_stretcher())
+            super().addWidget(self._corner_widget)
+        else:
+            self._corner_separator_action = None
+
+    def _set_style(self):
+        """
+        Set the style of this toolbar with a stylesheet.
+        """
+        if is_dark_interface():
+            self.setStyleSheet(
+                "QToolButton {background-color: transparent;} "
+                "QToolButton:!hover:!pressed {border-color: transparent} "
+                "QToolBar {border: 0px;  background: rgb(25, 35, 45);}")
+        else:
+            self.setStyleSheet("QToolBar {border: 0px;}")
+

--- a/spyder/api/panes.py
+++ b/spyder/api/panes.py
@@ -90,3 +90,104 @@ class SpyderPaneToolbar(QToolBar):
         else:
             self.setStyleSheet("QToolBar {border: 0px;}")
 
+
+class SpyderPaneWidget(QMainWindow):
+    """
+    Spyder pane widget class.
+
+    All Spyder plugins that need to add a pane to the Spyder mainwindow
+    *must* use a Spyder pane widget to encapsulate their main interface.
+
+    A Spyder pane widget is a Qt main window that consists of a central
+    widget and a set of toolbars that are stacked above or below the central
+    widget. The toolbars are not moveable nor floatable and must occupy
+    the entire horizontal space available for the pane, i.e. that toolbars
+    must be stacked vertically and cannot be placed horizontally
+    next to each others.
+    """
+
+    def __init__(self, parent=None, options_button=None):
+        super().__init__(parent)
+        self.setWindowFlags(Qt.Widget)
+
+        self._main_toolbar = SpyderPaneToolbar(corner_widget=options_button)
+        self.addToolBar(self._main_toolbar)
+        self._aux_toolbars = {Qt.TopToolBarArea: [], Qt.BottomToolBarArea: []}
+
+    # ---- Public methods
+    def create_auxialiary_toolbar(self, where='above'):
+        """
+        Add to this pane an auxiliary toolbar above or below this
+        pane central widget.
+
+        Parameters
+        ----------
+        where: str
+            A string whose value is used to determine where to add the
+            toolbar in the pane. The toolbar is added above the pane's central
+            widget when the value of 'where' is 'above', while it is added
+            below the central widget when it is 'below'.
+
+        Returns
+        -------
+        QToolBar
+            The toolbar that was created and added as an auxiliary toolbar
+            to this pane.
+        """
+        where = (Qt.BottomToolBarArea if where == 'below'
+                 else Qt.TopToolBarArea)
+        toolbar = SpyderPaneToolbar(areas=where)
+
+        if (where == Qt.TopToolBarArea or
+                where == Qt.BottomToolBarArea and self._aux_toolbars[where]):
+            self.addToolBarBreak(where)
+        self.addToolBar(toolbar)
+        self._aux_toolbars[where].append(toolbar)
+
+        return toolbar
+
+    def get_main_toolbar(self):
+        """
+        Return the main toolbar of this pane.
+
+        Returns
+        -------
+        QToolBar
+            The main toolbar of this pane.
+        """
+        return self._main_toolbar
+
+    def get_central_widget(self):
+        """
+        Return the central widget of this pane.
+
+        Returns
+        -------
+        (QWidget, None)
+            The central widget of this pane or None if the central widget has
+            not been set.
+        """
+        return self.centralWidget()
+
+    def set_central_widget(self, widget):
+        """
+        Set the given widget to be the central widget of this pane.
+
+        Parameters
+        ----------
+        widget: QWidget
+            Widget to set as the central widget of this pane.
+        """
+        self.setCentralWidget(widget)
+
+    def set_iconsize(self, iconsize):
+        """
+        Set the icon size of this pane toolbars.
+
+        Parameters
+        ----------
+        iconsize: int
+            An integer corresponding to the size in pixels to which the icons
+            of this pane toolbars need to be set.
+        """
+        pass

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -12,16 +12,16 @@ import os.path as osp
 
 # Third party imports
 from qtpy.compat import from_qvariant
-from qtpy.QtCore import QSize, Qt, Signal, Slot
-from qtpy.QtWidgets import (QHBoxLayout, QTreeWidgetItem, QWidget,
-                            QTreeWidgetItemIterator)
+from qtpy.QtCore import Qt, Signal, Slot
+from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidgetItemIterator
 
 # Local imports
+from spyder.api.panes import SpyderPaneWidget
 from spyder.config.base import _, STDOUT
 from spyder.py3compat import to_text_string
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import (create_action, create_toolbutton,
-                                    set_item_user_text, create_plugin_layout)
+                                    set_item_user_text)
 from spyder.widgets.onecolumntree import OneColumnTree
 
 
@@ -716,7 +716,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         self.activated(item)
 
 
-class OutlineExplorerWidget(QWidget):
+class OutlineExplorerWidget(SpyderPaneWidget):
     """Class browser"""
     edit_goto = Signal(str, int, str)
     edit = Signal(str)
@@ -727,7 +727,7 @@ class OutlineExplorerWidget(QWidget):
                  sort_files_alphabetically=False,
                  follow_cursor=True,
                  options_button=None):
-        QWidget.__init__(self, parent)
+        super().__init__(parent, options_button)
 
         self.treewidget = OutlineExplorerTreeWidget(
             self,
@@ -738,6 +738,7 @@ class OutlineExplorerWidget(QWidget):
             sort_files_alphabetically=sort_files_alphabetically,
             follow_cursor=follow_cursor,
             )
+        self.set_central_widget(self.treewidget)
 
         self.visibility_action = create_action(self,
                                            _("Show/hide outline explorer"),
@@ -745,17 +746,7 @@ class OutlineExplorerWidget(QWidget):
                                            toggled=self.toggle_visibility)
         self.visibility_action.setChecked(True)
 
-        btn_layout = QHBoxLayout()
-        for btn in self.setup_buttons():
-            btn.setAutoRaise(True)
-            btn.setIconSize(QSize(16, 16))
-            btn_layout.addWidget(btn)
-        if options_button:
-            btn_layout.addStretch()
-            btn_layout.addWidget(options_button, Qt.AlignRight)
-
-        layout = create_plugin_layout(btn_layout, self.treewidget)
-        self.setLayout(layout)
+        self.setup_toolbar()
 
     @Slot(bool)
     def toggle_visibility(self, state):
@@ -766,21 +757,21 @@ class OutlineExplorerWidget(QWidget):
             if state:
                 self.is_visible.emit()
 
-    def setup_buttons(self):
+    def setup_toolbar(self):
         """Setup the buttons of the outline explorer widget toolbar."""
+        toolbar = self.get_main_toolbar()
+
         self.fromcursor_btn = create_toolbutton(
             self, icon=ima.icon('fromcursor'), tip=_('Go to cursor position'),
             triggered=self.treewidget.go_to_cursor_position)
+        toolbar.addWidget(self.fromcursor_btn)
 
-        buttons = [self.fromcursor_btn]
         for action in [self.treewidget.collapse_all_action,
                        self.treewidget.expand_all_action,
                        self.treewidget.restore_action,
                        self.treewidget.collapse_selection_action,
                        self.treewidget.expand_selection_action]:
-            buttons.append(create_toolbutton(self))
-            buttons[-1].setDefaultAction(action)
-        return buttons
+            toolbar.addAction(action)
 
     def set_current_editor(self, editor, update, clear):
         if clear:

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -20,7 +20,7 @@ from qtpy.QtCore import (QEvent, QLibraryInfo, QLocale, QObject, Qt, QTimer,
                          QTranslator, Signal, Slot)
 from qtpy.QtGui import QIcon, QKeyEvent, QKeySequence, QPixmap
 from qtpy.QtWidgets import (QAction, QApplication, QHBoxLayout, QLabel,
-                            QLineEdit, QMenu, QProxyStyle, QStyle, QToolBar,
+                            QLineEdit, QMenu, QProxyStyle, QSizePolicy, QStyle,
                             QToolButton, QVBoxLayout, QWidget)
 if sys.platform == "darwin":
     import applaunchservices as als
@@ -219,6 +219,13 @@ def create_toolbutton(parent, text=None, shortcut=None, icon=None, tip=None,
     if shortcut is not None:
         button.setShortcut(shortcut)
     return button
+
+
+def create_toolbar_stretcher():
+    """Create a stretcher widget to be used in a Qt toolbar."""
+    stretcher = QWidget()
+    stretcher.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+    return stretcher
 
 
 def create_waitspinner(size=32, n=11, parent=None):


### PR DESCRIPTION
## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


This is a second attempt at implementing the option to increase/decrease icon size in toolbars
following PR #9452.

This time, instead of using a custom toolbar for the Spyder plugins, I created a new `SpyderPaneWidget` class that inherits from a `QMainWindow` and that is used to encapsulate the main interface of each plugins. 

In addition to add the option to set the size of the icons in the toolbars, the changes proposed here should also:

- Make the layout of the plugins toolbar adaptative. When a toolbar is resized in such a way that it is too small to show all the items it contains, an extension button will appear as the last item in the toolbar. Pressing the extension button will pop up a menu containing the items that does not currently fit in the toolbar.
- Add a framework that will standardize the generation of the plugins layout across the entire application.


### Issue(s) Resolved

Fixes #9413
Fixes #9612


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
