### PR TITLE
PR: Fix completions bug in Kite introduced by PR 10605

### DIFF
--- a/spyder/plugins/completion/kite/providers/document.py
+++ b/spyder/plugins/completion/kite/providers/document.py
@@ -116,6 +116,9 @@ class DocumentProvider:
 
     @handles(LSPRequestTypes.DOCUMENT_COMPLETION)
     def convert_completion_request(self, response):
+        # The response schema is tested via mocking in
+        # spyder/plugins/editor/widgets/tests/test_introspection.py
+
         logger.debug(response)
         if response is None:
             return {'params': []}

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1071,7 +1071,8 @@ class CodeEditor(TextEditBaseWidget):
             completions = params['params']
             completions = ([] if completions is None else
                            [completion for completion in completions
-                            if completion['insertText']])
+                            if completion.get('insertText')
+                            or completion.get('textEdit', {}).get('newText')])
 
             replace_end = self.textCursor().position()
             under_cursor = self.get_current_word_and_position(completion=True)

--- a/spyder/plugins/editor/widgets/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/tests/conftest.py
@@ -139,7 +139,6 @@ def mock_completions_codeeditor(qtbot_module, request):
     editor.show()
 
     mock_response = Mock()
-    mock_response.side_effect = lambda *args: None
 
     def perform_request(lang, method, params):
         resp = mock_response(lang, method, params)

--- a/spyder/plugins/editor/widgets/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/tests/conftest.py
@@ -127,18 +127,22 @@ def lsp_plugin(qtbot_module, request):
 
 
 @pytest.fixture
-def mock_codeeditor(qtbot_module, request):
-    """CodeEditor instance with ability to mock the completions response"""
+def mock_completions_codeeditor(qtbot_module, request):
+    """CodeEditor instance with ability to mock the completions response.
+
+    Returns a tuple of (editor, mock_response). Tests using this fixture should
+    set `mock_response.side_effect = lambda lang, method, params: {}`.
+    """
     # Create a CodeEditor instance
     editor = codeeditor_factory()
     qtbot_module.addWidget(editor)
     editor.show()
 
-    mock = Mock()
-    mock.side_effect = lambda *args: None
+    mock_response = Mock()
+    mock_response.side_effect = lambda *args: None
 
     def perform_request(lang, method, params):
-        resp = mock(lang, method, params)
+        resp = mock_response(lang, method, params)
         print("DEBUG {}".format(resp))
         if resp is not None:
             editor.handle_response(method, resp)
@@ -154,7 +158,7 @@ def mock_codeeditor(qtbot_module, request):
         editor.completion_widget.hide()
     request.addfinalizer(teardown)
 
-    return editor, mock
+    return editor, mock_response
 
 
 @pytest.fixture

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -28,6 +28,8 @@ except Exception:
     rtree_available = False
 
 # Local imports
+from spyder.plugins.completion.languageserver import LSPRequestTypes, CompletionItemKind
+from spyder.plugins.completion.kite.providers.document import KITE_COMPLETION
 from spyder.py3compat import PY2
 from spyder.config.manager import CONF
 
@@ -759,6 +761,51 @@ def test_fallback_completions(fallback_codeeditor, qtbot):
         qtbot.keyPress(code_editor, Qt.Key_Tab, delay=300)
     word_set = {x['insertText'] for x in sig.args[0]}
     assert 'another' not in word_set
+
+    code_editor.toggle_automatic_completions(True)
+    code_editor.toggle_code_snippets(True)
+
+
+@pytest.mark.slow
+@pytest.mark.first
+@flaky(max_runs=5)
+def test_kite_textEdit_completions(mock_codeeditor, qtbot):
+    """Test on-the-fly completions."""
+    code_editor, mock = mock_codeeditor
+    completion = code_editor.completion_widget
+
+    code_editor.toggle_automatic_completions(False)
+    code_editor.toggle_code_snippets(False)
+
+    # Set cursor to start
+    code_editor.go_to_line(1)
+
+    qtbot.keyClicks(code_editor, 'my_dict.')
+
+    # Complete f -> from
+    mock.side_effect = lambda lang, method, params: {'params': [{
+        'kind': CompletionItemKind.TEXT,
+        'label': '["dict-key"]',
+        'textEdit': {
+            'newText': '["dict-key"]',
+            'range': {
+                'start': 7,
+                'end': 8,
+            },
+        },
+        'filterText': '',
+        'sortText': '',
+        'documentation': '',
+        'provider': KITE_COMPLETION,
+    }]} if method == LSPRequestTypes.DOCUMENT_COMPLETION else None
+    with qtbot.waitSignal(completion.sig_show_completions,
+                          timeout=10000) as sig:
+        qtbot.keyPress(code_editor, Qt.Key_Tab, delay=300)
+    mock.side_effect = None
+
+    assert '["dict-key"]' in [x['label'] for x in sig.args[0]]
+    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)
+    assert code_editor.toPlainText() == 'my_dict["dict-key"]\n'
 
     code_editor.toggle_automatic_completions(True)
     code_editor.toggle_code_snippets(True)

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -771,7 +771,11 @@ def test_fallback_completions(fallback_codeeditor, qtbot):
 @pytest.mark.first
 @flaky(max_runs=5)
 def test_kite_textEdit_completions(mock_codeeditor, qtbot):
-    """Test on-the-fly completions."""
+    """Test textEdit completions such as those returned by the Kite provider.
+
+    This mocks out the completions response, and does not test the Kite
+    provider directly.
+    """
     code_editor, mock = mock_codeeditor
     completion = code_editor.completion_widget
 
@@ -783,7 +787,7 @@ def test_kite_textEdit_completions(mock_codeeditor, qtbot):
 
     qtbot.keyClicks(code_editor, 'my_dict.')
 
-    # Complete f -> from
+    # Complete my_dict. -> my_dict["dict-key"]
     mock.side_effect = lambda lang, method, params: {'params': [{
         'kind': CompletionItemKind.TEXT,
         'label': '["dict-key"]',

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -28,7 +28,8 @@ except Exception:
     rtree_available = False
 
 # Local imports
-from spyder.plugins.completion.languageserver import LSPRequestTypes, CompletionItemKind
+from spyder.plugins.completion.languageserver import (
+    LSPRequestTypes, CompletionItemKind)
 from spyder.plugins.completion.kite.providers.document import KITE_COMPLETION
 from spyder.py3compat import PY2
 from spyder.config.manager import CONF

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -770,13 +770,13 @@ def test_fallback_completions(fallback_codeeditor, qtbot):
 @pytest.mark.slow
 @pytest.mark.first
 @flaky(max_runs=5)
-def test_kite_textEdit_completions(mock_codeeditor, qtbot):
+def test_kite_textEdit_completions(mock_completions_codeeditor, qtbot):
     """Test textEdit completions such as those returned by the Kite provider.
 
     This mocks out the completions response, and does not test the Kite
     provider directly.
     """
-    code_editor, mock = mock_codeeditor
+    code_editor, mock_response = mock_completions_codeeditor
     completion = code_editor.completion_widget
 
     code_editor.toggle_automatic_completions(False)
@@ -788,7 +788,7 @@ def test_kite_textEdit_completions(mock_codeeditor, qtbot):
     qtbot.keyClicks(code_editor, 'my_dict.')
 
     # Complete my_dict. -> my_dict["dict-key"]
-    mock.side_effect = lambda lang, method, params: {'params': [{
+    mock_response.side_effect = lambda lang, method, params: {'params': [{
         'kind': CompletionItemKind.TEXT,
         'label': '["dict-key"]',
         'textEdit': {
@@ -806,7 +806,7 @@ def test_kite_textEdit_completions(mock_codeeditor, qtbot):
     with qtbot.waitSignal(completion.sig_show_completions,
                           timeout=10000) as sig:
         qtbot.keyPress(code_editor, Qt.Key_Tab, delay=300)
-    mock.side_effect = None
+    mock_response.side_effect = None
 
     assert '["dict-key"]' in [x['label'] for x in sig.args[0]]
     qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)


### PR DESCRIPTION
## Description of Changes

Fixes exception raised due to #10605 (described [here](https://github.com/spyder-ide/spyder/pull/10605#issuecomment-550529046))

How can we make sure we don't regress again? Maybe we need fixturized test cases with sample completions dicts that we return to the completions logic and ensure it works properly with `textEdit`s. Thoughts?

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @metalogical 

<!--- Thanks for your help making Spyder better for everyone! --->
