### PR TITLE
PR: Prevent status bar widget blinking during startup

### DIFF
--- a/spyder/widgets/status.py
+++ b/spyder/widgets/status.py
@@ -44,6 +44,14 @@ class StatusBarWidget(QWidget):
         self.label_icon = QLabel()
         self.label_value = QLabel()
 
+        # Layout setup
+        layout = QHBoxLayout(self)
+        layout.setSpacing(0)  # Reduce space between icon and label
+        layout.addWidget(self.label_icon)
+        layout.addWidget(self.label_value)
+        layout.addSpacing(20)
+        layout.setContentsMargins(0, 0, 0, 0)
+
         # Widget setup
         self.set_icon(icon)
 
@@ -51,20 +59,6 @@ class StatusBarWidget(QWidget):
         self.text_font = QFont(QFont().defaultFamily(), weight=QFont.Normal)
         self.label_value.setAlignment(Qt.AlignRight)
         self.label_value.setFont(self.text_font)
-
-        # Layout
-        layout = QHBoxLayout()
-        layout.setSpacing(0)  # Reduce space between icon and label
-        layout.addWidget(self.label_icon)
-        self.label_icon.setVisible(icon is not None)
-
-
-        layout.addWidget(self.label_value)
-        layout.addSpacing(20)
-
-        # Layout setup
-        layout.setContentsMargins(0, 0, 0, 0)
-        self.setLayout(layout)
 
         # Setup
         statusbar.addPermanentWidget(self)


### PR DESCRIPTION
This is to fix some widget blinking that occurs during the startup of Spyder after PR #10483

![blinking](https://user-images.githubusercontent.com/10170372/68483648-f2d18500-0209-11ea-94ea-b5318af70afd.gif)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
