### PR TITLE
PR: Send Kite completions requests correctly for selections

### DIFF
--- a/spyder/plugins/completion/kite/providers/document.py
+++ b/spyder/plugins/completion/kite/providers/document.py
@@ -71,8 +71,8 @@ class DocumentProvider:
             'text': params['text'],
             'action': 'focus',
             'selections': [{
-                'start': params['offset'],
-                'end': params['offset'],
+                'start': params['selection_start'],
+                'end': params['selection_end'],
                 'encoding': 'utf-16',
             }],
         }
@@ -90,8 +90,8 @@ class DocumentProvider:
             'text': params['text'],
             'action': 'edit',
             'selections': [{
-                'start': params['offset'],
-                'end': params['offset'],
+                'start': params['selection_start'],
+                'end': params['selection_end'],
                 'encoding': 'utf-16',
             }],
         }
@@ -108,7 +108,8 @@ class DocumentProvider:
             'no_snippets': not self.enable_code_snippets,
             'text': text,
             'position': {
-                'begin': params['offset']
+                'begin': params['selection_start'],
+                'end': params['selection_end'],
             },
             'offset_encoding': 'utf-16',
         }

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1003,13 +1003,16 @@ class CodeEditor(TextEditBaseWidget):
     def document_did_open(self):
         """Send textDocument/didOpen request to the server."""
         self.document_opened = True
+        cursor = self.textCursor()
         params = {
             'file': self.filename,
             'language': self.language,
             'version': self.text_version,
             'text': self.toPlainText(),
             'codeeditor': self,
-            'offset': self.get_position('cursor')
+            'offset': cursor.position(),
+            'selection_start': cursor.selectionStart(),
+            'selection_end': cursor.selectionEnd(),
         }
         return params
 
@@ -1022,12 +1025,15 @@ class CodeEditor(TextEditBaseWidget):
         text = self.toPlainText()
         self.patch = self.differ.patch_make(self.previous_text, text)
         self.previous_text = text
+        cursor = self.textCursor()
         params = {
             'file': self.filename,
             'version': self.text_version,
             'text': text,
             'diff': self.patch,
-            'offset': self.get_position('cursor')
+            'offset': cursor.position(),
+            'selection_start': cursor.selectionStart(),
+            'selection_end': cursor.selectionEnd(),
         }
         return params
 
@@ -1048,12 +1054,14 @@ class CodeEditor(TextEditBaseWidget):
     def do_completion(self, automatic=False):
         """Trigger completion."""
         self.document_did_change('')
-        line, column = self.get_cursor_line_column()
+        cursor = self.textCursor()
         params = {
             'file': self.filename,
-            'line': line,
-            'column': column,
-            'offset': self.get_position('cursor')
+            'line': cursor.blockNumber(),
+            'column': cursor.columnNumber(),
+            'offset': cursor.position(),
+            'selection_start': cursor.selectionStart(),
+            'selection_end': cursor.selectionEnd(),
         }
         self.completion_args = (self.textCursor().position(), automatic)
         return params


### PR DESCRIPTION
## Description of Changes

Send a selection to Kite when the cursor is in fact a selection.

### Issue(s) Resolved

Makes ctrl-space when a placeholder is selected correctly return Kite completions.

Addresses part of the issue noted in #10277 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @metalogical 

<!--- Thanks for your help making Spyder better for everyone! --->
