### PR TITLE
PR Display file match items on one line in the find in files browser

### DIFF
--- a/spyder/plugins/findinfiles/widgets.py
+++ b/spyder/plugins/findinfiles/widgets.py
@@ -908,16 +908,7 @@ class ItemDelegate(QStyledItemDelegate):
         doc = QTextDocument()
         text = options.text
         doc.setHtml(text)
-
-        if 'FileMatchItem' in text:
-            doc.setDocumentMargin(0)
-        else:
-            if self._margin is None:
-                # To increase performance setUniformRowHeights is now True
-                # so we add a margin to file items to center them vertically
-                self._margin = int(doc.size().height() / 3)
-
-            doc.setDocumentMargin(self._margin)
+        doc.setDocumentMargin(0)
 
         # This needs to be an empty string to avoid the overlapping the
         # normal text of the QTreeWidgetItem

--- a/spyder/plugins/findinfiles/widgets.py
+++ b/spyder/plugins/findinfiles/widgets.py
@@ -869,7 +869,8 @@ class FileMatchItem(QTreeWidgetItem):
         self.filename = osp.basename(filename)
 
         title_format = to_text_string('<!-- FileMatchItem -->'
-                                      '<b style="color:{2}">{0}</b><br>'
+                                      '<b style="color:{2}">{0}</b>'
+                                      '&nbsp;&nbsp;&nbsp;'
                                       '<small style="color:{2}"><em>{1}</em>'
                                       '</small>')
         title = (title_format.format(osp.basename(filename),


### PR DESCRIPTION
## Description of Changes

For performance reasons, `setUniformRowHeights` was set to `True` for the `ResultsBrowser` in PR #10582.

However, this results in a lot of vertical space between each line match item, due to the fact that the file match items are displayed on two lines.

This PR proposes to put the file match items on one line, like it is done for the file switcher.

![image](https://user-images.githubusercontent.com/10170372/68528826-d09d3d00-02c5-11ea-995c-f0f839d849d1.png)

### Issue(s) Resolved

Follow PR #10582


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin
