### PR TITLE
PR: Calculate switcher items height from content, padding and font size instead of hard-coded values

### DIFF
--- a/spyder/widgets/switcher.py
+++ b/spyder/widgets/switcher.py
@@ -525,7 +525,6 @@ class Switcher(QDialog):
         self.edit.installEventFilter(self.filter)
         self.edit.setPlaceholderText(help_text if help_text else '')
         self.list.setMinimumWidth(self._MIN_WIDTH)
-        self.list.setSpacing(-2)
         self.list.setItemDelegate(HTMLDelegate(self))
         self.list.setFocusPolicy(Qt.NoFocus)
         self.list.setSelectionBehavior(self.list.SelectItems)

--- a/spyder/widgets/switcher.py
+++ b/spyder/widgets/switcher.py
@@ -354,8 +354,11 @@ class SwitcherItem(SwitcherBaseItem):
         the text margins.
         """
         doc = QTextDocument()
-        doc.setHtml('<span style="font-size:{}pt">Title</span>'
-                    .format(self._styles['title_font_size']))
+        try:
+            doc.setHtml('<span style="font-size:{}pt">Title</span>'
+                        .format(self._styles['title_font_size']))
+        except KeyError:
+            doc.setHtml('<span>Title</span>')
         doc.setDocumentMargin(self._PADDING)
         return doc.size().height()
 

--- a/spyder/widgets/switcher.py
+++ b/spyder/widgets/switcher.py
@@ -15,7 +15,7 @@ import sys
 # Third party imports
 from qtpy.QtCore import (QEvent, QObject, QSize, QSortFilterProxyModel, Qt,
                          Signal, Slot, QModelIndex)
-from qtpy.QtGui import QStandardItem, QStandardItemModel
+from qtpy.QtGui import QStandardItem, QStandardItemModel, QTextDocument
 from qtpy.QtWidgets import (QAbstractItemView, QApplication, QDialog,
                             QLineEdit, QListWidgetItem, QVBoxLayout, QListView)
 
@@ -80,7 +80,6 @@ class SwitcherBaseItem(QStandardItem):
 
     _PADDING = 5
     _WIDTH = 400
-    _HEIGHT = None
     _STYLES = None
     _TEMPLATE = None
 
@@ -90,14 +89,14 @@ class SwitcherBaseItem(QStandardItem):
 
         # Style
         self._width = self._WIDTH
-        self._height = self._HEIGHT
         self._padding = self._PADDING
         self._styles = styles if styles else {}
         self._action_item = False
         self._score = -1
+        self._height = self._get_height()
 
         # Setup
-        self.setSizeHint(QSize(0, self._HEIGHT))
+        self.setSizeHint(QSize(0, self._height))
 
     def _render_text(self):
         """Render the html template for this item."""
@@ -109,6 +108,13 @@ class SwitcherBaseItem(QStandardItem):
 
     def _set_styles(self):
         """Set the styles for this item."""
+        raise NotImplementedError
+
+    def _get_height(self):
+        """
+        Return the expected height of this item's text, including
+        the text margins.
+        """
         raise NotImplementedError
 
     # --- API
@@ -152,7 +158,6 @@ class SwitcherSeparatorItem(SwitcherBaseItem):
     """
 
     _SEPARATOR = '_'
-    _HEIGHT = 15
     _STYLE_ATTRIBUTES = ['color', 'font_size']
     _STYLES = {
         'color': QApplication.palette().text().color().name(),
@@ -195,10 +200,20 @@ class SwitcherSeparatorItem(SwitcherBaseItem):
         """Render the html template for this item."""
         padding = self._padding
         width = self._width
-        height = self._HEIGHT
+        height = self.get_height()
         text = self._TEMPLATE.format(width=width, height=height,
                                      padding=padding, **self._styles)
         return text
+
+    def _get_height(self):
+        """
+        Return the expected height of this item's text, including
+        the text margins.
+        """
+        doc = QTextDocument()
+        doc.setHtml('<hr>')
+        doc.setDocumentMargin(self._PADDING)
+        return doc.size().height()
 
 
 class SwitcherItem(SwitcherBaseItem):
@@ -212,7 +227,6 @@ class SwitcherItem(SwitcherBaseItem):
     """
 
     _FONT_SIZE = 10
-    _HEIGHT = 20
     _STYLE_ATTRIBUTES = ['title_color', 'description_color', 'section_color',
                          'shortcut_color', 'title_font_size',
                          'description_font_size', 'section_font_size',
@@ -299,7 +313,7 @@ class SwitcherItem(SwitcherBaseItem):
 
         padding = self._PADDING
         width = self._width - self._icon_width
-        height = self._HEIGHT
+        height = self.get_height()
         self.setSizeHint(QSize(width, height))
 
         shortcut = '&lt;' + self._shortcut + '&gt;' if self._shortcut else ''
@@ -333,6 +347,17 @@ class SwitcherItem(SwitcherBaseItem):
 
         self._styles['description_font_size'] = description_font_size
         self._styles['section_font_size'] = description_font_size
+
+    def _get_height(self):
+        """
+        Return the expected height of this item's text, including
+        the text margins.
+        """
+        doc = QTextDocument()
+        doc.setHtml('<span style="font-size:{}pt">Title</span>'
+                    .format(self._styles['title_font_size']))
+        doc.setDocumentMargin(self._PADDING)
+        return doc.size().height()
 
     # --- API
     def set_icon(self, icon):


### PR DESCRIPTION
## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

The goal here is to calculate the height of the file switcher items based on (1) their content, (2) the hard-coded padding value and (3) the font size, instead of using a hard-coded value (that was defined in `_HEIGHT`).

Here is how it looks after the changes :

![image](https://user-images.githubusercontent.com/10170372/68535837-b770ac80-0316-11ea-8cbf-322baeb14d3c.png)

### Issue(s) Resolved

The file switcher was not displaying it's content correctly for me on Spyder 4.0.0.dev0 (Commit: bae9aaff4) in Python 3.7.3 64-bit | Qt 5.9.6 | PyQt5 5.9.2 | Windows 10 

![file_switcher](https://user-images.githubusercontent.com/10170372/68535816-62cd3180-0316-11ea-8e8b-791000c6174e.gif)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
