### PR TITLE
PR: Make to HTMLDelegate drawControl

### DIFF
--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -110,6 +110,7 @@ class HTMLDelegate(QStyledItemDelegate):
 
     Taken from https://stackoverflow.com/a/5443112/2399799
     """
+
     def __init__(self, parent, margin=0):
         super(HTMLDelegate, self).__init__(parent)
         self._margin = margin
@@ -129,9 +130,14 @@ class HTMLDelegate(QStyledItemDelegate):
 
         style = (QApplication.style() if options.widget is None
                  else options.widget.style())
-
         options.text = ""
-        style.drawControl(QStyle.CE_ItemViewItem, options, painter)
+
+        # Note: We need to pass the options widget as an argument of
+        # drawCrontol to make sure the delegate is painted with a style
+        # consistent with the widget in which it is used.
+        # See spyder-ide/spyder#10677.
+        style.drawControl(QStyle.CE_ItemViewItem, options, painter,
+                          options.widget)
 
         ctx = QAbstractTextDocumentLayout.PaintContext()
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

From the [documentation](https://srinikom.github.io/pyside-docs/PySide/QtGui/QStyle.html#PySide.QtGui.PySide.QtGui.QStyle.drawControl):

> PySide.QtGui.QStyle.drawControl(element, opt, p[, widget=None])

> The widget argument is optional and can be used as aid in drawing the control. The option parameter is a pointer to a PySide.QtGui.QStyleOption object that can be cast to the correct subclass using the qstyleoption_cast() function.

Apparently, if we do not pass an appropriate widget argument, it causes some minor issues with the UI (see image below).

![image](https://user-images.githubusercontent.com/10170372/68639342-4544c700-04d2-11ea-9c8f-503915f7d439.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
