### PR TITLE
PR: Make the list view of the file switcher look active at all times.

### DIFF
--- a/spyder/widgets/switcher.py
+++ b/spyder/widgets/switcher.py
@@ -78,11 +78,14 @@ class KeyPressFilter(QObject):
 
 class SwitcherDelegate(HTMLDelegate):
     """
-    This delegate allow the list view of the switcher to look like it has
+    This delegate allows the list view of the switcher to look like it has
     the focus, even when its focus policy is set to Qt.NoFocus.
     """
 
     def paint(self, painter, option, index):
+        """
+        Override Qt method to force this delegate to look active at all times.
+        """
         option.state |= QStyle.State_Active
         super().paint(painter, option, index)
 

--- a/spyder/widgets/switcher.py
+++ b/spyder/widgets/switcher.py
@@ -17,7 +17,8 @@ from qtpy.QtCore import (QEvent, QObject, QSize, QSortFilterProxyModel, Qt,
                          Signal, Slot, QModelIndex)
 from qtpy.QtGui import QStandardItem, QStandardItemModel, QTextDocument
 from qtpy.QtWidgets import (QAbstractItemView, QApplication, QDialog,
-                            QLineEdit, QListWidgetItem, QVBoxLayout, QListView)
+                            QLineEdit, QListView, QListWidgetItem, QStyle,
+                            QVBoxLayout)
 
 # Local imports
 from spyder.config.base import _
@@ -73,6 +74,17 @@ class KeyPressFilter(QObject):
                 self.sig_enter_key_pressed.emit()
                 return True
         return super(KeyPressFilter, self).eventFilter(src, e)
+
+
+class SwitcherDelegate(HTMLDelegate):
+    """
+    This delegate allow the list view of the switcher to look like it has
+    the focus, even when its focus policy is set to Qt.NoFocus.
+    """
+
+    def paint(self, painter, option, index):
+        option.state |= QStyle.State_Active
+        super().paint(painter, option, index)
 
 
 class SwitcherBaseItem(QStandardItem):
@@ -528,7 +540,7 @@ class Switcher(QDialog):
         self.edit.installEventFilter(self.filter)
         self.edit.setPlaceholderText(help_text if help_text else '')
         self.list.setMinimumWidth(self._MIN_WIDTH)
-        self.list.setItemDelegate(HTMLDelegate(self))
+        self.list.setItemDelegate(SwitcherDelegate(self))
         self.list.setFocusPolicy(Qt.NoFocus)
         self.list.setSelectionBehavior(self.list.SelectItems)
         self.list.setSelectionMode(self.list.SingleSelection)

--- a/spyder/widgets/switcher.py
+++ b/spyder/widgets/switcher.py
@@ -87,7 +87,7 @@ class SwitcherDelegate(HTMLDelegate):
         Override Qt method to force this delegate to look active at all times.
         """
         option.state |= QStyle.State_Active
-        super().paint(painter, option, index)
+        super(SwitcherDelegate, self).paint(painter, option, index)
 
 
 class SwitcherBaseItem(QStandardItem):


### PR DESCRIPTION
## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

Trick the html delegate that is used in the list view of the file switcher into thinking that it is active at all times, even if strictly speaking it is not.

See #10682 for more details.

![image](https://user-images.githubusercontent.com/10170372/68693767-dd2fc880-0545-11ea-883f-109c4e5758be.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes item number 2 in https://github.com/spyder-ide/spyder/issues/10682


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
