### PR TITLE
PR: Fix an error with the Python path manager widget

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3009,7 +3009,7 @@ class MainWindow(QMainWindow):
     def show_path_manager(self):
         """Show path manager dialog."""
         from spyder.widgets.pathmanager import PathManager
-        read_only_path = self.projects.get_pythonpath()
+        read_only_path = tuple(self.projects.get_pythonpath())
 
         # TODO: update sync on windows
         dialog = PathManager(self, self.path, read_only_path,


### PR DESCRIPTION
## Description of Changes

This is simply to fixed a minor bug that was introduced by PR #10623.

### Issue(s) Resolved

Fixes the following error :

```python
  File "C:\Users\User\spyder\spyder\app\mainwindow.py", line 3016, in show_path_manager
    """Update dockwidgets features settings"""
  File "C:\Users\User\spyder\spyder\widgets\pathmanager.py", line 98, in __init__
    text=_("Move to top"),
  File "C:\Users\User\spyder\spyder\widgets\pathmanager.py", line 197, in setup
    if path not in self.not_active_pathlist:
TypeError: can only concatenate tuple (not "list") to tuple
```


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
