### PR TITLE
PR: Sort items in Switcher in ascending order and move logic to filter items in the proxy model

### DIFF
--- a/spyder/widgets/switcher.py
+++ b/spyder/widgets/switcher.py
@@ -494,7 +494,7 @@ class SwitcherProxyModel(QSortFilterProxyModel):
         """Override Qt method."""
         self.__sort_by = attr
         self.invalidate()
-        self.sort(0, Qt.DescendingOrder)
+        self.sort(0, Qt.AscendingOrder)
 
     def lessThan(self, left, right):
         """Override Qt method."""

--- a/spyder/widgets/switcher.py
+++ b/spyder/widgets/switcher.py
@@ -146,6 +146,10 @@ class SwitcherBaseItem(QStandardItem):
         """Return the content height."""
         return self._height
 
+    def get_score(self):
+        """Return the fuzzy matchig score."""
+        return self._score
+
     def set_score(self, value):
         """Set the search text fuzzy match score."""
         self._score = value
@@ -434,10 +438,6 @@ class SwitcherItem(SwitcherBaseItem):
     def get_data(self):
         """Return the additional data associated to the item."""
         return self._data
-
-    def get_score(self):
-        """Return the fuzzy matchig score."""
-        return self._score
 
     def set_section(self, value):
         """Set the item section name."""

--- a/spyder/widgets/switcher.py
+++ b/spyder/widgets/switcher.py
@@ -468,6 +468,27 @@ class SwitcherProxyModel(QSortFilterProxyModel):
         self.setFilterCaseSensitivity(Qt.CaseInsensitive)
         self.setSortCaseSensitivity(Qt.CaseInsensitive)
         self.setDynamicSortFilter(True)
+        self.__filter_on = False
+
+    def set_filter_on(self, value):
+        """
+        Set whether the items should be filtered.
+
+        Parameters
+        ----------
+        value : bool
+           Indicates whether the items should be filtered.
+        """
+        self.__filter_on = value
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, source_row, source_parent):
+        """Override Qt method to filter items by ther score result."""
+        item = self.sourceModel().item(source_row)
+        if self._filter_on is False or item.is_action_item():
+            return True
+        else:
+            return not item.get_score() == -1
 
     def sortBy(self, attr):
         """Override Qt method."""

--- a/spyder/widgets/switcher.py
+++ b/spyder/widgets/switcher.py
@@ -468,24 +468,25 @@ class SwitcherProxyModel(QSortFilterProxyModel):
         self.setFilterCaseSensitivity(Qt.CaseInsensitive)
         self.setSortCaseSensitivity(Qt.CaseInsensitive)
         self.setDynamicSortFilter(True)
-        self.__filter_on = False
+        self.__filter_by_score = False
 
-    def set_filter_on(self, value):
+    def set_filter_by_score(self, value):
         """
-        Set whether the items should be filtered.
+        Set whether the items should be filtered by their score result.
 
         Parameters
         ----------
         value : bool
-           Indicates whether the items should be filtered.
+           Indicates whether the items should be filtered by their
+           score result.
         """
-        self.__filter_on = value
+        self.__filter_by_score = value
         self.invalidateFilter()
 
     def filterAcceptsRow(self, source_row, source_parent):
         """Override Qt method to filter items by their score result."""
         item = self.sourceModel().item(source_row)
-        if self._filter_on is False or item.is_action_item():
+        if self.__filter_by_score is False or item.is_action_item():
             return True
         else:
             return not item.get_score() == -1
@@ -674,7 +675,7 @@ class Switcher(QDialog):
         if self.search_text() == '':
             self._mode_on = ''
             self.clear()
-            self.proxy.set_filter_on(False)
+            self.proxy.set_filter_by_score(False)
             self.sig_mode_selected.emit(self._mode_on)
             return
 
@@ -686,7 +687,6 @@ class Switcher(QDialog):
                 return
 
         # Filter by text
-        self.proxy.set_filter_on(True)
         titles = []
         for row in range(self.model.rowCount()):
             item = self.model.item(row)
@@ -706,6 +706,7 @@ class Switcher(QDialog):
                 rich_title = rich_title.replace(" ", "&nbsp;")
                 item.set_rich_title(rich_title)
             item.set_score(score_value)
+        self.proxy.set_filter_by_score(True)
 
         self.setup_sections()
         if self.count():

--- a/spyder/widgets/switcher.py
+++ b/spyder/widgets/switcher.py
@@ -483,7 +483,7 @@ class SwitcherProxyModel(QSortFilterProxyModel):
         self.invalidateFilter()
 
     def filterAcceptsRow(self, source_row, source_parent):
-        """Override Qt method to filter items by ther score result."""
+        """Override Qt method to filter items by their score result."""
         item = self.sourceModel().item(source_row)
         if self._filter_on is False or item.is_action_item():
             return True

--- a/spyder/widgets/tests/test_switcher.py
+++ b/spyder/widgets/tests/test_switcher.py
@@ -72,33 +72,33 @@ def test_switcher_filter_and_mode(dlg_switcher, qtbot):
     edit = dlg_switcher.edit
 
     # Initially cvs mode with five rows
-    assert dlg_switcher._visible_rows == 5
+    assert dlg_switcher.count() == 5
 
     # Match one row by name
     edit.setText("master")
     qtbot.wait(1000)
-    assert dlg_switcher._visible_rows == 2
+    assert dlg_switcher.count() == 2
 
     # Help mode
     edit.setText("")
     edit.setText("?")
     qtbot.wait(1000)
-    assert dlg_switcher._visible_rows == 5
+    assert dlg_switcher.count() == 5
 
     # Symbol mode
     edit.setText("")
     edit.setText("@")
     qtbot.wait(1000)
-    assert dlg_switcher._visible_rows == 2
+    assert dlg_switcher.count() == 2
 
     # Commands mode
     edit.setText("")
     edit.setText(">")
     qtbot.wait(1000)
-    assert dlg_switcher._visible_rows == 7
+    assert dlg_switcher.count() == 7
 
     # Text mode
     edit.setText("")
     edit.setText(":")
     qtbot.wait(1000)
-    assert dlg_switcher._visible_rows == 1
+    assert dlg_switcher.count() == 1


### PR DESCRIPTION
## Description of Changes
* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

- Items in the switcher are now sorted in Ascending order instead of Descending order.
- The filtering is now done by the `SwitcherProxyModel(QSortFilterProxyModel)` instead of hiding rows in the `Switcher(QDialog)`, which was causing problems with the new sorting order and was prone to errors.

![switcher](https://user-images.githubusercontent.com/10170372/68801758-aaabcb80-062a-11ea-8481-f96894367317.gif)


### Issue(s) Resolved

Fixes #10682


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
