### PR TITLE
PR: Add restart option to PluginConfigPage

### DIFF
--- a/spyder/api/preferences.py
+++ b/spyder/api/preferences.py
@@ -8,8 +8,10 @@
 API to create an entry in Spyder Preferences dialog associated to a
 given plugin.
 """
-
+# Third-party imports
+from qtpy.QtWidgets import QMessageBox
 # Local imports
+from spyder.config.base import _
 from spyder.preferences.configdialog import SpyderConfigPage
 
 class PluginConfigPage(SpyderConfigPage):
@@ -17,6 +19,7 @@ class PluginConfigPage(SpyderConfigPage):
 
     def __init__(self, plugin, parent):
         self.plugin = plugin
+        self.main = parent.main
         self.get_option = plugin.get_option
         self.set_option = plugin.set_option
         self.get_font = plugin.get_font
@@ -56,3 +59,32 @@ class PluginConfigPage(SpyderConfigPage):
         self.setLayout(layout)
         """
         raise NotImplementedError
+
+    def prompt_restart_required(self):
+        """Prompt the user with a request to restart."""
+        restart_opts = self.restart_options
+        changed_opts = self.changed_options
+        options = [restart_opts[o] for o in changed_opts if o in restart_opts]
+
+        if len(options) == 1:
+            msg_start = _("Spyder needs to restart to change the following "
+                          "setting:")
+        else:
+            msg_start = _("Spyder needs to restart to change the following "
+                          "settings:")
+        msg_end = _("Do you wish to restart now?")
+
+        msg_options = u""
+        for option in options:
+            msg_options += u"<li>{0}</li>".format(option)
+
+        msg_title = _("Information")
+        msg = u"{0}<ul>{1}</ul><br>{2}".format(msg_start, msg_options, msg_end)
+        answer = QMessageBox.information(self, msg_title, msg,
+                                         QMessageBox.Yes | QMessageBox.No)
+        if answer == QMessageBox.Yes:
+            self.restart()
+
+    def restart(self):
+        """Restart Spyder."""
+        self.main.restart()

--- a/spyder/api/preferences.py
+++ b/spyder/api/preferences.py
@@ -8,10 +8,8 @@
 API to create an entry in Spyder Preferences dialog associated to a
 given plugin.
 """
-# Third-party imports
-from qtpy.QtWidgets import QMessageBox
+
 # Local imports
-from spyder.config.base import _
 from spyder.preferences.configdialog import SpyderConfigPage
 
 class PluginConfigPage(SpyderConfigPage):
@@ -59,32 +57,3 @@ class PluginConfigPage(SpyderConfigPage):
         self.setLayout(layout)
         """
         raise NotImplementedError
-
-    def prompt_restart_required(self):
-        """Prompt the user with a request to restart."""
-        restart_opts = self.restart_options
-        changed_opts = self.changed_options
-        options = [restart_opts[o] for o in changed_opts if o in restart_opts]
-
-        if len(options) == 1:
-            msg_start = _("Spyder needs to restart to change the following "
-                          "setting:")
-        else:
-            msg_start = _("Spyder needs to restart to change the following "
-                          "settings:")
-        msg_end = _("Do you wish to restart now?")
-
-        msg_options = u""
-        for option in options:
-            msg_options += u"<li>{0}</li>".format(option)
-
-        msg_title = _("Information")
-        msg = u"{0}<ul>{1}</ul><br>{2}".format(msg_start, msg_options, msg_end)
-        answer = QMessageBox.information(self, msg_title, msg,
-                                         QMessageBox.Yes | QMessageBox.No)
-        if answer == QMessageBox.Yes:
-            self.restart()
-
-    def restart(self):
-        """Restart Spyder."""
-        self.main.restart()

--- a/spyder/preferences/configdialog.py
+++ b/spyder/preferences/configdialog.py
@@ -283,6 +283,7 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
         self.changed_options = set()
         self.restart_options = dict()  # Dict to store name and localized text
         self.default_button_group = None
+        self.main = parent.main
 
     def apply_settings(self, options):
         raise NotImplementedError
@@ -859,31 +860,6 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
         widget.setLayout(layout)
         return widget
 
-
-class GeneralConfigPage(SpyderConfigPage):
-    """Config page that maintains reference to main Spyder window
-       and allows to specify page name and icon declaratively
-    """
-    CONF_SECTION = None
-
-    NAME = None    # configuration page name, e.g. _("General")
-    ICON = None    # name of icon resource (24x24)
-
-    def __init__(self, parent, main):
-        SpyderConfigPage.__init__(self, parent)
-        self.main = main
-
-    def get_name(self):
-        """Configuration page name"""
-        return self.NAME
-
-    def get_icon(self):
-        """Loads page icon named by self.ICON"""
-        return self.ICON
-
-    def apply_settings(self, options):
-        raise NotImplementedError
-
     def prompt_restart_required(self):
         """Prompt the user with a request to restart."""
         restart_opts = self.restart_options
@@ -912,3 +888,28 @@ class GeneralConfigPage(SpyderConfigPage):
     def restart(self):
         """Restart Spyder."""
         self.main.restart()
+
+
+class GeneralConfigPage(SpyderConfigPage):
+    """Config page that maintains reference to main Spyder window
+       and allows to specify page name and icon declaratively
+    """
+    CONF_SECTION = None
+
+    NAME = None    # configuration page name, e.g. _("General")
+    ICON = None    # name of icon resource (24x24)
+
+    def __init__(self, parent, main):
+        SpyderConfigPage.__init__(self, parent)
+        self.main = main
+
+    def get_name(self):
+        """Configuration page name"""
+        return self.NAME
+
+    def get_icon(self):
+        """Loads page icon named by self.ICON"""
+        return self.ICON
+
+    def apply_settings(self, options):
+        raise NotImplementedError


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
This change allows to restart spyder from any configuration page that inherits from PluginConfigPage. 



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->
This change is necessary for PR https://github.com/spyder-ide/spyder-terminal/pull/156 to work

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
