### PR TITLE
PR: Fix updating actions tooltips after a change is applied to the shortcuts

### DIFF
--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -316,6 +316,10 @@ def create_action(parent, text, shortcut=None, icon=None, tip=None,
 def add_shortcut_to_tooltip(action, context, name):
     """Add the shortcut associated with a given action to its tooltip"""
     if not hasattr(action, '_tooltip_backup'):
+        # We store the original tooltip of the action without its associated
+        # shortcut so that we can update the tooltip properly if shortcuts
+        # are changed by the user over the course of the current session.
+        # See spyder-ide/spyder#10726.
         action._tooltip_backup = action.toolTip()
     action.setToolTip(action._tooltip_backup + ' (%s)' %
                       CONF.get_shortcut(context=context, name=name))

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -315,7 +315,9 @@ def create_action(parent, text, shortcut=None, icon=None, tip=None,
 
 def add_shortcut_to_tooltip(action, context, name):
     """Add the shortcut associated with a given action to its tooltip"""
-    action.setToolTip(action.toolTip() + ' (%s)' %
+    if not hasattr(action, '_tooltip_backup'):
+        action._tooltip_backup = action.toolTip()
+    action.setToolTip(action._tooltip_backup + ' (%s)' %
                       CONF.get_shortcut(context=context, name=name))
 
 


### PR DESCRIPTION
## Description of Changes

![shortcut_tooltips_fixed](https://user-images.githubusercontent.com/10170372/68968770-639c1280-07b1-11ea-986b-84b397d82b5f.gif)

### Issue(s) Resolved

Fixes #10726


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin
