### PR TITLE
PR: Don't request folding when rehighlighting the whole document

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1570,10 +1570,7 @@ class CodeEditor(TextEditBaseWidget):
             self.unindent()
 
     def rehighlight(self):
-        """
-        Rehighlight the whole document to rebuild outline explorer data
-        and import statements data from scratch
-        """
+        """Rehighlight the whole document."""
         if self.highlighter is not None:
             self.highlighter.rehighlight()
         if self.highlight_current_cell_enabled:

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -185,7 +185,7 @@ class BaseSH(QSyntaxHighlighter):
         self.setup_formats(font)
 
         self.cell_separators = None
-        self.fold_detector = None
+        self.request_folding = True
         self.editor = None
         self.patterns = DEFAULT_COMPILED_PATTERNS
 
@@ -290,20 +290,12 @@ class BaseSH(QSyntaxHighlighter):
         :param text: text to highlight.
         """
         self.highlight_block(text)
-        if self.editor:
-            if self.editor.folding_supported and self.editor.code_folding:
-                diff, _ = self.editor.text_diff
-                if len(diff) > 0:
-                    self.editor.request_folding()
-
-        # Process blocks for fold detection
-        # current_block = self.currentBlock()
-        # previous_block = self._find_prev_non_blank_block(current_block)
-        # if self.editor:
-        #     if self.fold_detector is not None:
-        #         self.fold_detector._editor = weakref.ref(self.editor)
-        #         self.fold_detector.process_block(
-        #             current_block, previous_block, text)
+        if self.request_folding:
+            if self.editor is not None:
+                if self.editor.folding_supported and self.editor.code_folding:
+                    diff, _ = self.editor.text_diff
+                    if len(diff) > 0:
+                        self.editor.request_folding()
 
     def highlight_block(self, text):
         """
@@ -368,7 +360,9 @@ class BaseSH(QSyntaxHighlighter):
 
     def rehighlight(self):
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        self.request_folding = False
         QSyntaxHighlighter.rehighlight(self)
+        self.request_folding = True
         QApplication.restoreOverrideCursor()
 
 


### PR DESCRIPTION
This avoids making a folding request per block for the entire document.

Fixes #10766.