### PR TITLE
PR: Prevent automatic completions on backspace and return

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -356,6 +356,7 @@ class CodeEditor(TextEditBaseWidget):
         # Typing keys / handling on the fly completions
         # See: keyPressEvent
         self._last_key_pressed_text = ''
+        self._last_pressed_key = None
         self._timer_autocomplete = QTimer(self)
         self._timer_autocomplete.setSingleShot(True)
         self._timer_autocomplete.timeout.connect(self._handle_completions)
@@ -3722,6 +3723,7 @@ class CodeEditor(TextEditBaseWidget):
             insert_text(event)
 
         self._last_key_pressed_text = text
+        self._last_pressed_key = key
         if self.automatic_completions_after_ms == 0:
             self._handle_completions()
 
@@ -3737,6 +3739,12 @@ class CodeEditor(TextEditBaseWidget):
         pos = cursor.position()
         cursor.select(QTextCursor.WordUnderCursor)
         text = to_text_string(cursor.selectedText())
+
+        key = self._last_pressed_key
+        if key is not None:
+            if key == Qt.Key_Backspace or key == Qt.Key_Return:
+                self._last_pressed_key = None
+                return
 
         # Text might be after a dot '.'
         if text == '':
@@ -3764,6 +3772,7 @@ class CodeEditor(TextEditBaseWidget):
                         or '.' in text):
                     self.do_completion(automatic=True)
                     self._last_key_pressed_text = ''
+                    self._last_pressed_key = None
 
     def fix_and_strip_indent(self, comment_or_string=False):
         """Automatically fix indent and strip previous automatic indent."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR fixes a regression where return and backspace would trigger automatic completions

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10797


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@andfoy

<!--- Thanks for your help making Spyder better for everyone! --->
