### PR TITLE
PR: Implement a faster paint event for cells

### DIFF
--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -31,7 +31,7 @@ from spyder.widgets.mixins import BaseEditMixin
 from spyder.plugins.editor.api.decoration import TextDecoration, DRAW_ORDERS
 from spyder.plugins.editor.utils.decoration import TextDecorationsManager
 from spyder.plugins.editor.widgets.completion import CompletionWidget
-from spyder.plugins.outlineexplorer.api import is_cell_header
+from spyder.plugins.outlineexplorer.api import is_cell_header, document_cells
 
 
 class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
@@ -93,6 +93,13 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         self.unmatched_p_color = QColor(Qt.red)
 
         self.decorations = TextDecorationsManager(self)
+
+        # Save current cell. This is invalidated as soon as the text changes.
+        # Useful to avoid recomputing while scrolling.
+        self.current_cell = None
+        def reset_current_cell():
+            self.current_cell = None
+        self.textChanged.connect(reset_current_cell)
 
     def setup_completion(self):
         size = CONF.get('main', 'completion/size')
@@ -210,7 +217,7 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         if self.cell_separators is None or \
           not self.highlight_current_cell_enabled:
             return
-        cursor, whole_file_selected, whole_screen_selected =\
+        cursor, whole_file_selected, _ =\
             self.select_current_cell_in_visible_portion()
         selection = TextDecoration(cursor)
         selection.format.setProperty(QTextFormat.FullWidthSelection,
@@ -219,17 +226,6 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
 
         if whole_file_selected:
             self.clear_extra_selections('current_cell')
-        elif whole_screen_selected:
-            has_cell_separators = False
-            for oedata in self.outlineexplorer_data_list():
-                if oedata.def_type == oedata.CELL:
-                    has_cell_separators = True
-                    break
-            if has_cell_separators:
-                self.set_extra_selections('current_cell', [selection])
-                self.update_extra_selections()
-            else:
-                self.clear_extra_selections('current_cell')
         else:
             self.set_extra_selections('current_cell', [selection])
             self.update_extra_selections()
@@ -459,11 +455,8 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         """Return True if cursor (or text block) is on a block separator"""
         assert cursor is not None or block is not None
         if cursor is not None:
-            cursor0 = QTextCursor(cursor)
-            cursor0.select(QTextCursor.BlockUnderCursor)
-            text = to_text_string(cursor0.selectedText())
-        else:
-            text = to_text_string(block.text())
+            block = cursor.block()
+        text = to_text_string(block.text())
         if self.cell_separators is None:
             return False
         else:
@@ -525,61 +518,57 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
          -the textCursor
          -a boolean indicating if the entire file is selected
          -a boolean indicating if the entire visible portion of the file is selected"""
-        cursor = self.textCursor()
-        cursor.movePosition(QTextCursor.StartOfBlock)
-        cur_pos = prev_pos = cursor.position()
-
+         #
         beg_pos = self.cursorForPosition(QPoint(0, 0)).position()
         bottom_right = QPoint(self.viewport().width() - 1,
                               self.viewport().height() - 1)
         end_pos = self.cursorForPosition(bottom_right).position()
 
-        # Moving to the next line that is not a separator, if we are
-        # exactly at one of them
-        while self.is_cell_separator(cursor):
-            cursor.movePosition(QTextCursor.NextBlock)
-            prev_pos = cur_pos
-            cur_pos = cursor.position()
-            if cur_pos == prev_pos:
-                return cursor, False, False
-        prev_pos = cur_pos
-        # If not, move backwards to find the previous separator
-        while not self.is_cell_separator(cursor)\
-          and cursor.position() >= beg_pos:
-            cursor.movePosition(QTextCursor.PreviousBlock)
-            prev_pos = cur_pos
-            cur_pos = cursor.position()
-            if cur_pos == prev_pos:
-                if self.is_cell_separator(cursor):
-                    return cursor, False, False
-                else:
-                    break
-        cell_at_screen_start = cursor.position() <= beg_pos
-        cursor.setPosition(prev_pos)
-        cell_at_file_start = cursor.atStart()
-        # Selecting cell header
-        if not cell_at_file_start:
-            cursor.movePosition(QTextCursor.PreviousBlock)
-            cursor.movePosition(QTextCursor.NextBlock,
-                                QTextCursor.KeepAnchor)
-        # Once we find it (or reach the beginning of the file)
-        # move to the next separator (or the end of the file)
-        # so we can grab the cell contents
-        while not self.is_cell_separator(cursor)\
-          and cursor.position() <= end_pos:
-            cursor.movePosition(QTextCursor.NextBlock,
-                                QTextCursor.KeepAnchor)
-            cur_pos = cursor.position()
-            if cur_pos == prev_pos:
-                cursor.movePosition(QTextCursor.EndOfBlock,
-                                    QTextCursor.KeepAnchor)
-                break
-            prev_pos = cur_pos
-        cell_at_file_end = cursor.atEnd()
-        cell_at_screen_end = cursor.position() >= end_pos
+        cursor = self.textCursor()
+        if self.current_cell:
+            current_cell, cell_full_file = self.current_cell
+            cell_start_pos = current_cell.selectionStart()
+            cell_end_position = current_cell.selectionEnd()
+            # Check if the saved current cell is still valid
+            if cell_start_pos <= cursor.position() <= cell_end_position:
+                return current_cell,\
+                   cell_full_file,\
+                   cell_start_pos <= beg_pos and cell_end_position >= end_pos
+            else:
+                self.current_cell = None
+
+        block = cursor.block()
+        try:
+            header = next(document_cells(block, forward=False))
+            cell_start_pos = header.block.position()
+            cell_at_screen_start = cell_start_pos <= beg_pos
+            cell_at_file_start = False
+            cursor.setPosition(cell_start_pos)
+        except StopIteration:
+            # This cell has no header, so it is the first cell.
+            cell_at_screen_start = True
+            cell_at_file_start = True
+            cursor.movePosition(QTextCursor.Start)
+
+        try:
+            footer = next(document_cells(block, forward=True))
+            cell_end_position = footer.block.position()
+            cell_at_screen_end = cell_end_position >= end_pos
+            cell_at_file_end = False
+            cursor.setPosition(cell_end_position, QTextCursor.KeepAnchor)
+        except StopIteration:
+            # This cell has no next header, so it is the last cell.
+            cell_at_file_end = True
+            cell_at_screen_end = True
+            cursor.movePosition(QTextCursor.End, QTextCursor.KeepAnchor)
+
+        cell_full_file = cell_at_file_start and cell_at_file_end
+        self.current_cell = (cursor, cell_full_file)
+
         return cursor,\
-               cell_at_file_start and cell_at_file_end,\
+               cell_full_file,\
                cell_at_screen_start and cell_at_screen_end
+
 
     def go_to_next_cell(self):
         """Go to the next cell of lines"""

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -97,8 +97,10 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         # Save current cell. This is invalidated as soon as the text changes.
         # Useful to avoid recomputing while scrolling.
         self.current_cell = None
+
         def reset_current_cell():
             self.current_cell = None
+
         self.textChanged.connect(reset_current_cell)
 
     def setup_completion(self):

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -514,12 +514,13 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         return cursor, cell_at_file_start and cell_at_file_end
 
     def select_current_cell_in_visible_portion(self):
-        """Select cell under cursor in the visible portion of the file
+        """
+        Select cell under cursor in the visible portion of the file
         cell = group of lines separated by CELL_SEPARATORS
         returns
          -the textCursor
          -a boolean indicating if the entire file is selected
-         -a boolean indicating if the entire visible portion of the file is selected"""
+         """
 
         cursor = self.textCursor()
         if self.current_cell:
@@ -534,7 +535,10 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
 
         block = cursor.block()
         try:
-            header = next(document_cells(block, forward=False))
+            if is_cell_header(block):
+                header = block.userData().oedata
+            else:
+                header = next(document_cells(block, forward=False))
             cell_start_pos = header.block.position()
             cell_at_file_start = False
             cursor.setPosition(cell_start_pos)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4248,7 +4248,7 @@ class CodeEditor(TextEditBaseWidget):
             painter.setPen(pen)
 
             for top, line_number, block in self.visible_blocks:
-                if self.is_cell_separator(block):
+                if self.is_cell_separator(block=block):
                     painter.drawLine(4, top, self.width(), top)
 
     @property


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Paint Events are quite slow on my machine, which makes Spyder not really responsive. This improves the situation by avoiding a useless call to `select`, which is relatively slow.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
