### PR TITLE
PR: Catch extra exception for external plugins

### DIFF
--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -267,7 +267,7 @@ class BasePluginWidgetMixin(object):
             name = 'switch to {}'.format(self.CONF_SECTION)
             self.shortcut = CONF.get_shortcut(context, name,
                                               plugin_name=self.CONF_SECTION)
-        except configparser.NoOptionError:
+        except (configparser.NoSectionError, configparser.NoOptionError):
             pass
 
         if self.shortcut is not None and self.main is not None:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


(https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Since external plugins might not define a shortcut for the pane, this extra exception needs to be caught.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->



### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
