### PR TITLE
PR: Fix the shortcut override in the ShortcutEditor.

### DIFF
--- a/spyder/preferences/shortcuts.py
+++ b/spyder/preferences/shortcuts.py
@@ -291,7 +291,16 @@ class ShortcutEditor(QDialog):
 
     def event(self, event):
         """Qt method override."""
-        if event.type() in (QEvent.Shortcut, QEvent.ShortcutOverride):
+        # We reroute all ShortcutOverride events to our keyPressEvent and block
+        # any KeyPress event. This allows to register some key sequences for
+        # which no key press event are created by Qt.
+        # See spyder-ide/spyder/issues/10786.
+        if event.type() == QEvent.ShortcutOverride:
+            event.accept()
+            self.keyPressEvent(event)
+            return True
+        elif event.type() == QEvent.KeyPress:
+            event.accept()
             return True
         else:
             return super(ShortcutEditor, self).event(event)

--- a/spyder/preferences/shortcuts.py
+++ b/spyder/preferences/shortcuts.py
@@ -292,8 +292,8 @@ class ShortcutEditor(QDialog):
     def event(self, event):
         """Qt method override."""
         # We reroute all ShortcutOverride events to our keyPressEvent and block
-        # any KeyPress event. This allows to register some key sequences for
-        # which no key press event are created by Qt.
+        # any KeyPress and Shortcut event. This allows to register default
+        # Qt shortcuts for which no key press event are emitted.
         # See spyder-ide/spyder/issues/10786.
         if event.type() == QEvent.ShortcutOverride:
             event.accept()

--- a/spyder/preferences/shortcuts.py
+++ b/spyder/preferences/shortcuts.py
@@ -296,11 +296,9 @@ class ShortcutEditor(QDialog):
         # Qt shortcuts for which no key press event are emitted.
         # See spyder-ide/spyder/issues/10786.
         if event.type() == QEvent.ShortcutOverride:
-            event.accept()
             self.keyPressEvent(event)
             return True
-        elif event.type() == QEvent.KeyPress:
-            event.accept()
+        elif event.type() in [QEvent.KeyPress, QEvent.Shortcut]:
             return True
         else:
             return super(ShortcutEditor, self).event(event)


### PR DESCRIPTION
## Description of Changes

### Issue(s) Resolved

With this change, I can now register correctly the `Ctrl + Space` keysequence in the `ShortcutEditor`.

This may also solve #10786, but this will need to be tested, because on Windows, `Alt + Space` is still not usable after these changes.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin

