### PR TITLE
PR: Fix restart when using an external interpreter in development mode

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3292,10 +3292,11 @@ class MainWindow(QMainWindow):
         env['SPYDER_RESET'] = str(reset)
 
         if DEV:
+            repo_dir = osp.dirname(spyder_start_directory)
             if os.name == 'nt':
-                env['PYTHONPATH'] = ';'.join(sys.path)
+                env['PYTHONPATH'] = ';'.join([repo_dir])
             else:
-                env['PYTHONPATH'] = ':'.join(sys.path)
+                env['PYTHONPATH'] = ':'.join([repo_dir])
 
         # Build the command and popen arguments depending on the OS
         if os.name == 'nt':

--- a/spyder/app/restart.py
+++ b/spyder/app/restart.py
@@ -185,7 +185,7 @@ def main():
     restarter.set_splash_message(_('Closing Spyder'))
 
     # Get variables
-    # Note: Variables defined in app/spyder.py 'restart()' method
+    # Note: Variables defined in app/mainwindow.py 'restart()' method
     spyder_args = os.environ.pop('SPYDER_ARGS', None)
     pid = os.environ.pop('SPYDER_PID', None)
     is_bootstrap = os.environ.pop('SPYDER_IS_BOOTSTRAP', None)

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -824,7 +824,7 @@ def is_module_installed(module_name, version=None, installed_version=None,
     in a determined interpreter
     """
     if interpreter:
-        if osp.isfile(interpreter) and ('python' in interpreter):
+        if is_python_interpreter(interpreter):
             checkver = inspect.getsource(check_version)
             get_modver = inspect.getsource(get_module_version)
             stable_ver = inspect.getsource(is_stable_version)
@@ -863,9 +863,8 @@ def is_module_installed(module_name, version=None, installed_version=None,
                     f.close()
                 os.remove(script)
         else:
-            # Try to not take a wrong decision if there is no interpreter
-            # available (needed for the change_pystartup method of ExtConsole
-            # config page)
+            # Try to not take a wrong decision if interpreter check
+            # fails
             return True
     else:
         if installed_version is None:
@@ -897,6 +896,7 @@ def is_module_installed(module_name, version=None, installed_version=None,
 
             return check_version(actver, version, symb)
 
+
 def is_python_interpreter_valid_name(filename):
     """Check that the python interpreter file has a valid name."""
     pattern = r'.*python(\d\.?\d*)?(w)?(.exe)?$'
@@ -904,6 +904,7 @@ def is_python_interpreter_valid_name(filename):
         return False
     else:
         return True
+
 
 def is_python_interpreter(filename):
     """Evaluate wether a file is a python interpreter or not."""
@@ -957,7 +958,7 @@ def check_python_help(filename):
             return True
         else:
             return False
-    except:
+    except Exception:
         return False
 
 


### PR DESCRIPTION
- The problem was caused because we were adding sys.path to PYTHONPATH, so the restart script could import the Spyder modules.
- But we only need to add the directory from which bootstrap.py was started.
- This was generating an error in both the IPython console and the PyLS.