### PR TITLE
PR: Show autosave dialog on top of splash screen in macOS

### DIFF
--- a/spyder/plugins/editor/widgets/recover.py
+++ b/spyder/plugins/editor/widgets/recover.py
@@ -104,9 +104,8 @@ class RecoveryDialog(QDialog):
             Qt.Dialog | Qt.MSWindowsFixedSizeDialogHint |
             Qt.WindowStaysOnTopHint)
 
-        # This is needed beause of this error in MacOS:
-        # https://bugreports.qt.io/browse/QTBUG-49576
-
+        # This is needed beause of an error in MacOS.
+        # See https://bugreports.qt.io/browse/QTBUG-49576
         if parent and hasattr(parent, 'splash'):
             self.splash = parent.splash
             self.splash.hide()
@@ -114,11 +113,15 @@ class RecoveryDialog(QDialog):
             self.splash = None
 
     def accept(self):
-        self.splash.show()
+        """Reimplement Qt method."""
+        if self.splash is not None:
+            self.splash.show()
         super(RecoveryDialog, self).accept()
 
     def reject(self):
-        self.splash.show()
+        """Reimplement Qt method."""
+        if self.splash is not None:
+            self.splash.show()
         super(RecoveryDialog, self).reject()
 
     def gather_data(self, autosave_mapping):

--- a/spyder/plugins/editor/widgets/recover.py
+++ b/spyder/plugins/editor/widgets/recover.py
@@ -104,6 +104,23 @@ class RecoveryDialog(QDialog):
             Qt.Dialog | Qt.MSWindowsFixedSizeDialogHint |
             Qt.WindowStaysOnTopHint)
 
+        # This is needed beause of this error in MacOS:
+        # https://bugreports.qt.io/browse/QTBUG-49576
+
+        if parent and hasattr(parent, 'splash'):
+            self.splash = parent.splash
+            self.splash.hide()
+        else:
+            self.splash = None
+
+    def accept(self):
+        self.splash.show()
+        super(RecoveryDialog, self).accept()
+
+    def reject(self):
+        self.splash.show()
+        super(RecoveryDialog, self).reject()
+
     def gather_data(self, autosave_mapping):
         """
         Gather data about files which may be recovered.


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->

Hide SplashScreen to show on top the RecoveryDialog since there is an issue regarding dialogs on MacOS: https://bugreports.qt.io/browse/QTBUG-49576 


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Juanis2112

<!--- Thanks for your help making Spyder better for everyone! --->