### PR TITLE
PR: Use proxy_model when refreshing plot actions state

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -709,7 +709,7 @@ class BaseTableView(QTableView):
 
     def refresh_plot_entries(self, index):
         if index.isValid():
-            key = self.source_model.get_key(index)
+            key = self.proxy_model.get_key(index)
             is_list = self.is_list(key)
             is_array = self.is_array(key) and self.get_len(key) != 0
             condition_plot = (is_array and len(self.get_array_shape(key)) <= 2)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Use `proxy_model` instead of `source_model` to properly map the update of the plot actions state
to the correct items in the Variable Explorer

A preview:

```python
import numpy as np
import matplotlib.pyplot as plt

def get_mse(target, synth):
    weights = np.sum(target, axis=0)
    mse = None
    return mse, weights

spec = np.random.rand(128, 159)
mse, energy_mel = get_mse(spec, spec)
mse, energy_spec = get_mse(spec, spec)

```

![vp](https://user-images.githubusercontent.com/16781833/70165417-def63300-1690-11ea-88a2-156635f42646.gif)



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10917 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
