### PR TITLE
PR: Remove Python 2 and 3.5 from our CIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,18 +17,6 @@ main: &main
           command: bash ./continuous_integration/circle/modules_test.sh || bash ./continuous_integration/circle/modules_test.sh
 
 jobs:
-  python2.7:
-    <<: *main
-    environment:
-      - PYTHON_VERSION: "2.7"
-      - USE_CONDA: "yes"
-
-  python3.5:
-    <<: *main
-    environment:
-      - PYTHON_VERSION: "3.5"
-      - USE_CONDA: "no"
-
   python3.6:
     <<: *main
     environment:
@@ -45,7 +33,5 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - python2.7
-      - python3.5
       - python3.6
       - python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ services:
 matrix:
   fast_finish: true
   include:
-    - env: PYTHON_VERSION=2.7 USE_CONDA=yes RUN_SLOW=true
-    - env: PYTHON_VERSION=2.7 USE_CONDA=yes RUN_SLOW=false
     - env: PYTHON_VERSION=3.7 USE_CONDA=no RUN_SLOW=true
     - env: PYTHON_VERSION=3.7 USE_CONDA=no RUN_SLOW=false
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
   pool:
     vmImage: 'macOS-10.13'
 
-  timeoutInMinutes: 30
+  timeoutInMinutes: 35
 
   variables:
     USE_CONDA: "yes"
@@ -20,12 +20,6 @@ jobs:
   # Run the pipeline with multiple Python versions
   strategy:
     matrix:
-      Python27-slow:
-        python.version: '2.7'
-        run.slow: 'true'
-      Python27-fast:
-        python.version: '2.7'
-        run.slow: 'false'
       Python37-slow:
         python.version: '3.7'
         run.slow: 'true'
@@ -88,7 +82,7 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
 
-  timeoutInMinutes: 100
+  timeoutInMinutes: 40
 
   variables:
     CI: True
@@ -99,8 +93,6 @@ jobs:
   # Run the pipeline with multiple Python versions
   strategy:
     matrix:
-      #Python27:
-      #  python.version: '2.7'
       Python36-slow:
         python.version: '3.6'
         use.conda: 'yes'

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ PY3 = sys.version_info[0] == 3
 # Taken from the notebook setup.py -- Modified BSD License
 #==============================================================================
 v = sys.version_info
-if v[:2] < (2, 7) or (v[0] >= 3 and v[:2] < (3, 5)):
-    error = "ERROR: Spyder requires Python version 2.7 or 3.5 and above."
+if v[0] >= 3 and v[:2] < (3, 6):
+    error = "ERROR: Spyder 5 requires Python version 3.6 or above."
     print(error, file=sys.stderr)
     sys.exit(1)
 


### PR DESCRIPTION
This is the first (and pretty simple) step to support only Python 3 in Spyder 5. Additionally, our plan is to support only Python 3.6+ in that version.

This will also be helpful to reduce the amount of available slots required to run our tests in each CI service.