### PR TITLE
PR: Remove serialized length limit when sending modified variables back to the kernel

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -22,7 +22,6 @@ dependencies:
 - psutil
 - pygments >=2.0
 - pylint
-- pympler
 - pyqt <5.13
 - python-language-server >=0.31.2,<0.32.0
 - pyxdg

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -17,7 +17,6 @@ pickleshare
 psutil
 pygments >=2.0
 pylint
-pympler
 pyqt <5.13
 python-language-server >=0.31.2,<0.32.0
 pyxdg

--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,6 @@ install_requires = [
     'psutil',
     'pygments>=2.0',
     'pylint',
-    'pympler',
     'pyqt5<5.13;python_version>="3"',
     'pyqtwebengine<5.13;python_version>="3"',
     'python-language-server[all]>=0.31.2,<0.32.0',

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -39,7 +39,6 @@ KEYRING_REQVER = None
 PEXPECT_REQVER = '>=4.4.0'
 PARAMIKO_REQVER = '>=2.4.0'
 PYXDG_REQVER = '>=0.26'
-PYMPLER_REQVER = None
 RTREE_REQVER = '>=0.8.3'
 SYMPY_REQVER = '>=0.7.3'
 CYTHON_REQVER = '>=0.21'
@@ -138,10 +137,6 @@ DEPENDENCIES_BASE = [
      'package_name': "pexpect",
      'features': _("Stdio support for our language server client"),
      'required_version': PEXPECT_REQVER},
-    {'modname': "pympler",
-     'package_name': "pympler",
-     'features': _("Tool to measure the memory behavior of Python objects"),
-     'required_version': PYMPLER_REQVER},
     {'modname': "sympy",
      'package_name': "sympy",
      'features': _("Symbolic mathematics in the IPython Console"),

--- a/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
@@ -46,7 +46,6 @@ class NamepaceBrowserWidget(RichJupyterWidget):
     _kernel_methods = {}
 
     # To save values and messages returned by the kernel
-    _kernel_value = None
     _kernel_is_starting = True
 
     # --- Public API --------------------------------------------------

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -26,7 +26,6 @@ import sys
 import warnings
 
 # Third party imports
-from pympler.asizeof import asizeof
 from qtpy.compat import getsavefilename, to_qvariant
 from qtpy.QtCore import (QAbstractTableModel, QModelIndex, Qt,
                          Signal, Slot)
@@ -1443,15 +1442,7 @@ class RemoteCollectionsEditorTableView(BaseTableView):
     def new_value(self, name, value):
         """Create new value in data"""
         try:
-            # Needed to prevent memory leaks. See spyder-ide/spyder#7158.
-            if asizeof(value) < MAX_SERIALIZED_LENGHT:
-                self.shellwidget.set_value(name, value)
-            else:
-                QMessageBox.warning(self, _("Warning"),
-                                    _("The object you are trying to modify is "
-                                      "too big to be sent back to the kernel. "
-                                      "Therefore, your modifications won't "
-                                      "take place."))
+            self.shellwidget.set_value(name, value)
         except TypeError as e:
             QMessageBox.critical(self, _("Error"),
                                  "TypeError: %s" % to_text_string(e))

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -1438,9 +1438,6 @@ class RemoteCollectionsEditorTableView(BaseTableView):
     def get_value(self, name):
         """Get the value of a variable"""
         value = self.shellwidget.get_value(name)
-        # Reset temporal variable where value is saved to
-        # save memory
-        self.shellwidget._kernel_value = None
         return value
 
     def new_value(self, name, value):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

 - asizeof doesn't seem to work correctly:
```
In [1]: import numpy as np

In [2]: from pympler.asizeof import asizeof

In [3]: val = np.zeros(1000*1000*20)

In [4]: asizeof(val)
Out[4]: 160000096

In [5]: # modify val in the variable explorer

In [6]: asizeof(val)
Out[6]: 96

In [7]: np.shape(val)
Out[7]: (20000000,)

In [8]: 
```

 - If a variable was loaded from the kernel, it should be sent back to the kernel.
 - I am not sure spyder-ide/spyder#7158 still applies with the current architecture anyway.
 - It there must be a limit, it should be implemented at the comms level, not here.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10955


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
