### PR TITLE
PR: Skip test_go_to_definition completely on macOS

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2355,8 +2355,8 @@ def test_preferences_last_page_is_loaded(qtbot, main_window):
 @pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.use_introspection
-@pytest.mark.skipif(os.name == 'nt' or (sys.platform == 'darwin' and PY2),
-                    reason="It times out on Windows and macOS/PY2")
+@pytest.mark.skipif(not sys.platform.startswith('linux'),
+                    reason="It times out too much on Windows and macOS")
 def test_go_to_definition(main_window, qtbot, capsys):
     """Test that go-to-definition works as expected."""
     # --- Code that gives no definition


### PR DESCRIPTION
It times out too much there.