### PR TITLE
PR: Optimize editor scrollflag panel painting

### DIFF
--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -12,8 +12,8 @@ from __future__ import division
 from math import ceil
 
 # Third party imports
-from qtpy.QtCore import QSize, Qt, QRect
-from qtpy.QtGui import QPainter, QBrush, QColor, QCursor
+from qtpy.QtCore import QSize, Qt
+from qtpy.QtGui import QPainter, QColor, QCursor
 from qtpy.QtWidgets import (QStyle, QStyleOptionSlider, QApplication)
 
 # Local imports

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -45,8 +45,8 @@ class ScrollFlagArea(Panel):
             'error': QColor(editor.error_color),
             'todo': QColor(editor.todo_color),
             'breakpoint': QColor(editor.breakpoint_color),
-            'occurrence': editor.occurrence_color,
-            'found_results': editor.found_results_color
+            'occurrence': QColor(editor.occurrence_color),
+            'found_results': QColor(editor.found_results_color)
             }
         self._edgecolors = {key: color.darker(120) for
                             key, color in self._facecolors.items()}
@@ -62,6 +62,7 @@ class ScrollFlagArea(Panel):
         editor.sig_alt_mouse_moved.connect(self.mouseMoveEvent)
         editor.sig_leave_out.connect(self.update)
         editor.sig_flags_changed.connect(self.update)
+        editor.sig_flag_colors_changed.connect(self.update_flag_colors)
 
     @property
     def slider(self):
@@ -71,6 +72,15 @@ class ScrollFlagArea(Panel):
     def sizeHint(self):
         """Override Qt method"""
         return QSize(self.WIDTH, 0)
+
+    def update_flag_colors(self, color_dict):
+        """
+        Update the permanent Qt colors that are used for painting the flags
+        and the slider range with the new colors defined in the given dict.
+        """
+        for name, color in color_dict.items():
+            self._facecolors[name] = QColor(color)
+            self._edgecolors[name] = self._facecolors[name].darker(120)
 
     def paintEvent(self, event):
         """

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -47,21 +47,6 @@ class ScrollFlagArea(Panel):
         """This property holds whether the vertical scrollbar is visible."""
         return self.editor.verticalScrollBar().isVisible()
 
-    @property
-    def offset(self):
-        """This property holds the vertical offset of the scroll flag area
-        relative to the top of the text editor."""
-        vsb = self.editor.verticalScrollBar()
-        style = QApplication.instance().style()
-        opt = QStyleOptionSlider()
-        vsb.initStyleOption(opt)
-
-        # Get the area in which the slider handle may move.
-        groove_rect = style.subControlRect(
-                QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarGroove, self)
-
-        return groove_rect.y()
-
     def sizeHint(self):
         """Override Qt method"""
         return QSize(self.WIDTH, 0)
@@ -169,6 +154,22 @@ class ScrollFlagArea(Panel):
         if event.key() == Qt.Key_Alt:
             self._alt_key_is_down = True
             self.update()
+
+    def get_vertical_offset(self):
+        """
+        Return the vertical offset of the scroll flag area relative to the
+        top of the text editor.
+        """
+        vsb = self.editor.verticalScrollBar()
+        style = QApplication.instance().style()
+        opt = QStyleOptionSlider()
+        vsb.initStyleOption(opt)
+
+        # Get the area in which the slider handle may move.
+        groove_rect = style.subControlRect(
+            QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarGroove, self)
+
+        return groove_rect.y()
 
     def get_scrollbar_position_height(self):
         """Return the pixel span height of the scrollbar area in which

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -62,7 +62,7 @@ class ScrollFlagArea(Panel):
         editor.sig_alt_mouse_moved.connect(self.mouseMoveEvent)
         editor.sig_leave_out.connect(self.update)
         editor.sig_flags_changed.connect(self.update)
-        editor.sig_flag_colors_changed.connect(self.update_flag_colors)
+        editor.sig_theme_colors_changed.connect(self.update_flag_colors)
 
     @property
     def slider(self):

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -42,7 +42,7 @@ class ScrollFlagArea(Panel):
         # and the slider range.
         self._facecolors = {
             'warning': QColor(editor.warning_color),
-            'error': QColor(editor.warning_color),
+            'error': QColor(editor.error_color),
             'todo': QColor(editor.todo_color),
             'breakpoint': QColor(editor.breakpoint_color),
             'occurrence': editor.occurrence_color,

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -34,6 +34,18 @@ class ScrollFlagArea(Panel):
         self._range_indicator_is_visible = False
         self._alt_key_is_down = False
 
+        # Define permanent Qt colors that are needed for painting the flags.
+        self._facecolors = {
+            'warning': QColor(editor.warning_color),
+            'error': QColor(editor.warning_color),
+            'todo': QColor(editor.todo_color),
+            'breakpoint': QColor(editor.breakpoint_color),
+            'occurrence': editor.occurrence_color,
+            'found_results': editor.found_results_color
+            }
+        self._edgecolors = {key: color.darker(120) for
+                            key, color in self._facecolors.items()}
+
         editor.sig_focus_changed.connect(self.update)
         editor.sig_key_pressed.connect(self.keyPressEvent)
         editor.sig_key_released.connect(self.keyReleaseEvent)
@@ -63,19 +75,6 @@ class ScrollFlagArea(Panel):
         rect_w = self.WIDTH - self.FLAGS_DX
         rect_h = self.FLAGS_DY
 
-        warning_color_f = QColor(self.editor.warning_color)
-        warning_color_e = warning_color_f.darker(120)
-        error_color_f = QColor(self.editor.warning_color)
-        error_color_e = error_color_f.darker(120)
-        todo_color_f = QColor(self.editor.todo_color)
-        todo_color_e = todo_color_f.darker(120)
-        breakpoint_color_f = QColor(self.editor.breakpoint_color)
-        breakpoint_color_e = breakpoint_color_f.darker(120)
-        occurrence_color_f = QColor(self.editor.occurrence_color)
-        occurrence_color_e = occurrence_color_f.darker(120)
-        found_results_color_f = QColor(self.editor.found_results_color)
-        found_results_color_e = found_results_color_f.darker(120)
-
         # Fill the whole painting area
         painter = QPainter(self)
         painter.fillRect(event.rect(), self.editor.sideareas_color)
@@ -90,12 +89,12 @@ class ScrollFlagArea(Panel):
                     for source, code, severity, message in data.code_analysis:
                         error = severity == DiagnosticSeverity.ERROR
                         if error:
-                            painter.setBrush(error_color_f)
-                            painter.setPen(error_color_e)
+                            painter.setBrush(self._facecolors['error'])
+                            painter.setPen(self._edgecolors['error'])
                             break
                     else:
-                        painter.setBrush(warning_color_f)
-                        painter.setPen(warning_color_e)
+                        painter.setBrush(self._facecolors['warning'])
+                        painter.setPen(self._edgecolors['warning'])
 
                     rect_y = self.calcul_flag_ypos(
                         line_number, scale_factor, offset)
@@ -104,22 +103,22 @@ class ScrollFlagArea(Panel):
                     # Paint the todos
                     rect_y = self.calcul_flag_ypos(
                         line_number, scale_factor, offset)
-                    painter.setBrush(todo_color_f)
-                    painter.setPen(todo_color_e)
+                    painter.setBrush(self._facecolors['todo'])
+                    painter.setPen(self._edgecolors['todo'])
                     painter.drawRect(rect_x, rect_y, rect_w, rect_h)
                 if data.breakpoint:
-                    painter.setBrush(breakpoint_color_f)
-                    painter.setPen(breakpoint_color_e)
                     # Paint the breakpoints
                     rect_y = self.calcul_flag_ypos(
                         line_number, scale_factor, offset)
+                    painter.setBrush(self._facecolors['breakpoint'])
+                    painter.setPen(self._edgecolors['breakpoint'])
                     painter.drawRect(rect_x, rect_y, rect_w, rect_h)
             block = block.next()
 
         # Paint the occurrences
         if self.editor.occurrences:
-            painter.setBrush(occurrence_color_f)
-            painter.setPen(occurrence_color_e)
+            painter.setBrush(self._facecolors['occurrence'])
+            painter.setPen(self._edgecolors['occurrence'])
             for line_number in self.editor.occurrences:
                 rect_y = self.calcul_flag_ypos(
                     line_number, scale_factor, offset)
@@ -127,8 +126,8 @@ class ScrollFlagArea(Panel):
 
         # Paint the found results
         if self.editor.found_results:
-            painter.setBrush(found_results_color_f)
-            painter.setPen(found_results_color_e)
+            painter.setBrush(self._facecolors['found_results'])
+            painter.setPen(self._edgecolors['found_results'])
             for line_number in self.editor.found_results:
                 rect_y = self.calcul_flag_ypos(
                     line_number, scale_factor, offset)

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -107,7 +107,7 @@ class ScrollFlagArea(Panel):
         cursor_pos = self.mapFromGlobal(QCursor().pos())
         is_over_self = self.rect().contains(cursor_pos)
         is_over_editor = self.editor.rect().contains(
-                self.editor.mapFromGlobal(QCursor().pos()))
+            self.editor.mapFromGlobal(QCursor().pos()))
         # We use QRect.contains instead of QWidget.underMouse method to
         # determined if the cursor is over the editor or the flag scrollbar
         # because the later gives a wrong result when a mouse button
@@ -181,7 +181,7 @@ class ScrollFlagArea(Panel):
 
         # Get the area in which the slider handle may move.
         groove_rect = style.subControlRect(
-                QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarGroove, self)
+            QStyle.CC_ScrollBar, opt, QStyle.SC_ScrollBarGroove, self)
 
         return float(groove_rect.height())
 
@@ -221,7 +221,7 @@ class ScrollFlagArea(Panel):
             # text block with no scaling.
             block = self.editor.document().findBlockByNumber(value)
             top = self.editor.blockBoundingGeometry(block).translated(
-                      self.editor.contentOffset()).top()
+                self.editor.contentOffset()).top()
             bottom = top + self.editor.blockBoundingRect(block).height()
             middle = (top + bottom)/2
 

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -276,10 +276,8 @@ class CodeEditor(TextEditBaseWidget):
     #: Signal emitted when the flags need to be updated in the scrollflagarea
     sig_flags_changed = Signal()
 
-    #: Signal emitted when the colors used to paint the flags in the
-    #  scrollflagarea need to be updated after a change was made to the
-    #  syntax color theme of the editor.
-    sig_flag_colors_changed = Signal(dict)
+    #: Signal emitted when the syntax color theme of the editor.
+    sig_theme_colors_changed = Signal(dict)
 
     #: Signal emitted when a new text is set on the widget
     new_text_set = Signal()
@@ -2058,7 +2056,7 @@ class CodeEditor(TextEditBaseWidget):
             self.edge_line.update_color()
             self.indent_guides.update_color()
 
-            self.sig_flag_colors_changed.emit(
+            self.sig_theme_colors_changed.emit(
                 {'occurrence': self.occurrence_color})
 
     def apply_highlighter_settings(self, color_scheme=None):

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -450,15 +450,18 @@ class CodeEditor(TextEditBaseWidget):
         # Linux Ubuntu. See spyder-ide/spyder#5215.
         self.setVerticalScrollBar(QScrollBar())
 
-        # Scrollbar flag area
-        self.scrollflagarea = self.panels.register(ScrollFlagArea(self),
-                                                   Panel.Position.RIGHT)
-        self.scrollflagarea.hide()
+        # Highlights and flag colors
         self.warning_color = "#FFAD07"
         self.error_color = "#EA2B0E"
         self.todo_color = "#B4D4F3"
         self.breakpoint_color = "#30E62E"
+        self.occurrence_color = QColor(Qt.yellow).lighter(160)
+        self.found_results_color = QColor(Qt.magenta).lighter(180)
 
+        # Scrollbar flag area
+        self.scrollflagarea = self.panels.register(ScrollFlagArea(self),
+                                                   Panel.Position.RIGHT)
+        self.scrollflagarea.hide()
         self.panels.refresh()
 
         self.document_id = id(self)
@@ -497,12 +500,10 @@ class CodeEditor(TextEditBaseWidget):
         self.occurrence_timer.setInterval(1500)
         self.occurrence_timer.timeout.connect(self.__mark_occurrences)
         self.occurrences = []
-        self.occurrence_color = QColor(Qt.yellow).lighter(160)
 
         # Mark found results
         self.textChanged.connect(self.__text_has_changed)
         self.found_results = []
-        self.found_results_color = QColor(Qt.magenta).lighter(180)
 
         # Docstring
         self.writer_docstring = DocstringWriterExtension(self)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -276,6 +276,11 @@ class CodeEditor(TextEditBaseWidget):
     #: Signal emitted when the flags need to be updated in the scrollflagarea
     sig_flags_changed = Signal()
 
+    #: Signal emitted when the colors used to paint the flags in the
+    #  scrollflagarea need to be updated after a change was made to the
+    #  syntax color theme of the editor.
+    sig_flag_colors_changed = Signal(dict)
+
     #: Signal emitted when a new text is set on the widget
     new_text_set = Signal()
 
@@ -2052,6 +2057,9 @@ class CodeEditor(TextEditBaseWidget):
 
             self.edge_line.update_color()
             self.indent_guides.update_color()
+
+            self.sig_flag_colors_changed.emit(
+                {'occurrence': self.occurrence_color})
 
     def apply_highlighter_settings(self, color_scheme=None):
         """Apply syntax highlighter settings"""


### PR DESCRIPTION
## Description of Changes

This makes the painting of the flags a lot more efficient.

However, I get the feeling that the scrollflag is getting updated way to often due to signals sent by the editor. So I think there is still room for improvements on the editor side.

Here is what made the most impacts on improving the performance of the scrollflag panel painting:
- Caching the `QColor` instead of generating them for every flag.
- Passing the `x, y, width, height` values directly to `QPainter.drawRect` instead of creating a `QRect`
- Caching the style pixel metrics instead of calculating them for every flag.

![scrollflag_painting](https://user-images.githubusercontent.com/10170372/70584523-7545bf80-1b8f-11ea-9c4a-359a8b37e3b5.gif)


### Issue(s) Resolved

I think this Fixes #11000, but as I said, there is still room for improvement on the editor side.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin
