### PR TITLE
PR: Set a minimum value for the scrollflag's slider height

### DIFF
--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -226,6 +226,14 @@ class ScrollFlagArea(Panel):
         groove_rect = self.get_scrollbar_groove_rect()
         return groove_rect.y()
 
+    def get_slider_min_height(self):
+        """
+        Return the minimum height of the slider range based on that set for
+        the scroll bar's slider.
+        """
+        return QApplication.instance().style().pixelMetric(
+            QStyle.PM_ScrollBarSliderMin)
+
     def get_scrollbar_groove_rect(self):
         """Return the area in which the slider handle may move."""
         vsb = self.editor.verticalScrollBar()
@@ -298,6 +306,7 @@ class ScrollFlagArea(Panel):
         vsb = self.editor.verticalScrollBar()
         slider_height = self.value_to_position(
             vsb.pageStep(), scale_factor, offset) - offset
+        slider_height = max(slider_height, self.get_slider_min_height())
 
         # Calcul the minimum and maximum y-value to constraint the slider
         # range indicator position to the height span of the scrollbar area


### PR DESCRIPTION
## Description of Changes

Set the minimum height of the srollflag slider to the pixel metric set in the style for the scrollbar's slider.

![image](https://user-images.githubusercontent.com/10170372/70745870-c5896280-1cf2-11ea-87ee-f56598d60369.png)

### Issue(s) Resolved

Fixes #11050


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin
