### PR TITLE
WIP: Fix copying or duplicating multiple selected lines

### DIFF
--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -617,6 +617,7 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         """Duplicate current line or selected text"""
         cursor = self.textCursor()
         cursor.beginEditBlock()
+        cur_pos = cursor.position()
         start_pos, end_pos = self.__save_selection()
         end_pos_orig = end_pos
         if to_text_string(cursor.selectedText()):
@@ -648,11 +649,15 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
             cursor.movePosition(QTextCursor.StartOfBlock)
             start_pos += len(text)
             end_pos_orig += len(text)
+            cur_pos += len(text)
 
         cursor.insertText(text)
         cursor.endEditBlock()
         self.setTextCursor(cursor)
-        self.__restore_selection(start_pos, end_pos_orig)
+        if cur_pos == start_pos:
+            self.__restore_selection(end_pos_orig, start_pos)
+        else:
+            self.__restore_selection(start_pos, end_pos_orig)
 
     def duplicate_line(self):
         """

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -618,6 +618,7 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         cursor = self.textCursor()
         cursor.beginEditBlock()
         start_pos, end_pos = self.__save_selection()
+        end_pos_orig = end_pos
         if to_text_string(cursor.selectedText()):
             cursor.setPosition(end_pos)
             # Check if end_pos is at the start of a block: if so, starting
@@ -646,12 +647,12 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
             cursor.setPosition(start_pos)
             cursor.movePosition(QTextCursor.StartOfBlock)
             start_pos += len(text)
-            end_pos += len(text)
+            end_pos_orig += len(text)
 
         cursor.insertText(text)
         cursor.endEditBlock()
         self.setTextCursor(cursor)
-        self.__restore_selection(start_pos, end_pos)
+        self.__restore_selection(start_pos, end_pos_orig)
 
     def duplicate_line(self):
         """


### PR DESCRIPTION
## Description of Changes

@ccordoba12 Ok, so the fix for this is pretty straightforward. I also fixed an issue where the position of the cursor was not preserved after duplicating or copying current line or selected text. I also would like to add a test since this feature doesn't seemed to be covered by one.

However, as you can see in the animation below, there is a glitch that is clearly noticeable when duplicating due to the fact that text selection gets automatically expanded when inserting text at the current position of the cursor. That, is not easy to fix...

After some efforts, I found a workaround that allow to avoid the glitch that I have implemented in my third commit. I don't like workarounds, but I haven't been able to find a better way. Maybe I've missed something... Anyway, feel free to reject this workaround if you don't like it. I will simply revert the commit.

Without the workaround: 

![duplicate_line_glitch](https://user-images.githubusercontent.com/10170372/70855403-4cc40b00-1e98-11ea-9063-a55608dcdd25.gif)

With the workaround: 

![duplicate_line_glitch_2](https://user-images.githubusercontent.com/10170372/70855473-471af500-1e99-11ea-900e-863cabbbfc24.gif)

### Issue(s) Resolved

Fixes #11070


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin
