### PR TITLE
PR: Handle CompletionWidget position when undocking editor

### DIFF
--- a/spyder/api/plugins.py
+++ b/spyder/api/plugins.py
@@ -523,3 +523,9 @@ class SpyderPluginWidget(SpyderPlugin, BasePluginWidget):
             self.dockwidget.raise_()
         else:
             self.dockwidget.hide()
+
+    def set_ancestor(self, ancestor):
+        """
+        Needed to update the ancestor/parent of child widgets when undocking.
+        """
+        pass

--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -131,6 +131,7 @@ class PluginWindow(QMainWindow):
 
     def closeEvent(self, event):
         """Reimplement Qt method."""
+        self.plugin.set_ancestor(self.plugin.main)
         self.plugin.dockwidget.setWidget(self.plugin)
         self.plugin.dockwidget.setVisible(True)
         self.plugin.switch_to_plugin()
@@ -356,7 +357,7 @@ class BasePluginWidgetMixin(object):
         window.setCentralWidget(self)
         window.resize(self.size())
         self.refresh_plugin()
-
+        self.set_ancestor(window)
         self.dockwidget.setFloating(False)
         self.dockwidget.setVisible(False)
 

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1115,7 +1115,9 @@ class Editor(SpyderPluginWidget):
         for editorstack in self.editorstacks:
             for finfo in editorstack.data:
                 comp_widget = finfo.editor.completion_widget
+                kite_call_to_action = finfo.editor.kite_call_to_action
                 comp_widget.setParent(ancestor)
+                kite_call_to_action.setParent(ancestor)
 
     def _create_checkable_action(self, text, conf_name, method=''):
         """Helper function to create a checkable action.

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1103,6 +1103,20 @@ class Editor(SpyderPluginWidget):
                 comp_widget.setup_appearance(completion_size, font)
                 kite_call_to_action.setFont(font)
 
+    def set_ancestor(self, ancestor):
+        """
+        Set ancestor of child widgets like the CompletionWidget.
+
+        Needed to properly set position of the widget based on the correct
+        parent/ancestor.
+
+        See spyder-ide/spyder#11076
+        """
+        for editorstack in self.editorstacks:
+            for finfo in editorstack.data:
+                comp_widget = finfo.editor.completion_widget
+                comp_widget.setParent(ancestor)
+
     def _create_checkable_action(self, text, conf_name, method=''):
         """Helper function to create a checkable action.
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

![undock](https://user-images.githubusercontent.com/16781833/70965924-5ea3da80-205f-11ea-9371-b4acda51c693.gif)



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11076 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
