### PR TITLE
PR: Fix creation of config files for external plugins

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -614,4 +614,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '53.3.0'
+CONF_VERSION = '54.0.0'

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -16,6 +16,7 @@ import os.path as osp
 from spyder.config.base import _, get_conf_paths, get_conf_path, get_home_dir
 from spyder.config.main import CONF_VERSION, DEFAULTS, NAME_MAP
 from spyder.config.user import UserConfig, MultiUserConfig, NoDefault
+from spyder.utils.programs import check_version
 
 
 EXTRA_VALID_SHORTCUT_CONTEXTS = [
@@ -104,7 +105,29 @@ class ConfigurationManager(object):
                 backup=True,
                 raw_mode=True,
                 remove_obsolete=False,
+                external_plugin=True
             )
+
+            # Recreate external plugin configs to deal with part two
+            # (the shortcut confliftcs) of spyder-ide/spyder#11132
+            spyder_config = self._user_config._configs_map['spyder']
+            if check_version(spyder_config._old_version, '54.0.0', '<'):
+                # Remove all previous .ini files
+                plugin_config.cleanup()
+
+                # Recreate config
+                plugin_config = MultiUserConfig(
+                    name_map,
+                    path=path,
+                    defaults=defaults,
+                    load=True,
+                    version=version,
+                    backup=True,
+                    raw_mode=True,
+                    remove_obsolete=False,
+                    external_plugin=True
+                )
+
             self._plugin_configs[conf_section] = (plugin_class, plugin_config)
 
     def remove_deprecated_config_locations(self):

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -109,7 +109,7 @@ class ConfigurationManager(object):
             )
 
             # Recreate external plugin configs to deal with part two
-            # (the shortcut confliftcs) of spyder-ide/spyder#11132
+            # (the shortcut conflicts) of spyder-ide/spyder#11132
             spyder_config = self._user_config._configs_map['spyder']
             if check_version(spyder_config._old_version, '54.0.0', '<'):
                 # Remove all previous .ini files

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -113,7 +113,10 @@ class ConfigurationManager(object):
             spyder_config = self._user_config._configs_map['spyder']
             if check_version(spyder_config._old_version, '54.0.0', '<'):
                 # Remove all previous .ini files
-                plugin_config.cleanup()
+                try:
+                    plugin_config.cleanup()
+                except EnvironmentError:
+                    pass
 
                 # Recreate config
                 plugin_config = MultiUserConfig(

--- a/spyder/config/tests/test_manager.py
+++ b/spyder/config/tests/test_manager.py
@@ -8,6 +8,7 @@
 
 # Standard library imports
 import os
+import os.path as osp
 import shutil
 import tempfile
 
@@ -15,8 +16,10 @@ import tempfile
 import pytest
 
 # Local imports
-from spyder.config.base import get_conf_paths
+from spyder.config.base import get_conf_path, get_conf_paths
 from spyder.config.manager import ConfigurationManager
+from spyder.plugins.console.plugin import Console
+from spyder.py3compat import configparser
 
 
 def clear_site_config():
@@ -31,6 +34,7 @@ def test_site_config_load():
     precedence.
     """
     clear_site_config()
+
     for i, path in enumerate(reversed(get_conf_paths())):
         exp_value = 100*(1 + i)
         content = '[main]\nmemory_usage/timeout = ' + str(exp_value) + '\n'
@@ -44,8 +48,78 @@ def test_site_config_load():
         value = config.get('main', 'memory_usage/timeout')
 
         print(path, value, exp_value)
-
         assert value == exp_value
+
+    clear_site_config()
+
+
+def test_external_plugin_config(qtbot):
+    """
+    Test that config for external plugins is saved as expected.
+
+    This includes a regression for issue spyder-ide/spyder#11132
+    """
+    clear_site_config()
+
+    # Emulate an old Spyder 3 configuration
+    spy3_config = """
+[main]
+version = 1.0.0
+
+[shortcuts]
+foo/bar = Alt+1
+
+[ipython_console]
+startup/run_lines =
+"""
+    conf_fpath = get_conf_path('spyder.ini')
+    with open(conf_fpath, 'w') as f:
+        f.write(spy3_config)
+
+    # Create config manager
+    manager = ConfigurationManager()
+
+    # Set default options for the internal console
+    Console.CONF_FILE = True
+    defaults = [
+        ('internal_console',
+         {
+            'max_line_count': 300,
+            'working_dir_history': 30,
+            'working_dir_adjusttocontents': False,
+            'wrap': True,
+            'codecompletion/auto': False,
+            'external_editor/path': 'SciTE',
+            'external_editor/gotoline': '-goto:'
+         }
+        ),
+    ]
+    Console.CONF_DEFAULTS = defaults
+
+    # Register console plugin config
+    manager.register_plugin(Console)
+
+    # Assert the dummy shortcut is not present in the plugin config
+    with pytest.raises(configparser.NoSectionError):
+        manager.get_shortcut('foo', 'bar', plugin_name='internal_console')
+
+    # Change an option in the console
+    console = Console()
+    console.set_option('max_line_count', 600)
+
+    # Read config filew directly
+    user_path = manager.get_user_config_path()
+    with open(osp.join(user_path, 'spyder.ini'), 'r') as f:
+        user_contents = f.read()
+
+    plugin_path = manager.get_plugin_config_path('internal_console')
+    with open(osp.join(plugin_path, 'spyder.ini'), 'r') as f:
+        plugin_contents = f.read()
+
+    # Assert that the change was written to the right config file
+    assert 'max_line_count = 600' not in user_contents
+    assert 'max_line_count = 600' in plugin_contents
+
     clear_site_config()
 
 

--- a/spyder/config/tests/test_manager.py
+++ b/spyder/config/tests/test_manager.py
@@ -121,6 +121,8 @@ startup/run_lines =
     assert 'max_line_count = 600' not in user_contents
     assert 'max_line_count = 600' in plugin_contents
 
+    shutil.rmtree(plugin_path)
+    Console.CONF_FILE = False
     clear_site_config()
 
 

--- a/spyder/config/tests/test_manager.py
+++ b/spyder/config/tests/test_manager.py
@@ -57,7 +57,8 @@ def test_external_plugin_config(qtbot):
     """
     Test that config for external plugins is saved as expected.
 
-    This includes a regression for issue spyder-ide/spyder#11132
+    This includes a regression for part two (the shortcuts conflict) of
+    issue spyder-ide/spyder#11132
     """
     clear_site_config()
 

--- a/spyder/config/user.py
+++ b/spyder/config/user.py
@@ -983,7 +983,7 @@ class MultiUserConfig(object):
 
     def cleanup(self):
         """Remove .ini files associated to configurations."""
-        for config in self._configs_map:
+        for _, config in self._configs_map.items():
             os.remove(config.get_config_fpath())
 
 

--- a/spyder/config/user.py
+++ b/spyder/config/user.py
@@ -813,7 +813,11 @@ class MultiUserConfig(object):
                     if sec_opt not in sections_options:
                         sections_options.append(sec_opt)
                     else:
-                        raise ValueError('Different files are holding the same section/option: "{}/{}"!'.format(section, option))
+                        error_msg = (
+                            'Different files are holding the same '
+                            'section/option: "{}/{}"!'.format(section, option)
+                        )
+                        raise ValueError(error_msg)
         return name_map
 
     @staticmethod

--- a/spyder/config/user.py
+++ b/spyder/config/user.py
@@ -182,7 +182,8 @@ class UserConfig(DefaultsConfig):
     DEFAULT_SECTION_NAME = 'main'
 
     def __init__(self, name, path, defaults=None, load=True, version=None,
-                 backup=False, raw_mode=False, remove_obsolete=False):
+                 backup=False, raw_mode=False, remove_obsolete=False,
+                 external_plugin=False):
         """UserConfig class, based on ConfigParser."""
         super(UserConfig, self).__init__(name=name, path=path)
 
@@ -191,8 +192,9 @@ class UserConfig(DefaultsConfig):
         self._backup = backup
         self._raw = 1 if raw_mode else 0
         self._remove_obsolete = remove_obsolete
-        self._module_source_path = get_module_source_path('spyder')
+        self._external_plugin = external_plugin
 
+        self._module_source_path = get_module_source_path('spyder')
         self._defaults_folder = 'defaults'
         self._backup_folder = 'backups'
         self._backup_suffix = '.bak'
@@ -329,7 +331,6 @@ class UserConfig(DefaultsConfig):
             else:
                 # Python 3
                 self.read(fpath, encoding='utf-8')
-
         except cp.MissingSectionHeaderError:
             error_text = 'Warning: File contains no section headers.'
             print(error_text)  # spyder: test-skip
@@ -632,12 +633,21 @@ class SpyderUserConfig(UserConfig):
         Return the last configuration file used if found.
         """
         fpath = self.get_config_fpath()
-        previous_paths = [
-            # >= 51.0.0
-            fpath,
-            # < 51.0.0
-            os.path.join(get_conf_path(), 'spyder.ini'),
-        ]
+
+        # We don't need to add the contents of the old spyder.ini to
+        # the configuration of external plugins. This was the cause
+        # of  part two (the shortcut conflicts) of issue
+        # spyder-ide/spyder#11132
+        if self._external_plugin:
+            previous_paths = [fpath]
+        else:
+            previous_paths = [
+                # >= 51.0.0
+                fpath,
+                # < 51.0.0
+                os.path.join(get_conf_path(), 'spyder.ini'),
+            ]
+
         for fpath in previous_paths:
             if osp.isfile(fpath):
                 break
@@ -652,7 +662,7 @@ class SpyderUserConfig(UserConfig):
 
         If no version is provided, it returns the current file path.
         """
-        if version is None:
+        if version is None or self._external_plugin:
             fpath = self.get_config_fpath()
         elif check_version(version, '51.0.0', '<'):
             fpath = osp.join(get_conf_path(), 'spyder.ini')
@@ -710,6 +720,8 @@ class SpyderUserConfig(UserConfig):
         """
         self._update_defaults(self.defaults, old_version)
 
+        if self._external_plugin:
+            return
         if old_version and check_version(old_version, '44.1.0', '<'):
             run_lines = to_text_string(self.get('ipython_console',
                                                 'startup/run_lines'))
@@ -731,7 +743,8 @@ class MultiUserConfig(object):
     DEFAULT_FILE_NAME = 'spyder'
 
     def __init__(self, name_map, path, defaults=None, load=True, version=None,
-                 backup=False, raw_mode=False, remove_obsolete=False):
+                 backup=False, raw_mode=False, remove_obsolete=False,
+                 external_plugin=False):
         """Multi user config class based on UserConfig class."""
         self._name_map = self._check_name_map(name_map)
         self._path = path
@@ -741,6 +754,7 @@ class MultiUserConfig(object):
         self._backup = backup
         self._raw_mode = 1 if raw_mode else 0
         self._remove_obsolete = remove_obsolete
+        self._external_plugin = external_plugin
 
         self._configs_map = {}
         self._config_defaults_map = self._get_defaults_for_name_map(defaults,
@@ -753,6 +767,7 @@ class MultiUserConfig(object):
             'backup': backup,
             'raw_mode': raw_mode,
             'remove_obsolete': False,  # This will be handled later on if True
+            'external_plugin': external_plugin
         }
 
         for name in name_map:

--- a/spyder/plugins/console/plugin.py
+++ b/spyder/plugins/console/plugin.py
@@ -77,7 +77,8 @@ class Console(SpyderPluginWidget):
         self.find_widget = FindReplace(self)
         self.find_widget.set_editor(self.shell)
         self.find_widget.hide()
-        self.register_widget_shortcuts(self.find_widget)
+        if parent is not None:
+            self.register_widget_shortcuts(self.find_widget)
 
         # Main layout
         btn_layout = QHBoxLayout()


### PR DESCRIPTION
The previous code was mixing the contents of the old Spyder 3 ini file with the configuration of the plugin itself. This was what was causing the shortcuts conflict reported on issue #11132.

This PR removes all previous config files for external plugins and regenerates them again once when users start 4.0.1 for the first time.

Fixes #11132