### PR TITLE
PR: Remove password-based authentication from the Github login dialog

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -93,7 +93,6 @@ DEFAULTS = [
               'toolbars_visible': True,
               'cursor/width': 2,
               'completion/size': (300, 180),
-              'report_error/remember_me': False,
               'report_error/remember_token': False,
               }),
             ('quick_layouts',
@@ -614,4 +613,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '54.0.0'
+CONF_VERSION = '55.0.0'

--- a/spyder/widgets/github/backend.py
+++ b/spyder/widgets/github/backend.py
@@ -136,8 +136,7 @@ class GithubBackend(BaseBackend):
             url = self.upload_log_file(application_log)
             body += '\nApplication log: %s' % url
         try:
-            if token:
-                gh = github.GitHub(access_token=token)
+            gh = github.GitHub(access_token=token)
             repo = gh.repos(self.gh_owner)(self.gh_repo)
             ret = repo.issues.post(title=title, body=body)
         except github.ApiError as e:
@@ -214,8 +213,10 @@ class GithubBackend(BaseBackend):
                                           'again.'))
 
         if not running_under_pytest():
-            credentials = DlgGitHubLogin.login(self.parent_widget,
-                token, remember_token)
+            credentials = DlgGitHubLogin.login(
+                self.parent_widget,
+                token,
+                remember_token)
 
             if credentials['token'] and valid_py_os:
                 self._store_token(credentials['token'],
@@ -223,7 +224,7 @@ class GithubBackend(BaseBackend):
                 CONF.set('main', 'report_error/remember_token',
                          credentials['remember_token'])
         else:
-            return dict(token='',
+            return dict(token=token,
                         remember_token=remember_token)
 
         return credentials

--- a/spyder/widgets/github/backend.py
+++ b/spyder/widgets/github/backend.py
@@ -124,13 +124,10 @@ class GithubBackend(BaseBackend):
 
         # Credentials
         credentials = self.get_user_credentials()
-        username = credentials['username']
-        password = credentials['password']
-        remember = credentials['remember']
         token = credentials['token']
         remember_token = credentials['remember_token']
 
-        if username is None and password is None and token is None:
+        if token is None:
             return False
         _logger().debug('got user credentials')
 
@@ -141,8 +138,6 @@ class GithubBackend(BaseBackend):
         try:
             if token:
                 gh = github.GitHub(access_token=token)
-            else:
-                gh = github.GitHub(username=username, password=password)
             repo = gh.repos(self.gh_owner)(self.gh_repo)
             ret = repo.issues.post(title=title, body=body)
         except github.ApiError as e:
@@ -179,31 +174,8 @@ class GithubBackend(BaseBackend):
 
     def _get_credentials_from_settings(self):
         """Get the stored credentials if any."""
-        remember_me = CONF.get('main', 'report_error/remember_me')
         remember_token = CONF.get('main', 'report_error/remember_token')
-        username = CONF.get('main', 'report_error/username', '')
-        if not remember_me:
-            username = ''
-
-        return username, remember_me, remember_token
-
-    def _store_credentials(self, username, password, remember=False):
-        """Store credentials for future use."""
-        if username and password and remember:
-            CONF.set('main', 'report_error/username', username)
-            try:
-                keyring.set_password('github', username, password)
-            except Exception:
-                if self._show_msgbox:
-                    QMessageBox.warning(self.parent_widget,
-                                        _('Failed to store password'),
-                                        _('It was not possible to securely '
-                                          'save your password. You will be '
-                                          'prompted for your Github '
-                                          'credentials next time you want '
-                                          'to report an issue.'))
-                remember = False
-        CONF.set('main', 'report_error/remember_me', remember)
+        return remember_token
 
     def _store_token(self, token, remember=False):
         """Store token for future use."""
@@ -225,23 +197,9 @@ class GithubBackend(BaseBackend):
 
     def get_user_credentials(self):
         """Get user credentials with the login dialog."""
-        password = None
         token = None
-        (username, remember_me,
-         remember_token) = self._get_credentials_from_settings()
+        remember_token = self._get_credentials_from_settings()
         valid_py_os = not (PY2 and sys.platform.startswith('linux'))
-        if username and remember_me and valid_py_os:
-            # Get password from keyring
-            try:
-                password = keyring.get_password('github', username)
-            except Exception:
-                # No safe keyring backend
-                if self._show_msgbox:
-                    QMessageBox.warning(self.parent_widget,
-                                        _('Failed to retrieve password'),
-                                        _('It was not possible to retrieve '
-                                          'your password. Please introduce '
-                                          'it again.'))
         if remember_token and valid_py_os:
             # Get token from keyring
             try:
@@ -256,17 +214,8 @@ class GithubBackend(BaseBackend):
                                           'again.'))
 
         if not running_under_pytest():
-            credentials = DlgGitHubLogin.login(self.parent_widget, username,
-                                            password, token, remember_me,
-                                            remember_token)
-
-            if (credentials['username'] and credentials['password'] and
-                    valid_py_os):
-                self._store_credentials(credentials['username'],
-                                        credentials['password'],
-                                        credentials['remember'])
-                CONF.set('main', 'report_error/remember_me',
-                         credentials['remember'])
+            credentials = DlgGitHubLogin.login(self.parent_widget,
+                token, remember_token)
 
             if credentials['token'] and valid_py_os:
                 self._store_token(credentials['token'],
@@ -274,10 +223,7 @@ class GithubBackend(BaseBackend):
                 CONF.set('main', 'report_error/remember_token',
                          credentials['remember_token'])
         else:
-            return dict(username=username,
-                        password=password,
-                        token='',
-                        remember=remember_me,
+            return dict(token='',
                         remember_token=remember_token)
 
         return credentials

--- a/spyder/widgets/github/tests/test_github_backend.py
+++ b/spyder/widgets/github/tests/test_github_backend.py
@@ -24,8 +24,7 @@ from spyder.py3compat import PY2
 from spyder.widgets.github import backend
 
 
-USERNAME = 'tester'
-PASSWORD = 'test1234'
+TOKEN = 'token1234'
 GH_OWNER = 'ccordoba12'
 GH_REPO = 'spyder'
 
@@ -47,10 +46,7 @@ def get_wrong_user_credentials():
     Monkeypatch GithubBackend.get_user_credentials to force the case where
     invalid credentias were provided
     """
-    return dict(username='invalid',
-                password='invalid',
-                token='invalid',
-                remember=False,
+    return dict(token='invalid',
                 remember_token=False)
 
 
@@ -59,10 +55,7 @@ def get_empty_user_credentials():
     Monkeypatch GithubBackend.get_user_credentials to force the case where
     invalid credentias were provided
     """
-    return dict(username='',
-                password='',
-                token='',
-                remember=False,
+    return dict(token='',
                 remember_token=False)
 
 
@@ -71,10 +64,7 @@ def get_fake_user_credentials():
     Monkeypatch GithubBackend.get_user_credentials to force the case where
     invalid credentias were provided
     """
-    return dict(username=USERNAME,
-                password=PASSWORD,
-                token='',
-                remember=False,
+    return dict(token=TOKEN,
                 remember_token=False)
 
 
@@ -101,18 +91,12 @@ def test_fake_credentials_bad_repo():
 
 def test_get_credentials_from_settings():
     b = get_backend()
-    username, remember_me, remember_token = b._get_credentials_from_settings()
-    assert username == ''
-    assert remember_me is False
+    remember_token = b._get_credentials_from_settings()
     assert remember_token is False
 
-    CONF.set('main', 'report_error/username', 'user')
-    CONF.set('main', 'report_error/remember_me', True)
     CONF.set('main', 'report_error/remember_token', True)
 
-    username, remember_me, remember_token = b._get_credentials_from_settings()
-    assert username == 'user'
-    assert remember_me is True
+    remember_token = b._get_credentials_from_settings()
     assert remember_token is True
 
 
@@ -123,9 +107,8 @@ def test_get_credentials_from_settings():
                             "CIs and skip it locally on Linux and Python 2"))
 def test_store_user_credentials():
     b = get_backend()
-    b._store_credentials('user', 'toto', True)
+    b._store_token('token', True)
     credentials = b.get_user_credentials()
 
-    assert credentials['username'] == 'user'
-    assert credentials['password'] == 'toto'
-    assert credentials['remember'] is True
+    assert credentials['token'] == 'token'
+    assert credentials['remember_token'] is True

--- a/spyder/widgets/github/tests/test_github_login.py
+++ b/spyder/widgets/github/tests/test_github_login.py
@@ -22,7 +22,7 @@ from spyder.widgets.github.gh_login import DlgGitHubLogin
 @pytest.fixture
 def github_dialog(qtbot):
     """Set up error report dialog."""
-    widget = DlgGitHubLogin(None, None, None, None)
+    widget = DlgGitHubLogin(None, None)
     qtbot.addWidget(widget)
     return widget
 
@@ -37,29 +37,7 @@ def test_dialog(github_dialog, qtbot):
     # Assert Sign in button is disabled at first
     assert not dlg.bt_sign_in.isEnabled()
 
-    # Introduce Username
-    qtbot.keyClicks(dlg.le_user, 'user')
-
-    # Assert Sign in button is still disabled
-    assert not dlg.bt_sign_in.isEnabled()
-
-    # Introduce now password
-    qtbot.keyClicks(dlg.le_password, 'password')
-
-    # Assert Sign in button is enabled
-    assert dlg.bt_sign_in.isEnabled()
-
-    # Remove user and password
-    dlg.le_user.selectAll()
-    dlg.le_user.cut()
-    dlg.le_password.selectAll()
-    dlg.le_user.cut()
-
-    # Assert Sign in is disabled
-    assert not dlg.bt_sign_in.isEnabled()
-
-    # Change tab and add token
-    dlg.tabs.setCurrentIndex(1)
+    # Add token
     qtbot.keyClicks(dlg.le_token, 'token')
 
     # Assert Sign in button is enabled


### PR DESCRIPTION
That's going to be removed by Github in the future for external applications, so it's better for us to do it right now.

This is how things look now:

![Selección_075](https://user-images.githubusercontent.com/365293/71675014-d4d85a80-2d4a-11ea-8a87-de93b8bea386.png)

Fixes #11059.