### PR TITLE
PR: Handle encoding when restarting Spyder to fix an error with Python 2.7

### DIFF
--- a/spyder/app/restart.py
+++ b/spyder/app/restart.py
@@ -28,7 +28,7 @@ from qtpy.QtWidgets import QApplication, QMessageBox, QSplashScreen, QWidget
 
 # Local imports
 from spyder.config.base import _, get_image_path
-from spyder.py3compat import to_text_string
+from spyder.utils.encoding import to_unicode
 from spyder.utils.qthelpers import qapplication
 from spyder.config.manager import CONF
 
@@ -52,7 +52,7 @@ def _is_pid_running_on_windows(pid):
                                stderr=subprocess.STDOUT,
                                startupinfo=startupinfo)
     stdoutdata, stderrdata = process.communicate()
-    stdoutdata = to_text_string(stdoutdata)
+    stdoutdata = to_unicode(stdoutdata)
     process.kill()
     check = pid in stdoutdata
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->


Handle encoding to prevent an `UnicodeDecodeError` when restarting (in Python 2.7)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11024


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
