### PR TITLE
PR: Handle AttributeError when generating context menu on dockwidget tabs

### DIFF
--- a/spyder/widgets/dock.py
+++ b/spyder/widgets/dock.py
@@ -49,11 +49,16 @@ class TabFilter(QObject):
         self.from_index = self.dock_tabbar.tabAt(event.pos())
         self.dock_tabbar.setCurrentIndex(self.from_index)
 
-        if event.button() == Qt.RightButton:
-            if self.from_index == -1:
-                self.show_nontab_menu(event)
-            else:
-                self.show_tab_menu(event)
+        try:
+            if event.button() == Qt.RightButton:
+                if self.from_index == -1:
+                    self.show_nontab_menu(event)
+                else:
+                    self.show_tab_menu(event)
+        except AttributeError:
+            # Needed to avoid an AttributeError will right-clicking for
+            # the context menu. See spyder-ide/spyder#11226
+            pass
 
     def show_tab_menu(self, event):
         """Show the context menu assigned to tabs."""

--- a/spyder/widgets/dock.py
+++ b/spyder/widgets/dock.py
@@ -56,8 +56,9 @@ class TabFilter(QObject):
                 else:
                     self.show_tab_menu(event)
         except AttributeError:
-            # Needed to avoid an AttributeError will right-clicking for
-            # the context menu. See spyder-ide/spyder#11226
+            # Needed to avoid an error when generating the
+            # context menu on top of the tab.
+            # See spyder-ide/spyder#11226
             pass
 
     def show_tab_menu(self, event):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Handle `AttributeError` when pressing dock tabs


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11226 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
