### PR TITLE
PR: Cache call to get_icon_by_extension_or_type

### DIFF
--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -45,6 +45,8 @@ DOCUMENT_FILES = {'vnd.ms-powerpoint': 'PowerpointFileIcon',
 OFFICE_FILES = {'.xlsx': 'ExcelFileIcon', '.docx': 'WordFileIcon',
                 '.pptx': 'PowerpointFileIcon'}
 
+ICONS_BY_EXTENSION = {}
+
 # Magnification factors for attribute icons
 # per platform
 if sys.platform.startswith('linux'):
@@ -419,10 +421,8 @@ def get_icon_by_extension_or_type(fname, scale_factor):
     if osp.isdir(fname):
         extension = "Folder"
 
-    icon_dict = get_icon_by_extension_or_type._icon_dict
-
-    if (extension, scale_factor) in icon_dict:
-        return icon_dict[(extension, scale_factor)]
+    if (extension, scale_factor) in ICONS_BY_EXTENSION:
+        return ICONS_BY_EXTENSION[(extension, scale_factor)]
 
     if osp.isdir(fname):
         icon_by_extension = icon('DirOpenIcon', scale_factor)
@@ -468,11 +468,9 @@ def get_icon_by_extension_or_type(fname, scale_factor):
                     if bin_name in application_icons:
                         icon_by_extension = icon(
                             application_icons[bin_name], scale_factor)
-    icon_dict[(extension, scale_factor)] = icon_by_extension
+
+    ICONS_BY_EXTENSION[(extension, scale_factor)] = icon_by_extension
     return icon_by_extension
-
-
-get_icon_by_extension_or_type._icon_dict = {}
 
 
 def base64_from_icon(icon_name, width, height):

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -411,12 +411,22 @@ def get_icon_by_extension_or_type(fname, scale_factor):
     application_icons = {}
     application_icons.update(BIN_FILES)
     application_icons.update(DOCUMENT_FILES)
+
+    basename = osp.basename(fname)
+    __, extension = osp.splitext(basename.lower())
+    mime_type, __ = mime.guess_type(basename)
+
     if osp.isdir(fname):
-        return icon('DirOpenIcon', scale_factor)
+        extension = "Folder"
+
+    icon_dict = get_icon_by_extension_or_type._icon_dict
+
+    if (extension, scale_factor) in icon_dict:
+        return icon_dict[(extension, scale_factor)]
+
+    if osp.isdir(fname):
+        icon_by_extension = icon('DirOpenIcon', scale_factor)
     else:
-        basename = osp.basename(fname)
-        __, extension = osp.splitext(basename.lower())
-        mime_type, __ = mime.guess_type(basename)
         icon_by_extension = get_icon('binary', adjust_for_interface=True)
 
         if extension in OFFICE_FILES:
@@ -458,7 +468,11 @@ def get_icon_by_extension_or_type(fname, scale_factor):
                     if bin_name in application_icons:
                         icon_by_extension = icon(
                             application_icons[bin_name], scale_factor)
+    icon_dict[(extension, scale_factor)] = icon_by_extension
     return icon_by_extension
+
+
+get_icon_by_extension_or_type._icon_dict = {}
 
 
 def base64_from_icon(icon_name, width, height):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
`get_icon_by_extension_or_type` is really slow for some files types. Here, I am caching the results to the calls.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11247 (Makes things better)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
