### PR TITLE
PR: Fix snippets completion with a single token with placeholder

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -18,4 +18,3 @@ matplotlib
 cython
 flaky
 coverage <5.0
-rtree

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -18,3 +18,4 @@ matplotlib
 cython
 flaky
 coverage <5.0
+rtree

--- a/spyder/plugins/completion/languageserver/tests/conftest.py
+++ b/spyder/plugins/completion/languageserver/tests/conftest.py
@@ -16,6 +16,7 @@ from spyder.utils.qthelpers import qapplication
 app = qapplication()
 
 from qtpy.QtCore import QObject, Signal, Slot
+from qtpy.QtWidgets import QWidget
 import pytest
 from pytestqt.plugin import QtBot
 
@@ -63,9 +64,26 @@ class ProjectsMock(QObject):
 
 
 class MainWindowMock(QObject):
-    """Mock for the Main Window."""
+    """Mock for the Main Window as a widget."""
     def __init__(self):
         QObject.__init__(self)
+        self.editor = EditorMock()
+        self.projects = ProjectsMock()
+
+    def __getattr__(self, attr):
+        if attr == 'editor':
+            return self.editor
+        elif attr == 'projects':
+            # TODO: Add tests for project switching
+            return self.projects
+        else:
+            return Mock()
+
+
+class MainWindowWidgetMock(QWidget):
+    """Mock for the Main Window."""
+    def __init__(self):
+        QWidget.__init__(self)
         self.editor = EditorMock()
         self.projects = ProjectsMock()
 

--- a/spyder/plugins/editor/extensions/snippets.py
+++ b/spyder/plugins/editor/extensions/snippets.py
@@ -486,7 +486,7 @@ class SnippetsExtension(EditorExtension):
                 if isinstance(possible_snippet, nodes.SnippetASTNode):
                     # Placeholder replacement
                     first_tokens = (
-                        list(possible_snippet.placeholder) +
+                        list(possible_snippet.placeholder.tokens) +
                         list(new_node.tokens[1:])
                     )
                     second_tokens = []

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -780,7 +780,6 @@ def test_kite_code_snippets(kite_codeeditor, qtbot):
     # Insert completion
     qtbot.keyPress(completion, Qt.Key_Tab)
     assert snippets.is_snippet_active
-    # assert code_editor.has_selected_text()
 
     # Get code selected text
     cursor = code_editor.textCursor()
@@ -795,8 +794,7 @@ def test_kite_code_snippets(kite_codeeditor, qtbot):
                           timeout=10000) as sig2:
         qtbot.keyPress(code_editor, Qt.Key_Space, modifier=Qt.ControlModifier,
                        delay=300)
-    assert '<x>)' in {
-        x['label'] for x in sig2.args[0]}
+    assert '<x>)' in {x['label'] for x in sig2.args[0]}
 
     expected_insert = '${1:[x]})$0'
     insert = sig2.args[0][0]

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -770,7 +770,7 @@ def test_kite_code_snippets(kite_codeeditor, qtbot):
                           timeout=10000) as sig:
         qtbot.keyPress(code_editor, Qt.Key_Tab, delay=300)
 
-    assert 'sin(…)' in {
+    assert 'sin('+u'\u2026'+')' in {
         x['label'] for x in sig.args[0]}
 
     expected_insert = 'sin($1)$0'

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -31,6 +31,8 @@ except Exception:
 from spyder.plugins.completion.languageserver import (
     LSPRequestTypes, CompletionItemKind)
 from spyder.plugins.completion.kite.providers.document import KITE_COMPLETION
+from spyder.plugins.completion.kite.utils.status import (
+    check_if_kite_installed, check_if_kite_running)
 from spyder.py3compat import PY2
 from spyder.config.manager import CONF
 
@@ -725,6 +727,97 @@ def test_code_snippets(lsp_codeeditor, qtbot):
 
     CONF.set('lsp-server', 'code_snippets', False)
     lsp.update_configuration()
+
+    code_editor.toggle_automatic_completions(True)
+    code_editor.toggle_code_snippets(True)
+
+
+@pytest.mark.slow
+@pytest.mark.skipif((not rtree_available
+                     or not check_if_kite_installed()
+                     or not check_if_kite_running()),
+                    reason="Only works if rtree is installed."
+                           "It's not meant to be run without kite installed "
+                           "and runnning")
+def test_kite_code_snippets(kite_codeeditor, qtbot):
+    """
+    Test kite code snippets completions without initial placeholder.
+
+    See spyder-ide/spyder#10971
+    """
+    assert rtree_available
+    code_editor, kite = kite_codeeditor
+    completion = code_editor.completion_widget
+    snippets = code_editor.editor_extensions.get('SnippetsExtension')
+
+    CONF.set('lsp-server', 'code_snippets', True)
+    CONF.set('kite', 'enable', True)
+    kite.update_configuration()
+
+    code_editor.toggle_automatic_completions(False)
+    code_editor.toggle_code_snippets(True)
+    # Set cursor to start
+    code_editor.go_to_line(1)
+
+    text = """
+    import numpy as np
+    """
+    text = textwrap.dedent(text)
+    code_editor.insert_text(text)
+
+    qtbot.keyClicks(code_editor, 'np.sin')
+    with qtbot.waitSignal(completion.sig_show_completions,
+                          timeout=10000) as sig:
+        qtbot.keyPress(code_editor, Qt.Key_Tab, delay=300)
+
+    assert 'sin(…)' in {
+        x['label'] for x in sig.args[0]}
+
+    expected_insert = 'sin($1)$0'
+    insert = sig.args[0][0]
+    assert expected_insert == insert['insertText']
+
+    # Insert completion
+    qtbot.keyPress(completion, Qt.Key_Tab)
+    assert snippets.is_snippet_active
+    # assert code_editor.has_selected_text()
+
+    # Get code selected text
+    cursor = code_editor.textCursor()
+    arg1 = cursor.selectedText()
+    assert '' == arg1
+    assert snippets.active_snippet == 1
+
+    code_editor.set_cursor_position('eol')
+    code_editor.move_cursor(-1)
+
+    with qtbot.waitSignal(completion.sig_show_completions,
+                          timeout=10000) as sig2:
+        qtbot.keyPress(code_editor, Qt.Key_Space, modifier=Qt.ControlModifier,
+                       delay=300)
+    assert '<x>)' in {
+        x['label'] for x in sig2.args[0]}
+
+    expected_insert = '${1:[x]})$0'
+    insert = sig2.args[0][0]
+    assert expected_insert == insert['textEdit']['newText']
+    qtbot.keyPress(completion, Qt.Key_Tab)
+
+    # Snippets are disabled when there are no more left
+    code_editor.set_cursor_position('eol')
+    qtbot.keyPress(code_editor, Qt.Key_Enter)
+    assert not snippets.is_snippet_active
+
+    cursor = code_editor.textCursor()
+    cursor.movePosition(QTextCursor.PreviousBlock)
+    cursor.movePosition(QTextCursor.StartOfBlock)
+    cursor.movePosition(QTextCursor.EndOfBlock, mode=QTextCursor.KeepAnchor)
+    text1 = cursor.selectedText()
+    assert text1 == 'np.sin([x])'
+
+    CONF.set('lsp-server', 'code_snippets', False)
+    CONF.set('kite', 'enable', False)
+    kite.update_configuration()
 
     code_editor.toggle_automatic_completions(True)
     code_editor.toggle_code_snippets(True)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Caused by trying to get a list of a node instead of the tokens of the node


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10971 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
