### PR TITLE
don't close autocompletion menu when AltGr is pressed

### DIFF
--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -300,7 +300,8 @@ class CompletionWidget(QListWidget):
         alt = event.modifiers() & Qt.AltModifier
         shift = event.modifiers() & Qt.ShiftModifier
         ctrl = event.modifiers() & Qt.ControlModifier
-        modifier = shift or ctrl or alt
+        altgr = (key == 0)
+        modifier = shift or ctrl or alt or altgr
         if key in (Qt.Key_Return, Qt.Key_Enter, Qt.Key_Tab):
             # Check that what was selected can be selected,
             # otherwise timing issues


### PR DESCRIPTION
## Description of Changes

When you enter one or more letters and then press _tab_ in the spyder editor, you get an autocompletion popup window. With this pull request the popup window doesn't close on pressing the _AltGr_ key anymore.

<!--- Explain what you've done and why --->

I've added a new variable (**altgr**) that will be true if the pressed key is _AltGr_. This variable is being checked in order to identify modifier keys.

I made this change because in my keyboard layout (and others like _Neo2_ and _Aus der Neo-Welt_) the down arrow can be sent with _AltGr_+_D_, so the popup window shouldn't be closed when _AltGr_ is pressed.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11293 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: MaxGyver83

<!--- Thanks for your help making Spyder better for everyone! --->
