### PR TITLE
PR: Fix tooltip position after the editor is undocked

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2395,10 +2395,10 @@ class EditorStack(QWidget):
             state = finfo.editor.document().isModified()
             self.set_stack_title(index, state)
 
-    def __reset_tooltip_tip(self):
-        """Reset last tooltip tip info."""
+    def __reset_tooltip(self):
+        """Reset tooltip tip info for all the editors."""
         for index, finfo in enumerate(self.data):
-            finfo.editor.reset_tooltip_tip()
+            finfo.editor.reset_tooltip()
 
     def refresh(self, index=None):
         """Refresh tabwidget"""
@@ -2416,7 +2416,7 @@ class EditorStack(QWidget):
             self.__refresh_readonly(index)
             self.__check_file_status(index)
             self.__modify_stack_title()
-            self.__reset_tooltip_tip()
+            self.__reset_tooltip()
             self.update_plugin_title.emit()
         else:
             editor = None

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2395,6 +2395,11 @@ class EditorStack(QWidget):
             state = finfo.editor.document().isModified()
             self.set_stack_title(index, state)
 
+    def __reset_tooltip_tip(self):
+        """Reset last tooltip tip info."""
+        for index, finfo in enumerate(self.data):
+            finfo.editor.reset_tooltip_tip()
+
     def refresh(self, index=None):
         """Refresh tabwidget"""
         if index is None:
@@ -2411,6 +2416,7 @@ class EditorStack(QWidget):
             self.__refresh_readonly(index)
             self.__check_file_status(index)
             self.__modify_stack_title()
+            self.__reset_tooltip_tip()
             self.update_plugin_title.emit()
         else:
             editor = None

--- a/spyder/widgets/calltip.py
+++ b/spyder/widgets/calltip.py
@@ -45,7 +45,7 @@ class ToolTipWidget(QLabel):
         """
         Shows tooltips that can be styled with the different themes.
         """
-        super(ToolTipWidget, self).__init__(parent, Qt.ToolTip)
+        super(ToolTipWidget, self).__init__(None, Qt.ToolTip)
 
         # Variables
         self.completion_doc = None
@@ -199,6 +199,10 @@ class ToolTipWidget(QLabel):
         if not self.isVisible():
             self.show()
         return True
+
+    def reset_tip(self):
+        """Reset tip to None."""
+        self.tip = None
 
     def mousePressEvent(self, event):
         """

--- a/spyder/widgets/calltip.py
+++ b/spyder/widgets/calltip.py
@@ -200,7 +200,7 @@ class ToolTipWidget(QLabel):
             self.show()
         return True
 
-    def reset_tip(self):
+    def reset_tooltip(self):
         """Reset tip to None."""
         self.tip = None
 

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -661,6 +661,10 @@ class BaseEditMixin(object):
         self._last_point = None
         self.tooltip_widget.hide()
 
+    def reset_tooltip_tip(self):
+        """Reset tooltip tip."""
+        self.tooltip_widget.reset_tip()
+
     #------EOL characters
     def set_eol_chars(self, text):
         """Set widget end-of-line (EOL) characters from text (analyzes text)"""

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -661,9 +661,9 @@ class BaseEditMixin(object):
         self._last_point = None
         self.tooltip_widget.hide()
 
-    def reset_tooltip_tip(self):
+    def reset_tooltip(self):
         """Reset tooltip tip."""
-        self.tooltip_widget.reset_tip()
+        self.tooltip_widget.reset_tooltip()
 
     #------EOL characters
     def set_eol_chars(self, text):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

![tooltip](https://user-images.githubusercontent.com/16781833/72756409-1e260800-3b9b-11ea-8986-ef6ea09e01cc.gif)



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11355 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
