### PR TITLE
PR: Use normpath to set network folders as cwd on Windows

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -10,6 +10,7 @@ Shell Widget for the IPython Console
 
 # Standard library imports
 import os
+import os.path as osp
 import uuid
 from textwrap import dedent
 
@@ -168,7 +169,9 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
         """Set shell current working directory."""
         # Replace single for double backslashes on Windows
         if os.name == 'nt':
-            dirname = dirname.replace(u"\\", u"\\\\")
+            # Use normpath instead of replacing '\' with '\\'
+            # See spyder-ide/spyder#10785
+            dirname = osp.normpath(dirname)
 
         if self.ipyclient.hostname is None:
             self.call_kernel(interrupt=True).set_cwd(dirname)

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -167,7 +167,6 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
 
     def set_cwd(self, dirname):
         """Set shell current working directory."""
-        # Replace single for double backslashes on Windows
         if os.name == 'nt':
             # Use normpath instead of replacing '\' with '\\'
             # See spyder-ide/spyder#10785


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Use `os.path.normpath` to handle backward slashes instead of escaping them with `\\` to prevent errors while setting network folders as cwd on Windows


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10785 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz


<!--- Thanks for your help making Spyder better for everyone! --->
