### PR TITLE
PR: Handle screen change to trigger restart and prevent display issues

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1453,7 +1453,7 @@ class MainWindow(QMainWindow):
         window.screenChanged.connect(self.handle_new_screen)
         self.screen = self.window().windowHandle().screen()
         self.screen.logicalDotsPerInchChanged.connect(
-            self.show_DPI_change_message)
+            self.show_dpi_change_message)
 
         # Notify that the setup of the mainwindow was finished
         self.sig_setup_finished.emit()
@@ -1461,15 +1461,15 @@ class MainWindow(QMainWindow):
     def handle_new_screen(self, screen):
         """Connect DPI signals for new screen."""
         self.screen.logicalDotsPerInchChanged.disconnect(
-            self.show_DPI_change_message)
+            self.show_dpi_change_message)
         self.screen = screen
         self.screen.logicalDotsPerInchChanged.connect(
-            self.show_DPI_change_message)
+            self.show_dpi_change_message)
 
-    def show_DPI_change_message(self):
+    def show_dpi_change_message(self):
         """Show message to restart Spyder since the DPI scale changed."""
         self.screen.logicalDotsPerInchChanged.disconnect(
-            self.show_DPI_change_message)
+            self.show_dpi_change_message)
         answer = QMessageBox.warning(
             self, _("Warning"),
             _("A monitor scale change was detected. <br><br>"
@@ -1491,7 +1491,7 @@ class MainWindow(QMainWindow):
         else:
             # Reconnect DPI scale changes to show a restart message
             self.screen.logicalDotsPerInchChanged.connect(
-                self.show_DPI_change_message)
+                self.show_dpi_change_message)
 
     def set_window_title(self):
         """Set window title."""

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1448,17 +1448,27 @@ class MainWindow(QMainWindow):
         self.menuBar().raise_()
         self.is_setting_up = False
 
-        # Handle DPI scale changes and show restart message
-        screen = self.window().windowHandle().screen()
-        screen.logicalDotsPerInchChanged.connect(self.show_DPI_change_message)
+        # Handle DPI scale and window changes to show a restart message
+        window = self.window().windowHandle()
+        window.screenChanged.connect(self.handle_new_screen)
+        self.screen = self.window().windowHandle().screen()
+        self.screen.logicalDotsPerInchChanged.connect(
+            self.show_DPI_change_message)
 
         # Notify that the setup of the mainwindow was finished
         self.sig_setup_finished.emit()
 
+    def handle_new_screen(self, screen):
+        """Connect DPI signals for new screen."""
+        self.screen.logicalDotsPerInchChanged.disconnect(
+            self.show_DPI_change_message)
+        self.screen = screen
+        self.screen.logicalDotsPerInchChanged.connect(
+            self.show_DPI_change_message)
+
     def show_DPI_change_message(self):
         """Show message to restart Spyder since the DPI scale changed."""
-        screen = self.window().windowHandle().screen()
-        screen.logicalDotsPerInchChanged.disconnect(
+        self.screen.logicalDotsPerInchChanged.disconnect(
             self.show_DPI_change_message)
         answer = QMessageBox.warning(
             self, _("Warning"),
@@ -1480,10 +1490,8 @@ class MainWindow(QMainWindow):
             self.restart()
         else:
             # Reconnect DPI scale changes to show a restart message
-            screen = self.window().windowHandle().screen()
-            screen.logicalDotsPerInchChanged.connect(
+            self.screen.logicalDotsPerInchChanged.connect(
                 self.show_DPI_change_message)
-
 
     def set_window_title(self):
         """Set window title."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Since the screen where Spyder is being displayed could change, the handle of signals to trigger the restart message for proper display needs to take the screen change into account.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
