### PR TITLE
PR: Interpret -p project argument relative to the directory of invocation

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2972,10 +2972,22 @@ class MainWindow(QMainWindow):
         variable explorer inside Spyder.
         """
         fname = encoding.to_unicode_from_fs(fname)
-        if osp.isfile(fname):
-            self.open_file(fname, external=True)
-        elif osp.isfile(osp.join(CWD, fname)):
-            self.open_file(osp.join(CWD, fname), external=True)
+        if osp.exists(osp.join(CWD, fname)):
+            fpath = osp.join(CWD, fname)
+        elif osp.exists(fname):
+            fpath = fname
+        else:
+            return
+
+        if osp.isfile(fpath):
+            self.open_file(fpath, external=True)
+        elif osp.isdir(fpath):
+            QMessageBox.warning(None, "Spyder",
+                _('Not opening folder <code>{fpath}</code> . To open that '
+                  'folder as a project from the CLI, use '
+                  '<code>spyder -p "{fname}"</code> .')
+                .format(fpath=osp.normpath(fpath), fname=fname)
+            )
 
     # --- Path Manager
     # ------------------------------------------------------------------------

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -348,7 +348,7 @@ class MainWindow(QMainWindow):
         self.profile = options.profile
         self.multithreaded = options.multithreaded
         self.new_instance = options.new_instance
-        self.open_project = options.project
+        self.open_project = osp.normpath(osp.join(CWD, options.project)) if options.project is not None else None
         self.window_title = options.window_title
 
         logger.info("Start of MainWindow constructor")

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2983,10 +2983,9 @@ class MainWindow(QMainWindow):
             self.open_file(fpath, external=True)
         elif osp.isdir(fpath):
             QMessageBox.warning(
-                None, "Spyder",
-                _('Not opening folder <code>{fpath}</code> . To open that '
-                  'folder as a project from the CLI, use '
-                  '<code>spyder -p "{fname}"</code> .')
+                self, _("Error"),
+                _('To open <code>{fpath}</code> as a project with Spyder, '
+                  'please use <code>spyder -p "{fname}"</code>.')
                 .format(fpath=osp.normpath(fpath), fname=fname)
             )
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -348,7 +348,10 @@ class MainWindow(QMainWindow):
         self.profile = options.profile
         self.multithreaded = options.multithreaded
         self.new_instance = options.new_instance
-        self.open_project = osp.normpath(osp.join(CWD, options.project)) if options.project is not None else None
+        if options.project is not None:
+            self.open_project = osp.normpath(osp.join(CWD, options.project))
+        else:
+            self.open_project = None
         self.window_title = options.window_title
 
         logger.info("Start of MainWindow constructor")

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2982,7 +2982,8 @@ class MainWindow(QMainWindow):
         if osp.isfile(fpath):
             self.open_file(fpath, external=True)
         elif osp.isdir(fpath):
-            QMessageBox.warning(None, "Spyder",
+            QMessageBox.warning(
+                None, "Spyder",
                 _('Not opening folder <code>{fpath}</code> . To open that '
                   'folder as a project from the CLI, use '
                   '<code>spyder -p "{fname}"</code> .')


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

When Spyder is invoked with `-p project`, this resolves `project` relative to the directory of invocation. IMO this is generally expected behaviour for running CLI tools. Currently it is interpreted relative to Spyder's working directory, which is generally my home directory.

E.g. if I am in `/home/akdor1154/src/python`, if I type `spyder -p folder1` or `spyder -p .`, I expect these to be interpreted as `/home/akdor1154/src/python/folder1` and `/home/akdor1154/src/python`, respectively. Currently they are interpreted as `/home/akdor1154/folder1` (surprising) and `/home/akdor1154` (really surprising).

N.B. existing behvaiour of `-p`, to create a project if it does not exist, is unchanged.

### Issue(s) Resolved

Fixes #11363 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: akdor1154

<!--- Thanks for your help making Spyder better for everyone! --->
