### PR TITLE
= is not a valid operator. Did you mean == ?

### DIFF
--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -8,7 +8,7 @@ chardet >=2.0.0
 cloudpickle
 diff-match-patch
 intervaltree
-jedi =0.14.1
+jedi == 0.14.1
 keyring
 nbconvert
 numpydoc


### PR DESCRIPTION
$ pip install -r ./requirements/conda.txt
ERROR: Invalid requirement: 'jedi =0.14.1' (from line 11 of ./requirements/conda.txt)
Hint: = is not a valid operator. Did you mean == ?

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:
suokunlong