### PR TITLE
PR: Properly register shortcuts for some actions of the Variable Explorer

### DIFF
--- a/spyder/plugins/variableexplorer/plugin.py
+++ b/spyder/plugins/variableexplorer/plugin.py
@@ -106,6 +106,7 @@ class VariableExplorer(SpyderPluginWidget):
         self.stack.removeWidget(nsb)
 
     def add_widget(self, nsb):
+        self.register_widget_shortcuts(nsb)
         self.stack.addWidget(nsb)
 
     # ----- Public API --------------------------------------------------------

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -187,7 +187,34 @@ class NamespaceBrowser(QWidget):
 
         self.setLayout(layout)
 
+        # Local shortcuts
+        self.shortcuts = self.create_shortcuts()
+
         self.sig_option_changed.connect(self.option_changed)
+
+    def create_shortcuts(self):
+        """Create local shortcut for the nsbrowser."""
+        search = CONF.config_shortcut(
+            lambda: self.show_finder(set_visible=True),
+            context='variable_explorer',
+            name='search',
+            parent=self)
+        refresh = CONF.config_shortcut(
+            self.refresh_table,
+            context='variable_explorer',
+            name='refresh',
+            parent=self)
+
+        return [search, refresh]
+
+    def get_shortcut_data(self):
+        """
+        Returns shortcut data, a list of tuples (shortcut, text, default)
+        shortcut (QShortcut or QAction instance)
+        text (string): action/shortcut description
+        default (string): default key sequence
+        """
+        return [sc.data for sc in self.shortcuts]
 
     def set_shellwidget(self, shellwidget):
         """Bind shellwidget instance to namespace browser"""
@@ -230,23 +257,11 @@ class NamespaceBrowser(QWidget):
             icon=ima.icon('find'),
             toggled=self.show_finder)
 
-        CONF.config_shortcut(
-            lambda: self.show_finder(set_visible=True),
-            context='variable_explorer',
-            name='search',
-            parent=self)
-
         self.refresh_button = create_toolbutton(
             self,
             text=_("Refresh variables"),
             icon=ima.icon('refresh'),
             triggered=lambda: self.refresh_table(interrupt=True))
-
-        CONF.config_shortcut(
-            self.refresh_table,
-            context='variable_explorer',
-            name='refresh',
-            parent=self)
 
         return [load_button, self.save_button, save_as_button,
                 reset_namespace_button, self.search_button,


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Properly register shortcuts for the `NamespaceBrowser` and `CollectionsEditor` widget of the Variable Explorer to update shortcuts without a restart:
- [x] Search
- [x] Refresh
~~- [ ] Copy (seems like it's being done using a `keyPressEvent`?)~~ The copy shortcut preference is only for the `ArrayEditor` and `DataframeEditor`

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10627 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
