### PR TITLE
PR: Preserve creation time when performing an atomic_write

### DIFF
--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -17,6 +17,7 @@ import locale
 import re
 import os
 import sys
+import time
 import errno
 
 # Third-party imports
@@ -240,12 +241,15 @@ def write(text, filename, encoding='utf-8', mode='wb'):
         # Needed to fix file permissions overwritting.
         # See spyder-ide/spyder#9381.
         try:
-            original_mode = os.stat(filename).st_mode
+            file_stat = os.stat(filename)
+            original_mode = file_stat.st_mode
+            creation = file_stat.st_atime
         except OSError:  # Change to FileNotFoundError for PY3
             # Creating a new file, emulate what os.open() does
             umask = os.umask(0)
             os.umask(umask)
             original_mode = 0o777 & ~umask
+            creation = time.time()
         try:
             with atomic_write(filename, overwrite=True,
                               mode=mode) as textfile:
@@ -257,6 +261,9 @@ def write(text, filename, encoding='utf-8', mode='wb'):
                 with open(filename, mode) as textfile:
                     textfile.write(text)
         os.chmod(filename, original_mode)
+        file_stat = os.stat(filename)
+        # Preserve creation timestamps
+        os.utime(filename, (creation, file_stat.st_mtime))
     return encoding
 
 

--- a/spyder/utils/tests/test_encoding.py
+++ b/spyder/utils/tests/test_encoding.py
@@ -36,6 +36,22 @@ def test_permissions(tmpdir):
     assert old_mode == new_mode
 
 
+def test_timestamp(tmpdir):
+    """Check that the modification timestamp is preserved."""
+    tmp_file = tmpdir.mkdir("timestamp").join('test_file.txt')
+    tmp_file = to_text_string(tmp_file)
+
+    # Write a file
+    write("Test text", tmp_file)
+    st = os.stat(tmp_file)
+    actual_creation_time = st.st_atime
+
+    # Write the file and check that creation time is preserved.
+    write('New text', tmp_file)
+    creation_time = os.stat(tmp_file).st_atime
+    assert actual_creation_time == creation_time
+
+
 def test_is_text_file(tmpdir):
     p = tmpdir.mkdir("sub").join("random_text.txt")
     p.write("Some random text")


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR keeps track of the original creation date for any file saved before executing an atomicwrite. If the file does not exist, then the current timestamp is assigned.

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved
Fixes #11403

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@andfoy 
<!--- Thanks for your help making Spyder better for everyone! --->
