### PR TITLE
PR: Prevent operation not permitted errors when writing to samba shares

### DIFF
--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -260,10 +260,15 @@ def write(text, filename, encoding='utf-8', mode='wb'):
             if error.errno != errno.EINVAL:
                 with open(filename, mode) as textfile:
                     textfile.write(text)
-        os.chmod(filename, original_mode)
-        file_stat = os.stat(filename)
-        # Preserve creation timestamps
-        os.utime(filename, (creation, file_stat.st_mtime))
+        try:
+            os.chmod(filename, original_mode)
+            file_stat = os.stat(filename)
+            # Preserve creation timestamps
+            os.utime(filename, (creation, file_stat.st_mtime))
+        except OSError:
+            # Prevent error when chmod/utime is not allowed
+            # See spyder-ide/spyder#11308
+            pass
     return encoding
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR captures and ignores OSError exceptions raised when trying to change permissions/timestamp information for files located in Samba network endpoints.


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11308 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@andfoy
<!--- Thanks for your help making Spyder better for everyone! --->
