### PR TITLE
PR: Avoid Python destroying Qt window and causing segfault

### DIFF
--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -138,7 +138,7 @@ class PluginWindow(QMainWindow):
         QMainWindow.closeEvent(self, event)
         # Qt might want to do something with this soon,
         # So it should not be deleted by python yet.
-        # Fixes #10704
+        # Fixes spyder-ide/spyder#10704
         self.plugin.__unsafe__window = self
         self.plugin._undocked_window = None
 

--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -136,6 +136,10 @@ class PluginWindow(QMainWindow):
         self.plugin.dockwidget.setVisible(True)
         self.plugin.switch_to_plugin()
         QMainWindow.closeEvent(self, event)
+        # Qt might want to do something with this soon,
+        # So it should not be deleted by python yet.
+        # Fixes #10704
+        self.plugin.__unsafe__window = self
         self.plugin._undocked_window = None
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Keep a reference to the window being closed when redocking a widget to avoid a segfault.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10704


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
