### PR TITLE
PR: Pin parso to 0.5.2 because version 0.6.0 is incompatible with Jedi 0.14

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,6 +17,7 @@ dependencies:
 - keyring
 - nbconvert
 - numpydoc
+- parso =0.5.2
 - pexpect
 - pickleshare
 - psutil

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -12,6 +12,7 @@ jedi =0.14.1
 keyring
 nbconvert
 numpydoc
+parso =0.5.2
 pexpect
 pickleshare
 psutil

--- a/setup.py
+++ b/setup.py
@@ -216,6 +216,7 @@ install_requires = [
     'numpydoc',
     # Required to get SSH connections to remote kernels
     'paramiko;platform_system=="Windows"',
+    'parso==0.5.2',
     'pexpect',
     'pickleshare',
     'psutil',


### PR DESCRIPTION
I noticed this while testing Spyder in Binder.