### PR TITLE
PR: Handle file renamed in the explorer correctly in the editor

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2096,7 +2096,8 @@ class Editor(SpyderPluginWidget):
         Propagate file rename to editor stacks and autosave component.
 
         This function is called when a file is renamed in the file explorer
-        widget or the project explorer.
+        widget or the project explorer. The file may not be opened in the
+        editor.
         """
         filename = osp.abspath(to_text_string(source))
         index = self.editorstacks[0].has_filename(filename)
@@ -2104,8 +2105,8 @@ class Editor(SpyderPluginWidget):
             for editorstack in self.editorstacks:
                 editorstack.rename_in_data(filename,
                                            new_filename=to_text_string(dest))
-        self.editorstacks[0].autosave.file_renamed(
-            filename, to_text_string(dest))
+            self.editorstacks[0].autosave.file_renamed(
+                filename, to_text_string(dest))
 
     def renamed_tree(self, source, dest):
         """Directory was renamed in file explorer or in project explorer."""

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -174,7 +174,9 @@ def test_closing_editor_plugin_stops_autosave_timer(editor_plugin):
 
 def test_renamed_propagates_to_autosave(editor_plugin_open_files, mocker):
     """Test that editor.renamed() propagates info to autosave component if,
-    and only if, renamed file is open in editor."""
+    and only if, renamed file is open in editor.
+
+    Regression test for spyder-ide/spyder#11348"""
     editor_factory = editor_plugin_open_files
     editor, expected_filenames, expected_current_filename = (
         editor_factory(None, None))

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -172,11 +172,25 @@ def test_closing_editor_plugin_stops_autosave_timer(editor_plugin):
     assert not editor.autosave.timer.isActive()
 
 
-def test_renamed_propagates_to_autosave(editor_plugin, mocker):
-    editorstack = editor_plugin.get_current_editorstack()
+def test_renamed_propagates_to_autosave(editor_plugin_open_files, mocker):
+    """Test that editor.renamed() propagates info to autosave component if,
+    and only if, renamed file is open in editor."""
+    editor_factory = editor_plugin_open_files
+    editor, expected_filenames, expected_current_filename = (
+        editor_factory(None, None))
+
+    editorstack = editor.get_current_editorstack()
+    mocker.patch.object(editorstack, 'rename_in_data')
     mocker.patch.object(editorstack.autosave, 'file_renamed')
-    editor_plugin.renamed('src', 'dest')
-    editorstack.autosave.file_renamed.assert_called()
+
+    # Test renaming a file that is not opened in the editor
+    editor.renamed('nonexisting', 'newname')
+    assert not editorstack.autosave.file_renamed.called
+
+    # Test renaming a file that is opened in the editor
+    filename = editorstack.get_filenames()[0]
+    editor.renamed(filename, 'newname')
+    assert editorstack.autosave.file_renamed.called
 
 
 def test_go_to_prev_next_cursor_position(editor_plugin, python_files):

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -902,7 +902,7 @@ class DirView(QTreeView):
                     return
             try:
                 misc.rename_file(fname, path)
-                if osp.isfile(fname):
+                if osp.isfile(path):
                     self.sig_renamed.emit(fname, path)
                 else:
                     self.sig_renamed_tree.emit(fname, path)


### PR DESCRIPTION
## Description of Changes

This PR fixes a bug in the file explorer, which caused the explorer to always emit `sig_renamed_tree` after a rename, instead of emitting `sig_renamed` if a file is renamed and `sig_renamed_tree` if a directory is renamed.

This PR also fixes a second bug, which became more apparent after the first fix. Before, the editor plugin propagated all file renames to the autosave component, which leads to an error if the file is not opened. Now, only renames of open files are propagated.

### Issue(s) Resolved

Fixes #11348 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
