### PR TITLE
PR: Prevent editor stealing focus of other widgets while scrolling

### DIFF
--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -1046,8 +1046,13 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
                         self.zoom_in.emit()
                 return
         QPlainTextEdit.wheelEvent(self, event)
+        # Needed to prevent stealing focus to the find widget when scrolling
+        # See spyder-ide/spyder#11502
+        current_widget = QApplication.focusWidget()
         self.hide_completion_widget()
         self.highlight_current_cell()
+        if current_widget is not None:
+            current_widget.setFocus()
 
     def position_widget_at_cursor(self, widget):
         # Retrieve current screen height


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->

Doing some updates while handling the `wheelEvent` (scroll related event) in the Editor, stealed focus of widgets like the Find widget:

A preview:

![find](https://user-images.githubusercontent.com/16781833/74265378-751d8980-4cd0-11ea-9e05-88754473c261.gif)



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11502 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
