### PR TITLE
PR: Fix running tests locally from file

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,9 +23,10 @@ os.environ['SPYDER_PYTEST'] = 'True'
 # Add external dependencies subrepo paths to sys.path
 # NOTE: Please don't move this from here!
 HERE = osp.dirname(os.path.realpath(__file__))
+DEPS_PATH = osp.join(HERE, 'external-deps')
 i = 0
-for path in os.listdir('external-deps'):
-    external_dep_path = osp.join(HERE, 'external-deps', path)
+for path in os.listdir(DEPS_PATH):
+    external_dep_path = osp.join(DEPS_PATH, path)
     sys.path.insert(i, external_dep_path)
     i += 1
 


### PR DESCRIPTION
# Description of Changes

This is a follow up of PR #11541 to implement the same fix for `conftests.py`.

Whithout this, running a test file locally results in the following traceback:

```python
ImportError while loading conftest 'C:\Users\User\spyder\conftest.py'.
..\..\..\..\..\conftest.py:27: in <module>
    for path in os.listdir('external-deps'):
E   FileNotFoundError: [WinError 3] The system cannot find the path specified: 'external-deps'
```
### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
