### PR TITLE
PR: Handle TextEdit correctly when receiving completions

### DIFF
--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -878,9 +878,17 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         selection_start, selection_end = self.get_selection_start_end()
 
         if isinstance(completion, dict) and 'textEdit' in completion:
-            cursor.setPosition(completion['textEdit']['range']['start'])
-            cursor.setPosition(completion['textEdit']['range']['end'],
-                               QTextCursor.KeepAnchor)
+            completion_range = completion['textEdit']['range']
+            start = completion_range['start']
+            end = completion_range['end']
+            if isinstance(completion_range['start'], dict):
+                start_line, start_col = start['line'], start['character']
+                start = self.get_position_line_number(start_line, start_col)
+            if isinstance(completion_range['start'], dict):
+                end_line, end_col = end['line'], end['character']
+                end = self.get_position_line_number(end_line, end_col)
+            cursor.setPosition(start)
+            cursor.setPosition(end, QTextCursor.KeepAnchor)
             text = to_text_string(completion['textEdit']['newText'])
         else:
             text = completion

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -767,6 +767,15 @@ class BaseEditMixin(object):
         """Return cursor line number"""
         return self.textCursor().blockNumber()+1
 
+    def get_position_line_number(self, line, col):
+        """Get position offset from (line, col) coordinates."""
+        block = self.document().findBlockByNumber(line)
+        cursor = QTextCursor(block)
+        cursor.movePosition(QTextCursor.StartOfBlock)
+        cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor,
+                            n=col + 1)
+        return cursor.position()
+
     def set_cursor_position(self, position):
         """Set cursor position"""
         position = self.get_position(position)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR prevents errors when LSP completion returns entries that contain TextEdit objects.

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11526


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@andfoy 
<!--- Thanks for your help making Spyder better for everyone! --->
