### PR TITLE
PR: Handle corrupted pid files in autosave component

### DIFF
--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -146,7 +146,14 @@ class AutosaveForPlugin(object):
                 logger.debug('Reading pid file: {}'.format(full_name))
                 with open(full_name) as pidfile:
                     txt = pidfile.read()
-                    txt_as_dict = ast.literal_eval(txt)
+                    try:
+                        txt_as_dict = ast.literal_eval(txt)
+                    except (SyntaxError, ValueError):
+                        # Pid file got corrupted, see spyder-ide/spyder#11375
+                        logger.error('Error parsing pid file {}'
+                                     .format(full_name))
+                        logger.error('Contents: {}'.format(repr(txt)))
+                        txt_as_dict = {}
                     files_mentioned += [autosave for (orig, autosave)
                                         in txt_as_dict.items()]
                 pid = int(match.group(1))


### PR DESCRIPTION
The autosave component stores information in pid files with filenames of the form `pidNNN.txt`. This PR ignored pid files whose contents cannot be parsed. The pid files will be deleted as normal.

A regression test is also included.

### Issue(s) Resolved

Fixes #11375 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
