### PR TITLE
PR: Convert autosave mapping to ASCII before saving

### DIFF
--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -11,7 +11,6 @@ import ast
 import logging
 import os
 import os.path as osp
-import pprint
 import re
 
 # Third party imports
@@ -21,6 +20,7 @@ from qtpy.QtCore import QTimer
 from spyder.config.base import _, get_conf_path, running_under_pytest
 from spyder.plugins.editor.widgets.autosaveerror import AutosaveErrorDialog
 from spyder.plugins.editor.widgets.recover import RecoveryDialog
+from spyder.py3compat import PY2
 from spyder.utils.programs import is_spyder_process
 
 
@@ -262,7 +262,10 @@ class AutosaveForStack(object):
         pidfile_name = osp.join(autosave_dir, 'pid{}.txt'.format(my_pid))
         if self.name_mapping:
             with open(pidfile_name, 'w') as pidfile:
-                pidfile.write(pprint.pformat(self.name_mapping))
+                if PY2:
+                    pidfile.write(repr(self.name_mapping))
+                else:
+                    pidfile.write(ascii(self.name_mapping))
         else:
             try:
                 os.remove(pidfile_name)

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -167,14 +167,18 @@ def test_autosave(mocker):
     assert addon.file_hashes == {'orig': 1, 'autosave': 3}
 
 
-def test_save_autosave_mapping_with_nonempty_mapping(mocker, tmpdir):
+@pytest.mark.parametrize('latin', [True, False])
+def test_save_autosave_mapping_with_nonempty_mapping(mocker, tmpdir, latin):
     """Test that save_autosave_mapping() writes the current autosave mapping
     to the correct file if the mapping is not empty."""
     mocker.patch('os.getpid', return_value=42)
     mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
                  return_value=str(tmpdir))
     addon = AutosaveForStack(None)
-    addon.name_mapping = {'orig': 'autosave'}
+    if latin:
+        addon.name_mapping = {'orig': 'autosave'}
+    else:
+        addon.name_mapping = {'原件': 'autosave'}
 
     addon.save_autosave_mapping()
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Convert the autosave mapping to ASCII before saving in on disk, because saving Unicode filenames in a text file opened with the default encoding may raise an UnicodeEncodeError. Also add a regression test.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11609


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
