### PR TITLE
PR: Prevent Tab/Backtab from triggering completions

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -3678,6 +3678,7 @@ class CodeEditor(TextEditBaseWidget):
         """Reimplement Qt method."""
         self._start_completion_timer()
 
+        tab_pressed = False
         if self.completions_hint_after_ms > 0:
             self._completions_hint_idle = False
             self._timer_completions_hint.start(self.completions_hint_after_ms)
@@ -3852,6 +3853,7 @@ class CodeEditor(TextEditBaseWidget):
         elif key == Qt.Key_Tab and not ctrl:
             # Important note: <TAB> can't be called with a QShortcut because
             # of its singular role with respect to widget focus management
+            tab_pressed = True
             if not has_selection and not self.tab_mode:
                 self.intelligent_tab()
             else:
@@ -3860,6 +3862,7 @@ class CodeEditor(TextEditBaseWidget):
         elif key == Qt.Key_Backtab and not ctrl:
             # Backtab, i.e. Shift+<TAB>, could be treated as a QShortcut but
             # there is no point since <TAB> can't (see above)
+            tab_pressed = True
             if not has_selection and not self.tab_mode:
                 self.intelligent_backtab()
             else:
@@ -3871,7 +3874,7 @@ class CodeEditor(TextEditBaseWidget):
 
         self._last_key_pressed_text = text
         self._last_pressed_key = key
-        if self.automatic_completions_after_ms == 0:
+        if self.automatic_completions_after_ms == 0 and not tab_pressed:
             self._handle_completions()
 
         if not event.modifiers():
@@ -3889,7 +3892,8 @@ class CodeEditor(TextEditBaseWidget):
 
         key = self._last_pressed_key
         if key is not None:
-            if key in [Qt.Key_Backspace, Qt.Key_Return, Qt.Key_Escape]:
+            if key in [Qt.Key_Backspace, Qt.Key_Return, Qt.Key_Escape,
+                       Qt.Key_Tab, Qt.Key_Backtab]:
                 self._last_pressed_key = None
                 return
 

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -265,6 +265,7 @@ def test_automatic_completions_tab_bug(lsp_codeeditor, qtbot):
     except pytestqt.exceptions.TimeoutError:
         pass
 
+
 @pytest.mark.slow
 @flaky(max_runs=3)
 def test_automatic_completions_parens_bug(lsp_codeeditor, qtbot):

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -232,6 +232,40 @@ def test_automatic_completions(lsp_codeeditor, qtbot):
 
 
 @pytest.mark.slow
+@pytest.mark.first
+@flaky(max_runs=5)
+def test_automatic_completions_tab_bug(lsp_codeeditor, qtbot):
+    """
+    Test on-the-fly completions.
+
+    Autocompletions sohuld not be invoked when Tab/Backtab is pressed.
+
+    See: spyder-ide/spyder#11625
+    """
+    code_editor, _ = lsp_codeeditor
+    completion = code_editor.completion_widget
+    code_editor.toggle_code_snippets(False)
+
+    code_editor.set_text('x = 1')
+    code_editor.set_cursor_position('sol')
+
+    try:
+        with qtbot.waitSignal(completion.sig_show_completions,
+                              timeout=5000):
+            qtbot.keyPress(code_editor, Qt.Key_Tab)
+        assert False
+    except pytestqt.exceptions.TimeoutError:
+        pass
+
+    try:
+        with qtbot.waitSignal(completion.sig_show_completions,
+                              timeout=5000):
+            qtbot.keyPress(code_editor, Qt.Key_Backtab)
+        assert False
+    except pytestqt.exceptions.TimeoutError:
+        pass
+
+@pytest.mark.slow
 @flaky(max_runs=3)
 def test_automatic_completions_parens_bug(lsp_codeeditor, qtbot):
     """


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR prevents triggering autocompletions when Tab/Backtab is pressed.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/1878982/75303793-bef98a00-580f-11ea-8791-4540019e5bae.gif)


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11625


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@andfoy
<!--- Thanks for your help making Spyder better for everyone! --->
