### PR TITLE
PR: Fix hover endpoint for Kite on Windows and allow docs without signature in Help

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -504,7 +504,12 @@ def test_get_help_ipython_console(main_window, qtbot):
 @pytest.mark.skipif(not sys.platform.startswith('linux'),
                     reason="Only works on Linux")
 @pytest.mark.use_introspection
-def test_get_help_editor(main_window, qtbot):
+@pytest.mark.parametrize(
+    "object_info",
+    [("range", "range"),
+     ("import matplotlib.pyplot as plt",
+      "The object-oriented API is recommended for more complex plots.")])
+def test_get_help_editor(main_window, qtbot, object_info):
     """Test that Help works when called from the Editor."""
     help_plugin = main_window.help
     webview = help_plugin.rich_text.webview._webview
@@ -517,8 +522,9 @@ def test_get_help_editor(main_window, qtbot):
         code_editor.document_did_open()
 
     # Write some object in the editor
-    code_editor.set_text('range')
-    code_editor.move_cursor(len('range'))
+    object_name, expected_text = object_info
+    code_editor.set_text(object_name)
+    code_editor.move_cursor(len(object_name))
     with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
         code_editor.document_did_change()
 
@@ -527,7 +533,7 @@ def test_get_help_editor(main_window, qtbot):
         editorstack.inspect_current_object()
 
     # Check that a expected text is part of the page
-    qtbot.waitUntil(lambda: check_text(webpage, "range"), timeout=30000)
+    qtbot.waitUntil(lambda: check_text(webpage, expected_text), timeout=30000)
 
 
 @pytest.mark.slow

--- a/spyder/plugins/completion/kite/providers/document.py
+++ b/spyder/plugins/completion/kite/providers/document.py
@@ -198,7 +198,7 @@ class DocumentProvider:
         logger.debug(path)
         if os.name == 'nt':
             path = path.replace('::', ':')
-            path = 'windows:' + path
+            path = ':windows:' + path
         request = {
             'filename': path,
             'hash': md5,

--- a/spyder/plugins/completion/kite/utils/tests/test_install.py
+++ b/spyder/plugins/completion/kite/utils/tests/test_install.py
@@ -27,6 +27,7 @@ INSTALL_TIMEOUT = 360000
 
 
 @pytest.mark.slow
+@pytest.mark.first
 @pytest.mark.skipif((not sys.platform.startswith('linux')
                      or os.environ.get('CI', None) is None),
                     reason=("Only works reliably on Linux and "

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2623,13 +2623,15 @@ class EditorStack(QWidget):
             return
         if self.help is not None \
           and (force or self.help.dockwidget.isVisible()):
+            editor = self.get_current_editor()
+            language = editor.language.lower()
             signature = to_text_string(signature)
             signature = unicodedata.normalize("NFKD", signature)
             parts = signature.split('\n\n')
             definition = parts[0]
             documentation = '\n\n'.join(parts[1:])
             args = ''
-            if '(' in definition:
+            if '(' in definition and language == 'python':
                 args = definition[definition.find('('):]
             else:
                 documentation = signature
@@ -2638,7 +2640,6 @@ class EditorStack(QWidget):
                    'argspec': args, 'note': '',
                    'docstring': documentation}
             self.help.set_editor_doc(doc, force_refresh=force)
-            editor = self.get_current_editor()
             editor.setFocus()
 
     def new(self, filename, encoding, text, default_content=False,

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2631,6 +2631,8 @@ class EditorStack(QWidget):
             args = ''
             if '(' in definition:
                 args = definition[definition.find('('):]
+            else:
+                documentation = signature
 
             doc = {'obj_text': '', 'name': name,
                    'argspec': args, 'note': '',


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

* Missing `:` to use the hover endpoint in Windows.
* Allow render of documentation without signature in the Help pane.

A preview:

![fix_hover](https://user-images.githubusercontent.com/16781833/75473244-cda48600-5962-11ea-8a32-5ed64a92158b.gif)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11579 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
