### PR TITLE
PR: Move CodeFolding panel's PaintEvent to a separate thread

### DIFF
--- a/spyder/plugins/editor/panels/codefolding.py
+++ b/spyder/plugins/editor/panels/codefolding.py
@@ -22,7 +22,8 @@ from math import ceil
 from intervaltree import IntervalTree
 
 # Third party imports
-from qtpy.QtCore import Signal, QSize, QPointF, QRectF, QRect, Qt
+from qtpy.QtCore import (Signal, QSize, QPointF, QRectF, QRect,
+                         Qt, QThread, QObject, QMutex, QMutexLocker)
 from qtpy.QtWidgets import QApplication, QStyleOptionViewItem, QStyle
 from qtpy.QtGui import (QTextBlock, QColor, QFontMetricsF, QPainter,
                         QLinearGradient, QPen, QPalette, QResizeEvent,
@@ -34,6 +35,92 @@ from spyder.api.panel import Panel
 from spyder.plugins.editor.utils.editor import (TextHelper, DelayJobRunner,
                                                 drift_color)
 import spyder.utils.icon_manager as ima
+
+
+class PainterThread(QObject):
+    sig_trigger_paint = Signal(object)
+
+    def __init__(self, panel):
+        QObject.__init__(self)
+        self.panel = panel
+        self.painting = False
+        self.painting_mutex = QMutex()
+        self.thread = QThread()
+        self.sig_trigger_paint.connect(self.repaint)
+        self.moveToThread(self.thread)
+
+    def start(self):
+        self.thread.start()
+
+    def stop(self):
+        with QMutexLocker(self.painting_mutex):
+            self.painting = False
+            self.thread.quit()
+
+    def stop_painting(self):
+        with QMutexLocker(self.painting_mutex):
+            self.painting = False
+
+    def start_painting(self):
+        with QMutexLocker(self.painting_mutex):
+            self.painting = True
+
+    def is_painting(self):
+        is_painting = False
+        with QMutexLocker(self.painting_mutex):
+            is_painting = self.painting
+        return is_painting
+
+    def repaint(self, event):
+        Panel.paintEvent(self.panel, event)
+        painter = QPainter(self.panel)
+        self.start_painting()
+        # Draw background over the selected non collapsed fold region
+        if self.panel._mouse_over_line is not None:
+            block = self.panel.editor.document().findBlockByNumber(
+                self.panel._mouse_over_line)
+            try:
+                self.panel._draw_fold_region_background(block, painter)
+            except (ValueError, KeyError):
+                # Catching the KeyError above is necessary to avoid
+                # issue spyder-ide/spyder#10918.
+                # It happens when users have the mouse on top of the
+                # folding panel and make some text modifications
+                # that trigger a folding recomputation.
+                pass
+        # Draw fold triggers
+        for info in self.panel.editor.visible_blocks:
+            top_position, line_number, block = info
+            if not self.is_painting():
+                break
+            if line_number in self.panel.folding_regions:
+                collapsed = self.panel.folding_status[line_number]
+                line_end = self.panel.folding_regions[line_number]
+                mouse_over = self.panel._mouse_over_line == line_number
+                self.panel._draw_fold_indicator(
+                    top_position, mouse_over, collapsed, painter)
+                if collapsed:
+                    # check if the block already has a decoration, it might
+                    # have been folded by the parent editor/document in the
+                    # case of cloned editor
+                    for deco in self.panel._block_decos:
+                        if deco.block == block:
+                            # no need to add a deco, just go to the next block
+                            break
+                    else:
+                        self.panel._add_fold_decoration(block, line_end)
+                else:
+                    for deco in self.panel._block_decos:
+                        # check if the block decoration has been removed, it
+                        # might have been unfolded by the parent
+                        # editor/document in the case of cloned editor
+                        if deco.block == block:
+                            # remove it and
+                            self.panel._block_decos.remove(deco)
+                            self.panel.editor.decorations.remove(deco)
+                            del deco
+                            break
+        self.stop_painting()
 
 
 class FoldingPanel(Panel):
@@ -169,6 +256,8 @@ class FoldingPanel(Panel):
         self.action_expand_all = None
         self._original_background = None
         self._highlight_runner = DelayJobRunner(delay=250)
+        self.folding_painter_thread = PainterThread(self)
+        self.folding_painter_thread.start()
         self.folding_regions = {}
         self.folding_status = {}
         self.folding_levels = {}
@@ -246,50 +335,8 @@ class FoldingPanel(Panel):
     def paintEvent(self, event):
         # Paints the fold indicators and the possible fold region background
         # on the folding panel.
-        super(FoldingPanel, self).paintEvent(event)
-        painter = QPainter(self)
-        # Draw background over the selected non collapsed fold region
-        if self._mouse_over_line is not None:
-            block = self.editor.document().findBlockByNumber(
-                self._mouse_over_line)
-            try:
-                self._draw_fold_region_background(block, painter)
-            except (ValueError, KeyError):
-                # Catching the KeyError above is necessary to avoid
-                # issue spyder-ide/spyder#10918.
-                # It happens when users have the mouse on top of the
-                # folding panel and make some text modifications
-                # that trigger a folding recomputation.
-                pass
-        # Draw fold triggers
-        for top_position, line_number, block in self.editor.visible_blocks:
-            if line_number in self.folding_regions:
-                collapsed = self.folding_status[line_number]
-                line_end = self.folding_regions[line_number]
-                mouse_over = self._mouse_over_line == line_number
-                self._draw_fold_indicator(
-                    top_position, mouse_over, collapsed, painter)
-                if collapsed:
-                    # check if the block already has a decoration, it might
-                    # have been folded by the parent editor/document in the
-                    # case of cloned editor
-                    for deco in self._block_decos:
-                        if deco.block == block:
-                            # no need to add a deco, just go to the next block
-                            break
-                    else:
-                        self._add_fold_decoration(block, line_end)
-                else:
-                    for deco in self._block_decos:
-                        # check if the block decoration has been removed, it
-                        # might have been unfolded by the parent
-                        # editor/document in the case of cloned editor
-                        if deco.block == block:
-                            # remove it and
-                            self._block_decos.remove(deco)
-                            self.editor.decorations.remove(deco)
-                            del deco
-                            break
+        self.folding_painter_thread.stop_painting()
+        self.folding_painter_thread.sig_trigger_paint.emit(event)
 
     def _draw_fold_region_background(self, block, painter):
         """


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Moved the code folding painting handler to a thread in order to prevent the main thread from being blocked whenever the folding needs recomputing. This update also allows to cancel ongoing paint events whenever another one arrives. 

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11614 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@andfoy
<!--- Thanks for your help making Spyder better for everyone! --->
