### PR TITLE
PR: Fix issues parsing runtests.py args and passing them properly to Spyder and Pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ MANIFEST
 .ropeproject/
 .vscode/
 result.xml
+
+# Pylint dirs/files
+.pylint.d/

--- a/runtests.py
+++ b/runtests.py
@@ -61,13 +61,12 @@ def run_pytest(run_slow=False, extra_args=None):
 def main():
     """Parse args then run the pytest suite for Spyder."""
     test_parser = argparse.ArgumentParser(
+        usage='python runtests.py [-h] [--run-slow] [pytest_args]',
         description="Helper script to run Spyder's test suite")
     test_parser.add_argument('--run-slow', action='store_true', default=False,
                              help='Run the slow tests')
-    test_parser.add_argument('pytest_args', nargs=argparse.REMAINDER,
-                             metavar="...", help="Args to pass to pytest")
-    test_args = test_parser.parse_args()
-    run_pytest(run_slow=test_args.run_slow, extra_args=test_args.pytest_args)
+    test_args, pytest_args = test_parser.parse_known_args()
+    run_pytest(run_slow=test_args.run_slow, extra_args=pytest_args)
 
 
 if __name__ == '__main__':

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -103,10 +103,11 @@ if hasattr(Qt, 'AA_EnableHighDpiScaling'):
 #==============================================================================
 from spyder.app.utils import set_opengl_implementation
 from spyder.app.cli_options import get_options
+from spyder.config.base import running_under_pytest
 
-# Get CLI options/args and make them available for future use
-# Ignore args if running tests or Spyder will try and fail to parse pytests's
-if bool(os.environ.get('SPYDER_PYTEST')):
+# Get CLI options/args and make them available for future use.
+# Ignore args if running tests or Spyder will try and fail to parse pytests's.
+if running_under_pytest():
     sys_argv = [sys.argv[0]]
 else:
     sys_argv = sys.argv
@@ -139,7 +140,7 @@ MAIN_APP.setWindowIcon(APP_ICON)
 #==============================================================================
 # Create splash screen out of MainWindow to reduce perceived startup time.
 #==============================================================================
-from spyder.config.base import _, get_image_path, DEV, running_under_pytest
+from spyder.config.base import _, get_image_path, DEV
 
 if not running_under_pytest():
     SPLASH = QSplashScreen(QPixmap(get_image_path('splash.svg')))

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3670,32 +3670,13 @@ def run_spyder(app, options, args):
 def main():
     """Main function"""
     # **** For Pytest ****
-    # We need to create MainWindow **here** to avoid passing pytest
-    # options to Spyder
     if running_under_pytest():
-        try:
-            from unittest.mock import Mock
-        except ImportError:
-            from mock import Mock  # Python 2
-
-        options = Mock()
-        options.working_directory = None
-        options.profile = False
-        options.multithreaded = False
-        options.new_instance = False
-        options.project = None
-        options.window_title = None
-        options.opengl_implementation = None
-        options.debug_info = None
-        options.debug_output = None
-        options.paths = None
-
         if CONF.get('main', 'opengl') != 'automatic':
             option = CONF.get('main', 'opengl')
             set_opengl_implementation(option)
 
         app = initialize()
-        window = run_spyder(app, options, None)
+        window = run_spyder(app, CLI_OPTIONS, None)
         return window
 
     # **** Collect command line options ****

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -105,7 +105,12 @@ from spyder.app.utils import set_opengl_implementation
 from spyder.app.cli_options import get_options
 
 # Get CLI options/args and make them available for future use
-CLI_OPTIONS, CLI_ARGS = get_options()
+# Ignore args if running tests or Spyder will try and fail to parse pytests's
+if bool(os.environ.get('SPYDER_PYTEST')):
+    sys_argv = [sys.argv[0]]
+else:
+    sys_argv = sys.argv
+CLI_OPTIONS, CLI_ARGS = get_options(sys_argv)
 
 # **** Set OpenGL implementation to use ****
 if CLI_OPTIONS.opengl_implementation:

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -546,8 +546,9 @@ def test_get_help_ipython_console(main_window, qtbot):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
-@pytest.mark.skipif(not sys.platform.startswith('linux'),
-                    reason="Only works on Linux")
+@pytest.mark.skipif((not sys.platform.startswith('linux') or
+                     os.environ.get('CI', None) is None),
+                    reason="Only works on Linux and CIs")
 @pytest.mark.use_introspection
 @pytest.mark.parametrize(
     "object_info",


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* ~~[x] Added unit test(s) covering the changes (if testable)~~
<!--- Remember that an image/animation is worth a thousand words! --->
* ~~[x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))~~

Fixes #11870.

<!--- Explain what you've done and why --->

Currently, passing any arg/option, such as ``--run-slow`` to ``runtests.py`` doesn't work, because if `test_mainwindow.py` is run, which imports `mainwindow.py`, Spyder's arg parser sees the args it doesn't recognize and causes the tests to fail during initial collection. While there is code that is supposed to handle this, it isn't executed nearly early enough to catch parser errors due to this. I didn't use the utility function to get whether we're running in a pytest env since it is only imported a number of lines after, so I didn't want to import it too early and cause latent bugs.

Furthermore, users cannot pass a custom test path/spec to pytest through the script since it inserts `spyder` in all cases, and there are other issues and inconsistencies with parsing. Ergo, there is no supported way to run just the mainwindow tests without them failing due to the QtWebEngine import.

Thus, this PR fixes all that. As a mostly-unrelated minor change too small for its own PR, it adds `.pylint.d` to `.gitignore` which gets produced when running modern versions of pylint in Spyder.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM-Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
