### PR TITLE
PR: Disable code folding when files are too long and add an option to disable code folding

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -194,6 +194,8 @@ DEFAULTS = [
               'edge_line': True,
               'edge_line_columns': '79',
               'indent_guides': False,
+              'code_folding': True,
+              'code_folding_warn': False,
               'scroll_past_end': False,
               'toolbox_panel': True,
               'close_parentheses': True,

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -195,7 +195,7 @@ DEFAULTS = [
               'edge_line_columns': '79',
               'indent_guides': False,
               'code_folding': True,
-              'code_folding_warn': False,
+              'code_folding_warn': True,
               'scroll_past_end': False,
               'toolbox_panel': True,
               'close_parentheses': True,

--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -38,6 +38,7 @@ class EditorConfigPage(PluginConfigPage):
                 'show_class_func_dropdown')
         showindentguides_box = newcb(_("Show indent guides"),
                                      'indent_guides')
+        showcodefolding_box = newcb(_("Show code folding"), 'code_folding')
         linenumbers_box = newcb(_("Show line numbers"), 'line_numbers')
         blanks_box = newcb(_("Show blank spaces"), 'blank_spaces')
         currentline_box = newcb(_("Highlight current line"),
@@ -90,6 +91,7 @@ class EditorConfigPage(PluginConfigPage):
         display_layout.addWidget(showtabbar_box)
         display_layout.addWidget(showclassfuncdropdown_box)
         display_layout.addWidget(showindentguides_box)
+        display_layout.addWidget(showcodefolding_box)
         display_layout.addWidget(linenumbers_box)
         display_layout.addWidget(blanks_box)
         display_layout.addWidget(currentline_box)

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -802,6 +802,9 @@ class Editor(SpyderPluginWidget):
         showindentguides_action = self._create_checkable_action(
             _("Show indent guides"), 'indent_guides', 'set_indent_guides')
 
+        showcodefolding_action = self._create_checkable_action(
+            _("Show code folding"), 'code_folding', 'set_code_folding_enabled')
+
         show_classfunc_dropdown_action = self._create_checkable_action(
             _("Show selector for classes and functions"),
             'show_class_func_dropdown', 'set_classfunc_dropdown_visible')
@@ -820,6 +823,7 @@ class Editor(SpyderPluginWidget):
                 'blank_spaces': showblanks_action,
                 'scroll_past_end': scrollpastend_action,
                 'indent_guides': showindentguides_action,
+                'code_folding': showcodefolding_action,
                 'show_class_func_dropdown': show_classfunc_dropdown_action,
                 'pycodestyle': show_codestyle_warnings_action,
                 'pydocstyle': show_docstring_warnings_action,
@@ -989,6 +993,7 @@ class Editor(SpyderPluginWidget):
             showblanks_action,
             scrollpastend_action,
             showindentguides_action,
+            showcodefolding_action,
             show_classfunc_dropdown_action,
             show_codestyle_warnings_action,
             show_docstring_warnings_action,
@@ -1276,6 +1281,7 @@ class Editor(SpyderPluginWidget):
             ('set_edgeline_enabled',                'edge_line'),
             ('set_edgeline_columns',                'edge_line_columns'),
             ('set_indent_guides',                   'indent_guides'),
+            ('set_code_folding_enabled',            'code_folding'),
             ('set_focus_to_editor',                 'focus_to_editor'),
             ('set_run_cell_copy',                   'run_cell_copy'),
             ('set_close_parentheses_enabled',       'close_parentheses'),
@@ -2697,6 +2703,8 @@ class Editor(SpyderPluginWidget):
             wrap_o = self.get_option(wrap_n)
             indentguides_n = 'indent_guides'
             indentguides_o = self.get_option(indentguides_n)
+            codefolding_n = 'code_folding'
+            codefolding_o = self.get_option(codefolding_n)
             tabindent_n = 'tab_always_indent'
             tabindent_o = self.get_option(tabindent_n)
             stripindent_n = 'strip_trailing_spaces_on_modify'
@@ -2743,6 +2751,8 @@ class Editor(SpyderPluginWidget):
                     editorstack.set_scrollpastend_enabled(scrollpastend_o)
                 if indentguides_n in options:
                     editorstack.set_indent_guides(indentguides_o)
+                if codefolding_n in options:
+                    editorstack.set_code_folding_enabled(codefolding_o)
                 if classfuncdropdown_n in options:
                     editorstack.set_classfunc_dropdown_visible(
                         classfuncdropdown_o)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -858,7 +858,6 @@ class CodeEditor(TextEditBaseWidget):
         self.edge_line.set_columns(edge_line_columns)
 
         # Indent guides
-        # self.indent_guides.set_enabled(indent_guides)
         self.toggle_identation_guides(indent_guides)
         if self.indent_chars == '\t':
             self.indent_guides.set_indentation_width(self.tab_stop_width_spaces)
@@ -1394,8 +1393,7 @@ class CodeEditor(TextEditBaseWidget):
             warn_seen = CONF.get('editor', 'code_folding_warn')
             warn_str = _('This file contains more than 2000 lines! All '
                          'code folding functionality will be disabled in '
-                         'order to prevent further performance degradation. '
-                         'This message will be ignored in the future.')
+                         'order to prevent further performance degradation.')
             if not warn_seen:
                 QMessageBox.information(self, _('File too long'), warn_str,
                                         QMessageBox.Ok)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1390,14 +1390,15 @@ class CodeEditor(TextEditBaseWidget):
         """Request folding."""
         total_lines = self.get_line_count()
         if total_lines > 2000 and self.code_folding:
-            warn_seen = CONF.get('editor', 'code_folding_warn')
-            warn_str = _('This file contains more than 2000 lines! All '
-                         'code folding functionality will be disabled in '
-                         'order to prevent further performance degradation.')
-            if not warn_seen:
+            warn = CONF.get('editor', 'code_folding_warn')
+            warn_str = _("This file contains more than 2000 lines!  "
+                         "Code folding and indent guidelines will be  "
+                         "disabled in order to prevent performance "
+                         "degradation.")
+            if warn:
                 QMessageBox.information(self, _('File too long'), warn_str,
                                         QMessageBox.Ok)
-                CONF.set('editor', 'code_folding_warn', True)
+                CONF.set('editor', 'code_folding_warn', False)
             self.toggle_code_folding(False)
             self.toggle_identation_guides(False)
 

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -560,6 +560,7 @@ class EditorStack(QWidget):
         self.completions_hint_after_ms = 500
         self.hover_hints_enabled = True
         self.code_snippets_enabled = True
+        self.code_folding_enabled = True
         self.underline_errors_enabled = False
         self.highlight_current_line_enabled = False
         self.highlight_current_cell_enabled = False
@@ -1175,7 +1176,7 @@ class EditorStack(QWidget):
         self.indent_guides = state
         if self.data:
             for finfo in self.data:
-                finfo.editor.indent_guides.set_enabled(state)
+                finfo.editor.toggle_identation_guides(state)
 
     def set_close_parentheses_enabled(self, state):
         # CONF.get(self.CONF_SECTION, 'close_parentheses')
@@ -1271,6 +1272,12 @@ class EditorStack(QWidget):
         if self.data:
             for finfo in self.data:
                 finfo.editor.toggle_code_snippets(state)
+
+    def set_code_folding_enabled(self, state):
+        self.code_folding_enabled = state
+        if self.data:
+            for finfo in self.data:
+                finfo.editor.toggle_code_folding(state)
 
     def set_automatic_completions_enabled(self, state):
         self.automatic_completions_enabled = state
@@ -2560,6 +2567,7 @@ class EditorStack(QWidget):
             filename=fname,
             show_class_func_dropdown=self.show_class_func_dropdown,
             indent_guides=self.indent_guides,
+            folding=self.code_folding_enabled,
         )
         if cloned_from is None:
             editor.set_text(txt)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR introduces a preference option to disable code folding. Additionally, a flag is introduced in order to notify users about code folding unavailability when large files (lines > 2000) are opened.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

![Captura de pantalla de 2020-03-03 22-08-14](https://user-images.githubusercontent.com/1878982/75841417-ab17d000-5d9b-11ea-924a-82635db35af1.png)

![imagen](https://user-images.githubusercontent.com/1878982/75841495-e1ede600-5d9b-11ea-86da-1a915881a1fb.png)



<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@andfoy
<!--- Thanks for your help making Spyder better for everyone! --->
