### PR TITLE
PR: Use resolved path (without symlinks) to save files

### DIFF
--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -26,8 +26,13 @@ from atomicwrites import atomic_write
 
 # Local imports
 from spyder.py3compat import (is_string, to_text_string, is_binary_string,
-                              is_unicode)
+                              is_unicode, PY2)
 from spyder.utils.external.binaryornot.check import is_binary
+
+if PY2:
+    import pathlib2 as pathlib
+else:
+    import pathlib
 
 
 PREFERRED_ENCODING = locale.getpreferredencoding()
@@ -233,7 +238,7 @@ def write(text, filename, encoding='utf-8', mode='wb'):
     Return (eventually new) encoding
     """
     text, encoding = encode(text, encoding)
-    absolute_filename = os.path.realpath(filename)
+    absolute_filename = to_text_string(pathlib.Path(filename).resolve())
     if 'a' in mode:
         with open(absolute_filename, mode) as textfile:
             textfile.write(text)

--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -240,8 +240,12 @@ def write(text, filename, encoding='utf-8', mode='wb'):
     """
     text, encoding = encode(text, encoding)
 
-    if os.name == "nt":
-        absolute_filename = to_text_string(pathlib.Path(filename).resolve())
+    if os.name == 'nt':
+        try:
+            absolute_filename = to_text_string(
+                pathlib.Path(filename).resolve())
+        except (OSError, RuntimeError):
+            absolute_filename = osp.realpath(filename)
     else:
         absolute_filename = osp.realpath(filename)
 

--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -16,6 +16,7 @@ from codecs import BOM_UTF8, BOM_UTF16, BOM_UTF32
 import locale
 import re
 import os
+import os.path as osp
 import sys
 import time
 import errno
@@ -238,7 +239,12 @@ def write(text, filename, encoding='utf-8', mode='wb'):
     Return (eventually new) encoding
     """
     text, encoding = encode(text, encoding)
-    absolute_filename = to_text_string(pathlib.Path(filename).resolve())
+
+    if os.name == "nt":
+        absolute_filename = to_text_string(pathlib.Path(filename).resolve())
+    else:
+        absolute_filename = osp.realpath(filename)
+
     if 'a' in mode:
         with open(absolute_filename, mode) as textfile:
             textfile.write(text)

--- a/spyder/utils/tests/test_encoding.py
+++ b/spyder/utils/tests/test_encoding.py
@@ -42,12 +42,12 @@ def test_symlinks(tmpdir):
     assert os.path.islink(symlink_file_path)
 
     # Write using the symlink
-    enconding = write("New text for symlink", symlink_file_path)
+    encoding = write("New text for symlink", symlink_file_path)
 
     # Assert symlink is valid and contents of the file
     assert os.path.islink(symlink_file_path)
-    assert base_file.read_text(enconding) == symlink_file.read_text(enconding)
-    assert symlink_file.read_text(enconding) == 'New text for symlink'
+    assert base_file.read_text(encoding) == symlink_file.read_text(encoding)
+    assert symlink_file.read_text(encoding) == 'New text for symlink'
 
 
 def test_permissions(tmpdir):

--- a/spyder/utils/tests/test_encoding.py
+++ b/spyder/utils/tests/test_encoding.py
@@ -30,7 +30,7 @@ def test_symlinks(tmpdir):
     base_file_path = to_text_string(base_file)
 
     # Write base file
-    write("Some text for symlink", base_file)
+    write("Some text for symlink", base_file_path)
 
     # Create symlink
     symlink_file = pathlib.Path(base_dir.join(


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

To properly handle saves of files using symlinks the path used for atomicwrites needs to be the real path of the file


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11718 

NOTE: Seems like using `realpath` only works on Windows with Python 3.8+: https://bugs.python.org/issue9949 so maybe `pathlib` is a better alternative (although for Python 2 `pathlib2` needs to be used)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
