### PR TITLE
PR: Fix highlighting based on Pygments

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -3678,7 +3678,13 @@ class CodeEditor(TextEditBaseWidget):
         if key in direction_keys:
             self.request_cursor_event()
 
-        # self.timer_syntax_highlight.start()
+        # This necessary to run our Pygments highlighter again after the
+        # user generated text changes
+        if event.text():
+            if self.timer_syntax_highlight.isActive():
+                self.timer_syntax_highlight.stop()
+            self.timer_syntax_highlight.start()
+
         self._restore_editor_cursor_and_selections()
         super(CodeEditor, self).keyReleaseEvent(event)
         event.ignore()

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -492,9 +492,6 @@ class CodeEditor(TextEditBaseWidget):
         # the highlighter in order to generate the correct coloring.
         self.timer_syntax_highlight = QTimer(self)
         self.timer_syntax_highlight.setSingleShot(True)
-        # We wait 300 ms to trigger a new coloring as this value is a good
-        # proxy for estimating when an user has stopped typing
-        self.timer_syntax_highlight.setInterval(300)
         self.timer_syntax_highlight.timeout.connect(
             self.run_pygments_highlighter)
 
@@ -3681,8 +3678,20 @@ class CodeEditor(TextEditBaseWidget):
         # This necessary to run our Pygments highlighter again after the
         # user generated text changes
         if event.text():
+            # Stop the active timer and start it again to not run it on
+            # every event
             if self.timer_syntax_highlight.isActive():
                 self.timer_syntax_highlight.stop()
+
+            # Adjust interval to rehighlight according to the lines
+            # present in the file
+            total_lines = self.get_line_count()
+            if total_lines < 1000:
+                self.timer_syntax_highlight.setInterval(600)
+            elif total_lines < 2000:
+                self.timer_syntax_highlight.setInterval(800)
+            else:
+                self.timer_syntax_highlight.setInterval(1000)
             self.timer_syntax_highlight.start()
 
         self._restore_editor_cursor_and_selections()

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -84,7 +84,7 @@ CUSTOM_EXTENSION_LEXER = {
     '.nt': 'bat',
     '.m': 'matlab',
     ('.properties', '.session', '.inf', '.reg', '.url',
-    '.cfg', '.cnf', '.aut', '.iss'): 'ini'
+     '.cfg', '.cnf', '.aut', '.iss'): 'ini'
 }
 
 # Convert custom extensions into a one-to-one mapping for easier lookup.

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -54,34 +54,40 @@ DEFAULT_PATTERNS = {
     'url':
         r"https?://([\da-z\.-]+)\.([a-z\.]{2,6})([/\w\.-]*)[^ ^'^\"]+",
 }
+
 COLOR_SCHEME_KEYS = {
-                      "background":     _("Background:"),
-                      "currentline":    _("Current line:"),
-                      "currentcell":    _("Current cell:"),
-                      "occurrence":     _("Occurrence:"),
-                      "ctrlclick":      _("Link:"),
-                      "sideareas":      _("Side areas:"),
-                      "matched_p":      _("Matched <br>parens:"),
-                      "unmatched_p":    _("Unmatched <br>parens:"),
-                      "normal":         _("Normal text:"),
-                      "keyword":        _("Keyword:"),
-                      "builtin":        _("Builtin:"),
-                      "definition":     _("Definition:"),
-                      "comment":        _("Comment:"),
-                      "string":         _("String:"),
-                      "number":         _("Number:"),
-                      "instance":       _("Instance:"),
-                      }
+    "background":     _("Background:"),
+    "currentline":    _("Current line:"),
+    "currentcell":    _("Current cell:"),
+    "occurrence":     _("Occurrence:"),
+    "ctrlclick":      _("Link:"),
+    "sideareas":      _("Side areas:"),
+    "matched_p":      _("Matched <br>parens:"),
+    "unmatched_p":    _("Unmatched <br>parens:"),
+    "normal":         _("Normal text:"),
+    "keyword":        _("Keyword:"),
+    "builtin":        _("Builtin:"),
+    "definition":     _("Definition:"),
+    "comment":        _("Comment:"),
+    "string":         _("String:"),
+    "number":         _("Number:"),
+    "instance":       _("Instance:"),
+}
+
 COLOR_SCHEME_NAMES = CONF.get('appearance', 'names')
+
 # Mapping for file extensions that use Pygments highlighting but should use
 # different lexers than Pygments' autodetection suggests.  Keys are file
 # extensions or tuples of extensions, values are Pygments lexer names.
-CUSTOM_EXTENSION_LEXER = {'.ipynb': 'json',
-                          '.txt': 'text',
-                          '.nt': 'bat',
-                          '.m': 'matlab',
-                          ('.properties', '.session', '.inf', '.reg', '.url',
-                           '.cfg', '.cnf', '.aut', '.iss'): 'ini'}
+CUSTOM_EXTENSION_LEXER = {
+    '.ipynb': 'json',
+    '.txt': 'text',
+    '.nt': 'bat',
+    '.m': 'matlab',
+    ('.properties', '.session', '.inf', '.reg', '.url',
+    '.cfg', '.cnf', '.aut', '.iss'): 'ini'
+}
+
 # Convert custom extensions into a one-to-one mapping for easier lookup.
 custom_extension_lexer_mapping = {}
 for key, value in CUSTOM_EXTENSION_LEXER.items():
@@ -1224,7 +1230,7 @@ class MarkdownSH(BaseSH):
 # current native PythonSH syntax highlighter.
 
 class PygmentsSH(BaseSH):
-    """ Generic Pygments syntax highlighter """
+    """Generic Pygments syntax highlighter."""
     # Store the language name and a ref to the lexer
     _lang_name = None
     _lexer = None

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -81,7 +81,6 @@ COLOR_SCHEME_NAMES = CONF.get('appearance', 'names')
 # extensions or tuples of extensions, values are Pygments lexer names.
 CUSTOM_EXTENSION_LEXER = {
     '.ipynb': 'json',
-    '.txt': 'text',
     '.nt': 'bat',
     '.m': 'matlab',
     ('.properties', '.session', '.inf', '.reg', '.url',
@@ -1378,20 +1377,25 @@ class PythonLoggingLexer(RegexLexer):
 
 
 def guess_pygments_highlighter(filename):
-    """Factory to generate syntax highlighter for the given filename.
+    """
+    Factory to generate syntax highlighter for the given filename.
 
     If a syntax highlighter is not available for a particular file, this
-    function will attempt to generate one based on the lexers in Pygments.  If
+    function will attempt to generate one based on the lexers in Pygments. If
     Pygments is not available or does not have an appropriate lexer, TextSH
     will be returned instead.
-
     """
     try:
         from pygments.lexers import get_lexer_for_filename, get_lexer_by_name
     except Exception:
         return TextSH
+
     root, ext = os.path.splitext(filename)
-    if ext in custom_extension_lexer_mapping:
+    if ext == '.txt':
+        # Pygments assigns a lexer that doesn’t highlight anything to
+        # txt files. So we avoid that here.
+        return TextSH
+    elif ext in custom_extension_lexer_mapping:
         try:
             lexer = get_lexer_by_name(custom_extension_lexer_mapping[ext])
         except Exception:
@@ -1403,6 +1407,8 @@ def guess_pygments_highlighter(filename):
             lexer = get_lexer_for_filename(filename)
         except Exception:
             return TextSH
+
     class GuessedPygmentsSH(PygmentsSH):
         _lexer = lexer
+
     return GuessedPygmentsSH


### PR DESCRIPTION
This improves highlighting with Pygments and avoids using it for txt files.

This also reverts PR #11664 because it broke re-highlighting for files that use Pygments.