### PR TITLE
PR: Some improvements to fallback completions

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2999,6 +2999,8 @@ def test_runcell_after_restart(main_window, qtbot):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
+@pytest.mark.skipif(sys.platform.startswith('linux'),
+                    reason="It fails sometimes on Linux")
 @pytest.mark.parametrize(
     "ipython", [True, False])
 @pytest.mark.parametrize(

--- a/spyder/plugins/completion/fallback/actor.py
+++ b/spyder/plugins/completion/fallback/actor.py
@@ -62,6 +62,8 @@ class FallbackActor(QObject):
         valid = is_prefix_valid(text, offset, language)
         if not valid:
             return []
+
+        # Get language keywords provided by Pygments
         try:
             lexer = get_lexer_by_name(language)
             keywords = get_keywords(lexer)
@@ -76,11 +78,11 @@ class FallbackActor(QObject):
                      'documentation': '',
                      'provider': FALLBACK_COMPLETION}
                     for keyword in keywords]
-        # logger.debug(keywords)
-        # tokens = list(lexer.get_tokens(text))
-        # logger.debug(tokens)
+
+        # Get file tokens
         tokens = get_words(text, offset, language)
-        tokens = [{'kind': CompletionItemKind.TEXT, 'insertText': token,
+        tokens = [{'kind': CompletionItemKind.TEXT,
+                   'insertText': token,
                    'label': token,
                    'sortText': token,
                    'filterText': token,
@@ -90,7 +92,13 @@ class FallbackActor(QObject):
         for token in tokens:
             if token['insertText'] not in keyword_set:
                 keywords.append(token)
-        return keywords
+
+        # Filter matching results
+        current_word = text[:offset].split()[-1]
+        matching_keywords = [k for k in keywords
+                             if current_word in k['insertText']]
+
+        return matching_keywords
 
     def stop(self):
         """Stop actor."""

--- a/spyder/plugins/completion/fallback/actor.py
+++ b/spyder/plugins/completion/fallback/actor.py
@@ -95,8 +95,9 @@ class FallbackActor(QObject):
 
         # Filter matching results
         if current_word is not None:
+            current_word = current_word.lower()
             keywords = [k for k in keywords
-                        if current_word in k['insertText']]
+                        if current_word in k['insertText'].lower()]
 
         return keywords
 

--- a/spyder/plugins/completion/fallback/actor.py
+++ b/spyder/plugins/completion/fallback/actor.py
@@ -54,7 +54,7 @@ class FallbackActor(QObject):
         self.thread.started.connect(self.started)
         self.sig_mailbox.connect(self.handle_msg)
 
-    def tokenize(self, text, offset, language):
+    def tokenize(self, text, offset, language, current_word):
         """
         Return all tokens in `text` and all keywords associated by
         Pygments to `language`.
@@ -94,11 +94,11 @@ class FallbackActor(QObject):
                 keywords.append(token)
 
         # Filter matching results
-        current_word = text[:offset].split()[-1]
-        matching_keywords = [k for k in keywords
-                             if current_word in k['insertText']]
+        if current_word is not None:
+            keywords = [k for k in keywords
+                        if current_word in k['insertText']]
 
-        return matching_keywords
+        return keywords
 
     def stop(self):
         """Stop actor."""
@@ -150,6 +150,7 @@ class FallbackActor(QObject):
                 tokens = self.tokenize(
                     text_info['text'],
                     text_info['offset'],
-                    text_info['language'])
+                    text_info['language'],
+                    msg['current_word'])
             tokens = {'params': tokens}
             self.sig_set_tokens.emit(_id, tokens)

--- a/spyder/plugins/completion/fallback/tests/test_fallback.py
+++ b/spyder/plugins/completion/fallback/tests/test_fallback.py
@@ -109,7 +109,8 @@ def test_tokenize(qtbot_module, fallback_fixture, file_fixture):
     qtbot_module.wait(1000)
 
     tokens_request = {
-        'file': filename
+        'file': filename,
+        'current_word': ''
     }
     with qtbot_module.waitSignal(completions.sig_recv_tokens,
                                  timeout=3000) as blocker:
@@ -136,6 +137,7 @@ def test_token_update(qtbot_module, fallback_fixture):
 
     tokens_request = {
         'file': 'test.py',
+        'current_word': ''
     }
     with qtbot_module.waitSignal(completions.sig_recv_tokens,
                                  timeout=3000) as blocker:

--- a/spyder/plugins/completion/fallback/utils.py
+++ b/spyder/plugins/completion/fallback/utils.py
@@ -116,7 +116,7 @@ def get_words(text, exclude_offset=None, language=None):
 
 
 def is_prefix_valid(text, offset, language):
-    """Check if current offset prefix ."""
+    """Check if current offset prefix is valid."""
     regex = LANGUAGE_REGEX.get(language.lower(), all_regex)
     prefix = ''
     current_pos_text = text[offset - 1]

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -50,6 +50,7 @@ class CompletionManager(SpyderCompletionPlugin):
             LSPRequestTypes.DOCUMENT_COMPLETION: {
                 KiteCompletionPlugin.COMPLETION_CLIENT_NAME,
                 LanguageServerPlugin.COMPLETION_CLIENT_NAME,
+                FallbackPlugin.COMPLETION_CLIENT_NAME
             },
             LSPRequestTypes.DOCUMENT_SIGNATURE: {
                 KiteCompletionPlugin.COMPLETION_CLIENT_NAME,
@@ -143,7 +144,7 @@ class CompletionManager(SpyderCompletionPlugin):
         request_responses = self.requests[req_id]
 
         def send():
-            # Needed to prevent the send of completions for old requests
+            # Needed to prevent send of completions for old requests
             # See spyder-ide/spyder#10798
             req_type = self.requests[req_id]['req_type']
             response_instance = id(self.requests[req_id]['response_instance'])

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -144,7 +144,7 @@ class CompletionManager(SpyderCompletionPlugin):
         request_responses = self.requests[req_id]
 
         def send():
-            # Needed to prevent send of completions for old requests
+            # Needed to prevent sending completions for old requests
             # See spyder-ide/spyder#10798
             req_type = self.requests[req_id]['req_type']
             response_instance = id(self.requests[req_id]['response_instance'])
@@ -157,6 +157,8 @@ class CompletionManager(SpyderCompletionPlugin):
                     or [-1])
                 send = req_id == max_req_id
 
+            logger.debug("Completion plugin: Request {} "
+                         "removed".format(req_id))
             del self.requests[req_id]
 
             # Response only to recent requests.

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1110,6 +1110,11 @@ class CodeEditor(TextEditBaseWidget):
         """Trigger completion."""
         self.document_did_change('')
         cursor = self.textCursor()
+        current_word = self.get_current_word(
+            completion=True,
+            valid_python_variable=False
+        )
+
         params = {
             'file': self.filename,
             'line': cursor.blockNumber(),
@@ -1117,6 +1122,7 @@ class CodeEditor(TextEditBaseWidget):
             'offset': cursor.position(),
             'selection_start': cursor.selectionStart(),
             'selection_end': cursor.selectionEnd(),
+            'current_word': current_word
         }
         self.completion_args = (self.textCursor().position(), automatic)
         return params

--- a/spyder/plugins/editor/widgets/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/tests/conftest.py
@@ -76,6 +76,7 @@ def fallback_codeeditor(qtbot_module, request):
     completions = CompletionManager(None, ['fallback'])
     completions.start()
     completions.start_client('python')
+    completions.language_status['python']['fallback'] = True
     qtbot_module.addWidget(completions)
 
     # Create a CodeEditor instance
@@ -116,6 +117,7 @@ def kite_codeeditor(qtbot_module, request):
     completions = CompletionManager(main, ['kite'])
     completions.start()
     completions.start_client('python')
+    completions.language_status['python']['kite'] = True
     qtbot_module.addWidget(completions)
 
     # Create a CodeEditor instance
@@ -168,6 +170,7 @@ def lsp_plugin(qtbot_module, request):
     with qtbot_module.waitSignal(
             main.editor.sig_lsp_initialized, timeout=30000):
         completions.start_client('python')
+    completions.language_status['python']['lsp'] = True
 
     def teardown():
         completions.shutdown()

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -941,20 +941,22 @@ def test_fallback_completions(fallback_codeeditor, qtbot):
     code_editor.go_to_line(1)
 
     # Add some words in comments
-    qtbot.keyClicks(code_editor, '# some comment and words')
+    qtbot.keyClicks(code_editor, '# some comment and whole words')
     code_editor.document_did_change()
 
     # Enter for new line
     qtbot.keyPress(code_editor, Qt.Key_Enter, delay=1000)
     with qtbot.waitSignal(completion.sig_show_completions,
                           timeout=10000) as sig:
-        qtbot.keyClicks(code_editor, 'w')
+        qtbot.keyClicks(code_editor, 'wh')
         qtbot.keyPress(code_editor, Qt.Key_Tab, delay=300)
 
-    assert 'words' in {x['insertText'] for x in sig.args[0]}
+    # Assert all retrieved words start with 'wh'
+    assert all({x['insertText'].startswith('wh') for x in sig.args[0]})
 
-    # Delete 'w'
-    qtbot.keyPress(code_editor, Qt.Key_Backspace)
+    # Delete 'wh'
+    for _ in range(2):
+        qtbot.keyPress(code_editor, Qt.Key_Backspace)
 
     # Insert another word
     qtbot.keyClicks(code_editor, 'another')
@@ -970,9 +972,8 @@ def test_fallback_completions(fallback_codeeditor, qtbot):
     # Assert that keywords are also retrieved
     assert 'assert' in word_set
 
-    qtbot.keyPress(code_editor, Qt.Key_Backspace)
-    qtbot.keyPress(code_editor, Qt.Key_Backspace)
-    qtbot.keyPress(code_editor, Qt.Key_Backspace)
+    for _ in range(3):
+        qtbot.keyPress(code_editor, Qt.Key_Backspace)
 
     qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)
     with qtbot.waitSignal(completion.sig_show_completions,

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -295,6 +295,7 @@ def test_automatic_completions_parens_bug(lsp_codeeditor, qtbot):
     Test on-the-fly completions.
 
     Autocompletions for variables don't work inside function calls.
+    Note: Don't mark this as first because it fails on Windows.
 
     See: spyder-ide/spyder#10448
     """

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -997,7 +997,11 @@ class BaseEditMixin(object):
         # Find a valid Python variable name
         if valid_python_variable:
             match = re.findall(r'([^\d\W]\w*)', text, re.UNICODE)
-            if match:
+            if not match:
+                # This is assumed in several places of our codebase,
+                # so please don't change this return!
+                return None
+            else:
                 text = match[0]
 
         if completion:

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -942,9 +942,12 @@ class BaseEditMixin(object):
             self.sig_will_remove_selection.emit(start, end)
         cursor.removeSelectedText()
 
-    def get_current_word_and_position(self, completion=False, help_req=False):
-        """Return current word, i.e. word at cursor position,
-            and the start position."""
+    def get_current_word_and_position(self, completion=False, help_req=False,
+                                      valid_python_variable=True):
+        """
+        Return current word, i.e. word at cursor position, and the start
+        position.
+        """
         cursor = self.textCursor()
         cursor_pos = cursor.position()
 
@@ -989,18 +992,28 @@ class BaseEditMixin(object):
 
         cursor.select(QTextCursor.WordUnderCursor)
         text = to_text_string(cursor.selectedText())
-        # find a valid python variable name
-        match = re.findall(r'([^\d\W]\w*)', text, re.UNICODE)
-        if match:
-            text, startpos = match[0], cursor.selectionStart()
-            if completion:
-                text = text[:cursor_pos - startpos]
-            return text, startpos
+        startpos = cursor.selectionStart()
 
-    def get_current_word(self, completion=False, help_req=False):
+        # Find a valid Python variable name
+        if valid_python_variable:
+            match = re.findall(r'([^\d\W]\w*)', text, re.UNICODE)
+            if match:
+                text = match[0]
+
+        if completion:
+            text = text[:cursor_pos - startpos]
+
+        return text, startpos
+
+    def get_current_word(self, completion=False, help_req=False,
+                         valid_python_variable=True):
         """Return current word, i.e. word at cursor position."""
         ret = self.get_current_word_and_position(
-            completion=completion, help_req=help_req)
+            completion=completion,
+            help_req=help_req,
+            valid_python_variable=valid_python_variable
+        )
+
         if ret is not None:
             return ret[0]
 


### PR DESCRIPTION
This PR does the following things:

* It sends the current word to be completed to the fallback plugin, so it can filter among all tokens those that start with that word.
* It avoids the waiting logic between Kite and the LSP when fallback is the only client available.

With these changes, now we can have nice fallback completions for any file, as shown below:

![Selección_040](https://user-images.githubusercontent.com/365293/76257627-0cb6bf00-6220-11ea-8cb0-a33d4968461e.png)