### PR TITLE
PR: Use the same temp base dir for Sphinx config, src and build paths

### DIFF
--- a/spyder/plugins/help/utils/sphinxify.py
+++ b/spyder/plugins/help/utils/sphinxify.py
@@ -186,20 +186,23 @@ def sphinxify(docstring, context, buildername='html'):
     """
 
     confdir = osp.join(get_module_source_path('spyder.plugins.help.utils'))
-    drive_confdir = pathlib.Path(confdir).parts[0]
-
     srcdir = mkdtemp()
     srcdir = encoding.to_unicode_from_fs(srcdir)
     destdir = osp.join(srcdir, '_build')
-    drive_srcdir = pathlib.Path(srcdir).parts[0]
+    temp_confdir_needed = False
 
-    temp_confdir_needed = drive_confdir != drive_srcdir
+    if os.name == 'nt':
+        # Check if confdir and srcdir are in the same drive
+        # See spyder-ide/spyder#11762
+        drive_confdir = pathlib.Path(confdir).parts[0]
+        drive_srcdir = pathlib.Path(srcdir).parts[0]
+        temp_confdir_needed = drive_confdir != drive_srcdir
 
-    if os.name == 'nt' and temp_confdir_needed:
-        # TODO: This may be inefficient. Find a faster way to do it.
-        confdir = mkdtemp()
-        confdir = encoding.to_unicode_from_fs(confdir)
-        generate_configuration(confdir)
+        if temp_confdir_needed:
+            # TODO: This may be inefficient. Find a faster way to do it.
+            confdir = mkdtemp()
+            confdir = encoding.to_unicode_from_fs(confdir)
+            generate_configuration(confdir)
 
     rst_name = osp.join(srcdir, 'docstring.rst')
     if buildername == 'html':

--- a/spyder/plugins/help/utils/sphinxify.py
+++ b/spyder/plugins/help/utils/sphinxify.py
@@ -196,8 +196,11 @@ def sphinxify(docstring, context, buildername='html'):
 
     if os.name == 'nt':
         drive = pathlib.Path(confdir).parts[0]
-        srcdir = mkdtemp(dir=osp.join(drive, 'TMP'))
-    srcdir = mkdtemp()
+        base_dir = osp.join(drive, 'TMP', 'spyder')
+        pathlib.Path(base_dir).mkdir(exist_ok=True)
+        srcdir = mkdtemp(dir=base_dir)
+    else:
+        srcdir = mkdtemp()
     srcdir = encoding.to_unicode_from_fs(srcdir)
     destdir = osp.join(srcdir, '_build')
 

--- a/spyder/plugins/help/utils/sphinxify.py
+++ b/spyder/plugins/help/utils/sphinxify.py
@@ -197,7 +197,7 @@ def sphinxify(docstring, context, buildername='html'):
     if os.name == 'nt':
         drive = pathlib.Path(confdir).parts[0]
         base_dir = osp.join(drive, 'TMP', 'spyder')
-        pathlib.Path(base_dir).mkdir(exist_ok=True)
+        pathlib.Path(base_dir).mkdir(parents=True, exist_ok=True)
         srcdir = mkdtemp(dir=base_dir)
     else:
         srcdir = mkdtemp()

--- a/spyder/plugins/help/utils/sphinxify.py
+++ b/spyder/plugins/help/utils/sphinxify.py
@@ -38,8 +38,13 @@ from sphinx.application import Sphinx
 # Local imports
 from spyder.config.base import (_, get_module_data_path,
                                 get_module_source_path)
+from spyder.py3compat import PY2
 from spyder.utils import encoding
 
+if PY2:
+    import pathlib2 as pathlib
+else:
+    import pathlib
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -180,6 +185,18 @@ def sphinxify(docstring, context, buildername='html'):
     on the value of `buildername`
     """
 
+    temp_confdir = False
+    if temp_confdir:
+        # TODO: This may be inefficient. Find a faster way to do it.
+        confdir = mkdtemp()
+        confdir = encoding.to_unicode_from_fs(confdir)
+        generate_configuration(confdir)
+    else:
+        confdir = osp.join(get_module_source_path('spyder.plugins.help.utils'))
+
+    if os.name == 'nt':
+        drive = pathlib.Path(confdir).parts[0]
+        srcdir = mkdtemp(dir=osp.join(drive, 'TMP'))
     srcdir = mkdtemp()
     srcdir = encoding.to_unicode_from_fs(srcdir)
     destdir = osp.join(srcdir, '_build')
@@ -213,15 +230,6 @@ def sphinxify(docstring, context, buildername='html'):
     doc_file = codecs.open(rst_name, 'w', encoding='utf-8')
     doc_file.write(docstring)
     doc_file.close()
-
-    temp_confdir = False
-    if temp_confdir:
-        # TODO: This may be inefficient. Find a faster way to do it.
-        confdir = mkdtemp()
-        confdir = encoding.to_unicode_from_fs(confdir)
-        generate_configuration(confdir)
-    else:
-        confdir = osp.join(get_module_source_path('spyder.plugins.help.utils'))
 
     confoverrides = {'html_context': context}
 

--- a/spyder/plugins/help/utils/sphinxify.py
+++ b/spyder/plugins/help/utils/sphinxify.py
@@ -185,24 +185,21 @@ def sphinxify(docstring, context, buildername='html'):
     on the value of `buildername`
     """
 
-    temp_confdir = False
-    if temp_confdir:
+    confdir = osp.join(get_module_source_path('spyder.plugins.help.utils'))
+    drive_confdir = pathlib.Path(confdir).parts[0]
+
+    srcdir = mkdtemp()
+    srcdir = encoding.to_unicode_from_fs(srcdir)
+    destdir = osp.join(srcdir, '_build')
+    drive_srcdir = pathlib.Path(srcdir).parts[0]
+
+    temp_confdir_needed = drive_confdir != drive_srcdir
+
+    if os.name == 'nt' and temp_confdir_needed:
         # TODO: This may be inefficient. Find a faster way to do it.
         confdir = mkdtemp()
         confdir = encoding.to_unicode_from_fs(confdir)
         generate_configuration(confdir)
-    else:
-        confdir = osp.join(get_module_source_path('spyder.plugins.help.utils'))
-
-    if os.name == 'nt':
-        drive = pathlib.Path(confdir).parts[0]
-        base_dir = osp.join(drive, 'TMP', 'spyder')
-        pathlib.Path(base_dir).mkdir(parents=True, exist_ok=True)
-        srcdir = mkdtemp(dir=base_dir)
-    else:
-        srcdir = mkdtemp()
-    srcdir = encoding.to_unicode_from_fs(srcdir)
-    destdir = osp.join(srcdir, '_build')
 
     rst_name = osp.join(srcdir, 'docstring.rst')
     if buildername == 'html':
@@ -259,7 +256,7 @@ def sphinxify(docstring, context, buildername='html'):
                     "Please see it in plain text.")
         return warning(output)
 
-    if temp_confdir:
+    if temp_confdir_needed:
         shutil.rmtree(confdir, ignore_errors=True)
     shutil.rmtree(srcdir, ignore_errors=True)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Use as base dir, for temp sphinx build, one that is in the same drive than the Sphinx config

**Note:** Seems like the issue only happens with Sphinx 2.2.0. Testing with Sphinx 2.2.2, 2.3.1 and 2.4.0 the Help render works.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11652 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
