### PR TITLE
PR: Fix saving protected files on Windows by checking if they are read-only

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2329,14 +2329,15 @@ class EditorStack(QWidget):
             if not osp.isfile(finfo.filename):
                 # This is an 'untitledX.py' file (newly created)
                 read_only = False
-            try:
-                # Try to open the file to see if the permissions allow writing
-                # in Windows. For further info, see issue
-                # https://github.com/spyder-ide/spyder/issues/10657
-                fd = open(finfo.filename, os.O_RDWR)
-                fd.close()
-            except PermissionError:
-                read_only = True
+            elif os.name == 'nt':
+                try:
+                    # Try to open the file to see if its permissions allow
+                    # to write on it
+                    # Fixes spyder-ide/spyder#10657
+                    fd = os.open(finfo.filename, os.O_RDWR)
+                    os.close(fd)
+                except (IOError, OSError):
+                    read_only = True
             finfo.editor.setReadOnly(read_only)
             self.readonly_changed.emit(read_only)
 

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2329,6 +2329,14 @@ class EditorStack(QWidget):
             if not osp.isfile(finfo.filename):
                 # This is an 'untitledX.py' file (newly created)
                 read_only = False
+            try:
+                # Try to open the file to see if the permissions allow writing
+                # in Windows. For further info, see issue
+                # https://github.com/spyder-ide/spyder/issues/10657
+                fd = open(finfo.filename, os.O_RDWR)
+                fd.close()
+            except PermissionError:
+                read_only = True
             finfo.editor.setReadOnly(read_only)
             self.readonly_changed.emit(read_only)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Open the protected files in Windows by verifying if they have only read access, so they cannot be modified inside spyder and saved.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10657 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
