### PR TITLE
PR: Fix broken completions highlighting in the iPython console

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/style.py
+++ b/spyder/plugins/ipythonconsole/utils/style.py
@@ -74,8 +74,8 @@ def create_qss_style(color_scheme):
                                    in_prompt_number_font_weight,
                                    out_prompt_color, out_prompt_color,
                                    out_prompt_number_font_weight,
-                                   inverted_background_color,
-                                   inverted_font_color)
+                                   inverted_font_color,
+                                   inverted_background_color)
 
     return (sheet_formatted, dark_color(font_color))
 


### PR DESCRIPTION
The entries were swapped, resulting in no highlighting for the current
entry when using 'terminal' style completion.

Fixes #11765

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: keepiru

<!--- Thanks for your help making Spyder better for everyone! --->
