### PR TITLE
PR: Correctly hide already complete word in completion widget

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1185,9 +1185,8 @@ class CodeEditor(TextEditBaseWidget):
                         completion['insertText'] = insert_text
                         del completion['textEdit']
 
-            if len(completion_list) > 0:
-                self.completion_widget.show_list(
-                        completion_list, position, automatic)
+            self.completion_widget.show_list(
+                completion_list, position, automatic)
 
             self.kite_call_to_action.handle_processed_completions(completions)
         except RuntimeError:

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1141,8 +1141,12 @@ class CodeEditor(TextEditBaseWidget):
             prefix = self.get_current_word()
             completions = ([] if completions is None else
                            [completion for completion in completions
-                            if completion.get('insertText') != prefix
+                            if completion.get('insertText')
                             or completion.get('textEdit', {}).get('newText')])
+            if (len(completions) == 1
+                    and completions[0].get('insertText') == prefix
+                    and not completions[0].get('textEdit', {}).get('newText')):
+                completions.pop()
 
             replace_end = self.textCursor().position()
             under_cursor = self.get_current_word_and_position(completion=True)

--- a/spyder/plugins/editor/widgets/tests/test_completion.py
+++ b/spyder/plugins/editor/widgets/tests/test_completion.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+#
+
+"""Tests for completion that doesn't fit in instropection.py due to Windows."""
+
+# Third party imports
+from flaky import flaky
+import pytest
+
+
+@pytest.mark.slow
+@pytest.mark.first
+@flaky(max_runs=5)
+def test_automatic_completions_hide_complete(lsp_codeeditor, qtbot):
+    """Test on-the-fly completion closing when already complete.
+
+    Regression test for issue #11600 and pull request #11824.
+    """
+    code_editor, _ = lsp_codeeditor
+    completion = code_editor.completion_widget
+    code_editor.toggle_code_snippets(False)
+
+    code_editor.set_text('some = 0\nsomething = 1\n')
+    cursor = code_editor.textCursor()
+    code_editor.moveCursor(cursor.End)
+
+    # Complete some -> [some, something]
+    with qtbot.waitSignal(completion.sig_show_completions,
+                          timeout=10000) as sig:
+        qtbot.keyClicks(code_editor, 'some')
+    assert "some" in [x['label'] for x in sig.args[0]]
+    assert "something" in [x['label'] for x in sig.args[0]]
+
+    # No completion for 'something' as already complete
+    qtbot.keyClicks(code_editor, 'thing')
+    qtbot.wait(500)
+    assert completion.isHidden()
+
+    code_editor.toggle_code_snippets(True)
+
+
+if __name__ == '__main__':
+    pytest.main(['test_completion.py', '--run-slow'])

--- a/spyder/plugins/editor/widgets/tests/test_completions_hide.py
+++ b/spyder/plugins/editor/widgets/tests/test_completions_hide.py
@@ -4,7 +4,7 @@
 # Licensed under the terms of the MIT License
 #
 
-"""Tests for completion that doesn't fit in instropection.py due to Windows."""
+"""Tests some cases were completions need to be hidden."""
 
 # Third party imports
 from flaky import flaky


### PR DESCRIPTION
##  Description of Changes

This pull request contains two commits:
* e1b39295a **corrects** a bug in #11732: now the completion widget is actually hidden when no completion is available.
* 5a51edc2b **modifies** the behavior to match these described in  https://github.com/spyder-ide/spyder/issues/11600#issuecomment-591374070. This is obviously a personal choice and I would understand if you prefer previous behavior.
* 0813477d6 **adds** a regression test for this PR.

Result can be seen (with only letter keys stroke):
![Peek 17-03-2020 14-32](https://user-images.githubusercontent.com/28013131/76860971-22e60000-685c-11ea-8e42-73759a842acc.gif)


I did not include new test since the one introduced by #11732 should be sufficient (even if it doesn't test everything).

### Issue(s) Resolved

Should fix better #11600
Correct #11732


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
ElieGouzien

<!--- Thanks for your help making Spyder better for everyone! --->
