### PR TITLE
PR: Install the right version of jupyter_client for Python 2 in our CIs

### DIFF
--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -24,6 +24,11 @@ if [ "$USE_CONDA" = "yes" ]; then
 
     # Install python-language-server from Github with no deps
     pip install -q --no-deps git+https://github.com/palantir/python-language-server
+
+    # Avoid problems with wrong jupyter_client version being picked up
+    if [ "$PYTHON_VERSION" = "2.7" ]; then
+        conda install -q -y jupyter_client=5.3.4
+    fi
 else
     # Github backend tests are failing with 1.1.1d
     conda install -q -y openssl=1.1.1c

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -39,6 +39,11 @@ if [ "$USE_CONDA" = "yes" ]; then
 
     # Install python-language-server from Github with no deps
     pip install -q --no-deps git+https://github.com/palantir/python-language-server
+
+    # Avoid problems with wrong jupyter_client version being picked up
+    if [ "$PYTHON_VERSION" = "2.7" ]; then
+        conda install -q -y jupyter_client=5.3.4
+    fi
 else
     # Downgrade to Python 3.7.3 because 3.7.4 is not pulling
     # wheels for all packages


### PR DESCRIPTION
jupyter_client 6 was incorrectly built as `noarch`, which installs it for Python 2 no matter what.