### PR TITLE
PR: Disable screen resolution change message in macOS and allow to hide it during the current session

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1404,7 +1404,7 @@ class MainWindow(QMainWindow):
         # main window is fullscreen
         window = self.window().windowHandle()
         if window.windowState() == Qt.WindowFullScreen and (
-            sys.platform == 'darwin'):
+                sys.platform == 'darwin'):
             return
 
         answer = QMessageBox.warning(

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1399,6 +1399,14 @@ class MainWindow(QMainWindow):
         """Show message to restart Spyder since the DPI scale changed."""
         self.screen.logicalDotsPerInchChanged.disconnect(
             self.show_dpi_change_message)
+
+        # Check the window state in MacOS for not showing the message if the
+        # main window is fullscreen
+        window = self.window().windowHandle()
+        if window.windowState() == Qt.WindowFullScreen and (
+            sys.platform == 'darwin'):
+            return
+
         answer = QMessageBox.warning(
             self, _("Warning"),
             _("A monitor scale change was detected. <br><br>"

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1381,11 +1381,16 @@ class MainWindow(QMainWindow):
         self.is_setting_up = False
 
         # Handle DPI scale and window changes to show a restart message
-        window = self.window().windowHandle()
-        window.screenChanged.connect(self.handle_new_screen)
-        self.screen = self.window().windowHandle().screen()
-        self.screen.logicalDotsPerInchChanged.connect(
-            self.show_dpi_change_message)
+        # Handle DPI scale and window changes to show a restart message.
+        # Don't activate this functionality on macOS because it's being
+        # triggered in the wrong situations.
+        # See spyder-ide/spyder#11846
+        if not sys.platform == 'darwin':
+            window = self.window().windowHandle()
+            window.screenChanged.connect(self.handle_new_screen)
+            self.screen = self.window().windowHandle().screen()
+            self.screen.logicalDotsPerInchChanged.connect(
+                self.show_dpi_change_message)
 
         # Notify that the setup of the mainwindow was finished
         self.sig_setup_finished.emit()
@@ -1406,14 +1411,16 @@ class MainWindow(QMainWindow):
         if not self.show_dpi_message:
             return
 
-        # Check the window state in MacOS for not showing the message if the
-        # main window is fullscreen
+        # Check the window state to not show the message if the window
+        # is in fullscreen mode.
         window = self.window().windowHandle()
         if (window.windowState() == Qt.WindowFullScreen and
                 sys.platform == 'darwin'):
             return
 
-        dismiss_box = QCheckBox(_("Hide this message during this session"))
+        dismiss_box = QCheckBox(
+            _("Hide this message during the current session")
+        )
 
         msgbox = QMessageBox(self)
         msgbox.setIcon(QMessageBox.Warning)

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1428,7 +1428,7 @@ class MainWindow(QMainWindow):
         yes_button = msgbox.addButton(QMessageBox.Yes)
         msgbox.addButton(QMessageBox.No)
         msgbox.setCheckBox(dismiss_box)
-        msgbox.exec()
+        msgbox.exec_()
 
         if dismiss_box.isChecked():
             self.show_dpi_message = False

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1403,7 +1403,7 @@ class MainWindow(QMainWindow):
         # Check the window state in MacOS for not showing the message if the
         # main window is fullscreen
         window = self.window().windowHandle()
-        if window.windowState() == Qt.WindowFullScreen and (
+        if (window.windowState() == Qt.WindowFullScreen and
                 sys.platform == 'darwin'):
             return
 


### PR DESCRIPTION


<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Verify the screen mode before generating a warning pop-up of a monitor scale change when using spyder in the fullscreen mode.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11846 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
