### PR TITLE
PR: Fix tests in Azure/macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # History of changes
 
-## 4.1.1 (2020-03-18)
+## Version 4.1.1 (2020-03-18)
 
 ### New features
 
 * Add file path completions to the Editor. This works by writing the
   beginning of a file path, either absolute or relative, inside a
-  string and pressing `Tab` or `Ctrl+Space`.
+  string and pressing `Tab` or `Ctrl+Space` to get completions for
+  it.
 * Add a new command line option called `--report-segfault` to be
   able to send segmentation fault reports to Github.
 
@@ -49,13 +50,13 @@ In this release 8 pull requests were closed.
 ### New features
 
 * Several improvements to the interface and user experience of the Plots pane.
-* Allow to show hidden files in Files and Project panes.
-* Allow automatic introduction of docstrings in the Sphhinx format.
+* Show hidden files in Files and Project panes.
+* Allow automatic introduction of docstrings in the Sphinx format.
 * Implicitly create a project when Spyder is launched with a folder path as
   argument in the command line
 * Activate conda environment prior to kernel start in the IPython console.
-* Allow to run again IPython magics in cells.
-* Allow to run PyQt applications multiple times.
+* Re-add the ability to run IPython magics inside of cells.
+* Allow running PyQt applications multiple times.
 * Make adjustable the maximum number of recent projects in the Projects
   menu.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
     displayName: Fix Conda env permissions
 
   - script: sudo chown -R 501:20 /usr/local/miniconda/pkgs
-    displayName: Fix Conda cache permissions
+    displayName: Fix Conda pkgs permissions
 
     # Conda setup environment.
     # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/conda-environment?view=vsts

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,9 @@ jobs:
   - script: sudo install -d -m 0777 /usr/local/miniconda/envs/
     displayName: Fix Conda env permissions
 
+  - script: sudo chown -R 501:20 /usr/local/miniconda/pkgs
+    displayName: Fix Conda cache permissions
+
     # Conda setup environment.
     # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/conda-environment?view=vsts
   - task: CondaEnvironment@0

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -1101,11 +1101,8 @@ def test_completions_environment(lsp_codeeditor, qtbot, tmpdir):
     code_editor.toggle_code_snippets(False)
 
     # Get jedi test env
-    if sys.platform == 'darwin':
-        conda_jedi_env = '/Users/runner/.conda/envs/jedi-test-env'
-    else:
-        conda_envs_path = os.path.dirname(sys.prefix)
-        conda_jedi_env = os.path.join(conda_envs_path, 'jedi-test-env')
+    conda_envs_path = os.path.dirname(sys.prefix)
+    conda_jedi_env = os.path.join(conda_envs_path, 'jedi-test-env')
 
     if os.name == 'nt':
         py_exe = os.path.join(conda_jedi_env, 'python.exe')


### PR DESCRIPTION
It seems Azure changed the way it handles conda envs in its images.

* First, this fixes an error when conda tries to save files in its pkgs directory.
* And second, this fixes `test_completions_environment` because now conda creates its envs in the expected place.