### PR TITLE
PR: Fix deprecation warnings

### DIFF
--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -313,7 +313,7 @@ class ScrollFlagArea(Panel):
         if self.slider and event.button() == Qt.LeftButton:
             vsb = self.editor.verticalScrollBar()
             value = self.position_to_value(event.pos().y())
-            vsb.setValue(value-vsb.pageStep()/2)
+            vsb.setValue(int(value-vsb.pageStep()/2))
 
     def keyReleaseEvent(self, event):
         """Override Qt method."""
@@ -376,7 +376,7 @@ class ScrollFlagArea(Panel):
     def value_to_position(self, y, scale_factor, offset):
         """Convert value to position in pixels"""
         vsb = self.editor.verticalScrollBar()
-        return (y - vsb.minimum()) * scale_factor + offset
+        return int((y - vsb.minimum()) * scale_factor + offset)
 
     def position_to_value(self, y):
         """Convert position in pixels to value"""

--- a/spyder/plugins/editor/panels/tests/test_scrollflag.py
+++ b/spyder/plugins/editor/panels/tests/test_scrollflag.py
@@ -167,8 +167,8 @@ def test_range_indicator_visible_on_hover_only(editor_bot, qtbot):
     # that the slider range indicator remains hidden. The slider range
     # indicator should remains hidden at all times when the vertical scrollbar
     # of the editor is not visible.
-    x = sfa.width()/2
-    y = sfa.height()/2
+    x = int(sfa.width()/2)
+    y = int(sfa.height()/2)
     qtbot.mouseMove(sfa, pos=QPoint(x, y), delay=-1)
 
     assert sfa._range_indicator_is_visible is False
@@ -181,16 +181,16 @@ def test_range_indicator_visible_on_hover_only(editor_bot, qtbot):
     # that the slider range indicator is now shown. When the vertical scrollbar
     # of the editor is visible, the slider range indicator should be visible
     # only when the mouse cursor hover above the scrollflagarea.
-    x = sfa.width()/2
-    y = sfa.height()/2
+    x = int(sfa.width()/2)
+    y = int(sfa.height()/2)
     qtbot.mouseMove(sfa, pos=QPoint(x, y), delay=-1)
 
     assert sfa._range_indicator_is_visible is True
 
     # Move the mouse cursor outside of the scrollflagarea and assert that the
     # slider range indicator becomes hidden.
-    x = editor.width()/2
-    y = editor.height()/2
+    x = int(editor.width()/2)
+    y = int(editor.height()/2)
     qtbot.mouseMove(editor, pos=QPoint(x, y), delay=-1)
     qtbot.waitUntil(lambda: not sfa._range_indicator_is_visible)
 

--- a/spyder/plugins/editor/widgets/recover.py
+++ b/spyder/plugins/editor/widgets/recover.py
@@ -227,8 +227,8 @@ class RecoveryDialog(QDialog):
     def center(self):
         """Center the dialog."""
         screen = QApplication.desktop().screenGeometry(0)
-        x = screen.center().x() - self.width() / 2
-        y = screen.center().y() - self.height() / 2
+        x = int(screen.center().x() - self.width() / 2)
+        y = int(screen.center().y() - self.height() / 2)
         self.move(x, y)
 
     def restore(self, idx):

--- a/spyder/plugins/findinfiles/widgets.py
+++ b/spyder/plugins/findinfiles/widgets.py
@@ -658,7 +658,7 @@ class FindOptions(QWidget):
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         fm = self.ok_button.fontMetrics()
-        width = fm.width('Search') * 1.8
+        width = int(fm.width('Search') * 1.8)
         self.ok_button.setMinimumWidth(width)
         self.stop_button.setMinimumWidth(width)
         self.refresh_buttons(start=False)

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -169,7 +169,9 @@ class ArrayModel(QAbstractTableModel):
 
         # Array with infinite values cannot display background colors and
         # crashes. See: spyder-ide/spyder#8093
-        self.has_inf = np.inf in data
+        self.has_inf = False
+        if data.dtype.kind in ['f', 'c']:
+            self.has_inf = np.any(np.isinf(data))
 
         # Deactivate coloring for object arrays or arrays with inf values
         if self._data.dtype.name == 'object' or self.has_inf:

--- a/spyder/plugins/variableexplorer/widgets/basedialog.py
+++ b/spyder/plugins/variableexplorer/widgets/basedialog.py
@@ -19,13 +19,13 @@ class BaseDialog(QDialog):
         Update width and height using an updated screen geometry.
         Use a ratio for the width and height of the dialog.
         """
-        screen_width = screen_geometry.width()
-        screen_height = screen_geometry.height()
-        self.resize(screen_width * width_ratio, screen_height * height_ratio)
+        screen_width = int(screen_geometry.width() * width_ratio)
+        screen_height = int(screen_geometry.height() * height_ratio)
+        self.resize(screen_width, screen_height)
 
         # Make the dialog window appear in the center of the screen
-        x = screen_geometry.center().x() - self.width() / 2
-        y = screen_geometry.center().y() - self.height() / 2
+        x = int(screen_geometry.center().x() - self.width() / 2)
+        y = int(screen_geometry.center().y() - self.height() / 2)
         self.move(x, y)
 
     def show(self):

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -136,7 +136,7 @@ class BaseEditMixin(object):
         self._styled_widgets.add(id(widget))
 
         if is_dark_interface():
-            css = qdarkstyle.load_stylesheet_from_environment()
+            css = qdarkstyle.load_stylesheet(qt_api='')
             widget.setStyleSheet(css)
             palette = widget.palette()
             background = palette.color(palette.Window).lighter(150).name()

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -96,16 +96,18 @@ class BaseEditMixin(object):
         if at_point is not None:
             # Showing tooltip at point position
             margin = (self.document().documentMargin() / 2) + 1
-            cx, cy = at_point.x() - margin, at_point.y() - margin
+            cx = int(at_point.x() - margin)
+            cy = int(at_point.y() - margin)
         elif at_line is not None:
             # Showing tooltip at line
             cx = 5
             line = at_line - 1
             cursor = QTextCursor(self.document().findBlockByNumber(line))
-            cy = self.cursorRect(cursor).top()
+            cy = int(self.cursorRect(cursor).top())
         else:
             # Showing tooltip at cursor position
             cx, cy = self.get_coordinates('cursor')
+            cx = int(cx)
             cy = int(cy - font.pointSize() / 2)
 
         # Calculate vertical delta
@@ -1276,9 +1278,9 @@ class BaseEditMixin(object):
 
         # TODO: adapt to font size
         x = rect.left()
-        x = x - 14
+        x = int(x - 14)
         y = rect.top() + (rect.bottom() - rect.top())/2
-        y = y - dlg.height()/2 - 3
+        y = int(y - dlg.height()/2 - 3)
 
         pos = QPoint(x, y)
         pos = self.calculate_real_position(pos)

--- a/spyder/widgets/switcher.py
+++ b/spyder/widgets/switcher.py
@@ -111,7 +111,9 @@ class SwitcherBaseItem(QStandardItem):
         self._height = self._get_height()
 
         # Setup
-        self.setSizeHint(QSize(0, self._height))
+        # self._height is a float from QSizeF but
+        # QSize() expects a QSize or (int, int) as parameters
+        self.setSizeHint(QSize(0, int(self._height)))
 
     def _render_text(self):
         """Render the html template for this item."""
@@ -332,8 +334,8 @@ class SwitcherItem(SwitcherBaseItem):
             section = ''
 
         padding = self._PADDING
-        width = self._width - self._icon_width
-        height = self.get_height()
+        width = int(self._width - self._icon_width)
+        height = int(self.get_height())
         self.setSizeHint(QSize(width, height))
 
         shortcut = '&lt;' + self._shortcut + '&gt;' if self._shortcut else ''

--- a/spyder/widgets/switcher.py
+++ b/spyder/widgets/switcher.py
@@ -770,7 +770,7 @@ class Switcher(QDialog):
             switcher_height = max(switcher_height, self._MIN_HEIGHT)
         else:
             switcher_height = self._MIN_HEIGHT
-        self.setFixedHeight(switcher_height)
+        self.setFixedHeight(int(switcher_height))
 
     def set_position(self, top):
         """Set the position of the dialog."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Some Qt functions expect `int` but get `float`. Implicit conversion results in a `Deprecation Warning`
which tripped a unit test. Fixed some more warnings on the way.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11885 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: bnavigator

<!--- Thanks for your help making Spyder better for everyone! --->
