### PR TITLE
PR: Make a string translatable

### DIFF
--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -248,7 +248,7 @@ class EditorConfigPage(PluginConfigPage):
                                    (_("Google"), 'Googledoc'),
                                    (_("Sphinx"), 'Sphinxdoc'),)
         docstring_combo = self.create_combobox(
-            "Type:",
+            _("Type:"),
             docstring_combo_choices,
             'docstring_type')
 


### PR DESCRIPTION
The configuration page for `Advanced settings` in the Editor plugin had an untranslated label.

I did not regenerate the strings yet, because I am not familiar with the workflow in and out of Crowdin. (see #11977)

German translation would be "Typ:"
