### PR TITLE
PR: Avoid segfault when painting flags after removing lines

### DIFF
--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -221,9 +221,9 @@ class ScrollFlagArea(Panel):
 
         # All the lists of block numbers for flags
         dict_flags_lists = {
-            **self._dict_flag_list,
             "occurrence": editor.occurrences,
-            "found_results": editor.found_results}
+            "found_results": editor.found_results
+            }.update(self._dict_flag_list)
 
         for flag_type in dict_flags_lists:
             painter.setBrush(self._facecolors[flag_type])

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -70,9 +70,8 @@ class ScrollFlagArea(Panel):
         self._update_list_timer = QTimer(self)
         self._update_list_timer.setSingleShot(True)
         self._update_list_timer.timeout.connect(self.update_flags)
-        self._todo_list = []
-        self._code_analysis_list = []
-        self._breakpoint_list = []
+        # Dictionnary with flag lists
+        self._dict_flag_list = {}
 
     @property
     def slider(self):
@@ -111,9 +110,13 @@ class ScrollFlagArea(Panel):
         large files. Save all the flags in lists for painting during
         paint events.
         """
-        self._todo_list = []
-        self._code_analysis_list = []
-        self._breakpoint_list = []
+        self._dict_flag_list = {
+            'error': [],
+            'warning': [],
+            'todo': [],
+            'breakpoint': [],
+            }
+
         editor = self.editor
         block = editor.document().firstBlock()
         while block.isValid():
@@ -121,13 +124,24 @@ class ScrollFlagArea(Panel):
             data = block.userData()
             if data:
                 if data.code_analysis:
-                    self._code_analysis_list.append((block, data))
+                    # Paint the errors and warnings
+                    for _, _, severity, _ in data.code_analysis:
+                        if severity == DiagnosticSeverity.ERROR:
+                            flag_type = 'error'
+                            break
+                    else:
+                        flag_type = 'warning'
 
-                if data.todo:
-                    self._todo_list.append((block, data))
+                elif data.todo:
+                    flag_type = 'todo'
 
-                if data.breakpoint:
-                    self._breakpoint_list.append((block, data))
+                elif data.breakpoint:
+                    flag_type = 'breakpoint'
+                else:
+                    flag_type = None
+
+                if flag_type is not None:
+                    self._dict_flag_list[flag_type].append(block.blockNumber())
 
             block = block.next()
 
@@ -205,75 +219,25 @@ class ScrollFlagArea(Panel):
 
                 return ceil(middle-self.FLAGS_DY/2)
 
-        def should_paint_block(block):
-            """Check if the block should be painted."""
-            if not block.isValid():
-                return False
-            # Don't paint local flags outside of the window
-            if paint_local and not (
-                    min_line <= block.blockNumber() + 1 <= max_line):
-                return False
-            return True
+        # All the lists of block numbers for flags
+        dict_flags_lists = {
+            **self._dict_flag_list,
+            "occurrence": editor.occurrences,
+            "found_results": editor.found_results}
 
-        # Paint all the code analysis flags
-        for block, data in self._code_analysis_list:
-            if not should_paint_block(block):
-                continue
-            # Paint the warnings
-            for source, code, severity, message in data.code_analysis:
-                error = severity == DiagnosticSeverity.ERROR
-                if error:
-                    painter.setBrush(self._facecolors['error'])
-                    painter.setPen(self._edgecolors['error'])
-                    break
-            else:
-                painter.setBrush(self._facecolors['warning'])
-                painter.setPen(self._edgecolors['warning'])
-
-            rect_y = compute_flag_ypos(block)
-            painter.drawRect(rect_x, rect_y, rect_w, rect_h)
-
-        # Paint all the todo flags
-        for block, data in self._todo_list:
-            if not should_paint_block(block):
-                continue
-            # Paint the todos
-            rect_y = compute_flag_ypos(block)
-            painter.setBrush(self._facecolors['todo'])
-            painter.setPen(self._edgecolors['todo'])
-            painter.drawRect(rect_x, rect_y, rect_w, rect_h)
-
-        # Paint all the breakpoints flags
-        for block, data in self._breakpoint_list:
-            if not should_paint_block(block):
-                continue
-            # Paint the breakpoints
-            rect_y = compute_flag_ypos(block)
-            painter.setBrush(self._facecolors['breakpoint'])
-            painter.setPen(self._edgecolors['breakpoint'])
-            painter.drawRect(rect_x, rect_y, rect_w, rect_h)
-
-        # Paint the occurrences of selected word flags
-        if editor.occurrences:
-            painter.setBrush(self._facecolors['occurrence'])
-            painter.setPen(self._edgecolors['occurrence'])
-            for line_number in editor.occurrences:
+        for flag_type in dict_flags_lists:
+            painter.setBrush(self._facecolors[flag_type])
+            painter.setPen(self._edgecolors[flag_type])
+            for block_number in dict_flags_lists[flag_type]:
+                # Don't paint local flags outside of the window
                 if paint_local and not (
-                        min_line <= line_number + 1 <= max_line):
+                        min_line <= block_number + 1 <= max_line):
                     continue
-                block = editor.document().findBlockByNumber(line_number)
-                rect_y = compute_flag_ypos(block)
-                painter.drawRect(rect_x, rect_y, rect_w, rect_h)
-
-        # Paint the found results flags
-        if editor.found_results:
-            painter.setBrush(self._facecolors['found_results'])
-            painter.setPen(self._edgecolors['found_results'])
-            for line_number in editor.found_results:
-                if paint_local and not (
-                        min_line <= line_number + 1 <= max_line):
+                # Find the block
+                block = editor.document().findBlockByNumber(block_number)
+                if not block.isValid():
                     continue
-                block = editor.document().findBlockByNumber(line_number)
+                # paint if everything else is fine
                 rect_y = compute_flag_ypos(block)
                 painter.drawRect(rect_x, rect_y, rect_w, rect_h)
 

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -115,7 +115,7 @@ class ScrollFlagArea(Panel):
             'warning': [],
             'todo': [],
             'breakpoint': [],
-            }
+        }
 
         editor = self.editor
         block = editor.document().firstBlock()
@@ -131,10 +131,8 @@ class ScrollFlagArea(Panel):
                             break
                     else:
                         flag_type = 'warning'
-
                 elif data.todo:
                     flag_type = 'todo'
-
                 elif data.breakpoint:
                     flag_type = 'breakpoint'
                 else:
@@ -220,16 +218,16 @@ class ScrollFlagArea(Panel):
                 return ceil(middle-self.FLAGS_DY/2)
 
         # All the lists of block numbers for flags
-        dict_flags_lists = {
+        dict_flag_lists = {
             "occurrence": editor.occurrences,
             "found_results": editor.found_results
-            }
-        dict_flags_lists.update(self._dict_flag_list)
+        }
+        dict_flag_lists.update(self._dict_flag_list)
 
-        for flag_type in dict_flags_lists:
+        for flag_type in dict_flag_lists:
             painter.setBrush(self._facecolors[flag_type])
             painter.setPen(self._edgecolors[flag_type])
-            for block_number in dict_flags_lists[flag_type]:
+            for block_number in dict_flag_lists[flag_type]:
                 # Don't paint local flags outside of the window
                 if paint_local and not (
                         min_line <= block_number + 1 <= max_line):

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -223,7 +223,8 @@ class ScrollFlagArea(Panel):
         dict_flags_lists = {
             "occurrence": editor.occurrences,
             "found_results": editor.found_results
-            }.update(self._dict_flag_list)
+            }
+        dict_flags_lists.update(self._dict_flag_list)
 
         for flag_type in dict_flags_lists:
             painter.setBrush(self._facecolors[flag_type])

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2188,7 +2188,7 @@ class EditorStack(QWidget):
             return
         if index is None:
             index = self.get_stack_index()
-        if self.data:
+        if self.data and len(self.data) > index:
             finfo = self.data[index]
             if self.todolist_enabled:
                 finfo.run_todo_finder()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
#12026 seems to be caused by the usage of blocks. If a block is valid but all the next blocks are destroyed, `blockBoundingRect` creates a segmentation fault. The solution here is to get a new block iterator so the reference to the destroyed block is not used by `blockBoundingRect`.

This also simplifies the code and reduces the number of operations done while painting 



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12026


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
