### PR TITLE
PR: Fix typo in Windows executable filename extensions

### DIFF
--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -533,7 +533,7 @@ def open_files_with_application(app_path, fnames):
             return_code = 1
         return_codes[' '.join(cmd)] = return_code
     elif os.name == 'nt':
-        if not (app_path.endswith(('.exe', '.bar', '.com'))
+        if not (app_path.endswith(('.exe', '.bat', '.com', '.cmd'))
                 and os.path.isfile(app_path)):
             raise ValueError('`app_path`  must point to a valid Windows '
                              'executable!')


### PR DESCRIPTION
## Description of Changes

* fix typo in list of Windows executable filename extensions
* add `.cmd` as alternative to `.bat` files



<!--- Explain what you've done and why --->




### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @StefRe

<!--- Thanks for your help making Spyder better for everyone! --->
