### PR TITLE
PR: Correctly unindent code for valid Python

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -3982,7 +3982,7 @@ class CodeEditor(TextEditBaseWidget):
                 ind = lambda txt: len(txt)-len(txt.lstrip())
                 prevtxt = to_text_string(self.textCursor(
                                                 ).block().previous().text())
-                if ind(leading_text) == ind(prevtxt):
+                if ind(leading_text) == ind(prevtxt.rstrip()):
                     self.unindent(force=True)
             insert_text(event)
         elif key == Qt.Key_Space and not shift and not ctrl \
@@ -3993,7 +3993,7 @@ class CodeEditor(TextEditBaseWidget):
                 ind = lambda txt: len(txt)-len(txt.lstrip())
                 prevtxt = to_text_string(self.textCursor(
                                                 ).block().previous().text())
-                if ind(leading_text) == ind(prevtxt):
+                if ind(leading_text) == ind(prevtxt.rstrip()):
                     self.unindent(force=True)
             insert_text(event)
         elif key == Qt.Key_Tab and not ctrl:

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -3982,7 +3982,9 @@ class CodeEditor(TextEditBaseWidget):
                 ind = lambda txt: len(txt)-len(txt.lstrip())
                 prevtxt = to_text_string(self.textCursor(
                                                 ).block().previous().text())
-                if ind(leading_text) == ind(prevtxt.rstrip()):
+                if self.language == 'Python':
+                    prevtxt = prevtxt.rstrip()
+                if ind(leading_text) == ind(prevtxt):
                     self.unindent(force=True)
             insert_text(event)
         elif key == Qt.Key_Space and not shift and not ctrl \
@@ -3993,7 +3995,9 @@ class CodeEditor(TextEditBaseWidget):
                 ind = lambda txt: len(txt)-len(txt.lstrip())
                 prevtxt = to_text_string(self.textCursor(
                                                 ).block().previous().text())
-                if ind(leading_text) == ind(prevtxt.rstrip()):
+                if self.language == 'Python':
+                    prevtxt = prevtxt.rstrip()
+                if ind(leading_text) == ind(prevtxt):
                     self.unindent(force=True)
             insert_text(event)
         elif key == Qt.Key_Tab and not ctrl:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Does not fix the original issue where for ex. a `if` statement is immediately followed by a `else` statement (not valid Python)

To fix the original issue, `if ind(leading_text) == ind(prevtxt.rstrip()) and not prevtxt[-1] == ':':` works but is unnecessary in my opinion

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10148


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: remisalmon

<!--- Thanks for your help making Spyder better for everyone! --->
