### PR TITLE
PR: Remove size parameter in TextEditor constructor call

### DIFF
--- a/spyder/plugins/profiler/widgets/profilergui.py
+++ b/spyder/plugins/profiler/widgets/profilergui.py
@@ -232,12 +232,12 @@ class ProfilerWidget(QWidget):
     def show_log(self):
         if self.output:
             TextEditor(self.output, title=_("Profiler output"),
-                       readonly=True, size=(700, 500), parent=self).exec_()
+                       readonly=True, parent=self).exec_()
 
     def show_errorlog(self):
         if self.error_output:
             TextEditor(self.error_output, title=_("Profiler output"),
-                       readonly=True, size=(700, 500), parent=self).exec_()
+                       readonly=True, parent=self).exec_()
 
     def start(self, wdir=None, args=None, pythonpath=None):
         filename = to_text_string(self.filecombo.currentText())

--- a/spyder/plugins/profiler/widgets/profilergui.py
+++ b/spyder/plugins/profiler/widgets/profilergui.py
@@ -231,13 +231,18 @@ class ProfilerWidget(QWidget):
 
     def show_log(self):
         if self.output:
-            TextEditor(self.output, title=_("Profiler output"),
-                       readonly=True, parent=self).exec_()
+            output_dialog = TextEditor(self.output, title=_("Profiler output"),
+                                       readonly=True, parent=self)
+            output_dialog.resize(700, 500)
+            output_dialog.exec_()
 
     def show_errorlog(self):
         if self.error_output:
-            TextEditor(self.error_output, title=_("Profiler output"),
-                       readonly=True, parent=self).exec_()
+            output_dialog = TextEditor(self.error_output,
+                                       title=_("Profiler output"),
+                                       readonly=True, parent=self)
+            output_dialog.resize(700, 500)
+            output_dialog.exec_()
 
     def start(self, wdir=None, args=None, pythonpath=None):
         filename = to_text_string(self.filecombo.currentText())


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Remove the `size` parameter in TextEditor constructor call in the profiler to avoid crash.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11875 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
