### PR TITLE
PR: Fix links to PyQt5 docs

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -228,10 +228,10 @@ class MainWindow(QMainWindow):
          ('matplotlib', "https://matplotlib.org/contents.html",
           _("Matplotlib documentation")),
          ('PyQt5',
-          "http://pyqt.sourceforge.net/Docs/PyQt5/",
+          "https://www.riverbankcomputing.com/static/Docs/PyQt5/",
           _("PyQt5 Reference Guide")),
          ('PyQt5',
-          "http://pyqt.sourceforge.net/Docs/PyQt5/class_reference.html",
+          "https://www.riverbankcomputing.com/static/Docs/PyQt5/module_index.html",
           _("PyQt5 API Reference")),
          ('winpython', "https://winpython.github.io/",
           _("WinPython"))


### PR DESCRIPTION
## Description of Changes

Fix and update links to PyQt5 docs

The link to the PyQt5 API Reference is dead; the link to the Reference Guide
gets redirected from sourceforge to riverbankscomputing, so I updated
it too to have it consistent.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: @StefRe 
