### PR TITLE
PR: Fix completion hiding when within function or comprehension.

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1139,11 +1139,12 @@ class CodeEditor(TextEditBaseWidget):
         position, automatic = args
         try:
             completions = params['params']
-            prefix = self.get_current_word()
             completions = ([] if completions is None else
                            [completion for completion in completions
                             if completion.get('insertText')
                             or completion.get('textEdit', {}).get('newText')])
+            prefix = self.get_current_word(completion=True,
+                                           valid_python_variable=False)
             if (len(completions) == 1
                     and completions[0].get('insertText') == prefix
                     and not completions[0].get('textEdit', {}).get('newText')):

--- a/spyder/plugins/editor/widgets/tests/test_completions_hide.py
+++ b/spyder/plugins/editor/widgets/tests/test_completions_hide.py
@@ -10,6 +10,8 @@
 from flaky import flaky
 import pytest
 
+from qtpy.QtCore import Qt
+
 
 @pytest.mark.slow
 @pytest.mark.first
@@ -17,7 +19,7 @@ import pytest
 def test_automatic_completions_hide_complete(lsp_codeeditor, qtbot):
     """Test on-the-fly completion closing when already complete.
 
-    Regression test for issue #11600 and pull request #11824.
+    Regression test for issue #11600 and pull requests #11824 and #12140.
     """
     code_editor, _ = lsp_codeeditor
     completion = code_editor.completion_widget
@@ -36,6 +38,19 @@ def test_automatic_completions_hide_complete(lsp_codeeditor, qtbot):
 
     # No completion for 'something' as already complete
     qtbot.keyClicks(code_editor, 'thing')
+    qtbot.wait(500)
+    assert completion.isHidden()
+    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)  # newline
+
+    # Hide even within a function
+    qtbot.keyClicks(code_editor, 'print(something')
+    qtbot.wait(500)
+    assert completion.isHidden()
+    qtbot.keyClicks(code_editor, ')')
+    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)  # newline
+
+    # Hide even inside comprehension
+    qtbot.keyClicks(code_editor, 'a = {something')
     qtbot.wait(500)
     assert completion.isHidden()
 


### PR DESCRIPTION
## Description of Changes

Completion widget hiding for complete words failed when within a function or comprehension.

* [x] Added unit tests covering the changes
* [x] Included a screenshot or animation

<!--- Explain what you've done and why --->

### Before
![Peek 04-04-2020 19-11](https://user-images.githubusercontent.com/28013131/78457128-4e644980-76a8-11ea-91f5-cd1c46e87cf8.gif)


### After
![Peek 04-04-2020 19-10](https://user-images.githubusercontent.com/28013131/78457119-45737800-76a8-11ea-8ffd-099406f94100.gif)

### Issue(s) Resolved
I didn't open any issue for this one.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@ElieGouzien

<!--- Thanks for your help making Spyder better for everyone! --->
