### PR TITLE
PR: Register actions without shortcuts and only display registered actions

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3212,26 +3212,40 @@ class MainWindow(QMainWindow):
                                    name, add_shortcut_to_tip, plugin_name))
 
     def apply_shortcuts(self):
-        """Apply shortcuts settings to all widgets/plugins"""
+        """Apply shortcuts settings to all widgets/plugins."""
         toberemoved = []
         for index, (qobject, context, name, add_shortcut_to_tip,
                     plugin_name) in enumerate(self.shortcut_data):
-            keyseq = QKeySequence(CONF.get_shortcut(context, name,
-                                                    plugin_name))
             try:
-                if isinstance(qobject, QAction):
-                    if sys.platform == 'darwin' and \
-                      qobject._shown_shortcut == 'missing':
-                        qobject._shown_shortcut = keyseq
-                    else:
-                        qobject.setShortcut(keyseq)
-                    if add_shortcut_to_tip:
-                        add_shortcut_to_tooltip(qobject, context, name)
-                elif isinstance(qobject, QShortcut):
-                    qobject.setKey(keyseq)
-            except RuntimeError:
-                # Object has been deleted
-                toberemoved.append(index)
+                shortcut_sequence = CONF.get_shortcut(context, name,
+                                                      plugin_name)
+            except (cp.NoSectionError, cp.NoOptionError):
+                # If shortcut does not exist, save it to CONF. This is an
+                # action for which there is no shortcut assigned (yet) in
+                # the configuration
+                CONF.set_shortcut(context, name, '', plugin_name)
+                shortcut_sequence = ''
+
+            if shortcut_sequence:
+                keyseq = QKeySequence(shortcut_sequence)
+                try:
+                    if isinstance(qobject, QAction):
+                        if (sys.platform == 'darwin'
+                                and qobject._shown_shortcut == 'missing'):
+                            qobject._shown_shortcut = keyseq
+                        else:
+                            qobject.setShortcut(keyseq)
+
+                        if add_shortcut_to_tip:
+                            add_shortcut_to_tooltip(qobject, context, name)
+
+                    elif isinstance(qobject, QShortcut):
+                        qobject.setKey(keyseq)
+
+                except RuntimeError:
+                    # Object has been deleted
+                    toberemoved.append(index)
+
         for index in sorted(toberemoved, reverse=True):
             self.shortcut_data.pop(index)
 

--- a/spyder/preferences/shortcuts.py
+++ b/spyder/preferences/shortcuts.py
@@ -631,7 +631,7 @@ class ShortcutsTable(QTableView):
         QTableView.__init__(self, parent)
         self._parent = parent
         self.finder = None
-
+        self.shortcut_data = None
         self.source_model = ShortcutsModel(
                                     self,
                                     text_color=text_color,
@@ -654,7 +654,14 @@ class ShortcutsTable(QTableView):
         self.selectionModel().selectionChanged.connect(self.selection)
 
         self.verticalHeader().hide()
-        self.load_shortcuts()
+
+    def set_shortcut_data(self, shortcut_data):
+        """
+        Shortcut data comes from the registration of actions on the main
+        window. This allows to only display the right actions on the
+        shortcut table. This also allows to display the localize text.
+        """
+        self.shortcut_data = shortcut_data
 
     def focusOutEvent(self, e):
         """Qt Override."""
@@ -681,14 +688,22 @@ class ShortcutsTable(QTableView):
 
     def load_shortcuts(self):
         """Load shortcuts and assign to table model."""
+        # item[1] -> context, item[2] -> name
+        shortcut_data = [(item[1], item[2]) for item in self.shortcut_data]
         shortcuts = []
         for context, name, keystr in CONF.iter_shortcuts():
-            shortcut = Shortcut(context, name, keystr)
-            shortcuts.append(shortcut)
+            if (context, name) in shortcut_data:
+                # Only add to table actions that are registered from the main
+                # window
+                shortcut = Shortcut(context, name, keystr)
+                shortcuts.append(shortcut)
+
         shortcuts = sorted(shortcuts, key=lambda x: x.context+x.name)
+
         # Store the original order of shortcuts
         for i, shortcut in enumerate(shortcuts):
             shortcut.index = i
+
         self.source_model.shortcuts = shortcuts
         self.source_model.scores = [0]*len(shortcuts)
         self.source_model.rich_text = [s.name for s in shortcuts]
@@ -807,6 +822,8 @@ class ShortcutsConfigPage(GeneralConfigPage):
         self.ICON = ima.icon('keyboard')
         # Widgets
         self.table = ShortcutsTable(self, text_color=ima.MAIN_FG_COLOR)
+        self.table.set_shortcut_data(self.main.shortcut_data)
+        self.table.load_shortcuts()
         self.finder = ShortcutFinder(self.table, self.table.set_regex)
         self.table.finder = self.finder
         self.table.finder.setPlaceholderText(
@@ -872,6 +889,7 @@ def test():
     from spyder.utils.qthelpers import qapplication
     app = qapplication()
     table = ShortcutsTable()
+    table.load_shortcuts()
     table.show()
     app.exec_()
 

--- a/spyder/preferences/tests/conftest.py
+++ b/spyder/preferences/tests/conftest.py
@@ -19,6 +19,7 @@ from qtpy.QtGui import QIcon
 import pytest
 
 # Local imports
+from spyder.config.manager import CONF
 from spyder.preferences.appearance import AppearanceConfigPage
 from spyder.preferences.configdialog import ConfigDialog
 from spyder.preferences.general import MainConfigPage
@@ -31,6 +32,11 @@ class MainWindowMock:
         self.default_style = None
         self.widgetlist = []
         self.thirdparty_plugins = []
+        self.shortcut_data = []
+
+        # Load shortcuts for tests
+        for context, name, __ in CONF.iter_shortcuts():
+            self.shortcut_data.append((None, context, name, None, None))
 
         for attr in ['mem_status', 'cpu_status']:
             mock_attr = Mock()

--- a/spyder/preferences/tests/test_shorcuts.py
+++ b/spyder/preferences/tests/test_shorcuts.py
@@ -22,12 +22,8 @@ from spyder.preferences.shortcuts import (
     INVALID_KEY, SEQUENCE_EMPTY)
 
 
-# ---- Qt Test Fixtures
-@pytest.fixture
-def shortcut_table(qtbot):
-    """Set up shortcuts."""
-    shortcut_table = ShortcutsTable()
-
+# --- Helpers
+def load_shortcuts(shortcut_table):
     # Load shortcuts from CONF
     shortcut_data = []
     for context, name, __ in CONF.iter_shortcuts():
@@ -35,7 +31,15 @@ def shortcut_table(qtbot):
 
     shortcut_table.set_shortcut_data(shortcut_data)
     shortcut_table.load_shortcuts()
+    return shortcut_table
 
+
+# ---- Qt Test Fixtures
+@pytest.fixture
+def shortcut_table(qtbot):
+    """Set up shortcuts."""
+    shortcut_table = ShortcutsTable()
+    shortcut_table = load_shortcuts(shortcut_table)
     qtbot.addWidget(shortcut_table)
     return shortcut_table
 
@@ -72,6 +76,24 @@ def test_shortcuts(shortcut_table):
     shortcut_table.show()
     shortcut_table.check_shortcuts()
     assert shortcut_table
+
+
+def test_shortcut_in_conf_is_filtered_with_shortcut_data(qtbot):
+    shortcut_table = ShortcutsTable()
+    shortcut_table = load_shortcuts(shortcut_table)
+    qtbot.addWidget(shortcut_table)
+    row_count = shortcut_table.model().rowCount()
+    assert row_count != 0
+
+    shortcut_table_empty = ShortcutsTable()
+    shortcut_table_empty.set_shortcut_data([
+        (None, '_', 'switch to plots', None, None),
+        (None, '_', 'switch to editor', None, None),
+    ])
+    shortcut_table_empty.load_shortcuts()
+    qtbot.addWidget(shortcut_table_empty)
+    row_count = shortcut_table_empty.model().rowCount()
+    assert row_count == 2
 
 
 def test_shortcuts_filtering(shortcut_table):

--- a/spyder/preferences/tests/test_shorcuts.py
+++ b/spyder/preferences/tests/test_shorcuts.py
@@ -27,6 +27,15 @@ from spyder.preferences.shortcuts import (
 def shortcut_table(qtbot):
     """Set up shortcuts."""
     shortcut_table = ShortcutsTable()
+
+    # Load shortcuts from CONF
+    shortcut_data = []
+    for context, name, __ in CONF.iter_shortcuts():
+        shortcut_data.append((None, context, name, None, None))
+
+    shortcut_table.set_shortcut_data(shortcut_data)
+    shortcut_table.load_shortcuts()
+
     qtbot.addWidget(shortcut_table)
     return shortcut_table
 
@@ -178,6 +187,7 @@ def test_sequence_conflict(create_shortcut_editor, qtbot):
     assert shortcut_editor.new_sequence == 'Ctrl+X'
     assert shortcut_editor.warning == SEQUENCE_CONFLICT
     assert shortcut_editor.button_ok.isEnabled()
+
 
     # Check that the conflict is detected for a compound of key sequences.
     qtbot.keyClick(shortcut_editor, Qt.Key_X)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

We currently load shortcuts from the configuration. This means anything there will be loaded, even if it is a leftover from a shortcut name rename or similar.

This PR adds a check on the shortcut preferences so that we displayed shortcuts that ara registered on the main window. This way we display only valid active shortcuts. Additional to this we update the `apply_shortcuts` method so that actions without a shortcut in CONF can be successfully registered. With the new work on API migration we will expose many actions without shortcuts and leave it to the user to define them if they want to use them.

Also by using the `shortcut_data` info  from the main window, we can offer translations for shortcuts via those QActions and QShortcuts. (Work for a separate PR)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12179

### Current behavior (adding some random shortcut on the shortcut section)

![image](https://user-images.githubusercontent.com/3627835/78613234-e4c37700-7830-11ea-8a0a-b7a60949e773.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
