### PR TITLE
Fix slow test error when run locally

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -51,7 +51,9 @@ def main(run_slow=False, extra_args=None):
             pytest_args += ['--cache-clear', '--junitxml=result.xml']
     elif run_slow:
         pytest_args += ['--run-slow']
-    elif extra_args:
+        sys.argv.remove('--run-slow')  # cli_options doesn't know this option
+
+    if extra_args:
         pytest_args += extra_args
 
     print("Pytest Arguments: " + str(pytest_args))


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

When running slow tests locally, via `runtests.py`, `cli_options` complains that `--run-slow` is an unknown option when loading the `mainwindow.py` module upon test collection.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary
<!--- Thanks for your help making Spyder better for everyone! --->
