### PR TITLE
WIP: MacApp: Launch jedi with Spyder's python executable

### DIFF
--- a/spyder/plugins/completion/languageserver/plugin.py
+++ b/spyder/plugins/completion/languageserver/plugin.py
@@ -574,13 +574,8 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
         }
 
         # Jedi configuration
-        if self.get_option('default', section='main_interpreter'):
-            environment = None
-        else:
-            environment = self.get_option('custom_interpreter',
-                                          section='main_interpreter')
         jedi = {
-            'environment': environment,
+            'environment': sys.executable,
             'extra_paths': self.get_option('spyder_pythonpath',
                                            section='main', default=[]),
         }


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Ensured that jedi is launched with Spyder's python executable, regardless of what iPython console executable is selected.

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Previously, the `jedi` environment was set to the configured `main_interpreter`, which could be Spyder's python executable _or_ an external one. If Spyder is launched from a conda environment, this is inconsequential; but if Spyder is launched from elsewhere (such as in the Mac standalone application) `jedi` will fail with error:

```
jedi.api.exceptions.InternalError: The subprocess <environment path>/bin/python3.7 has crashed (EOFError('Ran out of input'), stderr=)
```


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes spyder-ide/mac-application#5 and spyder-ide/mac-application#4

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary
<!--- Thanks for your help making Spyder better for everyone! --->
