### PR TITLE
PR: Display interpreter status if Spyder not launched from conda envrionment (Mac app)

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -425,7 +425,7 @@ class MainWindow(QMainWindow):
         self.help_menu_actions = []
 
         # Status bar widgets
-        self.conda_status = None
+        self.interpreter_status = None
         self.mem_status = None
         self.cpu_status = None
         self.clock_status = None
@@ -903,11 +903,10 @@ class MainWindow(QMainWindow):
             self.outlineexplorer = OutlineExplorer(self)
             self.outlineexplorer.register_plugin()
 
-        if is_anaconda():
-            from spyder.widgets.status import CondaStatus
-            self.conda_status = CondaStatus(self, status,
-                                            icon=ima.icon('environment'))
-            self.conda_status.update_interpreter(self.get_main_interpreter())
+        from spyder.widgets.status import InterpreterStatus
+        self.interpreter_status = InterpreterStatus(self, status,
+                                              icon=ima.icon('environment'))
+        self.interpreter_status.update_interpreter(self.get_main_interpreter())
 
         # Editor plugin
         self.set_splash(_("Loading editor..."))
@@ -3057,9 +3056,9 @@ class MainWindow(QMainWindow):
                     widget.set_interval(CONF.get('main', '%s/timeout' % name))
 
             # Update conda status widget
-            if is_anaconda() and self.conda_status:
+            if self.interpreter_status:
                 interpreter = self.get_main_interpreter()
-                self.conda_status.update_interpreter(interpreter)
+                self.interpreter_status.update_interpreter(interpreter)
         else:
             return
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3058,7 +3058,7 @@ class MainWindow(QMainWindow):
                     widget.setVisible(CONF.get('main', '%s/enable' % name))
                     widget.set_interval(CONF.get('main', '%s/timeout' % name))
 
-            # Update conda status widget
+            # Update interpreter status widget
             if self.interpreter_status:
                 interpreter = self.get_main_interpreter()
                 self.interpreter_status.update_interpreter(interpreter)

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -904,8 +904,11 @@ class MainWindow(QMainWindow):
             self.outlineexplorer.register_plugin()
 
         from spyder.widgets.status import InterpreterStatus
-        self.interpreter_status = InterpreterStatus(self, status,
-                                              icon=ima.icon('environment'))
+        self.interpreter_status = InterpreterStatus(
+            self,
+            status,
+            icon=ima.icon('environment'),
+        )
         self.interpreter_status.update_interpreter(self.get_main_interpreter())
 
         # Editor plugin

--- a/spyder/widgets/tests/test_status.py
+++ b/spyder/widgets/tests/test_status.py
@@ -105,7 +105,8 @@ def test_status_bar_conda_interpreter_status(status_bar, qtbot, mocker):
 
 
 def test_status_bar_other_interpreter_status(status_bar, qtbot, mocker):
-    mocker.patch.object(conda, 'is_conda_env', return_value=False)
+    mocker.patch.object(spyder.widgets.status, 'is_conda_env',
+                        return_value=False)
 
     win, statusbar = status_bar
     w = InterpreterStatus(win, statusbar)
@@ -120,7 +121,10 @@ def test_status_bar_other_interpreter_status(status_bar, qtbot, mocker):
 
 @pytest.mark.skipif(sys.platform != 'darwin', reason="Only valid on Mac")
 def test_status_bar_internal_interpreter_status(status_bar, qtbot, mocker):
-    mocker.patch.object(conda, 'is_conda_env', return_value=False)
+    mocker.patch.object(spyder.widgets.status, 'is_conda_env',
+                        return_value=False)
+    mocker.patch.object(spyder.widgets.status, 'running_in_mac_app',
+                        return_value=True)
 
     win, statusbar = status_bar
     w = InterpreterStatus(win, statusbar)

--- a/spyder/widgets/tests/test_status.py
+++ b/spyder/widgets/tests/test_status.py
@@ -9,6 +9,7 @@
 
 # Standard library imports
 import os
+import sys
 
 # Thrid party imports
 from qtpy.QtCore import Qt
@@ -117,6 +118,7 @@ def test_status_bar_other_interpreter_status(status_bar, qtbot, mocker):
     assert 'venv (Python 3.6.6)' == w._process_interpreter_env_info()
 
 
+@pytest.mark.skipif(sys.platform != 'darwin', reason="Only valid on Mac")
 def test_status_bar_internal_interpreter_status(status_bar, qtbot, mocker):
     mocker.patch.object(conda, 'is_conda_env', return_value=False)
 


### PR DESCRIPTION
* display interpreter status in statusbar, even if it isn't a conda interpreter or spyder isn't started from conda environment.

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
The conda status bar no longer tests if Spyder's python interpreter is from a conda environment.

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Currently, when updating the conda status in the status bar, Spyder's python environment is tested for being a conda environment rather than the iPython console's interpreter environment.
When Spyder is launched from a non-conda environment (such as in a standalone Mac application), the iPython console interpreter status is not displayed.
This PR fixes that.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes spyder-ide/mac-application#6

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary
<!--- Thanks for your help making Spyder better for everyone! --->
