### PR TITLE
PR: Use clean environment for Python version and module checks (Mac app)

### DIFF
--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -271,10 +271,9 @@ class Dependency(object):
 
     def check(self):
         """Check if dependency is installed"""
-        if self.required_version and self.installed_version:
+        if self.required_version:
             return programs.is_module_installed(self.modname,
-                                                self.required_version,
-                                                self.installed_version)
+                                                self.required_version)
         else:
             return True
 

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -884,7 +884,8 @@ class IPythonConsole(SpyderPluginWidget):
                     cmd = cmd.encode('utf-8')
 
                 try:
-                    proc = programs.run_shell_command(cmd)
+                    # Use clean environment
+                    proc = programs.run_shell_command(cmd, env={})
                     output, _err = proc.communicate()
                 except subprocess.CalledProcessError:
                     output = ''

--- a/spyder/preferences/maininterpreter.py
+++ b/spyder/preferences/maininterpreter.py
@@ -155,7 +155,7 @@ class MainInterpreterConfigPage(GeneralConfigPage):
         spyder_version = sys.version_info[0]
         try:
             args = ["-c", "import sys; print(sys.version_info[0])"]
-            proc = programs.run_program(pyexec, args)
+            proc = programs.run_program(pyexec, args, env={})
             console_version = int(proc.communicate()[0])
         except IOError:
             console_version = spyder_version

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -139,17 +139,18 @@ def alter_subprocess_kwargs_by_platform(**kwargs):
         CONSOLE_CREATION_FLAGS |= CREATE_NO_WINDOW
         kwargs.setdefault('creationflags', CONSOLE_CREATION_FLAGS)
 
-        # ensure Windows subprocess environment has SYSTEMROOT, but variable
-        # is case insensitive
-        if ((kwargs.get('env') is not None) and
-            ('SYSTEMROOT' not in map(str.upper, kwargs['env'].keys()))):
-            sys_root_key = None
-            for k, v in os.environ.items():
-                if 'SYSTEMROOT' == k.upper():
-                    sys_root_key = k
-                    break  # don't risk multiple values
-            if sys_root_key is not None:
-                kwargs['env'].update({sys_root_key: os.environ[sys_root_key]})
+        # ensure Windows subprocess environment has SYSTEMROOT
+        if (kwargs.get('env') is not None):
+            # Is SYSTEMROOT in env? case insensitive
+            if ('SYSTEMROOT' not in map(str.upper, kwargs['env'].keys())):
+                # Add SYSTEMROOT from os.environ
+                sys_root_key = None
+                for k, v in os.environ.items():
+                    if 'SYSTEMROOT' == k.upper():
+                        sys_root_key = k
+                        break  # don't risk multiple values
+                if sys_root_key is not None:
+                    kwargs['env'].update({sys_root_key: os.environ[sys_root_key]})
 
     return kwargs
 

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -822,8 +822,7 @@ def get_module_version(module_name):
     return getattr(mod, '__version__', getattr(mod, 'VERSION', None))
 
 
-def is_module_installed(module_name, version=None, installed_version=None,
-                        interpreter=None):
+def is_module_installed(module_name, version=None, interpreter=None):
     """
     Return True if module *module_name* is installed
 
@@ -836,14 +835,6 @@ def is_module_installed(module_name, version=None, installed_version=None,
     interpreter: check if a module is installed with a given version
     in a determined interpreter
     """
-    if installed_version is not None:
-        '''
-        installed_version only passed in from dependencies.Dependency.check
-        which retrieved it from get_module_version, so we know the module is
-        already installed
-        '''
-        return True
-
     module_version = None
     if interpreter is not None:
         if is_python_interpreter(interpreter):

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -830,84 +830,67 @@ def is_module_installed(module_name, version=None, installed_version=None,
     If version is not None, checking module version
     (module must have an attribute named '__version__')
 
-    version may starts with =, >=, > or < to specify the exact requirement ;
+    version may start with =, >=, > or < to specify the exact requirement ;
     multiple conditions may be separated by ';' (e.g. '>=0.13;<1.0')
 
     interpreter: check if a module is installed with a given version
     in a determined interpreter
     """
-    if interpreter:
+    if installed_version is not None:
+        '''
+        installed_version only passed in from dependencies.Dependency.check
+        which retrieved it from get_module_version, so we know the module is
+        already installed
+        '''
+        return True
+
+    module_version = None
+    if interpreter is not None:
         if is_python_interpreter(interpreter):
-            checkver = inspect.getsource(check_version)
-            get_modver = inspect.getsource(get_module_version)
-            stable_ver = inspect.getsource(is_stable_version)
-            ismod_inst = inspect.getsource(is_module_installed)
-
-            f = tempfile.NamedTemporaryFile('wt', suffix='.py',
-                                            dir=get_temp_dir(), delete=False)
+            cmd = 'import %s; print(%s.__version__)' % ((module_name,) * 2)
             try:
-                script = f.name
-                f.write("# -*- coding: utf-8 -*-" + "\n\n")
-                f.write("from distutils.version import LooseVersion" + "\n")
-                f.write("import re" + "\n\n")
-                f.write(stable_ver + "\n")
-                f.write(checkver + "\n")
-                f.write(get_modver + "\n")
-                f.write(ismod_inst + "\n")
-                if version:
-                    f.write("print(is_module_installed('%s','%s'))"\
-                            % (module_name, version))
-                else:
-                    f.write("print(is_module_installed('%s'))" % module_name)
+                # use clean environment
+                proc = run_program(interpreter, ['-c', cmd], env={})
+                output, _err = proc.communicate()
+            except Exception:
+                return False
 
-                # We need to flush and sync changes to ensure that the content
-                # of the file is in disk before running the script
-                f.flush()
-                os.fsync(f)
-                f.close()
-                try:
-                    proc = run_program(interpreter, [script])
-                    output, _err = proc.communicate()
-                except subprocess.CalledProcessError:
-                    return True
-                return eval(output.decode())
-            finally:
-                if not f.closed:
-                    f.close()
-                os.remove(script)
+            if _err.decode() == '':
+                module_version = output.decode().strip()
+            else:
+                return False
         else:
             # Try to not take a wrong decision if interpreter check
             # fails
             return True
-    else:
-        if installed_version is None:
-            try:
-                actver = get_module_version(module_name)
-            except:
-                # Module is not installed
-                return False
-        else:
-            actver = installed_version
-        if actver is None and version is not None:
+
+    if module_version is None:
+        try:
+            module_version = get_module_version(module_name)
+        except Exception:
+            # Module is not installed
             return False
-        elif version is None:
-            return True
+
+    if version is None:
+        return True
+    else:
+        if ';' in version:
+            versions = version.split(';')
         else:
-            if ';' in version:
-                output = True
-                for ver in version.split(';'):
-                    output = output and is_module_installed(module_name, ver)
-                return output
-            match = re.search(r'[0-9]', version)
+            versions = [version]
+
+        output = True
+        for _ver in versions:
+            match = re.search(r'[0-9]', _ver)
             assert match is not None, "Invalid version number"
-            symb = version[:match.start()]
+            symb = _ver[:match.start()]
             if not symb:
                 symb = '='
             assert symb in ('>=', '>', '=', '<', '<='),\
-                    "Invalid version condition '%s'" % symb
-            version = version[match.start():]
-
-            return check_version(actver, version, symb)
+                "Invalid version condition '%s'" % symb
+            ver = _ver[match.start():]
+            output = output and check_version(module_version, ver, symb)
+        return output
 
 
 def is_python_interpreter_valid_name(filename):
@@ -963,7 +946,7 @@ def is_pythonw(filename):
 def check_python_help(filename):
     """Check that the python interpreter can compile and provide the zen."""
     try:
-        proc = run_program(filename, ['-c', 'import this'])
+        proc = run_program(filename, ['-c', 'import this'], env={})
         stdout, _ = proc.communicate()
         stdout = to_text_string(stdout)
         valid_lines = [

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -840,14 +840,13 @@ def is_module_installed(module_name, version=None, interpreter=None):
     """
     if interpreter is not None:
         if is_python_interpreter(interpreter):
-            cmd = dedent('''
-                         try:
-                             import %s as mod
-                         except Exception:
-                             print('No Module')
-                         print(getattr(mod, '__version__',
-                                       getattr(mod, 'VERSION', None)))
-                         ''' % module_name)
+            cmd = dedent("""
+                try:
+                    import {} as mod
+                except Exception:
+                    print('No Module')  # spyder: test-skip
+                print(getattr(mod, '__version__', getattr(mod, 'VERSION', None)))  # spyder: test-skip
+                """).format(module_name)
             try:
                 # use clean environment
                 proc = run_program(interpreter, ['-c', cmd], env={})

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -140,9 +140,9 @@ def alter_subprocess_kwargs_by_platform(**kwargs):
         kwargs.setdefault('creationflags', CONSOLE_CREATION_FLAGS)
 
         # ensure Windows subprocess environment has SYSTEMROOT
-        if (kwargs.get('env') is not None):
+        if kwargs.get('env') is not None:
             # Is SYSTEMROOT in env? case insensitive
-            if ('SYSTEMROOT' not in map(str.upper, kwargs['env'].keys())):
+            if 'SYSTEMROOT' not in map(str.upper, kwargs['env'].keys()):
                 # Add SYSTEMROOT from os.environ
                 sys_root_key = None
                 for k, v in os.environ.items():

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -138,6 +138,19 @@ def alter_subprocess_kwargs_by_platform(**kwargs):
         # We "or" them together
         CONSOLE_CREATION_FLAGS |= CREATE_NO_WINDOW
         kwargs.setdefault('creationflags', CONSOLE_CREATION_FLAGS)
+
+        # ensure Windows subprocess environment has SYSTEMROOT, but variable
+        # is case insensitive
+        if ((kwargs.get('env') is not None) and
+            ('SYSTEMROOT' not in map(str.upper, kwargs['env'].keys()))):
+            sys_root_key = None
+            for k, v in os.environ.items():
+                if 'SYSTEMROOT' == k.upper():
+                    sys_root_key = k
+                    break  # don't risk multiple values
+            if sys_root_key is not None:
+                kwargs['env'].update({sys_root_key: os.environ[sys_root_key]})
+
     return kwargs
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Use a clean shell environment when obtaining python interpreter version or installed module version.

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Currently, when checking for python version or installed module versions in subprocesses in preparation for launching a `spyder_kernel`, the subprocess inherits Spyder's environment variables, which can lead to incorrect results if Spyder's environment is not a conda environment (such as in a standalone Mac application). By using a clean subprocess environment, the python version and installed module versions are correctly checked.

Currently, installed module versions are checked by writing a new script to a temporary script file and running it in a python subprocess, possibly several times, depending on the version requirements. This is replaced with a much simpler, single python subprocess call to obtain the installed module version, which can be compared to the requirement(s).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->
This allows the stand-alone Mac application to function properly.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary
<!--- Thanks for your help making Spyder better for everyone! --->
