### PR TITLE
PR: Start kernels and Jedi envs with explicit environment (Mac app)

### DIFF
--- a/spyder/config/lsp.py
+++ b/spyder/config/lsp.py
@@ -67,6 +67,7 @@ PYTHON_CONFIG = {
                 'jedi': {
                     'environment': None,
                     'extra_paths': None,
+                    'env_vars': None,
                 },
                 'jedi_completion': {
                     'enabled': True,

--- a/spyder/plugins/completion/languageserver/plugin.py
+++ b/spyder/plugins/completion/languageserver/plugin.py
@@ -21,7 +21,8 @@ from qtpy.QtCore import Slot, QTimer
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports
-from spyder.config.base import _, get_conf_path, running_under_pytest
+from spyder.config.base import (_, get_conf_path, running_under_pytest,
+                                running_in_mac_app)
 from spyder.config.lsp import PYTHON_CONFIG
 from spyder.config.manager import CONF
 from spyder.api.completion import SpyderCompletionPlugin
@@ -654,13 +655,21 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
         # Jedi configuration
         if self.get_option('default', section='main_interpreter'):
             environment = None
+            env_vars = None
         else:
             environment = self.get_option('custom_interpreter',
                                           section='main_interpreter')
+            env_vars = os.environ.copy()
+            # external interpreter should not use internal PYTHONPATH
+            env_vars.pop('PYTHONPATH', None)
+            if running_in_mac_app():
+                env_vars.pop('PYTHONHOME', None)
+
         jedi = {
             'environment': environment,
             'extra_paths': self.get_option('spyder_pythonpath',
                                            section='main', default=[]),
+            'env_vars': env_vars,
         }
         jedi_completion = {
             'enabled': self.get_option('code_completion'),

--- a/spyder/plugins/completion/languageserver/plugin.py
+++ b/spyder/plugins/completion/languageserver/plugin.py
@@ -14,7 +14,6 @@ import functools
 import logging
 import os
 import os.path as osp
-import sys
 
 # Third-party imports
 from qtpy.QtCore import Slot, QTimer
@@ -26,7 +25,7 @@ from spyder.config.base import (_, get_conf_path, running_under_pytest,
 from spyder.config.lsp import PYTHON_CONFIG
 from spyder.config.manager import CONF
 from spyder.api.completion import SpyderCompletionPlugin
-from spyder.utils.misc import check_connection_port, getcwd_or_home
+from spyder.utils.misc import check_connection_port
 from spyder.plugins.completion.languageserver import LSP_LANGUAGES
 from spyder.plugins.completion.languageserver.client import LSPClient
 from spyder.plugins.completion.languageserver.confpage import (

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -1243,7 +1243,8 @@ class IPythonConsole(SpyderPluginWidget):
         # Catch any error generated when trying to start the kernel.
         # See spyder-ide/spyder#7302.
         try:
-            kernel_manager.start_kernel(stderr=stderr_handle)
+            kernel_manager.start_kernel(stderr=stderr_handle,
+                                        env=kernel_spec.env)
         except Exception:
             error_msg = _("The error is:<br><br>"
                           "<tt>{}</tt>").format(traceback.format_exc())

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -18,7 +18,8 @@ import sys
 from jupyter_client.kernelspec import KernelSpec
 
 # Local imports
-from spyder.config.base import DEV, running_under_pytest, SAFE_MODE
+from spyder.config.base import (DEV, running_under_pytest, SAFE_MODE,
+                                running_in_mac_app)
 from spyder.config.manager import CONF
 from spyder.py3compat import PY2, iteritems, to_binary_string, to_text_string
 from spyder.utils.conda import (add_quotes, get_conda_activation_script,
@@ -84,9 +85,6 @@ class SpyderKernelSpec(KernelSpec):
         if CONF.get('main_interpreter', 'default'):
             pyexec = get_python_executable()
         else:
-            # Avoid IPython adding the virtualenv on which Spyder is running
-            # to the kernel sys.path
-            os.environ.pop('VIRTUAL_ENV', None)
             pyexec = CONF.get('main_interpreter', 'executable')
             if not is_python_interpreter(pyexec):
                 pyexec = get_python_executable()
@@ -106,7 +104,7 @@ class SpyderKernelSpec(KernelSpec):
             # the activation scripts at spyder/plugins/ipythonconsole/scripts/
             kernel_cmd = [
                 get_activation_script(),  # This is bundled with Spyder
-                get_conda_activation_script(),
+                get_conda_activation_script(pyexec),
                 get_conda_env_path(pyexec),  # Might be external
                 pyexec,
                 '{connection_file}',
@@ -127,6 +125,12 @@ class SpyderKernelSpec(KernelSpec):
     def env(self):
         """Env vars for kernels"""
         default_interpreter = CONF.get('main_interpreter', 'default')
+        env_vars = os.environ.copy()
+
+        # Avoid IPython adding the virtualenv on which Spyder is running
+        # to the kernel sys.path
+        env_vars.pop('VIRTUAL_ENV', None)
+
         pathlist = CONF.get('main', 'spyder_pythonpath', default=[])
 
         # Add spyder-kernels subrepo path to pathlist
@@ -146,6 +150,9 @@ class SpyderKernelSpec(KernelSpec):
         pypath = add_pathlist_to_PYTHONPATH([], pathlist, ipyconsole=True,
                                             drop_env=False)
 
+        # Add our PYTHONPATH to env_vars
+        env_vars.update(pypath)
+
         # Environment variables that we need to pass to our sitecustomize
         umr_namelist = CONF.get('main_interpreter', 'umr/namelist')
 
@@ -159,7 +166,7 @@ class SpyderKernelSpec(KernelSpec):
             if original_list != umr_namelist:
                 CONF.set('main_interpreter', 'umr/namelist', umr_namelist)
 
-        env_vars = {
+        env_vars.update({
             'SPY_EXTERNAL_INTERPRETER': not default_interpreter,
             'SPY_UMR_ENABLED': CONF.get('main_interpreter', 'umr/enabled'),
             'SPY_UMR_VERBOSE': CONF.get('main_interpreter', 'umr/verbose'),
@@ -186,7 +193,7 @@ class SpyderKernelSpec(KernelSpec):
             'SPY_SYMPY_O': CONF.get('ipython_console', 'symbolic_math'),
             'SPY_TESTING': running_under_pytest() or SAFE_MODE,
             'SPY_HIDE_CMD': CONF.get('ipython_console', 'hide_cmd_windows')
-        }
+        })
 
         if self.is_pylab is True:
             env_vars['SPY_AUTOLOAD_PYLAB_O'] = True
@@ -201,8 +208,9 @@ class SpyderKernelSpec(KernelSpec):
             env_vars['SPY_SYMPY_O'] = False
             env_vars['SPY_RUN_CYTHON'] = True
 
-        # Add our PYTHONPATH to env_vars
-        env_vars.update(pypath)
+        # macOS app considerations
+        if running_in_mac_app() and not default_interpreter:
+            env_vars.pop('PYTHONHOME', None)
 
         # Making all env_vars strings
         clean_env_vars = clean_env(env_vars)

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -21,10 +21,9 @@ from jupyter_client.kernelspec import KernelSpec
 from spyder.config.base import (DEV, running_under_pytest, SAFE_MODE,
                                 running_in_mac_app)
 from spyder.config.manager import CONF
-from spyder.py3compat import PY2, iteritems, to_binary_string, to_text_string
+from spyder.py3compat import PY2
 from spyder.utils.conda import (add_quotes, get_conda_activation_script,
                                 get_conda_env_path, is_conda_env)
-from spyder.utils.encoding import to_unicode_from_fs
 from spyder.utils.environ import clean_env
 from spyder.utils.misc import add_pathlist_to_PYTHONPATH, get_python_executable
 from spyder.utils.programs import is_python_interpreter

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -148,7 +148,7 @@ class SpyderKernelSpec(KernelSpec):
 
         # Create PYTHONPATH env entry to add it to the kernel
         pypath = add_pathlist_to_PYTHONPATH([], pathlist, ipyconsole=True,
-                                            drop_env=False)
+                                            drop_env=True)
 
         # Add our PYTHONPATH to env_vars
         env_vars.update(pypath)

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -21,7 +21,6 @@ from jupyter_client.kernelspec import KernelSpec
 from spyder.config.base import (DEV, running_under_pytest, SAFE_MODE,
                                 running_in_mac_app)
 from spyder.config.manager import CONF
-from spyder.py3compat import PY2
 from spyder.utils.conda import (add_quotes, get_conda_activation_script,
                                 get_conda_env_path, is_conda_env)
 from spyder.utils.environ import clean_env
@@ -73,8 +72,8 @@ class SpyderKernelSpec(KernelSpec):
         self.is_pylab = is_pylab
         self.is_sympy = is_sympy
 
-        self.display_name = 'Python 2 (Spyder)' if PY2 else 'Python 3 (Spyder)'
-        self.language = 'python2' if PY2 else 'python3'
+        self.display_name = 'Python 3 (Spyder)'
+        self.language = 'python3'
         self.resource_dir = ''
 
     @property
@@ -154,16 +153,6 @@ class SpyderKernelSpec(KernelSpec):
 
         # Environment variables that we need to pass to our sitecustomize
         umr_namelist = CONF.get('main_interpreter', 'umr/namelist')
-
-        if PY2:
-            original_list = umr_namelist[:]
-            for umr_n in umr_namelist:
-                try:
-                    umr_n.encode('utf-8')
-                except UnicodeDecodeError:
-                    umr_namelist.remove(umr_n)
-            if original_list != umr_namelist:
-                CONF.set('main_interpreter', 'umr/namelist', umr_namelist)
 
         env_vars.update({
             'SPY_EXTERNAL_INTERPRETER': not default_interpreter,

--- a/spyder/plugins/ipythonconsole/utils/tests/test_spyder_kernel.py
+++ b/spyder/plugins/ipythonconsole/utils/tests/test_spyder_kernel.py
@@ -18,9 +18,9 @@ from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec
 
 
 @pytest.mark.parametrize('default_interpreter', [True, False])
-def test_preserve_pypath(tmpdir, default_interpreter):
+def test_dont_preserve_pypath(tmpdir, default_interpreter):
     """
-    Test that we preserve PYTHONPATH in the env vars passed to the kernel
+    Test that PYTHONPATH is not preserved in the env vars passed to the kernel
     when an external interpreter is used or not.
 
     Regression test for spyder-ide/spyder#8681.
@@ -32,9 +32,9 @@ def test_preserve_pypath(tmpdir, default_interpreter):
     pypath = to_text_string(tmpdir.mkdir('test-pypath'))
     os.environ['PYTHONPATH'] = pypath
 
-    # Check that PYTHONPATH is in our kernelspec
+    # Check that PYTHONPATH is not the same as in our kernelspec
     kernel_spec = SpyderKernelSpec()
-    assert pypath in kernel_spec.env['PYTHONPATH']
+    assert pypath not in kernel_spec.env['PYTHONPATH']
 
     # Restore default value
     CONF.set('main_interpreter', 'default', True)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Currently, `spyder_kernel` shell environment variables are inherited from Spyder's environment _implicitly_. This prevents `spyder_kernel` from launching if Spyder is not launched from a conda environment (such as in a standalone Mac application). This PR solves this issue by _explicitly_ passing the desired environment variables to the `spyder_kernel` via `kernel_spec`.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

This allows a stand-alone Mac application to work properly.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary
<!--- Thanks for your help making Spyder better for everyone! --->
