### PR TITLE
WIP: MacApp: Use login-shell option on spyder_kernel launch

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -290,7 +290,7 @@ def test_single_instance_and_edit_magic(main_window, qtbot, tmpdir):
     # Test single instance
     with qtbot.waitSignal(shell.executed, timeout=2000):
         shell.execute(lock_code)
-    assert not shell.get_value('lock_created')
+    assert shell.get_value('lock_created')
 
     # Test %edit magic
     n_editors = editorstack.get_stack_count()

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -533,17 +533,21 @@ else:
     MAC_APP_NAME = 'Spyder-Py2.app'
 
 
-def running_in_mac_app():
+def running_in_mac_app(pyexec=None):
     """
-    Check if Spyder is running inside an app on macOS.
+    Check if Python executable is located inside a standalone Mac app.
 
-    Check if the app is a stand-alone app.
-    This means this file is located inside 'Spyder.app' and not in the
-    python path.
-    This is important for example for the single_instance option.
+    If no executable is provided, the default will check `sys.executable`, i.e.
+    whether Spyder is running from a standalone Mac app.
+
+    This is important for example for the single_instance option and the
+    interpreter status in the statusbar.
     """
+    if pyexec is None:
+        pyexec = sys.executable
+
     if sys.platform == "darwin":
-        if MAC_APP_NAME not in __file__:
+        if MAC_APP_NAME not in pyexec:
             return False
         return True
     else:

--- a/spyder/config/lsp.py
+++ b/spyder/config/lsp.py
@@ -67,6 +67,9 @@ PYTHON_CONFIG = {
                 'jedi': {
                     'environment': None,
                     'extra_paths': None,
+                    # jedi should have clean environment to work properly with
+                    # external interpreters
+                    'env_vars': {},
                 },
                 'jedi_completion': {
                     'enabled': True,

--- a/spyder/plugins/completion/languageserver/plugin.py
+++ b/spyder/plugins/completion/languageserver/plugin.py
@@ -661,6 +661,9 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
             'environment': environment,
             'extra_paths': self.get_option('spyder_pythonpath',
                                            section='main', default=[]),
+            # jedi should have clean environment to work properly with external
+            # interpreters
+            'env_vars': {},
         }
         jedi_completion = {
             'enabled': self.get_option('code_completion'),

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -1242,7 +1242,8 @@ class IPythonConsole(SpyderPluginWidget):
         # Catch any error generated when trying to start the kernel.
         # See spyder-ide/spyder#7302.
         try:
-            kernel_manager.start_kernel(stderr=stderr_handle)
+            kernel_manager.start_kernel(stderr=stderr_handle,
+                                        env=kernel_spec.env)
         except Exception:
             error_msg = _("The error is:<br><br>"
                           "<tt>{}</tt>").format(traceback.format_exc())

--- a/spyder/plugins/ipythonconsole/scripts/conda-activate.sh
+++ b/spyder/plugins/ipythonconsole/scripts/conda-activate.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash -l
 # This script helps activate a conda environment before running a spyder-kernel
 
 # Create variables for arguments

--- a/spyder/plugins/ipythonconsole/scripts/env-activate.bat
+++ b/spyder/plugins/ipythonconsole/scripts/env-activate.bat
@@ -1,0 +1,12 @@
+:: This scripts helps activate a conda environment before running a spyder-kernel
+@echo off
+
+:: Create variables for arguments
+set ENV_PYTHON=%1
+set SPYDER_KERNEL_SPEC=%2
+
+:: Enforce encoding
+chcp 65001>nul
+
+:: Start kernel
+%ENV_PYTHON% -m spyder_kernels.console -f %SPYDER_KERNEL_SPEC%

--- a/spyder/plugins/ipythonconsole/scripts/env-activate.sh
+++ b/spyder/plugins/ipythonconsole/scripts/env-activate.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash -l
 # This script helps activate an internal environment before running a spyder-kernel
 
 # Create variables for arguments

--- a/spyder/plugins/ipythonconsole/scripts/env-activate.sh
+++ b/spyder/plugins/ipythonconsole/scripts/env-activate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# This script helps activate an internal environment before running a spyder-kernel
+
+# Create variables for arguments
+ENV_PYTHON=$1
+SPYDER_KERNEL_SPEC=$2
+
+# Start kernel
+$ENV_PYTHON -m spyder_kernels.console -f $SPYDER_KERNEL_SPEC

--- a/spyder/plugins/ipythonconsole/utils/tests/test_spyder_kernel.py
+++ b/spyder/plugins/ipythonconsole/utils/tests/test_spyder_kernel.py
@@ -20,7 +20,7 @@ from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec
 @pytest.mark.parametrize('default_interpreter', [True, False])
 def test_preserve_pypath(tmpdir, default_interpreter):
     """
-    Test that we preserve PYTHONPATH in the env vars passed to the kernel
+    Test that PYTHONPATH is not preserved in the env vars passed to the kernel
     when an external interpreter is used or not.
 
     Regression test for spyder-ide/spyder#8681.
@@ -34,7 +34,7 @@ def test_preserve_pypath(tmpdir, default_interpreter):
 
     # Check that PYTHONPATH is in our kernelspec
     kernel_spec = SpyderKernelSpec()
-    assert pypath in kernel_spec.env['PYTHONPATH']
+    assert pypath not in kernel_spec.env['PYTHONPATH']
 
     # Restore default value
     CONF.set('main_interpreter', 'default', True)

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -138,6 +138,19 @@ def alter_subprocess_kwargs_by_platform(**kwargs):
         # We "or" them together
         CONSOLE_CREATION_FLAGS |= CREATE_NO_WINDOW
         kwargs.setdefault('creationflags', CONSOLE_CREATION_FLAGS)
+
+        # ensure Windows subprocess environment has SYSTEMROOT, but variable
+        # is case insensitive
+        if ((kwargs.get('env') is not None) and
+            ('SYSTEMROOT' not in map(str.upper, kwargs['env'].keys()))):
+            sys_root_key = None
+            for k, v in os.environ.items():
+                if 'SYSTEMROOT' == k.upper():
+                    sys_root_key = k
+                    break  # don't risk multiple values
+            if sys_root_key is not None:
+                kwargs['env'].update({sys_root_key: os.environ[sys_root_key]})
+
     return kwargs
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Use login shell option in shell script to start `spyder_kernel` for both internal and external iPython console interpreters.

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
By adding the login shell option, a user's local environment variables will be passed to the iPython console interpreter environment. This is required when using external applications such as LaTeX or MDSPlus.

This is an issue when Spyder is not launched from a login-shell environment, such as with a stand-alone Mac application.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary
<!--- Thanks for your help making Spyder better for everyone! --->
