### PR TITLE
PR: Remove restriction to populate object attributes in the Object Explorer

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -322,8 +322,6 @@ class ObjectExplorer(BaseDialog):
         self.central_splitter.setCollapsible(0, False)
         self.central_splitter.setCollapsible(1, True)
         self.central_splitter.setSizes([500, 320])
-        self.central_splitter.setStretchFactor(0, 10)
-        self.central_splitter.setStretchFactor(1, 0)
 
         # Connect signals
         # Keep a temporary reference of the selection_model to prevent

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/test_objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/test_objectexplorer.py
@@ -107,17 +107,17 @@ def test_objectexplorer(objectexplorer):
 
 
 @pytest.mark.parametrize('params', [
-            'kjkj kj k j j kj k jkj',
-            [1, 3, 4, 'kjkj', None],
-            {1, 2, 1, 3, None, 'A', 'B', 'C', True, False},
-            1.2233,
-            np.random.rand(10, 10),
-            datetime.date(1945, 5, 8),
-            datetime.datetime(1945, 5, 8)
+            # variable to show, rowCount for python 3 and 2
+            ('kjkj kj k j j kj k jkj', [71, 78]),
+            ([1, 3, 4, 'kjkj', None], [45, 46]),
+            ({1, 2, 1, 3, None, 'A', 'B', 'C', True, False}, [54, 55]),
+            (1.2233, [57, 58]),
+            (np.random.rand(10, 10), [166, 162]),
+            (datetime.date(1945, 5, 8), [43, 46])
         ])
 def test_objectexplorer_collection_types(objectexplorer, params):
     """Test to validate proper handling of collection data types."""
-    test = params
+    test, row_count = params
     editor = objectexplorer(test,
                             name='variable',
                             show_callable_attributes=True,
@@ -129,8 +129,8 @@ def test_objectexplorer_collection_types(objectexplorer, params):
     model = editor.obj_tree.model()
     # The row for the variable
     assert model.rowCount() == 1
-    # Root row without children
-    assert model.rowCount(model.index(0, 0)) == 0
+    # Root row with children
+    assert model.rowCount(model.index(0, 0)) in row_count
     assert model.columnCount() == 11
 
 

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/tree_model.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/tree_model.py
@@ -284,29 +284,27 @@ class TreeModel(QAbstractItemModel):
         path_strings = []
         tree_items = []
 
-        # Only populate children for objects without their own editor
-        if not is_editable_type(obj):
-            is_attr_list = [False] * len(obj_children)
+        is_attr_list = [False] * len(obj_children)
 
-            # Object attributes
-            # Needed to handle errors while getting object's attributes
-            # Related with spyder-ide/spyder#6728 and spyder-ide/spyder#9959
-            for attr_name in dir(obj):
-                try:
-                    attr_value = getattr(obj, attr_name)
-                    obj_children.append((attr_name, attr_value))
-                    path_strings.append('{}.{}'.format(obj_path, attr_name)
-                                        if obj_path else attr_name)
-                    is_attr_list.append(True)
-                except Exception:
-                    # Attribute could not be get
-                    pass
-            assert len(obj_children) == len(path_strings), "sanity check"
+        # Object attributes
+        # Needed to handle errors while getting object's attributes
+        # Related with spyder-ide/spyder#6728 and spyder-ide/spyder#9959
+        for attr_name in dir(obj):
+            try:
+                attr_value = getattr(obj, attr_name)
+                obj_children.append((attr_name, attr_value))
+                path_strings.append('{}.{}'.format(obj_path, attr_name)
+                                    if obj_path else attr_name)
+                is_attr_list.append(True)
+            except Exception:
+                # Attribute could not be get
+                pass
+        assert len(obj_children) == len(path_strings), "sanity check"
 
-            for item, path_str, is_attr in zip(obj_children, path_strings,
-                                               is_attr_list):
-                name, child_obj = item
-                tree_items.append(TreeItem(child_obj, name, path_str, is_attr))
+        for item, path_str, is_attr in zip(obj_children, path_strings,
+                                           is_attr_list):
+            name, child_obj = item
+            tree_items.append(TreeItem(child_obj, name, path_str, is_attr))
 
         return tree_items
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

![oe](https://user-images.githubusercontent.com/16781833/79018351-3d4c8a00-7b39-11ea-93ed-87f35abb2f56.gif)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12215


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
