### PR TITLE
MacApp: add site-packages to jedi configuration

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -56,7 +56,6 @@ from spyder.plugins.help.widgets import ObjectComboBox
 from spyder.plugins.help.tests.test_plugin import check_text
 from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec
 from spyder.py3compat import PY2, to_text_string
-from spyder.utils.programs import is_module_installed
 from spyder.widgets.dock import DockTitleBar
 from spyder.utils.misc import remove_backslashes
 

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -536,17 +536,21 @@ else:
     MAC_APP_NAME = 'Spyder-Py2.app'
 
 
-def running_in_mac_app():
+def running_in_mac_app(pyexec=None):
     """
-    Check if Spyder is running inside an app on macOS.
+    Check if Python executable is located inside a standalone Mac app.
 
-    Check if the app is a stand-alone app.
-    This means this file is located inside 'Spyder.app' and not in the
-    python path.
-    This is important for example for the single_instance option.
+    If no executable is provided, the default will check `sys.executable`, i.e.
+    whether Spyder is running from a standalone Mac app.
+
+    This is important for example for the single_instance option and the
+    interpreter status in the statusbar.
     """
+    if pyexec is None:
+        pyexec = sys.executable
+
     if sys.platform == "darwin":
-        if MAC_APP_NAME not in __file__:
+        if MAC_APP_NAME not in pyexec:
             return False
         return True
     else:

--- a/spyder/plugins/completion/languageserver/plugin.py
+++ b/spyder/plugins/completion/languageserver/plugin.py
@@ -26,6 +26,8 @@ from spyder.config.lsp import PYTHON_CONFIG
 from spyder.config.manager import CONF
 from spyder.api.completion import SpyderCompletionPlugin
 from spyder.utils.misc import check_connection_port, getcwd_or_home
+from spyder.utils.programs import get_python_site_packages  # TODO: issue 12664
+from spyder.utils.conda import is_conda_env                 # TODO: issue 12664
 from spyder.plugins.completion.languageserver import LSP_LANGUAGES
 from spyder.plugins.completion.languageserver.client import LSPClient
 from spyder.plugins.completion.languageserver.confpage import (
@@ -623,15 +625,23 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
         }
 
         # Jedi configuration
+        extra_paths = self.get_option('spyder_pythonpath', section='main',
+                                      default=[])
         if self.get_option('default', section='main_interpreter'):
             environment = None
         else:
             environment = self.get_option('custom_interpreter',
                                           section='main_interpreter')
+
+            # jedi can miss the site-package: see davidhalter/jedi#1540.
+            # TODO: issue #12664; Remove if block when pyls adopts jedi>0.17.0.
+            if (not is_conda_env(pyexec=sys.executable)
+                and is_conda_env(pyexec=environment)):
+                extra_paths += get_python_site_packages(environment)
+
         jedi = {
             'environment': environment,
-            'extra_paths': self.get_option('spyder_pythonpath',
-                                           section='main', default=[]),
+            'extra_paths': extra_paths,
         }
         jedi_completion = {
             'enabled': self.get_option('code_completion'),

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -24,6 +24,7 @@ import sys
 import tempfile
 import threading
 import time
+import ast  # TODO: issue #12664
 
 # Third party imports
 import psutil
@@ -978,6 +979,24 @@ def check_python_help(filename):
             return False
     except Exception:
         return False
+
+
+def get_python_site_packages(pyexec):
+    """Get the site-packages for a given python executable.
+    TODO: issue #12664. This function is only used as part of a patch for
+          davidhalter/jedi#1540 and can be removed when python-language-server
+          adopts jedi>0.17.0 (palantir/python-language-server#744).
+    """
+    script = 'import site; print(site.getsitepackages())'
+    try:
+        # clean environment is more reliable
+        proc = run_program(pyexec, ['-c', script], env={})
+        stdout, stderr = proc.communicate()
+        pkgs = ast.literal_eval(stdout.decode())
+    except Exception:
+        pkgs = []
+
+    return pkgs
 
 
 def is_spyder_process(pid):

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -138,6 +138,19 @@ def alter_subprocess_kwargs_by_platform(**kwargs):
         # We "or" them together
         CONSOLE_CREATION_FLAGS |= CREATE_NO_WINDOW
         kwargs.setdefault('creationflags', CONSOLE_CREATION_FLAGS)
+
+        # ensure Windows subprocess environment has SYSTEMROOT, but variable
+        # is case insensitive
+        if ((kwargs.get('env') is not None) and
+            ('SYSTEMROOT' not in map(str.upper, kwargs['env'].keys()))):
+            sys_root_key = None
+            for k, v in os.environ.items():
+                if 'SYSTEMROOT' == k.upper():
+                    sys_root_key = k
+                    break  # don't risk multiple values
+            if sys_root_key is not None:
+                kwargs['env'].update({sys_root_key: os.environ[sys_root_key]})
+
     return kwargs
 
 


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

When launching Spyder from non-conda environments, jedi does not add site-packages for target conda environments properly (see davidhalter/jedi#1540).
I've added the site-package for the target environment to the `extra_paths` configuration for jedi.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12259


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary
<!--- Thanks for your help making Spyder better for everyone! --->
