### PR TITLE
PR: Emit sig_editor_shown for objects that can be edited inline in the Variable Explorer

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -177,6 +177,7 @@ class CollectionsDelegate(QItemDelegate):
                     editor = QDateEdit(value, parent=parent)
                 editor.setCalendarPopup(True)
                 editor.setFont(get_font(font_size_delta=DEFAULT_SMALL_DELTA))
+                self.sig_editor_shown.emit()
                 return editor
         # TextEditor for a long string
         elif is_text_string(value) and len(value) > 40 and not object_explorer:

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -202,6 +202,7 @@ class CollectionsDelegate(QItemDelegate):
                 # evaluation. So the object on which this method is trying to
                 # act doesn't exist anymore.
                 # editor.returnPressed.connect(self.commitAndCloseEditor)
+                self.sig_editor_shown.emit()
                 return editor
         # ObjectExplorer for an arbitrary Python object
         else:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Fixed the loading signal for datetime objects in Variable Explorer
![Screen Shot 2020-04-11 at 11 52 46 PM](https://user-images.githubusercontent.com/18587879/79061286-441bef80-7c54-11ea-986a-e1cc98fe3005.png)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Juanis2112
<!--- Thanks for your help making Spyder better for everyone! --->
