### PR TITLE
PR: Don't pass sys.argv to get_options if not running tests

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -109,9 +109,9 @@ from spyder.config.base import running_under_pytest
 # Ignore args if running tests or Spyder will try and fail to parse pytests's.
 if running_under_pytest():
     sys_argv = [sys.argv[0]]
+    CLI_OPTIONS, CLI_ARGS = get_options(sys_argv)
 else:
-    sys_argv = sys.argv
-CLI_OPTIONS, CLI_ARGS = get_options(sys_argv)
+    CLI_OPTIONS, CLI_ARGS = get_options()
 
 # **** Set OpenGL implementation to use ****
 if CLI_OPTIONS.opengl_implementation:


### PR DESCRIPTION
@CAM-Gerlach, could you quickly review this one? I don't understand very well why you decided to pass `sys.argv` to `get_options` when not running our tests.

Fixes #12313