### PR TITLE
PR: Use def instead of lambda to define slots for data conversion (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -583,7 +583,8 @@ class DataFrameView(QTableView):
                      (_("To str"), to_text_string))
         types_in_menu = [copy_action]
         for name, func in functions:
-            slot = lambda func=func: self.change_type(func)
+            def slot():
+                self.change_type(func)
             types_in_menu += [create_action(self, name,
                                             triggered=slot,
                                             context=Qt.WidgetShortcut)]

--- a/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
@@ -83,6 +83,31 @@ def generate_pandas_indexes():
 # =============================================================================
 # Tests
 # =============================================================================
+def test_dataframe_to_type(qtbot):
+    """Regression test for spyder-ide/spyder#12296"""
+    # Setup editor
+    d = {'col1': [1, 2], 'col2': [3, 4]}
+    df = DataFrame(data=d)
+    editor = DataFrameEditor()
+    assert editor.setup_and_check(df, 'Test DataFrame To action')
+    editor.show()
+    qtbot.waitForWindowShown(editor)
+
+    # Check editor doesn't have changes to save and select an initial element
+    assert not editor.btn_save_and_close.isEnabled()
+    view = editor.dataTable
+    view.setCurrentIndex(view.model().index(0, 0))
+
+    # Show context menu and select option `To bool`
+    view.menu.show()
+    qtbot.keyPress(view.menu, Qt.Key_Down)
+    qtbot.keyPress(view.menu, Qt.Key_Down)
+    qtbot.keyPress(view.menu, Qt.Key_Return)
+
+    # Check that changes where made from the editor
+    assert editor.btn_save_and_close.isEnabled()
+
+
 def test_dataframe_datetimeindex(qtbot):
     """Regression test for spyder-ide/spyder#11129 ."""
     ds = Series(


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12296 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
