### PR TITLE
PR: Fix inconsistent behavior when creating/saving files with default names

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1783,6 +1783,16 @@ class Editor(SpyderPluginWidget):
             current_es = editorstack
         created_from_here = fname is None
         if created_from_here:
+            for finfo in current_es.data:
+                current_filename = finfo.editor.filename
+                if 'untitled' in current_filename:
+                    # Start the counter of the untitled_num with respect
+                    # to this number if there's other untitled file in spyder
+                    # Please see spyder-ide/spyder#7831
+                    fname_data = osp.splitext(current_filename)
+                    act_num = int(fname_data[0].split('untitled')[-1])
+                    self.untitled_num = act_num + 1
+
             while True:
                 fname = create_fname(self.untitled_num)
                 self.untitled_num += 1

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1783,15 +1783,16 @@ class Editor(SpyderPluginWidget):
             current_es = editorstack
         created_from_here = fname is None
         if created_from_here:
-            for finfo in current_es.data:
-                current_filename = finfo.editor.filename
-                if 'untitled' in current_filename:
-                    # Start the counter of the untitled_num with respect
-                    # to this number if there's other untitled file in spyder
-                    # Please see spyder-ide/spyder#7831
-                    fname_data = osp.splitext(current_filename)
-                    act_num = int(fname_data[0].split('untitled')[-1])
-                    self.untitled_num = act_num + 1
+            if self.untitled_num == 0:
+                for finfo in current_es.data:
+                    current_filename = finfo.editor.filename
+                    if 'untitled' in current_filename:
+                        # Start the counter of the untitled_num with respect
+                        # to this number if there's other untitled file in
+                        # spyder. Please see spyder-ide/spyder#7831
+                        fname_data = osp.splitext(current_filename)
+                        act_num = int(fname_data[0].split('untitled')[-1])
+                        self.untitled_num = act_num + 1
 
             while True:
                 fname = create_fname(self.untitled_num)

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1786,12 +1786,12 @@ class Editor(SpyderPluginWidget):
             if self.untitled_num == 0:
                 for finfo in current_es.data:
                     current_filename = finfo.editor.filename
-                    if 'untitled' in current_filename:
+                    if _("untitled") in current_filename:
                         # Start the counter of the untitled_num with respect
                         # to this number if there's other untitled file in
                         # spyder. Please see spyder-ide/spyder#7831
                         fname_data = osp.splitext(current_filename)
-                        act_num = int(fname_data[0].split('untitled')[-1])
+                        act_num = int(fname_data[0].split(_("untitled"))[-1])
                         self.untitled_num = act_num + 1
 
             while True:

--- a/spyder/plugins/editor/tests/conftest.py
+++ b/spyder/plugins/editor/tests/conftest.py
@@ -78,7 +78,8 @@ def python_files(tmpdir_factory):
     tmpdir = osp.normcase(tmpdir.strpath)
 
     filenames = [osp.join(tmpdir, f) for f in
-                 ('file1.py', 'file2.py', 'file3.py', 'file4.py')]
+                 ('file1.py', 'file2.py', 'file3.py', 'file4.py',
+                  'untitled4.py')]
     for filename in filenames:
         with open(filename, 'w') as f:
             f.write("# -*- coding: utf-8 -*-\n"

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -73,6 +73,24 @@ def test_setup_open_files_cleanprefs(editor_plugin_open_files):
     assert current_filename == expected_current_filename
 
 
+def test_open_untitled_files(editor_plugin_open_files):
+    """
+    Test for checking the counter of the untitled files is starting
+    correctly when there is one or more `untitledx.py` files saved.
+
+    Regression test for spyder-ide/spyder#7831
+    """
+    editor_factory = editor_plugin_open_files
+    editor, expected_filenames, expected_current_filename = (
+        editor_factory(None, None))
+
+    editor.new()
+    filenames = editor.get_current_editorstack().get_filenames()
+    new_filename = filenames[-1]
+    assert 'untitled5.py' in new_filename
+
+
+
 def test_renamed_tree(editor_plugin, mocker):
     """Test editor.renamed_tree().
 
@@ -223,7 +241,7 @@ def test_go_to_prev_next_cursor_position(editor_plugin, python_files):
     filenames = editor_plugin.get_filenames()
     expected_cursor_pos_history = [
         (filenames[0], 0),
-        (filenames[4], len(editorstack.data[4].get_source_code())),
+        (filenames[-1], len(editorstack.data[-1].get_source_code())),
         (filenames[2], 0)
         ]
     assert editor_plugin.cursor_pos_history == expected_cursor_pos_history


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Change the counter to start in the following number after the open `untitled` file. This check is done only when creating the first default name file.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #7831


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
