### PR TITLE
PR: Make test_get_git_refs work when merging against 4.x

### DIFF
--- a/spyder/utils/tests/test_vcs.py
+++ b/spyder/utils/tests/test_vcs.py
@@ -74,11 +74,7 @@ def test_get_git_refs():
     branch_tags, branch, files_modified = get_git_refs(__file__)
     assert bool(branch)  # This must always return a branch_name
     assert len(files_modified) >= 0
-
-    # It seems when Travis run tests on tags, master doesn't
-    # appear among the list of git branches.
-    if not os.environ.get('TRAVIS_TAG'):
-        assert any(['master' in b for b in branch_tags])
+    assert any([('master' in b or '4.x' in b) for b in branch_tags])
 
 
 @skipnogit


### PR DESCRIPTION
That test started to fail after PR #12298.