### PR TITLE
PR: Add support for a str response when getting Kite available languages

### DIFF
--- a/spyder/plugins/completion/kite/client.py
+++ b/spyder/plugins/completion/kite/client.py
@@ -79,7 +79,7 @@ class KiteClient(QObject, KiteMethodProviderMixIn):
     def get_languages(self):
         verb, url = KITE_ENDPOINTS.LANGUAGES_ENDPOINT
         success, response = self.perform_http_request(verb, url)
-        if response is None:
+        if response is None or isinstance(response, TEXT_TYPES):
             response = ['python']
         return response
 
@@ -112,16 +112,12 @@ class KiteClient(QObject, KiteMethodProviderMixIn):
             kite_status = status()
             self.sig_status_response_ready[str].emit(kite_status)
         elif isinstance(kite_status, TEXT_TYPES):
-            if not success_status:
-                status_str = status(extra_status=' with errors')
-                long_str = _("<code>{error}</code><br><br>"
-                             "Note: If you are using a VPN, "
-                             "please don't route requests to "
-                             "localhost/127.0.0.1 with it").format(
-                                 error=kite_status)
-            else:
-                status_str = status()
-                long_str = kite_status
+            status_str = status(extra_status=' with errors')
+            long_str = _("<code>{error}</code><br><br>"
+                         "Note: If you are using a VPN, "
+                         "please don't route requests to "
+                         "localhost/127.0.0.1 with it").format(
+                             error=kite_status)
             kite_status_dict = {
                 'status': status_str,
                 'short': status_str,


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

When using a VPN, requests to Kite can end up being unable to convert to json and passing as str to the handler methods like `get_language` or `get_status`



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12410 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
