### PR TITLE
PR: Remove warning message when undocking panes

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2530,7 +2530,8 @@ class MainWindow(QMainWindow):
             if self.interface_locked:
                 if plugin.dockwidget.isFloating():
                     plugin.dockwidget.setFloating(False)
-                plugin.dockwidget.setTitleBarWidget(QWidget())
+
+                plugin.dockwidget.remove_title_bar()
             else:
                 plugin.dockwidget.set_title_bar()
 

--- a/spyder/widgets/dock.py
+++ b/spyder/widgets/dock.py
@@ -200,15 +200,28 @@ class SpyderDockWidget(QDockWidget):
     def __init__(self, title, parent):
         super(SpyderDockWidget, self).__init__(title, parent)
 
-        # Set our custom title bar
+        self.title = title
+
+        # Widgets
+        self.main = parent
+        self.empty_titlebar = QWidget(self)
         self.titlebar = DockTitleBar(self)
+        self.dock_tabbar = None  # Needed for event filter
+
+        # Layout
+        # Prevent message on internal console
+        # See: https://bugreports.qt.io/browse/QTBUG-42986
+        layout = QHBoxLayout(self.empty_titlebar)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        self.empty_titlebar.setLayout(layout)
+        self.empty_titlebar.setMinimumSize(0, 0)
+        self.empty_titlebar.setMaximumSize(0, 0)
+
+        # Setup
         self.set_title_bar()
 
-        # Needed for the installation of the event filter
-        self.title = title
-        self.main = parent
-        self.dock_tabbar = None
-
+        # Signals
         # To track dockwidget changes the filter is installed when dockwidget
         # visibility changes. This installs the filter on startup and also
         # on dockwidgets that are undocked and then docked to a new location.
@@ -242,6 +255,10 @@ class SpyderDockWidget(QDockWidget):
                 self.dock_tabbar.filter = TabFilter(self.dock_tabbar,
                                                     self.main)
                 self.dock_tabbar.installEventFilter(self.dock_tabbar.filter)
+
+    def remove_title_bar(self):
+        """Set empty qwidget on title bar."""
+        self.setTitleBarWidget(self.empty_titlebar)
 
     def set_title_bar(self):
         """Set custom title bar."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

This messages kept appearing on undocking panes. Seems like a Qt issue but this seems to fix it,

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->



<img width="638" alt="Screen Shot 2020-04-22 at 11 57 12" src="https://user-images.githubusercontent.com/3627835/80010704-6d2c5380-8490-11ea-8443-5506142914e3.png">

### Issue(s) Resolved

I think this also fixed the issue of being able relocate a pane from a tiny pixel region even when the lock panes option was enabled.


<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
