### PR TITLE
PR: Handle KeyError when processing rename in autosave

### DIFF
--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -419,9 +419,16 @@ class AutosaveForStack(object):
             old_name (str): name of file before it is renamed
             new_name (str): name of file after it is renamed
         """
-        old_hash = self.file_hashes[old_name]
+        try:
+            old_hash = self.file_hashes[old_name]
+        except KeyError:
+            # This should not happen, but it does: spyder-ide/spyder#12396
+            logger.error('KeyError when handling rename %s -> %s',
+                         old_name, new_name)
+            old_hash = None
         self.remove_autosave_file(old_name)
-        del self.file_hashes[old_name]
-        self.file_hashes[new_name] = old_hash
+        if old_hash is not None:
+            del self.file_hashes[old_name]
+            self.file_hashes[new_name] = old_hash
         index = self.stack.has_filename(new_name)
         self.maybe_autosave(index)

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -237,7 +237,8 @@ def test_autosave_remove_autosave_file(mocker, exception):
     assert mock_dialog.called == exception
 
 
-def test_autosave_file_renamed(mocker, tmpdir):
+@pytest.mark.parametrize('have_hash', [True, False])
+def test_autosave_file_renamed(mocker, tmpdir, have_hash):
     """Test that AutosaveForStack.file_renamed removes the old autosave file,
     creates a new one, and updates `name_mapping` and `file_hashes`."""
     mock_remove = mocker.patch('os.remove')
@@ -256,6 +257,10 @@ def test_autosave_file_renamed(mocker, tmpdir):
     new_autosavefile = str(tmpdir.join('new_foo.py'))
     addon.name_mapping = {'old_foo.py': old_autosavefile}
     addon.file_hashes = {'old_foo.py': 1, old_autosavefile: 42}
+    if have_hash:
+        addon.file_hashes = {'old_foo.py': 1, old_autosavefile: 42}
+    else:
+        addon.file_hashes = {old_autosavefile: 42}
 
     addon.file_renamed('old_foo.py', 'new_foo.py')
 
@@ -263,7 +268,10 @@ def test_autosave_file_renamed(mocker, tmpdir):
     mock_stack._write_to_file.assert_called_with(
         mock_fileinfo, new_autosavefile)
     assert addon.name_mapping == {'new_foo.py': new_autosavefile}
-    assert addon.file_hashes == {'new_foo.py': 1, new_autosavefile: 3}
+    if have_hash:
+        assert addon.file_hashes == {'new_foo.py': 1, new_autosavefile: 3}
+    else:
+        assert addon.file_hashes == {new_autosavefile: 3}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] <s>Wrote at least one-line docstrings (for any new functions)</s>
* [x] Added unit test(s) covering the changes (if testable)
* [x] <s>Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))</s>

This is similar to PR #11647 which handled KeyErrors when deciding whether to autosave. As explained there, the immediate reason is that the hash of the file currently considered is not stored in the autosave component, but I do not know why not. If a file whose hash is not recorded, is renamed, then when handling this rename a KeyError will be raised in a different function. This PR catches and handles the KeyError when handling file renames.

I had a look and I don't think there are other places where we can get a KeyError, but given that I don't understand the root cause I am not certain of this.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12396


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
