### PR TITLE
PR: Handle error when checking if Kite is already running

### DIFF
--- a/spyder/plugins/completion/kite/utils/status.py
+++ b/spyder/plugins/completion/kite/utils/status.py
@@ -47,7 +47,7 @@ def check_if_kite_running():
                 running = True
                 break
     except OSError:
-        # Needed to handle a possible WinError 0
+        # Needed to handle a possible WinError 0. See spyder-ide/spyder#12510
         pass
     return running
 

--- a/spyder/plugins/completion/kite/utils/status.py
+++ b/spyder/plugins/completion/kite/utils/status.py
@@ -38,13 +38,17 @@ def check_if_kite_installed():
 def check_if_kite_running():
     """Detect if kite is running."""
     running = False
-    for proc in psutil.process_iter(attrs=['pid', 'name', 'username',
-                                           'status']):
-        if is_proc_kite(proc):
-            logger.debug('Kite process already '
-                         'running with PID {0}'.format(proc.pid))
-            running = True
-            break
+    try:
+        for proc in psutil.process_iter(attrs=['pid', 'name', 'username',
+                                               'status']):
+            if is_proc_kite(proc):
+                logger.debug('Kite process already '
+                             'running with PID {0}'.format(proc.pid))
+                running = True
+                break
+    except OSError:
+        # Needed to handle a possible WinError 0
+        pass
     return running
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

To check that Kite is running we iterate over all the available process and check if any of them refers to Kite. The case where the operation to retrieve the processes information fails wasn't being handled.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12510 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
