### PR TITLE
PR: Fix segfault on Unix systems when removing plots

### DIFF
--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -216,7 +216,7 @@ def test_close_all_figures(figbrowser, tmpdir, fmt):
 
 
 @pytest.mark.parametrize("fmt", ['image/png', 'image/svg+xml'])
-def test_close_one_thumbnail(figbrowser, tmpdir, fmt):
+def test_close_one_thumbnail(qtbot, figbrowser, tmpdir, fmt):
     """
     Test the thumbnail is removed from the GUI.
     """
@@ -227,6 +227,9 @@ def test_close_one_thumbnail(figbrowser, tmpdir, fmt):
     # Remove the first figure
     figures = figbrowser.thumbnails_sb.findChildren(FigureThumbnail)
     figbrowser.thumbnails_sb.remove_thumbnail(figures[0])
+
+    # Removed thumbnails are unparented with a timer to prevent segfaults
+    qtbot.wait(200)
 
     assert len(figbrowser.thumbnails_sb.findChildren(FigureThumbnail)) == 1
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

It seems `thumbnail.setParent(None)` was causing the problem.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12459


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
