### PR TITLE
PR: A couple of fixes for the python-language-server subrepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ result.xml
 
 # Pylint dirs/files
 .pylint.d/
+
+# Ignore setuptools development files in the PyLS subrepo
+external-deps/python-language-server/python_language_server.egg-info/

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -146,7 +146,8 @@ try:
     pkg = pkg_resources.get_distribution('python-language-server')
 
     # Remove the PyLS stable version first (in case it's present)
-    if 'dirty' not in pkg.egg_name():
+    if ('external-deps' not in pkg.module_path and
+            'site-packages' in pkg.module_path):
         print("*. Removing stable version of the PyLS.")
         uninstall_with_pip = False
         is_conda = osp.exists(osp.join(sys.prefix, 'conda-meta'))


### PR DESCRIPTION
* Ignore setuptools development files in the PyLS subrepo.
*   Improve the way we detect if there's an stable version of the PyLS we need to remove in `boostrap.py` (the previous method was failing, which made `boostrap.py` to take longer to start).

