### PR TITLE
PR: Install Pylint 2.4 in our CIs

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -19,6 +19,11 @@ if [ "$USE_CONDA" = "true" ]; then
     # Install test ones
     conda install python=$PYTHON_VERSION --file requirements/tests.txt -c spyder-ide -q -y
 
+    # Install Pylint 2.4 untill version 2.5 is fixed in Anaconda
+    if [ "$PYTHON_VERSION" != "2.7" ]; then
+        conda install python=$PYTHON_VERSION pylint=2.4*
+    fi
+
     # Remove packages we have subrepos for
     conda remove spyder-kernels --force -q -y
     conda remove python-language-server --force -q -y


### PR DESCRIPTION
* This solves the errors we were seeing in our tests for the last couple of days.
* A real fix needs to be provided by the Anaconda team, by declaring the right dependencies for 2.5.0.