### PR TITLE
PR: Update check-manifest ignore rules to work with its 0.42 version

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -113,7 +113,7 @@ jobs:
           conda info
           conda list
       - name: Run manifest checks
-        if: env.RUN_BUILD == 'true'
+        if: env.RUN_BUILD == 'true' && matrix.PYTHON_VERSION != '2.7'
         shell: bash -l {0}
         run: check-manifest
       - name: Run tests

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -94,7 +94,7 @@ jobs:
           conda info
           conda list
       - name: Run manifest checks
-        if: env.RUN_BUILD == 'true'
+        if: env.RUN_BUILD == 'true' && matrix.PYTHON_VERSION != '2.7'
         shell: bash -l {0}
         run: check-manifest
       - name: Run tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,13 +13,13 @@ ignore =
     TROUBLESHOOTING.md
     azure-pipelines.yml
     binder
-    binder/*
+    binder/**
     conftest.py
     continuous_integration
-    continuous_integration/*
+    continuous_integration/**
     crowdin.yml
     external-deps
-    external-deps/*
+    external-deps/**
     img_src/*.svg
     img_src/*.png
     img_src/*.bmp
@@ -28,12 +28,12 @@ ignore =
     img_src/*.icns
     pytest.ini
     requirements
-    requirements/*
+    requirements/**
     rope_profiling
-    rope_profiling/*
+    rope_profiling/**
     runtests.py
-    *tests*
+    *tests/**
     tools
-    tools/*
+    tools/**
 ignore-bad-ideas =
     *.mo


### PR DESCRIPTION
Our tests started to fail due to this a couple of hours ago.