### PR TITLE
PR: Make middle mouse button click on editor tabs close the intended tab

### DIFF
--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -361,7 +361,9 @@ class BaseTabs(QTabWidget):
     def mousePressEvent(self, event):
         """Override Qt method"""
         if event.button() == Qt.MidButton:
-            index = self.tabBar().tabAt(event.pos())
+            point = event.pos()
+            point.setX(point.x() + 5)
+            index = self.tabBar().tabAt(point)
             if index >= 0:
                 self.sig_close_tab.emit(index)
                 event.accept()

--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -352,18 +352,34 @@ class BaseTabs(QTabWidget):
         self.set_corner_widgets({corner:
                                  self.corner_widgets.get(corner, [])+widgets})
 
+    def get_offset_pos(self, event):
+        """
+        Add offset to position event to capture the mouse cursor
+        inside a tab.
+        """
+        # This is necessary because self.tabBar().tabAt(event.pos()) is not
+        # returning the expected index. For further information see
+        # spyder-ide/spyder#12617
+        point = event.pos()
+        if sys.platform == 'darwin':
+            # The close button on tab is on the left
+            point.setX(point.x() + 3)
+        else:
+            # The close buttton on tab is on the right
+            point.setX(point.x() - 30)
+        return self.tabBar().tabAt(point)
+
     def contextMenuEvent(self, event):
         """Override Qt method"""
-        self.setCurrentIndex(self.tabBar().tabAt(event.pos()))
+        index = self.get_offset_pos(event)
+        self.setCurrentIndex(index)
         if self.menu:
             self.menu.popup(event.globalPos())
 
     def mousePressEvent(self, event):
         """Override Qt method"""
         if event.button() == Qt.MidButton:
-            point = event.pos()
-            point.setX(point.x() + 5)
-            index = self.tabBar().tabAt(point)
+            index = self.get_offset_pos(event)
             if index >= 0:
                 self.sig_close_tab.emit(index)
                 event.accept()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Add offset to remain the region of tab given an event and be able to close intended tab

![tab](https://user-images.githubusercontent.com/20992645/81122762-40982300-8ef7-11ea-809d-7e756319642d.gif)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12558 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
