### PR TITLE
PR: Fix showing/hiding completions when backspace is pressed

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4072,6 +4072,8 @@ class CodeEditor(TextEditBaseWidget):
                 self._last_pressed_key = None
                 return
 
+        # Handle the correct completion when Backspace key is pressed
+        # We should not show the widget if deleting a space before a word.
         if key == Qt.Key_Backspace:
             cursor.setPosition(pos - 1, QTextCursor.MoveAnchor)
             cursor.select(QTextCursor.WordUnderCursor)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4072,7 +4072,7 @@ class CodeEditor(TextEditBaseWidget):
                 self._last_pressed_key = None
                 return
 
-        # Handle the correct completion when Backspace key is pressed
+        # Correctly handle completions when Backspace key is pressed.
         # We should not show the widget if deleting a space before a word.
         if key == Qt.Key_Backspace:
             cursor.setPosition(pos - 1, QTextCursor.MoveAnchor)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4050,6 +4050,14 @@ class CodeEditor(TextEditBaseWidget):
                 self._last_pressed_key = None
                 return
 
+        cursor.setPosition(pos - 1, QTextCursor.MoveAnchor)
+        cursor.select(QTextCursor.WordUnderCursor)
+        prev_text = to_text_string(cursor.selectedText())
+        cursor.setPosition(pos + 1, QTextCursor.MoveAnchor)
+
+        if prev_text == '' and key == Qt.Key_Backspace:
+            return
+
         # Text might be after a dot '.'
         if text == '':
             cursor.setPosition(pos - 1, QTextCursor.MoveAnchor)
@@ -4069,6 +4077,7 @@ class CodeEditor(TextEditBaseWidget):
 
         is_backspace = (
             self.is_completion_widget_visible() and key == Qt.Key_Backspace)
+
         if (len(text) >= self.automatic_completions_after_chars
                 and self._last_key_pressed_text or is_backspace):
             # Perform completion on the fly

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -364,7 +364,6 @@ class CodeEditor(TextEditBaseWidget):
 
         # Typing keys / handling on the fly completions
         # See: keyPressEvent
-        self._count_backspace = 0
         self._last_key_pressed_text = ''
         self._last_pressed_key = None
         self._timer_autocomplete = QTimer(self)
@@ -4026,11 +4025,6 @@ class CodeEditor(TextEditBaseWidget):
         elif not event.isAccepted():
             insert_text(event)
 
-        if key == Qt.Key_Backspace:
-            self._count_backspace += 1
-        else:
-            self._count_backspace = 0
-
         self._last_key_pressed_text = text
         self._last_pressed_key = key
         if self.automatic_completions_after_ms == 0 and not tab_pressed:
@@ -4063,7 +4057,6 @@ class CodeEditor(TextEditBaseWidget):
             text = to_text_string(cursor.selectedText())
             if text != '.':
                 text = ''
-                self._count_backspace = 0
 
         # WordUnderCursor fails if the cursor is next to a right brace.
         # If the returned text starts with it, we move to the left.
@@ -4075,7 +4068,7 @@ class CodeEditor(TextEditBaseWidget):
         self.document_did_change(text)
 
         is_backspace = (
-            self._count_backspace >= self.automatic_completions_after_chars)
+            self.is_completion_widget_visible() and key == Qt.Key_Backspace)
         if (len(text) >= self.automatic_completions_after_chars
                 and self._last_key_pressed_text or is_backspace):
             # Perform completion on the fly

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4050,13 +4050,13 @@ class CodeEditor(TextEditBaseWidget):
                 self._last_pressed_key = None
                 return
 
-        cursor.setPosition(pos - 1, QTextCursor.MoveAnchor)
-        cursor.select(QTextCursor.WordUnderCursor)
-        prev_text = to_text_string(cursor.selectedText())
-        cursor.setPosition(pos + 1, QTextCursor.MoveAnchor)
-
-        if prev_text == '' and key == Qt.Key_Backspace:
-            return
+        if key == Qt.Key_Backspace:
+            cursor.setPosition(pos - 1, QTextCursor.MoveAnchor)
+            cursor.select(QTextCursor.WordUnderCursor)
+            prev_text = to_text_string(cursor.selectedText())
+            cursor.setPosition(pos + 1, QTextCursor.MoveAnchor)
+            if prev_text == '':
+                return
 
         # Text might be after a dot '.'
         if text == '':

--- a/spyder/plugins/editor/widgets/tests/test_completions_hide.py
+++ b/spyder/plugins/editor/widgets/tests/test_completions_hide.py
@@ -13,7 +13,7 @@ import pytest
 from qtpy.QtCore import Qt
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 @pytest.mark.first
 @flaky(max_runs=5)
 def test_automatic_completions_hide_complete(lsp_codeeditor, qtbot):
@@ -67,6 +67,9 @@ def test_automatic_completions_hide_complete(lsp_codeeditor, qtbot):
     code_editor.toggle_code_snippets(True)
 
 
+@pytest.mark.slow
+@pytest.mark.first
+@flaky(max_runs=5)
 def test_automatic_completions_widget_visible(lsp_codeeditor, qtbot):
     """Test on-the-fly completion when widget is visible and the backspace key
     is pressed.

--- a/spyder/plugins/editor/widgets/tests/test_completions_hide.py
+++ b/spyder/plugins/editor/widgets/tests/test_completions_hide.py
@@ -71,8 +71,9 @@ def test_automatic_completions_hide_complete(lsp_codeeditor, qtbot):
 @pytest.mark.first
 @flaky(max_runs=5)
 def test_automatic_completions_widget_visible(lsp_codeeditor, qtbot):
-    """Test on-the-fly completion when widget is visible and the backspace key
-    is pressed.
+    """
+    Test on-the-fly completions when the widget is visible and the Backspace
+    key is pressed.
 
     Regression test for PR #12710
     """

--- a/spyder/plugins/editor/widgets/tests/test_completions_hide.py
+++ b/spyder/plugins/editor/widgets/tests/test_completions_hide.py
@@ -13,13 +13,14 @@ import pytest
 from qtpy.QtCore import Qt
 
 
-@pytest.mark.slow
+# @pytest.mark.slow
 @pytest.mark.first
 @flaky(max_runs=5)
 def test_automatic_completions_hide_complete(lsp_codeeditor, qtbot):
     """Test on-the-fly completion closing when already complete.
 
-    Regression test for issue #11600 and pull requests #11824 and #12140.
+    Regression test for issue #11600 and pull requests #11824, #12140
+    and #12710.
     """
     code_editor, _ = lsp_codeeditor
     completion = code_editor.completion_widget
@@ -54,7 +55,44 @@ def test_automatic_completions_hide_complete(lsp_codeeditor, qtbot):
     qtbot.wait(500)
     assert completion.isHidden()
 
+    # Hide if removing spaces before a word
+    code_editor.moveCursor(cursor.End)
+    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)  # newline
+    qtbot.keyClicks(code_editor, '   None')
+    qtbot.wait(500)
+    code_editor.moveCursor(cursor.End - 4)
+    qtbot.keyPress(code_editor, Qt.Key_Backspace, delay=300)
+    assert completion.isHidden()
+
     code_editor.toggle_code_snippets(True)
+
+
+def test_automatic_completions_widget_visible(lsp_codeeditor, qtbot):
+    """Test on-the-fly completion when widget is visible and the backspace key
+    is pressed.
+
+    Regression test for PR #12710
+    """
+    code_editor, _ = lsp_codeeditor
+    completion = code_editor.completion_widget
+    code_editor.toggle_code_snippets(False)
+
+    code_editor.set_text('import math')
+    cursor = code_editor.textCursor()
+    code_editor.moveCursor(cursor.End)
+    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)  # newline
+
+    with qtbot.waitSignal(completion.sig_show_completions,
+                          timeout=10000) as sig:
+        qtbot.keyClicks(code_editor, 'math.aco')
+
+    assert completion.isVisible()
+
+    qtbot.keyPress(code_editor, Qt.Key_Backspace, delay=300)
+    assert completion.isVisible()
+
+    qtbot.keyPress(code_editor, Qt.Key_Backspace, delay=300)
+    assert completion.isVisible()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Add counter to backspace and check if the text is not empty before showing the completions widget.

![completions](https://user-images.githubusercontent.com/20992645/81774402-11158780-94b0-11ea-99bd-1c5176c27544.gif)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12704 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
