### PR TITLE
PR: Improve completions provided by FileComboBox

### DIFF
--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -319,10 +319,12 @@ class FileComboBox(PathComboBox):
             self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
     def is_valid(self, qstr=None):
-        """Return True if string is valid"""
+        """Return True if string is valid."""
         if qstr is None:
             qstr = self.currentText()
-        return osp.isfile(to_text_string(qstr))
+        valid = (osp.isfile(to_text_string(qstr)) or
+                    osp.isdir(to_text_string(qstr)))
+        return valid
 
 
 def is_module_or_package(path):

--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -18,6 +18,7 @@ import os
 import os.path as osp
 
 # Third party imports
+import qdarkstyle
 from qtpy.QtCore import QEvent, Qt, QTimer, QUrl, Signal
 from qtpy.QtGui import QFont
 from qtpy.QtWidgets import (QComboBox, QCompleter, QLineEdit,
@@ -231,7 +232,12 @@ class PathComboBox(EditableComboBox):
         text = to_text_string(self.currentText())
         opts = glob.glob(text + "*")
         opts = sorted([opt for opt in opts if osp.isdir(opt)])
-        self.setCompleter(QCompleter(opts, self))
+
+        dark_qss = qdarkstyle.load_stylesheet_from_environment()
+        completer = QCompleter(opts, self)
+        completer.popup().setStyleSheet(dark_qss)
+        self.setCompleter(completer)
+
         return opts
 
     def tab_complete(self):

--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -26,6 +26,7 @@ from qtpy.QtWidgets import (QComboBox, QCompleter, QLineEdit,
 
 # Local imports
 from spyder.config.base import _
+from spyder.config.gui import is_dark_interface
 from spyder.py3compat import to_text_string
 from spyder.widgets.helperwidgets import IconLineEdit
 
@@ -233,9 +234,10 @@ class PathComboBox(EditableComboBox):
         opts = glob.glob(text + "*")
         opts = sorted([opt for opt in opts if osp.isdir(opt)])
 
-        dark_qss = qdarkstyle.load_stylesheet_from_environment()
         completer = QCompleter(opts, self)
-        completer.popup().setStyleSheet(dark_qss)
+        if is_dark_interface():
+            dark_qss = qdarkstyle.load_stylesheet_from_environment()
+            completer.popup().setStyleSheet(dark_qss)
         self.setCompleter(completer)
 
         return opts
@@ -323,7 +325,7 @@ class FileComboBox(PathComboBox):
         if qstr is None:
             qstr = self.currentText()
         valid = (osp.isfile(to_text_string(qstr)) or
-                    osp.isdir(to_text_string(qstr)))
+                 osp.isdir(to_text_string(qstr)))
         return valid
 
     def _complete_options(self):
@@ -333,9 +335,10 @@ class FileComboBox(PathComboBox):
         opts = sorted([opt for opt in opts
                        if osp.isdir(opt) or osp.isfile(opt)])
 
-        dark_qss = qdarkstyle.load_stylesheet_from_environment()
         completer = QCompleter(opts, self)
-        completer.popup().setStyleSheet(dark_qss)
+        if is_dark_interface():
+            dark_qss = qdarkstyle.load_stylesheet_from_environment()
+            completer.popup().setStyleSheet(dark_qss)
         self.setCompleter(completer)
 
         return opts

--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -326,6 +326,20 @@ class FileComboBox(PathComboBox):
                     osp.isdir(to_text_string(qstr)))
         return valid
 
+    def _complete_options(self):
+        """Find available completion options."""
+        text = to_text_string(self.currentText())
+        opts = glob.glob(text + "*")
+        opts = sorted([opt for opt in opts
+                       if osp.isdir(opt) or osp.isfile(opt)])
+
+        dark_qss = qdarkstyle.load_stylesheet_from_environment()
+        completer = QCompleter(opts, self)
+        completer.popup().setStyleSheet(dark_qss)
+        self.setCompleter(completer)
+
+        return opts
+
 
 def is_module_or_package(path):
     """Return True if path is a Python module/package"""


### PR DESCRIPTION
This PR does the following:

* Remove the need to press `Tab` twice to get completions when there are several completions available. I forgot this was added several years ago and found it very confusing.
* Style the completer's popup. No one noticed it was not following the dark theme.
* Don't remove valid directory names when pressing `Enter` after selecting them. This was really confusing because the completer offered several directories but then pressing `Enter` in any of their names remove it from the combobox.
* Add file completions. The combobox was only showing directories.

----

**Before**:

![Selección_041](https://user-images.githubusercontent.com/365293/82129485-d863ff80-9788-11ea-96b0-656cee568075.png)

**After**:

![Selección_038](https://user-images.githubusercontent.com/365293/82129449-87eca200-9788-11ea-9c4e-a0b071abc55d.png)
