### PR TITLE
PR: Set LSP server stdout to None on Windows

### DIFF
--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -166,7 +166,11 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         self.transport_args += ['--zmq-in-port', self.zmq_out_port,
                                 '--zmq-out-port', self.zmq_in_port]
 
-        server_log = subprocess.PIPE
+        # The server stdout needs to be set to 'None' by default on Windows
+        # to correctly handle errors that come from the server.
+        # Fixes spyder-ide/spyder#11506
+        server_log = None if os.name == 'nt' else subprocess.PIPE
+
         pid = os.getpid()
         if get_debug_level() > 0:
             # Create server log file


### PR DESCRIPTION
This finally fixes the "linter is dead" problem reported a lot during the last couple of months!

By changing the server's stdout to None on Windows, our client is now able to process errors correctly (e.g. errors that come from Jedi, which are the most frequent).

Before this, the client was unable to process any message coming from the server after the error. So not only the linter, but also folding and symbols totally died.

Fixes #11506.