### PR TITLE
PR: Ensure autosave files don't overwrite existing files

### DIFF
--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -253,16 +253,21 @@ class AutosaveForStack(object):
         """
         Create unique autosave file name for specified file name.
 
+        The created autosave file name does not yet exist either in
+        `self.name_mapping` or on disk.
+
         Args:
             filename (str): original file name
             autosave_dir (str): directory in which autosave files are stored
         """
         basename = osp.basename(filename)
         autosave_filename = osp.join(autosave_dir, basename)
-        if autosave_filename in self.name_mapping.values():
+        if (autosave_filename in self.name_mapping.values()
+                or osp.exists(autosave_filename)):
             counter = 0
             root, ext = osp.splitext(basename)
-            while autosave_filename in self.name_mapping.values():
+            while (autosave_filename in self.name_mapping.values()
+                   or osp.exists(autosave_filename)):
                 counter += 1
                 autosave_basename = '{}-{}{}'.format(root, counter, ext)
                 autosave_filename = osp.join(autosave_dir, autosave_basename)

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -167,7 +167,7 @@ def test_create_unique_autosave_filename(mocker, in_mapping, on_disk):
                               osp.join('autosave', 'ham.py')}
 
     autosave_filename = addon.create_unique_autosave_filename(
-        osp.join('orig', 'ham.py') , 'autosave')
+        osp.join('orig', 'ham.py'), 'autosave')
 
     if in_mapping or on_disk:
         assert autosave_filename == osp.join('autosave', 'ham-1.py')

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -146,6 +146,33 @@ def test_try_recover(mocker, tmpdir, error_on_remove):
         assert not pidfile.check()
 
 
+@pytest.mark.parametrize('in_mapping,on_disk',
+                         [(False, False), (True, False), (False, True)])
+def test_create_unique_autosave_filename(mocker, in_mapping, on_disk):
+    """Test that AutosaveForStack.create_unique_autosave_filename() returns
+    a file name in the autosave directory with the same base name as the
+    original file name, unless that already exists in the autosave mapping
+    or on disk."""
+    def new_exists(path):
+        if path == 'autosave/ham.py':
+            return on_disk
+        else:
+            return False
+
+    mocker.patch('os.path.exists', side_effect=new_exists)
+    addon = AutosaveForStack(mocker.Mock())
+    if in_mapping:
+        addon.name_mapping = {'somedir/ham.py': 'autosave/ham.py'}
+
+    autosave_filename = addon.create_unique_autosave_filename(
+        'orig/ham.py', 'autosave')
+
+    if in_mapping or on_disk:
+        assert autosave_filename == 'autosave/ham-1.py'
+    else:
+        assert autosave_filename == 'autosave/ham.py'
+
+
 @pytest.mark.parametrize('have_hash', [True, False])
 def test_autosave(mocker, have_hash):
     """Test that AutosaveForStack.maybe_autosave writes the contents to the

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -264,6 +264,21 @@ def test_autosave_remove_autosave_file(mocker, exception):
     assert mock_dialog.called == exception
 
 
+def test_get_autosave_filename(mocker, tmpdir):
+    """Test that AutosaveForStack.get_autosave_filename returns a consistent and
+    unique name for the autosave file is returned."""
+    addon = AutosaveForStack(mocker.Mock())
+    mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
+                 return_value=str(tmpdir))
+
+    expected = str(tmpdir.join('foo.py'))
+    assert addon.get_autosave_filename('foo.py') == expected
+
+    expected2 = str(tmpdir.join('foo-1.py'))
+    assert addon.get_autosave_filename('foo.py') == expected
+    assert addon.get_autosave_filename('ham/foo.py') == expected2
+
+
 @pytest.mark.parametrize('have_hash', [True, False])
 def test_autosave_file_renamed(mocker, tmpdir, have_hash):
     """Test that AutosaveForStack.file_renamed removes the old autosave file,

--- a/spyder/plugins/editor/utils/tests/test_autosave.py
+++ b/spyder/plugins/editor/utils/tests/test_autosave.py
@@ -7,6 +7,7 @@
 
 # Standard library imports
 import ast
+import os.path as osp
 
 # Third party imports
 import pytest
@@ -154,7 +155,7 @@ def test_create_unique_autosave_filename(mocker, in_mapping, on_disk):
     original file name, unless that already exists in the autosave mapping
     or on disk."""
     def new_exists(path):
-        if path == 'autosave/ham.py':
+        if path == osp.join('autosave', 'ham.py'):
             return on_disk
         else:
             return False
@@ -162,15 +163,16 @@ def test_create_unique_autosave_filename(mocker, in_mapping, on_disk):
     mocker.patch('os.path.exists', side_effect=new_exists)
     addon = AutosaveForStack(mocker.Mock())
     if in_mapping:
-        addon.name_mapping = {'somedir/ham.py': 'autosave/ham.py'}
+        addon.name_mapping = {osp.join('somedir', 'ham.py'):
+                              osp.join('autosave', 'ham.py')}
 
     autosave_filename = addon.create_unique_autosave_filename(
-        'orig/ham.py', 'autosave')
+        osp.join('orig', 'ham.py') , 'autosave')
 
     if in_mapping or on_disk:
-        assert autosave_filename == 'autosave/ham-1.py'
+        assert autosave_filename == osp.join('autosave', 'ham-1.py')
     else:
-        assert autosave_filename == 'autosave/ham.py'
+        assert autosave_filename == osp.join('autosave', 'ham.py')
 
 
 @pytest.mark.parametrize('have_hash', [True, False])
@@ -265,8 +267,8 @@ def test_autosave_remove_autosave_file(mocker, exception):
 
 
 def test_get_autosave_filename(mocker, tmpdir):
-    """Test that AutosaveForStack.get_autosave_filename returns a consistent and
-    unique name for the autosave file is returned."""
+    """Test that AutosaveForStack.get_autosave_filename returns a consistent
+    and unique name for the autosave file is returned."""
     addon = AutosaveForStack(mocker.Mock())
     mocker.patch('spyder.plugins.editor.utils.autosave.get_conf_path',
                  return_value=str(tmpdir))

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -696,8 +696,9 @@ def test_maybe_autosave(editor_bot):
     editor_stack, editor = editor_bot
     editor.set_text('spam\n')
     editor_stack.autosave.maybe_autosave(0)
-    contents = open(os.path.join(get_conf_path('autosave'), 'foo.py')).read()
-    assert contents == 'spam\n'
+    autosave_filename = os.path.join(get_conf_path('autosave'), 'foo.py')
+    assert open(autosave_filename).read() == 'spam\n'
+    os.remove(autosave_filename)
 
 
 def test_maybe_autosave_saves_only_if_changed(editor_bot, mocker):
@@ -802,7 +803,6 @@ def test_maybe_autosave_does_not_save_after_reload(base_editor_bot, mocker):
     editor_stack.reload(0)
     editor_stack.autosave.maybe_autosave(0)
     editor_stack._write_to_file.assert_not_called()
-
 
 def test_autosave_updates_name_mapping(editor_bot, mocker, qtbot):
     """Test that maybe_autosave() updates name_mapping."""

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -656,22 +656,6 @@ def test_tab_copies_find_to_replace(editor_find_replace_bot, qtbot):
     assert finder.replace_text.currentText() == 'This is some test text!'
 
 
-def test_get_autosave_filename(editor_bot):
-    """
-    Test filename returned by `get_autosave_filename`.
-
-    Test a consistent and unique name for the autosave file is returned.
-    """
-    editor_stack, editor = editor_bot
-    autosave = editor_stack.autosave
-    expected = os.path.join(get_conf_path('autosave'), 'foo.py')
-    assert autosave.get_autosave_filename('foo.py') == expected
-    editor_stack.new('ham/foo.py', 'utf-8', '')
-    expected2 = os.path.join(get_conf_path('autosave'), 'foo-1.py')
-    assert autosave.get_autosave_filename('foo.py') == expected
-    assert autosave.get_autosave_filename('ham/foo.py') == expected2
-
-
 def test_autosave_all(editor_bot, mocker):
     """
     Test that `autosave_all()` calls maybe_autosave() on all open buffers.


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))  **N/A**


<!--- Explain what you've done and why --->

This PR ensures that if a file is autosaved, the name of the autosave file does not coincide with the name of an existing file. Currently, if the user opens an autosave file in the editor (for instance, from the recovery dialog which Spyder displays at startup when finding autosave file) and then makes changes to the file, Spyder makes an autosave file with exactly the same name, which eventually leads to an error. This fixes that error.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12755


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
