### PR TITLE
PR: Test that a file with the same name of a standard library module doesn't break the console

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 1.x
-	commit = 70651f2bff9aceccfabde24b7316ba11c0433e23
-	parent = 052089e3ca67947a4dfedb4a78ae7b97773c2de9
+	branch = remove-cwd-py37
+	commit = c9d018f08be52a4e60d6a4d2272dbaedd32f99ef
+	parent = 035a7224932442e6f48436ec068dcb51aa1d4977
 	method = merge
 	cmdver = 0.4.1

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = remove-cwd-py37
-	commit = c9d018f08be52a4e60d6a4d2272dbaedd32f99ef
-	parent = 035a7224932442e6f48436ec068dcb51aa1d4977
+	branch = 1.x
+	commit = 53304c85e5c352cf05aa4cbef1e188ce18bae358
+	parent = 30820a779367209f1c1b8d9300efde94a5a84bef
 	method = merge
 	cmdver = 0.4.1

--- a/external-deps/spyder-kernels/requirements/tests.txt
+++ b/external-deps/spyder-kernels/requirements/tests.txt
@@ -1,5 +1,6 @@
 codecov
 cython
+dask
 flaky
 matplotlib
 mock

--- a/external-deps/spyder-kernels/setup.py
+++ b/external-deps/spyder-kernels/setup.py
@@ -47,6 +47,7 @@ REQUIREMENTS = [
 TEST_REQUIREMENTS = [
     'codecov',
     'cython',
+    'dask',
     'flaky',
     'matplotlib',
     'mock',

--- a/external-deps/spyder-kernels/spyder_kernels/console/__main__.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/__main__.py
@@ -6,6 +6,18 @@
 # (see spyder_kernels/__init__.py for details)
 # -----------------------------------------------------------------------------
 
+import sys
+import os
+
+
 if __name__ == '__main__':
+    # Remove the current working directory from sys.path for Python 3.7+
+    # because since that version it's added by default to sys.path when
+    # using 'python -m'.
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 7:
+        cwd = os.getcwd()
+        if cwd in sys.path:
+            sys.path.remove(cwd)
+
     from spyder_kernels.console import start
     start.main()

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
@@ -273,8 +273,8 @@ except Exception:
 # =============================================================================
 # Multiprocessing adjustments
 # =============================================================================
-# This patch is only needed on Windows and Python 3
-if os.name == 'nt' and not PY2:
+# This patch is only needed on Python 3
+if not PY2:
     # This could fail with changes in Python itself, so we protect it
     # with a try/except
     try:

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1300,7 +1300,7 @@ def test_stderr_file_remains_two_kernels(ipyconsole, qtbot, monkeypatch):
 
 
 @flaky(max_runs=3)
-def test_kernel_crash(ipyconsole, mocker, qtbot):
+def test_kernel_crash(ipyconsole, qtbot):
     """Test that we show an error message when a kernel crash occurs."""
     # Create an IPython kernel config file with a bad config
     ipy_kernel_cfg = osp.join(get_ipython_dir(), 'profile_default',
@@ -1633,6 +1633,30 @@ def test_kernel_kill(ipyconsole, qtbot):
             'status'] == 'ready')
     assert shell.spyder_kernel_comm._comms[new_open_comms[0]][
         'status'] == 'ready'
+
+
+@flaky(max_runs=3)
+def test_wrong_std_module(ipyconsole, qtbot):
+    """
+    Test that a file with the same name of a standard library module in
+    the current working directory doesn't break the console.
+    """
+    # Create an empty file called random.py in the cwd
+    wrong_random_mod = osp.join(os.getcwd(), 'random.py')
+    with open(wrong_random_mod, 'w') as f:
+        f.write('')
+
+    # Create a new client to see if its kernel starts despite the
+    # faulty module.
+    ipyconsole.create_new_client()
+
+    # A prompt should be created if the kernel didn't crash.
+    shell = ipyconsole.get_current_shellwidget()
+    qtbot.waitUntil(lambda: shell._prompt_html is not None,
+                    timeout=SHELL_TIMEOUT)
+
+    # Remove wrong module
+    os.remove(wrong_random_mod)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is due to a change in Python 3.7, which added the current working directory to `sys.path` when running modules with `python -m`. And that's is precisely the way we start our kernels.

Depends on spyder-ide/spyder-kernels#222