### PR TITLE
PR: Unmaximize on new/open/close/delete project

### DIFF
--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -199,19 +199,12 @@ class Projects(SpyderPluginWidget):
         self.explorer.closing_widget()
         return True
 
-    def switch_to_plugin(self):
-        """Switch to plugin."""
-        # Unmaxizime currently maximized plugin
+    def unmaximize(self):
+        """Unmaximize the currently maximized plugin, if not self."""
         if (self.main.last_plugin is not None and
                 self.main.last_plugin._ismaximized and
                 self.main.last_plugin is not self):
             self.main.maximize_dockwidget()
-
-        # Show plugin only if it was already visible
-        if self.get_option('visible_if_project_open'):
-            if not self._toggle_view_action.isChecked():
-                self._toggle_view_action.setChecked(True)
-            self._visibility_changed(True)
 
     def build_opener(self, project):
         """Build function opening passed project"""
@@ -267,7 +260,7 @@ class Projects(SpyderPluginWidget):
     @Slot()
     def create_new_project(self):
         """Create new project"""
-        self.switch_to_plugin()
+        self.unmaximize()
         active_project = self.current_active_project
         dlg = ProjectDialog(self)
         dlg.sig_project_creation_requested.connect(self._create_project)
@@ -287,7 +280,7 @@ class Projects(SpyderPluginWidget):
                      save_previous_files=True):
         """Open the project located in `path`"""
         self.notify_project_open(path)
-        self.switch_to_plugin()
+        self.unmaximize()
         if path is None:
             basedir = get_home_dir()
             path = getexistingdirectory(parent=self,
@@ -338,7 +331,7 @@ class Projects(SpyderPluginWidget):
         project
         """
         if self.current_active_project:
-            self.switch_to_plugin()
+            self.unmaximize()
             if self.main.editor is not None:
                 self.set_project_filenames(
                     self.main.editor.get_open_filenames())
@@ -365,7 +358,7 @@ class Projects(SpyderPluginWidget):
         Delete the current project without deleting the files in the directory.
         """
         if self.current_active_project:
-            self.switch_to_plugin()
+            self.unmaximize()
             path = self.current_active_project.root_path
             buttons = QMessageBox.Yes | QMessageBox.No
             answer = QMessageBox.warning(

--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -63,7 +63,6 @@ def projects(qtbot, mocker):
     projects.shortcut = None
     mocker.patch.object(spyder.plugins.base.SpyderDockWidget,
                         'install_tab_event_filter')
-    mocker.patch.object(projects, '_toggle_view_action')
     projects._create_dockwidget()
 
     # This can only be done at this point
@@ -173,6 +172,17 @@ def test_open_project_uses_visible_config(projects, tmpdir, value):
     projects.set_option('visible_if_project_open', value)
     projects.open_project(path=to_text_string(tmpdir))
     assert projects.dockwidget.isVisible() == value
+
+
+@pytest.mark.parametrize('value', [True, False])
+def test_switch_to_plugin(projects, tmpdir, value):
+    """Test that switch_to_plugin always shows the plugin if a project is
+    opened, regardless of the config option visible_if_project_open.
+    Regression test for spyder-ide/spyder#12491."""
+    projects.set_option('visible_if_project_open', value)
+    projects.open_project(path=to_text_string(tmpdir))
+    projects.switch_to_plugin()
+    assert projects.dockwidget.isVisible()
 
 
 def test_set_get_project_filenames_when_closing_no_files(create_projects,


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Previously new/open/close/delete project called `.switch_to_plugin()` and this latter function was overridden so that the plugin is only shown if the `visible_if_project_open config` option is set. This override broke the Ctrl+Shift+P shortcut (issue #12491).

This commit replaces the `.switch_to_plugin()` override by a new `.unmaximize()` function and calls this on new/open/close/delete. As far as I can see, the unmaximize functionality is the only part of `.switch_to_plugin()` that is actually used on new/open/close/delete, because the new/open/close/delete functions have code later to show or hide the Project plugin.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12491


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
