### PR TITLE
PR: Fix hiding completion on backspace when nothing before cursor

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4078,8 +4078,10 @@ class CodeEditor(TextEditBaseWidget):
             cursor.setPosition(pos - 1, QTextCursor.MoveAnchor)
             cursor.select(QTextCursor.WordUnderCursor)
             prev_text = to_text_string(cursor.selectedText())
-            cursor.setPosition(pos + 1, QTextCursor.MoveAnchor)
-            if prev_text == '':
+            cursor.setPosition(pos - 1, QTextCursor.MoveAnchor)
+            cursor.setPosition(pos, QTextCursor.KeepAnchor)
+            prev_char = cursor.selectedText()
+            if prev_text == '' or prev_char in ('\u2029', ' ', '\t'):
                 return
 
         # Text might be after a dot '.'

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4081,7 +4081,7 @@ class CodeEditor(TextEditBaseWidget):
             cursor.setPosition(pos - 1, QTextCursor.MoveAnchor)
             cursor.setPosition(pos, QTextCursor.KeepAnchor)
             prev_char = cursor.selectedText()
-            if prev_text == '' or prev_char in ('\u2029', ' ', '\t'):
+            if prev_text == '' or prev_char in (u'\u2029', ' ', '\t'):
                 return
 
         # Text might be after a dot '.'

--- a/spyder/plugins/editor/widgets/tests/test_completions_hide.py
+++ b/spyder/plugins/editor/widgets/tests/test_completions_hide.py
@@ -57,11 +57,29 @@ def test_automatic_completions_hide_complete(lsp_codeeditor, qtbot):
 
     # Hide if removing spaces before a word
     code_editor.moveCursor(cursor.End)
-    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)  # newline
-    qtbot.keyClicks(code_editor, '   None')
-    qtbot.wait(500)
-    code_editor.moveCursor(cursor.End - 4)
-    qtbot.keyPress(code_editor, Qt.Key_Backspace, delay=300)
+    qtbot.keyPress(code_editor, Qt.Key_Enter)  # newline
+    qtbot.keyClicks(code_editor, 'some')
+    qtbot.keyPress(code_editor, Qt.Key_Enter)  # newline
+    qtbot.keyClicks(code_editor, '  None')
+    code_editor.moveCursor(cursor.End - 6)
+    qtbot.keyPress(code_editor, Qt.Key_Backspace)
+    qtbot.wait(2000)
+    assert completion.isHidden()
+    qtbot.keyPress(code_editor, Qt.Key_Backspace)
+    qtbot.wait(2000)
+    assert completion.isHidden()
+
+    # Hide if removing spaces before a word even not at the start of line.
+    code_editor.moveCursor(cursor.End)
+    qtbot.keyPress(code_editor, Qt.Key_Enter)  # newline
+    qtbot.keyClicks(code_editor, 'some +  some ')
+    qtbot.keyPress(code_editor, Qt.Key_Left)
+    qtbot.keyPress(code_editor, Qt.Key_Left)
+    qtbot.keyPress(code_editor, Qt.Key_Left)
+    qtbot.keyPress(code_editor, Qt.Key_Left)
+    qtbot.keyPress(code_editor, Qt.Key_Left)
+    qtbot.keyPress(code_editor, Qt.Key_Backspace)
+    qtbot.wait(2000)
     assert completion.isHidden()
 
     code_editor.toggle_code_snippets(True)


### PR DESCRIPTION
Dear spyder devs,

Using the fix brought by #12710, I realized it was not working as expected when not at the beginning of a line (or when end of previous line is a word).

Here is a proposition to fix those issues with #12637. 
Main idea is to also check for previous character, since "previous word" from qt behaves strangely.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@ElieGouzien
<!--- Thanks for your help making Spyder better for everyone! --->
