### PR TITLE
PR: Use QProcess instead of subprocess for the LPS transport layer and server

### DIFF
--- a/spyder/plugins/completion/languageserver/__init__.py
+++ b/spyder/plugins/completion/languageserver/__init__.py
@@ -9,14 +9,6 @@
 LSP client, code introspection and linting utilities.
 """
 
-from spyder.config.base import DEV
-
-
-# Language server communication verbosity at server logs.
-TRACE = 'messages'
-if DEV:
-    TRACE = 'verbose'
-
 # Supported LSP programming languages
 LSP_LANGUAGES = [
     'Bash', 'C#', 'Cpp', 'CSS/LESS/SASS', 'Go', 'GraphQL', 'Groovy', 'Elixir',

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -84,7 +84,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         self.zmq_in_port = None
         self.zmq_out_port = None
         self.transport = None
-        self.lsp_server = None
+        self.server = None
         self.stdio_pid = None
         self.notifier = None
         self.language = language
@@ -207,12 +207,12 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
                 cwd = None
 
             # Start server
-            self.lsp_server = QProcess(self)
-            self.lsp_server.setWorkingDirectory(cwd)
-            self.lsp_server.setProcessChannelMode(QProcess.MergedChannels)
+            self.server = QProcess(self)
+            self.server.setWorkingDirectory(cwd)
+            self.server.setProcessChannelMode(QProcess.MergedChannels)
             if server_log_file is not None:
-                self.lsp_server.setStandardOutputFile(server_log_file)
-            self.lsp_server.start(self.server_args[0], self.server_args[1:])
+                self.server.setStandardOutputFile(server_log_file)
+            self.server.start(self.server_args[0], self.server_args[1:])
 
         # --- Create transport
         self.transport_args = list(map(str, self.transport_args))
@@ -278,8 +278,8 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         if self.transport is not None:
             self.transport.kill()
         self.context.destroy()
-        if self.lsp_server is not None:
-            self.lsp_server.kill()
+        if self.server is not None:
+            self.server.kill()
 
     def is_transport_alive(self):
         """Detect if transport layer is alive."""
@@ -309,8 +309,8 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
     def is_tcp_alive(self):
         """Detect if a tcp server is alive."""
         alive = True
-        if self.lsp_server is not None:
-            if self.lsp_server.state() == QProcess.NotRunning:
+        if self.server is not None:
+            if self.server.state() == QProcess.NotRunning:
                 alive = False
 
         return alive

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -304,10 +304,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
     def is_transport_alive(self):
         """Detect if transport layer is alive."""
         state = self.transport.state()
-        if state == QProcess.Starting:
-            return True
-        else:
-            return state != QProcess.NotRunning
+        return state != QProcess.NotRunning
 
     def is_stdio_alive(self):
         """Check if an stdio server is alive."""
@@ -326,10 +323,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
     def is_server_alive(self):
         """Detect if a tcp server is alive."""
         state = self.server.state()
-        if state == QProcess.Starting:
-            return True
-        else:
-            return state != QProcess.NotRunning
+        return state != QProcess.NotRunning
 
     def is_down(self):
         """

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -29,7 +29,7 @@ import psutil
 from spyder.config.base import (DEV, get_conf_path, get_debug_level,
                                 running_under_pytest)
 from spyder.plugins.completion.languageserver import (
-    CLIENT_CAPABILITES, SERVER_CAPABILITES, TRACE,
+    CLIENT_CAPABILITES, SERVER_CAPABILITES,
     TEXT_DOCUMENT_SYNC_OPTIONS, LSPRequestTypes,
     ClientConstants)
 from spyder.plugins.completion.languageserver.decorators import (
@@ -53,6 +53,10 @@ PENDING = 'pending'
 SERVER_READY = 'server_ready'
 LOCALHOST = '127.0.0.1'
 
+# Language server communication verbosity at server logs.
+TRACE = 'messages'
+if DEV:
+    TRACE = 'verbose'
 
 logger = logging.getLogger(__name__)
 

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -38,7 +38,6 @@ from spyder.plugins.completion.languageserver.transport import MessageKind
 from spyder.plugins.completion.languageserver.providers import (
     LSPMethodProviderMixIn)
 from spyder.py3compat import PY2
-from spyder.utils.environ import clean_env
 from spyder.utils.misc import getcwd_or_home, select_port
 
 # Conditional imports
@@ -234,11 +233,6 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
             new_env.insert('PYTHONPATH', os.pathsep.join(sys.path)[:])
         else:
             new_env.insert('PYTHONPATH', python_path)
-
-        # On some CI systems there are unicode characters inside PYTHOPATH
-        # which raise errors if not removed
-        #if PY2:
-        #    new_env = clean_env(new_env)
 
         self.transport.setProcessEnvironment(new_env)
 

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -235,16 +235,15 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         self.transport = QProcess(self)
         self.transport.errorOccurred.connect(self.handle_process_errors)
 
-        # This allows running LSP tests directly without having to install
-        # Spyder
-        new_env = QProcessEnvironment.systemEnvironment()
-        python_path = os.pathsep.join(sys.path)[1:]
-        if running_under_pytest():
-            new_env.insert('PYTHONPATH', os.pathsep.join(sys.path)[:])
-        else:
-            new_env.insert('PYTHONPATH', python_path)
-
-        self.transport.setProcessEnvironment(new_env)
+        # Modifying PYTHONPATH to run transport in development mode or
+        # tests
+        if DEV or running_under_pytest():
+            env = QProcessEnvironment()
+            if running_under_pytest():
+                env.insert('PYTHONPATH', os.pathsep.join(sys.path)[:])
+            else:
+                env.insert('PYTHONPATH', os.pathsep.join(sys.path)[1:])
+            self.transport.setProcessEnvironment(env)
 
         # Set transport log file
         transport_log_file = None

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -69,8 +69,8 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
     sig_server_error = Signal(str)
 
     #: Signal to warn the user when either the transport layer or the
-    #  server are down
-    sig_down = Signal(str)
+    #  server went down
+    sig_went_down = Signal(str)
 
     def __init__(self, parent,
                  server_settings={},
@@ -333,21 +333,21 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
                 "Transport layer for {} is down!!".format(self.language))
             if not self.transport_unresponsive:
                 self.transport_unresponsive = True
-                self.sig_down.emit(self.language)
+                self.sig_went_down.emit(self.language)
             is_down = True
 
         if not self.is_tcp_alive():
             logger.debug("LSP server for {} is down!!".format(self.language))
             if not self.server_unresponsive:
                 self.server_unresponsive = True
-                self.sig_down.emit(self.language)
+                self.sig_went_down.emit(self.language)
             is_down = True
 
         if not self.is_stdio_alive():
             logger.debug("LSP server for {} is down!!".format(self.language))
             if not self.server_unresponsive:
                 self.server_unresponsive = True
-                self.sig_down.emit(self.language)
+                self.sig_went_down.emit(self.language)
             is_down = True
 
         return is_down
@@ -392,7 +392,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
                 return int(_id)
             except zmq.error.Again:
                 if time.time() > timeout_time:
-                    self.sig_down.emit(self.language)
+                    self.sig_went_down.emit(self.language)
                     return
                 # The send queue is full! wait 0.1 seconds before retrying.
                 if self.initialized:

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -71,7 +71,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
 
     #: Signal to warn the user when either the transport layer or the
     #  server are down
-    sig_lsp_down = Signal(str)
+    sig_down = Signal(str)
 
     def __init__(self, parent,
                  server_settings={},
@@ -339,21 +339,21 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
                 "Transport layer for {} is down!!".format(self.language))
             if not self.transport_unresponsive:
                 self.transport_unresponsive = True
-                self.sig_lsp_down.emit(self.language)
+                self.sig_down.emit(self.language)
             is_down = True
 
         if not self.is_tcp_alive():
             logger.debug("LSP server for {} is down!!".format(self.language))
             if not self.server_unresponsive:
                 self.server_unresponsive = True
-                self.sig_lsp_down.emit(self.language)
+                self.sig_down.emit(self.language)
             is_down = True
 
         if not self.is_stdio_alive():
             logger.debug("LSP server for {} is down!!".format(self.language))
             if not self.server_unresponsive:
                 self.server_unresponsive = True
-                self.sig_lsp_down.emit(self.language)
+                self.sig_down.emit(self.language)
             is_down = True
 
         return is_down
@@ -398,7 +398,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
                 return int(_id)
             except zmq.error.Again:
                 if time.time() > timeout_time:
-                    self.sig_lsp_down.emit(self.language)
+                    self.sig_down.emit(self.language)
                     return
                 # The send queue is full! wait 0.1 seconds before retrying.
                 if self.initialized:

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -482,7 +482,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
     @send_request(method=LSPRequestTypes.INITIALIZE)
     def initialize(self, params, *args, **kwargs):
         self.stdio_pid = params['pid']
-        pid = self.transport.pid() if not self.external_server else None
+        pid = self.transport.processId() if not self.external_server else None
         params = {
             'processId': pid,
             'rootUri': pathlib.Path(osp.abspath(self.folder)).as_uri(),

--- a/spyder/plugins/completion/languageserver/plugin.py
+++ b/spyder/plugins/completion/languageserver/plugin.py
@@ -150,7 +150,7 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
             tcp_check = not instance.is_tcp_alive()
             stdio_check = not instance.is_stdio_alive()
             if (tcp_check or stdio_check or status != self.RUNNING):
-                instance.sig_lsp_down.emit(language)
+                instance.sig_down.emit(language)
 
     def set_status(self, language, status):
         """
@@ -422,7 +422,7 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
                 self.update_configuration)
             self.main.sig_main_interpreter_changed.connect(
                 self.update_configuration)
-            instance.sig_lsp_down.connect(self.handle_lsp_down)
+            instance.sig_down.connect(self.handle_lsp_down)
             instance.sig_initialize.connect(self.on_initialize)
 
             if self.main.editor:

--- a/spyder/plugins/completion/languageserver/plugin.py
+++ b/spyder/plugins/completion/languageserver/plugin.py
@@ -123,7 +123,7 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
 
         # This check is only necessary for stdio servers
         check = True
-        if instance.stdio:
+        if instance.stdio_pid:
             check = instance.is_stdio_alive()
 
         if status == self.RUNNING and check:
@@ -142,9 +142,7 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
         status = client['status']
         instance = client.get('instance', None)
         if instance is not None:
-            tcp_check = not instance.is_tcp_alive()
-            stdio_check = not instance.is_stdio_alive()
-            if (tcp_check or stdio_check or status != self.RUNNING):
+            if instance.is_down() or status != self.RUNNING:
                 instance.sig_went_down.emit(language)
 
     def set_status(self, language, status):

--- a/spyder/plugins/completion/languageserver/plugin.py
+++ b/spyder/plugins/completion/languageserver/plugin.py
@@ -107,6 +107,7 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
                 try:
                     self.clients_hearbeat[language].stop()
                     client['instance'].disconnect()
+                    client['instance'].stop()
                 except (TypeError, KeyError, RuntimeError):
                     pass
                 self.clients_hearbeat[language] = None

--- a/spyder/plugins/completion/languageserver/plugin.py
+++ b/spyder/plugins/completion/languageserver/plugin.py
@@ -150,7 +150,7 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
             tcp_check = not instance.is_tcp_alive()
             stdio_check = not instance.is_stdio_alive()
             if (tcp_check or stdio_check or status != self.RUNNING):
-                instance.sig_down.emit(language)
+                instance.sig_went_down.emit(language)
 
     def set_status(self, language, status):
         """
@@ -422,7 +422,7 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
                 self.update_configuration)
             self.main.sig_main_interpreter_changed.connect(
                 self.update_configuration)
-            instance.sig_down.connect(self.handle_lsp_down)
+            instance.sig_went_down.connect(self.handle_lsp_down)
             instance.sig_initialize.connect(self.on_initialize)
 
             if self.main.editor:


### PR DESCRIPTION
* This will allow us to have better control over those external processes. Specifically, Qt emits signals when they fail to start and when they crash, so we only need to connect to those signals and run our restart mechanism.
* In particular, this fixes the infinite restarting-ready-starting sequence we have right now when the PyLS fails to start. That happens because `subprocess` doesn't have an option to check if the process started correctly (calling `poll` works if we wait a little bit for the process to start, but that little bit depends on the OS and user hardware).
* Finally, this has some refactoring of the `LSPClient` code to make it more readable and easier to follow.

Fixes #12225.

TODO:

- [x] Connect to QProcess errorOccurred and finished signals.
- [x] Simplify hearbeat and restarting logic.
- [x] Check if `new_env` needs to have the entire environment or just PYTHONPATH.