### PR TITLE
PR: Enable/disable folding guides when cursor enters/exits the left panel

### DIFF
--- a/spyder/plugins/editor/panels/codefolding.py
+++ b/spyder/plugins/editor/panels/codefolding.py
@@ -249,9 +249,27 @@ class FoldingPanel(Panel):
         # Paints the fold indicators and the possible fold region background
         # on the folding panel.
         super(FoldingPanel, self).paintEvent(event)
-        if not self._display_folding and not self._key_pressed:
-            return
         painter = QPainter(self)
+        if not self._display_folding and not self._key_pressed:
+            if any(self.folding_status.values()):
+                for top_position, line_number, block in self.editor.visible_blocks:
+                    if line_number in self.folding_regions:
+                        collapsed = self.folding_status[line_number]
+                        line_end = self.folding_regions[line_number]
+                        mouse_over = self._mouse_over_line == line_number
+                        if collapsed:
+                            self._draw_fold_indicator(
+                                top_position, mouse_over, collapsed, painter)
+                            # check if the block already has a decoration, it might
+                            # have been folded by the parent editor/document in the
+                            # case of cloned editor
+                            for deco in self._block_decos:
+                                if deco.block == block:
+                                    # no need to add a deco, just go to the next block
+                                    break
+                            else:
+                                self._add_fold_decoration(block, line_end)
+            return
         # Draw background over the selected non collapsed fold region
         if self._mouse_over_line is not None:
             block = self.editor.document().findBlockByNumber(

--- a/spyder/plugins/editor/panels/codefolding.py
+++ b/spyder/plugins/editor/panels/codefolding.py
@@ -252,7 +252,8 @@ class FoldingPanel(Panel):
         painter = QPainter(self)
         if not self._display_folding and not self._key_pressed:
             if any(self.folding_status.values()):
-                for top_position, line_number, block in self.editor.visible_blocks:
+                for info in self.editor.visible_blocks:
+                    top_position, line_number, block = info
                     if line_number in self.folding_regions:
                         collapsed = self.folding_status[line_number]
                         line_end = self.folding_regions[line_number]
@@ -260,12 +261,13 @@ class FoldingPanel(Panel):
                         if collapsed:
                             self._draw_fold_indicator(
                                 top_position, mouse_over, collapsed, painter)
-                            # check if the block already has a decoration, it might
-                            # have been folded by the parent editor/document in the
-                            # case of cloned editor
+                            # check if the block already has a decoration,
+                            # it might have been folded by the parent
+                            # editor/document in the case of cloned editor
                             for deco in self._block_decos:
                                 if deco.block == block:
-                                    # no need to add a deco, just go to the next block
+                                    # no need to add a deco, just go to the
+                                    # next block
                                     break
                             else:
                                 self._add_fold_decoration(block, line_end)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1472,32 +1472,6 @@ class CodeEditor(TextEditBaseWidget):
     @request(method=LSPRequestTypes.DOCUMENT_FOLDING_RANGE)
     def request_folding(self):
         """Request folding."""
-        total_lines = self.get_line_count()
-        if total_lines > 2000 and self.code_folding:
-            warn = CONF.get('editor', 'show_code_folding_warning')
-            warn_str = _(
-                "One of the files in the editor or the file you are trying "
-                "to open contains more than 2000 lines.<br><br>"
-                "Code folding and indent guidelines will be disabled for "
-                "this kind of files in order to prevent performance "
-                "degradation."
-            )
-            if warn:
-                box = MessageCheckBox(
-                    icon=QMessageBox.Warning, parent=self)
-                box.setWindowTitle(_('File too long'))
-                box.set_checkbox_text(_("Don't show again."))
-                box.setStandardButtons(QMessageBox.Ok)
-                box.set_checked(False)
-                box.set_check_visible(True)
-                box.setText(warn_str)
-                box.exec_()
-
-                CONF.set('editor', 'show_code_folding_warning',
-                         not box.is_checked())
-            self.toggle_code_folding(False)
-            self.toggle_identation_guides(False)
-
         if not self.folding_supported or not self.code_folding:
             return
         params = {'file': self.filename}


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR disables folding guides visibility by default, instead, they will be shown only if the cursor enters the left panel and disabled when the cursor leaves it. We also re-enable the folding support for large files that was disabled previously. 

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

![Peek 02-06-2020 14-39](https://user-images.githubusercontent.com/1878982/83562436-2d20ad80-a4df-11ea-9971-3a13ae0c510c.gif)

<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12315.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @andfoy 

<!--- Thanks for your help making Spyder better for everyone! --->
