### PR TITLE
PR: Add minimum width for the color names in the edit appearance panel

### DIFF
--- a/spyder/widgets/colors.py
+++ b/spyder/widgets/colors.py
@@ -7,20 +7,20 @@
 # Third party imports
 from qtpy.QtCore import Property, QSize, Signal, Slot
 from qtpy.QtGui import QColor, QIcon, QPixmap
-from qtpy.QtWidgets import QColorDialog, QHBoxLayout, QLineEdit, QPushButton
+from qtpy.QtWidgets import QColorDialog, QHBoxLayout, QLineEdit, QToolButton
 
 # Local imports
 from spyder.py3compat import is_text_string
 
 
-class ColorButton(QPushButton):
+class ColorButton(QToolButton):
     """
     Color choosing push button
     """
     colorChanged = Signal(QColor)
 
     def __init__(self, parent=None):
-        QPushButton.__init__(self, parent)
+        QToolButton.__init__(self, parent)
         self.setFixedSize(20, 20)
         self.setIconSize(QSize(12, 12))
         self.clicked.connect(self.choose_color)
@@ -75,7 +75,7 @@ class ColorLayout(QHBoxLayout):
         assert isinstance(color, QColor)
         self.lineedit = QLineEdit(color.name(), parent)
         fm = self.lineedit.fontMetrics()
-        self.lineedit.setMinimumWidth(fm.width(color.name()) * 1.5)
+        self.lineedit.setMinimumWidth(fm.width(color.name()) * 1.2)
         self.lineedit.textChanged.connect(self.update_color)
         self.addWidget(self.lineedit)
         self.colorbtn = ColorButton(parent)

--- a/spyder/widgets/colors.py
+++ b/spyder/widgets/colors.py
@@ -74,6 +74,8 @@ class ColorLayout(QHBoxLayout):
         QHBoxLayout.__init__(self)
         assert isinstance(color, QColor)
         self.lineedit = QLineEdit(color.name(), parent)
+        fm = self.lineedit.fontMetrics()
+        self.lineedit.setMinimumWidth(fm.width(color.name()) * 1.5)
         self.lineedit.textChanged.connect(self.update_color)
         self.addWidget(self.lineedit)
         self.colorbtn = ColorButton(parent)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Set a minimum width for the color names in the edit appearance panel so the widget will show the complete name.

![image](https://user-images.githubusercontent.com/20992645/84198143-ba787a80-aa68-11ea-92a5-dba7cf7793bc.png)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12562 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
