### PR TITLE
PR: Check when prefix size is less than zero or longer than the string size (Fallback completions)

### DIFF
--- a/spyder/plugins/completion/fallback/utils.py
+++ b/spyder/plugins/completion/fallback/utils.py
@@ -122,7 +122,12 @@ def is_prefix_valid(text, offset, language):
     # such as emojis in the editor.
     # Fixes spyder-ide/spyder#11862
     utf16_diff = qstring_length(text) - len(text)
-    current_pos_text = text[offset - utf16_diff - 1]
+
+    new_offset = offset - utf16_diff - 1
+    if new_offset >= len(text) or new_offset < 0:
+        return False
+
+    current_pos_text = text[new_offset]
 
     empty_start = empty_regex.match(current_pos_text) is not None
     max_end = -1


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR prevents spurious IndexError when computing the prefix for a fallback completion. As we don't have a clear, reproducible case of the error, we return false as prefix and prevent completions on cases where the error would appear

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12266


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @andfoy 

<!--- Thanks for your help making Spyder better for everyone! --->
