### PR TITLE
PR: Clear old set shortcuts if they are now empty (Shortcuts)

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3267,8 +3267,7 @@ class MainWindow(QMainWindow):
                     if (sys.platform == 'darwin'
                             and qobject._shown_shortcut == 'missing'):
                         qobject._shown_shortcut = keyseq
-                    else:
-                        qobject.setShortcut(keyseq)
+                    qobject.setShortcut(keyseq)
 
                     if add_shortcut_to_tip:
                         add_shortcut_to_tooltip(qobject, context, name)

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3258,23 +3258,27 @@ class MainWindow(QMainWindow):
 
             if shortcut_sequence:
                 keyseq = QKeySequence(shortcut_sequence)
-                try:
-                    if isinstance(qobject, QAction):
-                        if (sys.platform == 'darwin'
-                                and qobject._shown_shortcut == 'missing'):
-                            qobject._shown_shortcut = keyseq
-                        else:
-                            qobject.setShortcut(keyseq)
+            else:
+                # Needed to remove old sequences that were cleared.
+                # See spyder-ide/spyder#12992
+                keyseq = QKeySequence()
+            try:
+                if isinstance(qobject, QAction):
+                    if (sys.platform == 'darwin'
+                            and qobject._shown_shortcut == 'missing'):
+                        qobject._shown_shortcut = keyseq
+                    else:
+                        qobject.setShortcut(keyseq)
 
-                        if add_shortcut_to_tip:
-                            add_shortcut_to_tooltip(qobject, context, name)
+                    if add_shortcut_to_tip:
+                        add_shortcut_to_tooltip(qobject, context, name)
 
-                    elif isinstance(qobject, QShortcut):
-                        qobject.setKey(keyseq)
+                elif isinstance(qobject, QShortcut):
+                    qobject.setKey(keyseq)
 
-                except RuntimeError:
-                    # Object has been deleted
-                    toberemoved.append(index)
+            except RuntimeError:
+                # Object has been deleted
+                toberemoved.append(index)
 
         for index in sorted(toberemoved, reverse=True):
             self.shortcut_data.pop(index)

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3267,7 +3267,8 @@ class MainWindow(QMainWindow):
                     if (sys.platform == 'darwin'
                             and qobject._shown_shortcut == 'missing'):
                         qobject._shown_shortcut = keyseq
-                    qobject.setShortcut(keyseq)
+                    else:
+                        qobject.setShortcut(keyseq)
 
                     if add_shortcut_to_tip:
                         add_shortcut_to_tooltip(qobject, context, name)

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2453,12 +2453,12 @@ def test_preferences_empty_shortcut_regression(main_window, qtbot):
     # Create new file
     main_window.editor.new()
     code_editor = main_window.editor.get_focus_widget()
-    code_editor.set_text('print(0)\nprint(1)\nprint(2)')
+    code_editor.set_text(u'print(0)\nprint(ññ)')
 
     with qtbot.waitSignal(shell.executed):
         qtbot.keyClick(code_editor, Qt.Key_Return, modifier=Qt.ShiftModifier)
-    qtbot.waitUntil(lambda: 'print(0)' in shell._control.toPlainText())
-    assert 'print(1)' not in shell._control.toPlainText()
+    qtbot.waitUntil(lambda: u'print(0)' in shell._control.toPlainText())
+    assert u'ññ' not in shell._control.toPlainText()
 
     # Reset shortcuts
     CONF.set_shortcut(

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2422,6 +2422,57 @@ def test_preferences_change_font_regression(main_window, qtbot):
 
 
 @pytest.mark.slow
+def test_preferences_empty_shortcut_regression(main_window, qtbot):
+    """
+    Test for spyder-ide/spyder/#12992 regression.
+
+    Overwritting shortcuts results in a shortcuts conflict.
+    """
+    # Wait until the window is fully up
+    shell = main_window.ipyconsole.get_current_shellwidget()
+    qtbot.waitUntil(lambda: shell._prompt_html is not None,
+                    timeout=SHELL_TIMEOUT)
+
+    # Setup shortcuts (set run cell and advance shortcut to run selection)
+    base_run_cell_advance = CONF.get_shortcut(
+        'editor', 'run cell and advance')  # Should be Shift+Return
+    base_run_selection = CONF.get_shortcut(
+        'editor', 'run selection')  # Should be F9
+    assert base_run_cell_advance == 'Shift+Return'
+    assert base_run_selection == 'F9'
+    CONF.set_shortcut(
+        'editor', 'run cell and advance', '')
+    CONF.set_shortcut(
+        'editor', 'run selection', base_run_cell_advance)
+    main_window.apply_shortcuts()
+
+    # Check execution of shortcut
+    # Create new file
+    main_window.editor.new()
+    code_editor = main_window.editor.get_focus_widget()
+    code_editor.set_text('print(0)\nprint(1)\nprint(2)')
+
+    with qtbot.waitSignal(shell.executed):
+        qtbot.keyClick(code_editor, Qt.Key_Return, modifier=Qt.ShiftModifier)
+    qtbot.waitUntil(lambda: 'print(0)' in shell._control.toPlainText())
+    assert 'print(1)' not in shell._control.toPlainText()
+
+    # Reset shortcuts
+    CONF.set_shortcut(
+        'editor', 'run selection', 'F9')
+    CONF.set_shortcut(
+        'editor', 'run cell and advance', 'Shift+Return')
+    main_window.apply_shortcuts()
+    qtbot.wait(500)  # Wait for shortcut change to actually be applied
+
+    # Check shortcut run cell and advance reset
+    code_editor.setFocus()
+    with qtbot.waitSignal(shell.executed):
+        qtbot.keyClick(code_editor, Qt.Key_Return, modifier=Qt.ShiftModifier)
+    qtbot.waitUntil(lambda: 'runcell(0' in shell._control.toPlainText())
+
+
+@pytest.mark.slow
 def test_preferences_shortcut_reset_regression(main_window, qtbot):
     """
     Test for spyder-ide/spyder/#11132 regression.
@@ -2786,6 +2837,7 @@ def test_runcell_edge_cases(main_window, qtbot, tmpdir):
     qtbot.waitUntil(lambda: shell._prompt_html is not None,
                     timeout=SHELL_TIMEOUT)
     code_editor = main_window.editor.get_focus_widget()
+
     # call runcell
     with qtbot.waitSignal(shell.executed):
         qtbot.keyClick(code_editor, Qt.Key_Return, modifier=Qt.ShiftModifier)

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2422,6 +2422,9 @@ def test_preferences_change_font_regression(main_window, qtbot):
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(
+    sys.platform == 'darwin',
+    reason="Changes of Shitf+Return shortcut cause an ambiguos shortcut")
 def test_preferences_empty_shortcut_regression(main_window, qtbot):
     """
     Test for spyder-ide/spyder/#12992 regression.
@@ -2837,7 +2840,6 @@ def test_runcell_edge_cases(main_window, qtbot, tmpdir):
     qtbot.waitUntil(lambda: shell._prompt_html is not None,
                     timeout=SHELL_TIMEOUT)
     code_editor = main_window.editor.get_focus_widget()
-
     # call runcell
     with qtbot.waitSignal(shell.executed):
         qtbot.keyClick(code_editor, Qt.Key_Return, modifier=Qt.ShiftModifier)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

If a shortcut conflict is detected, and the user decides to do an overwrite of a shortcut, the old action needs to unset the shortcut to prevent having two actions with the same shortcut.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12992 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
