### PR TITLE
PR: Show the scrollflag in macOS

### DIFF
--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -177,8 +177,6 @@ class ScrollFlagArea(Panel):
         painter.fillRect(event.rect(), self.editor.sideareas_color)
 
         editor = self.editor
-        # Check if the slider is visible
-        paint_local = not bool(self.slider)
 
         # Define compute_flag_ypos to position the flags:
         # Paint flags for the entire document
@@ -192,7 +190,10 @@ class ScrollFlagArea(Panel):
 
         def compute_flag_ypos(block):
             line_number = block.firstLineNumber()
-            frac = line_number / last_line
+            if last_line != 0:
+                frac = line_number / last_line
+            else:
+                frac = line_number
             pos = first_y_pos + frac * (last_y_pos - first_y_pos)
             return ceil(pos)
 
@@ -207,9 +208,6 @@ class ScrollFlagArea(Panel):
             painter.setBrush(self._facecolors[flag_type])
             painter.setPen(self._edgecolors[flag_type])
             for block_number in dict_flag_lists[flag_type]:
-                # Don't paint local flags outside of the window
-                if paint_local:
-                    continue
                 # Find the block
                 block = editor.document().findBlockByNumber(block_number)
                 if not block.isValid():

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -19,6 +19,7 @@ from qtpy.QtWidgets import (QStyle, QStyleOptionSlider, QApplication)
 
 # Local imports
 from spyder.api.panel import Panel
+from spyder.config.gui import is_dark_interface
 from spyder.plugins.completion.languageserver import DiagnosticSeverity
 
 
@@ -27,7 +28,7 @@ REFRESH_RATE = 1000
 
 class ScrollFlagArea(Panel):
     """Source code editor's scroll flag area"""
-    WIDTH = 24 if sys.platform == 'darwin' else 12
+    WIDTH = 24 if sys.platform == 'darwin' and is_dark_interface() else 12
     FLAGS_DX = 4
     FLAGS_DY = 2
 

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -9,6 +9,7 @@ This module contains the Scroll Flag panel
 
 # Standard library imports
 from __future__ import division
+import sys
 from math import ceil
 
 # Third party imports
@@ -26,7 +27,7 @@ REFRESH_RATE = 1000
 
 class ScrollFlagArea(Panel):
     """Source code editor's scroll flag area"""
-    WIDTH = 12
+    WIDTH = 24 if sys.platform == 'darwin' else 12
     FLAGS_DX = 4
     FLAGS_DY = 2
 
@@ -167,7 +168,6 @@ class ScrollFlagArea(Panel):
         # Note that we calculate the pixel metrics required to draw the flags
         # here instead of using the convenience methods of the ScrollFlagArea
         # for performance reason.
-
         rect_x = ceil(self.FLAGS_DX / 2)
         rect_w = self.WIDTH - self.FLAGS_DX
         rect_h = self.FLAGS_DY
@@ -181,41 +181,20 @@ class ScrollFlagArea(Panel):
         paint_local = not bool(self.slider)
 
         # Define compute_flag_ypos to position the flags:
-        if not paint_local:
-            # Paint flags for the entire document
-            last_line = editor.document().lastBlock().firstLineNumber()
-            # The 0.5 offset is used to align the flags with the center of
-            # their corresponding text edit block before scaling.
-            first_y_pos = self.value_to_position(
-                0.5, scale_factor, offset) - self.FLAGS_DY / 2
-            last_y_pos = self.value_to_position(
-                last_line + 0.5, scale_factor, offset) - self.FLAGS_DY / 2
+        # Paint flags for the entire document
+        last_line = editor.document().lastBlock().firstLineNumber()
+        # The 0.5 offset is used to align the flags with the center of
+        # their corresponding text edit block before scaling.
+        first_y_pos = self.value_to_position(
+            0.5, scale_factor, offset) - self.FLAGS_DY / 2
+        last_y_pos = self.value_to_position(
+            last_line + 0.5, scale_factor, offset) - self.FLAGS_DY / 2
 
-            def compute_flag_ypos(block):
-                line_number = block.firstLineNumber()
-                frac = line_number / last_line
-                pos = first_y_pos + frac * (last_y_pos - first_y_pos)
-                return ceil(pos)
-
-        else:
-            # Only paint flags for visible lines
-            visible_lines = [val[1] for val in editor.visible_blocks]
-            if not visible_lines:
-                # Nothing to do
-                return
-            min_line = min(visible_lines)
-            max_line = max(visible_lines)
-
-            def compute_flag_ypos(block):
-                # When the vertical scrollbar is not visible, the flags are
-                # vertically aligned with the center of their corresponding
-                # text block with no scaling.
-                top = editor.blockBoundingGeometry(block).translated(
-                    editor.contentOffset()).top()
-                bottom = top + editor.blockBoundingRect(block).height()
-                middle = (top + bottom)/2
-
-                return ceil(middle-self.FLAGS_DY/2)
+        def compute_flag_ypos(block):
+            line_number = block.firstLineNumber()
+            frac = line_number / last_line
+            pos = first_y_pos + frac * (last_y_pos - first_y_pos)
+            return ceil(pos)
 
         # All the lists of block numbers for flags
         dict_flag_lists = {
@@ -229,8 +208,7 @@ class ScrollFlagArea(Panel):
             painter.setPen(self._edgecolors[flag_type])
             for block_number in dict_flag_lists[flag_type]:
                 # Don't paint local flags outside of the window
-                if paint_local and not (
-                        min_line <= block_number + 1 <= max_line):
+                if paint_local:
                     continue
                 # Find the block
                 block = editor.document().findBlockByNumber(block_number)

--- a/spyder/plugins/editor/panels/tests/test_scrollflag.py
+++ b/spyder/plugins/editor/panels/tests/test_scrollflag.py
@@ -6,6 +6,7 @@
 
 # Standard library imports
 import os
+import sys
 
 # Third party imports
 import pytest
@@ -85,7 +86,8 @@ def test_enabled(editor_bot):
     assert not sfa.isVisible()
 
 
-@pytest.mark.skipif(not os.name == 'nt', reason="It fails on Travis")
+@pytest.mark.skipif(sys.platform.startswith('linux'),
+                    reason="Fails in Linux")
 def test_flag_painting(editor_bot, qtbot):
     """"Test that there is no error when painting all flag types on the
     scrollbar area when the editor vertical scrollbar is visible and not
@@ -123,7 +125,6 @@ def test_flag_painting(editor_bot, qtbot):
 
     # Set a long text in the editor and assert that the slider is visible.
     editor.set_text(long_code)
-    qtbot.waitUntil(lambda: sfa.slider)
 
     # Trigger the painting of all flag types.
     editor.debugger.toogle_breakpoint(line_number=2)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -455,6 +455,7 @@ class CodeEditor(TextEditBaseWidget):
         # functions or signals for objects not created from Python" in
         # Linux Ubuntu. See spyder-ide/spyder#5215.
         self.setVerticalScrollBar(QScrollBar())
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
 
         # Highlights and flag colors
         self.warning_color = "#FFAD07"
@@ -467,7 +468,6 @@ class CodeEditor(TextEditBaseWidget):
         # Scrollbar flag area
         self.scrollflagarea = self.panels.register(ScrollFlagArea(self),
                                                    Panel.Position.RIGHT)
-        self.scrollflagarea.hide()
         self.panels.refresh()
 
         self.document_id = id(self)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -455,7 +455,6 @@ class CodeEditor(TextEditBaseWidget):
         # functions or signals for objects not created from Python" in
         # Linux Ubuntu. See spyder-ide/spyder#5215.
         self.setVerticalScrollBar(QScrollBar())
-        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
 
         # Highlights and flag colors
         self.warning_color = "#FFAD07"


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Expand the width of the scrollflag object if macOS so the scrollbar doesn't place on the minimap. The fix works for light and dark themes,

![image](https://user-images.githubusercontent.com/20992645/85193089-d4953280-b28a-11ea-8e50-17d77519abb8.png)

![image](https://user-images.githubusercontent.com/20992645/85193090-d9f27d00-b28a-11ea-88fe-e1537f25af12.png)

An important note for the light theme is that the user needs to have the scrollbars always present in their system. That can be modified by `System preferences>General>Show scrollbar>Always`. If this option is not checked, both the scrollbar and scrollflag will hide given the position of the mouse or trackpad.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12637 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
