### PR TITLE
PR: Change time units in Profiler to match the International System of Units

### DIFF
--- a/spyder/plugins/profiler/tests/test_profiler.py
+++ b/spyder/plugins/profiler/tests/test_profiler.py
@@ -46,17 +46,17 @@ def test_format_measure(profiler_datatree_bot):
     fm = tree.format_measure
     assert fm(125) == '125'
     assert fm(1.25e-8) == '12.50 ns'
-    assert fm(1.25e-5) == '12.50 us'
+    assert fm(1.25e-5) == u'12.50 \u03BCs'
     assert fm(1.25e-2) == '12.50 ms'
-    assert fm(12.5) == '12.50 sec'
+    assert fm(12.5) == '12.50 s'
     assert fm(125.5) == '2.5 min'
     assert fm(12555.5) == '3h:29min'
 
     assert fm(-125) == '125'
     assert fm(-1.25e-8) == '12.50 ns'
-    assert fm(-1.25e-5) == '12.50 us'
+    assert fm(-1.25e-5) == u'12.50 \u03BCs'
     assert fm(-1.25e-2) == '12.50 ms'
-    assert fm(-12.5) == '12.50 sec'
+    assert fm(-12.5) == '12.50 s'
     assert fm(-125.5) == '2.5 min'
     assert fm(-12555.5) == '3h:29min'
 
@@ -67,13 +67,13 @@ def test_color_string(profiler_datatree_bot):
     cs = tree.color_string
 
     tree.compare_file = 'test'
-    assert cs([5.0]) == ['5.00 sec', ['', 'black']]
-    assert cs([1.251e-5, 1.251e-5]) == ['12.51 us', ['', 'black']]
-    assert cs([5.0, 4.0]) == ['5.00 sec', ['+1000.00 ms', 'red']]
-    assert cs([4.0, 5.0]) == ['4.00 sec', ['-1000.00 ms', 'green']]
+    assert cs([5.0]) == ['5.00 s', ['', 'black']]
+    assert cs([1.251e-5, 1.251e-5]) == [u'12.51 \u03BCs', ['', 'black']]
+    assert cs([5.0, 4.0]) == ['5.00 s', ['+1000.00 ms', 'red']]
+    assert cs([4.0, 5.0]) == ['4.00 s', ['-1000.00 ms', 'green']]
 
     tree.compare_file = None
-    assert cs([4.0, 5.0]) == ['4.00 sec', ['', 'black']]
+    assert cs([4.0, 5.0]) == ['4.00 s', ['', 'black']]
 
 
 def test_format_output(profiler_datatree_bot):
@@ -95,11 +95,11 @@ def test_format_output(profiler_datatree_bot):
 
     tree.compare_file = 'test'
     assert list((fo('key1'))) == [['1000', ['', 'black']],
-                                  ['3.50 sec', ['-200.00 ms', 'green']],
-                                  ['1.50 sec', ['+200.00 ms', 'red']]]
+                                  ['3.50 s', ['-200.00 ms', 'green']],
+                                  ['1.50 s', ['+200.00 ms', 'red']]]
     assert list((fo('key2'))) == [['1200', ['+1', 'red']],
-                                  ['2.00 sec', ['-400.00 ms', 'green']],
-                                  ['2.00 sec', ['-400.00 ms', 'green']]]
+                                  ['2.00 s', ['-400.00 ms', 'green']],
+                                  ['2.00 s', ['-400.00 ms', 'green']]]
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/profiler/widgets/profilergui.py
+++ b/spyder/plugins/profiler/widgets/profilergui.py
@@ -393,7 +393,7 @@ def gettime_s(text):
         tmp = float(res[0])
         if res[1] == 'ns':
             tmp *= 1e-9
-        elif res[1] == 'us':
+        elif res[1] == u'\u03BCs':
             tmp *= 1e-6
         elif res[1] == 'ms':
             tmp *= 1e-3
@@ -589,11 +589,11 @@ class ProfilerDataTree(QTreeWidget):
         if 1.e-9 < measure <= 1.e-6:
             measure = u"{0:.2f} ns".format(measure / 1.e-9)
         elif 1.e-6 < measure <= 1.e-3:
-            measure = u"{0:.2f} us".format(measure / 1.e-6)
+            measure = u"{0:.2f} \u03BCs".format(measure / 1.e-6)
         elif 1.e-3 < measure <= 1:
             measure = u"{0:.2f} ms".format(measure / 1.e-3)
         elif 1 < measure <= 60:
-            measure = u"{0:.2f} sec".format(measure)
+            measure = u"{0:.2f} s".format(measure)
         elif 60 < measure <= 3600:
             m, s = divmod(measure, 3600)
             if s > 60:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

 Changed time units in profiler to match International Systems of Units. "sec was changed to "s" and "us" was changed to μ


![Screen Shot 2020-06-22 at 7 55 29 PM](https://user-images.githubusercontent.com/18587879/85349747-e235fc80-b4c4-11ea-84ce-71ce32df1ad1.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13059 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Juanis2112

<!--- Thanks for your help making Spyder better for everyone! --->
