### PR TITLE
PR: Make an in-depth audit of different LSP calls

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install dependencies
         if: env.RUN_BUILD == 'true'
         shell: bash
-        run: sudo apt-get install libxcb-randr0-dev libxcb-xtest0-dev libxcb-xinerama0-dev libxcb-shape0-dev libxcb-xkb-dev libegl1-mesa libxkbcommon-x11-0
+        run: sudo apt-get install libxcb-randr0-dev libxcb-xtest0-dev libxcb-xinerama0-dev libxcb-shape0-dev libxcb-xkb-dev libegl1-mesa libxkbcommon-x11-0 xterm
       - name: Cache conda
         uses: actions/cache@v1
         env:

--- a/spyder/plugins/completion/fallback/actor.py
+++ b/spyder/plugins/completion/fallback/actor.py
@@ -121,8 +121,7 @@ class FallbackActor(QObject):
         """Handle one message"""
         msg_type, _id, file, msg = [
             message[k] for k in ('type', 'id', 'file', 'msg')]
-        logger.debug(u'Got request id {0}: {1} for file {2}'.format(
-            _id, msg_type, file))
+        logger.debug(u'Perform request {0} with id {1}'.format(msg_type, _id))
         if msg_type == LSPRequestTypes.DOCUMENT_DID_OPEN:
             self.file_tokens[file] = {
                 'text': msg['text'],

--- a/spyder/plugins/completion/kite/client.py
+++ b/spyder/plugins/completion/kite/client.py
@@ -160,7 +160,7 @@ class KiteClient(QObject, KiteMethodProviderMixIn):
     def perform_request(self, req_id, method, params):
         response = None
         if method in self.sender_registry:
-            logger.debug('Perform {0} request with id {1}'.format(
+            logger.debug('Perform request {0} with id {1}'.format(
                 method, req_id))
             handler_name = self.sender_registry[method]
             handler = getattr(self, handler_name)

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -437,7 +437,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
                 'params': params
             }
 
-        logger.debug('{} request: {}'.format(self.language, method))
+        logger.debug('Perform request {0} with id {1}'.format(method, _id))
 
         # Try sending a message. If the send queue is full, keep trying for a
         # a second before giving up.

--- a/spyder/plugins/completion/languageserver/providers/document.py
+++ b/spyder/plugins/completion/languageserver/providers/document.py
@@ -263,15 +263,13 @@ class DocumentProvider:
     @send_notification(method=LSPRequestTypes.DOCUMENT_DID_CLOSE)
     def document_did_close(self, params):
         codeeditor = params['codeeditor']
-        logger.debug(u'[{0}] File: {1}'.format(
-            LSPRequestTypes.DOCUMENT_DID_CLOSE, params['file']))
         filename = path_as_uri(params['file'])
-
         params = {
             'textDocument': {
                 'uri': filename
             }
         }
+
         if filename not in self.watched_files:
             params[ClientConstants.CANCEL] = True
         else:

--- a/spyder/plugins/console/widgets/shell.py
+++ b/spyder/plugins/console/widgets/shell.py
@@ -953,13 +953,6 @@ class PythonShellWidget(TracebackLinksMixin, ShellBaseWidget,
                                           completion_text=text[q_pos+1:])
             return
 
-    def document_did_change(self, text=None):
-        """
-        This is here to be compatible with CodeEditor and be able to use
-        code completion.
-        """
-        pass
-
     #------ Drag'n Drop
     def drop_pathlist(self, pathlist):
         """Drop path list"""

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -325,7 +325,8 @@ class Editor(SpyderPluginWidget):
             editorstack.completion_server_ready(language)
 
     def send_completion_request(self, language, request, params):
-        logger.debug("%s completion server request: %r" % (language, request))
+        logger.debug("Perform request {0} for: {1}".format(
+            request, params['file']))
         self.main.completions.send_request(language, request, params)
 
     def kite_completions_file_status(self):

--- a/spyder/plugins/editor/tests/conftest.py
+++ b/spyder/plugins/editor/tests/conftest.py
@@ -101,13 +101,28 @@ def editor_plugin_open_files(request, editor_plugin, python_files):
                                expected_current_filename):
         editor = editor_plugin
         expected_filenames, tmpdir = python_files
+
         if expected_current_filename is None:
             expected_current_filename = expected_filenames[0]
         expected_current_filename = osp.join(tmpdir, expected_current_filename)
+
         options_dict = {
+            # For tests
             'filenames': expected_filenames,
             'max_recent_files': 20,
-            }
+            # To make tests pass
+            'indent_chars': '*    *',
+            'show_tab_bar': True,
+            'code_folding': True,
+            'edge_line': True,
+            'indent_guides': False,
+            'scroll_past_end': False,
+            'line_numbers': True,
+            'occurrence_highlighting/timeout': 1500,
+            'tab_stop_width_spaces': 4,
+            'show_class_func_dropdown': False,
+        }
+
         if last_focused_filename is not None:
             splitsettings = [(False,
                               osp.join(tmpdir, last_focused_filename),

--- a/spyder/plugins/editor/utils/editor.py
+++ b/spyder/plugins/editor/utils/editor.py
@@ -456,6 +456,7 @@ class TextHelper(object):
 
         text_cursor.endEditBlock()
         editor._cleaning = False
+        editor.document_did_change()
 
     def select_whole_line(self, line=None, apply_selection=True):
         """
@@ -645,6 +646,7 @@ class TextHelper(object):
             text_cursor.setPosition(s)
             text_cursor.setPosition(e, text_cursor.KeepAnchor)
         self._editor.setTextCursor(text_cursor)
+        self._editor.document_did_change()
 
     def clear_selection(self):
         """Clears text cursor selection."""

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -617,6 +617,8 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         cursor.insertText(text)
         cursor.endEditBlock()
 
+        self.document_did_change()
+
     def duplicate_line_down(self):
         """
         Copy current line or selected text and paste the duplicated text
@@ -639,7 +641,6 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         last_line = False
 
         # ------ Select text
-
         # Get selection start location
         cursor.setPosition(start_pos)
         cursor.movePosition(QTextCursor.StartOfBlock)
@@ -658,7 +659,6 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
                 last_line = True
 
         # ------ Stop if at document boundary
-
         cursor.setPosition(start_pos)
         if cursor.atStart() and not after_current_line:
             # Stop if selection is already at top of the file while moving up
@@ -676,10 +676,8 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
             return
 
         # ------ Move text
-
         sel_text = to_text_string(cursor.selectedText())
         cursor.removeSelectedText()
-
 
         if after_current_line:
             # Shift selection down
@@ -709,6 +707,8 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         cursor.endEditBlock()
         self.setTextCursor(cursor)
         self.__restore_selection(start_pos, end_pos)
+
+        self.document_did_change()
 
     def move_line_up(self):
         """Move up current line or selected text"""

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2894,6 +2894,7 @@ class CodeEditor(TextEditBaseWidget):
             cursor.movePosition(QTextCursor.Right,
                                 QTextCursor.KeepAnchor, len(prefix))
             cursor.removeSelectedText()
+
         self.document_did_change()
 
     def __even_number_of_spaces(self, line_text, group=0):
@@ -4538,8 +4539,11 @@ class CodeEditor(TextEditBaseWidget):
 
     #------ Drag and drop
     def dragEnterEvent(self, event):
-        """Reimplement Qt method
-        Inform Qt about the types of data that the widget accepts"""
+        """
+        Reimplemented Qt method.
+
+        Inform Qt about the types of data that the widget accepts.
+        """
         logger.debug("dragEnterEvent was received")
         all_urls = mimedata2url(event.mimeData())
         if all_urls:
@@ -4551,13 +4555,19 @@ class CodeEditor(TextEditBaseWidget):
             TextEditBaseWidget.dragEnterEvent(self, event)
 
     def dropEvent(self, event):
-        """Reimplement Qt method
-        Unpack dropped data and handle it"""
+        """
+        Reimplemented Qt method.
+
+        Unpack dropped data and handle it.
+        """
+        logger.debug("dropEvent was received")
         if mimedata2url(event.mimeData()):
-            # Let the parent widget handle this
+            logger.debug("Let the parent widget handle this")
             event.ignore()
         else:
+            logger.debug("Call TextEditBaseWidget dropEvent method")
             TextEditBaseWidget.dropEvent(self, event)
+            self.document_did_change()
 
     #------ Paint event
     def paintEvent(self, event):

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2854,7 +2854,6 @@ class CodeEditor(TextEditBaseWidget):
             cursor.movePosition(QTextCursor.StartOfBlock)
             line_text = to_text_string(cursor.block().text())
             self.__remove_prefix(prefix, cursor, line_text)
-        self.document_did_change()
 
     def __remove_prefix(self, prefix, cursor, line_text):
         """Handle the removal of the prefix for a single line."""

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2260,6 +2260,7 @@ class CodeEditor(TextEditBaseWidget):
         """Set the text of the editor"""
         self.setPlainText(text)
         self.set_eol_chars(text)
+        self.document_did_change(text)
 
         if (isinstance(self.highlighter, sh.PygmentsSH)
                 and not running_under_pytest()):

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1478,6 +1478,11 @@ class CodeEditor(TextEditBaseWidget):
             total_whitespace = compute_whitespace(text)
             self.leading_whitespaces[i] = total_whitespace
 
+    def cleanup_folding(self):
+        """Cleanup folding pane."""
+        folding_panel = self.panels.get(FoldingPanel)
+        folding_panel.folding_regions = {}
+
     @request(method=LSPRequestTypes.DOCUMENT_FOLDING_RANGE)
     def request_folding(self):
         """Request folding."""

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1676,6 +1676,7 @@ class CodeEditor(TextEditBaseWidget):
         self.tab_indents = language in self.TAB_ALWAYS_INDENTS
         self.comment_string = ''
         self.language = 'Text'
+        self.supported_language = False
         sh_class = sh.TextSH
         language = 'None' if language is None else language
         if language is not None:

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1869,7 +1869,6 @@ class CodeEditor(TextEditBaseWidget):
                 cursor.setPosition(position + 1, QTextCursor.KeepAnchor)
             self.setTextCursor(cursor)
         self.remove_selected_text()
-        self.document_did_change()
 
     #------Find occurrences
     def __find_first(self, text):
@@ -3210,7 +3209,6 @@ class CodeEditor(TextEditBaseWidget):
                 self.insert_text(" "*(length-(len(leading_text) % length)))
             else:
                 self.insert_text(self.indent_chars)
-            self.document_did_change()
 
     def indent_or_replace(self):
         """Indent or replace by 4 spaces depending on selection and tab mode"""
@@ -3230,7 +3228,6 @@ class CodeEditor(TextEditBaseWidget):
                     self.indent()
                 else:
                     self.replace(self.indent_chars)
-                    self.document_did_change()
 
     def unindent(self, force=False):
         """

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2260,7 +2260,6 @@ class CodeEditor(TextEditBaseWidget):
         """Set the text of the editor"""
         self.setPlainText(text)
         self.set_eol_chars(text)
-        self.document_did_change(text)
 
         if (isinstance(self.highlighter, sh.PygmentsSH)
                 and not running_under_pytest()):

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -80,7 +80,7 @@ from spyder.plugins.editor.widgets.base import TextEditBaseWidget
 from spyder.plugins.outlineexplorer.languages import PythonCFM
 from spyder.plugins.outlineexplorer.api import (OutlineExplorerData as OED,
                                                 is_cell_header)
-from spyder.py3compat import PY2, to_text_string, is_string
+from spyder.py3compat import PY2, to_text_string, is_string, is_text_string
 from spyder.utils import encoding, programs, sourcecode
 from spyder.utils import icon_manager as ima
 from spyder.utils import syntaxhighlighters as sh
@@ -1544,7 +1544,9 @@ class CodeEditor(TextEditBaseWidget):
     def set_debug_panel(self, show_debug_panel, language):
         """Enable/disable debug panel."""
         debugger_panel = self.panels.get(DebuggerPanel)
-        if language in ALL_LANGUAGES['Python'] and show_debug_panel:
+        if (is_text_string(language) and
+                language.lower() in ALL_LANGUAGES['Python'] and
+                show_debug_panel):
             debugger_panel.setVisible(True)
         else:
             debugger_panel.setVisible(False)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1189,7 +1189,6 @@ class CodeEditor(TextEditBaseWidget):
     @request(method=LSPRequestTypes.DOCUMENT_COMPLETION)
     def do_completion(self, automatic=False):
         """Trigger completion."""
-        self.document_did_change('')
         cursor = self.textCursor()
         current_word = self.get_current_word(
             completion=True,

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -830,7 +830,7 @@ class CodeEditor(TextEditBaseWidget):
                      show_class_func_dropdown=False,
                      indent_guides=False,
                      scroll_past_end=False,
-                     debug_panel=True,
+                     show_debug_panel=True,
                      folding=True):
         """
         Set-up configuration for the CodeEditor instance.
@@ -904,7 +904,7 @@ class CodeEditor(TextEditBaseWidget):
             Default False.
         scroll_past_end: Enable/Disable possibility to scroll file passed
             its end. Default False.
-        debug_panel: Enable/Disable debug panel. Default True.
+        show_debug_panel: Enable/Disable debug panel. Default True.
         folding: Enable/Disable code folding. Default True.
         """
 
@@ -915,7 +915,7 @@ class CodeEditor(TextEditBaseWidget):
         self.set_indent_chars(indent_chars)
 
         # Show/hide the debug panel depending on the language and parameter
-        self.set_debug_panel(debug_panel, language)
+        self.set_debug_panel(show_debug_panel, language)
 
         # Show/hide folding panel depending on parameter
         self.toggle_code_folding(folding)
@@ -1536,10 +1536,10 @@ class CodeEditor(TextEditBaseWidget):
             return params
 
     # -------------------------------------------------------------------------
-    def set_debug_panel(self, debug_panel, language):
+    def set_debug_panel(self, show_debug_panel, language):
         """Enable/disable debug panel."""
         debugger_panel = self.panels.get(DebuggerPanel)
-        if language == 'py' and debug_panel:
+        if language in ALL_LANGUAGES['Python'] and show_debug_panel:
             debugger_panel.setVisible(True)
         else:
             debugger_panel.setVisible(False)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -574,7 +574,7 @@ class EditorStack(QWidget):
         self.run_cell_copy = False
         self.create_new_file_if_empty = True
         self.indent_guides = False
-        ccs = 'Spyder'
+        ccs = 'spyder/dark'
         if ccs not in syntaxhighlighters.COLOR_SCHEME_NAMES:
             ccs = syntaxhighlighters.COLOR_SCHEME_NAMES[0]
         self.color_scheme = ccs
@@ -3016,7 +3016,8 @@ class EditorSplitter(QSplitter):
                      lambda: self.split(orientation=Qt.Horizontal))
         self.addWidget(self.editorstack)
 
-        self.editorstack.set_color_scheme(plugin.get_color_scheme())
+        if not running_under_pytest():
+            self.editorstack.set_color_scheme(plugin.get_color_scheme())
 
     def closeEvent(self, event):
         """Override QWidget closeEvent().

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2890,8 +2890,11 @@ class EditorStack(QWidget):
 
     #------ Drag and drop
     def dragEnterEvent(self, event):
-        """Reimplement Qt method
-        Inform Qt about the types of data that the widget accepts"""
+        """
+        Reimplemented Qt method.
+
+        Inform Qt about the types of data that the widget accepts.
+        """
         logger.debug("dragEnterEvent was received")
         source = event.mimeData()
         # The second check is necessary on Windows, where source.hasUrls()
@@ -2928,8 +2931,12 @@ class EditorStack(QWidget):
             event.ignore()
 
     def dropEvent(self, event):
-        """Reimplement Qt method
-        Unpack dropped data and handle it"""
+        """
+        Reimplement Qt method.
+
+        Unpack dropped data and handle it.
+        """
+        logger.debug("dropEvent was received")
         source = event.mimeData()
         # The second check is necessary when mimedata2url(source)
         # returns None.

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -3016,6 +3016,8 @@ class EditorSplitter(QSplitter):
                      lambda: self.split(orientation=Qt.Horizontal))
         self.addWidget(self.editorstack)
 
+        self.editorstack.set_color_scheme(plugin.get_color_scheme())
+
     def closeEvent(self, event):
         """Override QWidget closeEvent().
 

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -3563,6 +3563,9 @@ class EditorPluginExample(QSplitter):
         """Fake!"""
         pass
 
+    def get_color_scheme(self):
+        pass
+
 
 def test():
     from spyder.utils.qthelpers import qapplication

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -943,7 +943,8 @@ class EditorStack(QWidget):
                 self.outlineexplorer.remove_editor(finfo.editor.oe_proxy)
 
         for finfo in self.data:
-            finfo.editor.notify_close()
+            if not finfo.editor.is_cloned:
+                finfo.editor.notify_close()
         QWidget.closeEvent(self, event)
 
     def clone_editor_from(self, other_finfo, set_current):
@@ -1484,7 +1485,7 @@ class EditorStack(QWidget):
             finfo.editor.run_pygments_highlighter()
             self.sig_open_file.emit(options)
         else:
-            # If not there's no language change, we simply need to request a
+            # If there's no language change, we simply need to request a
             # document_did_open for the new file.
             finfo.editor.document_did_open()
 
@@ -1735,7 +1736,8 @@ class EditorStack(QWidget):
 
             filename = self.data[index].filename
             self.remove_from_data(index)
-            finfo.editor.notify_close()
+            if not finfo.editor.is_cloned:
+                finfo.editor.notify_close()
 
             # We pass self object ID as a QString, because otherwise it would
             # depend on the platform: long for 64bit, int for 32bit. Replacing
@@ -2243,8 +2245,6 @@ class EditorStack(QWidget):
 #        for btn in (self.filelist_btn, self.previous_btn, self.next_btn):
 #            btn.setEnabled(count > 1)
         editor = self.get_current_editor()
-        if editor.completions_available and not editor.document_opened:
-            editor.document_did_open()
         if index != -1:
             editor.setFocus()
             logger.debug("Set focus to: %s" % editor.filename)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1470,20 +1470,30 @@ class EditorStack(QWidget):
         finfo.editor.filename = new_filename
 
         # File type has changed!
-        if osp.splitext(original_filename)[1] != osp.splitext(new_filename)[1]:
-            # If the user renamed the file to a different language, we need
-            # to emit sig_open_file to see if we can start a language server
-            # for it.
+        original_ext = osp.splitext(original_filename)[1]
+        new_ext = osp.splitext(new_filename)[1]
+        if original_ext != new_ext:
+            # Set file language and re-run highlighter
             txt = to_text_string(finfo.editor.get_text_with_eol())
             language = get_file_language(new_filename, txt)
             finfo.editor.set_language(language, new_filename)
+            finfo.editor.run_pygments_highlighter()
+
+            # If the user renamed the file to a different language, we
+            # need to emit sig_open_file to see if we can start a
+            # language server for it.
             options = {
                 'language': language,
                 'filename': new_filename,
                 'codeeditor': finfo.editor
             }
-            finfo.editor.run_pygments_highlighter()
             self.sig_open_file.emit(options)
+
+            # Update panels
+            finfo.editor.set_debug_panel(
+                show_debug_panel=True, language=language)
+            finfo.editor.cleanup_code_analysis()
+            finfo.editor.cleanup_folding()
         else:
             # If there's no language change, we simply need to request a
             # document_did_open for the new file.

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1736,8 +1736,7 @@ class EditorStack(QWidget):
 
             filename = self.data[index].filename
             self.remove_from_data(index)
-            if not finfo.editor.is_cloned:
-                finfo.editor.notify_close()
+            finfo.editor.notify_close()
 
             # We pass self object ID as a QString, because otherwise it would
             # depend on the platform: long for 64bit, int for 32bit. Replacing

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2506,8 +2506,10 @@ class EditorStack(QWidget):
 
     #------ Load, reload
     def reload(self, index):
-        """Reload file from disk"""
+        """Reload file from disk."""
         finfo = self.data[index]
+        logger.debug("Reloading {}".format(finfo.filename))
+
         txt, finfo.encoding = encoding.read(finfo.filename)
         finfo.lastmodified = QFileInfo(finfo.filename).lastModified()
         position = finfo.editor.get_position('cursor')
@@ -2526,9 +2528,11 @@ class EditorStack(QWidget):
         self._refresh_outlineexplorer(index)
 
     def revert(self):
-        """Revert file from disk"""
+        """Revert file from disk."""
         index = self.get_stack_index()
         finfo = self.data[index]
+        logger.debug("Reverting {}".format(finfo.filename))
+
         filename = finfo.filename
         if finfo.editor.document().isModified():
             self.msgbox = QMessageBox(

--- a/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
+++ b/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
@@ -42,6 +42,7 @@ def editor_splitter_bot(qtbot):
     """Create editor splitter."""
     es = EditorSplitter(None, Mock(), [], first=True)
     qtbot.addWidget(es)
+    es.resize(640, 480)
     es.show()
     return es
 
@@ -95,6 +96,7 @@ def editor_splitter_lsp(qtbot_module, lsp_plugin, request):
     mock_plugin.clone_editorstack.side_effect = partial(
         clone, template=editorsplitter.editorstack)
     qtbot_module.addWidget(editorsplitter)
+    editorsplitter.resize(640, 480)
     editorsplitter.show()
 
     def teardown():

--- a/spyder/plugins/editor/widgets/tests/test_save.py
+++ b/spyder/plugins/editor/widgets/tests/test_save.py
@@ -19,6 +19,7 @@ except ImportError:
 import pytest
 
 # Local imports
+from spyder.plugins.editor.panels import DebuggerPanel
 from spyder.plugins.editor.widgets import editor
 from spyder.plugins.outlineexplorer.widgets import OutlineExplorerWidget
 
@@ -446,6 +447,10 @@ def test_save_as_change_file_type(editor_bot, mocker, tmpdir):
     # Assert we sent notify_close and emitted sig_open_file
     assert editor.notify_close.call_count == 1
     assert editorstack.sig_open_file.emit.called == 1
+
+    # Test the debugger panel is hidden
+    debugger_panel = editor.panels.get(DebuggerPanel)
+    assert not debugger_panel.isVisible()
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/editor/widgets/tests/test_save.py
+++ b/spyder/plugins/editor/widgets/tests/test_save.py
@@ -381,5 +381,72 @@ def test_save_all(editor_bot, mocker):
         editor_stack.save.assert_any_call(3, save_new_files=True)
 
 
+@pytest.mark.show_save_dialog
+def test_save_as_lsp_calls(editor_bot, mocker, tmpdir):
+    """
+    Test that EditorStack.save_as() sends the expected LSP requests.
+
+    Regression test for spyder-ide/spyder#13085.
+    """
+    editorstack, qtbot = editor_bot
+
+    # Set and assert the initial state.
+    editorstack.tabs.setCurrentIndex(1)
+    assert editorstack.get_current_filename() == 'secondtab.py'
+    editor = editorstack.get_current_editor()
+    mocker.patch.object(editor, 'notify_close')
+    mocker.patch.object(editor, 'document_did_open')
+
+    # Save file with a different name.
+    new_filename = osp.join(tmpdir.strpath, 'foo.py')
+    mocker.patch.object(editorstack, 'select_savename',
+                        return_value=new_filename)
+    assert not osp.exists(new_filename)
+    assert editorstack.save_as() is True
+    assert editorstack.get_filenames() == ['foo.py', new_filename, __file__]
+    assert osp.exists(new_filename)
+
+    # Assert we sent notify_close and document_did_open
+    assert editor.notify_close.call_count == 1
+    assert editor.document_did_open.call_count == 1
+
+
+@pytest.mark.show_save_dialog
+def test_save_as_change_file_type(editor_bot, mocker, tmpdir):
+    """
+    Test EditorStack.save_as() when changing the file type.
+
+    Regression test for spyder-ide/spyder#13085.
+    """
+    editorstack, qtbot = editor_bot
+
+    # Set and assert the initial state.
+    editorstack.tabs.setCurrentIndex(1)
+    assert editorstack.get_current_filename() == 'secondtab.py'
+    editor = editorstack.get_current_editor()
+    mocker.patch.object(editor, 'notify_close')
+    editorstack.sig_open_file = Mock()
+
+    # Save file with a different extension.
+    new_filename = osp.join(tmpdir.strpath, 'foo.R')
+    mocker.patch.object(editorstack, 'select_savename',
+                        return_value=new_filename)
+    assert not osp.exists(new_filename)
+    assert editorstack.save_as() is True
+    assert editorstack.get_filenames() == ['foo.py', new_filename, __file__]
+    assert osp.exists(new_filename)
+
+    # Assert the new language was assigned correctly
+    assert editor.language == 'R'
+
+    # Assert highlighting is working as expected.
+    # This is the lexer name assigned by Pygments
+    assert editor.highlighter_class._lexer.name == 'S'
+
+    # Assert we sent notify_close and emitted sig_open_file
+    assert editor.notify_close.call_count == 1
+    assert editorstack.sig_open_file.emit.called == 1
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -568,6 +568,9 @@ class FindReplace(QWidget):
         else:
             self.editor.setFocus()
 
+        if getattr(self.editor, 'document_did_change', False):
+            self.editor.document_did_change()
+
     @Slot()
     def replace_find_all(self, focus_replace_text=False):
         """Replace and find all matching occurrences"""
@@ -620,6 +623,9 @@ class FindReplace(QWidget):
                 self.replace_text.setFocus()
             else:
                 self.editor.setFocus()
+
+            if getattr(self.editor, 'document_did_change', False):
+                self.editor.document_did_change()
 
     def change_number_matches(self, current_match=0, total_matches=0):
         """Change number of match and total matches."""

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -686,7 +686,7 @@ class BaseEditMixin(object):
             self.document().setModified(True)
             if self.sig_eol_chars_changed is not None:
                 self.sig_eol_chars_changed.emit(eol_chars)
-            self.document_did_change()
+            self.document_did_change(text)
 
     def get_line_separator(self):
         """Return line separator based on current EOL mode"""

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -670,6 +670,10 @@ class BaseEditMixin(object):
         self._last_point = None
         self.tooltip_widget.hide()
 
+    # ----- Required methods for the LSP
+    def document_did_change(self, text=None):
+        pass
+
     #------EOL characters
     def set_eol_chars(self, text):
         """Set widget end-of-line (EOL) characters from text (analyzes text)"""
@@ -682,6 +686,7 @@ class BaseEditMixin(object):
             self.document().setModified(True)
             if self.sig_eol_chars_changed is not None:
                 self.sig_eol_chars_changed.emit(eol_chars)
+            self.document_did_change()
 
     def get_line_separator(self):
         """Return line separator based on current EOL mode"""
@@ -928,6 +933,7 @@ class BaseEditMixin(object):
             self.textCursor().insertText(text)
             if self.sig_text_was_inserted is not None:
                 self.sig_text_was_inserted.emit()
+            self.document_did_change()
 
     def replace_text(self, position_from, position_to, text):
         cursor = self.__select_text(position_from, position_to)
@@ -940,6 +946,7 @@ class BaseEditMixin(object):
         cursor.insertText(text)
         if self.sig_text_was_inserted is not None:
             self.sig_text_was_inserted.emit()
+        self.document_did_change()
 
     def remove_text(self, position_from, position_to):
         cursor = self.__select_text(position_from, position_to)
@@ -947,6 +954,7 @@ class BaseEditMixin(object):
             start, end = self.get_selection_start_end(cursor)
             self.sig_will_remove_selection.emit(start, end)
         cursor.removeSelectedText()
+        self.document_did_change()
 
     def get_current_object(self):
         """
@@ -1158,6 +1166,7 @@ class BaseEditMixin(object):
     def remove_selected_text(self):
         """Delete selected text."""
         self.textCursor().removeSelectedText()
+        self.document_did_change()
 
     def replace(self, text, pattern=None):
         """Replace selected text by *text*.
@@ -1181,6 +1190,7 @@ class BaseEditMixin(object):
         if self.sig_text_was_inserted is not None:
             self.sig_text_was_inserted.emit()
         cursor.endEditBlock()
+        self.document_did_change()
 
 
     #------Find/replace
@@ -1357,6 +1367,7 @@ class BaseEditMixin(object):
                 if self.sig_text_was_inserted is not None:
                     self.sig_text_was_inserted.emit()
                 cursor.endEditBlock()
+                self.document_did_change()
 
 
 class TracebackLinksMixin(object):


### PR DESCRIPTION
This PR does the following:

* Try to detect all places where we need to call or stop calling `document_did_change`. That's very important because:
    * Not calling `document_did_change` leads to completion, linting and folding not being updated correctly.
    * Calling it in excess leads to numerous requests to the language server, which consumes a lot of CPU. For instance, this was done when pressing *any* key in the editor, without checking if the key really introduced text on it or not.
* Call `notify_close` and `document_did_open` when doing "Save as" and "Save copy as".
* Correctly set highlighting and language when renaming files to another language.
* Don't call `notify_close` nor `document_did_open` for cloned editors when it's not necessary.
* Make uniform logging messages for completion requests of our different clients (Fallback, LSP and Kite).
* Show debug panel for all our supported Python extensions and not just `.py`.
* Update panels when changing file type to different languages (hide debugger for non-Python files and cleanup linting and folding).
* Set color scheme when creating new editorstacks.
* Use lowercase file extensions to decide if we show the debugger panel.

Fixes #13069.