### PR TITLE
PR: Fix rename of CodeEditor kwarg (History)

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -559,8 +559,8 @@ def test_get_help_ipython_console(main_window, qtbot):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
-@pytest.mark.skipif(sys.platform == 'darwin',
-                    reason="Does not work on Mac!")
+@pytest.mark.skipif(not sys.platform.startswith('linux'),
+                    reason="Does not work on Mac and Windows!")
 @pytest.mark.use_introspection
 @pytest.mark.parametrize(
     "object_info",

--- a/spyder/plugins/history/widgets.py
+++ b/spyder/plugins/history/widgets.py
@@ -264,7 +264,7 @@ class HistoryWidget(PluginMainWidget):
             linenumbers=self.get_option('line_numbers'),
             language=language,
             scrollflagarea=False,
-            debug_panel=False,
+            show_debug_panel=False,
         )
         editor.setReadOnly(True)
         editor.toggle_wrap_mode(self.get_option('wrap'))


### PR DESCRIPTION
This problem was introduced in PR #13085.