### PR TITLE
PR: Normcase breakpoints to avoid issues on Windows

### DIFF
--- a/spyder/plugins/breakpoints/widgets/breakpointsgui.py
+++ b/spyder/plugins/breakpoints/widgets/breakpointsgui.py
@@ -260,6 +260,15 @@ class BreakpointWidget(QWidget):
         for filename in list(bp_dict.keys()):
             if not osp.isfile(filename):
                 bp_dict.pop(filename)
+                continue
+            # Make sure we don't have the same file under different names
+            new_filename = osp.normcase(filename)
+            if new_filename != filename:
+                bp = bp_dict.pop(filename)
+                if new_filename in bp_dict:
+                    bp_dict[new_filename].extend(bp)
+                else:
+                    bp_dict[new_filename] = bp
         return bp_dict
 
     def get_data(self):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
On windows, breakpoints are sometimes saved with filenames using different capitalisation. 
This causes removable breakpoints.
This solves this annoying issue.

I was not able to understand how the bug is caused so there is no tests.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
