### PR TITLE
PR: Fix test_lsp_config_dialog

### DIFF
--- a/spyder/plugins/completion/languageserver/tests/test_lsp_config_dialog.py
+++ b/spyder/plugins/completion/languageserver/tests/test_lsp_config_dialog.py
@@ -27,6 +27,7 @@ class MainWindowMock(QObject):
     def __init__(self):
         super(MainWindowMock, self).__init__(None)
         self.statusBar = Mock()
+        self.console = Mock()
 
 
 @pytest.mark.parametrize(

--- a/spyder/preferences/tests/conftest.py
+++ b/spyder/preferences/tests/conftest.py
@@ -89,12 +89,7 @@ class ConfigDialogTester(ConfigDialog):
                     widget = self._main.create_plugin_conf_widget(plugin)
                 except Exception:
                     # Old API
-                    try:
-                        # Already initialized plugins
-                        plugin = plugin(parent=self._main)
-                    except Exception:
-                        pass
-
+                    plugin = plugin(parent=self._main)
                     widget = plugin._create_configwidget(self, self._main)
 
                 if widget:


### PR DESCRIPTION
This was due to a mismatch between 4.x and master introduced by PR #13146.