### PR TITLE
PR: Fix visible plugins on restart and online server start

### DIFF
--- a/spyder/api/widgets/__init__.py
+++ b/spyder/api/widgets/__init__.py
@@ -314,7 +314,6 @@ class PluginMainWidget(QMainWindow, SpyderWidgetMixin, SpyderToolBarMixin):
             context=Qt.WidgetShortcut,
             shortcut_context='_',
         )
-        self.toggle_view_action.setChecked(True)
 
         bottom_section = OptionsMenuSections.Bottom
         for item in [self.undock_action, self.close_action, self.dock_action]:
@@ -723,6 +722,7 @@ class PluginMainWidget(QMainWindow, SpyderWidgetMixin, SpyderToolBarMixin):
 
         self.set_ancestor(window)
         self._update_actions()
+        window.sig_closed.connect(self.close_window)
         window.show()
 
     @Slot()
@@ -741,12 +741,12 @@ class PluginMainWidget(QMainWindow, SpyderWidgetMixin, SpyderToolBarMixin):
             self.undock_action.setDisabled(False)
             self.close_action.setDisabled(False)
 
-        if self.dockwidget is not None:
-            self.sig_update_ancestor_requested.emit()
-            self.dockwidget.setWidget(self)
-            self.dockwidget.setVisible(True)
-            self.dockwidget.raise_()
-            self._update_actions()
+            if self.dockwidget is not None:
+                self.sig_update_ancestor_requested.emit()
+                self.dockwidget.setWidget(self)
+                self.dockwidget.setVisible(True)
+                self.dockwidget.raise_()
+                self._update_actions()
 
     def change_visibility(self, enable, force_focus=None):
         """

--- a/spyder/api/widgets/auxiliary_widgets.py
+++ b/spyder/api/widgets/auxiliary_widgets.py
@@ -9,6 +9,7 @@ Spyder API auxiliary widgets.
 """
 
 # Third party imports
+from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QHBoxLayout, QMainWindow, QWidget
 import qdarkstyle
 
@@ -21,6 +22,10 @@ class SpyderWindowWidget(QMainWindow):
     """
     MainWindow subclass that contains a Spyder Plugin.
     """
+    sig_closed = Signal()
+    """
+    This signal is emitted when this widget is closed.
+    """
 
     def __init__(self, widget):
         super().__init__()
@@ -29,6 +34,11 @@ class SpyderWindowWidget(QMainWindow):
         # Setting interface theme
         if is_dark_interface():
             self.setStyleSheet(qdarkstyle.load_stylesheet())
+
+    def closeEvent(self, event):
+        """Override Qt method to emit a custom `sig_close` signal."""
+        super().closeEvent(event)
+        self.sig_closed.emit()
 
 
 class MainCornerWidget(QWidget):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2003,6 +2003,7 @@ class MainWindow(QMainWindow):
 
             # Regenerate menu
             self.quick_layout_set_menu()
+
         self.set_window_settings(*settings)
 
         # Old API
@@ -2014,11 +2015,6 @@ class MainWindow(QMainWindow):
             except Exception as error:
                 print("%s: %s" % (plugin, str(error)), file=STDERR)
                 traceback.print_exc(file=STDERR)
-
-        # New API: Tabify at the end
-        for plugin in (self.widgetlist + self.thirdparty_plugins):
-            if isinstance(plugin, SpyderDockablePlugin):
-                self.tabify_plugin(plugin)
 
     def setup_default_layouts(self, index, settings):
         """Setup default layouts when run for the first time."""
@@ -2201,18 +2197,6 @@ class MainWindow(QMainWindow):
             for row in column:
                 for widget in row:
                     widgets.append(widget)
-
-        # Make every widget visible
-        for widget in widgets:
-            widget.toggle_view(True)
-            try:
-                # New API
-                if widget.toggle_view_action:
-                    widget.toggle_view_action.setChecked(True)
-            except AttributeError:
-                # Old API
-                if widget._toggle_view_action:
-                    widget._toggle_view_action.setChecked(True)
 
         # We use both directions to ensure proper update when moving from
         # 'Horizontal Split' to 'Spyder Default'

--- a/spyder/plugins/onlinehelp/tests/test_pydocgui.py
+++ b/spyder/plugins/onlinehelp/tests/test_pydocgui.py
@@ -24,9 +24,10 @@ def pydocbrowser(qtbot):
     widget = PydocBrowser(parent=None, name='pydoc')
     options = PydocBrowser.DEFAULT_OPTIONS.copy()
     widget._setup(options)
+    widget.setup(options)
 
     with qtbot.waitSignal(widget.sig_load_finished, timeout=6000):
-        widget.setup(options)
+        widget.initialize()
 
     qtbot.addWidget(widget)
     return qtbot, widget


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

This PR correctly addresses some issues with plugins on startup and on close. With this PR online server is never started unless the plugin was open on shutdown. This includes the first startup as well.

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13142
Fixes #13127

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
