### PR TITLE
PR: Fix segfault when right-clicking any entry in the project explorer

### DIFF
--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -577,8 +577,8 @@ class DirView(QTreeView):
         # empty folder. See spyder-ide/spyder#13004
         if len(fnames) == 1 and self.selectionModel():
             rows = self.selectionModel().selectedRows()
-            if (self.fsmodel.type(rows[0]) == 'Folder' and
-                    self.fsmodel.rowCount(rows[0]) == 0):
+            if (self.fsmodel.rowCount(rows[0]) == 0 and
+                    self.fsmodel.type(rows[0]) == 'Folder'):
                 fnames = []
         if not fnames:
             for action in actions:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

I just flip the condition to prevent `fsmodel.type` to make a segfault. I did not discover why this happen, but I suspect that is related to the model itself.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

None


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: trollodel

<!--- Thanks for your help making Spyder better for everyone! --->
P.S. This is my first contribute on Spyder. I hope that I respect the CONTRIBUTING correctly.