### PR TITLE
PR: Validate Python interpreter when applying options (Main interpreter)

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -3353,6 +3353,8 @@ def test_varexp_cleared_after_reset(main_window, qtbot):
                     timeout=3000)
 
 
+@pytest.mark.slow
+@flaky(max_runs=3)
 def test_immediate_debug(main_window, qtbot):
     """
     Check if we can enter debugging immediately

--- a/spyder/preferences/configdialog.py
+++ b/spyder/preferences/configdialog.py
@@ -778,7 +778,8 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
     def create_file_combobox(self, text, choices, option, default=NoDefault,
                              tip=None, restart=False, filters=None,
                              adjust_to_contents=False,
-                             default_line_edit=False, section=None):
+                             default_line_edit=False, section=None,
+                             validate_callback=None):
         """choices: couples (name, key)"""
         combobox = FileComboBox(self, adjust_to_contents=adjust_to_contents,
                                 default_line_edit=default_line_edit)
@@ -794,7 +795,9 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
         combobox.addItems(choices)
 
         msg = _('Invalid file path')
-        self.validate_data[edit] = (osp.isfile, msg)
+        self.validate_data[edit] = (
+            validate_callback if validate_callback else osp.isfile,
+            msg)
         browse_btn = QPushButton(ima.icon('FileIcon'), '', self)
         browse_btn.setToolTip(_("Select file"))
         browse_btn.clicked.connect(lambda: self.select_file(edit, filters))

--- a/spyder/preferences/maininterpreter.py
+++ b/spyder/preferences/maininterpreter.py
@@ -244,9 +244,20 @@ class MainInterpreterConfigPage(GeneralConfigPage):
             executable = osp.normpath(executable)
             if executable.endswith('pythonw.exe'):
                 executable = executable.replace("pythonw.exe", "python.exe")
+
+            # Set new interpreter
             self.set_custom_interpreters_list(executable)
             self.set_option('executable', executable)
             self.set_option('custom_interpreter', executable)
+
+            # Update combobox items.
+            custom_list = self.get_option('custom_interpreters_list')
+            self.cus_exec_combo.combobox.clear()
+            self.cus_exec_combo.combobox.addItems(custom_list)
+            self.pyexec_edit.setText(executable)
+
+            # Show warning compatibility message.
+            self.warn_python_compatibility(executable)
         if not self.pyexec_edit.text():
             self.set_option('custom_interpreter', '')
         if 'default' in options or 'custom' in options:

--- a/spyder/preferences/maininterpreter.py
+++ b/spyder/preferences/maininterpreter.py
@@ -95,7 +95,7 @@ class MainInterpreterConfigPage(GeneralConfigPage):
             filters=filters,
             default_line_edit=True,
             adjust_to_contents=True,
-            validate_callback=self.validate_python_interpreter,
+            validate_callback=programs.is_python_interpreter,
         )
         self.def_exec_radio.toggled.connect(self.cus_exec_combo.setDisabled)
         self.cus_exec_radio.toggled.connect(self.cus_exec_combo.setEnabled)
@@ -148,15 +148,6 @@ class MainInterpreterConfigPage(GeneralConfigPage):
         vlayout.addWidget(umr_group)
         vlayout.addStretch(1)
         self.setLayout(vlayout)
-
-    def validate_python_interpreter(self, pyexec):
-        if not programs.is_python_interpreter(pyexec):
-            # This prevents showing wrong file names in this line
-            # edit.
-            self.pyexec_edit.clear()
-            return False
-        else:
-            return True
 
     def warn_python_compatibility(self, pyexec):
         if not osp.isfile(pyexec):
@@ -260,6 +251,12 @@ class MainInterpreterConfigPage(GeneralConfigPage):
             self.warn_python_compatibility(executable)
         if not self.pyexec_edit.text():
             self.set_option('custom_interpreter', '')
+        else:
+            # This prevents showing an incorrect file name in the custom
+            # line edit.
+            if not programs.is_python_interpreter(self.pyexec_edit.text()):
+                self.pyexec_edit.clear()
+                self.set_option('custom_interpreter', '')
         if ('default' in options or 'custom' in options
                 or 'custom_interpreter' in options):
             self.main.sig_main_interpreter_changed.emit()

--- a/spyder/preferences/maininterpreter.py
+++ b/spyder/preferences/maininterpreter.py
@@ -260,6 +260,7 @@ class MainInterpreterConfigPage(GeneralConfigPage):
             self.warn_python_compatibility(executable)
         if not self.pyexec_edit.text():
             self.set_option('custom_interpreter', '')
-        if 'default' in options or 'custom' in options:
+        if ('default' in options or 'custom' in options
+                or 'custom_interpreter' in options):
             self.main.sig_main_interpreter_changed.emit()
         self.main.apply_settings()

--- a/spyder/preferences/maininterpreter.py
+++ b/spyder/preferences/maininterpreter.py
@@ -161,6 +161,16 @@ class MainInterpreterConfigPage(GeneralConfigPage):
                       "console so the previous interpreter will stay. Please "
                       "make sure to select a valid one."), QMessageBox.Ok)
             self.def_exec_radio.setChecked(True)
+
+            # Set options after validation fails. This is necessary for them
+            # to be picked up correctly by other plugins.
+            # Fixes spyder-ide/spyder#13205
+            self.set_option('default', True)
+            self.set_option('custom', False)
+
+            # Clear the line edit because there's no need to display a wrong
+            # interpreter
+            self.pyexec_edit.clear()
             return False
         return True
 

--- a/spyder/preferences/maininterpreter.py
+++ b/spyder/preferences/maininterpreter.py
@@ -95,7 +95,7 @@ class MainInterpreterConfigPage(GeneralConfigPage):
             filters=filters,
             default_line_edit=True,
             adjust_to_contents=True,
-            validate_callback=programs.is_python_interpreter,
+            validate_callback=self.validate_python_interpreter,
         )
         self.def_exec_radio.toggled.connect(self.cus_exec_combo.setDisabled)
         self.cus_exec_radio.toggled.connect(self.cus_exec_combo.setEnabled)
@@ -148,6 +148,15 @@ class MainInterpreterConfigPage(GeneralConfigPage):
         vlayout.addWidget(umr_group)
         vlayout.addStretch(1)
         self.setLayout(vlayout)
+
+    def validate_python_interpreter(self, pyexec):
+        if not programs.is_python_interpreter(pyexec):
+            # This prevents showing wrong file names in this line
+            # edit.
+            self.pyexec_edit.clear()
+            return False
+        else:
+            return True
 
     def warn_python_compatibility(self, pyexec):
         if not osp.isfile(pyexec):

--- a/spyder/preferences/maininterpreter.py
+++ b/spyder/preferences/maininterpreter.py
@@ -263,4 +263,4 @@ class MainInterpreterConfigPage(GeneralConfigPage):
         if ('default' in options or 'custom' in options
                 or 'custom_interpreter' in options):
             self.main.sig_main_interpreter_changed.emit()
-        self.main.apply_settings()
+        self.main.apply_statusbar_settings()

--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -328,6 +328,20 @@ class FileComboBox(PathComboBox):
                  osp.isdir(to_text_string(qstr)))
         return valid
 
+    def tab_complete(self):
+        """
+        If there is a single option available one tab completes the option.
+        """
+        opts = self._complete_options()
+        if len(opts) == 1:
+            text = opts[0]
+            if osp.isdir(text):
+                text = text + os.sep
+            self.set_current_text(text)
+            self.hide_completer()
+        else:
+            self.completer().complete()
+
     def _complete_options(self):
         """Find available completion options."""
         text = to_text_string(self.currentText())


### PR DESCRIPTION
This PR does the following:

* Validate a custom interpreter when trying to apply our Preferences. That prevents saving a wrong interpreter to our config file and also forces users to select a valid interpreter if they want to apply their changes. Before, the validation was done after our preferences were applied, which lead to several odd situations.
* Call `main.apply_statusbar_settings` Instead of `main.apply_settings` after applying our preferences because the first one is much less expensive than the second. That prevents a very long pause when changing interpreters.
* Remove wrong interpreters introduced in the custom line edit after applying our preferences. That (again) prevents saving a wrong interpreter in our config file.
* Update the custom interpreters combobox as soon as a new interpreter is selected. It was very strange to not be able to see that interpreter among the available ones.
* Emit `sig_main_interpreter_changed` when switching custom interpreters. This was preventing to update the PyLS with the new interpreter path.
* Don't add `os.path.sep` when there's a single entry to complete in `FileComboBox`.


Fixes #13205.