### PR TITLE
PR: Fix segfault when right-clicking any entry in the project explorer (2)

### DIFF
--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -576,9 +576,9 @@ class DirView(QTreeView):
         # Needed to disable actions in the context menu if there's an
         # empty folder. See spyder-ide/spyder#13004
         if len(fnames) == 1 and self.selectionModel():
-            rows = self.selectionModel().selectedRows()
-            if (self.fsmodel.type(rows[0]) == 'Folder' and
-                    self.fsmodel.rowCount(rows[0]) == 0):
+            current_index = self.selectionModel().currentIndex()
+            if (self.model().type(current_index) == 'Folder' and
+                    self.model().rowCount(current_index) == 0):
                 fnames = []
         if not fnames:
             for action in actions:

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -1405,6 +1405,10 @@ class ProxyModel(QSortFilterProxyModel):
                 return osp.join(self.root_path, root_dir)
         return QSortFilterProxyModel.data(self, index, role)
 
+    def type(self, index):
+        """Returns the type of file for the given index."""
+        return self.sourceModel().type(self.mapToSource(index))
+
 
 class FilteredDirView(DirView):
     """Filtered file/directory tree view"""


### PR DESCRIPTION
## Description of Changes

Right clicking on any item in the Project explorer tree causes Spyder to segfault. This issue was introduced in PR #13032.

The problem was caused by trying to access data from the source model of the project explorer tree view using indexes from its proxy model.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Supersede PR #13216


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin
