### PR TITLE
PR: Add fonts-ubuntu to the list of deb packages installed on Binder

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -8,3 +8,4 @@ xubuntu-icon-theme
 libxss1
 libpci3
 libasound2
+fonts-ubuntu


### PR DESCRIPTION
This is to make Spyder look better on Binder.