### PR TITLE
DOC: Proper numpydoc formatting.

### DIFF
--- a/spyder/api/widgets/mixins.py
+++ b/spyder/api/widgets/mixins.py
@@ -358,7 +358,6 @@ class SpyderMenuMixin:
             Unique str identifier.
         text: str
             Localized text string.
-
         Return: QMenu
             Return the created menu.
         """

--- a/spyder/api/widgets/toolbars.py
+++ b/spyder/api/widgets/toolbars.py
@@ -55,7 +55,7 @@ class SpyderToolBar(QToolBar):
 
     def add_item(self, action_or_widget, section=None, before=None):
         """
-        Add action or widget item to given toolbar `section`. 
+        Add action or widget item to given toolbar `section`.
         """
         if section is not None:
             action_or_widget._section = section

--- a/spyder/plugins/help/plugin.py
+++ b/spyder/plugins/help/plugin.py
@@ -225,7 +225,7 @@ class Help(SpyderDockablePlugin):
 
         See Also
         --------
-        :py:meth:spyder.widgets.mixins.GetHelpMixin.show_object_info
+        :py:meth:`spyder.widgets.mixins.GetHelpMixin.show_object_info`
         """
         self.switch_to_plugin()
         self.get_widget().set_object_text(
@@ -256,7 +256,7 @@ class Help(SpyderDockablePlugin):
 
         See Also
         --------
-        :py:meth:spyder.plugins.editor.widgets.editor.EditorStack.send_to_help
+        :py:meth:`spyder.plugins.editor.widgets.editor.EditorStack.send_to_help`
         """
         force_refresh = help_data.pop('force_refresh', False)
         self.switch_to_plugin()

--- a/spyder/plugins/help/widgets.py
+++ b/spyder/plugins/help/widgets.py
@@ -810,7 +810,7 @@ class HelpWidget(PluginMainWidget):
 
         See Also
         --------
-        :py:meth:spyder.widgets.mixins.GetHelpMixin.show_object_info
+        :py:meth:`spyder.widgets.mixins.GetHelpMixin.show_object_info`
         """
         if self.get_option('locked') and not force_refresh:
             return

--- a/spyder/utils/external/dafsa/dafsa.py
+++ b/spyder/utils/external/dafsa/dafsa.py
@@ -221,7 +221,7 @@ class DAFSANode:
         Please note that this method checks for *equivalence* (in particular,
         disregarding edge weight), and not for *equality*.
 
-        Paremeters
+        Parameters
         ----------
         other : DAFSANode
             The DAFSANode to be compared with the current one.
@@ -268,7 +268,7 @@ class DAFSANode:
         "information amount", only providing a convenient complementary
         method to ``.__eq__()``.
 
-        Paremeters
+        Parameters
         ----------
         other : DAFSANode
             The DAFSANode to be compared with the current one.


### PR DESCRIPTION
See also with roles needs to have backticks.

I'm working on an auto formatter for docstrings that uses NumpyDoc, and it is choking on these.
Also included a couple of whitespace fixes to be proper numpydoc formatting. 

There is a bug in numpydoc that does not handled `:py:meth`, as the regex there is too strict, but I have a local fix which will make this understood by numpydoc (https://github.com/numpy/numpydoc/pull/280).

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @Carreau

<!--- Thanks for your help making Spyder better for everyone! --->
