### PR TITLE
PR: Catch KeyError in codefolding when folding regions

### DIFF
--- a/spyder/plugins/editor/panels/codefolding.py
+++ b/spyder/plugins/editor/panels/codefolding.py
@@ -504,7 +504,12 @@ class FoldingPanel(Panel):
                     # fold scope changed, a previous block was highlighter so
                     # we quickly update our highlighting
                     self._mouse_over_line = block.blockNumber()
-                    self._highlight_block(block)
+                    try:
+                        self._highlight_block(block)
+                    except KeyError:
+                        # Catching the KeyError above is necessary to avoid
+                        # issue spyder-ide/spyder#13230.
+                        pass
                 else:
                     # same fold scope, request highlight
                     self._mouse_over_line = block.blockNumber()
@@ -802,7 +807,12 @@ class FoldingPanel(Panel):
             line_number = block.blockNumber()
             if line_number in self.folding_regions:
                 self._mouse_over_line = block.blockNumber()
-                self._highlight_block(block)
+                try:
+                    self._highlight_block(block)
+                except KeyError:
+                    # Catching the KeyError above is necessary to avoid
+                    # issue spyder-ide/spyder#13230.
+                    pass
             else:
                 self._clear_scope_decos()
         self._block_nbr = block_nbr


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Add a couple of try excepts wraping `_highlight_block` that raise a KeyError when folding regions

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13230 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
