### PR TITLE
PR: Fix project logic to allow for extra dialogs

### DIFF
--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -91,6 +91,7 @@ def create_projects(projects, mocker):
             projects.main.editor, 'get_open_filenames', return_value=files)
 
         return projects
+
     return _create_projects
 
 

--- a/spyder/plugins/projects/widgets/projectdialog.py
+++ b/spyder/plugins/projects/widgets/projectdialog.py
@@ -54,10 +54,10 @@ class ProjectDialog(QDialog):
     ----------
     project_path: str
         Location of project.
-    project_type: str
-        Type of project as defined by project types.
-    project_packages: object
-        Package to install. Currently not in use.
+    project_type: str	
+        Type of project as defined by project types.	
+    project_packages: object	
+        Package to install. Currently not in use.	
     """
 
     def __init__(self, parent, project_types):
@@ -65,6 +65,7 @@ class ProjectDialog(QDialog):
         super(ProjectDialog, self).__init__(parent=parent)
         self.plugin = parent
         self._project_types = project_types
+        self.project_data = {}
 
         # Variables
         current_python_version = '.'.join([to_text_string(sys.version_info[0]),
@@ -157,9 +158,13 @@ class ProjectDialog(QDialog):
 
     def select_location(self):
         """Select directory."""
-        location = osp.normpath(getexistingdirectory(self,
-                                                     _("Select directory"),
-                                                     self.location))
+        location = osp.normpath(
+            getexistingdirectory(
+                self,
+                _("Select directory"),
+                self.location,
+            )
+        )
 
         if location:
             if is_writable(location):
@@ -185,12 +190,15 @@ class ProjectDialog(QDialog):
 
     def create_project(self):
         """Create project."""
-        packages = ['python={0}'.format(self.combo_python_version.currentText())]
+        self.project_data = {
+            "root_path": self.text_location.text(),
+            "project_type": self.combo_project_type.currentData(),
+        }
         self.sig_project_creation_requested.emit(
             self.text_location.text(),
             self.combo_project_type.currentData(),
-            packages)
-
+            [],
+        )
         self.accept()
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

- [x] Previously if a project type was creating additional dialogs, they were unfocused because the main creation dialog retained focus.
- [x] This also cleans up a bit where the signals are emitted and what they emit.

<img width="433" alt="Screen Shot 2020-07-15 at 8 01 36" src="https://user-images.githubusercontent.com/3627835/87547931-6c5f2400-c671-11ea-9f1f-eebcc94cd630.png">


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
