### PR TITLE
PR: Add name validation and status of project methods

### DIFF
--- a/spyder/plugins/projects/api.py
+++ b/spyder/plugins/projects/api.py
@@ -38,8 +38,8 @@ class BaseProjectType:
     """
     ID = None
 
-    def __init__(self, root_path, projects_plugin):
-        self.projects_plugin = projects_plugin
+    def __init__(self, root_path, parent_plugin=None):
+        self.plugin = parent_plugin
         self.root_path = root_path
         self.open_project_files = []
         self.open_non_project_files = []
@@ -94,38 +94,67 @@ class BaseProjectType:
 
         return list(OrderedDict.fromkeys(recent_files))
 
-    def get_plugin(self, plugin_name):
-        """
-        Return a plugin by unique `plugin_name`.
-        """
-        return self.projects_plugin.get_plugin(plugin_name)
-
     # --- API
     # ------------------------------------------------------------------------
     @staticmethod
-    def get_name(self):
+    def get_name():
         """
         Provide a human readable version of NAME.
         """
         raise NotImplementedError("Must implement a `get_name` method!")
 
+    @staticmethod
+    def validate_name(path, name):
+        """
+        Validate the project's name.
+
+        Returns
+        -------
+        tuple
+            The first item (bool) indicates if the name was validated
+            successfully, and the second item (str) indicates the error
+            message, if any.
+        """
+        return True, ""
+
     def create_project(self):
         """
         Create a project and do any additional setup for this project type.
+
+        Returns
+        -------
+        tuple
+            The first item (bool) indicates if the project was created
+            successfully, and the second item (str) indicates the error
+            message, if any.
         """
-        raise NotImplementedError("Must implement a `create_project` method!")
+        return False, "A ProjectType must define a `create_project` method!"
 
     def open_project(self):
         """
         Open a project and do any additional setup for this project type.
+
+        Returns
+        -------
+        tuple
+            The first item (bool) indicates if the project was opened
+            successfully, and the second item (str) indicates the error
+            message, if any.
         """
-        raise NotImplementedError("Must implement a `open_project` method!")
+        return False, "A ProjectType must define an `open_project` method!"
 
     def close_project(self):
         """
         Close a project and do any additional setup for this project type.
+
+        Returns
+        -------
+        tuple
+            The first item (bool) indicates if the project was closed
+            successfully, and the second item (str) indicates the error
+            message, if any.
         """
-        raise NotImplementedError("Must implement a `close_project` method!")
+        return False, "A ProjectType must define a `close_project` method!"
 
 
 class EmptyProject(BaseProjectType):
@@ -136,10 +165,10 @@ class EmptyProject(BaseProjectType):
         return _("Empty project")
 
     def create_project(self):
-        pass
+        return True, ""
 
     def open_project(self):
-        pass
+        return True, ""
 
     def close_project(self):
-        pass
+        return True, ""

--- a/spyder/plugins/projects/widgets/tests/test_projectdialog.py
+++ b/spyder/plugins/projects/widgets/tests/test_projectdialog.py
@@ -20,14 +20,16 @@ import pytest
 
 # Local imports
 from spyder.plugins.projects.widgets.projectdialog import ProjectDialog
+from spyder.plugins.projects.api import EmptyProject
 
 
 @pytest.fixture
 def projects_dialog(qtbot):
     """Set up ProjectDialog."""
-    dlg = ProjectDialog(None, [('Empty project', 'empty_project')])
+    dlg = ProjectDialog(None, {'Empty project': EmptyProject})
     qtbot.addWidget(dlg)
     return dlg
+
 
 def test_project_dialog(projects_dialog):
     """Run project dialog."""
@@ -38,7 +40,7 @@ def test_project_dialog(projects_dialog):
 @pytest.mark.skipif(os.name != 'nt', reason="Specific to Windows platform")
 def test_projectdialog_location(monkeypatch):
     """Test that select_location normalizes delimiters and updates the path."""
-    dlg = ProjectDialog(None, [('Empty project', 'empty_project')])
+    dlg = ProjectDialog(None, {'Empty project': EmptyProject})
     mock_getexistingdirectory = Mock()
     monkeypatch.setattr('spyder.plugins.projects.widgets.projectdialog' +
                         '.getexistingdirectory', mock_getexistingdirectory)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
- Now the project type methods (create/open/close) return a bool and a message in case of issues and a MessageBox is displayed
- The project type now only has access to the parent plugin via the `self.plugin` attribute
- The project type now provides a (optional) static method for validating project names. The result of this validation is displayed on the bottom of the create project dialog.

<img width="612" alt="Screen Shot 2020-07-16 at 10 04 23" src="https://user-images.githubusercontent.com/3627835/87687760-be747800-c74b-11ea-90ef-a32770e1935a.png">



<!--- Explain what you've done and why --->




### Issue(s) Resolved



### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->

