### PR TITLE
PR: Fix go to line with plus symbol

### DIFF
--- a/spyder/plugins/editor/utils/editor.py
+++ b/spyder/plugins/editor/utils/editor.py
@@ -195,7 +195,10 @@ class TextHelper(object):
         :return: The new text cursor
         :rtype: QtGui.QTextCursor
         """
-        line = min(line, self.line_count())
+        try:
+            line = min(line, self.line_count())
+        except TypeError:
+            line = self.line_count()
         text_cursor = self._move_cursor_to(line)
         if column:
             text_cursor.movePosition(text_cursor.Right, text_cursor.MoveAnchor,

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -158,7 +158,7 @@ class GoToLineDialog(QDialog):
         ok_button = bbox.button(QDialogButtonBox.Ok)
         ok_button.setEnabled(False)
         self.lineedit.textChanged.connect(
-                     lambda text: ok_button.setEnabled(len(text) > 0))
+            lambda text: ok_button.setEnabled(self.validate_text(text)))
 
         layout = QHBoxLayout()
         layout.addLayout(glayout)
@@ -167,11 +167,19 @@ class GoToLineDialog(QDialog):
 
         self.lineedit.setFocus()
 
+    def validate_text(self, text):
+        """Validate the text."""
+        return len(text) > 0 and text != '+'
+
     def text_has_changed(self, text):
         """Line edit's text has changed"""
         text = to_text_string(text)
         if text:
-            self.lineno = int(text)
+            try:
+                self.lineno = int(text)
+            except ValueError:
+                self.lineno = None
+                self.lineedit.clear()
         else:
             self.lineno = None
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Add a method that checks the text and prevents the user from typing a `+` symbol.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #12693 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
