### PR TITLE
PR: Fix for consistent numbering when saving multiple plots

### DIFF
--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -55,13 +55,17 @@ def save_figure_tofile(fig, fmt, fname):
             f.write(fig)
 
 
-def get_unique_figname(dirname, root, ext):
+def get_unique_figname(dirname, root, ext, start_at_zero=False):
     """
     Append a number to "root" to form a filename that does not already exist
     in "dirname".
     """
-    i = 0
-    figname = '{} ({}){}'.format(root, i, ext)
+    i = 1
+    figname = '{}{}'.format(root, ext)
+    if start_at_zero:
+        i = 0
+        figname = '{} ({}){}'.format(root, i, ext)
+
     while True:
         if osp.exists(osp.join(dirname, figname)):
             figname = '{} ({}){}'.format(root, i, ext)
@@ -762,7 +766,8 @@ class ThumbnailScrollBar(QFrame):
                     'image/jpeg': '.jpg',
                     'image/svg+xml': '.svg'}[fmt]
 
-            figname = get_unique_figname(dirname, figname_root, fext)
+            figname = get_unique_figname(dirname, figname_root, fext,
+                                         start_at_zero=True)
             save_figure_tofile(fig, fmt, figname)
             fignames.append(figname)
         return fignames

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -60,8 +60,8 @@ def get_unique_figname(dirname, root, ext):
     Append a number to "root" to form a filename that does not already exist
     in "dirname".
     """
-    i = 1
-    figname = '{}{}'.format(root, ext)
+    i = 0
+    figname = '{} ({}){}'.format(root, i, ext)
     while True:
         if osp.exists(osp.join(dirname, figname)):
             figname = '{} ({}){}'.format(root, i, ext)

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -177,6 +177,7 @@ def test_save_all_figures(figbrowser, tmpdir, mocker, fmt):
         assert osp.exists(figname)
         assert expected_qpix.toImage() == saved_qpix.toImage()
 
+
 def test_get_unique_figname(tmpdir):
     """
     Test that the unique fig names work when saving only one and when
@@ -192,7 +193,7 @@ def test_get_unique_figname(tmpdir):
 
     # Saving multiple figures
     figname_root = ('Figure ' +
-        datetime.datetime.now().strftime('%Y-%m-%d %H%M%S'))
+                    datetime.datetime.now().strftime('%Y-%m-%d %H%M%S'))
     for i in range(5):
         figname = get_unique_figname(tmpdir, figname_root, fext,
                                      start_at_zero=True)
@@ -202,6 +203,7 @@ def test_get_unique_figname(tmpdir):
 
         expected = osp.join(tmpdir, '{} ({}){}'.format(figname_root, i, fext))
         assert figname == expected
+
 
 @pytest.mark.parametrize("fmt", ['image/png', 'image/svg+xml'])
 def test_close_current_figure(figbrowser, tmpdir, fmt):

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -13,6 +13,7 @@ Tests for the widgets used in the Plots plugin.
 # Standard library imports
 from __future__ import division
 import os.path as osp
+import datetime
 try:
     from unittest.mock import Mock
 except ImportError:
@@ -30,6 +31,7 @@ from qtpy.QtCore import Qt
 # Local imports
 from spyder.plugins.plots.widgets.figurebrowser import (FigureBrowser,
                                                         FigureThumbnail)
+from spyder.plugins.plots.widgets.figurebrowser import get_unique_figname
 from spyder.py3compat import to_text_string
 
 
@@ -175,6 +177,27 @@ def test_save_all_figures(figbrowser, tmpdir, mocker, fmt):
         assert osp.exists(figname)
         assert expected_qpix.toImage() == saved_qpix.toImage()
 
+def test_get_unique_figname(tmpdir):
+    fext = '.png'
+    # Saving only one figure
+    figname_root = ('Figure ' +
+                    datetime.datetime.now().strftime('%Y-%m-%d %H%M%S'))
+    figname = get_unique_figname(tmpdir, figname_root, fext)
+    expected = osp.join(tmpdir, '{}{}'.format(figname_root, fext))
+    assert figname == expected
+
+    # Saving multiple figures
+    figname_root = ('Figure ' +
+                datetime.datetime.now().strftime('%Y-%m-%d %H%M%S'))
+    for i in range(5):
+        figname = get_unique_figname(tmpdir, figname_root, fext,
+                                     start_at_zero=True)
+        #Create empty file with figname
+        with open(figname, 'w') as _:
+            pass
+
+        expected = osp.join(tmpdir, '{} ({}){}'.format(figname_root, i, fext))
+        assert figname == expected
 
 @pytest.mark.parametrize("fmt", ['image/png', 'image/svg+xml'])
 def test_close_current_figure(figbrowser, tmpdir, fmt):

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -178,6 +178,10 @@ def test_save_all_figures(figbrowser, tmpdir, mocker, fmt):
         assert expected_qpix.toImage() == saved_qpix.toImage()
 
 def test_get_unique_figname(tmpdir):
+    """
+    Test that the unique fig names work when saving only one and when
+    saving multiple figures.
+    """
     fext = '.png'
     # Saving only one figure
     figname_root = ('Figure ' +
@@ -188,11 +192,11 @@ def test_get_unique_figname(tmpdir):
 
     # Saving multiple figures
     figname_root = ('Figure ' +
-                datetime.datetime.now().strftime('%Y-%m-%d %H%M%S'))
+        datetime.datetime.now().strftime('%Y-%m-%d %H%M%S'))
     for i in range(5):
         figname = get_unique_figname(tmpdir, figname_root, fext,
                                      start_at_zero=True)
-        #Create empty file with figname
+        # Create empty file with figname
         with open(figname, 'w') as _:
             pass
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
I simply updated the following code in the function `get_unique_figname` to get it to start numbering at zero. My only concern is that it affects the functionality to save only one plot, because now that only file will have (0) appended. If this is an issue, I could rewrite it by adding a parameter `start_at_zero` to the function in order to make it work differently when saving only one and when saving multiple.
```python
    i = 0
    figname = '{} ({}){}'.format(root, i, ext)
```
![image](https://user-images.githubusercontent.com/13966395/87861837-025bae80-c8ff-11ea-8bc5-d20441568d8f.png)

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13254


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: arteagac

<!--- Thanks for your help making Spyder better for everyone! --->
