### PR TITLE
PR: Fix some issues with the Find and Code Analysis panes

### DIFF
--- a/spyder/plugins/findinfiles/plugin.py
+++ b/spyder/plugins/findinfiles/plugin.py
@@ -115,16 +115,23 @@ class FindInFiles(SpyderPluginWidget):
 
     def show_max_results_input(self):
         """Show input dialog to set maximum amount of results."""
-        value, valid = QInputDialog.getInt(
-            self,
-            self.get_plugin_title(),
-            _('Set maximum number of results: '),
-            value=self.get_option('max_results'),
-            min=1,
-            step=1,
-        )
-        if valid:
-            self.set_max_results(value)
+        # Create dialog
+        dialog = QInputDialog(self)
+
+        # Set dialog properties
+        dialog.setModal(False)
+        dialog.setWindowTitle(self.get_plugin_title())
+        dialog.setLabelText(_('Set maximum number of results: '))
+        dialog.setInputMode(QInputDialog.IntInput)
+        dialog.setIntRange(1, 10000)
+        dialog.setIntStep(1)
+        dialog.setIntValue(self.get_option('max_results'))
+
+        # Connect slot
+        dialog.intValueSelected.connect(
+            lambda value: self.set_max_results(value))
+
+        dialog.show()
 
     def set_max_results(self, value):
         """Set maximum amount of results to add to result browser."""

--- a/spyder/plugins/findinfiles/widgets.py
+++ b/spyder/plugins/findinfiles/widgets.py
@@ -598,14 +598,14 @@ class FindOptions(QWidget):
         self.ok_button = create_toolbutton(self, text=_("Search"),
                                            icon=ima.icon('find'),
                                            triggered=lambda: self.find.emit(),
-                                           tip=_("Start search"),
+                                           tip="",
                                            text_beside_icon=True)
         self.ok_button.clicked.connect(self.update_combos)
         self.stop_button = create_toolbutton(self, text=_("Stop"),
                                              icon=ima.icon('stop'),
                                              triggered=lambda:
                                              self.stop.emit(),
-                                             tip=_("Stop search"),
+                                             tip="",
                                              text_beside_icon=True)
         for widget in [self.search_text, self.edit_regexp, self.case_button,
                        self.ok_button, self.stop_button, self.more_options]:

--- a/spyder/plugins/pylint/plugin.py
+++ b/spyder/plugins/pylint/plugin.py
@@ -137,15 +137,29 @@ class Pylint(SpyderPluginWidget):
     #------ Public API --------------------------------------------------------
     @Slot()
     def change_history_depth(self):
-        "Change history max entries"""
-        depth, valid = QInputDialog.getInt(self, _('History'),
-                                       _('Maximum entries'),
-                                       self.get_option('max_entries'),
-                                       MIN_HISTORY_ENTRIES,
-                                       MAX_HISTORY_ENTRIES)
-        if valid:
-            self.set_option('max_entries', depth)
-            self.pylint.change_history_limit(depth)
+        """Change history max entries."""
+        # Create dialog
+        dialog = QInputDialog(self)
+
+        # Set dialog properties
+        dialog.setModal(False)
+        dialog.setWindowTitle(_('History'))
+        dialog.setLabelText(_('Maximum entries'))
+        dialog.setInputMode(QInputDialog.IntInput)
+        dialog.setIntRange(MIN_HISTORY_ENTRIES, MAX_HISTORY_ENTRIES)
+        dialog.setIntStep(1)
+        dialog.setIntValue(self.get_option('max_entries'))
+
+        # Connect slot
+        dialog.intValueSelected.connect(
+            lambda value: self.set_history_limit(value))
+
+        dialog.show()
+
+    def set_history_limit(self, value):
+        """Set history limit."""
+        self.set_option('max_entries', value)
+        self.pylint.change_history_limit(value)
 
     def get_filename(self):
         """Get current filename in combobox."""


### PR DESCRIPTION
This PR does the following:

* Remove the Search and Stop button tooltips in Find. Those don't say anything important.
* Make the "Max number of results" input dialog non-modal in Find.
* Make the "History" dialog in Code Analysis also non-modal (at @CAM-Gerlach's suggestion).