### PR TITLE
PR: Verify path before notifying project was open

### DIFF
--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -285,7 +285,6 @@ class Projects(SpyderPluginWidget):
     def open_project(self, path=None, restart_consoles=True,
                      save_previous_files=True):
         """Open the project located in `path`"""
-        self.notify_project_open(path)
         self.unmaximize()
         if path is None:
             basedir = get_home_dir()
@@ -300,7 +299,7 @@ class Projects(SpyderPluginWidget):
                 return
         else:
             path = encoding.to_unicode_from_fs(path)
-
+        self.notify_project_open(path)
         self.add_to_recent(path)
 
         # A project was not open before

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -299,7 +299,6 @@ class Projects(SpyderPluginWidget):
                 return
         else:
             path = encoding.to_unicode_from_fs(path)
-        self.notify_project_open(path)
         self.add_to_recent(path)
 
         # A project was not open before
@@ -325,6 +324,7 @@ class Projects(SpyderPluginWidget):
         project = EmptyProject(path)
         self.current_active_project = project
         self.latest_project = project
+        self.notify_project_open(path)
         self.set_option('current_project_path', self.get_active_project_path())
 
         self.setup_menu_actions()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Prevent using an empty path to notify a project was open.

Note: I'm unsure why that was the first thing that was done since a validation of the path is already being done in the method.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13346 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
