### PR TITLE
PR: Add option to insert elements above/below in lists (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -605,19 +605,19 @@ class BaseTableView(QTableView):
                                                triggered=self.save_array)
         self.save_array_action.setVisible(False)
         self.insert_action = create_action(
-                      self, _("Insert"),
-                      icon=ima.icon('insert'),
-                      triggered=lambda: self.insert_item(below=False)
+            self, _("Insert"),
+            icon=ima.icon('insert'),
+            triggered=lambda: self.insert_item(below=False)
         )
         self.insert_action_above = create_action(
-                      self, _("Insert above"),
-                      icon=ima.icon('insert'),
-                      triggered=lambda: self.insert_item(below=False)
+            self, _("Insert above"),
+            icon=ima.icon('insert'),
+            triggered=lambda: self.insert_item(below=False)
         )
         self.insert_action_below = create_action(
-                      self, _("Insert below"),
-                      icon=ima.icon('insert'),
-                      triggered=lambda: self.insert_item(below=True)
+            self, _("Insert below"),
+            icon=ima.icon('insert'),
+            triggered=lambda: self.insert_item(below=True)
         )
         self.remove_action = create_action(self, _("Remove"),
                                            icon=ima.icon('editdelete'),

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -542,7 +542,7 @@ class BaseTableView(QTableView):
         self.imshow_action = None
         self.save_array_action = None
         self.insert_action_above = None
-        self.insert_action_bellow = None
+        self.insert_action_below = None
         self.remove_action = None
         self.minmax_action = None
         self.rename_action = None
@@ -606,11 +606,11 @@ class BaseTableView(QTableView):
         self.insert_action_above = create_action(
                       self, _("Insert above"),
                       icon=ima.icon('insert'),
-                      triggered=lambda: self.insert_item(bellow=False))
-        self.insert_action_bellow = create_action(
-                      self, _("Insert bellow"),
+                      triggered=lambda: self.insert_item(below=False))
+        self.insert_action_below = create_action(
+                      self, _("Insert below"),
                       icon=ima.icon('insert'),
-                      triggered=lambda: self.insert_item(bellow=True))
+                      triggered=lambda: self.insert_item(below=True))
         self.remove_action = create_action(self, _("Remove"),
                                            icon=ima.icon('editdelete'),
                                            triggered=self.remove_item)
@@ -632,7 +632,7 @@ class BaseTableView(QTableView):
         menu = QMenu(self)
         menu_actions = [self.edit_action, self.plot_action, self.hist_action,
                         self.imshow_action, self.save_array_action,
-                        self.insert_action_above, self.insert_action_bellow,
+                        self.insert_action_above, self.insert_action_below,
                         self.remove_action, self.copy_action,
                         self.paste_action, self.view_action,
                         None, self.rename_action, self.duplicate_action,
@@ -642,7 +642,7 @@ class BaseTableView(QTableView):
         add_actions(menu, menu_actions)
         self.empty_ws_menu = QMenu(self)
         add_actions(self.empty_ws_menu,
-                    [self.insert_action_above, self.insert_action_bellow,
+                    [self.insert_action_above, self.insert_action_below,
                      self.paste_action, None, resize_action,
                      resize_columns_action])
         return menu
@@ -939,20 +939,20 @@ class BaseTableView(QTableView):
         self.copy_item(erase_original=True, new_name=new_name)
 
     @Slot()
-    def insert_item(self, bellow=True):
+    def insert_item(self, below=True):
         """Insert item"""
         index = self.currentIndex()
         if not index.isValid():
             row = self.source_model.rowCount()
         else:
             if self.proxy_model:
-                if bellow:
-                    row = self.proxy_model.mapToSource(index).row()+1
+                if below:
+                    row = self.proxy_model.mapToSource(index).row() + 1
                 else:
                     row = self.proxy_model.mapToSource(index).row()
             else:
-                if bellow:
-                    row = index.row()+1
+                if below:
+                    row = index.row() + 1
                 else:
                     row = index.row()
         data = self.source_model.get_data()
@@ -1261,7 +1261,7 @@ class CollectionsEditorTableView(BaseTableView):
         self.edit_action.setEnabled( condition )
         self.remove_action.setEnabled( condition )
         self.insert_action_above.setEnabled(not self.readonly)
-        self.insert_action_bellow.setEnabled(not self.readonly)
+        self.insert_action_below.setEnabled(not self.readonly)
         self.duplicate_action.setEnabled(condition)
         condition_rename = not isinstance(data, (tuple, list, set))
         self.rename_action.setEnabled(condition_rename)

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -603,11 +603,13 @@ class BaseTableView(QTableView):
                                                icon=ima.icon('filesave'),
                                                triggered=self.save_array)
         self.save_array_action.setVisible(False)
-        self.insert_action_above = create_action(self, _("Insert above"),
-                                                 icon=ima.icon('insert'),
+        self.insert_action_above = \
+              create_action(self, _("Insert above"),
+                            icon=ima.icon('insert'),
                             triggered=lambda: self.insert_item(bellow=False))
-        self.insert_action_bellow = create_action(self, _("Insert bellow"),
-                                                  icon=ima.icon('insert'),
+        self.insert_action_bellow = \
+               create_action(self, _("Insert bellow"),
+                             icon=ima.icon('insert'),
                              triggered=lambda: self.insert_item(bellow=True))
         self.remove_action = create_action(self, _("Remove"),
                                            icon=ima.icon('editdelete'),

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -734,7 +734,7 @@ class BaseTableView(QTableView):
         else:
             is_array = condition_plot = condition_imshow = is_list \
                      = condition_hist = False
-        is_list_instance =  isinstance(self.source_model.get_data(), list)
+        is_list_instance = isinstance(self.source_model.get_data(), list)
         self.plot_action.setVisible(condition_plot or is_list)
         self.hist_action.setVisible(condition_hist or is_list)
         self.insert_action.setVisible(not is_list_instance)
@@ -1270,9 +1270,9 @@ class CollectionsEditorTableView(BaseTableView):
                     and not self.readonly
         self.edit_action.setEnabled( condition )
         self.remove_action.setEnabled( condition )
-        self.insert_action.setEnabled( not self.readonly )
-        self.insert_action_above.setEnabled( not self.readonly )
-        self.insert_action_below.setEnabled( not self.readonly )
+        self.insert_action.setEnabled(not self.readonly)
+        self.insert_action_above.setEnabled(not self.readonly)
+        self.insert_action_below.setEnabled(not self.readonly)
         self.duplicate_action.setEnabled(condition)
         condition_rename = not isinstance(data, (tuple, list, set))
         self.rename_action.setEnabled(condition_rename)

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -607,15 +607,18 @@ class BaseTableView(QTableView):
         self.insert_action = create_action(
                       self, _("Insert"),
                       icon=ima.icon('insert'),
-                      triggered=lambda: self.insert_item(below=False))
+                      triggered=lambda: self.insert_item(below=False)
+        )
         self.insert_action_above = create_action(
                       self, _("Insert above"),
                       icon=ima.icon('insert'),
-                      triggered=lambda: self.insert_item(below=False))
+                      triggered=lambda: self.insert_item(below=False)
+        )
         self.insert_action_below = create_action(
                       self, _("Insert below"),
                       icon=ima.icon('insert'),
-                      triggered=lambda: self.insert_item(below=True))
+                      triggered=lambda: self.insert_item(below=True)
+        )
         self.remove_action = create_action(self, _("Remove"),
                                            icon=ima.icon('editdelete'),
                                            triggered=self.remove_item)

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -541,6 +541,7 @@ class BaseTableView(QTableView):
         self.hist_action = None
         self.imshow_action = None
         self.save_array_action = None
+        self.insert_action = None
         self.insert_action_above = None
         self.insert_action_below = None
         self.remove_action = None
@@ -603,6 +604,10 @@ class BaseTableView(QTableView):
                                                icon=ima.icon('filesave'),
                                                triggered=self.save_array)
         self.save_array_action.setVisible(False)
+        self.insert_action = create_action(
+                      self, _("Insert"),
+                      icon=ima.icon('insert'),
+                      triggered=lambda: self.insert_item(below=False))
         self.insert_action_above = create_action(
                       self, _("Insert above"),
                       icon=ima.icon('insert'),
@@ -632,6 +637,7 @@ class BaseTableView(QTableView):
         menu = QMenu(self)
         menu_actions = [self.edit_action, self.plot_action, self.hist_action,
                         self.imshow_action, self.save_array_action,
+                        self.insert_action,
                         self.insert_action_above, self.insert_action_below,
                         self.remove_action, self.copy_action,
                         self.paste_action, self.view_action,
@@ -643,8 +649,8 @@ class BaseTableView(QTableView):
         self.empty_ws_menu = QMenu(self)
         add_actions(self.empty_ws_menu,
                     [self.insert_action_above, self.insert_action_below,
-                     self.paste_action, None, resize_action,
-                     resize_columns_action])
+                    self.insert_action, self.paste_action, None, 
+                    resize_action, resize_columns_action])
         return menu
 
     # ------ Remote/local API -------------------------------------------------
@@ -728,8 +734,12 @@ class BaseTableView(QTableView):
         else:
             is_array = condition_plot = condition_imshow = is_list \
                      = condition_hist = False
+        is_list_instance =  isinstance(self.source_model.get_data(), list)
         self.plot_action.setVisible(condition_plot or is_list)
         self.hist_action.setVisible(condition_hist or is_list)
+        self.insert_action.setVisible(not is_list_instance)
+        self.insert_action_above.setVisible(is_list_instance)
+        self.insert_action_below.setVisible(is_list_instance)
         self.imshow_action.setVisible(condition_imshow)
         self.save_array_action.setVisible(is_array)
 
@@ -1260,8 +1270,9 @@ class CollectionsEditorTableView(BaseTableView):
                     and not self.readonly
         self.edit_action.setEnabled( condition )
         self.remove_action.setEnabled( condition )
-        self.insert_action_above.setEnabled(not self.readonly)
-        self.insert_action_below.setEnabled(not self.readonly)
+        self.insert_action.setEnabled( not self.readonly )
+        self.insert_action_above.setEnabled( not self.readonly )
+        self.insert_action_below.setEnabled( not self.readonly )
         self.duplicate_action.setEnabled(condition)
         condition_rename = not isinstance(data, (tuple, list, set))
         self.rename_action.setEnabled(condition_rename)

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -604,13 +604,13 @@ class BaseTableView(QTableView):
                                                triggered=self.save_array)
         self.save_array_action.setVisible(False)
         self.insert_action_above = \
-              create_action(self, _("Insert above"),
-                            icon=ima.icon('insert'),
-                            triggered=lambda: self.insert_item(bellow=False))
+        create_action(self, _("Insert above"),
+                      icon=ima.icon('insert'),
+                      triggered=lambda: self.insert_item(bellow=False))
         self.insert_action_bellow = \
-               create_action(self, _("Insert bellow"),
-                             icon=ima.icon('insert'),
-                             triggered=lambda: self.insert_item(bellow=True))
+             create_action(self, _("Insert bellow"),
+                           icon=ima.icon('insert'),
+                           triggered=lambda: self.insert_item(bellow=True))
         self.remove_action = create_action(self, _("Remove"),
                                            icon=ima.icon('editdelete'),
                                            triggered=self.remove_item)

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -604,10 +604,10 @@ class BaseTableView(QTableView):
                                                triggered=self.save_array)
         self.save_array_action.setVisible(False)
         self.insert_action_above = create_action(self, _("Insert above"),
-                            icon=ima.icon('insert'),
+                                                 icon=ima.icon('insert'),
                             triggered=lambda: self.insert_item(bellow=False))
         self.insert_action_bellow = create_action(self, _("Insert bellow"),
-                             icon=ima.icon('insert'),
+                                                  icon=ima.icon('insert'),
                              triggered=lambda: self.insert_item(bellow=True))
         self.remove_action = create_action(self, _("Remove"),
                                            icon=ima.icon('editdelete'),
@@ -630,8 +630,8 @@ class BaseTableView(QTableView):
         menu = QMenu(self)
         menu_actions = [self.edit_action, self.plot_action, self.hist_action,
                         self.imshow_action, self.save_array_action,
-                        self.insert_action_above, self.insert_action_bellow, 
-                        self.remove_action, self.copy_action, 
+                        self.insert_action_above, self.insert_action_bellow,
+                        self.remove_action, self.copy_action,
                         self.paste_action, self.view_action,
                         None, self.rename_action, self.duplicate_action,
                         None, resize_action, resize_columns_action]
@@ -640,8 +640,9 @@ class BaseTableView(QTableView):
         add_actions(menu, menu_actions)
         self.empty_ws_menu = QMenu(self)
         add_actions(self.empty_ws_menu,
-                    [self.insert_action_above, self.insert_action_bellow, self.paste_action,
-                     None, resize_action, resize_columns_action])
+                    [self.insert_action_above, self.insert_action_bellow,
+                     self.paste_action, None, resize_action,
+                     resize_columns_action])
         return menu
 
     # ------ Remote/local API -------------------------------------------------

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -604,11 +604,11 @@ class BaseTableView(QTableView):
                                                triggered=self.save_array)
         self.save_array_action.setVisible(False)
         self.insert_action_above = create_action(self, _("Insert above"),
-                                           icon=ima.icon('insert'),
-                                           triggered=lambda:self.insert_item(bellow=False))
+                            icon=ima.icon('insert'),
+                            triggered=lambda: self.insert_item(bellow=False))
         self.insert_action_bellow = create_action(self, _("Insert bellow"),
-                                           icon=ima.icon('insert'),
-                                           triggered=lambda:self.insert_item(bellow=True))
+                             icon=ima.icon('insert'),
+                             triggered=lambda: self.insert_item(bellow=True))
         self.remove_action = create_action(self, _("Remove"),
                                            icon=ima.icon('editdelete'),
                                            triggered=self.remove_item)
@@ -630,9 +630,9 @@ class BaseTableView(QTableView):
         menu = QMenu(self)
         menu_actions = [self.edit_action, self.plot_action, self.hist_action,
                         self.imshow_action, self.save_array_action,
-                        self.insert_action_above, self.insert_action_bellow, self.remove_action,
-                        self.copy_action, self.paste_action,
-                        self.view_action,
+                        self.insert_action_above, self.insert_action_bellow, 
+                        self.remove_action, self.copy_action, 
+                        self.paste_action, self.view_action,
                         None, self.rename_action, self.duplicate_action,
                         None, resize_action, resize_columns_action]
         if ndarray is not FakeObject:
@@ -1257,8 +1257,8 @@ class CollectionsEditorTableView(BaseTableView):
                     and not self.readonly
         self.edit_action.setEnabled( condition )
         self.remove_action.setEnabled( condition )
-        self.insert_action_above.setEnabled( not self.readonly )
-        self.insert_action_bellow.setEnabled( not self.readonly )
+        self.insert_action_above.setEnabled(not self.readonly)
+        self.insert_action_bellow.setEnabled(not self.readonly)
         self.duplicate_action.setEnabled(condition)
         condition_rename = not isinstance(data, (tuple, list, set))
         self.rename_action.setEnabled(condition_rename)

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -603,14 +603,14 @@ class BaseTableView(QTableView):
                                                icon=ima.icon('filesave'),
                                                triggered=self.save_array)
         self.save_array_action.setVisible(False)
-        self.insert_action_above = \
-        create_action(self, _("Insert above"),
+        self.insert_action_above = create_action(
+                      self, _("Insert above"),
                       icon=ima.icon('insert'),
                       triggered=lambda: self.insert_item(bellow=False))
-        self.insert_action_bellow = \
-             create_action(self, _("Insert bellow"),
-                           icon=ima.icon('insert'),
-                           triggered=lambda: self.insert_item(bellow=True))
+        self.insert_action_bellow = create_action(
+                      self, _("Insert bellow"),
+                      icon=ima.icon('insert'),
+                      triggered=lambda: self.insert_item(bellow=True))
         self.remove_action = create_action(self, _("Remove"),
                                            icon=ima.icon('editdelete'),
                                            triggered=self.remove_item)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [X] Wrote at least one-line docstrings (for any new functions)
* [X] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [X] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Added option **insert above/bellow** in variable explorer(to add new line when editing a list for example) as there was only the option **insert**, and the native behavior was to insert above. So to add new line in the end of a list, you had to duplicate that line and edit it(which is not very intuitive). 
![isseuSpyderInsertAboveBellow](https://user-images.githubusercontent.com/19315417/88449317-3f063900-ce1c-11ea-9f32-a005d31f6704.png)



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13371 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
dpturibio/Diego Prosperi Turibio
<!--- Thanks for your help making Spyder better for everyone! --->
