### PR TITLE
PR: Add Github actions to display a Binder badge in our PRs

### DIFF
--- a/.github/workflows/binder-badge.yaml
+++ b/.github/workflows/binder-badge.yaml
@@ -1,0 +1,21 @@
+name: Binder Badge
+on: [pull_request]
+
+jobs:
+  binder:
+    runs-on: ubuntu-latest
+    steps: 
+    - name: comment on PR with Binder link
+      uses: actions/github-script@v1
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          var BRANCH_NAME = process.env.BRANCH_NAME;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${context.repo.owner}/${context.repo.repo}/${BRANCH_NAME}?urlpath=%2Fdesktop) :point_left: Launch a binder instance on this branch`
+          }) 
+      env:
+        BRANCH_NAME: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/chatops-binder.yaml
+++ b/.github/workflows/chatops-binder.yaml
@@ -1,0 +1,41 @@
+name: Chatops Binder
+on: [issue_comment] # issues and PRs are equivalent in terms of comments for the GitHub API
+
+jobs:
+  trigger-chatops:
+    # Make sure the comment is from one in our organization, it's on a PR, and contains the command "/binder"
+    if: |
+      (
+        (github.event.issue.author_association == 'OWNER') ||
+        (github.event.issue.author_association == 'COLLABORATOR') ||
+        (github.event.issue.author_association == 'CONTRIBUTOR') ||
+        (github.event.issue.author_association == 'MEMBER') &&
+        (github.event.issue.pull_request != null) &&
+        contains(github.event.comment.body, '/binder')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      # Use the GitHub API to: 
+      #  (1) Get the branch name of the PR that has been commented on with "/binder" 
+      #  (2) make a comment on the PR with the binder badge
+    - name: comment on PR with Binder link
+      uses: actions/github-script@v1
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          // Get the branch name
+          github.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.issue.number
+          }).then( (pr) => {
+
+            // use the branch name to make a comment  on the PR with a Binder badge
+            var BRANCH_NAME = pr.data.head.ref
+            github.issues.createComment({
+              issue_number: context.payload.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${context.repo.owner}/${context.repo.repo}/${BRANCH_NAME}?urlpath=%2Fdesktop) :point_left: Launch a binder instance on this branch`
+            })
+          })


### PR DESCRIPTION
This way we could launch a Binder instance on every PR, which will make far more easier to test other people's PRs directly on the browser.

For previous PRs, a member of our organization can make a comment with the `/binder` text on it and a comment will be added with the right badge.

*Notes*:

* I'm still unsure if this works because first I need to add the new actions, but I'm adding them through a PR so other people know about this new functionality.
* In case others want to know more about this, I got the idea from the [Binder docs](https://mybinder.readthedocs.io/en/latest/howto/gh-actions-badges.html).