### PR TITLE
PR: Find internal plugins in plugin module for Spyder installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -284,24 +284,24 @@ spyder_plugins_entry_points = [
     'explorer = spyder.plugins.explorer.plugin:Explorer',
     ('fallback_completion = spyder.plugins.completion.fallback.plugin:'
      'FallbackPlugin'),
-    'findinfiles = spyder.plugins.findinfiles.plugin:FindInFiles',
+    'find_in_files = spyder.plugins.findinfiles.plugin:FindInFiles',
     'help = spyder.plugins.help.plugin:Help',
-    'history = spyder.plugins.history.plugin:HistoryLog',
-    'ipythonconsole = spyder.plugins.ipythonconsole.plugin:IPythonConsole',
+    'historylog = spyder.plugins.history.plugin:HistoryLog',
+    'ipython_console = spyder.plugins.ipythonconsole.plugin:IPythonConsole',
     ('kite_completion = spyder.plugins.completion.kite.plugin:'
      'KiteCompletionPlugin'),
     'onlinehelp = spyder.plugins.onlinehelp.plugin:OnlineHelp',
-    'outlineexplorer = spyder.plugins.outlineexplorer.plugin:OutlineExplorer',
+    'outline_explorer = spyder.plugins.outlineexplorer.plugin:OutlineExplorer',
     'plots = spyder.plugins.plots.plugin:Plots',
     'profiler = spyder.plugins.profiler.plugin:Profiler',
-    'projects = spyder.plugins.projects.plugin:Projects',
+    'project_explorer = spyder.plugins.projects.plugin:Projects',
     'pylint = spyder.plugins.pylint.plugin:Pylint',
     ('lsp_completion = spyder.plugins.completion.languageserver.plugin:'
      'LanguageServerPlugin'),
     'python = spyder.plugins.python.plugin:Python',
-    ('variableexplorer = spyder.plugins.variableexplorer.plugin:'
+    ('variable_explorer = spyder.plugins.variableexplorer.plugin:'
      'VariableExplorer'),
-    ('workingdirectory = spyder.plugins.workingdirectory.plugin:'
+    ('workingdir = spyder.plugins.workingdirectory.plugin:'
      'WorkingDirectory'),
 ]
 

--- a/spyder/plugins/breakpoints/__init__.py
+++ b/spyder/plugins/breakpoints/__init__.py
@@ -6,9 +6,7 @@
 # (see spyder/__init__.py for details)
 # -----------------------------------------------------------------------------
 
+from spyder.plugins.breakpoints.plugin import Breakpoints
 
-# =============================================================================
-# The following statement is required to register this 3rd party plugin:
-# =============================================================================
-
-from .plugin import Breakpoints as PLUGIN_CLASS
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [Breakpoints]

--- a/spyder/plugins/console/__init__.py
+++ b/spyder/plugins/console/__init__.py
@@ -13,3 +13,8 @@ spyder.plugins.console
 
 Internal Console Plugin.
 """
+
+from spyder.plugins.console.plugin import Console
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [Console]

--- a/spyder/plugins/findinfiles/__init__.py
+++ b/spyder/plugins/findinfiles/__init__.py
@@ -10,3 +10,8 @@ spyder.plugins.findinfiles.plugin.plugin
 
 Find in files plugin.
 """
+
+from spyder.plugins.findinfiles.plugin import FindInFiles
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [FindInFiles]

--- a/spyder/plugins/help/__init__.py
+++ b/spyder/plugins/help/__init__.py
@@ -10,3 +10,8 @@ spyder.plugins.help
 
 Help plugin using a WebView
 """
+
+from spyder.plugins.help.plugin import Help
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [Help]

--- a/spyder/plugins/history/__init__.py
+++ b/spyder/plugins/history/__init__.py
@@ -10,3 +10,8 @@ spyder.plugins.history
 
 History plugin.
 """
+
+from spyder.plugins.history.plugin import HistoryLog
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [HistoryLog]

--- a/spyder/plugins/onlinehelp/__init__.py
+++ b/spyder/plugins/onlinehelp/__init__.py
@@ -7,3 +7,8 @@
 """
 Spyder Online help plugin using Pydoc.
 """
+
+from spyder.plugins.onlinehelp.plugin import OnlineHelp
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [OnlineHelp]

--- a/spyder/plugins/plots/__init__.py
+++ b/spyder/plugins/plots/__init__.py
@@ -10,3 +10,8 @@ spyder.plugins.plots
 
 Plots plugin
 """
+
+from spyder.plugins.plots.plugin import Plots
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [Plots]

--- a/spyder/plugins/profiler/__init__.py
+++ b/spyder/plugins/profiler/__init__.py
@@ -6,9 +6,7 @@
 # (see spyder/__init__.py for details)
 # -----------------------------------------------------------------------------
 
+from spyder.plugins.profiler.plugin import Profiler
 
-# =============================================================================
-# The following statement is required to register this 3rd party plugin:
-# =============================================================================
-
-from .plugin import Profiler as PLUGIN_CLASS
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [Profiler]

--- a/spyder/plugins/pylint/__init__.py
+++ b/spyder/plugins/pylint/__init__.py
@@ -6,9 +6,4 @@
 # (see spyder/__init__.py for details)
 # -----------------------------------------------------------------------------
 
-
-# =============================================================================
-# The following statement is required to register this 3rd party plugin:
-# =============================================================================
-
-from .plugin import Pylint as PLUGIN_CLASS
+from spyder.plugins.pylint.plugin import Pylint as PLUGIN_CLASS

--- a/spyder/plugins/workingdirectory/__init__.py
+++ b/spyder/plugins/workingdirectory/__init__.py
@@ -7,3 +7,8 @@
 """
 Spyder Working Directory plugin.
 """
+
+from spyder.plugins.workingdirectory.plugin import WorkingDirectory
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [WorkingDirectory]


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

- This PR correctly finds internal plugins by checking in the `spyder.plugins` folder for installs running outside the normal spyder tests environment. This is needed to run Spyder with other plugins like the [ATE one](https://github.com/Semi-ATE/Semi-ATE/pull/10)
- PLUGIN_CLASS is replaced with PLUGIN_CLASSES as one plugin folder could potentially expose more than 1 plugin. Now that entry points are the way to expose plugins, this PLUGIN_CLASS is no longer needed for external plugins.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
