### PR TITLE
PR: Create a simple code editor and use that for other plugins

### DIFF
--- a/spyder/plugins/appearance/confpage.py
+++ b/spyder/plugins/appearance/confpage.py
@@ -18,10 +18,8 @@ from spyder.config.gui import (get_font, is_dark_font_color, is_dark_interface,
 from spyder.config.manager import CONF
 from spyder.config.utils import is_gtk_desktop
 from spyder.plugins.appearance.widgets import SchemeEditor
-# TODO: This should load befor the editor, but depends on the editor
-# the code editor, needs to be moved to core.
-from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 from spyder.utils import syntaxhighlighters
+from spyder.widgets.simplecodeeditor import SimpleCodeEditor
 
 # Localization
 _ = get_translation('spyder')
@@ -88,7 +86,7 @@ class AppearanceConfigPage(PluginConfigPage):
         self.delete_button = QPushButton(_("Delete scheme"))
         self.reset_button = QPushButton(_("Reset to defaults"))
 
-        self.preview_editor = CodeEditor(self)
+        self.preview_editor = SimpleCodeEditor(self)
         self.stacked_widget = QStackedWidget(self)
         self.scheme_editor_dialog = SchemeEditor(parent=self,
                                                  stack=self.stacked_widget)
@@ -321,27 +319,23 @@ class AppearanceConfigPage(PluginConfigPage):
         """
         text = ('"""A string"""\n\n'
                 '# A comment\n\n'
-                '# %% A cell\n\n'
                 'class Foo(object):\n'
                 '    def __init__(self):\n'
                 '        bar = 42\n'
                 '        print(bar)\n'
                 )
-        show_blanks = CONF.get('editor', 'blank_spaces')
-        update_scrollbar = CONF.get('editor', 'scroll_past_end')
-        underline_errors = CONF.get('editor', 'underline_errors')
+
         if scheme_name is None:
             scheme_name = self.current_scheme
-        self.preview_editor.setup_editor(linenumbers=True,
-                                         markers=True,
-                                         tab_mode=False,
-                                         font=get_font(),
-                                         show_blanks=show_blanks,
-                                         underline_errors=underline_errors,
-                                         color_scheme=scheme_name,
-                                         scroll_past_end=update_scrollbar)
-        self.preview_editor.set_text(text)
+
+        self.preview_editor.setup_editor(
+            font=get_font(),
+            color_scheme=scheme_name,
+            show_blanks=False,
+            scroll_past_end=False,
+        )
         self.preview_editor.set_language('Python')
+        self.preview_editor.set_text(text)
 
     # Actions
     # -------------------------------------------------------------------------

--- a/spyder/plugins/appearance/plugin.py
+++ b/spyder/plugins/appearance/plugin.py
@@ -47,6 +47,3 @@ class Appearance(SpyderPluginV2):
 
     def register(self):
         pass
-
-    # --- Public API
-    # ------------------------------------------------------------------------

--- a/spyder/plugins/help/widgets.py
+++ b/spyder/plugins/help/widgets.py
@@ -58,7 +58,7 @@ class HelpWidgetActions:
     ToggleRichMode = 'toggle_rich_mode_action'
     ToggleShowSource = 'toggle_show_source_action'
     ToggleWrap = 'toggle_wrap_action'
-    CopyAction = "copy_action"
+    CopyAction = "help_widget_copy_action"
     SelectAll = "select_all_action",
 
 
@@ -205,7 +205,11 @@ class PlainText(QWidget):
 
         # Read-only simple code editor
         self.editor = SimpleCodeEditor(self)
-        self.editor.setup_editor(language='py')
+        self.editor.setup_editor(
+            language='py',
+            highlight_current_line=False,
+            linenumbers=False,
+        )
         self.editor.sig_focus_changed.connect(self.focus_changed)
         self.editor.setReadOnly(True)
         self.editor.setContextMenuPolicy(Qt.CustomContextMenu)

--- a/spyder/plugins/help/widgets.py
+++ b/spyder/plugins/help/widgets.py
@@ -14,7 +14,7 @@ import socket
 import sys
 
 # Third party imports
-from qtpy.QtCore import QUrl, Signal, Slot
+from qtpy.QtCore import Qt, QUrl, Signal, Slot, QPoint
 from qtpy.QtGui import QColor
 from qtpy.QtWebEngineWidgets import WEBENGINE, QWebEnginePage
 from qtpy.QtWidgets import (QActionGroup, QComboBox, QLabel, QLineEdit,
@@ -26,7 +26,6 @@ from spyder.api.translations import get_translation
 from spyder.api.widgets import PluginMainWidget
 from spyder.config.base import get_image_path, get_module_source_path
 from spyder.config.gui import is_dark_interface
-from spyder.plugins.editor.widgets import codeeditor
 from spyder.plugins.help.utils.sphinxify import (CSS_PATH, DARK_CSS_PATH,
                                                  generate_context, loading,
                                                  usage, warning)
@@ -36,6 +35,7 @@ from spyder.utils import programs
 from spyder.widgets.browser import FrameWebView
 from spyder.widgets.comboboxes import EditableComboBox
 from spyder.widgets.findreplace import FindReplace
+from spyder.widgets.simplecodeeditor import SimpleCodeEditor
 
 
 # Localization
@@ -58,6 +58,8 @@ class HelpWidgetActions:
     ToggleRichMode = 'toggle_rich_mode_action'
     ToggleShowSource = 'toggle_show_source_action'
     ToggleWrap = 'toggle_wrap_action'
+    CopyAction = "copy_action"
+    SelectAll = "select_all_action",
 
 
 class HelpWidgetOptionsMenuSections:
@@ -195,16 +197,18 @@ class PlainText(QWidget):
     # Signals
     focus_changed = Signal()
 
+    sig_custom_context_menu_requested = Signal(QPoint)
+
     def __init__(self, parent):
         QWidget.__init__(self, parent)
         self.editor = None
 
-        # Read-only editor
-        self.editor = codeeditor.CodeEditor(self)
-        self.editor.setup_editor(linenumbers=False, language='py',
-                                 scrollflagarea=False, edge_line=False)
-        self.editor.focus_changed.connect(lambda: self.focus_changed.emit())
+        # Read-only simple code editor
+        self.editor = SimpleCodeEditor(self)
+        self.editor.setup_editor(language='py')
+        self.editor.sig_focus_changed.connect(self.focus_changed)
         self.editor.setReadOnly(True)
+        self.editor.setContextMenuPolicy(Qt.CustomContextMenu)
 
         # Find/replace widget
         self.find_widget = FindReplace(self)
@@ -217,21 +221,24 @@ class PlainText(QWidget):
         layout.addWidget(self.find_widget)
         self.setLayout(layout)
 
+        self.editor.customContextMenuRequested.connect(
+            self.sig_custom_context_menu_requested)
+
     def set_font(self, font, color_scheme=None):
         """Set font"""
-        self.editor.set_font(font, color_scheme=color_scheme)
+        self.editor.set_color_scheme(color_scheme)
+        self.editor.set_font(font)
 
     def set_color_scheme(self, color_scheme):
         """Set color scheme"""
         self.editor.set_color_scheme(color_scheme)
 
     def set_text(self, text, is_code):
-        self.editor.set_highlight_current_line(is_code)
-        self.editor.set_occurrence_highlighting(is_code)
         if is_code:
             self.editor.set_language('py')
         else:
             self.editor.set_language(None)
+
         self.editor.set_text(text)
         self.editor.set_cursor_position('sof')
 
@@ -241,12 +248,11 @@ class PlainText(QWidget):
     def set_wrap_mode(self, value):
         self.editor.toggle_wrap_mode(value)
 
-    def set_wrap_action(self, action):
-        """
-        Add wrap action on editor.
-        """
-        self.editor.readonly_menu.addSeparator()
-        self.editor.readonly_menu.addAction(action)
+    def copy(self):
+        self.editor.copy()
+
+    def select_all(self):
+        self.editor.selectAll()
 
 
 class HelpWidget(PluginMainWidget):
@@ -351,6 +357,18 @@ class HelpWidget(PluginMainWidget):
             toggled=lambda value: self.set_option('wrap', value),
             initial=self.get_option('wrap'),
         )
+        self.copy_action = self.create_action(
+            name=HelpWidgetActions.CopyAction,
+            text=_("Copy"),
+            triggered=lambda value: self.plain_text.copy(),
+            register_shortcut=False,
+        )
+        self.select_all_action = self.create_action(
+            name=HelpWidgetActions.SelectAll,
+            text=_("Select All"),
+            triggered=lambda value: self.plain_text.select_all(),
+            register_shortcut=False,
+        )
         self.auto_import_action = self.create_action(
             name=HelpWidgetActions.ToggleAutomaticImport,
             text=_("Automatic import"),
@@ -382,9 +400,6 @@ class HelpWidget(PluginMainWidget):
             initial=self.get_option('locked'),
         )
 
-        # TODO: Temporal while code editor migrates to SpyderMixin
-        self.plain_text.set_wrap_action(self.wrap_action)
-
         # Add the help actions to an exclusive QActionGroup
         help_actions = QActionGroup(self)
         help_actions.setExclusive(True)
@@ -407,6 +422,25 @@ class HelpWidget(PluginMainWidget):
             section=HelpWidgetOptionsMenuSections.Other,
         )
 
+        # Plain text menu
+        self._plain_text_context_menu = self.create_menu(
+            "plain_text_context_menu")
+        self.add_item_to_menu(
+            self.copy_action,
+            self._plain_text_context_menu,
+            section="copy_section",
+        )
+        self.add_item_to_menu(
+            self.select_all_action,
+            self._plain_text_context_menu,
+            section="select_section",
+        )
+        self.add_item_to_menu(
+            self.wrap_action,
+            self._plain_text_context_menu,
+            section="wrap_section",
+        )
+
         # Toolbar
         toolbar = self.get_main_toolbar()
         for item in [self.source_label, self.source_combo, self.object_label,
@@ -420,6 +454,10 @@ class HelpWidget(PluginMainWidget):
         self.source_changed()
         self.switch_to_rich_text()
         self.show_intro_message()
+
+        # Signals
+        self.plain_text.sig_custom_context_menu_requested.connect(
+            self._show_plain_text_context_menu)
 
     def on_option_update(self, option, value):
         if option == 'wrap':
@@ -483,6 +521,11 @@ class HelpWidget(PluginMainWidget):
 
     # --- Private API
     # ------------------------------------------------------------------------
+    @Slot(QPoint)
+    def _show_plain_text_context_menu(self, point):
+        point = self.plain_text.mapToGlobal(point)
+        self._plain_text_context_menu.popup(point)
+
     def _on_sphinx_thread_html_ready(self, html_text):
         """
         Set our sphinx documentation based on thread result.

--- a/spyder/plugins/history/plugin.py
+++ b/spyder/plugins/history/plugin.py
@@ -36,6 +36,7 @@ class HistoryLog(SpyderDockablePlugin):
     CONF_FROM_OPTIONS = {
         'color_scheme_name': ('appearance', 'selected'),
     }
+
     # --- Signals
     # ------------------------------------------------------------------------
     sig_focus_changed = Signal()

--- a/spyder/plugins/history/tests/test_plugin.py
+++ b/spyder/plugins/history/tests/test_plugin.py
@@ -147,13 +147,11 @@ def test_add_history(historylog):
 
     # Check differences between tabs based on setup.
     assert hw.editors[0].supported_language
-    assert hw.editors[0].is_python()
     assert hw.editors[0].isReadOnly()
     assert not hw.editors[0].isVisible()
     assert hw.editors[0].toPlainText() == text1
 
     assert not hw.editors[1].supported_language
-    assert not hw.editors[1].is_python()
     assert hw.editors[1].isReadOnly()
     assert hw.editors[1].isVisible()
     assert hw.editors[1].toPlainText() == text2

--- a/spyder/plugins/history/widgets.py
+++ b/spyder/plugins/history/widgets.py
@@ -54,7 +54,6 @@ class HistoryWidget(PluginMainWidget):
 
     DEFAULT_OPTIONS = {
         'color_scheme_name': 'spyder/dark',
-        'font': QFont(),
         'go_to_eof': True,
         'line_numbers': True,
         'max_entries': 100,
@@ -80,6 +79,7 @@ class HistoryWidget(PluginMainWidget):
         self.linenumbers_action = None
         self.editors = []
         self.filenames = []
+        self.font = None
 
         # Widgets
         self.tabwidget = Tabs(self)
@@ -162,7 +162,7 @@ class HistoryWidget(PluginMainWidget):
                     editor.toggle_line_numbers(value)
             elif option == 'color_scheme_name':
                 for editor in self.editors:
-                    editor.set_font(self.get_option('font'))
+                    editor.set_font(self.font)
 
     # --- Public API
     # ------------------------------------------------------------------------
@@ -177,8 +177,9 @@ class HistoryWidget(PluginMainWidget):
         color_scheme: str
             Name of the color scheme to use.
         """
-        self.font = font
         self.color_scheme = color_scheme
+        self.font = font
+
         for editor in self.editors:
             editor.set_font(font)
             editor.set_color_scheme(color_scheme)
@@ -262,7 +263,7 @@ class HistoryWidget(PluginMainWidget):
             linenumbers=self.get_option('line_numbers'),
             language=language,
             color_scheme=self.get_option('color_scheme_name'),
-            font=self.get_option('font'),
+            font=self.font,
             wrap=self.get_option('wrap'),
         )
         editor.setReadOnly(True)

--- a/spyder/plugins/history/widgets.py
+++ b/spyder/plugins/history/widgets.py
@@ -19,11 +19,11 @@ from qtpy.QtWidgets import QInputDialog, QVBoxLayout, QWidget
 # Local imports
 from spyder.api.translations import get_translation
 from spyder.api.widgets import PluginMainWidget
-from spyder.plugins.editor.widgets import codeeditor
 from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils import encoding
 from spyder.utils.sourcecode import normalize_eols
 from spyder.widgets.findreplace import FindReplace
+from spyder.widgets.simplecodeeditor import SimpleCodeEditor
 from spyder.widgets.tabs import Tabs
 
 # Localization
@@ -159,13 +159,10 @@ class HistoryWidget(PluginMainWidget):
                     editor.toggle_wrap_mode(value)
             elif option == 'line_numbers':
                 for editor in self.editors:
-                    editor.toggle_line_numbers(
-                        linenumbers=value,
-                        markers=False,
-                    )
+                    editor.toggle_line_numbers(value)
             elif option == 'color_scheme_name':
                 for editor in self.editors:
-                    editor.set_font(self.get_option('font'), value)
+                    editor.set_font(self.get_option('font'))
 
     # --- Public API
     # ------------------------------------------------------------------------
@@ -183,7 +180,8 @@ class HistoryWidget(PluginMainWidget):
         self.font = font
         self.color_scheme = color_scheme
         for editor in self.editors:
-            editor.set_font(font, color_scheme)
+            editor.set_font(font)
+            editor.set_color_scheme(color_scheme)
 
     def move_tab(self, index_from, index_to):
         """
@@ -256,24 +254,20 @@ class HistoryWidget(PluginMainWidget):
             return
 
         # Widgets
-        editor = codeeditor.CodeEditor(self)
+        editor = SimpleCodeEditor(self)
 
         # Setup
         language = 'py' if osp.splitext(filename)[1] == '.py' else 'bat'
         editor.setup_editor(
             linenumbers=self.get_option('line_numbers'),
             language=language,
-            scrollflagarea=False,
-            show_debug_panel=False,
+            color_scheme=self.get_option('color_scheme_name'),
+            font=self.get_option('font'),
+            wrap=self.get_option('wrap'),
         )
         editor.setReadOnly(True)
-        editor.toggle_wrap_mode(self.get_option('wrap'))
         editor.set_text(self.get_filename_text(filename))
         editor.set_cursor_position('eof')
-        editor.set_font(
-            self.get_option('font'),
-            self.get_option('color_scheme_name'),
-        )
         self.find_widget.set_editor(editor)
 
         index = self.tabwidget.addTab(editor, osp.basename(filename))
@@ -283,7 +277,7 @@ class HistoryWidget(PluginMainWidget):
         self.tabwidget.setTabToolTip(index, filename)
 
         # Signals
-        editor.focus_changed.connect(lambda: self.sig_focus_changed.emit())
+        editor.sig_focus_changed.connect(lambda: self.sig_focus_changed.emit())
 
     @Slot(str, str)
     def append_to_history(self, filename, command):

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -28,14 +28,14 @@ from spyder.config.base import _
 from spyder.config.fonts import DEFAULT_SMALL_DELTA
 from spyder.config.gui import get_font, is_dark_interface
 from spyder.config.manager import CONF
-from spyder.utils.qthelpers import (add_actions, create_plugin_layout,
-                                    create_toolbutton, qapplication)
-from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 from spyder.plugins.variableexplorer.widgets.basedialog import BaseDialog
 from spyder.plugins.variableexplorer.widgets.objectexplorer import (
     DEFAULT_ATTR_COLS, DEFAULT_ATTR_DETAILS, ToggleColumnTreeView,
     TreeItem, TreeModel, TreeProxyModel)
 from spyder.utils import icon_manager as ima
+from spyder.utils.qthelpers import (add_actions, create_plugin_layout,
+                                    create_toolbutton, qapplication)
+from spyder.widgets.simplecodeeditor import SimpleCodeEditor
 
 
 logger = logging.getLogger(__name__)
@@ -297,7 +297,7 @@ class ObjectExplorer(BaseDialog):
         h_group_layout.addWidget(radio_widget)
 
         # Editor widget
-        self.editor = CodeEditor(self)
+        self.editor = SimpleCodeEditor(self)
         self.editor.setReadOnly(True)
         h_group_layout.addWidget(self.editor)
 
@@ -420,20 +420,19 @@ class ObjectExplorer(BaseDialog):
             data = attr_details.data_fn(tree_item)
             self.editor.setPlainText(data)
             self.editor.setWordWrapMode(attr_details.line_wrap)
-            show_blanks = CONF.get('editor', 'blank_spaces')
-            update_scrollbar = CONF.get('editor', 'scroll_past_end')
-            scheme_name = CONF.get('appearance', 'selected')
             self.editor.setup_editor(
-                tab_mode=False,
                 font=get_font(font_size_delta=DEFAULT_SMALL_DELTA),
-                show_blanks=show_blanks,
-                color_scheme=scheme_name,
-                scroll_past_end=update_scrollbar)
+                show_blanks=False,
+                color_scheme=CONF.get('appearance', 'selected'),
+                scroll_past_end=False,
+            )
             self.editor.set_text(data)
+
             if attr_details.name == 'Source code':
                 self.editor.set_language('Python')
             else:
                 self.editor.set_language('Rst')
+
         except Exception as ex:
             self.editor.setStyleSheet("color: red;")
             stack_trace = traceback.format_exc()

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -260,6 +260,7 @@ class BaseSH(QSyntaxHighlighter):
             self.color_scheme = get_color_scheme(color_scheme)
         else:
             self.color_scheme = color_scheme
+
         self.setup_formats()
         self.rehighlight()
 

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -50,6 +50,7 @@ class DescriptionWidget(SimpleCodeEditor):
             font=get_font(),
             wrap=True,
             linenumbers=False,
+            highlight_current_line=False,
         )
 
         # Header

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -25,11 +25,11 @@ from spyder import (__project_url__, __trouble_url__, dependencies,
 from spyder.config.base import _, running_under_pytest
 from spyder.config.gui import get_font
 from spyder.plugins.console.widgets.console import ConsoleBaseWidget
-from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import restore_keyevent
 from spyder.widgets.github.backend import GithubBackend
 from spyder.widgets.mixins import BaseEditMixin, TracebackLinksMixin
+from spyder.widgets.simplecodeeditor import SimpleCodeEditor
 
 # Minimum number of characters to introduce in the title and
 # description fields before being able to send the report to
@@ -38,32 +38,26 @@ TITLE_MIN_CHARS = 15
 DESC_MIN_CHARS = 50
 
 
-class DescriptionWidget(CodeEditor):
+class DescriptionWidget(SimpleCodeEditor):
     """Widget to enter error description."""
 
     def __init__(self, parent=None):
-        CodeEditor.__init__(self, parent)
+        super().__init__(parent)
+
         # Editor options
         self.setup_editor(
             language='md',
-            color_scheme=None,
-            linenumbers=False,
-            scrollflagarea=False,
+            font=get_font(),
             wrap=True,
-            edge_line=False,
-            highlight_current_line=False,
-            highlight_current_cell=False,
-            occurrence_highlighting=False,
-            auto_unindent=False)
-
-        # Set font
-        self.set_font(get_font())
+            linenumbers=False,
+        )
 
         # Header
         self.header = (
             "### What steps will reproduce the problem?\n\n"
             "<!--- You can use Markdown here --->\n\n")
         self.set_text(self.header)
+
         self.move_cursor(len(self.header))
         self.header_end_pos = self.get_position('eof')
 
@@ -76,7 +70,7 @@ class DescriptionWidget(CodeEditor):
         """Cut text"""
         self.truncate_selection(self.header_end_pos)
         if self.has_selected_text():
-            CodeEditor.cut(self)
+            super().cut()
 
     def keyPressEvent(self, event):
         """Reimplemented Qt Method to avoid removing the header."""
@@ -95,7 +89,7 @@ class DescriptionWidget(CodeEditor):
         elif key == Qt.Key_X and ctrl:
             self.cut()
         else:
-            CodeEditor.keyPressEvent(self, event)
+            super().keyPressEvent(event)
 
     def delete(self):
         """Reimplemented to avoid removing the header."""

--- a/spyder/widgets/simplecodeeditor.py
+++ b/spyder/widgets/simplecodeeditor.py
@@ -1,0 +1,551 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+# ----------------------------------------------------------------------------
+
+"""
+Simple code editor with syntax highlighting and line number area.
+
+Adapted from:
+https://doc.qt.io/qt-5/qtwidgets-widgets-codeeditor-example.html
+"""
+
+# Standard library imports
+import re
+
+# Third party imports
+from qtpy.QtCore import QRect, QSize, Qt, Signal
+from qtpy.QtGui import QColor, QPainter, QTextCursor, QTextFormat, QTextOption
+from qtpy.QtWidgets import QApplication, QPlainTextEdit, QTextEdit, QWidget
+
+# Local imports
+import spyder.utils.syntaxhighlighters as sh
+from spyder.widgets.mixins import BaseEditMixin
+
+
+# Constants
+LANGUAGE_EXTENSIONS = {
+    'Python': ('py', 'pyw', 'python', 'ipy'),
+    'Cython': ('pyx', 'pxi', 'pxd'),
+    'Enaml': ('enaml',),
+    'Fortran77': ('f', 'for', 'f77'),
+    'Fortran': ('f90', 'f95', 'f2k', 'f03', 'f08'),
+    'Idl': ('pro',),
+    'Diff': ('diff', 'patch', 'rej'),
+    'GetText': ('po', 'pot'),
+    'Nsis': ('nsi', 'nsh'),
+    'Html': ('htm', 'html'),
+    'Cpp': ('c', 'cc', 'cpp', 'cxx', 'h', 'hh', 'hpp', 'hxx'),
+    'OpenCL': ('cl',),
+    'Yaml': ('yaml', 'yml'),
+    'Markdown': ('md', 'mdw'),
+    # Every other language
+    'None': ('', ),
+}
+
+
+class LineNumberArea(QWidget):
+    """
+    Adapted from:
+    https://doc.qt.io/qt-5/qtwidgets-widgets-codeeditor-example.html
+    """
+
+    def __init__(self, code_editor=None):
+        super().__init__(code_editor)
+
+        self._editor = code_editor
+        self._left_padding = 6  # Pixels
+        self._right_padding = 3  # Pixels
+
+    # --- Qt overrides
+    # ------------------------------------------------------------------------
+    def sizeHint(self):
+        return QSize(self._editor.linenumberarea_width(), 0)
+
+    def paintEvent(self, event):
+        self._editor.linenumberarea_paint_event(event)
+
+
+class SimpleCodeEditor(QPlainTextEdit, BaseEditMixin):
+    """Simple editor with highlight features."""
+
+    LANGUAGE_HIGHLIGHTERS = {
+        'Python': (sh.PythonSH, '#'),
+        'Cython': (sh.CythonSH, '#'),
+        'Fortran77': (sh.Fortran77SH, 'c'),
+        'Fortran': (sh.FortranSH, '!'),
+        'Idl': (sh.IdlSH, ';'),
+        'Diff': (sh.DiffSH, ''),
+        'GetText': (sh.GetTextSH, '#'),
+        'Nsis': (sh.NsisSH, '#'),
+        'Html': (sh.HtmlSH, ''),
+        'Yaml': (sh.YamlSH, '#'),
+        'Cpp': (sh.CppSH, '//'),
+        'OpenCL': (sh.OpenCLSH, '//'),
+        'Enaml': (sh.EnamlSH, '#'),
+        'Markdown': (sh.MarkdownSH, '#'),
+        # Every other language
+        'None': (sh.TextSH, ''),
+    }
+
+    # --- Signals
+    # ------------------------------------------------------------------------
+    sig_focus_changed = Signal()
+    """
+    This signal when the focus of the editor changes, either by a
+    `focusInEvent` or `focusOutEvent` event.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        # Variables
+        self._linenumber_enabled = None
+        self._color_scheme = "spyder/dark"
+        self._language = None
+        self._blanks_enabled = None
+        self._scrollpastend_enabled = None
+        self._wrap_mode = None
+        self.supported_language = False
+
+        # Widgets
+        self._highlighter = None
+        self.linenumberarea = LineNumberArea(self)
+
+        # Widget setup
+        self.setObjectName(self.__class__.__name__ + str(id(self)))
+        self.update_linenumberarea_width(0)
+        self._highlight_current_line()
+
+        # Signals
+        self.blockCountChanged.connect(self.update_linenumberarea_width)
+        self.updateRequest.connect(self.update_linenumberarea)
+        self.cursorPositionChanged.connect(self._highlight_current_line)
+
+    # --- Private API
+    # ------------------------------------------------------------------------
+    def _apply_color_scheme(self):
+        hl = self._highlighter
+        hl.set_color_scheme(self._color_scheme)
+        self._set_palette(background=hl.get_background_color(),
+                          foreground=hl.get_foreground_color())
+
+    def _set_palette(self, background, foreground):
+        style = ("QPlainTextEdit#%s {background: %s; color: %s;}" %
+                 (self.objectName(), background.name(), foreground.name()))
+        self.setStyleSheet(style)
+        self.rehighlight()
+
+    def _highlight_current_line(self):
+        if self._highlighter:
+            extra_selections = []
+            selection = QTextEdit.ExtraSelection()
+            line_color = self._highlighter.get_currentline_color()
+            selection.format.setBackground(line_color)
+            selection.format.setProperty(QTextFormat.FullWidthSelection, True)
+            selection.cursor = self.textCursor()
+            selection.cursor.clearSelection()
+            extra_selections.append(selection)
+
+            self.setExtraSelections(extra_selections)
+
+    # --- Qt Overrides
+    # ------------------------------------------------------------------------
+    def focusInEvent(self, event):
+        self.sig_focus_changed.emit()
+        super().focusInEvent(event)
+
+    def focusOutEvent(self, event):
+        self.sig_focus_changed.emit()
+        super().focusInEvent(event)
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        if self._linenumber_enabled:
+            cr = self.contentsRect()
+            self.linenumberarea.setGeometry(
+                QRect(
+                    cr.left(),
+                    cr.top(),
+                    self.linenumberarea_width(),
+                    cr.height(),
+                )
+            )
+
+    # --- Public API
+    # ------------------------------------------------------------------------
+    def setup_editor(self,
+                     linenumbers=True,
+                     color_scheme="spyder/dark",
+                     language="py",
+                     font=None,
+                     show_blanks=False,
+                     wrap=False,
+                     scroll_past_end=False):
+        """
+        Setup editor options.
+
+        Parameters
+        ----------
+        color_scheme: str, optional
+            Default is "spyder/dark".
+        language: str, optional
+            Default is "py".
+        font: QFont or None
+            Default is None.
+        show_blanks: bool, optional
+            Default is False/
+        wrap: bool, optional
+            Default is False.
+        scroll_past_end: bool, optional
+            Default is False
+        """
+        if font is None:
+            font = self.font()
+            font.setFamily("Courier New")
+            font.setFixedPitch(True)
+            font.setPointSize(10)
+
+        self.set_font(font)
+        self.set_blanks_enabled(show_blanks)
+        self.toggle_line_numbers(linenumbers)
+        self.set_scrollpastend_enabled(scroll_past_end)
+        self.set_language(language)
+        self.toggle_wrap_mode(wrap)
+
+    def set_font(self, font):
+        """
+        Set the editor font.
+
+        Parameters
+        ----------
+        font: QFont
+            Font to use.
+        """
+        self.setFont(font)
+
+    def set_color_scheme(self, color_scheme):
+        """
+        Set the editor color scheme.
+
+        Parameters
+        ----------
+        color_scheme: str
+            Color scheme to use.
+        """
+        self._color_scheme = color_scheme
+        self._apply_color_scheme()
+
+    def set_language(self, language):
+        """
+        Set current syntax highlighting to use `language`.
+
+        Paramaters
+        ----------
+        language: str or None
+            Language name or known extensions.
+        """
+        sh_class = sh.TextSH
+        language = str(language).lower()
+        self.supported_language = False
+        for (key, value) in LANGUAGE_EXTENSIONS.items():
+            if language in (key.lower(), ) + value:
+                sh_class, __ = self.LANGUAGE_HIGHLIGHTERS[key]
+                self._language = key
+                self.supported_language = True
+
+        self._highlighter = sh_class(
+            self.document(), self.font(), self._color_scheme)
+        self._apply_color_scheme()
+
+    def toggle_line_numbers(self, state):
+        """
+        Set visibility of line number area
+
+        Paramaters
+        ----------
+        state: bool
+            Visible state of the line number area.
+        """
+
+        self._linenumber_enabled = state
+        self.linenumberarea.setVisible(state)
+        self.update_linenumberarea_width(())
+
+    def set_scrollpastend_enabled(self, state):
+        """
+        Set scroll past end state.
+
+        Paramaters
+        ----------
+        state: bool
+            Scroll past end state.
+        """
+        self._scrollpastend_enabled = state
+        self.setCenterOnScroll(state)
+        self.setDocument(self.document())
+
+    def toggle_wrap_mode(self, state):
+        """
+        Set line wrap..
+
+        Paramaters
+        ----------
+        state: bool
+            Wrap state.
+        """
+        self.set_wrap_mode('word' if state else None)
+
+    def set_wrap_mode(self, mode=None):
+        """
+        Set line wrap mode.
+
+        Parameters
+        ----------
+        mode: str or None, optional
+            "word", or "character". Default is None.
+        """
+        if mode == 'word':
+            wrap_mode = QTextOption.WrapAtWordBoundaryOrAnywhere
+        elif mode == 'character':
+            wrap_mode = QTextOption.WrapAnywhere
+        else:
+            wrap_mode = QTextOption.NoWrap
+
+        self.setWordWrapMode(wrap_mode)
+
+    def set_blanks_enabled(self, state):
+        """
+        Show blank spaces.
+
+        Paramaters
+        ----------
+        state: bool
+            Blank spaces visibility.
+        """
+        self._blanks_enabled = state
+        option = self.document().defaultTextOption()
+        option.setFlags(option.flags()
+                        | QTextOption.AddSpaceForLineAndParagraphSeparators)
+
+        if self._blanks_enabled:
+            option.setFlags(option.flags() | QTextOption.ShowTabsAndSpaces)
+        else:
+            option.setFlags(option.flags() & ~QTextOption.ShowTabsAndSpaces)
+
+        self.document().setDefaultTextOption(option)
+
+        # Rehighlight to make the spaces less apparent.
+        self.rehighlight()
+
+    # --- Line number area
+    # ------------------------------------------------------------------------
+    def linenumberarea_paint_event(self, event):
+        """
+        Paint the line number area.
+        """
+        if self._linenumber_enabled:
+            painter = QPainter(self.linenumberarea)
+            painter.fillRect(
+                event.rect(),
+                self._highlighter.get_sideareas_color(),
+            )
+
+            block = self.firstVisibleBlock()
+            block_number = block.blockNumber()
+            top = round(self.blockBoundingGeometry(block).translated(
+                self.contentOffset()).top())
+            bottom = top + round(self.blockBoundingRect(block).height())
+
+            font = self.font()
+            active_block = self.textCursor().block()
+            active_line_number = active_block.blockNumber() + 1
+
+            while block.isValid() and top <= event.rect().bottom():
+                if block.isVisible() and bottom >= event.rect().top():
+                    number = block_number + 1
+
+                    if number == active_line_number:
+                        font.setWeight(font.Bold)
+                        painter.setFont(font)
+                        painter.setPen(
+                            self._highlighter.get_foreground_color())
+                    else:
+                        font.setWeight(font.Normal)
+                        painter.setFont(font)
+                        painter.setPen(QColor(Qt.darkGray))
+                    right_padding = self.linenumberarea._right_padding
+                    painter.drawText(
+                        0,
+                        top,
+                        self.linenumberarea.width() - right_padding,
+                        self.fontMetrics().height(),
+                        Qt.AlignRight, str(number),
+                    )
+
+                block = block.next()
+                top = bottom
+                bottom = top + round(self.blockBoundingRect(block).height())
+                block_number += 1
+
+    def linenumberarea_width(self):
+        """
+        Return the line number area width.
+
+        Returns
+        -------
+        int
+            Line number are width in pixels.
+
+        Notes
+        -----
+        If the line number area is disabled this will return zero.
+        """
+        width = 0
+        if self._linenumber_enabled:
+            digits = 1
+            count = max(1, self.blockCount())
+            while count >= 10:
+                count /= 10
+                digits += 1
+
+            fm = self.fontMetrics()
+            width = (self.linenumberarea._left_padding
+                     + self.linenumberarea._right_padding
+                     + fm.width('9') * digits)
+
+        return width
+
+    def update_linenumberarea_width(self, new_block_count=None):
+        """
+        Update the line number area width based on the number of blocks in
+        the document.
+
+        Parameters
+        ----------
+        new_block_count: int
+            The current number of blocks in the document.
+        """
+        self.setViewportMargins(self.linenumberarea_width(), 0, 0, 0)
+
+    def update_linenumberarea(self, rect, dy):
+        """
+        Update scroll position of line number area.
+        """
+        if self._linenumber_enabled:
+            if dy:
+                self.linenumberarea.scroll(0, dy)
+            else:
+                self.linenumberarea.update(
+                    0, rect.y(), self.linenumberarea.width(), rect.height())
+
+            if rect.contains(self.viewport().rect()):
+                self.update_linenumberarea_width(0)
+
+    # --- Text and cursor handling
+    # ------------------------------------------------------------------------
+    def set_selection(self, start, end):
+        """
+        Set current text selection.
+
+        Parameters
+        ----------
+        start: int
+            Selection start position.
+        end: int
+            Selection end position.
+        """
+        cursor = self.textCursor()
+        cursor.setPosition(start)
+        cursor.setPosition(end, QTextCursor.KeepAnchor)
+        self.setTextCursor(cursor)
+
+    def stdkey_backspace(self):
+        if not self.has_selected_text():
+            self.moveCursor(QTextCursor.PreviousCharacter,
+                            QTextCursor.KeepAnchor)
+        self.remove_selected_text()
+
+    def restrict_cursor_position(self, position_from, position_to):
+        """
+        Restrict the cursor from being inside from and to positions.
+
+        Parameters
+        ----------
+        position_from: int
+            Selection start position.
+        position_to: int
+            Selection end position.
+        """
+        position_from = self.get_position(position_from)
+        position_to = self.get_position(position_to)
+        cursor = self.textCursor()
+        cursor_position = cursor.position()
+        if cursor_position < position_from or cursor_position > position_to:
+            self.set_cursor_position(position_to)
+
+    def truncate_selection(self, position_from):
+        """
+        Restrict the cursor selection to start from the given position.
+
+        Parameters
+        ----------
+        position_from: int
+            Selection start position.
+        """
+        position_from = self.get_position(position_from)
+        cursor = self.textCursor()
+        start, end = cursor.selectionStart(), cursor.selectionEnd()
+        if start < end:
+            start = max([position_from, start])
+        else:
+            end = max([position_from, end])
+
+        self.set_selection(start, end)
+
+    def set_text(self, text):
+        """
+        Set `text` of the document.
+
+        Parameters
+        ----------
+        text: str
+            Text to set.
+        """
+        self.setPlainText(text)
+
+    def append(self, text):
+        """
+        Add `text` to the end of the document.
+
+        Parameters
+        ----------
+        text: str
+            Text to append.
+        """
+        cursor = self.textCursor()
+        cursor.movePosition(QTextCursor.End)
+        cursor.insertText(text)
+
+    # --- Syntax highlighter
+    # ------------------------------------------------------------------------
+    def rehighlight(self):
+        """
+        Reapply syntax highligthing to the document.
+        """
+        if self._highlighter:
+            self._highlighter.rehighlight()
+
+
+if __name__ == "__main__":
+    from spyder.utils.qthelpers import qapplication
+
+    app = qapplication()
+    editor = SimpleCodeEditor()
+    editor.setup_editor(language="markdown")
+    editor.set_text("# Hello!")
+    editor.show()
+    app.exec_()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

This is a preliminary step in the migration of the Editor Plugin to the new API. 

The CodeEditor is a very complex widget and has been used by many other plugins for providing a code editor, where the only basic need seems to have syntax highlighting capabilities at most.

Currently, the following widgets use the CodeEditor

### Variable Explorer

Object Editor (For python highlight)

### Before

<img width="832" alt="Screen Shot 2020-08-03 at 8 30 17" src="https://user-images.githubusercontent.com/3627835/89187939-94042680-d563-11ea-8a63-bcc2ee2bfa2d.png">

### Now
<img width="832" alt="Screen Shot 2020-08-03 at 8 27 26" src="https://user-images.githubusercontent.com/3627835/89187653-2f48cc00-d563-11ea-833b-6a03544ab482.png">

## History Plugin
For python highlight

### Before

<img width="718" alt="Screen Shot 2020-08-03 at 8 30 43" src="https://user-images.githubusercontent.com/3627835/89187986-a2524280-d563-11ea-801a-7b4c9a87a548.png">

### Now
<img width="759" alt="Screen Shot 2020-08-03 at 8 25 46" src="https://user-images.githubusercontent.com/3627835/89187460-f27cd500-d562-11ea-8f29-944299a8fe72.png">

## Help Plugin

For the plain text view (For python highlight)

### Before

<img width="720" alt="Screen Shot 2020-08-03 at 8 31 10" src="https://user-images.githubusercontent.com/3627835/89188017-b26a2200-d563-11ea-9af8-4c7eca8e0cba.png">

### Now

<img width="756" alt="Screen Shot 2020-08-03 at 8 26 06" src="https://user-images.githubusercontent.com/3627835/89187499-ff99c400-d562-11ea-88cd-db7bc03b1053.png">

## Appearance plugin

For the Syntax Highlighter preview (For python highlight)

### Before

<img width="1162" alt="Screen Shot 2020-08-03 at 8 31 24" src="https://user-images.githubusercontent.com/3627835/89188053-bb5af380-d563-11ea-8347-84d5bad37676.png">

### Now

<img width="1162" alt="Screen Shot 2020-08-03 at 8 27 09" src="https://user-images.githubusercontent.com/3627835/89187606-235d0a00-d563-11ea-8e5b-5a48ddbbc36f.png">

## Error report

For markdown highlight. This one uses more of the editor cursor and selection capabilities, but only a handful.

### Before

<img width="682" alt="Screen Shot 2020-08-03 at 8 31 37" src="https://user-images.githubusercontent.com/3627835/89188076-c31a9800-d563-11ea-964c-a11a6333f6d5.png">

### Now

<img width="682" alt="Screen Shot 2020-08-03 at 8 26 25" src="https://user-images.githubusercontent.com/3627835/89187527-0a545900-d563-11ea-8b8b-6c15e5321c12.png">


As an initial attempt to really decouple the different plugins the simplest way (by far) is to provide a simple code editor with the needed capabilities in the `spyder.widgets` module. This boils down to syntax highlighting and a few options. No Panels, no Extensions etc...

This has the following benefits.
- **Performance**: Spyder now can live without 5 extra instances (in the worst case) of a complex (and heavier) widget like the fully blown code editor. This could be more if the History plugin eventually tracks consoles separately.
- **Plugin dependencies**: hardcoded required dependencies are now optional so Spyder can start without the Code Editor and have all the other plugins work normally (History, VarExp, Help, Appearance).
- **Cleaner code** that avoids circular (or impossible) dependencies between plugins. (The appearance plugin needs to be loaded before the editor, but it uses the editor...)


- The new API dependencies (except for the Editor) can now really be tested.
- With the new work on syntax highlighting, having a simple code editor to test things might help in the process.

### (minor) Drawbacks:

   * Appearance: some things are not visible now on this panel. But, this panel is just a preview and the most important thing is the actual colors, not having line numbers in this context seems like a really minor issue.

**Update**

The simple code editor now implements line numbers, so there is no longer any limitation with replacing CodeEditor by this SimpleCodeEditor on the before mentioned places.

Some small cleanup is needed still but so far

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
