### PR TITLE
PR: Explorer "New" actions now depend on selected files

### DIFF
--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -433,7 +433,24 @@ class DirView(QTreeView):
 
     def create_file_new_actions(self, fnames):
         """Return actions for submenu 'New...'"""
-        root_path = self.fsmodel.rootPath()
+        if not fnames:
+            root_path = self.fsmodel.rootPath()
+        else:
+            # Verify if the user is trying to add something new inside a folder
+            # so it can be added in that folder and not in the rootpath
+            # See spyder-ide/spyder#13444
+            level_list = []
+            current_index = self.currentIndex()
+            if current_index.isValid():
+                level_list.append(current_index.data())
+
+            while current_index.isValid():
+                current_index = current_index.parent()
+                if current_index.data() is not None:
+                    level_list.insert(0, current_index.data())
+
+            root_path = osp.join(*level_list)
+
         new_file_act = create_action(self, _("File..."),
                                      icon=ima.icon('TextFileIcon'),
                                      triggered=lambda:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Add support for adding new files/folders/etc in the selected directory on the explorer tree

![image](https://user-images.githubusercontent.com/20992645/89462030-71743800-d732-11ea-8fae-a5804e254543.png)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13444 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
