### PR TITLE
PR: FIX: remove cls parameter from generated docstring

### DIFF
--- a/spyder/plugins/editor/extensions/docstring.py
+++ b/spyder/plugins/editor/extensions/docstring.py
@@ -275,7 +275,7 @@ class DocstringWriterExtension(object):
         arg_types = func_info.arg_type_list
         arg_values = func_info.arg_value_list
 
-        if len(arg_names) > 0 and arg_names[0] == 'self':
+        if len(arg_names) > 0 and arg_names[0] in ('self', 'cls'):
             del arg_names[0]
             del arg_types[0]
             del arg_values[0]
@@ -358,7 +358,7 @@ class DocstringWriterExtension(object):
         arg_types = func_info.arg_type_list
         arg_values = func_info.arg_value_list
 
-        if len(arg_names) > 0 and arg_names[0] == 'self':
+        if len(arg_names) > 0 and arg_names[0] in ('self', 'cls'):
             del arg_names[0]
             del arg_types[0]
             del arg_values[0]
@@ -440,7 +440,7 @@ class DocstringWriterExtension(object):
         arg_types = func_info.arg_type_list
         arg_values = func_info.arg_value_list
 
-        if len(arg_names) > 0 and arg_names[0] == 'self':
+        if len(arg_names) > 0 and arg_names[0] in ('self', 'cls'):
             del arg_names[0]
             del arg_types[0]
             del arg_values[0]


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

I simply check for the 'cls' parameter in the same way of 'self' is done.

This is necessary for [classmethods](https://docs.python.org/3/library/functions.html#classmethod) where the cls parameter is well-known, as the self parameter.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

None.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: trollodel

<!--- Thanks for your help making Spyder better for everyone! --->
