### PR TITLE
PR: Don't add manics conda channel to Binder's environment.yml

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -71,4 +71,6 @@ dependencies:
 - sympy
 
 # Required for desktop view on mybinder.org
-- jupyter-desktop-server
+- websockify
+- pip:
+  - jupyter-desktop-server

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -70,7 +70,5 @@ dependencies:
 - scipy
 - sympy
 
-# Required for jupyter-desktop-server
-- websockify
-- pip:
-    - jupyter-desktop-server
+# Required for desktop view on mybinder.org
+- jupyter-desktop-server

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,5 +1,5 @@
 channels:
-- manics # Used by jupyter-desktop-server
+- conda-forge # Used by jupyter-desktop-server
 dependencies:
 # We can not refer to an environment.yml file from another
 # So to get performant launches on mybinder.org, we have copied


### PR DESCRIPTION
conda-forge has working websockify now

## Description of Changes

conda-forge now [has](https://github.com/conda-forge/staged-recipes/pull/12168) websockify,
so we no longer need to add the manics channel (helpfully maintained by @manics)
to our environment.yml



### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

yuvipanda

<!--- Thanks for your help making Spyder better for everyone! --->
