### PR TITLE
PR: Create new MainMenu plugin

### DIFF
--- a/spyder/api/widgets/menus.py
+++ b/spyder/api/widgets/menus.py
@@ -54,7 +54,8 @@ class SpyderMenu(QMenu):
         self.MENUS.append((parent, title, self))
         self.aboutToShow.connect(self._render)
 
-    def add_action(self, action, section=None, before=None):
+    def add_action(self, action, section=None, before=None,
+                   before_section=None):
         """
         Add action to a given menu section.
         """
@@ -70,7 +71,15 @@ class SpyderMenu(QMenu):
 
             self._actions = new_actions
 
-        if section not in self._sections:
+        if before_section is not None and before_section in self._sections:
+            new_sections = []
+            for sec in self._sections:
+                if sec == before_section:
+                    new_sections.append(section)
+                if sec != section:
+                    new_sections.append(sec)
+            self._sections = new_sections
+        elif section not in self._sections:
             self._sections.append(section)
 
         # Track state of menu to avoid re-rendering if menu has not changed
@@ -82,6 +91,21 @@ class SpyderMenu(QMenu):
         Return the title for menu.
         """
         return self._title
+
+    def get_actions(self):
+        """
+        Return a parsed list of menu actions.
+
+        Includes MENU_SEPARATOR taking into account the sections defined.
+        """
+        actions = []
+        for section in self._sections:
+            for (sec, action) in self._actions:
+                if sec == section:
+                    actions.append(action)
+
+            actions.append(MENU_SEPARATOR)
+        return actions
 
     def get_sections(self):
         """
@@ -96,16 +120,8 @@ class SpyderMenu(QMenu):
         """
         if self._dirty:
             self.clear()
-            actions = []
-            for section in self._sections:
-                for (sec, action) in self._actions:
-                    if sec == section:
-                        actions.append(action)
-
-                actions.append(MENU_SEPARATOR)
-
+            actions = self.get_actions()
             add_actions(self, actions)
-
             self._ordered_actions = actions
             self._dirty = False
 
@@ -140,12 +156,3 @@ class MainWidgetMenu(SpyderMenu):
 
             self._ordered_actions = actions
             self._dirty = False
-
-
-class ApplicationMenu(SpyderMenu):
-    """
-    Spyder Main Window application Menu.
-
-    This class provides application menus with some predefined functionality
-    and section definition.
-    """

--- a/spyder/plugins/breakpoints/plugin.py
+++ b/spyder/plugins/breakpoints/plugin.py
@@ -17,9 +17,10 @@ import os.path as osp
 from qtpy.QtCore import Signal
 
 # Local imports
-from spyder.api.plugins import ApplicationMenus, Plugins, SpyderDockablePlugin
+from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.translations import get_translation
 from spyder.plugins.breakpoints.widgets.main_widget import BreakpointWidget
+from spyder.plugins.mainmenu.api import ApplicationMenus
 
 # Localization
 _ = get_translation('spyder')
@@ -39,6 +40,7 @@ class Breakpoints(SpyderDockablePlugin):
     """
     NAME = 'breakpoints'
     REQUIRES = [Plugins.Editor]
+    OPTIONAL = [Plugins.MainMenu]
     TABIFY = [Plugins.Help]
     WIDGET_CLASS = BreakpointWidget
     CONF_SECTION = NAME
@@ -98,6 +100,7 @@ class Breakpoints(SpyderDockablePlugin):
     def register(self):
         widget = self.get_widget()
         editor = self.get_plugin(Plugins.Editor)
+        mainmenu = self.get_plugin(Plugins.MainMenu)
 
         # TODO: change name of this signal on editor
         editor.breakpoints_saved.connect(self.set_data)
@@ -123,9 +126,11 @@ class Breakpoints(SpyderDockablePlugin):
             icon=self.get_icon(),
         )
 
+        if mainmenu:
+            debug_menu = mainmenu.get_application_menu(ApplicationMenus.Debug)
+            mainmenu.add_item_to_application_menu(list_action, debug_menu)
+
         # TODO: Fix location once the sections are defined
-        debug_menu = self.get_application_menu(ApplicationMenus.Debug)
-        self.add_item_to_application_menu(list_action, debug_menu)
         editor.pythonfile_dependent_actions += [list_action]
 
     # --- Private API

--- a/spyder/plugins/console/tests/test_plugin.py
+++ b/spyder/plugins/console/tests/test_plugin.py
@@ -37,7 +37,9 @@ def console_plugin(qtbot):
             self._INTERNAL_PLUGINS = {'internal_console': Console}
 
         def __getattr__(self, attr):
-            if attr != '_INTERNAL_PLUGINS':
+            if attr == '_PLUGINS':
+                return {}
+            elif attr != '_INTERNAL_PLUGINS':
                 return Mock()
             else:
                 return self.__dict__[attr]

--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -335,6 +335,12 @@ class ConsoleWidget(PluginMainWidget):
         """
         self.shell.help = help_plugin
 
+    def report_issue(self):
+        """Report an issue with the SpyderErrorDialog."""
+        self._report_dlg = SpyderErrorDialog(self, is_report=True)
+        self._report_dlg.set_color_scheme(self.get_option('color_theme'))
+        self._report_dlg.show()
+
     @Slot(dict)
     def handle_exception(self, error_data, sender=None, internal_plugins=None):
         """

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -55,6 +55,8 @@ from spyder.api.plugins import SpyderPluginWidget
 from spyder.plugins.run.widgets import (ALWAYS_OPEN_FIRST_RUN_OPTION,
                                         get_run_configuration,
                                         RunConfigDialog, RunConfigOneDialog)
+from spyder.plugins.mainmenu.api import ApplicationMenus
+
 
 
 logger = logging.getLogger(__name__)
@@ -1493,6 +1495,10 @@ class Editor(SpyderPluginWidget):
     #------ Handling editor windows
     def setup_other_windows(self):
         """Setup toolbars and menus for 'New window' instances"""
+        # TODO: All the actions here should be taken from
+        # the MainMenus plugin
+        help_menu_actions = self.main.mainmenu.get_application_menu(
+            ApplicationMenus.Help).get_actions()
 
         self.toolbar_list = ((_("File toolbar"), "file_toolbar",
                               self.main.file_toolbar_actions),
@@ -1506,6 +1512,7 @@ class Editor(SpyderPluginWidget):
                               self.main.debug_toolbar_actions),
                              (_("Edit toolbar"), "edit_toolbar",
                               self.main.edit_toolbar_actions))
+
         self.menu_list = ((_("&File"), self.main.file_menu_actions),
                           (_("&Edit"), self.main.edit_menu_actions),
                           (_("&Search"), self.main.search_menu_actions),
@@ -1513,7 +1520,7 @@ class Editor(SpyderPluginWidget):
                           (_("&Run"), self.main.run_menu_actions),
                           (_("&Tools"), self.main.tools_menu_actions),
                           (_("&View"), []),
-                          (_("&Help"), self.main.help_menu_actions))
+                          (_("&Help"), help_menu_actions))
         # Create pending new windows:
         for layout_settings in self.editorwindows_to_be_created:
             win = self.create_new_window()

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -88,7 +88,7 @@ from spyder.utils import encoding, programs, sourcecode
 from spyder.utils import icon_manager as ima
 from spyder.utils import syntaxhighlighters as sh
 from spyder.utils.qthelpers import (add_actions, create_action, file_uri,
-                                    mimedata2url)
+                                    mimedata2url, start_file)
 from spyder.utils.vcs import get_git_remotes, remote_to_url
 from spyder.utils.qstringhelpers import qstring_length
 from spyder.widgets.helperwidgets import MessageCheckBox
@@ -4707,7 +4707,7 @@ class CodeEditor(TextEditBaseWidget):
             else:
                 # Use external program
                 fname = file_uri(fname)
-                programs.start_file(fname)
+                start_file(fname)
         elif key in ['mail', 'url']:
             if '@' in uri and not uri.startswith('mailto:'):
                 full_uri = 'mailto:' + uri

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -44,7 +44,7 @@ from spyder.utils.misc import getcwd_or_home
 from spyder.utils.qthelpers import (add_actions, create_action,
                                     create_plugin_layout, create_toolbutton,
                                     file_uri, MENU_SEPARATOR,
-                                    QInputDialogMultiline)
+                                    QInputDialogMultiline, start_file)
 
 try:
     from nbconvert import PythonExporter as nbexporter
@@ -844,7 +844,7 @@ class DirView(QTreeView):
         If this does not work, opening unknown file in Spyder, as text file"""
         for path in sorted(fnames):
             path = file_uri(path)
-            ok = programs.start_file(path)
+            ok = start_file(path)
             if not ok:
                 self.sig_edit.emit(path)
 

--- a/spyder/plugins/findinfiles/plugin.py
+++ b/spyder/plugins/findinfiles/plugin.py
@@ -12,12 +12,12 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication
 
 # Local imports
-from spyder.api.menus import ApplicationMenus
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.toolbars import ApplicationToolBars
 from spyder.api.translations import get_translation
 from spyder.plugins.findinfiles.widgets import (FindInFilesWidget,
                                                 FindInFilesWidgetActions)
+from spyder.plugins.mainmenu.api import ApplicationMenus
 from spyder.utils.misc import getcwd_or_home
 
 # Localization
@@ -37,7 +37,9 @@ class FindInFiles(SpyderDockablePlugin):
     Find in files DockWidget.
     """
     NAME = 'find_in_files'
-    OPTIONAL = [Plugins.Editor, Plugins.Projects, Plugins.WorkingDirectory]
+    REQUIRES = []
+    OPTIONAL = [Plugins.Editor, Plugins.Projects, Plugins.WorkingDirectory,
+                Plugins.MainMenu]
     TABIFY = [Plugins.VariableExplorer]
     WIDGET_CLASS = FindInFilesWidget
     CONF_SECTION = NAME
@@ -56,6 +58,7 @@ class FindInFiles(SpyderDockablePlugin):
 
     def register(self):
         widget = self.get_widget()
+        mainmenu = self.get_plugin(Plugins.MainMenu)
         editor = self.get_plugin(Plugins.Editor)
         projects = self.get_plugin(Plugins.Projects)
         working_directory = self.get_plugin(Plugins.WorkingDirectory)
@@ -81,11 +84,12 @@ class FindInFiles(SpyderDockablePlugin):
             register_shortcut=True,
             context=Qt.WindowShortcut
         )
-        menu = self.get_application_menu(ApplicationMenus.Search)
-        self.add_item_to_application_menu(
-            findinfiles_action,
-            menu=menu,
-        )
+        if mainmenu:
+            menu = mainmenu.get_application_menu(ApplicationMenus.Search)
+            mainmenu.add_item_to_application_menu(
+                findinfiles_action,
+                menu=menu,
+            )
 
         search_toolbar = self.get_application_toolbar(
             ApplicationToolBars.Search)

--- a/spyder/plugins/help/api.py
+++ b/spyder/plugins/help/api.py
@@ -9,6 +9,7 @@ Help Plugin API.
 """
 
 # Local imports
+from spyder.plugins.help.plugin import HelpActions
 from spyder.plugins.help.widgets import (HelpWidgetActions,
                                          HelpWidgetMainToolBarSections,
                                          HelpWidgetOptionsMenuSections)

--- a/spyder/plugins/help/plugin.py
+++ b/spyder/plugins/help/plugin.py
@@ -12,18 +12,33 @@ Help Plugin.
 import os
 
 # Third party imports
-from qtpy.QtCore import Signal
+from qtpy.QtCore import Qt, Signal
 
 # Local imports
+from spyder import __docs_url__, __forum_url__, __trouble_url__
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.translations import get_translation
 from spyder.config.base import get_conf_path
 from spyder.config.fonts import DEFAULT_SMALL_DELTA
+from spyder.plugins.console.plugin import ConsoleActions
 from spyder.plugins.help.confpage import HelpConfigPage
 from spyder.plugins.help.widgets import HelpWidget
+from spyder.utils.qthelpers import start_file
 
 # Localization
 _ = get_translation('spyder')
+
+
+class HelpActions:
+    # Documentation related
+    SpyderDocumentationAction = "spyder documentation"
+    SpyderDocumentationVideoAction = "spyder_documentation_video_action"
+    ShowSpyderTutorialAction = "spyder_tutorial_action"
+
+    # Support related
+    SpyderTroubleshootingAction = "spyder_troubleshooting_action"
+    SpyderSupportAction = "spyder_support_action"
+
 
 
 class Help(SpyderDockablePlugin):
@@ -32,7 +47,7 @@ class Help(SpyderDockablePlugin):
     """
     NAME = 'help'
     REQUIRES = [Plugins.Console, Plugins.Editor]
-    OPTIONAL = [Plugins.IPythonConsole, Plugins.Shortcuts]
+    OPTIONAL = [Plugins.IPythonConsole, Plugins.Shortcuts, Plugins.MainMenu]
     TABIFY = Plugins.VariableExplorer
     WIDGET_CLASS = HelpWidget
     CONF_SECTION = NAME
@@ -102,6 +117,44 @@ class Help(SpyderDockablePlugin):
             shortcuts.sig_shortcuts_updated.connect(
                 lambda: self.show_intro_message())
 
+        # Documentation actions
+        self.doc_action = self.create_action(
+            HelpActions.SpyderDocumentationAction,
+            text=_("Spyder documentation"),
+            icon=self.create_icon("DialogHelpButton"),
+            triggered=lambda: start_file(__docs_url__),
+            context=Qt.ApplicationShortcut,
+            register_shortcut=shortcuts is not None,
+            shortcut_context="_")
+
+        spyder_video_url = ("https://www.youtube.com/playlist"
+                            "?list=PLPonohdiDqg9epClEcXoAPUiK0pN5eRoc")
+        self.video_action = self.create_action(
+            HelpActions.SpyderDocumentationVideoAction,
+            text=_("Tutorial videos"),
+            icon=self.create_icon("VideoIcon"),
+            triggered=lambda: start_file(spyder_video_url))
+
+        self.tutorial_action = self.create_action(
+            HelpActions.ShowSpyderTutorialAction,
+            text=_("Spyder tutorial"),
+            triggered=self.show_tutorial,
+            register_shortcut=False,
+        )
+
+        # Support actions
+        self.trouble_action = self.create_action(
+            HelpActions.SpyderTroubleshootingAction,
+            _("Troubleshooting..."),
+            triggered=lambda: start_file(__trouble_url__))
+        self.support_group_action = self.create_action(
+            HelpActions.SpyderSupportAction,
+            _("Spyder support..."),
+            triggered=lambda: start_file(__forum_url__))
+
+        # Add actions in menus
+        self._setup_menus()
+
     def update_font(self):
         color_scheme = self.get_color_scheme()
         font = self.get_font()
@@ -131,7 +184,45 @@ class Help(SpyderDockablePlugin):
         if ipyconsole:
             ipyconsole.apply_plugin_settings({'connect_to_oi'})
 
-    # --- API
+    # --- Private API
+    # ------------------------------------------------------------------------
+    def _setup_menus(self):
+        internal_console = self.get_plugin(Plugins.Console)
+        mainmenu = self.get_plugin(Plugins.MainMenu)
+        shortcuts = self.get_plugin(Plugins.Shortcuts)
+        shortcuts_summary_action = None
+        if shortcuts:
+            from spyder.plugins.shortcuts.plugin import ShortcutActions
+            shortcuts_summary_action = shortcuts.get_action(
+                ShortcutActions.ShortcutSummaryAction)
+        if mainmenu:
+            from spyder.plugins.mainmenu.api import (
+                ApplicationMenus, HelpMenuSections)
+            # Documentation actions
+            for documentation_action in [
+                    self.doc_action, self.video_action, self.tutorial_action]:
+                mainmenu.add_item_to_application_menu(
+                    documentation_action,
+                    menu_id=ApplicationMenus.Help,
+                    section=HelpMenuSections.Documentation,
+                    before=shortcuts_summary_action,
+                    before_section=HelpMenuSections.Support)
+            # Support actions
+            report_action = internal_console.get_action(
+                ConsoleActions.SpyderReportAction)
+            mainmenu.add_item_to_application_menu(
+                self.trouble_action,
+                menu_id=ApplicationMenus.Help,
+                section=HelpMenuSections.Support,
+                before=report_action,
+                before_section=HelpMenuSections.ExternalDocumentation)
+            mainmenu.add_item_to_application_menu(
+                self.support_group_action,
+                menu_id=ApplicationMenus.Help,
+                section=HelpMenuSections.Support,
+                before_section=HelpMenuSections.ExternalDocumentation)
+
+    # --- Public API
     # ------------------------------------------------------------------------
     def set_shellwidget(self, shellwidget):
         """

--- a/spyder/plugins/help/widgets.py
+++ b/spyder/plugins/help/widgets.py
@@ -32,6 +32,7 @@ from spyder.plugins.help.utils.sphinxify import (CSS_PATH, DARK_CSS_PATH,
 from spyder.plugins.help.utils.sphinxthread import SphinxThread
 from spyder.py3compat import get_meth_class_inst, to_text_string
 from spyder.utils import programs
+from spyder.utils.qthelpers import start_file
 from spyder.widgets.browser import FrameWebView
 from spyder.widgets.comboboxes import EditableComboBox
 from spyder.widgets.findreplace import FindReplace
@@ -840,7 +841,7 @@ class HelpWidget(PluginMainWidget):
         if url == "spy://tutorial":
             self.show_tutorial()
         elif url.startswith('http'):
-            programs.start_file(url)
+            start_file(url)
         else:
             self.rich_text.load_url(url)
 

--- a/spyder/plugins/mainmenu/__init__.py
+++ b/spyder/plugins/mainmenu/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Main menu plugin.
+"""

--- a/spyder/plugins/mainmenu/api.py
+++ b/spyder/plugins/mainmenu/api.py
@@ -7,6 +7,13 @@
 """
 Spyder application menu constants.
 """
+# Local imports
+from spyder.api.widgets.menus import SpyderMenu
+
+
+class ApplicationContextMenu:
+    Documentation = 'context_documentation_section'
+    About = 'context_about_section'
 
 
 class ApplicationMenus:
@@ -90,3 +97,13 @@ class HelpMenuSections:
     Documentation = 'documentation_section'
     Support = 'support_section'
     ExternalDocumentation = 'external_documentation_section'
+    About = 'about_section'
+
+
+class ApplicationMenu(SpyderMenu):
+    """
+    Spyder Main Window application Menu.
+
+    This class provides application menus with some predefined functionality
+    and section definition.
+    """

--- a/spyder/plugins/mainmenu/container.py
+++ b/spyder/plugins/mainmenu/container.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Container Widget.
+
+Holds references for base actions in the Main Menu of Spyder.
+"""
+
+# Third party imports
+from qtpy.QtCore import QThread, Slot
+from qtpy.QtWidgets import QMessageBox
+
+# Local imports
+from spyder import __project_url__
+from spyder import dependencies
+from spyder.api.translations import get_translation
+from spyder.api.widgets import PluginMainContainer
+from spyder.config.base import DEV
+from spyder.config.utils import is_anaconda
+from spyder.widgets.about import AboutDialog
+from spyder.widgets.dependencies import DependenciesDialog
+from spyder.widgets.helperwidgets import MessageCheckBox
+from spyder.workers.updates import WorkerUpdates
+
+
+# Localization
+_ = get_translation('spyder')
+
+
+# Actions
+class MainMenuActions:
+    # Support
+    SpyderDependenciesAction = "spyder_dependencies_action"
+    SpyderCheckUpdatesAction = "spyder_check_updates_action"
+
+    # About
+    SpyderAbout = "spyder_about_action"
+
+
+class MainMenuContainer(PluginMainContainer):
+
+    DEFAULT_OPTIONS = {
+        'check_updates_on_startup': True
+    }
+
+    def setup(self, options=DEFAULT_OPTIONS):
+        # Attributes
+        self.give_updates_feedback = False
+        self.thread_updates = None
+        self.worker_updates = None
+
+        # Actions
+        self.check_updates_action = self.create_action(
+            MainMenuActions.SpyderCheckUpdatesAction,
+            _("Check for updates..."),
+            triggered=self.check_updates)
+        self.dependencies_action = self.create_action(
+            MainMenuActions.SpyderDependenciesAction,
+            _("Dependencies..."),
+            triggered=self.show_dependencies,
+            icon=self.create_icon('advanced'))
+        self.about_action = self.create_action(
+            MainMenuActions.SpyderAbout,
+            _("About %s...") % "Spyder",
+            icon=self.create_icon('MessageBoxInformation'),
+            triggered=self.show_about)
+
+        # Initialize
+        if DEV is None and options.get('main', 'check_updates_on_startup'):
+            self.give_updates_feedback = False
+            self.check_updates(startup=True)
+
+    def on_option_update(self, option, value):
+        pass
+
+    def update_actions(self):
+        pass
+
+    def _check_updates_ready(self):
+        """Show results of the Spyder update checking process."""
+
+        # `feedback` = False is used on startup, so only positive feedback is
+        # given. `feedback` = True is used when after startup (when using the
+        # menu action, and gives feeback if updates are, or are not found.
+        feedback = self.give_updates_feedback
+
+        # Get results from worker
+        update_available = self.worker_updates.update_available
+        latest_release = self.worker_updates.latest_release
+        error_msg = self.worker_updates.error
+
+        # Release url
+        url_r = __project_url__ + '/releases/tag/v{}'.format(latest_release)
+        url_i = 'https://docs.spyder-ide.org/installation.html'
+
+        # Define the custom QMessageBox
+        box = MessageCheckBox(icon=QMessageBox.Information,
+                              parent=self)
+        box.setWindowTitle(_("New Spyder version"))
+        box.set_checkbox_text(_("Check for updates at startup"))
+        box.setStandardButtons(QMessageBox.Ok)
+        box.setDefaultButton(QMessageBox.Ok)
+
+        # Adjust the checkbox depending on the stored configuration
+        option = 'check_updates_on_startup'
+        check_updates = self.get_option(option)
+        box.set_checked(check_updates)
+
+        if error_msg is not None:
+            msg = error_msg
+            box.setText(msg)
+            box.set_check_visible(False)
+            box.exec_()
+            check_updates = box.is_checked()
+        else:
+            if update_available:
+                header = _("<b>Spyder {} is available!</b><br><br>").format(
+                    latest_release)
+                footer = _(
+                    "For more information visit our "
+                    "<a href=\"{}\">installation guide</a>."
+                ).format(url_i)
+                if is_anaconda():
+                    content = _(
+                        "<b>Important note:</b> Since you installed "
+                        "Spyder with Anaconda, please <b>don't</b> use "
+                        "<code>pip</code> to update it as that will break "
+                        "your installation.<br><br>"
+                        "Instead, run the following commands in a "
+                        "terminal:<br>"
+                        "<code>conda update anaconda</code><br>"
+                        "<code>conda install spyder={}</code><br><br>"
+                    ).format(latest_release)
+                else:
+                    content = _(
+                        "Please go to <a href=\"{}\">this page</a> to "
+                        "download it.<br><br>"
+                    ).format(url_r)
+                msg = header + content + footer
+                box.setText(msg)
+                box.set_check_visible(True)
+                box.exec_()
+                check_updates = box.is_checked()
+            elif feedback:
+                msg = _("Spyder is up to date.")
+                box.setText(msg)
+                box.set_check_visible(False)
+                box.exec_()
+                check_updates = box.is_checked()
+
+        # Update checkbox based on user interaction
+        self.set_option(option, check_updates)
+
+        # Enable check_updates_action after the thread has finished
+        self.check_updates_action.setDisabled(False)
+
+        # Provide feeback when clicking menu if check on startup is on
+        self.give_updates_feedback = True
+
+    @Slot()
+    def check_updates(self, startup=False):
+        """Check for spyder updates on github releases using a QThread."""
+
+        # Disable check_updates_action while the thread is working
+        self.check_updates_action.setDisabled(True)
+
+        if self.thread_updates is not None:
+            self.thread_updates.terminate()
+
+        self.thread_updates = QThread(self)
+        self.worker_updates = WorkerUpdates(self, startup=startup)
+        self.worker_updates.sig_ready.connect(self._check_updates_ready)
+        self.worker_updates.sig_ready.connect(self.thread_updates.quit)
+        self.worker_updates.moveToThread(self.thread_updates)
+        self.thread_updates.started.connect(self.worker_updates.start)
+        self.thread_updates.start()
+
+    @Slot()
+    def show_dependencies(self):
+        """Show Spyder Dependencies dialog."""
+        dlg = DependenciesDialog(self)
+        dlg.set_data(dependencies.DEPENDENCIES)
+        dlg.show()
+
+    @Slot()
+    def show_about(self):
+        """Show Spyder About dialog."""
+        abt = AboutDialog(self)
+        abt.show()

--- a/spyder/plugins/mainmenu/plugin.py
+++ b/spyder/plugins/mainmenu/plugin.py
@@ -1,0 +1,353 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Main menu Plugin.
+"""
+
+# Standard library imports
+from collections import OrderedDict
+import os
+import os.path as osp
+import re
+import sys
+
+# Third party imports
+from qtpy import API, PYQT5
+from qtpy.QtCore import Qt, Slot
+from qtpy.QtGui import QKeySequence
+from qtpy.QtWidgets import QMenu
+
+# Local imports
+from spyder import __docs_url__
+from spyder.api.exceptions import SpyderAPIError
+from spyder.api.plugins import Plugins, SpyderPluginV2, SpyderDockablePlugin
+from spyder.api.widgets.menus import SpyderMenu
+from spyder.api.translations import get_translation
+from spyder.api.widgets.menus import MENU_SEPARATOR
+from spyder.app.utils import get_python_doc_path
+from spyder.plugins.mainmenu.api import (
+    ApplicationContextMenu, ApplicationMenu, ApplicationMenus,
+    HelpMenuSections)
+from spyder.plugins.mainmenu.container import (
+    MainMenuActions, MainMenuContainer)
+from spyder.utils import programs
+from spyder.utils.qthelpers import (
+    add_actions, create_module_bookmark_actions, create_program_action,
+    file_uri, set_menu_icons)
+
+# Localization
+_ = get_translation('spyder')
+
+
+class MainMenu(SpyderPluginV2):
+    NAME = 'mainmenu'
+    OPTIONAL = [Plugins.Help, Plugins.Shortcuts]
+    CONTAINER_CLASS = MainMenuContainer
+    CONF_SECTION = NAME
+    CONF_FILE = False
+    CONF_FROM_OPTIONS = {
+        'check_updates_on_startup': ('main', 'check_updates_on_startup'),
+    }
+
+    def get_name(self):
+        return _('Main menus')
+
+    def get_icon(self):
+        return self.create_icon('genprefs')
+
+    def get_description(self):
+        return _('Provide main application menu management.')
+
+    def register(self):
+        # Reference holder dict for the menus
+        self._APPLICATION_MENUS = OrderedDict()
+        # Create Application menus using plugin public API
+        create_app_menu = self.create_application_menu
+        create_app_menu(ApplicationMenus.File, _("&File"))
+        create_app_menu(ApplicationMenus.Edit, _("&Edit"))
+        create_app_menu(ApplicationMenus.Search, _("&Search"))
+        create_app_menu(ApplicationMenus.Source, _("Sour&ce"))
+        create_app_menu(ApplicationMenus.Run, _("&Run"))
+        create_app_menu(ApplicationMenus.Debug, _("&Debug"))
+        create_app_menu(ApplicationMenus.Consoles, _("C&onsoles"))
+        create_app_menu(ApplicationMenus.Projects, _("&Projects"))
+        create_app_menu(ApplicationMenus.Tools, _("&Tools"))
+        create_app_menu(ApplicationMenus.View, _("&View"))
+        create_app_menu(ApplicationMenus.Help, _("&Help"))
+
+    def on_mainwindow_visible(self):
+        self._setup_menus()
+
+    # --- Private methods
+    # ------------------------------------------------------------------------
+
+    def _populate_help_menu(self):
+        """Add base actions and menus to te Help menu."""
+        self._populate_help_menu_support_section()
+        self._populate_help_menu_about_section()
+
+    def _populate_help_menu_support_section(self):
+        """Create Spyder base support actions."""
+        help_plugin = self.get_plugin(Plugins.Help)
+        help_support_action = None
+        if help_plugin:
+            from spyder.plugins.help.plugin import HelpActions
+            help_support_action = help_plugin.get_action(
+                HelpActions.SpyderSupportAction)
+
+        for support_action in [self.dependencies_action,
+                               self.check_updates_action]:
+            self.add_item_to_application_menu(
+                support_action,
+                menu_id=ApplicationMenus.Help,
+                section=HelpMenuSections.Support,
+                before=help_support_action,
+                before_section=HelpMenuSections.ExternalDocumentation)
+
+    def _populate_help_menu_about_section(self):
+        """Create Spyder base about actions."""
+        self.add_item_to_application_menu(
+            self.about_action,
+            menu_id=ApplicationMenus.Help,
+            section=HelpMenuSections.About)
+
+    def _show_shortcuts(self, menu):
+        """
+        Show action shortcuts in menu.
+
+        Parameters
+        ----------
+        menu: SpyderMenu
+            Instance of a spyder menu.
+        """
+        menu_actions = menu.actions()
+        for action in menu_actions:
+            if getattr(action, '_shown_shortcut', False):
+                # This is a SpyderAction
+                if action._shown_shortcut is not None:
+                    action.setShortcut(action._shown_shortcut)
+            elif action.menu() is not None:
+                # This is submenu, so we need to call this again
+                self._show_shortcuts(action.menu())
+            else:
+                # We don't need to do anything for other elements
+                continue
+
+    def _hide_shortcuts(self, menu):
+        """
+        Hide action shortcuts in menu.
+
+        Parameters
+        ----------
+        menu: SpyderMenu
+            Instance of a spyder menu.
+        """
+        menu_actions = menu.actions()
+        for action in menu_actions:
+            if getattr(action, '_shown_shortcut', False):
+                # This is a SpyderAction
+                if action._shown_shortcut is not None:
+                    action.setShortcut(QKeySequence())
+            elif action.menu() is not None:
+                # This is submenu, so we need to call this again
+                self._hide_shortcuts(action.menu())
+            else:
+                # We don't need to do anything for other elements
+                continue
+
+    def _hide_options_menus(self):
+        """Hide options menu when menubar is pressed in macOS."""
+        for _plugin_id, plugin in self.main._PLUGINS.items():
+            if isinstance(plugin, SpyderDockablePlugin):
+                if plugin.CONF_SECTION == 'editor':
+                    editorstack = self.editor.get_current_editorstack()
+                    editorstack.menu.hide()
+                else:
+                    try:
+                        # New API
+                        plugin.options_menu.hide()
+                    except AttributeError:
+                        # Old API
+                        plugin._options_menu.hide()
+
+    def _setup_menus(self):
+        """Setup menus."""
+        # Show and hide shortcuts and icons in menus for macOS
+        if sys.platform == 'darwin':
+            for menu in self._APPLICATION_MENUS:
+                if menu is not None:
+                    menu.aboutToShow.connect(
+                        lambda menu=menu: self.show_shortcuts(menu))
+                    menu.aboutToHide.connect(
+                        lambda menu=menu: self.hide_shortcuts(menu))
+                    menu.aboutToShow.connect(
+                        lambda menu=menu: set_menu_icons(menu, False))
+                    menu.aboutToShow.connect(self.hide_options_menus)
+        self._populate_help_menu()
+
+    # --- Public API
+    # ------------------------------------------------------------------------
+    def create_application_menu(self, menu_id, title):
+        """
+        Create a Spyder application menu.
+
+        Paramaters
+        ----------
+        menu_id: str
+            The menu unique identifier string.
+        title: str
+            The localized menu title to be displayed.
+        """
+        if menu_id in self._APPLICATION_MENUS:
+            raise SpyderAPIError(
+                'Menu with id "{}" already added!'.format(menu_id))
+
+        menu = ApplicationMenu(self.main, title)
+        menu.menu_id = menu_id
+        self._APPLICATION_MENUS[menu_id] = menu
+        self.main.menuBar().addMenu(menu)
+
+        # Show and hide shortcuts and icons in menus for macOS
+        if sys.platform == 'darwin':
+            menu.aboutToShow.connect(
+                lambda menu=menu: self._show_shortcuts(menu))
+            menu.aboutToHide.connect(
+                lambda menu=menu: self._hide_shortcuts(menu))
+            menu.aboutToShow.connect(
+                lambda menu=menu: set_menu_icons(menu, False))
+            menu.aboutToShow.connect(self._hide_options_menus)
+
+        return menu
+
+    def add_item_to_application_menu(self, item, menu=None, menu_id=None,
+                                     section=None, before=None,
+                                     before_section=None):
+        """
+        Add action or widget `item` to given application menu `section`.
+
+        Parameters
+        ----------
+        item: SpyderAction or SpyderMenu
+            The item to add to the `menu`.
+        menu: ApplicationMenu or None
+            Instance of a Spyder application menu.
+        menu_id: str or None
+            The application menu unique string identifier.
+        section: str or None
+            The section id in which to insert the `item` on the `menu`.
+        before: SpyderAction/SpyderMenu or None
+            Make the item appear before another given item.
+        before_section: Section or None
+            Make the item section (if provided) appear before another
+            given section.
+
+        Notes
+        -----
+        Must provide a `menu` or a `menu_id`.
+        """
+        if menu and menu_id:
+            raise SpyderAPIError('Must provide only menu or menu_id!')
+
+        if menu is None and menu_id is None:
+            raise SpyderAPIError('Must provide at least menu or menu_id!')
+
+        if menu and not isinstance(menu, ApplicationMenu):
+            raise SpyderAPIError('Not an `ApplicationMenu`!')
+
+        if menu_id and menu_id not in self._APPLICATION_MENUS:
+            raise SpyderAPIError('{} is not a valid menu_id'.format(menu_id))
+
+        # TODO: For now just add the item to the bottom for non-migrated menus.
+        #       Temporal solution while migration is complete
+        app_menu_actions = {
+            ApplicationMenus.File: self._main.file_menu_actions,
+            ApplicationMenus.Edit: self._main.edit_menu_actions,
+            ApplicationMenus.Search: self._main.search_menu_actions,
+            ApplicationMenus.Source: self._main.source_menu_actions,
+            ApplicationMenus.Run: self._main.run_menu_actions,
+            ApplicationMenus.Debug: self._main.debug_menu_actions,
+            ApplicationMenus.Consoles: self._main.consoles_menu_actions,
+            ApplicationMenus.Projects: self._main.projects_menu_actions,
+            ApplicationMenus.Tools: self._main.tools_menu_actions,
+        }
+
+        menu_id = menu_id if menu_id else menu.menu_id
+        menu = menu if menu else self.get_application_menu(menu_id)
+
+        if menu_id in app_menu_actions:
+            actions = app_menu_actions[menu_id]
+            actions.append(MENU_SEPARATOR)
+            actions.append(item)
+        else:
+            menu.add_action(item, section=section, before=before,
+                            before_section=before_section)
+
+    def get_application_menu(self, menu_id):
+        """
+        Return an application menu by menu unique id.
+
+        Parameters
+        ----------
+        menu_id: ApplicationMenu
+            The menu unique identifier string.
+        """
+        if menu_id not in self._APPLICATION_MENUS:
+            raise SpyderAPIError(
+                'Application menu "{0}" not found! Available '
+                'menus are: {1}'.format(
+                    menu_id, list(self._APPLICATION_MENUS.keys()))
+            )
+
+        return self._APPLICATION_MENUS[menu_id]
+
+    def get_application_context_menu(self, parent=None):
+        """
+        Return menu with the actions to be shown by the Spyder context menu.
+        """
+        documentation_action = None
+        tutorial_action = None
+        shortcuts_action = None
+
+        help_plugin = self.get_plugin(Plugins.Help)
+        shortcuts = self.get_plugin(Plugins.Shortcuts)
+        menu = QMenu(parent=parent)
+        actions = []
+        # Help actions
+        if help_plugin:
+            from spyder.plugins.help.plugin import HelpActions
+            documentation_action = help_plugin.get_action(
+                HelpActions.SpyderDocumentationAction)
+            tutorial_action = help_plugin.get_action(
+                HelpActions.ShowSpyderTutorialAction)
+            actions += [documentation_action, tutorial_action]
+        # Shortcuts actions
+        if shortcuts:
+            from spyder.plugins.shortcuts.plugin import ShortcutActions
+            shortcuts_action = shortcuts.get_action(
+                ShortcutActions.ShortcutSummaryAction)
+            actions.append(shortcuts_action)
+        # MainMenu actions
+        actions += [MENU_SEPARATOR, self.about_action]
+
+        add_actions(menu, actions)
+
+        return menu
+
+    @property
+    def dependencies_action(self):
+        """Show Spyder's Dependencies dialog box."""
+        return self.get_container().dependencies_action
+
+    @property
+    def check_updates_action(self):
+        """Check if a new version of Spyder is available."""
+        return self.get_container().check_updates_action
+
+    @property
+    def about_action(self):
+        """Show Spyder's About dialog box."""
+        return self.get_container().about_action

--- a/spyder/plugins/profiler/plugin.py
+++ b/spyder/plugins/profiler/plugin.py
@@ -15,8 +15,9 @@ import os.path as osp
 from qtpy.QtCore import Signal
 
 # Local imports
-from spyder.api.plugins import ApplicationMenus, Plugins, SpyderDockablePlugin
+from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.translations import get_translation
+from spyder.plugins.mainmenu.api import ApplicationMenus
 from spyder.plugins.profiler.confpage import ProfilerConfigPage
 from spyder.plugins.profiler.widgets.main_widget import (ProfilerWidget,
                                                          ProfilerWidgetActions,
@@ -42,6 +43,7 @@ class Profiler(SpyderDockablePlugin):
 
     NAME = 'profiler'
     REQUIRES = [Plugins.Editor, Plugins.VariableExplorer]
+    OPTIONAL = [Plugins.MainMenu]
     TABIFY = Plugins.Help
     WIDGET_CLASS = ProfilerWidget
     CONF_SECTION = NAME
@@ -71,6 +73,7 @@ class Profiler(SpyderDockablePlugin):
     def register(self):
         widget = self.get_widget()
         editor = self.get_plugin(Plugins.Editor)
+        mainmenu = self.get_plugin(Plugins.MainMenu)
 
         widget.sig_edit_goto_requested.connect(editor.load)
         widget.sig_started.connect(self.sig_started)
@@ -86,8 +89,9 @@ class Profiler(SpyderDockablePlugin):
         )
         run_action.setEnabled(is_profiler_installed())
 
-        run_menu = self.get_application_menu(ApplicationMenus.Run)
-        self.add_item_to_application_menu(run_action, menu=run_menu)
+        if mainmenu:
+            run_menu = mainmenu.get_application_menu(ApplicationMenus.Run)
+            mainmenu.add_item_to_application_menu(run_action, menu=run_menu)
 
         # TODO: On a separate PR when core plugin is merged
         # self.main.editor.pythonfile_dependent_actions += [profiler_act]

--- a/spyder/plugins/pylint/plugin.py
+++ b/spyder/plugins/pylint/plugin.py
@@ -15,7 +15,7 @@ import os.path as osp
 from qtpy.QtCore import Signal, Slot
 
 # Local imports
-from spyder.api.menus import ApplicationMenus
+from spyder.plugins.mainmenu.api import ApplicationMenus
 from spyder.api.translations import get_translation
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.utils.programs import is_module_installed
@@ -35,7 +35,7 @@ class Pylint(SpyderDockablePlugin):
     CONF_SECTION = NAME
     CONF_WIDGET_CLASS = PylintConfigPage
     REQUIRES = [Plugins.Editor]
-    OPTIONAL = [Plugins.Projects]
+    OPTIONAL = [Plugins.MainMenu, Plugins.Projects]
     CONF_FILE = False
     DISABLE_ACTIONS_WHEN_HIDDEN = False
 
@@ -68,6 +68,7 @@ class Pylint(SpyderDockablePlugin):
     def register(self):
         widget = self.get_widget()
         editor = self.get_plugin(Plugins.Editor)
+        mainmenu = self.get_plugin(Plugins.MainMenu)
 
         # Expose widget signals at the plugin level
         widget.sig_edit_goto_requested.connect(self.sig_edit_goto_requested)
@@ -92,8 +93,10 @@ class Pylint(SpyderDockablePlugin):
         pylint_act = self.get_action(PylintWidgetActions.RunCodeAnalysis)
         pylint_act.setEnabled(is_module_installed("pylint"))
 
-        source_menu = self.get_application_menu(ApplicationMenus.Source)
-        self.add_item_to_application_menu(pylint_act, menu=source_menu)
+        if mainmenu:
+            source_menu = mainmenu.get_application_menu(
+                ApplicationMenus.Source)
+            mainmenu.add_item_to_application_menu(pylint_act, menu=source_menu)
 
         # TODO: use new API when editor has migrated
         self.main.editor.pythonfile_dependent_actions += [pylint_act]

--- a/spyder/plugins/shortcuts/plugin.py
+++ b/spyder/plugins/shortcuts/plugin.py
@@ -20,9 +20,9 @@ from qtpy.QtGui import QKeySequence
 from qtpy.QtWidgets import QAction, QShortcut
 
 # Local imports
-from spyder.api.menus import ApplicationMenus, HelpMenuSections
-from spyder.api.plugins import SpyderPluginV2
+from spyder.api.plugins import Plugins, SpyderPluginV2
 from spyder.api.translations import get_translation
+from spyder.plugins.mainmenu.api import ApplicationMenus, HelpMenuSections
 from spyder.plugins.shortcuts.confpage import ShortcutsConfigPage
 from spyder.plugins.shortcuts.widgets.summary import ShortcutsSummaryDialog
 from spyder.utils.qthelpers import add_shortcut_to_tooltip, SpyderAction
@@ -44,7 +44,7 @@ class Shortcuts(SpyderPluginV2):
 
     NAME = 'shortcuts'
     # TODO: Fix requires to reflect the desired order in the preferences
-    REQUIRES = []
+    OPTIONAL = [Plugins.MainMenu]
     CONF_WIDGET_CLASS = ShortcutsConfigPage
     CONF_SECTION = NAME
     CONF_FILE = False
@@ -68,6 +68,8 @@ class Shortcuts(SpyderPluginV2):
         return self.create_icon('keyboard')
 
     def register(self):
+        mainmenu = self.get_plugin(Plugins.MainMenu)
+
         self._shortcut_data = []
         shortcuts_action = self.create_action(
             ShortcutActions.ShortcutSummaryAction,
@@ -78,12 +80,13 @@ class Shortcuts(SpyderPluginV2):
         )
 
         # Add to Help menu.
-        help_menu = self.get_application_menu(ApplicationMenus.Help)
-        self.add_item_to_application_menu(
-            shortcuts_action,
-            help_menu,
-            section=HelpMenuSections.Documentation,
-        )
+        if mainmenu:
+            help_menu = mainmenu.get_application_menu(ApplicationMenus.Help)
+            mainmenu.add_item_to_application_menu(
+                shortcuts_action,
+                help_menu,
+                section=HelpMenuSections.Documentation,
+            )
 
     def on_mainwindow_visible(self):
         self.apply_shortcuts()

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -278,26 +278,6 @@ def run_program(program, args=None, **subprocess_kwargs):
     return subprocess.Popen(fullcmd, **subprocess_kwargs)
 
 
-def start_file(filename):
-    """
-    Generalized os.startfile for all platforms supported by Qt
-
-    This function is simply wrapping QDesktopServices.openUrl
-
-    Returns True if successful, otherwise returns False.
-    """
-    from qtpy.QtCore import QUrl
-    from qtpy.QtGui import QDesktopServices
-
-    # We need to use setUrl instead of setPath because this is the only
-    # cross-platform way to open external files. setPath fails completely on
-    # Mac and doesn't open non-ascii files on Linux.
-    # Fixes spyder-ide/spyder#740.
-    url = QUrl()
-    url.setUrl(filename)
-    return QDesktopServices.openUrl(url)
-
-
 def parse_linux_desktop_entry(fpath):
     """Load data from desktop entry with xdg specification."""
     from xdg.DesktopEntry import DesktopEntry

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -17,8 +17,9 @@ import sys
 # Third party imports
 from qtpy.compat import from_qvariant, to_qvariant
 from qtpy.QtCore import (QEvent, QLibraryInfo, QLocale, QObject, Qt, QTimer,
-                         QTranslator, Signal, Slot)
-from qtpy.QtGui import QIcon, QKeyEvent, QKeySequence, QPixmap
+                         QTranslator, QUrl, Signal, Slot)
+from qtpy.QtGui import (
+    QDesktopServices, QIcon, QKeyEvent, QKeySequence, QPixmap)
 from qtpy.QtWidgets import (QAction, QApplication, QDialog, QHBoxLayout,
                             QLabel, QLineEdit, QMenu, QPlainTextEdit,
                             QProxyStyle, QPushButton, QStyle, QToolBar,
@@ -56,6 +57,24 @@ else:
 #                 lambda *args: self.emit(SIGNAL('option_changed'), *args))
 logger = logging.getLogger(__name__)
 MENU_SEPARATOR = None
+
+
+def start_file(filename):
+    """
+    Generalized os.startfile for all platforms supported by Qt
+
+    This function is simply wrapping QDesktopServices.openUrl
+
+    Returns True if successful, otherwise returns False.
+    """
+
+    # We need to use setUrl instead of setPath because this is the only
+    # cross-platform way to open external files. setPath fails completely on
+    # Mac and doesn't open non-ascii files on Linux.
+    # Fixes spyder-ide/spyder#740.
+    url = QUrl()
+    url.setUrl(filename)
+    return QDesktopServices.openUrl(url)
 
 
 def get_image_label(name, default="not_found.png"):
@@ -393,7 +412,7 @@ def create_bookmark_action(parent, url, title, icon=None, shortcut=None):
 
     @Slot()
     def open_url():
-        return programs.start_file(url)
+        return start_file(url)
 
     return create_action( parent, title, shortcut=shortcut, icon=icon,
                           triggered=open_url)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

## This PR implements

- A new `MainMenu` plugin in charge of managing the application menu bar, menus, and menu sections.
- Plugins that need to add menus or add items (Actions or submenus) to the main application menu bar will require this plugin.
- The API of menus now lives in this plugin instead of the global `spyder.api` since the plugin is in charge of those specifics.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
