### PR TITLE
PR: Add new toolbar plugin

### DIFF
--- a/spyder/api/plugins.py
+++ b/spyder/api/plugins.py
@@ -34,12 +34,11 @@ from qtpy.QtWidgets import QApplication, QToolBar, QWidget
 
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
-from spyder.api.toolbars import ApplicationToolBars
 from spyder.api.translations import get_translation
 from spyder.api.widgets import PluginMainContainer, PluginMainWidget
 from spyder.api.widgets.mixins import (SpyderActionMixin, SpyderOptionMixin,
                                        SpyderWidgetMixin)
-from spyder.api.widgets.toolbars import ApplicationToolBar
+from spyder.api.widgets.toolbars import ApplicationToolbar
 from spyder.config.gui import get_color_scheme, get_font
 from spyder.config.manager import CONF  # TODO: Remove after migration
 from spyder.config.user import NoDefault
@@ -596,6 +595,7 @@ class Plugins:
     Projects = 'project_explorer'
     Pylint = 'pylint'
     Shortcuts = 'shortcuts'
+    Toolbar = "toolbar"
     VariableExplorer = 'variable_explorer'
     WorkingDirectory = 'workingdir'
 
@@ -1338,70 +1338,6 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderOptionMixin):
         """
         pass
 
-    # --- API Application Toolbars
-    # ------------------------------------------------------------------------
-    def add_application_toolbar(self, name, toolbar):
-        """
-        Add toolbar to application toolbars.
-        """
-        if name in self._main._APPLICATION_TOOLBARS:
-            raise SpyderAPIError(
-                'Toolbar with name "{}" already added!'.format(name))
-
-        # TODO: Make the icon size adjustable in Preferences later on.
-        iconsize = 24
-        toolbar.setIconSize(QSize(iconsize, iconsize))
-        self._main._APPLICATION_TOOLBARS[name] = toolbar
-        self._added_toolbars[name] = toolbar
-        self.main.addToolBar(toolbar)
-
-    def add_item_to_application_toolbar(self, item, toolbar, section=None,
-                                        before=None):
-        """
-        Add action or widget `item` to given application toolbar section.
-        """
-        # TODO: Restrict to application toolbar types
-        if not isinstance(toolbar, (ApplicationToolBar, QToolBar)):
-            raise SpyderAPIError('Not an ApplicationToolBar!')
-
-        toolbar.addAction(item)
-
-    def get_application_toolbar(self, name):
-        """
-        Return an application toolbar by name.
-        """
-        # TODO: Temporal solution while API for managing app menus is created
-        app_toolbars = {
-            ApplicationToolBars.File: self._main.file_toolbar,
-            ApplicationToolBars.Run: self._main.run_toolbar,
-            ApplicationToolBars.Debug: self._main.debug_toolbar,
-            ApplicationToolBars.Main: self._main.main_toolbar,
-            ApplicationToolBars.Search: self._main.search_toolbar,
-            ApplicationToolBars.Edit: self._main.edit_toolbar,
-            ApplicationToolBars.Source: self._main.source_toolbar,
-        }
-        if name in app_toolbars:
-            return app_toolbars[name]
-        else:
-            raise SpyderAPIError(
-                'Application toolbar "{0}" not found! '
-                'Available toolbars are: {1}'.format(
-                    name,
-                    list(app_toolbars.keys())
-                )
-            )
-
-    def get_application_toolbars(self):
-        """
-        Return all created application toolbars.
-        """
-        return self._main._APPLICATION_TOOLBARS
-
-    def get_registered_application_toolbars(self):
-        """
-        Return all created application toolbars.
-        """
-        return self._added_toolbars
 
     # --- API Application Status Widgets
     # ------------------------------------------------------------------------

--- a/spyder/api/widgets/__init__.py
+++ b/spyder/api/widgets/__init__.py
@@ -39,7 +39,7 @@ from spyder.api.widgets.auxiliary_widgets import (MainCornerWidget,
                                                   SpyderWindowWidget)
 from spyder.api.widgets.menus import (MainWidgetMenu, OptionsMenuSections,
                                       PluginMainWidgetMenus, SpyderMenu)
-from spyder.api.widgets.mixins import SpyderToolBarMixin, SpyderWidgetMixin
+from spyder.api.widgets.mixins import SpyderToolbarMixin, SpyderWidgetMixin
 from spyder.api.widgets.toolbars import MainWidgetToolbar
 from spyder.config.gui import is_dark_interface
 from spyder.utils.qthelpers import (add_actions, create_waitspinner,
@@ -68,7 +68,7 @@ class PluginMainWidgetActions:
 
 # --- Spyder Widgets
 # ----------------------------------------------------------------------------
-class PluginMainContainer(QWidget, SpyderWidgetMixin, SpyderToolBarMixin):
+class PluginMainContainer(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
     """
     Spyder plugin main container class.
 
@@ -163,6 +163,16 @@ class PluginMainContainer(QWidget, SpyderWidgetMixin, SpyderToolBarMixin):
         self._plugin = plugin
         self._parent = parent
 
+        # Widget setup
+        # A PluginMainContainer inherits from QWidget so it can be a parent
+        # for the widgets it contains. Since it is a QWidget it will occupy a
+        # physical space on the screen and may cast "shadow" on the top left
+        # of the main window. To prevent this we ensure the widget has zero
+        # width and zero height.
+        # See: spyder-ide/spyder#13547
+        self.setMaximumWidth(0)
+        self.setMaximumHeight(0)
+
     # --- API: methods to define or override
     # ------------------------------------------------------------------------
     def setup(self, options=DEFAULT_OPTIONS):
@@ -192,7 +202,7 @@ class PluginMainContainer(QWidget, SpyderWidgetMixin, SpyderToolBarMixin):
             'method!')
 
 
-class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolBarMixin):
+class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
     """
     Spyder plugin main widget class.
 
@@ -434,7 +444,7 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolBarMixin):
                 child.setCornerWidget(self._corner_widget)
 
                 # This is needed to ensure the corner ToolButton (hamburguer
-                # menu) is aligned with plugins that use ToolBars vs
+                # menu) is aligned with plugins that use Toolbars vs
                 # CornerWidgets
                 # See: spyder-ide/spyder#13600
                 # left, top, right, bottom

--- a/spyder/api/widgets/mixins.py
+++ b/spyder/api/widgets/mixins.py
@@ -269,7 +269,7 @@ class SpyderToolButtonMixin:
         return self._toolbuttons
 
 
-class SpyderToolBarMixin:
+class SpyderToolbarMixin:
     """
     Provide methods to create, add and get toolbars.
     """

--- a/spyder/api/widgets/toolbars.py
+++ b/spyder/api/widgets/toolbars.py
@@ -19,12 +19,13 @@ from qtpy.QtWidgets import (QAction, QSizePolicy, QToolBar, QToolButton,
                             QWidget)
 
 # Local imports
+from spyder.api.exceptions import SpyderAPIError
 from spyder.config.gui import is_dark_interface
 
 
 # --- Constants
 # ----------------------------------------------------------------------------
-class ApplicationToolBars:
+class ApplicationToolbars:
     File = 'file_toolbar'
     Run = 'run_toolbar'
     Debug = 'defbug_toolbar'
@@ -35,7 +36,7 @@ class ApplicationToolBars:
     WorkingDirectory = 'working_directory_toolbar'
 
 
-class ToolBarLocation:
+class ToolbarLocation:
     Top = Qt.TopToolBarArea
     Bottom = Qt.BottomToolBarArea
 
@@ -59,9 +60,9 @@ class ToolTipFilter(QObject):
 
 # --- Widgets
 # ----------------------------------------------------------------------------
-class SpyderToolBar(QToolBar):
+class SpyderToolbar(QToolBar):
     """
-    Spyder ToolBar.
+    Spyder Toolbar.
 
     This class provides toolbars with some predefined functionality.
     """
@@ -70,16 +71,18 @@ class SpyderToolBar(QToolBar):
         super().__init__(parent=parent)
         self._section_items = OrderedDict()
         self._title = title
+        self._default_section = "default_section"
 
         self.setWindowTitle(title)
 
     def add_item(self, action_or_widget, section=None, before=None):
         """
-        Add action or widget item to given toolbar `section`. 
+        Add action or widget item to given toolbar `section`.
         """
-        if section is not None:
-            action_or_widget._section = section
+        if section is None:
+            section = self._default_section
 
+        action_or_widget._section = section
         if section is None and before is not None:
             action_or_widget._section = before._section
             section = before._section
@@ -126,13 +129,24 @@ class SpyderToolBar(QToolBar):
                     widget.setCheckable(True)
 
 
-class ApplicationToolBar(SpyderToolBar):
+class ApplicationToolbar(SpyderToolbar):
     """
-    Spyder Main application ToolBar.
+    Spyder Main application Toolbar.
     """
 
+    ID = None
+    """
+    Unique string toolbar identifier.
 
-class MainWidgetToolbar(SpyderToolBar):
+    This is used by Qt to be able to save and restore the state of widgets.
+    """
+
+    def _check_interface(self):
+        if self.ID is None:
+            raise SpyderAPIError("Toolbar must define an ID attribute.")
+
+
+class MainWidgetToolbar(SpyderToolbar):
     """
     Spyder Widget toolbar class.
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -915,6 +915,7 @@ def test_connection_to_external_kernel(main_window, qtbot):
     kc.stop_channels()
 
 
+@pytest.mark.first
 @pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -88,12 +88,17 @@ DEFAULTS = [
               'use_custom_cursor_blinking': False,
               'show_internal_errors': True,
               'check_updates_on_startup': True,
-              'toolbars_visible': True,
               'cursor/width': 2,
               'completion/size': (300, 180),
               'report_error/remember_token': False,
               'show_tour_message': True,
               }),
+            ('toolbar',
+             {
+              'enable': True,
+              'toolbars_visible': True,
+              'last_visible_toolbars': [],
+             }),
             ('quick_layouts',
              {
               'place_holder': '',
@@ -568,12 +573,15 @@ NAME_MAP = {
             'crash',
             'current_version',
             'historylog_filename',
-            'last_visible_toolbars',
             'spyder_pythonpath',
             'window/position',
             'window/prefs_dialog_size',
             'window/size',
             'window/state',
+            ]
+         ),
+        ('toolbar', [
+            'last_visible_toolbars',
             ]
          ),
         ('appearance', [
@@ -651,4 +659,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '63.0.0'
+CONF_VERSION = '64.0.0'

--- a/spyder/plugins/findinfiles/plugin.py
+++ b/spyder/plugins/findinfiles/plugin.py
@@ -13,11 +13,10 @@ from qtpy.QtWidgets import QApplication
 
 # Local imports
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
-from spyder.api.toolbars import ApplicationToolBars
 from spyder.api.translations import get_translation
-from spyder.plugins.findinfiles.widgets import (FindInFilesWidget,
-                                                FindInFilesWidgetActions)
+from spyder.plugins.findinfiles.widgets import FindInFilesWidget
 from spyder.plugins.mainmenu.api import ApplicationMenus
+from spyder.plugins.toolbar.api import ApplicationToolbars
 from spyder.utils.misc import getcwd_or_home
 
 # Localization
@@ -39,7 +38,7 @@ class FindInFiles(SpyderDockablePlugin):
     NAME = 'find_in_files'
     REQUIRES = []
     OPTIONAL = [Plugins.Editor, Plugins.Projects, Plugins.WorkingDirectory,
-                Plugins.MainMenu]
+                Plugins.MainMenu, Plugins.Toolbar]
     TABIFY = [Plugins.VariableExplorer]
     WIDGET_CLASS = FindInFilesWidget
     CONF_SECTION = NAME
@@ -59,6 +58,7 @@ class FindInFiles(SpyderDockablePlugin):
     def register(self):
         widget = self.get_widget()
         mainmenu = self.get_plugin(Plugins.MainMenu)
+        toolbar = self.get_plugin(Plugins.Toolbar)
         editor = self.get_plugin(Plugins.Editor)
         projects = self.get_plugin(Plugins.Projects)
         working_directory = self.get_plugin(Plugins.WorkingDirectory)
@@ -84,6 +84,7 @@ class FindInFiles(SpyderDockablePlugin):
             register_shortcut=True,
             context=Qt.WindowShortcut
         )
+
         if mainmenu:
             menu = mainmenu.get_application_menu(ApplicationMenus.Search)
             mainmenu.add_item_to_application_menu(
@@ -91,12 +92,14 @@ class FindInFiles(SpyderDockablePlugin):
                 menu=menu,
             )
 
-        search_toolbar = self.get_application_toolbar(
-            ApplicationToolBars.Search)
-        self.add_item_to_application_toolbar(
-            findinfiles_action,
-            search_toolbar,
-        )
+        if toolbar:
+            search_toolbar = toolbar.get_application_toolbar(
+                ApplicationToolbars.Search)
+            toolbar.add_item_to_application_toolbar(
+                findinfiles_action,
+                search_toolbar,
+            )
+
         self.refresh_search_directory()
 
     def on_close(self, cancelable=False):

--- a/spyder/plugins/findinfiles/widgets.py
+++ b/spyder/plugins/findinfiles/widgets.py
@@ -76,20 +76,20 @@ class FindInFilesWidgetActions:
     ToggleSearchRegex = 'toggle_use_regex_on_search_action'
 
 
-class FindInFilesWidgetToolBars:
+class FindInFilesWidgetToolbars:
     Exclude = 'exclude_toolbar'
     Location = 'location_toolbar'
 
 
-class FindInFilesWidgetMainToolBarSections:
+class FindInFilesWidgetMainToolbarSections:
     Main = 'main_section'
 
 
-class FindInFilesWidgetExcludeToolBarSections:
+class FindInFilesWidgetExcludeToolbarSections:
     Main = 'main_section'
 
 
-class FindInFilesWidgetLocationToolBarSections:
+class FindInFilesWidgetLocationToolbarSections:
     Main = 'main_section'
 
 
@@ -994,28 +994,28 @@ class FindInFilesWidget(PluginMainWidget):
             self.add_item_to_toolbar(
                 item,
                 toolbar=toolbar,
-                section=FindInFilesWidgetMainToolBarSections.Main,
+                section=FindInFilesWidgetMainToolbarSections.Main,
             )
 
         # Exclude Toolbar
         self.extras_toolbar = self.create_toolbar(
-            FindInFilesWidgetToolBars.Exclude)
+            FindInFilesWidgetToolbars.Exclude)
         for item in [self.exclude_label, self.exclude_pattern_edit,
                      self.exclude_regexp_action, self.create_stretcher()]:
             self.add_item_to_toolbar(
                 item,
                 toolbar=self.extras_toolbar,
-                section=FindInFilesWidgetExcludeToolBarSections.Main,
+                section=FindInFilesWidgetExcludeToolbarSections.Main,
             )
 
         # Location toolbar
         location_toolbar = self.create_toolbar(
-            FindInFilesWidgetToolBars.Location)
+            FindInFilesWidgetToolbars.Location)
         for item in [self.search_in_label, self.path_selection_combo]:
             self.add_item_to_toolbar(
                 item,
                 toolbar=location_toolbar,
-                section=FindInFilesWidgetLocationToolBarSections.Main,
+                section=FindInFilesWidgetLocationToolbarSections.Main,
             )
 
         menu = self.get_options_menu()

--- a/spyder/plugins/help/api.py
+++ b/spyder/plugins/help/api.py
@@ -11,5 +11,5 @@ Help Plugin API.
 # Local imports
 from spyder.plugins.help.plugin import HelpActions
 from spyder.plugins.help.widgets import (HelpWidgetActions,
-                                         HelpWidgetMainToolBarSections,
+                                         HelpWidgetMainToolbarSections,
                                          HelpWidgetOptionsMenuSections)

--- a/spyder/plugins/help/widgets.py
+++ b/spyder/plugins/help/widgets.py
@@ -69,7 +69,7 @@ class HelpWidgetOptionsMenuSections:
     Other = 'other_section'
 
 
-class HelpWidgetMainToolBarSections:
+class HelpWidgetMainToolbarSections:
     Main = 'main_section'
 
 
@@ -462,7 +462,7 @@ class HelpWidget(PluginMainWidget):
             self.add_item_to_toolbar(
                 item,
                 toolbar=toolbar,
-                section=HelpWidgetMainToolBarSections.Main,
+                section=HelpWidgetMainToolbarSections.Main,
             )
 
         self.source_changed()

--- a/spyder/plugins/mainmenu/api.py
+++ b/spyder/plugins/mainmenu/api.py
@@ -88,7 +88,7 @@ class ToolsMenuSections:
 class ViewMenuSections:
     Top = 'top_section'
     Pane = 'pane_section'
-    ToolBar = 'toolbar_section'
+    Toolbar = 'toolbar_section'
     Layout = 'layout_section'
     Bottom = 'bottom_section'
 

--- a/spyder/plugins/onlinehelp/widgets.py
+++ b/spyder/plugins/onlinehelp/widgets.py
@@ -46,7 +46,7 @@ class PydocBrowserActions:
     Find = 'find_action'
 
 
-class PydocBrowserMainToolBarSections:
+class PydocBrowserMainToolbarSections:
     Main = 'main_section'
 
 
@@ -225,7 +225,7 @@ class PydocBrowser(PluginMainWidget):
             self.add_item_to_toolbar(
                 item,
                 toolbar=toolbar,
-                section=PydocBrowserMainToolBarSections.Main,
+                section=PydocBrowserMainToolbarSections.Main,
             )
 
         # Signals

--- a/spyder/plugins/plots/widgets/main_widget.py
+++ b/spyder/plugins/plots/widgets/main_widget.py
@@ -50,7 +50,7 @@ class PlotsWidgetActions:
     ToggleAutoFitPlotting = 'toggle_auto_fit_plotting_action'
 
 
-class PlotsWidgetMainToolBarSections:
+class PlotsWidgetMainToolbarSections:
     Edit = 'edit_section'
     Move = 'move_section'
     Zoom = 'zoom_section'
@@ -308,7 +308,7 @@ class PlotsWidget(PluginMainWidget):
             self.add_item_to_toolbar(
                 item,
                 toolbar=main_toolbar,
-                section=PlotsWidgetMainToolBarSections.Edit,
+                section=PlotsWidgetMainToolbarSections.Edit,
             )
 
         # Context menu

--- a/spyder/plugins/profiler/api.py
+++ b/spyder/plugins/profiler/api.py
@@ -10,5 +10,5 @@ Profiler Plugin.
 # Local imports
 from spyder.plugins.profiler.plugin import ProfilerActions
 from spyder.plugins.profiler.widgets.main_widget import (
-    ProfilerWidgetActions, ProfilerWidgetInformationToolBarSections,
-    ProfilerWidgetMainToolBarSections, ProfilerWidgetToolBars)
+    ProfilerWidgetActions, ProfilerWidgetInformationToolbarSections,
+    ProfilerWidgetMainToolbarSections, ProfilerWidgetToolbars)

--- a/spyder/plugins/profiler/widgets/main_widget.py
+++ b/spyder/plugins/profiler/widgets/main_widget.py
@@ -69,15 +69,15 @@ class ProfilerWidgetActions:
     ShowOutput = 'show_output_action'
 
 
-class ProfilerWidgetToolBars:
+class ProfilerWidgetToolbars:
     Information = 'information_toolbar'
 
 
-class ProfilerWidgetMainToolBarSections:
+class ProfilerWidgetMainToolbarSections:
     Main = 'main_section'
 
 
-class ProfilerWidgetInformationToolBarSections:
+class ProfilerWidgetInformationToolbarSections:
     Main = 'main_section'
 
 
@@ -267,13 +267,13 @@ class ProfilerWidget(PluginMainWidget):
             self.add_item_to_toolbar(
                 item,
                 toolbar=toolbar,
-                section=ProfilerWidgetMainToolBarSections.Main,
+                section=ProfilerWidgetMainToolbarSections.Main,
             )
         toolbar.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
 
         # Secondary Toolbar
         secondary_toolbar = self.create_toolbar(
-            ProfilerWidgetToolBars.Information)
+            ProfilerWidgetToolbars.Information)
         for item in [self.collapse_action, self.expand_action,
                      self.create_stretcher(), self.datelabel,
                      self.create_stretcher(), self.log_action,
@@ -281,7 +281,7 @@ class ProfilerWidget(PluginMainWidget):
             self.add_item_to_toolbar(
                 item,
                 toolbar=secondary_toolbar,
-                section=ProfilerWidgetInformationToolBarSections.Main,
+                section=ProfilerWidgetInformationToolbarSections.Main,
             )
 
         # Setup

--- a/spyder/plugins/pylint/api.py
+++ b/spyder/plugins/pylint/api.py
@@ -11,5 +11,5 @@ Code Analysis plugin API.
 
 # Local imports
 from spyder.plugins.pylint.main_widget import (
-    PylintWidgetActions, PylintWidgetMainToolBarSections,
+    PylintWidgetActions, PylintWidgetMainToolbarSections,
     PylintWidgetOptionsMenuSections)

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -77,7 +77,7 @@ class PylintWidgetOptionsMenuSections:
     History = "history_section"
 
 
-class PylintWidgetMainToolBarSections:
+class PylintWidgetMainToolbarSections:
     Main = "main_section"
 
 
@@ -502,7 +502,7 @@ class PylintWidget(PluginMainWidget):
             self.add_item_to_toolbar(
                 item,
                 toolbar,
-                section=PylintWidgetMainToolBarSections.Main,
+                section=PylintWidgetMainToolbarSections.Main,
             )
 
         secondary_toolbar = self.create_toolbar("secondary")
@@ -511,7 +511,7 @@ class PylintWidget(PluginMainWidget):
             self.add_item_to_toolbar(
                 item,
                 secondary_toolbar,
-                section=PylintWidgetMainToolBarSections.Main,
+                section=PylintWidgetMainToolbarSections.Main,
             )
 
         self.show_data()

--- a/spyder/plugins/toolbar/__init__.py
+++ b/spyder/plugins/toolbar/__init__.py
@@ -5,8 +5,5 @@
 # (see spyder/__init__.py for details)
 
 """
-Plots Plugin API.
+Toolbar plugin.
 """
-
-from spyder.plugins.plots.widgets.main_widget import (
-    PlotsWidgetActions, PlotsWidgetMainToolbarSections)

--- a/spyder/plugins/toolbar/api.py
+++ b/spyder/plugins/toolbar/api.py
@@ -11,10 +11,10 @@ Spyder application toolbar constants.
 
 # --- Constants
 # ----------------------------------------------------------------------------
-class ApplicationToolBars:
+class ApplicationToolbars:
     File = 'file_toolbar'
     Run = 'run_toolbar'
-    Debug = 'defbug_toolbar'
+    Debug = 'debug_toolbar'
     Main = 'main_toolbar'
     Search = 'search_toolbar'
     Edit = 'edit_toolbar'

--- a/spyder/plugins/toolbar/container.py
+++ b/spyder/plugins/toolbar/container.py
@@ -1,0 +1,317 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Toolbar Container.
+"""
+
+# Standard library imports
+from collections import OrderedDict
+
+# Third party imports
+from qtpy.QtCore import QSize, Qt, Signal, Slot
+from qtpy.QtWidgets import QMenu, QToolBar
+
+# Local imports
+from spyder.api.exceptions import SpyderAPIError
+from spyder.api.translations import get_translation
+from spyder.api.widgets import PluginMainContainer
+from spyder.api.widgets.toolbars import ApplicationToolbar
+from spyder.plugins.toolbar.api import ApplicationToolbars
+
+# Localization
+_ = get_translation('spyder')
+
+
+# --- Constants
+# ------------------------------------------------------------------------
+
+class ToolbarMenus:
+    ToolbarsMenu = "toolbars_menu"
+
+
+class ToolbarsMenuSections:
+    Main = "main_section"
+    Secondary = "secondary_section"
+
+
+class ToolbarActions:
+    ShowToolbars = "show toolbars"
+
+
+class ToolbarContainer(PluginMainContainer):
+    DEFAULT_OPTIONS = {
+        'last_visible_toolbars': [],
+        'toolbars_visible': True,
+    }
+
+    def __init__(self, name, plugin, parent=None, options=DEFAULT_OPTIONS):
+        super().__init__(name, plugin, parent=parent, options=options)
+
+        self._APPLICATION_TOOLBARS = OrderedDict()
+        self._ADDED_TOOLBARS = OrderedDict()
+        self._toolbarslist = []
+        self._visible_toolbars = []
+
+    # --- Private Methods
+    # ------------------------------------------------------------------------
+    def _save_visible_toolbars(self):
+        """Save the name of the visible toolbars in the options."""
+        toolbars = []
+        for toolbar in self._visible_toolbars:
+            toolbars.append(toolbar.objectName())
+
+        self.set_option('last_visible_toolbars', toolbars)
+
+    def _get_visible_toolbars(self):
+        """Collect the visible toolbars."""
+        toolbars = []
+        for toolbar in self._toolbarslist:
+            if (toolbar.toggleViewAction().isChecked()
+                    and toolbar not in toolbars):
+                toolbars.append(toolbar)
+
+        self._visible_toolbars = toolbars
+
+    @Slot()
+    def _show_toolbars(self):
+        """Show/Hide toolbars."""
+        value = not self.get_option("toolbars_visible")
+        self.set_option("toolbars_visible", value)
+        if value:
+            self._save_visible_toolbars()
+        else:
+            self._get_visible_toolbars()
+
+        for toolbar in self._visible_toolbars:
+            toolbar.toggleViewAction().setChecked(value)
+            toolbar.setVisible(value)
+
+        self.update_actions()
+
+    # --- PluginMainContainer API
+    # ------------------------------------------------------------------------
+    def setup(self, options=DEFAULT_OPTIONS):
+        self.show_toolbars_action = self.create_action(
+            ToolbarActions.ShowToolbars,
+            text=_("Show toolbars"),
+            triggered=self._show_toolbars,
+            context=Qt.ApplicationShortcut,
+            shortcut_context="_",
+            register_shortcut=True
+        )
+
+        self.toolbars_menu = self.create_menu(
+            ToolbarMenus.ToolbarsMenu,
+            _("Toolbars"),
+        )
+
+    def on_option_update(self, options, value):
+        pass
+
+    def update_actions(self):
+        if self.get_option("toolbars_visible"):
+            text = _("Hide toolbars")
+            tip = _("Hide toolbars")
+        else:
+            text = _("Show toolbars")
+            tip = _("Show toolbars")
+
+        self.show_toolbars_action.setText(text)
+        self.show_toolbars_action.setToolTip(tip)
+
+    # --- Public API
+    # ------------------------------------------------------------------------
+    def create_application_toolbar(self, toolbar_id, title):
+        """
+        Create an application toolbar and add it to the main window.
+
+        Paramaters
+        ----------
+        toolbar_id: str
+            The toolbar unique identifier string.
+        title: str
+            The localized toolbar title to be displayed.
+
+        Returns
+        -------
+        spyder.api.widgets.toolbar.ApplicationToolbar
+            The created application toolbar.
+        """
+        if toolbar_id in self._APPLICATION_TOOLBARS:
+            raise SpyderAPIError(
+                'Toolbar with ID "{}" already added!'.format(toolbar_id))
+
+        toolbar = ApplicationToolbar(self, title)
+        toolbar.ID = toolbar_id
+        toolbar.setObjectName(toolbar_id)
+        self._APPLICATION_TOOLBARS[toolbar_id] = toolbar
+        self._toolbarslist.append(toolbar)
+
+        return toolbar
+
+    def add_application_toolbar(self, toolbar, mainwindow=None):
+        """
+        Add toolbar to application toolbars.
+
+        Parameters
+        ----------
+        toolbar: spyder.api.widgets.toolbars.ApplicationToolbar
+            The application toolbar to add to the `mainwindow`.
+        mainwindow: QMainWindow
+            The main application window.
+        """
+        toolbar_id = toolbar.ID
+        toolbar._check_interface()
+
+        if toolbar_id in self._ADDED_TOOLBARS:
+            raise SpyderAPIError(
+                'Toolbar with ID "{}" already added!'.format(toolbar_id))
+
+        # TODO: Make the icon size adjustable in Preferences later on.
+        iconsize = 24
+        toolbar.setIconSize(QSize(iconsize, iconsize))
+        toolbar.setObjectName(toolbar_id)
+
+        self._ADDED_TOOLBARS[toolbar_id] = toolbar
+        self._toolbarslist.append(toolbar)
+
+        if mainwindow:
+            mainwindow.addToolBar(toolbar)
+
+    def add_item_to_application_toolbar(self, item, toolbar=None, toolbar_id=None,
+                                        section=None, before=None):
+        """
+        Add action or widget `item` to given application toolbar `section`.
+
+        Parameters
+        ----------
+        item: SpyderAction or QWidget
+            The item to add to the `toolbar`.
+        toolbar: ApplicationToolbar or None
+            Instance of a Spyder application toolbar.
+        toolbar_id: str or None
+            The application toolbar unique string identifier.
+        section: str or None
+            The section id in which to insert the `item` on the `toolbar`.
+        before: str or None
+            Make the item appear before another given item.
+
+        Notes
+        -----
+        Must provide a `toolbar` or a `toolbar_id`.
+        """
+        if toolbar and toolbar_id:
+            raise SpyderAPIError('Must provide only toolbar or toolbar_id!')
+
+        if toolbar is None and toolbar_id is None:
+            raise SpyderAPIError(
+                'Must provide at least toolbar or toolbar_id!')
+
+        if toolbar and not isinstance(toolbar, ApplicationToolbar):
+            raise SpyderAPIError('Not an `ApplicationToolbar`!')
+
+        if toolbar_id and toolbar_id not in self._APPLICATION_TOOLBARS:
+            raise SpyderAPIError(
+                '{} is not a valid toolbar_id'.format(toolbar_id))
+
+        toolbar_id = toolbar_id if toolbar_id else toolbar.ID
+        toolbar = toolbar if toolbar else self.get_application_toolbar(
+            toolbar_id)
+
+        toolbar.add_item(item, section=section, before=before)
+
+    def get_application_toolbar(self, toolbar_id):
+        """
+        Return an application toolbar by toolbar_id.
+
+        Parameters
+        ----------
+        toolbar_id: str
+            The toolbar unique string identifier.
+
+        Returns
+        -------
+        spyder.api.widgets.toolbars.ApplicationToolbar
+            The application toolbar.
+        """
+        if toolbar_id not in self._APPLICATION_TOOLBARS:
+            raise SpyderAPIError(
+                'Application toolbar "{0}" not found! '
+                'Available toolbars are: {1}'.format(
+                    toolbar_id,
+                    list(self._APPLICATION_TOOLBARS.keys())
+                )
+            )
+
+        return self._APPLICATION_TOOLBARS[toolbar_id]
+
+    def get_application_toolbars(self):
+        """
+        Return all created application toolbars.
+
+        Returns
+        -------
+        list
+            The list of all the added application toolbars.
+        """
+        return self._toolbarslist
+
+    def load_last_visible_toolbars(self):
+        """Load the last visible toolbars from our preferences.."""
+        toolbars_names = self.get_option('last_visible_toolbars')
+
+        if toolbars_names:
+            toolbars_dict = {}
+            for toolbar in self._toolbarslist:
+                toolbars_dict[toolbar.objectName()] = toolbar
+
+            toolbars = []
+            for name in toolbars_names:
+                if name in toolbars_dict:
+                    toolbars.append(toolbars_dict[name])
+
+            self._visible_toolbars = toolbars
+        else:
+            self._get_visible_toolbars()
+
+        self.update_actions()
+
+    def create_toolbars_menu(self):
+        """
+        Populate the toolbars menu inside the view application menu.
+        """
+        # TODO: This is hardcoding an order and assuming the working
+        # directory toolbar plugin exists. This should probably just
+        # use the order of creation as the order, or even sort
+        # alphabetically.
+        order = [
+            ApplicationToolbars.File,
+            ApplicationToolbars.Run,
+            ApplicationToolbars.Debug,
+            ApplicationToolbars.Main,
+            "working_directory_toolbar",
+            None,
+            ApplicationToolbars.Search,
+            ApplicationToolbars.Edit,
+            ApplicationToolbars.Source,
+        ]
+
+        section = 0
+        for toolbar_id in order:
+            if toolbar_id is None:
+                section += 1
+                continue
+
+            toolbar = self._ADDED_TOOLBARS.get(toolbar_id)
+            if toolbar:
+                action = toolbar.toggleViewAction()
+
+            self.add_item_to_menu(
+                action,
+                menu=self.toolbars_menu,
+                section=str(section),
+            )

--- a/spyder/plugins/workingdirectory/container.py
+++ b/spyder/plugins/workingdirectory/container.py
@@ -19,7 +19,7 @@ from qtpy.QtCore import Signal, Slot
 # Local imports
 from spyder.api.translations import get_translation
 from spyder.api.widgets import PluginMainContainer
-from spyder.api.widgets.toolbars import ApplicationToolBar
+from spyder.api.widgets.toolbars import ApplicationToolbar
 from spyder.config.base import get_home_dir
 from spyder.utils.misc import getcwd_or_home
 from spyder.widgets.comboboxes import PathComboBox
@@ -38,8 +38,14 @@ class WorkingDirectoryActions:
     Parent = "parent_action"
 
 
-class WorkingDirectoryToolBarSections:
+class WorkingDirectoryToolbarSections:
     Main = "main_section"
+
+
+# --- Widgets
+# ----------------------------------------------------------------------------
+class WorkingDirectoryToolbar(ApplicationToolbar):
+    ID = 'working_directory_toolbar'
 
 
 # --- Container
@@ -79,7 +85,7 @@ class WorkingDirectoryContainer(PluginMainContainer):
 
         # Widgets
         title = _('Current working directory')
-        self.toolbar = ApplicationToolBar(self, title)
+        self.toolbar = WorkingDirectoryToolbar(self, title)
         self.pathedit = PathComboBox(
             self,
             adjust_to_contents=self.get_option('working_dir_adjusttocontents'),
@@ -141,7 +147,7 @@ class WorkingDirectoryContainer(PluginMainContainer):
             self.add_item_to_toolbar(
                 item,
                 self.toolbar,
-                section=WorkingDirectoryToolBarSections.Main,
+                section=WorkingDirectoryToolbarSections.Main,
             )
 
     def update_actions(self):

--- a/spyder/plugins/workingdirectory/plugin.py
+++ b/spyder/plugins/workingdirectory/plugin.py
@@ -33,7 +33,7 @@ class WorkingDirectory(SpyderPluginV2):
     """
 
     NAME = 'workingdir'
-    REQUIRES = [Plugins.Console]
+    REQUIRES = [Plugins.Console, Plugins.Toolbar]
     OPTIONAL = [Plugins.Editor, Plugins.Explorer, Plugins.IPythonConsole,
                 Plugins.Projects]
     CONTAINER_CLASS = WorkingDirectoryContainer
@@ -67,11 +67,12 @@ class WorkingDirectory(SpyderPluginV2):
 
     def register(self):
         container = self.get_container()
+        toolbar = self.get_plugin(Plugins.Toolbar)
         editor = self.get_plugin(Plugins.Editor)
         explorer = self.get_plugin(Plugins.Explorer)
         ipyconsole = self.get_plugin(Plugins.IPythonConsole)
 
-        self.add_application_toolbar(self.NAME, container.toolbar)
+        toolbar.add_application_toolbar(container.toolbar)
         container.sig_current_directory_changed.connect(
             self.sig_current_directory_changed)
         self.sig_current_directory_changed.connect(


### PR DESCRIPTION
# Description of changes

- A new ToolBar plugin in charge of managing the application toolbars, and toolbar sections sections.
- Plugins that need to add a toolbar or add items (Actions/Widgets) to the main application toolbar area bar will require this plugin.
- The API of toolbars now lives in this plugin instead of the global `spyder.api` since the plugin is in charge of those specifics.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
