### PR TITLE
Natural sorting for dicts in variable explorer

### DIFF
--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -67,6 +67,13 @@ LARGE_NROWS = 100
 ROWS_TO_LOAD = 50
 
 
+def natsort(s):
+    """
+    natural sorting, e.g. test3 comes before test100
+    taken from https://stackoverflow.com/a/16090640/3110740
+    """
+    return [int(t) if t.isdigit() else t.lower() for t in re.split('(\d+)', s)]
+
 class ProxyObject(object):
     """Dictionary proxy to an unknown object."""
 
@@ -171,10 +178,6 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
             self._data = list(data)
         elif isinstance(data, dict):
             try:
-                # natural sorting, e.g. test3 comes before test100
-                # taken from https://stackoverflow.com/a/16090640/3110740
-                natsort = lambda s: [int(t) if t.isdigit() else t.lower()
-                                     for t in re.split('(\d+)', s)]
                 self.keys = sorted(list(data.keys()), key=natsort)
             except TypeError:
                 # This is necessary to display dictionaries with mixed

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -171,7 +171,11 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
             self._data = list(data)
         elif isinstance(data, dict):
             try:
-                self.keys = sorted(list(data.keys()))
+                # natural sorting, e.g. test3 comes before test100
+                # taken from https://stackoverflow.com/a/16090640/3110740
+                natsort = lambda s: [int(t) if t.isdigit() else t.lower()
+                                     for t in re.split('(\d+)', s)]
+                self.keys = sorted(list(data.keys()), key=natsort)
             except TypeError:
                 # This is necessary to display dictionaries with mixed
                 # types as keys.

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -72,7 +72,7 @@ def natsort(s):
     natural sorting, e.g. test3 comes before test100
     taken from https://stackoverflow.com/a/16090640/3110740
     """
-    return [int(t) if t.isdigit() else t.lower() for t in re.split('(\d+)', s)]
+    return [int(t) if t.isdigit() else t.lower() for t in re.split('([0-9]+)', s)]
 
 class ProxyObject(object):
     """Dictionary proxy to an unknown object."""

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -824,5 +824,23 @@ def test_dicts_with_mixed_types_as_key(qtbot):
     assert editor.widget.editor.source_model.keys == [1, 'Y']
 
 
+def test_dicts_natural_sorting(qtbot):
+    """
+    Test that we can show dictionaries with mixed data types as keys.
+
+    This is a regression for spyder-ide/spyder#13481.
+    """
+    import random
+    numbers = list(range(100))
+    random.shuffle(numbers)
+    numberedlist = {'test{}'.format(i):None for i in numbers}
+    # numbers should be as a human would sort, e.g. test3 before test100
+    # regular sort would sort test1, test10, test11,..., test2, test20,...
+    expected = ['test{}'.format(i) for i in numbers]
+    editor = CollectionsEditor()
+    editor.setup(numberedlist)
+    assert editor.widget.editor.source_model.keys == expected
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -833,7 +833,7 @@ def test_dicts_natural_sorting(qtbot):
     import random
     numbers = list(range(100))
     random.shuffle(numbers)
-    numberedlist = {'test{}'.format(i):None for i in numbers}
+    numberedlist = {'test{}'.format(i): None for i in numbers}
     # numbers should be as a human would sort, e.g. test3 before test100
     # regular sort would sort test1, test10, test11,..., test2, test20,...
     expected = ['test{}'.format(i) for i in numbers]

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -836,7 +836,7 @@ def test_dicts_natural_sorting(qtbot):
     numberedlist = {'test{}'.format(i): None for i in numbers}
     # numbers should be as a human would sort, e.g. test3 before test100
     # regular sort would sort test1, test10, test11,..., test2, test20,...
-    expected = ['test{}'.format(i) for i in numbers]
+    expected = ['test{}'.format(i) for i in list(range(100))]
     editor = CollectionsEditor()
     editor.setup(numberedlist)
     assert editor.widget.editor.source_model.keys == expected


### PR DESCRIPTION
* [ N/A] Wrote at least one-line docstrings (for any new functions) / 
* [X ] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

As suggested in  https://github.com/spyder-ide/spyder/issues/13481#event-3658990833 I've implemented natural/human sorting for the keys. This means that numbers within strings are sorted correctly as well, e.g. test3 comes before test10, which with standard sorting would not be the case (as it just compares per character).

This could also be easily added to the main sorting mechanism of the variable explorer at https://github.com/spyder-ide/spyder/blob/9991196c311074236bb7cd0e56230919453560ab/spyder/widgets/collectionseditor.py#L250, should that be done? Might be quite useful.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: skjerns

<!--- Thanks for your help making Spyder better for everyone! --->
