### PR TITLE
PR: Change About and Dependencies dialogs to non-modal

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2676,7 +2676,7 @@ class MainWindow(QMainWindow):
         """Show About Spyder dialog box"""
         from spyder.widgets.about import AboutDialog
         abt = AboutDialog(self)
-        abt.exec_()
+        abt.show()
 
     @Slot()
     def show_dependencies(self):
@@ -2684,7 +2684,7 @@ class MainWindow(QMainWindow):
         from spyder.widgets.dependencies import DependenciesDialog
         dlg = DependenciesDialog(self)
         dlg.set_data(dependencies.DEPENDENCIES)
-        dlg.exec_()
+        dlg.show()
 
     def render_issue(self, description='', traceback=''):
         """Render issue before sending it to Github"""

--- a/spyder/widgets/about.py
+++ b/spyder/widgets/about.py
@@ -149,7 +149,7 @@ class AboutDialog(QDialog):
 
         # Widget setup
         self.setWindowIcon(ima.icon('tooloptions'))
-        self.setModal(True)
+        self.setModal(False)
 
         # Layout
         tophlayout = QHBoxLayout()

--- a/spyder/widgets/dependencies.py
+++ b/spyder/widgets/dependencies.py
@@ -98,7 +98,7 @@ class DependenciesDialog(QDialog):
         self.setWindowTitle("Spyder %s: %s" % (__version__,
                                                _("Dependencies")))
         self.setWindowIcon(ima.icon('tooloptions'))
-        self.setModal(True)
+        self.setModal(False)
 
         # Layout
         hlayout = QHBoxLayout()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

I changed spyder about and dependencies dialogs to non-modal
![Screen Shot 2020-08-17 at 8 17 11 PM](https://user-images.githubusercontent.com/18587879/90459360-b602ba80-e0c6-11ea-9d55-8238dc2f424b.png)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
