### PR TITLE
PR: Add natural sorting for dicts (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -254,11 +254,11 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
     def sort(self, column, order=Qt.AscendingOrder):
         """Overriding sort method"""
 
-        def all_string(l):
-            return all([isinstance(x, str) for x in l])
+        def all_string(listlike):
+            return all([isinstance(x, str) for x in listlike])
 
         reverse = (order == Qt.DescendingOrder)\
-            
+
         sort_key = natsort if all_string(self.keys) else None
 
         if column == 0:

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -197,7 +197,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
                 self.header0 = _("Attribute")
         if not isinstance(self._data, ProxyObject):
             self.title += (' (' + str(len(self.keys)) + ' ' +
-                          _("element" + "s"*(len(self.keys)!=1)) + ')')
+                              _("element" + "s" * (len(self.keys) != 1)) + ')')
         else:
             self.title += data_type
         self.total_rows = len(self.keys)
@@ -256,7 +256,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
 
         def all_string(listlike):
             return all([isinstance(x, str) for x in listlike])
-          
+
         reverse = (order == Qt.DescendingOrder)
         sort_key = natsort if all_string(self.keys) else None
 
@@ -1673,7 +1673,7 @@ class CollectionsCustomSortFilterProxy(CustomSortFilterProxy):
         if isinstance(leftData, str) and isinstance(rightData, str):
             return natsort(leftData) < natsort(rightData)
         else:
-            return leftData<rightData
+            return leftData < rightData
 
 # =============================================================================
 # Tests

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -253,8 +253,12 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
 
     def sort(self, column, order=Qt.AscendingOrder):
         """Overriding sort method"""
-        reverse = (order == Qt.DescendingOrder)
-        all_string = lambda string: all([isinstance(x, str) for x in string])
+
+        def all_string(l):
+            return all([isinstance(x, str) for x in l])
+
+        reverse = (order == Qt.DescendingOrder)\
+            
         sort_key = natsort if all_string(self.keys) else None
 
         if column == 0:

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -1670,7 +1670,10 @@ class CollectionsCustomSortFilterProxy(CustomSortFilterProxy):
         """Implements ordering in a natural way, as a human would sort"""
         leftData = self.sourceModel().data(left)
         rightData = self.sourceModel().data(right)
-        return natsort(leftData) < natsort(rightData)
+        if isinstance(leftData, str) and isinstance(rightData, str):
+            return natsort(leftData) < natsort(rightData)
+        else:
+            return leftData<rightData
 
 # =============================================================================
 # Tests

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -743,7 +743,6 @@ class BaseTableView(QTableView):
 
     def set_data(self, data):
         """Set table data"""
-        print("setting", data)
         if data is not None:
             self.source_model.set_data(data, self.dictfilter)
             self.source_model.reset()

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -72,6 +72,7 @@ def natsort(s):
     natural sorting, e.g. test3 comes before test100
     taken from https://stackoverflow.com/a/16090640/3110740
     """
+    # if not isinstance(s, (str, bytes)): return s
     x = [int(t) if t.isdigit() else t.lower() for t in re.split('([0-9]+)', s)]
     return x
 
@@ -253,12 +254,14 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
     def sort(self, column, order=Qt.AscendingOrder):
         """Overriding sort method"""
         reverse = (order == Qt.DescendingOrder)
+        all_string = lambda string: all([isinstance(x, str) for x in string])
+        sort_key = natsort if all_string(self.keys) else None
 
         if column == 0:
             self.sizes = sort_against(self.sizes, self.keys, reverse)
             self.types = sort_against(self.types, self.keys, reverse)
             try:
-                self.keys.sort(reverse=reverse, key=natsort)
+                self.keys.sort(reverse=reverse, key=sort_key)
             except:
                 pass
         elif column == 1:
@@ -266,7 +269,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
                                                         reverse)
             self.sizes = sort_against(self.sizes, self.types, reverse)
             try:
-                self.types.sort(reverse=reverse, key=natsort)
+                self.types.sort(reverse=reverse, key=sort_key)
             except:
                 pass
         elif column == 2:
@@ -274,7 +277,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
                                                         reverse)
             self.types = sort_against(self.types, self.sizes, reverse)
             try:
-                self.sizes.sort(reverse=reverse, key=natsort)
+                self.sizes.sort(reverse=reverse, key=sort_key)
             except:
                 pass
         elif column in [3, 4]:

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -197,7 +197,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
                 self.header0 = _("Attribute")
         if not isinstance(self._data, ProxyObject):
             self.title += (' (' + str(len(self.keys)) + ' ' +
-                              _("element" + "s" * (len(self.keys) != 1)) + ')')
+                           _("element" + "s" * (len(self.keys) != 1)) + ')')
         else:
             self.title += data_type
         self.total_rows = len(self.keys)

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -1666,7 +1666,7 @@ class CollectionsCustomSortFilterProxy(CustomSortFilterProxy):
             return True
 
     def lessThan(self, left, right):
-        """Implements ordering in a natural way, as a human would sort"""
+        """Implements ordering in a natural way, as a human would sort."""
         leftData = self.sourceModel().data(left)
         rightData = self.sourceModel().data(right)
         if isinstance(leftData, str) and isinstance(rightData, str):

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -66,12 +66,14 @@ MAX_SERIALIZED_LENGHT = 1e6
 LARGE_NROWS = 100
 ROWS_TO_LOAD = 50
 
+
 def natsort(s):
     """
     natural sorting, e.g. test3 comes before test100
     taken from https://stackoverflow.com/a/16090640/3110740
     """
-    return [int(t) if t.isdigit() else t.lower() for t in re.split('([0-9]+)', s)]
+    x = [int(t) if t.isdigit() else t.lower() for t in re.split('([0-9]+)', s)]
+    return x
 
 
 class ProxyObject(object):

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -197,7 +197,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
                 self.header0 = _("Attribute")
         if not isinstance(self._data, ProxyObject):
             self.title += (' (' + str(len(self.keys)) + ' ' +
-                          _("elements") + ')')
+                          _("element" + "s"*(len(self.keys)!=1)) + ')')
         else:
             self.title += data_type
         self.total_rows = len(self.keys)
@@ -744,6 +744,7 @@ class BaseTableView(QTableView):
 
     def set_data(self, data):
         """Set table data"""
+        print("setting", data)
         if data is not None:
             self.source_model.set_data(data, self.dictfilter)
             self.source_model.reset()
@@ -1666,6 +1667,11 @@ class CollectionsCustomSortFilterProxy(CustomSortFilterProxy):
         else:
             return True
 
+    def lessThan(self, left, right):
+        """Implements ordering in a natural way, as a human would sort"""
+        leftData = self.sourceModel().data(left)
+        rightData = self.sourceModel().data(right)
+        return natsort(leftData) < natsort(rightData)
 
 # =============================================================================
 # Tests

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -66,6 +66,13 @@ MAX_SERIALIZED_LENGHT = 1e6
 LARGE_NROWS = 100
 ROWS_TO_LOAD = 50
 
+def natsort(s):
+    """
+    natural sorting, e.g. test3 comes before test100
+    taken from https://stackoverflow.com/a/16090640/3110740
+    """
+    return [int(t) if t.isdigit() else t.lower() for t in re.split('([0-9]+)', s)]
+
 
 class ProxyObject(object):
     """Dictionary proxy to an unknown object."""
@@ -171,7 +178,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
             self._data = list(data)
         elif isinstance(data, dict):
             try:
-                self.keys = sorted(list(data.keys()))
+                self.keys = sorted(list(data.keys()), key=natsort)
             except TypeError:
                 # This is necessary to display dictionaries with mixed
                 # types as keys.
@@ -185,13 +192,11 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
             self._data = data = self.showndata = ProxyObject(data)
             if not self.names:
                 self.header0 = _("Attribute")
-
         if not isinstance(self._data, ProxyObject):
             self.title += (' (' + str(len(self.keys)) + ' ' +
                           _("elements") + ')')
         else:
             self.title += data_type
-
         self.total_rows = len(self.keys)
         if self.total_rows > LARGE_NROWS:
             self.rows_loaded = ROWS_TO_LOAD
@@ -251,7 +256,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
             self.sizes = sort_against(self.sizes, self.keys, reverse)
             self.types = sort_against(self.types, self.keys, reverse)
             try:
-                self.keys.sort(reverse=reverse)
+                self.keys.sort(reverse=reverse, key=natsort)
             except:
                 pass
         elif column == 1:
@@ -259,7 +264,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
                                                         reverse)
             self.sizes = sort_against(self.sizes, self.types, reverse)
             try:
-                self.types.sort(reverse=reverse)
+                self.types.sort(reverse=reverse, key=natsort)
             except:
                 pass
         elif column == 2:
@@ -267,7 +272,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
                                                         reverse)
             self.types = sort_against(self.types, self.sizes, reverse)
             try:
-                self.sizes.sort(reverse=reverse)
+                self.sizes.sort(reverse=reverse, key=natsort)
             except:
                 pass
         elif column in [3, 4]:

--- a/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
@@ -35,8 +35,8 @@ from spyder.plugins.variableexplorer.widgets.collectionseditor import (
     CollectionsModel, CollectionsEditor, LARGE_NROWS, ROWS_TO_LOAD)
 from spyder.plugins.variableexplorer.widgets.namespacebrowser import (
     NamespacesBrowserFinder)
-# from spyder.plugins.variableexplorer.widgets.tests.test_dataframeeditor import \
-#     generate_pandas_indexes
+from spyder.plugins.variableexplorer.widgets.tests.test_dataframeeditor import \
+    generate_pandas_indexes
 from spyder.py3compat import PY2, to_text_string
 
 

--- a/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
@@ -32,7 +32,7 @@ from qtpy.QtWidgets import QWidget
 # Local imports
 from spyder.plugins.variableexplorer.widgets.collectionseditor import (
     RemoteCollectionsEditorTableView, CollectionsEditorTableView,
-    CollectionsModel, CollectionsEditor, LARGE_NROWS, ROWS_TO_LOAD)
+    CollectionsModel, CollectionsEditor, LARGE_NROWS, ROWS_TO_LOAD, natsort)
 from spyder.plugins.variableexplorer.widgets.namespacebrowser import (
     NamespacesBrowserFinder)
 from spyder.plugins.variableexplorer.widgets.tests.test_dataframeeditor import \
@@ -831,14 +831,18 @@ def test_dicts_natural_sorting(qtbot):
     import random
     numbers = list(range(100))
     random.shuffle(numbers)
-    data = {'test{}'.format(i): None for i in numbers}
+    dictionary = {'test{}'.format(i): None for i in numbers}
+    data_sorted = sorted(list(dictionary.keys()), key=natsort)
     # numbers should be as a human would sort, e.g. test3 before test100
     # regular sort would sort test1, test10, test11,..., test2, test20,...
     expected = ['test{}'.format(i) for i in list(range(100))]
     editor = CollectionsEditor()
-    editor.setup(data)
+    editor.setup(dictionary)
+    editor.widget.editor.source_model.sort(0)
 
-    assert editor.widget.editor.source_model.keys == expected
+    assert data_sorted==expected, 'Function failed'
+    assert editor.widget.editor.source_model.keys == expected, \
+        'GUI sorting fail'
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
@@ -35,8 +35,8 @@ from spyder.plugins.variableexplorer.widgets.collectionseditor import (
     CollectionsModel, CollectionsEditor, LARGE_NROWS, ROWS_TO_LOAD)
 from spyder.plugins.variableexplorer.widgets.namespacebrowser import (
     NamespacesBrowserFinder)
-from spyder.plugins.variableexplorer.widgets.tests.test_dataframeeditor import \
-    generate_pandas_indexes
+# from spyder.plugins.variableexplorer.widgets.tests.test_dataframeeditor import \
+#     generate_pandas_indexes
 from spyder.py3compat import PY2, to_text_string
 
 
@@ -826,19 +826,18 @@ def test_dicts_with_mixed_types_as_key(qtbot):
 
 def test_dicts_natural_sorting(qtbot):
     """
-    Test that we can show dictionaries with mixed data types as keys.
-
-    This is a regression for spyder-ide/spyder#13481.
+    Test that natural sorting actually does what it should do
     """
     import random
     numbers = list(range(100))
     random.shuffle(numbers)
-    numberedlist = {'test{}'.format(i): None for i in numbers}
+    data = {'test{}'.format(i): None for i in numbers}
     # numbers should be as a human would sort, e.g. test3 before test100
     # regular sort would sort test1, test10, test11,..., test2, test20,...
     expected = ['test{}'.format(i) for i in list(range(100))]
     editor = CollectionsEditor()
-    editor.setup(numberedlist)
+    editor.setup(data)
+
     assert editor.widget.editor.source_model.keys == expected
 
 

--- a/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
@@ -824,5 +824,23 @@ def test_dicts_with_mixed_types_as_key(qtbot):
     assert editor.widget.editor.source_model.keys == [1, 'Y']
 
 
+def test_dicts_natural_sorting(qtbot):
+    """
+    Test that we can show dictionaries with mixed data types as keys.
+
+    This is a regression for spyder-ide/spyder#13481.
+    """
+    import random
+    numbers = list(range(100))
+    random.shuffle(numbers)
+    numberedlist = {'test{}'.format(i): None for i in numbers}
+    # numbers should be as a human would sort, e.g. test3 before test100
+    # regular sort would sort test1, test10, test11,..., test2, test20,...
+    expected = ['test{}'.format(i) for i in list(range(100))]
+    editor = CollectionsEditor()
+    editor.setup(numberedlist)
+    assert editor.widget.editor.source_model.keys == expected
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
@@ -840,7 +840,7 @@ def test_dicts_natural_sorting(qtbot):
     editor.setup(dictionary)
     editor.widget.editor.source_model.sort(0)
 
-    assert data_sorted==expected, 'Function failed'
+    assert data_sorted == expected, 'Function failed'
     assert editor.widget.editor.source_model.keys == expected, \
         'GUI sorting fail'
 


### PR DESCRIPTION
as I'm getting merge conflicts when rebasing to 4.x in #13548  I've simply created a new PR. Hope that's okay.
#########

* [X] Wrote at least one-line docstrings (for any new functions) / 
* [X] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

As suggested in  https://github.com/spyder-ide/spyder/issues/13481#event-3658990833 I've implemented natural/human sorting for the keys. This means that numbers within strings are sorted correctly as well, e.g. test3 comes before test10, which with standard sorting would not be the case (as it just compares per character). However, this is now only implemented for dictionaries that are opened in the collections editor. It could also be easily added to the main sorting mechanism of the variable explorer I guess? Should that be given a try?

I had to do a workaround so that non-strings and mixed types are not sorted. Else the other tests would fail and I didnt want to tamper with them

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: skjerns

<!--- Thanks for your help making Spyder better for everyone! --->
