### PR TITLE
PR: Fix using dir in the spyder module

### DIFF
--- a/spyder/__init__.py
+++ b/spyder/__init__.py
@@ -46,7 +46,7 @@ DATAPATH = LOCALEPATH = DOCPATH = MATHJAXPATH = JQUERYPATH = ''
 
 import os
 # Directory of the current file
-__dir__ = os.path.dirname(os.path.abspath(__file__))
+__current_directory__ = os.path.dirname(os.path.abspath(__file__))
 
 def add_to_distribution(dist):
     """Add package to py2exe/cx_Freeze distribution object
@@ -74,7 +74,7 @@ def get_versions(reporev=True):
     revision = None
     if reporev:
         from spyder.utils import vcs
-        revision, branch = vcs.get_git_revision(os.path.dirname(__dir__))
+        revision, branch = vcs.get_git_revision(os.path.dirname(__current_directory__))
 
     if not sys.platform == 'darwin':  # To avoid a crash with our Mac app
         system = platform.system()

--- a/spyder/__init__.py
+++ b/spyder/__init__.py
@@ -74,7 +74,8 @@ def get_versions(reporev=True):
     revision = None
     if reporev:
         from spyder.utils import vcs
-        revision, branch = vcs.get_git_revision(os.path.dirname(__current_directory__))
+        revision, branch = vcs.get_git_revision(
+            os.path.dirname(__current_directory__))
 
     if not sys.platform == 'darwin':  # To avoid a crash with our Mac app
         system = platform.system()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Fixes thsi problem:
```
In [1]: import spyder

In [2]: dir(spyder)
Traceback (most recent call last):

  File "<ipython-input-2-d9a631b9c2b0>", line 1, in <module>
    dir(spyder)

TypeError: 'str' object is not callable
```

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
