### PR TITLE
PR:  Refactor the toolbar handling on main widgets

### DIFF
--- a/spyder/api/plugins.py
+++ b/spyder/api/plugins.py
@@ -817,10 +817,8 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderOptionMixin):
             # Widget setup
             # ----------------------------------------------------------------
             try:
-                _setup = getattr(container, "_setup", None)
-                if _setup:
-                    _setup(options=options)
-            except AttributeError as error:
+                container._setup(options=options)
+            except Exception as error:
                 logger.debug(
                     "Running `_setup` on {0}: {1}".format(self, error))
 
@@ -1607,14 +1605,10 @@ class SpyderDockablePlugin(SpyderPluginV2):
         widget.set_icon(self.get_icon())
         widget.set_name(self.NAME)
 
-        # TODO: Streamline this by moving to postvisible setup
         # Render all toolbars as a final separate step on the main window
         # in case some plugins want to extend a toolbar. Since the rendering
         # can only be done once!
-        widget._main_toolbar._render()
-        widget._corner_toolbar._render()
-        for __, toolbar in widget._auxiliary_toolbars.items():
-            toolbar._render()
+        widget.render_toolbars()
 
         # Default Signals
         # --------------------------------------------------------------------

--- a/spyder/api/plugins.py
+++ b/spyder/api/plugins.py
@@ -24,6 +24,7 @@ There are two types of plugins available:
 # Standard library imports
 from collections import OrderedDict
 import inspect
+import logging
 import os
 
 # Third party imports
@@ -51,6 +52,7 @@ from spyder.utils.qthelpers import create_action
 
 # Localization
 _ = get_translation('spyder')
+logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -815,9 +817,12 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderOptionMixin):
             # Widget setup
             # ----------------------------------------------------------------
             try:
-                container._setup(options=options)
-            except AttributeError:
-                pass
+                _setup = getattr(container, "_setup", None)
+                if _setup:
+                    _setup(options=options)
+            except AttributeError as error:
+                logger.debug(
+                    "Running `_setup` on {0}: {1}".format(self, error))
 
             if isinstance(container, SpyderWidgetMixin):
                 container.setup(options=options)
@@ -1606,10 +1611,10 @@ class SpyderDockablePlugin(SpyderPluginV2):
         # Render all toolbars as a final separate step on the main window
         # in case some plugins want to extend a toolbar. Since the rendering
         # can only be done once!
-        widget.get_main_toolbar()._render()
-        for __, toolbars in widget._aux_toolbars.items():
-            for toolbar in toolbars:
-                toolbar._render()
+        widget._main_toolbar._render()
+        widget._corner_toolbar._render()
+        for __, toolbar in widget._auxiliary_toolbars.items():
+            toolbar._render()
 
         # Default Signals
         # --------------------------------------------------------------------

--- a/spyder/api/widgets/auxiliary_widgets.py
+++ b/spyder/api/widgets/auxiliary_widgets.py
@@ -67,22 +67,23 @@ class MainCornerWidget(QWidget):
         self._layout.setContentsMargins(spacing, 0, spacing, spacing)
         self.setContentsMargins(0, 0, 0, 0)
 
-    def add_widget(self, name, widget):
+    def add_widget(self, widget_id, widget):
         """
         Add a widget to the left of the last widget added to the corner.
         """
-        if name in self._widgets:
+        if widget_id in self._widgets:
             raise SpyderAPIError(
                 'Wigdet with name "{}" already added. Current names are: {}'
-                ''.format(name, list(self._widgets.keys()))
+                ''.format(widget_id, list(self._widgets.keys()))
             )
 
-        self._widgets[name] = widget
+        widget.ID = widget_id
+        self._widgets[widget_id] = widget
         self._layout.insertWidget(0, widget)
 
-    def get_widget(self, name):
+    def get_widget(self, widget_id):
         """
-        Return a widget by name.
+        Return a widget by unique id..
         """
-        if name in self._widgets:
-            return self._widgets[name]
+        if widget_id in self._widgets:
+            return self._widgets[widget_id]

--- a/spyder/api/widgets/toolbars.py
+++ b/spyder/api/widgets/toolbars.py
@@ -139,10 +139,13 @@ class MainWidgetToolbar(SpyderToolBar):
     to their interface.
     """
 
-    def __init__(self, parent=None, title=None, location=ToolBarLocation.Top,
-                 corner_widget=None):
+    ID = None
+    """
+    Unique string toolbar identifier.
+    """
+
+    def __init__(self, parent=None, title=None):
         super().__init__(parent, title=title or '')
-        self._set_corner_widget(corner_widget)
         self._icon_size = QSize(16, 16)
 
         # Setup
@@ -150,51 +153,15 @@ class MainWidgetToolbar(SpyderToolBar):
             str(uuid.uuid4())[:8]))
         self.setFloatable(False)
         self.setMovable(False)
-        self.setAllowedAreas(location)
         self.setContextMenuPolicy(Qt.PreventContextMenu)
         self.setIconSize(self._icon_size)
+
         self._setup_style()
         self._filter = ToolTipFilter()
 
     def set_icon_size(self, icon_size):
         self._icon_size = icon_size
         self.setIconSize(icon_size)
-
-    def addWidget(self, widget):
-        """
-        Override Qt method.
-
-        Take into account the existence of a corner widget when adding a new
-        widget to this toolbar.
-        """
-        if self._corner_widget is not None:
-            super().insertWidget(self._corner_separator_action, widget)
-        else:
-            super().addWidget(widget)
-
-    def create_toolbar_stretcher(self):
-        """
-        Create a stretcher widget to be used in a Qt toolbar.
-        """
-        stretcher = QWidget()
-        stretcher.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        return stretcher
-
-    def _set_corner_widget(self, corner_widget):
-        """
-        Add the given corner widget to this toolbar.
-
-        A stretcher widget is added before the corner widget so that
-        its position is forced to the right side of the toolbar when the
-        toolbar is resized.
-        """
-        self._corner_widget = corner_widget
-        if corner_widget is not None:
-            stretcher = self.create_toolbar_stretcher()
-            self._corner_separator = super().addWidget(stretcher)
-            super().addWidget(self._corner_widget)
-        else:
-            self._corner_separator = None
 
     def _render(self):
         """
@@ -217,15 +184,10 @@ class MainWidgetToolbar(SpyderToolBar):
         for (sec, item) in sec_items:
             if isinstance(item, QAction):
                 add_method = super().addAction
-                insert_method = super().insertAction
             else:
                 add_method = super().addWidget
-                insert_method = super().insertWidget
 
-            if self._corner_widget is not None:
-                insert_method(self._corner_separator, item)
-            else:
-                add_method(item)
+            add_method(item)
 
             if isinstance(item, QAction):
                 widget = self.widgetForAction(item)

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2832,7 +2832,8 @@ class MainWindow(QMainWindow):
                 # Old API
                 action = plugin._toggle_view_action
 
-            action.setChecked(plugin.dockwidget.isVisible())
+            if action:
+                action.setChecked(plugin.dockwidget.isVisible())
 
             try:
                 name = plugin.CONF_SECTION

--- a/spyder/plugins/findinfiles/widgets.py
+++ b/spyder/plugins/findinfiles/widgets.py
@@ -59,6 +59,9 @@ EXTERNAL_PATHS = 7
 MAX_PATH_LENGTH = 60
 MAX_PATH_HISTORY = 15
 
+# These additional pixels account for operating system spacing differences
+EXTRA_BUTTON_PADDING = 10
+
 
 class FindInFilesWidgetActions:
     # Triggers
@@ -813,6 +816,7 @@ class FindInFilesWidget(PluginMainWidget):
         'supported_encodings': ("utf-8", "iso-8859-1", "cp1252"),
         'text_color': MAIN_TEXT_COLOR,
     }
+    ENABLE_SPINNER = True
     REGEX_INVALID = "background-color:rgb(255, 80, 80);"
     REGEX_ERROR = _("Regular expression error")
 
@@ -1045,9 +1049,11 @@ class FindInFilesWidget(PluginMainWidget):
         if widget:
             w1 = widget.fontMetrics().width(stop_text)
             w2 = widget.fontMetrics().width(search_text)
+
             # Ensure the search/stop button has the same size independent on
             # the length of the words.
-            width = self.get_options_menu_button().width() + max([w1, w2]) + 2
+            width = (self.get_options_menu_button().width() + max([w1, w2])
+                     + EXTRA_BUTTON_PADDING)
             widget.setMinimumWidth(width)
 
         if self.extras_toolbar and self.more_options_action:

--- a/spyder/plugins/findinfiles/widgets.py
+++ b/spyder/plugins/findinfiles/widgets.py
@@ -895,9 +895,6 @@ class FindInFilesWidget(PluginMainWidget):
 
         fm = self.search_label.fontMetrics()
         base_size = int(fm.width(_('Location:')) * 1.2)
-        self.search_text_edit.setMinimumWidth(base_size * 6)
-        self.exclude_pattern_edit.setMinimumWidth(base_size * 6)
-        self.path_selection_combo.setMinimumWidth(base_size * 6)
         self.search_label.setMinimumWidth(base_size)
         self.search_in_label.setMinimumWidth(base_size)
         self.exclude_label.setMinimumWidth(base_size)
@@ -927,6 +924,7 @@ class FindInFilesWidget(PluginMainWidget):
             self.sig_max_results_reached)
         self.result_browser.sig_max_results_reached.connect(
             self._stop_and_reset_thread)
+        self.search_text_edit.sig_resized.connect(self._update_size)
 
     # --- PluginMainWidget API
     # ------------------------------------------------------------------------
@@ -1032,21 +1030,35 @@ class FindInFilesWidget(PluginMainWidget):
         )
 
     def update_actions(self):
+        stop_text = _('Stop')
+        search_text = _('Search')
         if self.running:
-            icon_text = _('Stop')
+            icon_text = stop_text
             icon = self.create_icon('stop')
         else:
-            icon_text = _('Search')
+            icon_text = search_text
             icon = self.create_icon('find')
 
         self.find_action.setIconText(icon_text)
         self.find_action.setIcon(icon)
+        widget = self.get_main_toolbar().widgetForAction(self.find_action)
+        if widget:
+            w1 = widget.fontMetrics().width(stop_text)
+            w2 = widget.fontMetrics().width(search_text)
+            # Ensure the search/stop button has the same size independent on
+            # the length of the words.
+            width = self.get_options_menu_button().width() + max([w1, w2]) + 2
+            widget.setMinimumWidth(width)
+
         if self.extras_toolbar and self.more_options_action:
             self.extras_toolbar.setVisible(
                 self.more_options_action.isChecked())
 
     def on_option_update(self, option, value):
         if option == 'more_options':
+            self.exclude_pattern_edit.setMinimumWidth(
+                self.search_text_edit.width())
+
             if value:
                 icon = self.create_icon('options_less')
                 tip = _('Hide advanced options')
@@ -1066,6 +1078,9 @@ class FindInFilesWidget(PluginMainWidget):
 
     # --- Private API
     # ------------------------------------------------------------------------
+    def _update_size(self, size, old_size):
+        self.exclude_pattern_edit.setMinimumWidth(size.width())
+
     def _get_options(self):
         """
         Get search options.

--- a/spyder/plugins/help/widgets.py
+++ b/spyder/plugins/help/widgets.py
@@ -278,6 +278,7 @@ class HelpWidget(PluginMainWidget):
         # Shortcut CONF
         'console_shortcut': 'Ctrl+I',
     }
+    ENABLE_SPINNER = True
 
     # Signals
     sig_item_found = Signal()

--- a/spyder/plugins/onlinehelp/widgets.py
+++ b/spyder/plugins/onlinehelp/widgets.py
@@ -131,6 +131,7 @@ class PydocBrowser(PluginMainWidget):
         'max_history_entries': 10,
         'zoom_factor': 1,
     }
+    ENABLE_SPINNER = True
 
     # --- Signals
     # ------------------------------------------------------------------------

--- a/spyder/plugins/profiler/widgets/main_widget.py
+++ b/spyder/plugins/profiler/widgets/main_widget.py
@@ -125,6 +125,7 @@ class ProfilerWidget(PluginMainWidget):
     DEFAULT_OPTIONS = {
         'text_color': MAIN_TEXT_COLOR,
     }
+    ENABLE_SPINNER = True
     DATAPATH = get_conf_path('profiler.results')
 
     # --- Signals

--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -19,7 +19,7 @@ import os.path as osp
 
 # Third party imports
 import qdarkstyle
-from qtpy.QtCore import QEvent, Qt, QTimer, QUrl, Signal
+from qtpy.QtCore import QEvent, Qt, QTimer, QUrl, Signal, QSize
 from qtpy.QtGui import QFont
 from qtpy.QtWidgets import (QComboBox, QCompleter, QLineEdit,
                             QSizePolicy, QToolTip)
@@ -35,6 +35,18 @@ class BaseComboBox(QComboBox):
     """Editable combo box base class"""
     valid = Signal(bool, bool)
     sig_tab_pressed = Signal(bool)
+
+    sig_resized = Signal(QSize, QSize)
+    """
+    This signal is emitted to inform the widget has been resized.
+
+    Parameters
+    ----------
+    size: QSize
+        The new size of the widget.
+    old_size: QSize
+        The previous size of the widget.
+    """
 
     def __init__(self, parent):
         QComboBox.__init__(self, parent)
@@ -67,6 +79,13 @@ class BaseComboBox(QComboBox):
             self.hide_completer()
         else:
             QComboBox.keyPressEvent(self, event)
+
+    def resizeEvent(self, event):
+        """
+        Emit a resize signal for widgets that need to adapt its size.
+        """
+        super().resizeEvent(event)
+        self.sig_resized.emit(event.size(), event.oldSize())
 
     # --- Own methods
     def is_valid(self, qstr):
@@ -124,6 +143,7 @@ class BaseComboBox(QComboBox):
 
 class PatternComboBox(BaseComboBox):
     """Search pattern combo box"""
+
     def __init__(self, parent, items=None, tip=None,
                  adjust_to_minimum=True):
         BaseComboBox.__init__(self, parent)

--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -12,6 +12,7 @@
 # pylint: disable=R0201
 
 # Standard library imports
+import os
 import os.path as osp
 import sys
 
@@ -256,15 +257,27 @@ class BaseTabs(QTabWidget):
         self.corner_widgets = {}
         self.menu_use_tooltips = menu_use_tooltips
 
-        self.setStyleSheet("QTabWidget::tab-bar {"
-                           "alignment: left;}")
-
         if menu is None:
             self.menu = QMenu(self)
             if actions:
                 add_actions(self.menu, actions)
         else:
             self.menu = menu
+
+        # QTabBar forces the corner widgets to be smaller than they should on
+        # some plugins, like History. The top margin added allows the
+        # toolbuttons to expand to their normal size.
+        # See: spyder-ide/spyder#13600
+        top_margin = 9 if os.name == "nt" else 5
+        self.setStyleSheet(
+            f"""
+            QTabBar::tab {{
+                margin-top: {top_margin}px;
+            }}
+            QTabWidget::tab-bar {{
+                alignment: left;
+            }}
+            """)
 
         # Corner widgets
         if corner_widgets is None:

--- a/spyder/widgets/waitingspinner.py
+++ b/spyder/widgets/waitingspinner.py
@@ -73,8 +73,12 @@ class QWaitingSpinner(QWidget):
 
         self.setWindowModality(modality)
         self.setAttribute(Qt.WA_TranslucentBackground)
+        self.show()
 
     def paintEvent(self, QPaintEvent):
+        if not self._isSpinning:
+            return
+
         self.updatePosition()
         painter = QPainter(self)
         painter.fillRect(self.rect(), Qt.transparent)
@@ -112,7 +116,6 @@ class QWaitingSpinner(QWidget):
     def start(self):
         self.updatePosition()
         self._isSpinning = True
-        self.show()
 
         if self.parentWidget and self._disableParentWhenSpinning:
             self.parentWidget().setEnabled(False)
@@ -121,9 +124,10 @@ class QWaitingSpinner(QWidget):
             self._timer.start()
             self._currentCounter = 0
 
+        self.show()
+
     def stop(self):
         self._isSpinning = False
-        self.hide()
 
         if self.parentWidget() and self._disableParentWhenSpinning:
             self.parentWidget().setEnabled(True)
@@ -131,6 +135,9 @@ class QWaitingSpinner(QWidget):
         if self._timer.isActive():
             self._timer.stop()
             self._currentCounter = 0
+
+        self.show()
+        self.repaint()
 
     def setNumberOfLines(self, lines):
         self._numberOfLines = lines


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

- The code was simplified so instead of using a QMainWindow and QToolBars added to the ToolBar Areas, we use a QWidget and QToolBars added to QBoxLayouts. This way we have full control of the location, and stretches which fix the issue.
- The API itself remained unchanged, the changes were internal to the `PluginMainWidget`.
- This is how Help and Find in Files look (which also had the similar issue found in Pylint)
- Included an extra fix on the find in files button, to make it have the same size, regardless of Search/Stop text.
- The spinner widget is "permanently visible"  so that it takes width and there are no jumps when it starts spinning (and is actually displayed).
- Added a fix for find in files to keep the search combobox and exclude combobox the same size.
<img width="710" alt="Screen Shot 2020-08-21 at 20 10 14" src="https://user-images.githubusercontent.com/3627835/90945408-5835e180-e3ea-11ea-96c3-cd13ad5a9ef4.png">



## Help
<img width="707" alt="Screen Shot 2020-08-21 at 20 03 16" src="https://user-images.githubusercontent.com/3627835/90945329-d645b880-e3e9-11ea-9f4a-a4490aef7625.png">

# Find
<img width="706" alt="Screen Shot 2020-08-21 at 20 03 23" src="https://user-images.githubusercontent.com/3627835/90945331-d8a81280-e3e9-11ea-8fc5-a1444ddd4d3e.png">
<img width="707" alt="Screen Shot 2020-08-21 at 20 03 29" src="https://user-images.githubusercontent.com/3627835/90945333-dba30300-e3e9-11ea-97fc-e8d8b5f6cda7.png">


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
