### PR TITLE
PR: Fix some issues with the PyLS subrepo

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -40,12 +40,16 @@ else
 
     # Remove packages we have subrepos for
     pip uninstall spyder-kernels -q -y
+    pip uninstall python-language-server -q -y
 fi
 
-# Install python-language-server from our subrepo
-pushd external-deps/python-language-server
-pip install --no-deps -q -e .
-popd
+# This is necessary only for Windows (don't know why).
+if [ "$OS" = "win" ]; then
+    # Install python-language-server from our subrepo
+    pushd external-deps/python-language-server
+    pip install --no-deps -q -e .
+    popd
+fi
 
 # To check our manifest
 pip install check-manifest

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -172,7 +172,7 @@ subprocess.check_output(
      '--no-deps',
      '--install-dir',
      pyls_installation_dir],
-    env={'PYTHONPATH': pyls_installation_dir},
+    env={**os.environ, **{'PYTHONPATH': pyls_installation_dir}},
     cwd=pyls_submodule
 )
 

--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,7 @@ NOTE: DO NOT add fixtures here. It could generate problems with
 import os
 import os.path as osp
 import shutil
+import subprocess
 import sys
 import warnings
 
@@ -29,7 +30,7 @@ os.environ['SPYDER_PYTEST'] = 'True'
 
 # Add external dependencies subrepo paths to sys.path
 # NOTE: Please don't move this from here!
-HERE = osp.dirname(os.path.realpath(__file__))
+HERE = osp.dirname(osp.abspath(__file__))
 DEPS_PATH = osp.join(HERE, 'external-deps')
 i = 0
 for path in os.listdir(DEPS_PATH):
@@ -37,6 +38,33 @@ for path in os.listdir(DEPS_PATH):
     sys.path.insert(i, external_dep_path)
     i += 1
 
+# Install PyLS locally. This fails on Windows and our CIs
+if os.name != 'nt' or os.name == 'nt' and not bool(os.environ.get('CI')):
+    # Create an egg-info folder to declare the PyLS subrepo entry points.
+    pyls_submodule = osp.join(DEPS_PATH, 'python-language-server')
+    pyls_installation_dir = osp.join(pyls_submodule, '.installation-dir')
+    pyls_installation_egg = osp.join(
+        pyls_submodule, 'python_language_server.egg-info')
+
+    # Remove previous local PyLS installation.
+    if osp.exists(pyls_installation_dir) or osp.exists(pyls_installation_egg):
+        shutil.rmtree(pyls_installation_dir, ignore_errors=True)
+        shutil.rmtree(pyls_installation_egg, ignore_errors=True)
+
+    subprocess.check_output(
+        [sys.executable,
+         '-W',
+         'ignore',
+         'setup.py',
+         'develop',
+         '--no-deps',
+         '--install-dir',
+        pyls_installation_dir],
+        env={**os.environ, **{'PYTHONPATH': pyls_installation_dir}},
+        cwd=pyls_submodule
+    )
+
+# Pytest adjustments
 import pytest
 
 # Remove temp conf_dir before starting the tests

--- a/conftest.py
+++ b/conftest.py
@@ -59,7 +59,7 @@ if os.name != 'nt' or os.name == 'nt' and not bool(os.environ.get('CI')):
          'develop',
          '--no-deps',
          '--install-dir',
-        pyls_installation_dir],
+         pyls_installation_dir],
         env={**os.environ, **{'PYTHONPATH': pyls_installation_dir}},
         cwd=pyls_submodule
     )

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -257,9 +257,11 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         self.server = QProcess(self)
         env = self.server.processEnvironment()
 
-        if DEV:
-            # Use local pyls instead of site-packages one
-            env.insert('PYTHONPATH', os.pathsep.join(sys.path)[:])
+        # Use local PyLS instead of site-packages one.
+        if DEV or running_under_pytest():
+            running_in_ci = bool(os.environ.get('CI'))
+            if os.name != 'nt' or os.name == 'nt' and not running_in_ci:
+                env.insert('PYTHONPATH', os.pathsep.join(sys.path)[:])
 
         # Adjustments for the Python language server.
         if self.language == 'python':

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -272,6 +272,13 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
             cwd = osp.join(get_conf_path(), 'lsp_paths', 'cwd')
             if not osp.exists(cwd):
                 os.makedirs(cwd)
+
+            # On Windows, some modules (notably Matplotlib)
+            # cause exceptions if they cannot get the user home.
+            # So, we need to pass the USERPROFILE env variable to
+            # the PyLS.
+            if os.name == "nt" and "USERPROFILE" in os.environ:
+                env.insert("USERPROFILE", os.environ["USERPROFILE"])
         else:
             # There's no need to define a cwd for other servers.
             cwd = None


### PR DESCRIPTION
* This uses the PyLS subrepo to run our tests, which was missing from PR #13621.
* This also fixes starting Spyder from `bootstrap.py` on Windows after PR #13621.