### PR TITLE
PR: Add a minimum width to the help pane

### DIFF
--- a/spyder/plugins/help/widgets.py
+++ b/spyder/plugins/help/widgets.py
@@ -321,6 +321,7 @@ class HelpWidget(PluginMainWidget):
         self.object_edit = QLineEdit(self)
 
         # Setup
+        self.setMinimumWidth(400)
         self.object_edit.setReadOnly(True)
         self.object_combo.setMaxCount(self.get_option('max_history_entries'))
         self.object_combo.setItemText(0, '')


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes



<!--- Explain what you've done and why --->

This PR adds a minimum width to the `Help` pane of `400px`.

This fixes the reported issue.
![image](https://user-images.githubusercontent.com/3627835/91775401-941e3300-ebb0-11ea-93af-dd9ea617a782.png)

However:
- Zooming in will get to a point where this fix will not work. Setting a minimum width cannot overcome this issue.
![image](https://user-images.githubusercontent.com/3627835/91775467-b6b04c00-ebb0-11ea-978e-206076e04d76.png)

- There may be modules that have very long imports (79 or higher columns) which will continue to display the issue. Setting a minimum width cannot overcome this issue.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13664


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
