### PR TITLE
PR: Restore submenu icon on internal console settings

### DIFF
--- a/spyder/api/widgets/__init__.py
+++ b/spyder/api/widgets/__init__.py
@@ -714,16 +714,18 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolBarMixin):
 
         return toolbar
 
-    def create_menu(self, menu_id, title=''):
+    def create_menu(self, menu_id, title='', icon=None):
         """
         Override SpyderMenuMixin method to use a different menu class.
 
         Parameters
         ----------
-        toolbar_id: str
+        menu_id: str
             Unique toolbar string identifier.
         title: str
             Toolbar localized title.
+        icon: QIcon or None
+            Icon to use for the menu.
 
         Returns
         -------
@@ -741,6 +743,11 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolBarMixin):
 
         menu = MainWidgetMenu(parent=self, title=title)
         menu.ID = menu_id
+
+        if icon is not None:
+            menu.menuAction().setIconVisibleInMenu(True)
+            menu.setIcon(icon)
+
         self._menus[menu_id] = menu
         return menu
 

--- a/spyder/api/widgets/mixins.py
+++ b/spyder/api/widgets/mixins.py
@@ -356,9 +356,9 @@ class SpyderMenuMixin:
         ----------
         name: str
             Unique str identifier.
-        text: str
+        text: str or None
             Localized text string.
-        icon: QIcon,
+        icon: QIcon or None
             Icon to use for the menu.
 
         Return: QMenu

--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -233,6 +233,7 @@ class ConsoleWidget(PluginMainWidget):
         internal_settings_menu = self.create_menu(
             ConsoleWidgetMenus.InternalSettings,
             _('Internal console settings'),
+            icon=self.create_icon('tooloptions'),
         )
         for item in [buffer_action, wrap_action, codecompletion_action,
                      exteditor_action]:
@@ -272,8 +273,6 @@ class ConsoleWidget(PluginMainWidget):
             self.shell.set_external_editor(value, '')
 
     def update_actions(self):
-        # This method is a required part of the PluginMainWidget API. On this
-        # widget it is not currently used.
         pass
 
     def get_focus_widget(self):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

I think the [Apple HIC guidelines](https://developer.apple.com/design/human-interface-guidelines/) do not recommend having Icons in SubMenus (they generally also advise against having submenus). So that is why this PR needs to override the default  settings Qt uses for Mac with:

`internal_settings_menu.menuAction().setIconVisibleInMenu(True)`

<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13683

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @goanpeca 

<!--- Thanks for your help making Spyder better for everyone! --->
