### PR TITLE
PR: Fix 2 issues related to PyLS on Windows

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -163,6 +163,8 @@ if osp.exists(pyls_installation_dir) or osp.exists(pyls_installation_egg):
 
 # Install PyLS locally
 print("*. Installing PyLS locally")
+pyls_env = os.environ.copy()
+pyls_env['PYTHONPATH'] = pyls_installation_dir
 subprocess.check_output(
     [sys.executable,
      '-W',
@@ -172,7 +174,7 @@ subprocess.check_output(
      '--no-deps',
      '--install-dir',
      pyls_installation_dir],
-    env={'PYTHONPATH': pyls_installation_dir},
+    env=pyls_env,
     cwd=pyls_submodule
 )
 

--- a/spyder/plugins/completion/languageserver/client.py
+++ b/spyder/plugins/completion/languageserver/client.py
@@ -270,6 +270,13 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
             cwd = osp.join(get_conf_path(), 'lsp_paths', 'cwd')
             if not osp.exists(cwd):
                 os.makedirs(cwd)
+
+            # On Windows, some modules (notably matplotlib)
+            # causes exception if they cannot get the user home.
+            # So, the USERPROFILE env variable is passed to PyLS.
+            # See https://docs.python.org/3/library/os.path.html#os.path.expanduser
+            if os.name == "nt" and "USERPROFILE" in os.environ:
+                env.insert("USERPROFILE", os.environ["USERPROFILE"])
         else:
             # There's no need to define a cwd for other servers.
             cwd = None


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Probably caused by #13440.

#### Spyder unable to start

I don't know what is the real problem, but I fix it by passing the boostrap.py
environment variables to the PyLS setup.py.

Here is the error printed by the interpreter, with the traceback.
```
Fatal Python error: _Py_HashRandomization_Init: failed to get random numbers to initialize Python
Python runtime state: preinitialized

Traceback (most recent call last):
  File "bootstrap.py", line 166, in <module>
    subprocess.check_output(
  File "C:\Program Files\Python38\lib\subprocess.py", line 411, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "C:\Program Files\Python38\lib\subprocess.py", line 512, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['C:\\Program Files\\Python38\\python.exe', '-W', 'ignore', 'setup.py', 'develop', '--no-deps', '--install-dir', 'C:\\Users\\User\\spyder\\external-deps\\python-language-server\\.installation-dir']' returned non-zero exit status 1.
```

#### PyLS unable to start

After Spyder loading, PyLS raises an exception that make it unavailable.
Analyzing the issue, I discover that a  `RuntimeError: Can't determine home directory` is raised by [os.path.expanduser](https://docs.python.org/3/library/os.path.html#os.path.expanduser) because the USERPROFILE env variable is not set (the call to that function is done by matplotlib). So I pass that variable to the PyLS process.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

None.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: trollodel

<!--- Thanks for your help making Spyder better for everyone! --->
