### PR TITLE
PR: Correctly import IPythonInputSplitter for IPython < 7.0

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/debugging.py
+++ b/spyder/plugins/ipythonconsole/widgets/debugging.py
@@ -9,19 +9,21 @@ Widget that handles communications between a console in debugging
 mode and Spyder
 """
 
+from distutils.version import LooseVersion
 import re
 import pdb
 
+from IPython import __version__ as ipy_version
 from IPython.core.history import HistoryManager
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
 
 from spyder.config.base import get_conf_path
 from spyder.config.manager import CONF
-from spyder.py3compat import PY2
-if not PY2:
-    from IPython.core.inputtransformer2 import TransformerManager
-else:
+
+if LooseVersion(ipy_version) < LooseVersion('7.0.0'):
     from IPython.core.inputsplitter import IPythonInputSplitter
+else:
+    from IPython.core.inputtransformer2 import TransformerManager
 
 
 class PdbHistory(HistoryManager):
@@ -277,7 +279,7 @@ class DebuggingWidget(RichJupyterWidget):
         """
         if source and source[0] == '!':
             source = source[1:]
-        if PY2:
+        if LooseVersion(ipy_version) < LooseVersion('7.0.0'):
             tm = IPythonInputSplitter()
         else:
             tm = TransformerManager()


### PR DESCRIPTION
Fixes #13719.