### PR TITLE
PR: Fix create folder in Projects

### DIFF
--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -440,7 +440,7 @@ class DirView(QTreeView):
             # so it can be added in that folder and not in the rootpath
             # See spyder-ide/spyder#13444
             # See spyder-ide/spyder#13722
-            
+
             current_index = self.currentIndex()
             root_path = self.get_dirname(current_index)
 

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -440,6 +440,7 @@ class DirView(QTreeView):
             # so it can be added in that folder and not in the rootpath
             # See spyder-ide/spyder#13444
             # See spyder-ide/spyder#13722
+            
             current_index = self.currentIndex()
             root_path = self.get_dirname(current_index)
 

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -439,6 +439,7 @@ class DirView(QTreeView):
             # Verify if the user is trying to add something new inside a folder
             # so it can be added in that folder and not in the rootpath
             # See spyder-ide/spyder#13444
+            # See spyder-ide/spyder#13722
             current_index = self.currentIndex()
             root_path = self.get_dirname(current_index)
 

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -439,17 +439,8 @@ class DirView(QTreeView):
             # Verify if the user is trying to add something new inside a folder
             # so it can be added in that folder and not in the rootpath
             # See spyder-ide/spyder#13444
-            level_list = []
             current_index = self.currentIndex()
-            if current_index.isValid():
-                level_list.append(current_index.data())
-
-            while current_index.isValid():
-                current_index = current_index.parent()
-                if current_index.data() is not None:
-                    level_list.insert(0, current_index.data())
-
-            root_path = osp.join(*level_list)
+            root_path = self.get_dirname(current_index)
 
         new_file_act = create_action(self, _("File..."),
                                      icon=ima.icon('TextFileIcon'),


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

This PR fixes an error that prevented creating a new folder in project explorer. The cause of the problem was the wrong form of the path generated by the script that looked like this:
`OS (C:)\\Users\\Admin\\test_project\\some_module`
This form caused `os.mkdir()` throws an error. 
Now, corrected script produces valid paths like this: `C:\\Users\\Admin\\test_project\\some_module`

 
<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13722


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
