### PR TITLE
PR: Fixes to Help plugin according to UX review

### DIFF
--- a/spyder/plugins/help/plugin.py
+++ b/spyder/plugins/help/plugin.py
@@ -146,6 +146,13 @@ class Help(SpyderPluginWidget):
         layout_edit.addWidget(self.locked_button)
         self._update_lock_icon()
 
+        # Home Button
+        self.home_button = create_toolbutton(self,
+                                             triggered=self.show_intro_message,
+                                             icon=ima.icon('home'),
+                                             tip=_("Home"))
+        layout_edit.addWidget(self.home_button)
+
         # Option menu
         layout_edit.addWidget(self.options_button)
 

--- a/spyder/plugins/help/plugin.py
+++ b/spyder/plugins/help/plugin.py
@@ -140,18 +140,18 @@ class Help(SpyderPluginWidget):
         auto_import_state = self.get_option('automatic_import')
         self.auto_import_action.setChecked(auto_import_state)
 
-        # Lock checkbox
-        self.locked_button = create_toolbutton(self,
-                                               triggered=self.toggle_locked)
-        layout_edit.addWidget(self.locked_button)
-        self._update_lock_icon()
-
         # Home Button
         self.home_button = create_toolbutton(self,
                                              triggered=self.show_intro_message,
                                              icon=ima.icon('home'),
                                              tip=_("Home"))
         layout_edit.addWidget(self.home_button)
+        
+        # Lock checkbox
+        self.locked_button = create_toolbutton(self,
+                                               triggered=self.toggle_locked)
+        layout_edit.addWidget(self.locked_button)
+        self._update_lock_icon()
 
         # Option menu
         layout_edit.addWidget(self.options_button)

--- a/spyder/plugins/help/utils/static/dark_css/default.css
+++ b/spyder/plugins/help/utils/static/dark_css/default.css
@@ -345,16 +345,16 @@ div.admonition p.admonition-title {
     margin-top: 0;
     margin-bottom: 0;
     font-size: 110%;
-    color: rgb(255,255,255);
+    color: white;
 }
 
 .panel-body {
     padding: 15px;
-    background-color: #3498DB;
+    background-color: #19232D;
 }
 
 .panel-usage {
-    border-color: #2fa4e7;
+    border-color: #3E6691;
     margin-top: 15px;
     width: 60%;
     margin-left: auto;
@@ -362,20 +362,20 @@ div.admonition p.admonition-title {
 }
 
 .panel-usage > .panel-heading {
-    color: #19232D;
-    background-color: #444;
-    border-color: #3498DB;
+    color: white;
+    background-color: #3E6691;
+    border-color: #19232D;
 }
 
 .panel-usage > .panel-body > center > a {
-    color: white;
+    color: #00bc8d;
 }
 
 .panel-usage > .panel-body > br {
     display: block;
     margin: 12px 0;
     content: "";
-    background-color: #3498DB;
+    background-color: #19232D;
 }
 
 .hr {

--- a/spyder/plugins/help/utils/templates/usage.html
+++ b/spyder/plugins/help/utils/templates/usage.html
@@ -29,7 +29,7 @@
       <br>
       <center>
         {{tutorial_message}}
-        <a href="spy://tutorial" style="text-decoration: underline;">{{tutorial}}</a>
+        <a href="spy://tutorial">{{tutorial}}</a>
       </center>
     </div>
   </div>


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

- [x]  Add Home button to for getting back the home screen of the pane and being able to open the tutorial. back
- [x] Change background color for the help pane home screen to the same blue in the pane
- [x] Change title background to same blue in the titles of the docstrings
- [x]  In the home screen links should be green not underlined.

![Screenshot 2020-09-09 at 9 45 37 PM](https://user-images.githubusercontent.com/18587879/92675796-d4369180-f2e5-11ea-9325-ce61fa23f13a.png)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13241 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
juanis2112

<!--- Thanks for your help making Spyder better for everyone! --->
