### PR TITLE
PR: Pin python-jsonrpc-server to a working version in our CIs (for now)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -38,6 +38,9 @@ else
     # Install qtconsole from Github
     pip install git+https://github.com/jupyter/qtconsole.git
 
+    # Pin python-jsonrpc-server to a working version (for now)
+    pip install python-jsonrpc-server==0.3.4
+
     # Remove packages we have subrepos for
     pip uninstall spyder-kernels -q -y
     pip uninstall python-language-server -q -y


### PR DESCRIPTION
This is until a new version of python-language-server is released.
