### PR TITLE
PR: Call QGuiApplication.setDesktopFileName to fix generic icon on GNOME/Wayland

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -128,6 +128,7 @@ else:
 #==============================================================================
 from spyder.utils.qthelpers import qapplication
 from spyder.config.base import get_image_path
+from spyder.py3compat import PY3
 MAIN_APP = qapplication()
 
 if PYQT5:
@@ -136,6 +137,10 @@ else:
     APP_ICON = QIcon(get_image_path("spyder.png"))
 
 MAIN_APP.setWindowIcon(APP_ICON)
+
+# Required for correct icon on GNOME/Wayland:
+if hasattr(MAIN_APP, 'setDesktopFileName'):
+    MAIN_APP.setDesktopFileName('spyder3' if PY3 else 'spyder')
 
 #==============================================================================
 # Create splash screen out of MainWindow to reduce perceived startup time.
@@ -170,7 +175,7 @@ from spyder.config.main import OPEN_FILES_PORT
 from spyder.config.utils import IMPORT_EXT, is_anaconda, is_gtk_desktop
 from spyder import dependencies
 from spyder.py3compat import (is_text_string, to_text_string,
-                              PY3, qbytearray_to_str, configparser as cp)
+                              qbytearray_to_str, configparser as cp)
 from spyder.utils import encoding, programs
 from spyder.utils import icon_manager as ima
 from spyder.utils.programs import is_module_installed


### PR DESCRIPTION
Call QGuiApplication.setDesktopFileName to fix generic icon on GNOME/Wayland

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions) **Not applicable**
* [x] Added unit test(s) covering the changes (if testable) **Not testable, as far as I can tell**
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/)) **See #13786.**

See #13786 for screenshots of the icon bug this fixes and for links to further details on the underlying issue.

<!--- Explain what you've done and why --->

This PR adds a call to [QGuiApplication.setDesktopFileName](https://www.riverbankcomputing.com/static/Docs/PyQt5/api/qtgui/qguiapplication.html?highlight=setdesktopfilename#setDesktopFileName), which ensures the correct icon is displayed for the running application on GNOME/Wayland (#13786). Manual testing showed that this change resolved the issue.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13786


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: `musicinmybrain` (Ben Beasley)

<!--- Thanks for your help making Spyder better for everyone! --->
