### PR TITLE
PR: Update contributing guide to install main dependencies from the dev label in our channel

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -38,8 +38,8 @@ else
     # Install qtconsole from Github
     pip install git+https://github.com/jupyter/qtconsole.git
 
-    # Pin python-jsonrpc-server to a working version (for now)
-    pip install python-jsonrpc-server==0.3.4
+    # Pin python-jsonrpc-server and ujson to working versions (for now)
+    pip install python-jsonrpc-server==0.3.4 ujson==1.35
 
     # Remove packages we have subrepos for
     pip uninstall spyder-kernels -q -y

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ $ workon spyder-dev
 After you have created your development environment, you need to install Spyder's necessary dependencies. The easiest way to do so (with Anaconda) is
 
 ```bash
-$ conda install -c spyder-ide --file requirements/conda.txt
+$ conda install -c spyder-ide/label/dev --file requirements/conda.txt
 ```
 
 This installs all Spyder's dependencies into the environment.


### PR DESCRIPTION
- This is to avoid mixing dependencies with `defaults` (and it's done like this already in master).
- I preferred to change the label to `dev` (instead of `alpha`, as in `master`) to not tie the new dependencies we've decided to add to a specific release name.
- This also pins `ujson` to a version that works with our PyLS subrepo.