### PR TITLE
PR: Restore sorting of types and natural sorting

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = 1.x
-	commit = f3916e668944bf777fb3e5a85003910706794718
-	parent = 930f156c27be45400ed0274e0e9c49efb82ecec9
+	commit = e3f33076406a0b7381406d6f7de73c6c20dc552b
+	parent = 0543c3033be41742e5bfe73ca6bf576f7842f646
 	method = merge
 	cmdver = 0.4.1

--- a/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
@@ -252,16 +252,20 @@ def is_editable_type(value):
 #==============================================================================
 # Sorting
 #==============================================================================
-def sort_against(list1, list2, reverse=False, sort_key=lambda x: x[0]):
+def sort_against(list1, list2, reverse=False, sort_key=None):
     """
     Arrange items of list1 in the same order as sorted(list2).
 
     In other words, apply to list1 the permutation which takes list2 
     to sorted(list2, reverse).
     """
+    if sort_key is None:
+        key = lambda x: x[0]
+    else:
+        key = lambda x: sort_key(x[0])
     try:
         return [item for _, item in 
-                sorted(zip(list2, list1), key=sort_key, reverse=reverse)]
+                sorted(zip(list2, list1), key=key, reverse=reverse)]
     except:
         return list1
 

--- a/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
@@ -252,7 +252,7 @@ def is_editable_type(value):
 #==============================================================================
 # Sorting
 #==============================================================================
-def sort_against(list1, list2, reverse=False):
+def sort_against(list1, list2, reverse=False, sort_key=lambda x: x[0]):
     """
     Arrange items of list1 in the same order as sorted(list2).
 
@@ -261,7 +261,7 @@ def sort_against(list1, list2, reverse=False):
     """
     try:
         return [item for _, item in 
-                sorted(zip(list2, list1), key=lambda x: x[0], reverse=reverse)]
+                sorted(zip(list2, list1), key=sort_key, reverse=reverse)]
     except:
         return list1
 

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -72,7 +72,8 @@ def natsort(s):
     Natural sorting, e.g. test3 comes before test100.
     Taken from https://stackoverflow.com/a/16090640/3110740
     """
-    if not isinstance(s, (str, bytes)): return s
+    if not isinstance(s, (str, bytes)):
+        return s
     x = [int(t) if t.isdigit() else t.lower() for t in re.split('([0-9]+)', s)]
     return x
 
@@ -1825,6 +1826,6 @@ def remote_editor_test():
     app.exec_()
 
 
-# if __name__ == "__main__":
-#     editor_test()
-#     remote_editor_test()
+if __name__ == "__main__":
+    editor_test()
+    remote_editor_test()

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -261,16 +261,21 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
         sort_key = natsort if all_string(self.keys) else None
 
         if column == 0:
-            self.sizes = sort_against(self.sizes, self.keys, 
+            print(1, self.keys, self.types, self.sizes)
+            self.sizes = sort_against(self.sizes, self.keys,
                                       reverse=reverse,
                                       sort_key=natsort)
+            print(2, self.keys, self.types, self.sizes)
             self.types = sort_against(self.types, self.keys, 
                                       reverse=reverse,
                                       sort_key=natsort)
+            print(3, self.keys, self.types, self.sizes)
             try:
                 self.keys.sort(reverse=reverse, key=sort_key)
-            except:
+            except Exception as e:
+                print(e)
                 pass
+            print(4, self.keys, self.types, self.sizes)
         elif column == 1:
             self.keys[:self.rows_loaded] = sort_against(self.keys,
                                                         self.types,
@@ -1825,6 +1830,6 @@ def remote_editor_test():
     app.exec_()
 
 
-if __name__ == "__main__":
-    editor_test()
-    remote_editor_test()
+# if __name__ == "__main__":
+#     editor_test()
+#     remote_editor_test()

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -261,21 +261,16 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
         sort_key = natsort if all_string(self.keys) else None
 
         if column == 0:
-            print(1, self.keys, self.types, self.sizes)
             self.sizes = sort_against(self.sizes, self.keys,
                                       reverse=reverse,
                                       sort_key=natsort)
-            print(2, self.keys, self.types, self.sizes)
-            self.types = sort_against(self.types, self.keys, 
+            self.types = sort_against(self.types, self.keys,
                                       reverse=reverse,
                                       sort_key=natsort)
-            print(3, self.keys, self.types, self.sizes)
             try:
                 self.keys.sort(reverse=reverse, key=sort_key)
-            except Exception as e:
-                print(e)
+            except:
                 pass
-            print(4, self.keys, self.types, self.sizes)
         elif column == 1:
             self.keys[:self.rows_loaded] = sort_against(self.keys,
                                                         self.types,

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -72,7 +72,7 @@ def natsort(s):
     Natural sorting, e.g. test3 comes before test100.
     Taken from https://stackoverflow.com/a/16090640/3110740
     """
-    # if not isinstance(s, (str, bytes)): return s
+    if not isinstance(s, (str, bytes)): return s
     x = [int(t) if t.isdigit() else t.lower() for t in re.split('([0-9]+)', s)]
     return x
 
@@ -261,33 +261,37 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
         sort_key = natsort if all_string(self.keys) else None
 
         if column == 0:
-            self.sizes = sort_against(self.sizes, self.keys, reverse)
-            self.types = sort_against(self.types, self.keys, reverse)
+            self.sizes = sort_against(self.sizes, self.keys, 
+                                      reverse=reverse,
+                                      sort_key=natsort)
+            self.types = sort_against(self.types, self.keys, 
+                                      reverse=reverse,
+                                      sort_key=natsort)
             try:
                 self.keys.sort(reverse=reverse, key=sort_key)
             except:
                 pass
         elif column == 1:
-            self.keys[:self.rows_loaded] = sort_against(self.keys, self.types,
-                                                        reverse)
-            self.sizes = sort_against(self.sizes, self.types, reverse)
+            self.keys[:self.rows_loaded] = sort_against(self.keys,
+                                                        self.types,
+                                                        reverse=reverse)
+            self.sizes = sort_against(self.sizes, self.types, reverse=reverse)
             try:
-                self.types.sort(reverse=reverse, key=sort_key)
+                self.types.sort(reverse=reverse)
             except:
                 pass
         elif column == 2:
-            self.keys[:self.rows_loaded] = sort_against(self.keys, self.sizes,
-                                                        reverse)
-            self.types = sort_against(self.types, self.sizes, reverse)
+            self.keys[:self.rows_loaded] = sort_against(self.keys, self.sizes)
+            self.types = sort_against(self.types, self.sizes, reverse=reverse)
             try:
-                self.sizes.sort(reverse=reverse, key=sort_key)
+                self.sizes.sort(reverse=reverse)
             except:
                 pass
         elif column in [3, 4]:
             values = [self._data[key] for key in self.keys]
-            self.keys = sort_against(self.keys, values, reverse)
-            self.sizes = sort_against(self.sizes, values, reverse)
-            self.types = sort_against(self.types, values, reverse)
+            self.keys = sort_against(self.keys, values, reverse=reverse)
+            self.sizes = sort_against(self.sizes, values, reverse=reverse)
+            self.types = sort_against(self.types, values, reverse=reverse)
         self.beginResetModel()
         self.endResetModel()
 
@@ -1694,7 +1698,11 @@ class CollectionsCustomSortFilterProxy(CustomSortFilterProxy):
             return True
 
     def lessThan(self, left, right):
-        """Implements ordering in a natural way, as a human would sort."""
+        """
+        Implements ordering in a natural way, as a human would sort.
+        This functions enables sorting of the main variable editor table,
+        which does not rely on 'self.sort()'.
+        """
         leftData = self.sourceModel().data(left)
         rightData = self.sourceModel().data(right)
         if isinstance(leftData, str) and isinstance(rightData, str):

--- a/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
@@ -895,9 +895,6 @@ def test_dicts_natural_sorting_mixed_types(qtbot):
 
     # now sort for sizes
     cm.sort(2)
-    print(cm.keys)
-    print(cm.types)
-    print(cm.sizes)
     assert data_table(cm, 4, 3) == [['DSeries', 'kDict', 'List', 'aStr'],
                                     ['Series', 'dict', 'list', 'str'],
                                     ['(0,)', 2, 3, str_size]]

--- a/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
@@ -846,7 +846,6 @@ def test_dicts_natural_sorting(qtbot):
         'GUI sorting fail'
 
 
-
 def test_dicts_natural_sorting_mixed_types(qtbot):
     """
     Test that natural sorting actually does what it should do.
@@ -855,8 +854,8 @@ def test_dicts_natural_sorting_mixed_types(qtbot):
     Sorting for other columns will be tested as well.
     """
     import pandas as pd
-    dictionary = {'DSeries':pd.Series(dtype=int), 'aStr':'algName',
-                  'kDict':{2:'asd', 3:2}}
+    dictionary = {'DSeries': pd.Series(dtype=int), 'aStr': 'algName',
+                  'kDict': {2: 'asd', 3: 2}}
 
     # put this here variable, as it might change later to reflect string length
     str_size = get_size(dictionary['aStr'])

--- a/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
@@ -877,7 +877,7 @@ def test_dicts_natural_sorting_mixed_types(qtbot):
                                     [1, '(0,)', 2]]
 
     # insert an item and check that it is still sorted correctly
-    editor.widget.editor.new_value('List', [1,2,3])
+    editor.widget.editor.new_value('List', [1, 2, 3])
     assert data_table(cm, 4, 3) == [['aStr', 'DSeries', 'kDict', 'List'],
                                     ['str', 'Series', 'dict', 'list'],
                                     [1, '(0,)', 2, 3]]

--- a/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
@@ -855,7 +855,7 @@ def test_dicts_natural_sorting_mixed_types(qtbot):
     Sorting for other columns will be tested as well.
     """
     import pandas as pd
-    dictionary = {'dSeries':pd.Series(dtype=int), 'aStr':'algName',
+    dictionary = {'DSeries':pd.Series(dtype=int), 'aStr':'algName',
                   'kDict':{2:'asd', 3:2}}
 
     # put this here variable, as it might change later to reflect string length
@@ -869,35 +869,38 @@ def test_dicts_natural_sorting_mixed_types(qtbot):
     types = cm.types
     sizes = cm.sizes
 
-    assert keys == ['aStr', 'dSeries', 'kDict']
+    assert keys == ['aStr', 'DSeries', 'kDict']
     assert types == ['str', 'Series', 'dict']
     assert sizes == [1, (0,), 2]
 
-    assert data_table(cm, 3, 3) == [['aStr', 'dSeries', 'kDict'],
+    assert data_table(cm, 3, 3) == [['aStr', 'DSeries', 'kDict'],
                                     ['str', 'Series', 'dict'],
                                     [1, '(0,)', 2]]
 
     # insert an item and check that it is still sorted correctly
-    editor.widget.editor.new_value('d', pd.Series(range(3)))
+    editor.widget.editor.new_value('List', [1,2,3])
+    assert data_table(cm, 4, 3) == [['aStr', 'DSeries', 'kDict', 'List'],
+                                    ['str', 'Series', 'dict', 'list'],
+                                    [1, '(0,)', 2, 3]]
     cm.sort(0)
-    assert data_table(cm, 4, 3) == [['aStr', 'd', 'dSeries', 'kDict'],
-                                    ['str', 'Series', 'Series', 'dict'],
-                                    [1, '(3,)', '(0,)', 2]]
+    assert data_table(cm, 4, 3) == [['aStr', 'DSeries', 'kDict', 'List'],
+                                    ['str', 'Series', 'dict', 'list'],
+                                    [1, '(0,)', 2, 3]]
 
     # now sort for types
     cm.sort(1)
-    assert data_table(cm, 4, 3) == [['d', 'dSeries', 'kDict', 'aStr'],
-                                    ['Series', 'Series', 'dict', 'str'],
-                                    ['(3,)', '(0,)', 2, 1]]
+    assert data_table(cm, 4, 3) == [['DSeries', 'kDict', 'List', 'aStr'],
+                                    ['Series', 'dict', 'list', 'str'],
+                                    ['(0,)', 2, 3, 1]]
 
     # now sort for sizes
     cm.sort(2)
     print(cm.keys)
     print(cm.types)
     print(cm.sizes)
-    assert data_table(cm, 4, 3) == [['d', 'dSeries', 'kDict', 'aStr'],
-                                    ['Series', 'Series', 'dict', 'str'],
-                                    ['(3,)', '(0,)', 2, str_size]]
+    assert data_table(cm, 4, 3) == [['DSeries', 'kDict', 'List', 'aStr'],
+                                    ['Series', 'dict', 'list', 'str'],
+                                    ['(0,)', 2, 3, str_size]]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
related: https://github.com/spyder-ide/spyder-kernels/pull/246

I've re-implemented the natural sorting, now it should also work when sorting for types, etc.

### Issue(s) Resolved
<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->
Fixes #13733 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
skjerns
<!--- Thanks for your help making Spyder better for everyone! --->
