### PR TITLE
PR: Press enter on completion test

### DIFF
--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1401,7 +1401,7 @@ def test_console_complete(ipyconsole, qtbot, tmpdir):
     qtbot.waitUntil(shell._completion_widget.isVisible)
     # cbs is another solution, so not completed yet
     assert control.toPlainText().split()[-1] == 'cb'
-    qtbot.keyClick(shell._completion_widget, Qt.Key_Tab)
+    qtbot.keyClick(shell._completion_widget, Qt.Key_Enter)
     qtbot.waitUntil(lambda: control.toPlainText().split()[-1] == 'cbba')
 
     # Generate a traceback and enter debugging mode
@@ -1452,7 +1452,7 @@ def test_console_complete(ipyconsole, qtbot, tmpdir):
     qtbot.keyClick(control, Qt.Key_Tab)
     qtbot.waitUntil(shell._completion_widget.isVisible)
     assert control.toPlainText().split()[-1] == 'ab'
-    qtbot.keyClick(shell._completion_widget, Qt.Key_Tab)
+    qtbot.keyClick(shell._completion_widget, Qt.Key_Enter)
     qtbot.waitUntil(lambda: control.toPlainText().split()[-1] == 'abba')
     qtbot.keyClick(control, Qt.Key_Enter)
     qtbot.waitUntil(lambda: control.toPlainText().split()[-1] == 'ipdb>')


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Problem


`test_console_complete` fails with recent versions because the completion widget expects a press of Enter instead of Tab and thus never completes the desired line:

### openSUSE Tumbleweed buildlog for spyder 4.1.5
```

[   39s] python3-qtconsole-4.7.7-1.1           ########################################
[   39s] jupyter-qtconsole-4.7.7-1.1           ########################################
...
[   59s] ============================= test session starts ==============================
[   59s] platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
[   59s] cachedir: .pytest_cache
[   59s] PyQt5 5.15.0 -- Qt runtime 5.15.1 -- Qt compiled 5.15.1
[   59s] rootdir: /home/abuild/rpmbuild/BUILD/spyder-4.1.5, configfile: pytest.ini
[   59s] plugins: lazy-fixture-0.6.3, mock-3.1.1, flaky-3.7.0, xvfb-2.0.0, ordering-0.6, qt-3.3.0, timeout-1.4.1
[   59s] timeout: 1800.0s
[   59s] timeout method: signal
[   59s] timeout func_only: False
[   71s] collecting ... collected 1080 items / 16 deselected / 1064 selected
[   71s] 
...
[  398s] =================================== FAILURES ===================================
[  398s] ____________________________ test_console_complete _____________________________
[  398s] 
[  398s] ipyconsole = <spyder.plugins.ipythonconsole.plugin.IPythonConsole object at 0x7f6f686d6ca0>
[  398s] qtbot = <pytestqt.qtbot.QtBot object at 0x7f6f683318b0>
[  398s] tmpdir = local('/tmp/pytest-of-abuild/pytest-0/test_console_complete2')
[  398s] 
[  398s]     @flaky(max_runs=3)
[  398s]     @pytest.mark.skipif(not sys.platform.startswith('linux') or PY2,
[  398s]                         reason="It only works on Linux with python 3.")
[  398s]     def test_console_complete(ipyconsole, qtbot, tmpdir):
[  398s]         """Test for checking the working directory."""
[  398s]         shell = ipyconsole.get_current_shellwidget()
[  398s]         qtbot.waitUntil(lambda: shell._prompt_html is not None,
[  398s]                         timeout=SHELL_TIMEOUT)
[  398s]     
[  398s]         # Give focus to the widget that's going to receive clicks
[  398s]         control = ipyconsole.get_focus_widget()
[  398s]         control.setFocus()
[  398s]     
[  398s]         def check_value(name, value):
[  398s]             try:
[  398s]                 return shell.get_value(name) == value
[  398s]             except KeyError:
[  398s]                 return False
[  398s]     
[  398s]         # test complete with one result
[  398s]         with qtbot.waitSignal(shell.executed):
[  398s]             shell.execute('cbs = 1')
[  398s]         qtbot.waitUntil(lambda: check_value('cbs', 1))
[  398s]         qtbot.wait(500)
[  398s]     
[  398s]         qtbot.keyClicks(control, 'cb')
[  398s]         qtbot.keyClick(control, Qt.Key_Tab)
[  398s]         # Jedi completion takes time to start up the first time
[  398s]         qtbot.waitUntil(lambda: control.toPlainText().split()[-1] == 'cbs',
[  398s]                         timeout=6000)
[  398s]     
[  398s]         # test complete with several result
[  398s]         with qtbot.waitSignal(shell.executed):
[  398s]             shell.execute('cbba = 1')
[  398s]         qtbot.waitUntil(lambda: check_value('cbba', 1))
[  398s]         qtbot.keyClicks(control, 'cb')
[  398s]         qtbot.keyClick(control, Qt.Key_Tab)
[  398s]         qtbot.waitUntil(shell._completion_widget.isVisible)
[  398s]         # cbs is another solution, so not completed yet
[  398s]         assert control.toPlainText().split()[-1] == 'cb'
[  398s]         qtbot.keyClick(shell._completion_widget, Qt.Key_Tab)
[  398s] >       qtbot.waitUntil(lambda: control.toPlainText().split()[-1] == 'cbba')
[  398s] E       AssertionError: waitUntil timed out in 1000 miliseconds
[  398s] E       assert not True
[  398s] E        +  where True = <function QtBot.waitUntil.<locals>.timed_out at 0x7f6f686b59d0>()
[  398s] 
[  398s] /home/abuild/rpmbuild/BUILD/spyder-4.1.5/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py:1405: AssertionError
[  398s] --------------------------- Captured stdout teardown ---------------------------
[  398s] Python 3.8.5 (default, Jul 20 2020, 17:41:41) [GCC]
[  398s] Type "copyright", "credits" or "license" for more information.
[  398s] 
[  398s] IPython 7.18.1 -- An enhanced Interactive Python.
[  398s] 
[  398s] In [1]: cbs = 1
[  398s] 
[  398s] In [2]: cbba = 1
[  398s] 
[  398s] In [3]: cb
[  398s] --------------------------- Captured stdout teardown ---------------------------

[same output captured a few times during test teardown]

[  398s] --------------------------- Captured stdout teardown ---------------------------
[  398s] Python 3.8.5 (default, Jul 20 2020, 17:41:41) [GCC]
[  398s] Type "copyright", "credits" or "license" for more information.
[  398s] 
[  398s] IPython 7.18.1 -- An enhanced Interactive Python.
[  398s] 
[  398s] In [1]: cbs = 1
[  398s] 
[  398s] In [2]: cbba = 1
[  398s] 
[  398s] In [3]: cb
[  398s] =============================== warnings summary ===============================
```

## Description of Changes

This PR makes qtbot press `Enter` instead of `Tab`

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: bnavigator
<!--- Thanks for your help making Spyder better for everyone! --->
