### PR TITLE
PR: Change tooltip of PYTHONPATH manager to match title in dialog

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -721,7 +721,7 @@ class MainWindow(QMainWindow):
                                 _("PYTHONPATH manager"),
                                 None, icon=ima.icon('pythonpath'),
                                 triggered=self.show_path_manager,
-                                tip=_("Python Path Manager"),
+                                tip=_("PYTHONPATH manager"),
                                 menurole=QAction.ApplicationSpecificRole)
         reset_spyder_action = create_action(
             self, _("Reset Spyder to factory defaults"),


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Makes the tooltip of the PYTHONPATH manager toolbar button match the title of the dialog it opens.

<img width="1438" alt="Screenshot 2020-09-20 at 12 53 22 AM" src="https://user-images.githubusercontent.com/71577931/93704962-c26f9e00-fade-11ea-988f-d656fc1a07f5.png">



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13741 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
juanitagomezr

<!--- Thanks for your help making Spyder better for everyone! --->
