### PR TITLE
PR: Synchronize symbols and folding after a timeout (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1294,6 +1294,117 @@ class CodeEditor(TextEditBaseWidget):
         self.request_folding()
         self.request_symbols()
 
+    def process_code_analysis(self, diagnostics):
+        """Process code analysis results in a thread."""
+        self.cleanup_code_analysis()
+        self._diagnostics = diagnostics
+
+        # Process diagnostics in a thread to improve performance.
+        self.update_diagnostics = QThread()
+        self.update_diagnostics.run = self.set_errors
+        self.update_diagnostics.finished.connect(self.finish_code_analysis)
+        self.update_diagnostics.start()
+
+    def cleanup_code_analysis(self):
+        """Remove all code analysis markers"""
+        self.setUpdatesEnabled(False)
+        self.clear_extra_selections('code_analysis_highlight')
+        self.clear_extra_selections('code_analysis_underline')
+        for data in self.blockuserdata_list():
+            data.code_analysis = []
+
+        self.setUpdatesEnabled(True)
+        # When the new code analysis results are empty, it is necessary
+        # to update manually the scrollflag and linenumber areas (otherwise,
+        # the old flags will still be displayed):
+        self.sig_flags_changed.emit()
+        self.linenumberarea.update()
+
+    def set_errors(self):
+        """Set errors and warnings in the line number area."""
+        try:
+            self._process_code_analysis(underline=False)
+        except RuntimeError:
+            # This is triggered when a codeeditor instance was removed
+            # before the response can be processed.
+            return
+        except Exception:
+            self.log_lsp_handle_errors("Error when processing linting")
+
+    def underline_errors(self):
+        """Underline errors and warnings."""
+        try:
+            self._process_code_analysis(underline=True)
+        except RuntimeError:
+            # This is triggered when a codeeditor instance was removed
+            # before the response can be processed.
+            return
+        except Exception:
+            self.log_lsp_handle_errors("Error when processing linting")
+
+    def finish_code_analysis(self):
+        """Finish processing code analysis results."""
+        self.linenumberarea.update()
+        self.underline_errors()
+        self.update_extra_selections()
+        self.sig_process_code_analysis.emit()
+        self.sig_flags_changed.emit()
+
+    def _process_code_analysis(self, underline):
+        """
+        Process all code analysis results.
+
+        Parameters
+        ----------
+        underline: bool
+            Determines if errors and warnings are going to be set in
+            the line number area or underlined. It's better to separate
+            these two processes for perfomance reasons. That's because
+            setting errors can be done in a thread whereas underlining
+            them can't.
+        """
+        document = self.document()
+        for diagnostic in self._diagnostics:
+            if self.is_ipython() and (
+                    diagnostic["message"] == "undefined name 'get_ipython'"):
+                # get_ipython is defined in IPython files
+                continue
+            source = diagnostic.get('source', '')
+            msg_range = diagnostic['range']
+            start = msg_range['start']
+            end = msg_range['end']
+            code = diagnostic.get('code', 'E')
+            message = diagnostic['message']
+            severity = diagnostic.get(
+                'severity', DiagnosticSeverity.ERROR)
+
+            block = document.findBlockByNumber(start['line'])
+            data = block.userData()
+            if not data:
+                data = BlockUserData(self)
+
+            if underline:
+                block_nb = block.blockNumber()
+                first, last = self.get_buffer_block_numbers()
+
+                if (self.underline_errors_enabled and
+                        first <= block_nb <= last):
+                    error = severity == DiagnosticSeverity.ERROR
+                    color = self.error_color if error else self.warning_color
+                    color = QColor(color)
+                    color.setAlpha(255)
+                    block.color = color
+
+                    data.selection_start = start
+                    data.selection_end = end
+
+                    self.highlight_selection('code_analysis_underline',
+                                             data._selection(),
+                                             underline_color=block.color)
+            else:
+                data.code_analysis.append((source, code, severity, message))
+                block.setUserData(data)
+
     # ------------- LSP: Completion ---------------------------------------
     @request(method=LSPRequestTypes.DOCUMENT_COMPLETION)
     def do_completion(self, automatic=False):
@@ -2770,117 +2881,6 @@ class CodeEditor(TextEditBaseWidget):
         dlg = GoToLineDialog(self)
         if dlg.exec_():
             self.go_to_line(dlg.get_line_number())
-
-    def cleanup_code_analysis(self):
-        """Remove all code analysis markers"""
-        self.setUpdatesEnabled(False)
-        self.clear_extra_selections('code_analysis_highlight')
-        self.clear_extra_selections('code_analysis_underline')
-        for data in self.blockuserdata_list():
-            data.code_analysis = []
-
-        self.setUpdatesEnabled(True)
-        # When the new code analysis results are empty, it is necessary
-        # to update manually the scrollflag and linenumber areas (otherwise,
-        # the old flags will still be displayed):
-        self.sig_flags_changed.emit()
-        self.linenumberarea.update()
-
-    def _process_code_analysis(self, underline):
-        """
-        Process all code analysis results.
-
-        Parameters
-        ----------
-        underline: bool
-            Determines if errors and warnings are going to be set in
-            the line number area or underlined. It's better to separate
-            these two processes for perfomance reasons. That's because
-            setting errors can be done in a thread whereas underlining
-            them can't.
-        """
-        document = self.document()
-        for diagnostic in self._diagnostics:
-            if self.is_ipython() and (
-                    diagnostic["message"] == "undefined name 'get_ipython'"):
-                # get_ipython is defined in IPython files
-                continue
-            source = diagnostic.get('source', '')
-            msg_range = diagnostic['range']
-            start = msg_range['start']
-            end = msg_range['end']
-            code = diagnostic.get('code', 'E')
-            message = diagnostic['message']
-            severity = diagnostic.get(
-                'severity', DiagnosticSeverity.ERROR)
-
-            block = document.findBlockByNumber(start['line'])
-            data = block.userData()
-            if not data:
-                data = BlockUserData(self)
-
-            if underline:
-                block_nb = block.blockNumber()
-                first, last = self.get_buffer_block_numbers()
-
-                if (self.underline_errors_enabled and
-                        first <= block_nb <= last):
-                    error = severity == DiagnosticSeverity.ERROR
-                    color = self.error_color if error else self.warning_color
-                    color = QColor(color)
-                    color.setAlpha(255)
-                    block.color = color
-
-                    data.selection_start = start
-                    data.selection_end = end
-
-                    self.highlight_selection('code_analysis_underline',
-                                             data._selection(),
-                                             underline_color=block.color)
-            else:
-                data.code_analysis.append((source, code, severity, message))
-                block.setUserData(data)
-
-    def set_errors(self):
-        """Set errors and warnings in the line number area."""
-        try:
-            self._process_code_analysis(underline=False)
-        except RuntimeError:
-            # This is triggered when a codeeditor instance was removed
-            # before the response can be processed.
-            return
-        except Exception:
-            self.log_lsp_handle_errors("Error when processing linting")
-
-    def underline_errors(self):
-        """Underline errors and warnings."""
-        try:
-            self._process_code_analysis(underline=True)
-        except RuntimeError:
-            # This is triggered when a codeeditor instance was removed
-            # before the response can be processed.
-            return
-        except Exception:
-            self.log_lsp_handle_errors("Error when processing linting")
-
-    def finish_code_analysis(self):
-        """Finish processing code analysis results."""
-        self.linenumberarea.update()
-        self.underline_errors()
-        self.update_extra_selections()
-        self.sig_process_code_analysis.emit()
-        self.sig_flags_changed.emit()
-
-    def process_code_analysis(self, diagnostics):
-        """Process all code analysis results."""
-        self.cleanup_code_analysis()
-        self._diagnostics = diagnostics
-
-        # Process diagnostics in a thread to improve performance.
-        self.update_diagnostics = QThread()
-        self.update_diagnostics.run = self.set_errors
-        self.update_diagnostics.finished.connect(self.finish_code_analysis)
-        self.update_diagnostics.start()
 
     def hide_tooltip(self):
         """

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -11,15 +11,12 @@ Editor widget based on QtGui.QPlainTextEdit
 # TODO: Try to separate this module from spyder to create a self
 #       consistent editor module (Qt source code and shell widgets library)
 
-# %% This line is for cell execution testing
 # pylint: disable=C0103
 # pylint: disable=R0903
 # pylint: disable=R0911
 # pylint: disable=R0201
 
 # Standard library imports
-from __future__ import division, print_function
-
 from unicodedata import category
 import logging
 import functools
@@ -34,13 +31,12 @@ import time
 from diff_match_patch import diff_match_patch
 from IPython.core.inputtransformer2 import TransformerManager
 from qtpy.compat import to_qvariant
-from qtpy.QtCore import (QEvent, QPoint, QRegExp, Qt, QTimer, QThread, QUrl,
-                         Signal, Slot)
+from qtpy.QtCore import (QEvent, QRegExp, Qt, QTimer, QThread, QUrl, Signal,
+                         Slot)
 from qtpy.QtGui import (QColor, QCursor, QFont, QIntValidator,
                         QKeySequence, QPaintEvent, QPainter, QMouseEvent,
                         QTextCharFormat, QTextCursor, QDesktopServices,
-                        QKeyEvent, QTextDocument, QTextFormat, QTextOption,
-                        QTextFrameFormat)
+                        QKeyEvent, QTextDocument, QTextFormat, QTextOption)
 from qtpy.QtPrintSupport import QPrinter
 from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
                             QGridLayout, QHBoxLayout, QLabel,
@@ -48,8 +44,6 @@ from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
                             QToolTip, QVBoxLayout, QScrollBar)
 from spyder_kernels.utils.dochelpers import getobj
 from three_merge import merge
-
-# %% This line is for cell execution testing
 
 
 # Local imports
@@ -94,7 +88,6 @@ from spyder.utils.qthelpers import (add_actions, create_action, file_uri,
                                     mimedata2url)
 from spyder.utils.vcs import get_git_remotes, remote_to_url
 from spyder.utils.qstringhelpers import qstring_length
-from spyder.widgets.helperwidgets import MessageCheckBox
 
 
 try:
@@ -110,12 +103,12 @@ logger = logging.getLogger(__name__)
 # the up/down arrow keys.
 UPDATE_DECORATIONS_TIMEOUT = 500  # miliseconds
 
-# %% This line is for cell execution testing
 def is_letter_or_number(char):
     """Returns whether the specified unicode character is a letter or a number.
     """
     cat = category(char)
     return cat.startswith('L') or cat.startswith('N')
+
 
 # =============================================================================
 # Go to line dialog box
@@ -1695,8 +1688,6 @@ class CodeEditor(TextEditBaseWidget):
         if edits is None:
             return
 
-        texts = []
-        diffs = []
         text = self.toPlainText()
         text_tokens = list(text)
         merged_text = None
@@ -2460,7 +2451,6 @@ class CodeEditor(TextEditBaseWidget):
         top = self.blockBoundingGeometry(block).translated(
                                                     self.contentOffset()).top()
         bottom = top + self.blockBoundingRect(block).height()
-        folding_panel = self.panels.get(FoldingPanel)
         while block.isValid() and top < event.pos().y():
             block = block.next()
             if block.isVisible():  # skip collapsed blocks
@@ -3035,7 +3025,7 @@ class CodeEditor(TextEditBaseWidget):
         """
         block = self.textCursor().block()
         line_count = self.document().blockCount()
-        for _ in range(line_count):
+        for __ in range(line_count):
             line_number = block.blockNumber() + 1
             if line_number < line_count:
                 block = block.next()
@@ -3055,7 +3045,7 @@ class CodeEditor(TextEditBaseWidget):
         """
         block = self.textCursor().block()
         line_count = self.document().blockCount()
-        for _ in range(line_count):
+        for __ in range(line_count):
             line_number = block.blockNumber() + 1
             if line_number > 1:
                 block = block.previous()
@@ -4968,7 +4958,6 @@ class CodeEditor(TextEditBaseWidget):
         self._last_point = pos
         alt = event.modifiers() & Qt.AltModifier
         ctrl = event.modifiers() & Qt.ControlModifier
-        shift = event.modifiers() & Qt.ShiftModifier
 
         if alt:
             self.sig_alt_mouse_moved.emit(event)
@@ -5159,7 +5148,6 @@ class CodeEditor(TextEditBaseWidget):
         top = int(self.blockBoundingGeometry(block).translated(
             self.contentOffset()).top())
         bottom = top + int(self.blockBoundingRect(block).height())
-        ebottom_top = 0
         ebottom_bottom = self.height()
 
         while block.isValid():

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1299,10 +1299,7 @@ class CodeEditor(TextEditBaseWidget):
         Synchronize symbols and folding after linting results arrive.
         """
         self.request_folding()
-
-        # Tests don't pass with this request here.
-        if not running_under_pytest():
-            self.request_symbols()
+        self.request_symbols()
 
     # ------------- LSP: Completion ---------------------------------------
     @request(method=LSPRequestTypes.DOCUMENT_COMPLETION)
@@ -1819,10 +1816,6 @@ class CodeEditor(TextEditBaseWidget):
         self.update_folding_thread.finished.connect(
             self.finish_code_folding)
         self.update_folding_thread.start()
-
-        # Tests for the class function selector need this.
-        if running_under_pytest():
-            self.request_symbols()
 
     def update_and_merge_folding(self, extended_ranges):
         """Update and merge new folding information."""

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -98,10 +98,6 @@ except Exception:
 
 logger = logging.getLogger(__name__)
 
-# Timeout to update decorations (through a QTimer) when a position
-# changed is detected in the vertical scrollbar or when releasing
-# the up/down arrow keys.
-UPDATE_DECORATIONS_TIMEOUT = 500  # miliseconds
 
 def is_letter_or_number(char):
     """Returns whether the specified unicode character is a letter or a number.
@@ -257,6 +253,11 @@ class CodeEditor(TextEditBaseWidget):
     TAB_ALWAYS_INDENTS = (
         'py', 'pyw', 'python', 'ipy', 'c', 'cpp', 'cl', 'h', 'pyt', 'pyi'
     )
+
+    # Timeout to update decorations (through a QTimer) when a position
+    # changed is detected in the vertical scrollbar or when releasing
+    # the up/down arrow keys.
+    UPDATE_DECORATIONS_TIMEOUT = 500  # miliseconds
 
     # Custom signal to be emitted upon completion of the editor's paintEvent
     painted = Signal(QPaintEvent)
@@ -540,7 +541,8 @@ class CodeEditor(TextEditBaseWidget):
         # Update decorations
         self.update_decorations_timer = QTimer(self)
         self.update_decorations_timer.setSingleShot(True)
-        self.update_decorations_timer.setInterval(UPDATE_DECORATIONS_TIMEOUT)
+        self.update_decorations_timer.setInterval(
+            self.UPDATE_DECORATIONS_TIMEOUT)
         self.update_decorations_timer.timeout.connect(
             self.update_decorations)
         self.verticalScrollBar().valueChanged.connect(

--- a/spyder/plugins/editor/widgets/tests/test_classfunc_selector.py
+++ b/spyder/plugins/editor/widgets/tests/test_classfunc_selector.py
@@ -51,17 +51,8 @@ def test_class_func_selector(lsp_codeeditor, qtbot):
     code_editor.toggle_automatic_completions(False)
     code_editor.set_text(text)
 
-    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-        code_editor.document_did_change()
-
-    # Wait a little bit before asking for symbols
-    qtbot.wait(2000)
-
-    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-        code_editor.request_symbols()
-
     # Wait for symbols info to arrive
-    qtbot.wait(2000)
+    qtbot.wait(3000)
 
     class_names = [item['name'] for item in panel.classes]
     func_names = [item['name'] for item in panel.funcs]

--- a/spyder/plugins/editor/widgets/tests/test_decorations.py
+++ b/spyder/plugins/editor/widgets/tests/test_decorations.py
@@ -18,8 +18,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtGui import QFont, QTextCursor, QTextFormat
 
 # Local imports
-from spyder.plugins.editor.widgets.codeeditor import (
-    CodeEditor, UPDATE_DECORATIONS_TIMEOUT)
+from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 
 
 HERE = osp.dirname(osp.realpath(__file__))
@@ -103,7 +102,7 @@ def test_decorations(construct_editor, qtbot):
     # updated.
     line_number = random.randint(100, editor.blockCount())
     editor.go_to_line(line_number)
-    qtbot.wait(UPDATE_DECORATIONS_TIMEOUT + 100)
+    qtbot.wait(editor.UPDATE_DECORATIONS_TIMEOUT + 100)
 
     # Assert a new cell is painted
     decorations = editor.decorations._decorations
@@ -160,7 +159,7 @@ def test_update_decorations_when_scrolling(qtbot):
         assert _update.call_count == 1
 
         # Wait for decorations to update
-        qtbot.wait(UPDATE_DECORATIONS_TIMEOUT + 100)
+        qtbot.wait(editor.UPDATE_DECORATIONS_TIMEOUT + 100)
 
         # Assert a new call to _update was done
         assert _update.call_count == 2
@@ -176,7 +175,7 @@ def test_update_decorations_when_scrolling(qtbot):
         assert _update.call_count == 2
 
         # Wait for decorations to update
-        qtbot.wait(UPDATE_DECORATIONS_TIMEOUT + 100)
+        qtbot.wait(editor.UPDATE_DECORATIONS_TIMEOUT + 100)
 
         # Assert a new call to _update was done
         assert _update.call_count == 3
@@ -192,7 +191,7 @@ def test_update_decorations_when_scrolling(qtbot):
                 qtbot.wait(5)
 
         # Only one call to _update should be done, after releasing the key.
-        qtbot.wait(UPDATE_DECORATIONS_TIMEOUT + 100)
+        qtbot.wait(editor.UPDATE_DECORATIONS_TIMEOUT + 100)
         assert _update.call_count == 4
 
         # Simulate continuously pressing the up arrow key.
@@ -202,7 +201,7 @@ def test_update_decorations_when_scrolling(qtbot):
                 qtbot.wait(5)
 
         # Only one call to _update should be done, after releasing the key.
-        qtbot.wait(UPDATE_DECORATIONS_TIMEOUT + 100)
+        qtbot.wait(editor.UPDATE_DECORATIONS_TIMEOUT + 100)
         assert _update.call_count == 5
 
 

--- a/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
@@ -312,11 +312,7 @@ def test_editor_outlineexplorer(qtbot, lsp_codeeditor_outline):
 
     # Put example text in editor
     code_editor.set_text(lines)
-    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-        code_editor.document_did_change()
-
-    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-        code_editor.request_symbols()
+    qtbot.wait(3000)
 
     # Check that the outline tree was initialized successfully
     tree = trees[0]
@@ -332,12 +328,7 @@ def test_editor_outlineexplorer(qtbot, lsp_codeeditor_outline):
     cursor.setPosition(end, QTextCursor.KeepAnchor)
     code_editor.setTextCursor(cursor)
     code_editor.cut()
-
-    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-        code_editor.document_did_change()
-
-    with qtbot.waitSignal(treewidget.sig_tree_updated, timeout=30000):
-        code_editor.request_symbols()
+    qtbot.wait(3000)
 
     tree = trees[1]
     root_tree = get_tree_elements(treewidget)
@@ -353,11 +344,7 @@ def test_editor_outlineexplorer(qtbot, lsp_codeeditor_outline):
     qtbot.keyPress(code_editor, Qt.Key_Up)
     code_editor.paste()
 
-    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-        code_editor.document_did_change()
-
-    with qtbot.waitSignal(treewidget.sig_tree_updated, timeout=30000):
-        code_editor.request_symbols()
+    qtbot.wait(3000)
 
     tree = trees[2]
     root_tree = get_tree_elements(treewidget)
@@ -372,12 +359,7 @@ def test_editor_outlineexplorer(qtbot, lsp_codeeditor_outline):
     cursor.setPosition(end, QTextCursor.KeepAnchor)
     code_editor.setTextCursor(cursor)
     code_editor.cut()
-
-    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-        code_editor.document_did_change()
-
-    with qtbot.waitSignal(treewidget.sig_tree_updated, timeout=30000):
-        code_editor.request_symbols()
+    qtbot.wait(3000)
 
     tree = trees[3]
     root_tree = get_tree_elements(treewidget)
@@ -392,12 +374,7 @@ def test_editor_outlineexplorer(qtbot, lsp_codeeditor_outline):
 
     qtbot.keyPress(code_editor, Qt.Key_Up)
     code_editor.paste()
-
-    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-        code_editor.document_did_change()
-
-    with qtbot.waitSignal(treewidget.sig_tree_updated, timeout=30000):
-        code_editor.request_symbols()
+    qtbot.wait(3000)
 
     tree = trees[4]
     root_tree = get_tree_elements(treewidget)
@@ -438,12 +415,7 @@ def test_empty_file(qtbot, lsp_codeeditor_outline):
     # Set empty contents
     code_editor.set_text('')
     code_editor.go_to_line(1)
-
-    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-        code_editor.document_did_change()
-
-    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-        code_editor.request_symbols()
+    qtbot.wait(3000)
 
     # Assert the spinner is not shown.
     assert not outlineexplorer.loading_widget.isSpinning()
@@ -454,12 +426,7 @@ def foo():
     a = 10
     return a
 """)
-
-    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-        code_editor.document_did_change()
-
-    with qtbot.waitSignal(treewidget.sig_tree_updated, timeout=30000):
-        code_editor.request_symbols()
+    qtbot.wait(3000)
 
     root_tree = get_tree_elements(treewidget)
     assert root_tree == {'test.py': [{'foo': [{'a': []}]}]}
@@ -471,8 +438,7 @@ def foo():
     with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
         code_editor.document_did_change()
 
-    with qtbot.waitSignal(treewidget.sig_tree_updated, timeout=30000):
-        code_editor.request_symbols()
+    qtbot.wait(3000)
 
     # Assert the tree is empty and the spinner is not shown.
     root_tree = get_tree_elements(treewidget)

--- a/spyder/plugins/editor/widgets/tests/test_folding.py
+++ b/spyder/plugins/editor/widgets/tests/test_folding.py
@@ -65,12 +65,6 @@ def test_folding(lsp_codeeditor, qtbot):
     code_editor.insert_text(text)
     folding_panel = code_editor.panels.get('FoldingPanel')
 
-    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-        code_editor.document_did_change()
-
-    with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
-        code_editor.request_folding()
-
     # Wait for the update thread to finish
     qtbot.wait(3000)
 
@@ -96,12 +90,6 @@ def test_unfold_when_searching(search_codeeditor, qtbot):
 
     folding_panel = editor.panels.get('FoldingPanel')
     editor.insert_text(text)
-
-    with qtbot.waitSignal(editor.lsp_response_signal, timeout=30000):
-        editor.document_did_change()
-
-    with qtbot.waitSignal(editor.lsp_response_signal, timeout=30000):
-        editor.request_folding()
 
     # Wait for the update thread to finish
     qtbot.wait(3000)
@@ -130,12 +118,6 @@ def test_unfold_goto(search_codeeditor, qtbot):
     editor.toggle_code_folding(True)
     editor.insert_text(text)
     folding_panel = editor.panels.get('FoldingPanel')
-
-    with qtbot.waitSignal(editor.lsp_response_signal, timeout=30000):
-        editor.document_did_change()
-
-    with qtbot.waitSignal(editor.lsp_response_signal, timeout=30000):
-        editor.request_folding()
 
     # Wait for the update thread to finish
     qtbot.wait(3000)


### PR DESCRIPTION
This avoids requesting symbols and folding after linting results arrive from the PyLS. Instead, it does that after a timeout.

This should avoid the freezes reported on issue #14384.