### PR TITLE
PR: Improve performance when painting indent guides

### DIFF
--- a/spyder/plugins/editor/panels/indentationguides.py
+++ b/spyder/plugins/editor/panels/indentationguides.py
@@ -37,36 +37,58 @@ class IndentationGuide(Panel):
         self.bar_offset = value
 
     def paintEvent(self, event):
-        """Override Qt method."""
-        painter = QPainter(self)
+        """
+        Overriden Qt method.
 
+        Paint indent guides.
+        """
+        # Set painter
+        painter = QPainter(self)
         color = QColor(self.color)
         color.setAlphaF(.5)
         painter.setPen(color)
+
+        # Compute offset
         offset = (self.editor.document().documentMargin() +
                   self.editor.contentOffset().x())
+
+        # Folding info
         folding_panel = self.editor.panels.get('FoldingPanel')
         folding_regions = folding_panel.folding_regions
         leading_whitespaces = self.editor.leading_whitespaces
-        for line_number in folding_regions:
-            end_line = folding_regions[line_number]
-            start_block = self.editor.document().findBlockByNumber(
-                line_number)
-            end_block = self.editor.document().findBlockByNumber(end_line - 1)
-            top = int(self.editor.blockBoundingGeometry(
-                start_block).translated(self.editor.contentOffset()).top())
-            bottom = int(self.editor.blockBoundingGeometry(
-                end_block).translated(self.editor.contentOffset()).bottom())
-            total_whitespace = leading_whitespaces.get(max(line_number - 1, 0))
-            end_whitespace = leading_whitespaces.get(end_line - 1)
-            if end_whitespace and end_whitespace != total_whitespace:
-                x = (self.editor.fontMetrics().width(total_whitespace * '9') +
-                     self.bar_offset + offset)
-                painter.drawLine(x, top, x, bottom)
+
+        # Visible block numbers
+        visible_blocks = self.editor.get_visible_block_numbers()
+
+        # Paint lines
+        for start_line in folding_regions:
+            end_line = folding_regions[start_line]
+            line_numbers = (start_line, end_line)
+
+            if self.do_paint(visible_blocks, line_numbers):
+                start_block = self.editor.document().findBlockByNumber(
+                    start_line)
+                end_block = self.editor.document().findBlockByNumber(
+                    end_line - 1)
+
+                content_offset = self.editor.contentOffset()
+                top = int(self.editor.blockBoundingGeometry(
+                    start_block).translated(content_offset).top())
+                bottom = int(self.editor.blockBoundingGeometry(
+                    end_block).translated(content_offset).bottom())
+
+                total_whitespace = leading_whitespaces.get(
+                    max(start_line - 1, 0))
+                end_whitespace = leading_whitespaces.get(end_line - 1)
+
+                if end_whitespace and end_whitespace != total_whitespace:
+                    font_metrics = self.editor.fontMetrics()
+                    x = (font_metrics.width(total_whitespace * '9') +
+                         self.bar_offset + offset)
+                    painter.drawLine(x, top, x, bottom)
 
     # --- Other methods
     # -----------------------------------------------------------------
-
     def set_enabled(self, state):
         """Toggle edge line visibility."""
         self._enabled = state
@@ -83,3 +105,38 @@ class IndentationGuide(Panel):
     def set_indentation_width(self, indentation_width):
         """Set indentation width to be used to draw indent guides."""
         self.i_width = indentation_width
+
+    def do_paint(self, visible_blocks, line_numbers):
+        """
+        Decide if we need to paint an indent guide according to the
+        visible region.
+        """
+        # Line numbers for the visible region.
+        first_visible_line = visible_blocks[0] + 1
+        last_visible_line = visible_blocks[1] + 1
+
+        # Line numbers for the indent guide.
+        start_line = line_numbers[0]
+        end_line = line_numbers[1]
+
+        # Guide starts before the visible region and ends inside it.
+        if (start_line < first_visible_line and
+                (first_visible_line <= end_line <= last_visible_line)):
+            return True
+
+        # Guide starts before the visible region and ends after it.
+        if start_line <= first_visible_line and end_line >= last_visible_line:
+            return True
+
+        # Guide starts inside the visible region and ends after it.
+        if ((first_visible_line <= start_line <= last_visible_line) and
+                end_line > last_visible_line):
+            return True
+
+        # Guide starts and ends inside the visible region.
+        if ((first_visible_line <= start_line <= last_visible_line) and
+                (first_visible_line <= end_line <= last_visible_line)):
+            return True
+
+        # If none of those cases are true, we don't need to paint this guide.
+        return False

--- a/spyder/plugins/editor/panels/indentationguides.py
+++ b/spyder/plugins/editor/panels/indentationguides.py
@@ -7,13 +7,12 @@
 """
 This module contains the indentation guide panel.
 """
+
 # Third party imports
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QPainter, QColor
-from intervaltree import IntervalTree
 
 # Local imports
-from spyder.plugins.editor.utils.editor import TextBlockHelper
 from spyder.api.panel import Panel
 
 
@@ -44,14 +43,12 @@ class IndentationGuide(Panel):
         color = QColor(self.color)
         color.setAlphaF(.5)
         painter.setPen(color)
-        offset = self.editor.document().documentMargin() + \
-            self.editor.contentOffset().x()
+        offset = (self.editor.document().documentMargin() +
+                  self.editor.contentOffset().x())
         folding_panel = self.editor.panels.get('FoldingPanel')
         folding_regions = folding_panel.folding_regions
-        folding_status = folding_panel.folding_status
         leading_whitespaces = self.editor.leading_whitespaces
         for line_number in folding_regions:
-            post_update = False
             end_line = folding_regions[line_number]
             start_block = self.editor.document().findBlockByNumber(
                 line_number)


### PR DESCRIPTION
Now we only paint those guides present in the visible region or that cross it. With that I was able to avoid the sluggishness observed when scrolling and typing in the editor for large files, specially on Windows.

A simple way to reproduce that slugishness is to open one of our largest files (mainwindow.py or codeeditor.py), activate "Show indent guides" in the Source menu and:

* Scroll by holding down the up/down arrow keys in the file (you'll see the current highlighted line stays at a specific place instead of moving with the cursor).
* Delete text by holding down the Backspace key (you'll see text is not removed smoothly but in chunks).

@CAM-Gerlach, sorry that it took us so long to fix this. It was not that hard after I understood how indent guides are painted (but I also had the experience of PR #13281 behind me).

Fixes #8864.