### PR TITLE
PR: Make date objects editable in the object explorer

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -195,19 +195,19 @@ class CollectionsDelegate(QItemDelegate):
             return None
         # QDateEdit and QDateTimeEdit for a dates or datetime respectively
         elif isinstance(value, datetime.date) and not object_explorer:
-            # Needed to handle NaT values
-            # See spyder-ide/spyder#8329
-            try:
-                value.time()
-            except ValueError:
-                self.sig_editor_shown.emit()
-                return None
             if readonly:
                 self.sig_editor_shown.emit()
                 return None
             else:
                 if isinstance(value, datetime.datetime):
                     editor = QDateTimeEdit(value, parent=parent)
+                    # Needed to handle NaT values
+                    # See spyder-ide/spyder#8329
+                    try:
+                        value.time()
+                    except ValueError:
+                        self.sig_editor_shown.emit()
+                        return None
                 else:
                     editor = QDateEdit(value, parent=parent)
                 editor.setCalendarPopup(True)

--- a/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_collectioneditor.py
@@ -27,7 +27,7 @@ import pandas
 import pytest
 from flaky import flaky
 from qtpy.QtCore import Qt, QPoint
-from qtpy.QtWidgets import QWidget
+from qtpy.QtWidgets import QWidget, QDateEdit
 
 # Local imports
 from spyder.plugins.variableexplorer.widgets.collectionseditor import (
@@ -477,6 +477,26 @@ def test_rename_and_duplicate_item_in_collection_editor():
         if isinstance(coll, list):
             editor.duplicate_item()
             assert editor.source_model.get_data() == coll_copy + [coll_copy[0]]
+
+
+def test_edit_datetime(monkeypatch):
+    """
+    Test datetimes are editable and NaT values are correctly handled.
+
+    Regression test for spyder-ide/spyder#13557 and spyder-ide/spyder#8329
+    """
+    variables = [pandas.NaT, datetime.date.today()]
+    editor_list = CollectionsEditorTableView(None, variables)
+
+    # Test that the NaT value cannot be edited on the variable explorer
+    editor_list_value = editor_list.delegate.createEditor(
+        None, None, editor_list.model.index(0, 3))
+    assert editor_list_value is None
+
+    # Test that a date can be edited on the variable explorer
+    editor_list_value = editor_list.delegate.createEditor(
+        None, None, editor_list.model.index(1, 3))
+    assert isinstance(editor_list_value, QDateEdit)
 
 
 def test_edit_mutable_and_immutable_types(monkeypatch):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Only try to get value.time() if the value is a date object

![image](https://user-images.githubusercontent.com/20992645/94469983-9910db00-018c-11eb-938e-183de5376fdf.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13557 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
