### PR TITLE
PR: Display an error message when Kite sends a non-dict response

### DIFF
--- a/spyder/plugins/completion/kite/client.py
+++ b/spyder/plugins/completion/kite/client.py
@@ -19,7 +19,7 @@ from qtpy.QtWidgets import QMessageBox
 import requests
 
 # Local imports
-from spyder.config.base import _
+from spyder.config.base import _, running_under_pytest
 from spyder.config.manager import CONF
 from spyder.plugins.completion.kite import KITE_ENDPOINTS, KITE_REQUEST_MAPPING
 from spyder.plugins.completion.kite.decorators import class_register
@@ -173,15 +173,16 @@ class KiteClient(QObject, KiteMethodProviderMixIn):
                 if response is not None:
                     response = converter(response)
         if not isinstance(response, dict):
-            QMessageBox.critical(
-                self, _('Kite error'),
-                _("The Kite completion engine returned an unexpected result "
-                  "for the request <tt>{0}</tt>: <br><br><tt>{1}</tt><br><br>"
-                  "Please make sure that your Kite installation is correct. "
-                  "In the meantime, Spyder will disable the Kite client to "
-                  "prevent further errors. For more information, please "
-                  "visit the <a href='https://help.kite.com/'>Kite help "
-                  "center</a>").format(method, response))
-            CONF.set('kite', 'enable', False)
+            if not running_under_pytest():
+                QMessageBox.critical(
+                    self, _('Kite error'),
+                    _("The Kite completion engine returned an unexpected result "
+                    "for the request <tt>{0}</tt>: <br><br><tt>{1}</tt><br><br>"
+                    "Please make sure that your Kite installation is correct. "
+                    "In the meantime, Spyder will disable the Kite client to "
+                    "prevent further errors. For more information, please "
+                    "visit the <a href='https://help.kite.com/'>Kite help "
+                    "center</a>").format(method, response))
+                CONF.set('kite', 'enable', False)
         else:
             self.sig_response_ready.emit(req_id, response or {})

--- a/spyder/plugins/completion/kite/client.py
+++ b/spyder/plugins/completion/kite/client.py
@@ -43,6 +43,7 @@ class KiteClient(QObject, KiteMethodProviderMixIn):
     sig_status_response_ready = Signal((str,), (dict,))
     sig_perform_onboarding_request = Signal()
     sig_onboarding_response_ready = Signal(str)
+    sig_client_wrong_response = Signal(str, object)
 
     def __init__(self, parent, enable_code_snippets=True):
         QObject.__init__(self, parent)
@@ -174,15 +175,6 @@ class KiteClient(QObject, KiteMethodProviderMixIn):
                     response = converter(response)
         if not isinstance(response, dict):
             if not running_under_pytest():
-                QMessageBox.critical(
-                    self, _('Kite error'),
-                    _("The Kite completion engine returned an unexpected result "
-                    "for the request <tt>{0}</tt>: <br><br><tt>{1}</tt><br><br>"
-                    "Please make sure that your Kite installation is correct. "
-                    "In the meantime, Spyder will disable the Kite client to "
-                    "prevent further errors. For more information, please "
-                    "visit the <a href='https://help.kite.com/'>Kite help "
-                    "center</a>").format(method, response))
-                CONF.set('kite', 'enable', False)
+                self.sig_client_wrong_response.emit(method, response)
         else:
             self.sig_response_ready.emit(req_id, response or {})

--- a/spyder/plugins/completion/kite/client.py
+++ b/spyder/plugins/completion/kite/client.py
@@ -173,7 +173,7 @@ class KiteClient(QObject, KiteMethodProviderMixIn):
                 converter = getattr(self, converter_name)
                 if response is not None:
                     response = converter(response)
-        if not isinstance(response, dict):
+        if not isinstance(response, (dict, type(None))):
             if not running_under_pytest():
                 self.sig_client_wrong_response.emit(method, response)
         else:

--- a/spyder/plugins/completion/kite/client.py
+++ b/spyder/plugins/completion/kite/client.py
@@ -173,16 +173,15 @@ class KiteClient(QObject, KiteMethodProviderMixIn):
                 if response is not None:
                     response = converter(response)
         if not isinstance(response, dict):
-            kite_url = '<a href="https://help.kite.com/"></a>'
             QMessageBox.critical(
                 self, _('Kite error'),
                 _("The Kite completion engine returned an unexpected result "
-                  "for the request {0}: <br><tt>{1}</tt><br>"
+                  "for the request <tt>{0}</tt>: <br><br><tt>{1}</tt><br><br>"
                   "Please make sure that your Kite installation is correct. "
                   "In the meantime, Spyder will disable the Kite client to "
-                  "prevent further errors. <br>"
-                  "For more information, please visit the Kite help "
-                  "center: {2}").format(method, response, kite_url))
+                  "prevent further errors. For more information, please "
+                  "visit the <a href='https://help.kite.com/'>Kite help "
+                  "center</a>").format(method, response))
             CONF.set('kite', 'enable', False)
         else:
             self.sig_response_ready.emit(req_id, response or {})

--- a/spyder/plugins/completion/kite/plugin.py
+++ b/spyder/plugins/completion/kite/plugin.py
@@ -230,10 +230,10 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
         QMessageBox.critical(
             self.main, _('Kite error'),
             _("The Kite completion engine returned an unexpected result "
-            "for the request <tt>{0}</tt>: <br><br><tt>{1}</tt><br><br>"
-            "Please make sure that your Kite installation is correct. "
-            "In the meantime, Spyder will disable the Kite client to "
-            "prevent further errors. For more information, please "
-            "visit the <a href='https://help.kite.com/'>Kite help "
-            "center</a>").format(method, response))
+              "for the request <tt>{0}</tt>: <br><br><tt>{1}</tt><br><br>"
+              "Please make sure that your Kite installation is correct. "
+              "In the meantime, Spyder will disable the Kite client to "
+              "prevent further errors. For more information, please "
+              "visit the <a href='https://help.kite.com/'>Kite help "
+              "center</a>").format(method, response))
         self.set_option('enable', False)

--- a/spyder/plugins/completion/kite/plugin.py
+++ b/spyder/plugins/completion/kite/plugin.py
@@ -70,6 +70,8 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
         self.client.sig_status_response_ready.connect(self._kite_onboarding)
         self.client.sig_onboarding_response_ready.connect(
             self._show_onboarding_file)
+        self.client.sig_client_wrong_response.connect(
+            self._wrong_response_error)
 
         self.installation_thread.sig_installation_status.connect(
             self.set_status)
@@ -222,3 +224,16 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
             return
         self.set_option('show_onboarding', False)
         self.main.open_file(onboarding_file)
+
+    @Slot(str, object)
+    def _wrong_response_error(self, method, resp):
+        QMessageBox.critical(
+            self.main, _('Kite error'),
+            _("The Kite completion engine returned an unexpected result "
+            "for the request <tt>{0}</tt>: <br><br><tt>{1}</tt><br><br>"
+            "Please make sure that your Kite installation is correct. "
+            "In the meantime, Spyder will disable the Kite client to "
+            "prevent further errors. For more information, please "
+            "visit the <a href='https://help.kite.com/'>Kite help "
+            "center</a>").format(method, response))
+        self.set_option('enable', False)

--- a/spyder/plugins/completion/kite/plugin.py
+++ b/spyder/plugins/completion/kite/plugin.py
@@ -235,5 +235,5 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
               "In the meantime, Spyder will disable the Kite client to "
               "prevent further errors. For more information, please "
               "visit the <a href='https://help.kite.com/'>Kite help "
-              "center</a>").format(method, response))
+              "center</a>").format(method, resp))
         self.set_option('enable', False)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR handles wrong Kite responses by displaying an error message and disabling Kite on Spyder 

![imagen](https://user-images.githubusercontent.com/1878982/94628782-8e3a7100-0286-11eb-8fcd-d397237b1d60.png)


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13121


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @andfoy 

<!--- Thanks for your help making Spyder better for everyone! --->
