### PR TITLE
PR: Disable toolbar fullscreen button for macOS

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -830,12 +830,12 @@ class MainWindow(QMainWindow):
         if sys.platform == 'darwin':
             self.fullscreen_action.setEnabled(False)
             self.fullscreen_action.setToolTip(_("For fullscreen mode use "
-                                              "macOS built-in feature"))
+                                               "macOS built-in feature"))
         else:
             self.register_shortcut(
-                self.fullscreen_action, 
+                self.fullscreen_action,
                 "_",
-                "Fullscreen mode", 
+                "Fullscreen mode",
                 add_shortcut_to_tip=True
             )
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -829,10 +829,15 @@ class MainWindow(QMainWindow):
                                         context=Qt.ApplicationShortcut)
         if sys.platform == 'darwin':
             self.fullscreen_action.setEnabled(False)
-            self.fullscreen_action.setToolTip("Disabled for macOS")
+            self.fullscreen_action.setToolTip(_("For fullscreen mode use "
+                                              "macOS built-in feature"))
         else:
-            self.register_shortcut(self.fullscreen_action, "_",
-                               "Fullscreen mode", add_shortcut_to_tip=True)
+            self.register_shortcut(
+                self.fullscreen_action, 
+                "_",
+                "Fullscreen mode", 
+                add_shortcut_to_tip=True
+            )
 
         # Main toolbar
         self.main_toolbar_actions = [self.maximize_action,

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -827,7 +827,12 @@ class MainWindow(QMainWindow):
                                         _("Fullscreen mode"),
                                         triggered=self.toggle_fullscreen,
                                         context=Qt.ApplicationShortcut)
-        self.register_shortcut(self.fullscreen_action, "_",
+        if sys.platform == 'darwin':
+            self.fullscreen_action.setEnabled(False)
+            self.fullscreen_action.setToolTip("Disabled for macOS")
+    
+        else: 
+            self.register_shortcut(self.fullscreen_action, "_",
                                "Fullscreen mode", add_shortcut_to_tip=True)
 
         # Main toolbar

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -830,8 +830,7 @@ class MainWindow(QMainWindow):
         if sys.platform == 'darwin':
             self.fullscreen_action.setEnabled(False)
             self.fullscreen_action.setToolTip("Disabled for macOS")
-    
-        else: 
+        else:
             self.register_shortcut(self.fullscreen_action, "_",
                                "Fullscreen mode", add_shortcut_to_tip=True)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
- Disabled toolbar fullscreen action for macOS because is redundant with the OS fullscreen
- Changed tooltip to explain why it is disabled

<img width="479" alt="Screenshot 2020-09-30 at 10 21 26 AM" src="https://user-images.githubusercontent.com/18587879/94705567-d26d5600-0306-11eb-83d4-d4ef6a7a3048.png">



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes spyder-ide/ux-improvements#5


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Juanis2112

<!--- Thanks for your help making Spyder better for everyone! --->
