### PR TITLE
PR: Avoid atomic writes leaving trail of temporary files in Dropbox directories

### DIFF
--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -13,6 +13,7 @@ source code (Utilities/__init___.py) Copyright © 2003-2009 Detlev Offenbach
 
 # Standard library imports
 from codecs import BOM_UTF8, BOM_UTF16, BOM_UTF32
+import tempfile
 import locale
 import re
 import os
@@ -264,8 +265,13 @@ def write(text, filename, encoding='utf-8', mode='wb'):
             original_mode = 0o777 & ~umask
             creation = time.time()
         try:
+            # fixes issues with scripts in Dropbox leaving
+            # temporary files in the folder, see spyder-ide/spyder#13041
+            tempfolder = None
+            if 'dropbox' in absolute_filename.lower():
+                tempfolder = tempfile.gettempdir()
             with atomic_write(absolute_filename, overwrite=True,
-                              mode=mode) as textfile:
+                              mode=mode, dir=tempfolder) as textfile:
                 textfile.write(text)
         except OSError as error:
             # Some filesystems don't support the option to sync directories


### PR DESCRIPTION
I have added a workaround/fix that atomicwrites left a trail of tempfiles behind when the a script was saved in a dropbox-folder. I found no way of testing this easily, so there is no test. As discussed, it will only do so when 'dropbox' is in the filepath

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13041


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
skjerns

<!--- Thanks for your help making Spyder better for everyone! --->
