### PR TITLE
PR: Change colors for kernel errors in IPython console

### DIFF
--- a/spyder/plugins/help/utils/static/css/default.css
+++ b/spyder/plugins/help/utils/static/css/default.css
@@ -406,12 +406,12 @@ div.admonition p.admonition-title {
 
 /* --- Kernel error messages --- */
 .panel-danger {
-    border-color: #eed3d7;
+    border-color: #E74C3C;
 }
 
 .panel-danger > .panel-heading {
     color: #b94a48;
     background-color: #f2dede;
-    border-color: #eed3d7;
-    background-color: rgb(199, 28, 34);
+    border-color: #E74C3C;
+    background-color: #E74C3C;
 }

--- a/spyder/plugins/help/utils/static/dark_css/default.css
+++ b/spyder/plugins/help/utils/static/dark_css/default.css
@@ -413,19 +413,19 @@ div.admonition p.admonition-title {
 
 /* --- Kernel error messages --- */
 .panel-danger {
-    border-color: #E74C3C;
-    background-color: #E74C3C;
+    border-color: #C63323;
+    background-color: #19232D;
     color: white;
 }
 
 .panel-danger > .panel-heading {
     color: white;
-    border-color: #E74C3C;
-    background-color: #444;
+    border-color: #C63323;
+    background-color: #C63323;
 }
 
 .panel-danger > .panel-body {
-    background-color: #E74C3C;
+    background-color: #19232D;
 }
 
 /* --- Scrollbar -- */


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Changed the colors of the kernel error in the IPython console to enhance contrast. I used the new darker red proposed by @isabela-pf for errors in https://github.com/spyder-ide/ux-improvements/issues/13.

<img width="565" alt="Screenshot 2020-10-11 at 3 21 41 PM" src="https://user-images.githubusercontent.com/18587879/95689549-1ac62700-0bd7-11eb-8498-d174cdf0b864.png">

<img width="574" alt="Screenshot 2020-10-11 at 3 33 37 PM" src="https://user-images.githubusercontent.com/18587879/95689554-244f8f00-0bd7-11eb-8a85-3d85d30652e2.png">




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13754 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Juanis2112

<!--- Thanks for your help making Spyder better for everyone! --->
