### PR TITLE
PR: Add warning for xdg-utils when trying to open a file in the editor in the external file explorer

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -628,9 +628,9 @@ class EditorStack(QWidget):
             file = str(error).split("'")[1]
             if "xdg-open" in file:
                 msg_title = _("Warning")
-                msg = _("Spyder can't show the file in the External file "
-                        "explorer because xdg-open is only available in "
-                        "Ubuntu and Debian.")
+                msg = _("Spyder can't show this file in the external file "
+                        "explorer because the <tt>xdg-utills</tt> package is "
+                        "not only available in your system.")
                 QMessageBox.information(self, msg_title, msg,
                                         QMessageBox.Ok)
 

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -622,7 +622,17 @@ class EditorStack(QWidget):
         """Show file in external file explorer"""
         if fnames is None:
             fnames = self.get_current_filename()
-        show_in_external_file_explorer(fnames)
+        try:
+            show_in_external_file_explorer(fnames)
+        except FileNotFoundError as error:
+            file = str(error).split("'")[1]
+            if "xdg-open" in file:
+                msg_title = _("Warning")
+                msg = _("Spyder can't show the file in the External file "
+                        "explorer because xdg-open is only available in "
+                        "Ubuntu and Debian.")
+                QMessageBox.information(self, msg_title, msg,
+                                        QMessageBox.Ok)
 
     def create_shortcuts(self):
         """Create local shortcuts"""

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -629,8 +629,8 @@ class EditorStack(QWidget):
             if "xdg-open" in file:
                 msg_title = _("Warning")
                 msg = _("Spyder can't show this file in the external file "
-                        "explorer because the <tt>xdg-utills</tt> package is "
-                        "not only available in your system.")
+                        "explorer because the <tt>xdg-utils</tt> package is "
+                        "not available on your system.")
                 QMessageBox.information(self, msg_title, msg,
                                         QMessageBox.Ok)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Added warning dialog for xdg-file when trying to open files in external file explorer



![Screenshot 2020-10-12 at 5 58 49 PM](https://user-images.githubusercontent.com/18587879/95797270-b083b400-0cb4-11eb-98c6-a3a325e6fe87.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13507 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Juanis2112

<!--- Thanks for your help making Spyder better for everyone! --->
