### PR TITLE
PR: Use a better method to check the spinner is not shown in a couple of Outline tests

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -3667,7 +3667,7 @@ def test_outline_at_startup(main_window, qtbot):
     assert len(tree) == 0
 
     # Assert spinner is not shown
-    assert outline_explorer.explorer.loading_widget.isHidden()
+    assert not outline_explorer.explorer.loading_widget.isSpinning()
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
@@ -445,7 +445,7 @@ def test_empty_file(qtbot, lsp_codeeditor_outline):
         code_editor.request_symbols()
 
     # Assert the spinner is not shown.
-    assert outlineexplorer.loading_widget.isHidden()
+    assert not outlineexplorer.loading_widget.isSpinning()
 
     # Add some content
     code_editor.set_text("""
@@ -476,7 +476,7 @@ def foo():
     # Assert the tree is empty and the spinner is not shown.
     root_tree = get_tree_elements(treewidget)
     assert root_tree == {'test.py': []}
-    assert outlineexplorer.loading_widget.isHidden()
+    assert not outlineexplorer.loading_widget.isSpinning()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is necessary to fix our tests in master, but better to make the change in 4.x to avoid conflicts in the future.