### PR TITLE
PR: Update Outline when opening or closing projects

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -3625,8 +3625,11 @@ def test_tour_message(main_window, qtbot):
 @pytest.mark.use_introspection
 @pytest.mark.preload_project
 @pytest.mark.skipif(os.name == 'nt', reason="Fails on Windows")
-def test_outline_at_startup(main_window, qtbot):
-    """Test that all files in the Outline pane are updated at startup."""
+def test_update_outline(main_window, qtbot, tmpdir):
+    """
+    Test that files in the Outline pane are updated at startup and
+    after switching projects.
+    """
     # Show outline explorer
     outline_explorer = main_window.outlineexplorer
     outline_explorer._toggle_view_action.setChecked(True)
@@ -3668,6 +3671,25 @@ def test_outline_at_startup(main_window, qtbot):
 
     # Assert spinner is not shown
     assert not outline_explorer.explorer.loading_widget.isSpinning()
+
+    # Set one file as session without projects
+    prev_file = tmpdir.join("foo.py")
+    prev_file.write("def zz(x):\n"
+                    "    return x**2\n")
+    CONF.set('editor', 'filenames', [str(prev_file)])
+
+    # Close project to open that file automatically
+    main_window.projects.close_project()
+
+    # Wait a bit for its tree to be filled
+    qtbot.wait(1000)
+
+    # Assert the editor was filled
+    editor = list(treewidget.editor_ids.keys())[0]
+    assert len(treewidget.editor_tree_cache[editor.get_id()]) > 0
+
+    # Remove test file from session
+    CONF.set('editor', 'filenames', [])
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/outlineexplorer/plugin.py
+++ b/spyder/plugins/outlineexplorer/plugin.py
@@ -130,3 +130,7 @@ class OutlineExplorer(SpyderPluginWidget):
     def stop_symbol_services(self, language):
         """Disable LSP symbols functionality."""
         self.explorer.stop_symbol_services(language)
+
+    def update_all_editors(self):
+        """Update all editors with an associated LSP server."""
+        self.explorer.update_all_editors()

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -547,7 +547,12 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         if self.editors_to_update.get(language):
             editor = self.editors_to_update[language][0]
             if editor.info is not None:
-                self.update_editor(editor.info, editor)
+                # Editor could be not there anymore after switching
+                # projects
+                try:
+                    self.update_editor(editor.info, editor)
+                except KeyError:
+                    pass
                 self.editors_to_update[language].remove(editor)
             self.update_timers[language].start()
 

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -164,6 +164,8 @@ class Projects(SpyderPluginWidget):
         self.sig_project_loaded.connect(
             lambda v: self.main.editor.setup_open_files())
         self.sig_project_loaded.connect(self.update_explorer)
+        self.sig_project_loaded.connect(
+            lambda v: self.main.outlineexplorer.update_all_editors())
         self.sig_project_closed[object].connect(
             lambda v: self.main.workingdirectory.chdir(
                 self.get_last_working_dir()))
@@ -174,6 +176,8 @@ class Projects(SpyderPluginWidget):
                               update_kind=WorkspaceUpdateKind.DELETION))
         self.sig_project_closed.connect(
             lambda v: self.main.editor.setup_open_files())
+        self.sig_project_closed.connect(
+            lambda v: self.main.outlineexplorer.update_all_editors())
         self.recent_project_menu.aboutToShow.connect(self.setup_menu_actions)
 
         self.main.restore_scrollbar_position.connect(


### PR DESCRIPTION
This also updates all files in the Outline after switching projects and finally solves issue #13897.

Fixes #13897 