### PR TITLE
PR: Catch TypeError when loading third-party plugins (Main Window)

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1034,7 +1034,9 @@ class MainWindow(QMainWindow):
 
                     dependencies.add(module, name, description,
                                      '', None, kind=dependencies.PLUGIN)
-
+            except TypeError:
+                # Fixes spyder-ide/spyder#13977
+                pass
             except Exception as error:
                 print("%s: %s" % (mod, str(error)), file=STDERR)
                 traceback.print_exc(file=STDERR)


### PR DESCRIPTION
We don't know how this error is generated (it's been reported several time), but this should avoid it.

Fixes #13977.