### PR TITLE
PR: Improve how the options in Preferences/Appearance are applied

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1259,12 +1259,6 @@ class MainWindow(QMainWindow):
         logger.info("Setting up window...")
         self.setup_layout(default=False)
 
-        # Enabling tear off for all menus except help menu
-        if CONF.get('main', 'tear_off_menus'):
-            for child in self.menuBar().children():
-                if isinstance(child, QMenu) and child != self.help_menu:
-                    child.setTearOffEnabled(True)
-
         # Menu about to show
         for child in self.menuBar().children():
             if isinstance(child, QMenu):
@@ -2538,9 +2532,6 @@ class MainWindow(QMainWindow):
         """Add a plugin QDockWidget to the window."""
         if plugin._is_compatible:
             dockwidget, location = plugin._create_dockwidget()
-            if CONF.get('main', 'vertical_dockwidget_titlebars'):
-                dockwidget.setFeatures(dockwidget.features()|
-                                       QDockWidget.DockWidgetVerticalTitleBar)
             self.addDockWidget(location, dockwidget)
             self.widgetlist.append(plugin)
 
@@ -3004,7 +2995,7 @@ class MainWindow(QMainWindow):
 
     #---- Preferences
     def apply_settings(self):
-        """Apply settings changed in 'Preferences' dialog box"""
+        """Apply main window settings."""
         qapp = QApplication.instance()
         # Set 'gtk+' as the default theme in Gtk-based desktops
         # Fixes spyder-ide/spyder#2036.
@@ -3040,8 +3031,6 @@ class MainWindow(QMainWindow):
         """Update dockwidgets features settings"""
         for plugin in (self.widgetlist + self.thirdparty_plugins):
             features = plugin.dockwidget.FEATURES
-            if CONF.get('main', 'vertical_dockwidget_titlebars'):
-                features = features | QDockWidget.DockWidgetVerticalTitleBar
             plugin.dockwidget.setFeatures(features)
             plugin._update_margins()
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -231,7 +231,10 @@ DEFAULT_TOUR = 0
 #==============================================================================
 class MainWindow(QMainWindow):
     """Spyder main window"""
-    DOCKOPTIONS = QMainWindow.AllowTabbedDocks|QMainWindow.AllowNestedDocks
+    DOCKOPTIONS = (
+        QMainWindow.AllowTabbedDocks | QMainWindow.AllowNestedDocks |
+        QMainWindow.AnimatedDocks
+    )
     CURSORBLINK_OSDEFAULT = QApplication.cursorFlashTime()
     SPYDER_PATH = get_conf_path('path')
     SPYDER_NOT_ACTIVE_PATH = get_conf_path('not_active_path')
@@ -536,7 +539,7 @@ class MainWindow(QMainWindow):
         # To show the message about starting the tour
         self.sig_setup_finished.connect(self.show_tour_message)
 
-        # Apply preferences
+        # Apply main window settings
         self.apply_settings()
 
         # To set all dockwidgets tabs to be on top (in case we want to do it
@@ -2997,6 +3000,7 @@ class MainWindow(QMainWindow):
     def apply_settings(self):
         """Apply main window settings."""
         qapp = QApplication.instance()
+
         # Set 'gtk+' as the default theme in Gtk-based desktops
         # Fixes spyder-ide/spyder#2036.
         if is_gtk_desktop() and ('GTK+' in QStyleFactory.keys()):
@@ -3015,15 +3019,14 @@ class MainWindow(QMainWindow):
         default = self.DOCKOPTIONS
         if CONF.get('main', 'vertical_tabs'):
             default = default|QMainWindow.VerticalTabs
-        if CONF.get('main', 'animated_docks'):
-            default = default|QMainWindow.AnimatedDocks
         self.setDockOptions(default)
 
         self.apply_panes_settings()
         self.apply_statusbar_settings()
 
         if CONF.get('main', 'use_custom_cursor_blinking'):
-            qapp.setCursorFlashTime(CONF.get('main', 'custom_cursor_blinking'))
+            qapp.setCursorFlashTime(
+                CONF.get('main', 'custom_cursor_blinking'))
         else:
             qapp.setCursorFlashTime(self.CURSORBLINK_OSDEFAULT)
 

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -62,13 +62,11 @@ DEFAULTS = [
               'opengl': 'software',
               'single_instance': True,
               'open_files_port': OPEN_FILES_PORT,
-              'tear_off_menus': False,
               'mac_open_file': False,
               'normal_screen_resolution': True,
               'high_dpi_scaling': False,
               'high_dpi_custom_scale_factor': False,
               'high_dpi_custom_scale_factors': '1.5',
-              'vertical_dockwidget_titlebars': False,
               'vertical_tabs': False,
               'animated_docks': True,
               'prompt_on_exit': False,
@@ -638,4 +636,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '58.1.0'
+CONF_VERSION = '59.0.0'

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -68,7 +68,6 @@ DEFAULTS = [
               'high_dpi_custom_scale_factor': False,
               'high_dpi_custom_scale_factors': '1.5',
               'vertical_tabs': False,
-              'animated_docks': True,
               'prompt_on_exit': False,
               'panes_locked': True,
               'window/size': (1260, 740),

--- a/spyder/preferences/appearance.py
+++ b/spyder/preferences/appearance.py
@@ -7,10 +7,11 @@
 """Appearance entry in Preferences."""
 
 from qtpy.QtCore import Qt, Slot
-from qtpy.QtWidgets import (QDialog, QDialogButtonBox, QFontComboBox,
-                            QGridLayout, QGroupBox, QHBoxLayout,
-                            QMessageBox, QPushButton, QStackedWidget,
-                            QStyleFactory, QVBoxLayout, QWidget)
+from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
+                            QFontComboBox, QGridLayout, QGroupBox,
+                            QHBoxLayout, QMessageBox, QPushButton,
+                            QStackedWidget, QStyleFactory, QVBoxLayout,
+                            QWidget)
 
 from spyder.config.base import _
 from spyder.config.gui import (get_font, set_font, is_dark_font_color,
@@ -233,7 +234,14 @@ class AppearanceConfigPage(GeneralConfigPage):
                     plugin.apply_plugin_settings(['color_scheme_name'])
                 self.update_combobox()
                 self.update_preview()
-        self.main.apply_settings()
+
+        qapp = QApplication.instance()
+        if 'windows_style' in options:
+            style_name = self.get_option('windows_style')
+            style = QStyleFactory.create(style_name)
+            if style is not None:
+                style.setProperty('name', style_name)
+                qapp.setStyle(style)
 
     # Helpers
     # -------------------------------------------------------------------------

--- a/spyder/preferences/general.py
+++ b/spyder/preferences/general.py
@@ -105,15 +105,10 @@ class MainConfigPage(GeneralConfigPage):
         # --- Theme
         interface_group = QGroupBox(_("Interface"))
 
-        vertdock_box = newcb(_("Vertical title bars in panes"),
-                             'vertical_dockwidget_titlebars')
         verttabs_box = newcb(_("Vertical tabs in panes"),
                              'vertical_tabs')
         animated_box = newcb(_("Animated toolbars and panes"),
                              'animated_docks')
-        tear_off_box = newcb(_("Tear off menus"), 'tear_off_menus',
-                             tip=_("Set this to detach any<br> "
-                                   "menu from the main window"))
         margin_box = newcb(_("Custom margin for panes:"),
                            'use_custom_margin')
         margin_spin = self.create_spinbox("", _("pixels"), 'custom_margin',
@@ -148,10 +143,8 @@ class MainConfigPage(GeneralConfigPage):
 
         # Layout interface
         interface_layout = QVBoxLayout()
-        interface_layout.addWidget(vertdock_box)
         interface_layout.addWidget(verttabs_box)
         interface_layout.addWidget(animated_box)
-        interface_layout.addWidget(tear_off_box)
         interface_layout.addLayout(margins_cursor_layout)
         interface_group.setLayout(interface_layout)
 

--- a/spyder/preferences/general.py
+++ b/spyder/preferences/general.py
@@ -107,8 +107,6 @@ class MainConfigPage(GeneralConfigPage):
 
         verttabs_box = newcb(_("Vertical tabs in panes"),
                              'vertical_tabs')
-        animated_box = newcb(_("Animated toolbars and panes"),
-                             'animated_docks')
         margin_box = newcb(_("Custom margin for panes:"),
                            'use_custom_margin')
         margin_spin = self.create_spinbox("", _("pixels"), 'custom_margin',
@@ -144,7 +142,6 @@ class MainConfigPage(GeneralConfigPage):
         # Layout interface
         interface_layout = QVBoxLayout()
         interface_layout.addWidget(verttabs_box)
-        interface_layout.addWidget(animated_box)
         interface_layout.addLayout(margins_cursor_layout)
         interface_group.setLayout(interface_layout)
 


### PR DESCRIPTION
This PR avoids calling `MainWindow.apply_settings` when applying changes in Appearance, which was unnecessary.

It also removes the following options from Preferences/General:

- Vertical title bars in panes
- Animated toolbars and panes
- Tear off menus

The first one was breaking the interface. And by removing the others, now changes in Appearance (e.g. syntax highlighting and fonts) apply much faster.