### PR TITLE
PR: Don't interrupt while copying (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -677,7 +677,9 @@ the sympy module (e.g. plot)
 
     # ---- Private methods (overrode by us) -----------------------------------
     def _event_filter_console_keypress(self, event):
-        """ Reimplemented for execution interruption.
+        """
+        Reimplemented to avoid interrupting execution when trying to
+        copy text.
         """
         key = event.key()
         if self._control_key_down(event.modifiers(), include_command=False):

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -15,7 +15,7 @@ import uuid
 from textwrap import dedent
 
 # Third party imports
-from qtpy.QtCore import Signal, QThread
+from qtpy.QtCore import Signal, QThread, Qt
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports
@@ -676,6 +676,21 @@ the sympy module (e.g. plot)
         self.ipyclient.restart_kernel()
 
     # ---- Private methods (overrode by us) -----------------------------------
+    def _event_filter_console_keypress(self, event):
+        """ Reimplemented for execution interruption.
+        """
+        key = event.key()
+        if self._control_key_down(event.modifiers(), include_command=False):
+            if key == Qt.Key_C and self._executing:
+                if self.can_copy():
+                    self.copy()
+                    return True
+                else:
+                    self.request_interrupt_kernel()
+                    return True
+
+        return super(ShellWidget, self)._event_filter_console_keypress(event)
+
     def _handle_error(self, msg):
         """
         Reimplemented to reset the prompt if the error comes after the reply


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
One annoyance I have with the console is that when the code is not executing, ctrl + c means copy, and when executing, ctrl + c means interrupt. This changes the behaviour so that if text is selected, it will copy rather than interrupt.

Should that be an option?

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
