### PR TITLE
PR: Don't pass PYTHONPATH directly to the kernel (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 1.x
-	commit = 39958996260e1057440ac21741b6024c71220b6c
-	parent = 5d7f95b712174ce1177ed3fdae07ddd8348979b7
+	branch = set-spyder-pythonpath
+	commit = 52531ce2126e04c58c9b2047606215d1df89e291
+	parent = cb13febc87d0b365d01ee184aaaf536076f96d48
 	method = merge
 	cmdver = 0.4.1

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = set-spyder-pythonpath
-	commit = 52531ce2126e04c58c9b2047606215d1df89e291
-	parent = cb13febc87d0b365d01ee184aaaf536076f96d48
+	branch = 1.x
+	commit = 1f18d92f6a7e576f5f5ae739476388d94c231b6b
+	parent = b2eb2d1cf3d9ce94b37191af3b6386886758da7e
 	method = merge
 	cmdver = 0.4.1

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
@@ -715,10 +715,12 @@ builtins.cell_count = cell_count
 
 
 # =============================================================================
-# Restoring original PYTHONPATH
+# Extend sys.path with paths that come from Spyder
 # =============================================================================
-try:
-    os.environ['PYTHONPATH'] = os.environ['OLD_PYTHONPATH']
-    del os.environ['OLD_PYTHONPATH']
-except KeyError:
-    pass
+def set_spyder_pythonpath():
+    pypath = os.environ.get('SPY_PYTHONPATH')
+    if pypath:
+        pathlist = pypath.split(os.pathsep)
+        sys.path.extend(pathlist)
+
+set_spyder_pythonpath()

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -24,7 +24,7 @@ from spyder.config.manager import CONF
 from spyder.utils.conda import (add_quotes, get_conda_activation_script,
                                 get_conda_env_path, is_conda_env)
 from spyder.utils.environ import clean_env
-from spyder.utils.misc import add_pathlist_to_PYTHONPATH, get_python_executable
+from spyder.utils.misc import get_python_executable
 from spyder.utils.programs import is_python_interpreter
 
 # Constants
@@ -129,31 +129,23 @@ class SpyderKernelSpec(KernelSpec):
         # to the kernel sys.path
         env_vars.pop('VIRTUAL_ENV', None)
 
-        pathlist = CONF.get('main', 'spyder_pythonpath', default=[])
-
-        # Add spyder-kernels subrepo path to pathlist
+        # Add spyder-kernels subrepo path to PYTHONPATH
         if DEV or running_under_pytest():
             repo_path = osp.normpath(osp.join(HERE, '..', '..', '..', '..'))
             subrepo_path = osp.join(repo_path, 'external-deps',
                                     'spyder-kernels')
 
-            if running_under_pytest():
-                # Oddly pathlist is not set as an empty list when running
-                # under pytest
-                pathlist = [subrepo_path]
-            else:
-                pathlist += [subrepo_path] + pathlist
+            env_vars.update({'PYTHONPATH': subrepo_path})
 
-        # Create PYTHONPATH env entry to add it to the kernel
-        pypath = add_pathlist_to_PYTHONPATH([], pathlist, ipyconsole=True,
-                                            drop_env=True)
+        # List of paths declared by the user, plus project's path, to
+        # add to PYTHONPATH
+        pathlist = CONF.get('main', 'spyder_pythonpath', default=[])
+        pypath = os.pathsep.join(pathlist)
 
-        # Add our PYTHONPATH to env_vars
-        env_vars.update(pypath)
-
-        # Environment variables that we need to pass to our sitecustomize
+        # List of modules to exclude from our UMR
         umr_namelist = CONF.get('main_interpreter', 'umr/namelist')
 
+        # Environment variables that we need to pass to the kernel
         env_vars.update({
             'SPY_EXTERNAL_INTERPRETER': not default_interpreter,
             'SPY_UMR_ENABLED': CONF.get('main_interpreter', 'umr/enabled'),
@@ -180,7 +172,8 @@ class SpyderKernelSpec(KernelSpec):
             'SPY_JEDI_O': CONF.get('ipython_console', 'jedi_completer'),
             'SPY_SYMPY_O': CONF.get('ipython_console', 'symbolic_math'),
             'SPY_TESTING': running_under_pytest() or get_safe_mode(),
-            'SPY_HIDE_CMD': CONF.get('ipython_console', 'hide_cmd_windows')
+            'SPY_HIDE_CMD': CONF.get('ipython_console', 'hide_cmd_windows'),
+            'SPY_PYTHONPATH': pypath
         })
 
         if self.is_pylab is True:


### PR DESCRIPTION
- This avoids a kernel crash when users have files with the same names as standard library modules either in their projects or the directories they set through our PYTHONPATH manager.
- Instead, we pass it through a new env var called SPY_PYTHONPATH, whose contents are added to sys.path in the kernel's sitecustomize.

Depends on spyder-ide/spyder-kernels#253.

Fixes #13519.