### PR TITLE
PR: Simplify add_pathlist_to_PYTHONPATH

### DIFF
--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -223,7 +223,7 @@ def get_common_path(pathlist):
                 return osp.abspath(common)
 
 
-def add_pathlist_to_PYTHONPATH(env, pathlist, drop_env=False):
+def add_pathlist_to_PYTHONPATH(env, pathlist, drop_env=True):
     """
     Add a PYTHONPATH entry to a list of enviroment variables.
 

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -223,31 +223,38 @@ def get_common_path(pathlist):
                 return osp.abspath(common)
 
 
-def add_pathlist_to_PYTHONPATH(env, pathlist, drop_env=False,
-                               ipyconsole=False):
+def add_pathlist_to_PYTHONPATH(env, pathlist, drop_env=False):
+    """
+    Add a PYTHONPATH entry to a list of enviroment variables.
+
+    This allows to extend the environment of an external process
+    created with QProcess with our additions to PYTHONPATH.
+
+    Parameters
+    ----------
+    env: list
+        List of environment variables
+    pathlist: list
+        List of paths to add to PYTHONPATH
+    drop_env: bool
+        Whether to drop PYTHONPATH previously found in the environment.
+    """
     # PyQt API 1/2 compatibility-related tests:
     assert isinstance(env, list)
     assert all([is_text_string(path) for path in env])
 
     pypath = "PYTHONPATH"
     pathstr = os.pathsep.join(pathlist)
-    if os.environ.get(pypath) is not None and not drop_env:
+    if os.environ.get(pypath) and not drop_env:
         old_pypath = os.environ[pypath]
-        if not ipyconsole:
-            for index, var in enumerate(env[:]):
-                if var.startswith(pypath+'='):
-                    env[index] = var.replace(pypath+'=',
-                                             pypath+'='+pathstr+os.pathsep)
-            env.append('OLD_PYTHONPATH='+old_pypath)
-        else:
-            pypath =  {'PYTHONPATH': pathstr + os.pathsep + old_pypath,
-                       'OLD_PYTHONPATH': old_pypath}
-            return pypath
+        for index, var in enumerate(env[:]):
+            if var.startswith(pypath + '='):
+                env[index] = var.replace(
+                    pypath + '=',
+                    pypath + '=' + pathstr + os.pathsep)
+        env.append('OLD_PYTHONPATH=' + old_pypath)
     else:
-        if not ipyconsole:
-            env.append(pypath+'='+pathstr)
-        else:
-            return {'PYTHONPATH': pathstr}
+        env.append(pypath + '=' + pathstr)
 
 
 def memoize(obj):

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -233,7 +233,8 @@ def add_pathlist_to_PYTHONPATH(env, pathlist, drop_env=True):
     Parameters
     ----------
     env: list
-        List of environment variables
+        List of environment variables in the format of
+        QProcessEnvironment.
     pathlist: list
         List of paths to add to PYTHONPATH
     drop_env: bool
@@ -245,7 +246,7 @@ def add_pathlist_to_PYTHONPATH(env, pathlist, drop_env=True):
 
     pypath = "PYTHONPATH"
     pathstr = os.pathsep.join(pathlist)
-    if os.environ.get(pypath) and not drop_env:
+    if not drop_env:
         for index, var in enumerate(env[:]):
             if var.startswith(pypath + '='):
                 env[index] = var.replace(

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -246,13 +246,12 @@ def add_pathlist_to_PYTHONPATH(env, pathlist, drop_env=False):
     pypath = "PYTHONPATH"
     pathstr = os.pathsep.join(pathlist)
     if os.environ.get(pypath) and not drop_env:
-        old_pypath = os.environ[pypath]
         for index, var in enumerate(env[:]):
             if var.startswith(pypath + '='):
                 env[index] = var.replace(
                     pypath + '=',
-                    pypath + '=' + pathstr + os.pathsep)
-        env.append('OLD_PYTHONPATH=' + old_pypath)
+                    pypath + '=' + pathstr + os.pathsep
+                )
     else:
         env.append(pypath + '=' + pathstr)
 

--- a/spyder/utils/tests/test_misc.py
+++ b/spyder/utils/tests/test_misc.py
@@ -15,7 +15,10 @@ import os
 import pytest
 
 # Local imports
-from spyder.utils.misc import get_common_path
+from spyder.utils.misc import (
+    get_common_path, add_pathlist_to_PYTHONPATH
+)
+
 
 def test_get_common_path():
     """Test getting the common path."""
@@ -33,6 +36,29 @@ def test_get_common_path():
                                 '/Python/spyder/spyder.widgets',
                                 '/Python/spyder-v21/spyder.utils',
                                 ]) == '/Python'
+
+
+@pytest.mark.parametrize("drop_env", [True, False])
+def test_add_pathlist_to_PYTHONPATH(drop_env):
+    """Test for add_pathlist_to_PYTHONPATH."""
+    pathlist = ['test123', 'test456']
+
+    if drop_env:
+        env = []
+        expected = ['PYTHONPATH=' + pathlist[0] + os.pathsep + pathlist[1]]
+    else:
+        env = ['PYTHONPATH=test0']
+        expected = [
+            'PYTHONPATH=' +
+            pathlist[0] +
+            os.pathsep +
+            pathlist[1] +
+            os.pathsep +
+            'test0'
+        ]
+
+    add_pathlist_to_PYTHONPATH(env, pathlist, drop_env=drop_env)
+    assert env == expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
After PR #14017, we are no longer using `add_pathlist_to_PYTHONPATH` in our kernelspec. That allowed us to simplify its code and fix some bugs about it.

Fixes #13964
Fixes #12564
Fixes #3161