### PR TITLE
PR: Some improvements to the "Run > Configuration per file" dialog (2)

### DIFF
--- a/spyder/preferences/runconfig.py
+++ b/spyder/preferences/runconfig.py
@@ -403,6 +403,7 @@ class RunConfigOneDialog(BaseRunConfigDialog):
         scrollarea = QScrollArea(self)
         scrollarea.setWidget(self.runconfigoptions)
         scrollarea.setMinimumWidth(560)
+        scrollarea.setWidgetResizable(True)
         self.add_widgets(scrollarea)
         self.add_button_box(QDialogButtonBox.Cancel)
         self.setWindowTitle(_("Run settings for %s") % osp.basename(fname))

--- a/spyder/preferences/runconfig.py
+++ b/spyder/preferences/runconfig.py
@@ -258,7 +258,6 @@ class RunConfigOptions(QWidget):
         self.firstrun_cb.setChecked(firstrun_o)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(interpreter_group)
         layout.addWidget(common_group)
         layout.addWidget(wdir_group)
@@ -458,6 +457,7 @@ class RunConfigDialog(BaseRunConfigDialog):
         for filename, options in configurations:
             widget = RunConfigOptions(self)
             widget.set(options)
+            widget.layout().setContentsMargins(0, 0, 0, 0)
             self.combo.addItem(filename)
             self.stack.addWidget(widget)
         self.combo.currentIndexChanged.connect(self.stack.setCurrentIndex)


### PR DESCRIPTION
This is a follow up of PR #13979 to fix the layout for the single file version of the `RunConfigOneDialog`.

I'm sorry for that, I totally missed this in my previous PR.


![image](https://user-images.githubusercontent.com/10170372/96633181-c150ad00-12e6-11eb-8c09-422372c66ab5.png)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin
