### PR TITLE
PR: Fix issue where external IPython consoles do not launch for macOS application

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -192,6 +192,7 @@ class SpyderKernelSpec(KernelSpec):
         # macOS app considerations
         if running_in_mac_app() and not default_interpreter:
             env_vars.pop('PYTHONHOME', None)
+            env_vars.pop('PYTHONPATH', None)
 
         # Making all env_vars strings
         clean_env_vars = clean_env(env_vars)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Remove `PYTHONPATH` from `env_vars` passed to external IPython consoles on the macOS application.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Commit cb13febc87d0b365d01ee184aaaf536076f96d48 introduced an error in which Spyder's runtime PYTHONPATH was passed to the kernel preventing external IPython consoles from launching.

<img width="824" alt="Screen Shot 2020-10-21 at 5 59 57 PM" src="https://user-images.githubusercontent.com/9618975/96814675-b3c42180-13d1-11eb-988d-28ef0af29ae5.png">

Now that the Python Path Manager values no longer overwrite `PYTHONPATH` in `env_vars`, we can just drop it for macOS app external consoles.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
mrclary
<!--- Thanks for your help making Spyder better for everyone! --->
