### PR TITLE
PR: Some improvements to the create project dialog.

### DIFF
--- a/spyder/plugins/projects/widgets/projectdialog.py
+++ b/spyder/plugins/projects/widgets/projectdialog.py
@@ -27,7 +27,8 @@ from qtpy.QtWidgets import (QVBoxLayout, QLabel, QLineEdit, QPushButton,
 
 # Local imports
 from spyder.config.base import _, get_home_dir
-from spyder.utils.qthelpers import get_std_icon
+from spyder.utils import icon_manager as ima
+from spyder.utils.qthelpers import create_toolbutton
 from spyder.py3compat import to_text_string
 from spyder.plugins.projects.widgets import get_available_project_types
 
@@ -79,7 +80,11 @@ class ProjectDialog(QDialog):
         self.combo_project_type = QComboBox()
         self.combo_python_version = QComboBox()
 
-        self.button_select_location = QToolButton()
+        self.button_select_location = create_toolbutton(
+            self,
+            triggered=self.select_location,
+            icon=ima.icon('DirOpenIcon'),
+            tip=_("Select directory"))
         self.button_cancel = QPushButton(_('Cancel'))
         self.button_create = QPushButton(_('Create'))
 
@@ -92,7 +97,6 @@ class ProjectDialog(QDialog):
         self.radio_new_dir.setChecked(True)
         self.text_location.setEnabled(True)
         self.text_location.setReadOnly(True)
-        self.button_select_location.setIcon(get_std_icon('DirOpenIcon'))
         self.button_cancel.setDefault(True)
         self.button_cancel.setAutoDefault(True)
         self.button_create.setEnabled(False)
@@ -133,7 +137,6 @@ class ProjectDialog(QDialog):
         self.setLayout(layout)
 
         # Signals and slots
-        self.button_select_location.clicked.connect(self.select_location)
         self.button_create.clicked.connect(self.create_project)
         self.button_cancel.clicked.connect(self.close)
         self.radio_from_dir.clicked.connect(self.update_location)

--- a/spyder/plugins/projects/widgets/projectdialog.py
+++ b/spyder/plugins/projects/widgets/projectdialog.py
@@ -53,6 +53,8 @@ class ProjectDialog(QDialog):
     def __init__(self, parent):
         """Project creation dialog."""
         super(ProjectDialog, self).__init__(parent=parent)
+        self.setWindowFlags(
+            self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
 
         # Variables
         current_python_version = '.'.join([to_text_string(sys.version_info[0]),

--- a/spyder/plugins/projects/widgets/projectdialog.py
+++ b/spyder/plugins/projects/widgets/projectdialog.py
@@ -19,11 +19,9 @@ import tempfile
 # Third party imports
 from qtpy.compat import getexistingdirectory
 from qtpy.QtCore import Qt, Signal
-from qtpy.QtWidgets import (QVBoxLayout, QLabel, QLineEdit, QPushButton,
-                            QDialog, QComboBox, QGridLayout, QToolButton,
-                            QDialogButtonBox, QGroupBox, QRadioButton,
-                            QHBoxLayout)
-
+from qtpy.QtWidgets import (QComboBox, QDialog, QDialogButtonBox, QGridLayout,
+                            QGroupBox, QHBoxLayout, QLabel, QLineEdit,
+                            QPushButton, QRadioButton, QVBoxLayout)
 
 # Local imports
 from spyder.config.base import _, get_home_dir


### PR DESCRIPTION
## Description of Changes

This PR proposes very minor changes to improve the style of the `ProjectDialog`:

- Remove the window context help button. Since we are not using this feature, there is no need to have this button there.
- Standardize the style of the 'Select directory' button to that used elsewhere in Spyder.

![image](https://user-images.githubusercontent.com/10170372/96875018-bf9cfb80-1444-11eb-8953-2a65d3986f7d.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin
