### PR TITLE
PR: Improvements to the About Spyder dialog

### DIFF
--- a/spyder/widgets/about.py
+++ b/spyder/widgets/about.py
@@ -143,7 +143,8 @@ class AboutDialog(QDialog):
 
         pixmap = QPixmap(get_image_path(icon_filename))
         self.label_pic = QLabel(self)
-        self.label_pic.setPixmap(pixmap.scaled(64, 64))
+        self.label_pic.setPixmap(
+            pixmap.scaledToWidth(64, Qt.SmoothTransformation))
         self.label_pic.setAlignment(Qt.AlignTop)
 
         btn = QPushButton(_("Copy to clipboard"), )

--- a/spyder/widgets/about.py
+++ b/spyder/widgets/about.py
@@ -151,7 +151,7 @@ class AboutDialog(QDialog):
         bbox = QDialogButtonBox(QDialogButtonBox.Ok)
 
         # Widget setup
-        self.setWindowIcon(ima.icon('tooloptions'))
+        self.setWindowIcon(ima.icon('MessageBoxInformation'))
         self.setModal(False)
 
         # Layout

--- a/spyder/widgets/about.py
+++ b/spyder/widgets/about.py
@@ -164,12 +164,11 @@ class AboutDialog(QDialog):
         btmhlayout.addStretch()
         btmhlayout.addWidget(bbox)
 
-        vlayout = QVBoxLayout()
+        vlayout = QVBoxLayout(self)
         vlayout.addLayout(tophlayout)
+        vlayout.addSpacing(25)
         vlayout.addLayout(btmhlayout)
-
-        self.setLayout(vlayout)
-        self.setFixedSize(410, 560)
+        vlayout.setSizeConstraint(vlayout.SetFixedSize)
 
         # Signals
         btn.clicked.connect(self.copy_to_clipboard)

--- a/spyder/widgets/about.py
+++ b/spyder/widgets/about.py
@@ -28,8 +28,9 @@ class AboutDialog(QDialog):
 
     def __init__(self, parent):
         """Create About Spyder dialog with general information."""
-
         QDialog.__init__(self, parent)
+        self.setWindowFlags(
+            self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         versions = get_versions()
         # Show Git revision for development version
         revlink = ''

--- a/spyder/widgets/about.py
+++ b/spyder/widgets/about.py
@@ -135,6 +135,7 @@ class AboutDialog(QDialog):
         self.label.setAlignment(Qt.AlignTop)
         self.label.setOpenExternalLinks(True)
         self.label.setTextInteractionFlags(Qt.TextBrowserInteraction)
+        self.label.setFixedWidth(350)
 
         if is_dark_interface():
             icon_filename = "spyder.svg"

--- a/spyder/widgets/about.py
+++ b/spyder/widgets/about.py
@@ -134,6 +134,7 @@ class AboutDialog(QDialog):
         self.label.setWordWrap(True)
         self.label.setAlignment(Qt.AlignTop)
         self.label.setOpenExternalLinks(True)
+        self.label.setTextInteractionFlags(Qt.TextBrowserInteraction)
 
         if is_dark_interface():
             icon_filename = "spyder.svg"


### PR DESCRIPTION
## Description of Changes
@ccordoba12 Feel free to revert any changes you don't agree with. I should have opened an issue first, but since I'm a little bit short on time these days, it is more efficient to open a PR directly, I apologize for that.

Also, I don't know how this will look in macOS or Linux.

1. Make text in the dialog selectable.
2. Change dialog logo to fit that used in the `Help` menu
3. Scale Spyder logo with a Smooth transform instead of Fast to improve how it look on-screen.
4. Don't hardcode the dialog size and let Qt determine the best size to fit the content.

![image](https://user-images.githubusercontent.com/10170372/97039087-da04d100-1539-11eb-8b3a-913c238ecf21.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Jean-Sébastien Gosselin
