### PR TITLE
PR: Update subrepo with python-language-server#879

### DIFF
--- a/external-deps/python-language-server/.gitrepo
+++ b/external-deps/python-language-server/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/palantir/python-language-server.git
 	branch = develop
-	commit = e9c7e9bcf07a08d7600cfd6e5ce60874df8e80c6
-	parent = dacb81ad8312324cb8376fba744597788b419dd8
+	commit = e0f8b3d0e6dfc27eb78da1ea2ce2d441f7930263
+	parent = a31205d58c54bfc77d9555ffee691ba4b304481f
 	method = merge
 	cmdver = 0.4.1

--- a/external-deps/python-language-server/pyls/plugins/pycodestyle_lint.py
+++ b/external-deps/python-language-server/pyls/plugins/pycodestyle_lint.py
@@ -78,5 +78,13 @@ class PyCodeStyleDiagnosticReport(pycodestyle.BaseReport):
             'message': text,
             'code': code,
             # Are style errors really ever errors?
-            'severity': lsp.DiagnosticSeverity.Warning
+            'severity': _get_severity(code)
         })
+
+
+def _get_severity(code):
+    # Are style errors ever really errors?
+    if code[0] == 'E' or code[0] == 'W':
+        return lsp.DiagnosticSeverity.Warning
+    # If no severity is specified, why wouldn't this be informational only?
+    return lsp.DiagnosticSeverity.Information

--- a/external-deps/python-language-server/pyls/workspace.py
+++ b/external-deps/python-language-server/pyls/workspace.py
@@ -258,7 +258,7 @@ class Document(object):
         env_vars.pop('PYTHONPATH', None)
 
         environment = self.get_enviroment(environment_path, env_vars=env_vars) if environment_path else None
-        sys_path = self.sys_path(environment_path, env_vars=env_vars) + extra_paths
+        sys_path = self.sys_path(environment_path, env_vars=env_vars) + extra_paths + [os.path.dirname(self.path)]
         project_path = self._workspace.root_path
 
         kwargs = {

--- a/external-deps/python-language-server/test/fixtures.py
+++ b/external-deps/python-language-server/test/fixtures.py
@@ -45,6 +45,15 @@ def workspace(tmpdir):
 
 
 @pytest.fixture
+def workspace_other_root_path(tmpdir):
+    """Return a workspace with a root_path other than tmpdir."""
+    ws_path = str(tmpdir.mkdir('test123').mkdir('test456'))
+    ws = Workspace(uris.from_fs_path(ws_path), Mock())
+    ws._config = Config(ws.root_uri, {}, 0, {})
+    return ws
+
+
+@pytest.fixture
 def config(workspace):  # pylint: disable=redefined-outer-name
     """Return a config object."""
     return Config(workspace.root_uri, {}, 0, {})

--- a/external-deps/python-language-server/test/plugins/test_completion.py
+++ b/external-deps/python-language-server/test/plugins/test_completion.py
@@ -334,3 +334,26 @@ def test_jedi_completion_environment(workspace):
     completions = pyls_jedi_completions(doc._config, doc, com_position)
     assert completions[0]['label'] == 'loghub'
     assert 'changelog generator' in completions[0]['documentation'].lower()
+
+
+def test_document_path_completions(tmpdir, workspace_other_root_path):
+    # Create a dummy module out of the workspace's root_path and try to get
+    # completions for it in another file placed next to it.
+    module_content = '''
+def foo():
+    pass
+'''
+
+    p = tmpdir.join("mymodule.py")
+    p.write(module_content)
+
+    # Content of doc to test completion
+    doc_content = """import mymodule
+mymodule.f"""
+    doc_path = str(tmpdir) + os.path.sep + 'myfile.py'
+    doc_uri = uris.from_fs_path(doc_path)
+    doc = Document(doc_uri, workspace_other_root_path, doc_content)
+
+    com_position = {'line': 1, 'character': 10}
+    completions = pyls_jedi_completions(doc._config, doc, com_position)
+    assert completions[0]['label'] == 'foo()'


### PR DESCRIPTION
The fix made in https://github.com/palantir/python-language-server/pull/879 allows us to have completions for files placed next to a module and out of the workspace's `root_path`.

Fixes #11118.