### PR TITLE
PR: Replace deprecated imp with importlib

### DIFF
--- a/spyder/otherplugins.py
+++ b/spyder/otherplugins.py
@@ -9,6 +9,7 @@ Spyder third-party plugins configuration management.
 """
 
 # Standard library imports
+import importlib
 import logging
 import os
 import os.path as osp
@@ -17,12 +18,8 @@ import traceback
 
 # Local imports
 from spyder.config.base import get_conf_path
-from spyder.py3compat import PY2, to_text_string
+from spyder.py3compat import to_text_string
 
-if PY2:
-    import imp
-else:
-    import importlib
 
 # Constants
 logger = logging.getLogger(__name__)
@@ -108,18 +105,12 @@ def _import_module_from_path(module_name, plugin_path):
     """
     module = None
     try:
-        if PY2:
-            info = imp.find_module(module_name, [plugin_path])
-            if info:
-                module = imp.load_module(module_name, *info)
-        else:
-            # Python 3.4+
-            spec = importlib.machinery.PathFinder.find_spec(
-                module_name,
-                [plugin_path])
+        spec = importlib.machinery.PathFinder.find_spec(
+            module_name,
+            [plugin_path])
 
-            if spec:
-                module = spec.loader.load_module(module_name)
+        if spec:
+            module = spec.loader.load_module(module_name)
     except Exception as err:
         debug_message = ("plugin: '{module_name}' load failed with `{err}`"
                          "").format(module_name=module_name,

--- a/spyder/plugins/completion/fallback/utils.py
+++ b/spyder/plugins/completion/fallback/utils.py
@@ -9,7 +9,7 @@ Utilities needed by the fallback completion engine.
 """
 
 # Standard imports
-import imp
+import importlib
 import os
 import os.path as osp
 import re
@@ -151,24 +151,21 @@ def get_parent_until(path):
     """
     Given a file path, determine the full module path.
 
-    e.g. '/usr/lib/python2.7/dist-packages/numpy/core/__init__.pyc' yields
-    'numpy.core'
+    e.g. '/usr/lib/python3.7/dist-packages/numpy/core/__init__.pyc' yields
+    'numpy.core.__init__'
     """
     dirname = osp.dirname(path)
-    try:
-        mod = osp.basename(path)
-        mod = osp.splitext(mod)[0]
-        imp.find_module(mod, [dirname])
-    except ImportError:
+    mod = osp.basename(path)
+    mod = osp.splitext(mod)[0]
+    spec = importlib.machinery.PathFinder.find_spec(mod, [dirname])
+    if not spec:
         return
     items = [mod]
-    while 1:
+    while spec:
         items.append(osp.basename(dirname))
-        try:
-            dirname = osp.dirname(dirname)
-            imp.find_module('__init__', [dirname + os.sep])
-        except ImportError:
-            break
+        dirname = osp.dirname(dirname)
+        spec = importlib.machinery.PathFinder.find_spec('__init__',
+                                                        [dirname + os.sep])
     return '.'.join(reversed(items))
 
 

--- a/spyder/plugins/io_hdf5/plugin.py
+++ b/spyder/plugins/io_hdf5/plugin.py
@@ -34,13 +34,13 @@ TODO: Check issues with valid python names vs valid h5f5 names
 
 from __future__ import print_function
 
-try:
-    # Do not import h5py here because it will try to import IPython,
-    # and this is freezing the Spyder GUI
-    import imp
-    imp.find_module('h5py')
-    import numpy as np
+import importlib
+# Do not import h5py here because it will try to import IPython,
+# and this is freezing the Spyder GUI
 
+import numpy as np
+
+if importlib.util.find_spec('h5py'):
     def load_hdf5(filename):
         import h5py
         def get_group(group):
@@ -71,7 +71,7 @@ try:
             f.close()
         except Exception as error:
             return str(error)
-except ImportError:
+else:
     load_hdf5 = None
     save_hdf5 = None
 

--- a/spyder/utils/introspection/old_fallback.py
+++ b/spyder/utils/introspection/old_fallback.py
@@ -9,7 +9,7 @@ Introspection utilities used by Spyder
 """
 
 from __future__ import print_function
-import imp
+import importlib
 import os
 import os.path as osp
 import re
@@ -162,9 +162,10 @@ def python_like_mod_finder(import_line, alt_path=None,
     tokens = re.split(r'\W', import_line)
     if tokens[0] in ['from', 'import']:
         # find the base location
-        try:
-            _, path, _ = imp.find_module(tokens[1])
-        except ImportError:
+        spec = importlib.util.find_spec(tokens[1])
+        if spec:
+            path = spec.origin
+        else:
             if alt_path:
                 path = osp.join(alt_path, tokens[1])
             else:

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -14,7 +14,7 @@ from distutils.version import LooseVersion
 from getpass import getuser
 from textwrap import dedent
 import glob
-import imp
+import importlib
 import itertools
 import os
 import os.path as osp
@@ -617,17 +617,23 @@ def python_script_exists(package=None, module=None):
     package=None -> module is in sys.path (standard library modules)
     """
     assert module is not None
-    try:
-        if package is None:
-            path = imp.find_module(module)[1]
+    if package is None:
+        spec = importlib.util.find_spec(module)
+        if spec:
+            path = spec.origin
         else:
-            path = osp.join(imp.find_module(package)[1], module)+'.py'
-    except ImportError:
-        return
-    if not osp.isfile(path):
-        path += 'w'
-    if osp.isfile(path):
-        return path
+            path = None
+    else:
+        spec = importlib.util.find_spec(package)
+        if spec:
+            path = osp.join(spec.origin, module)+'.py'
+        else:
+            path = None
+    if path:
+        if not osp.isfile(path):
+            path += 'w'
+        if osp.isfile(path):
+            return path
 
 
 def run_python_script(package=None, module=None, args=[], p_args=[]):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
imp is deprecated and should be replaced by importlib. I have changed all but one of the places where it was used. Not sure what the code in `get_parent_util` exactly should do.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: oscargus

<!--- Thanks for your help making Spyder better for everyone! --->
