### PR TITLE
PR: Remove PyYAML deprecation warning

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -26,7 +26,6 @@ dependencies:
 - pylint >=1.0
 - pyls-black
 - pyqt <5.13
-- pyyaml
 # NOTE: There's no need to set constraints for python-language-server
 # here because Spyder uses the subrepo for it when started in Binder.
 - python-language-server
@@ -57,13 +56,14 @@ dependencies:
 - pandas
 - pillow
 - pytest <5.0
-- pytest-mock
 - pytest-cov
-- pytest-qt
-- pytest-ordering
-- pytest-lazy-fixture
 - pytest-faulthandler <2.0
+- pytest-lazy-fixture
+- pytest-mock
+- pytest-ordering
+- pytest-qt
 - pytest-xvfb
+- pyyaml
 - scipy
 - sympy
 

--- a/spyder/tests/test_dependencies_in_sync.py
+++ b/spyder/tests/test_dependencies_in_sync.py
@@ -52,10 +52,10 @@ def parse_requirements(fpath):
 
 def parse_environment_yaml(fpath):
     """
-    Parse a environment yaml file and return a dict of deps and versions.
+    Parse an environment yaml file and return a dict of deps and versions.
     """
     with open(fpath, 'r') as fh:
-        data = yaml.load(fh)
+        data = yaml.load(fh, Loader=yaml.FullLoader)
 
     deps = {}
     yaml_deps = data.get('dependencies')


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Removed the following deprecation warning:
```
spyder/tests/test_dependencies_in_sync.py::test_dependencies_for_binder_in_sync
  /home/runner/work/spyder/spyder/spyder/tests/test_dependencies_in_sync.py:58: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    data = yaml.load(fh)
```

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Also figured out https://github.com/spyder-ide/spyder/pull/14014#issuecomment-716539881 and corrected the files.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: oscargus

<!--- Thanks for your help making Spyder better for everyone! --->
