### PR TITLE
PR: Use current size and position when saving window settings (Main Window)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Github helper pieces to make some files not show up in diffs automatically
 external-deps/* linguist-generated=true
+
+# Get better diffs for Python files
+*.py diff=python

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1976,11 +1976,9 @@ class MainWindow(QMainWindow):
         self.toggle_layout('next')
 
     def toggle_layout(self, direction='next'):
-        """ """
-        get = CONF.get
-        names = get('quick_layouts', 'names')
-        order = get('quick_layouts', 'order')
-        active = get('quick_layouts', 'active')
+        names = CONF.get('quick_layouts', 'names')
+        order = CONF.get('quick_layouts', 'order')
+        active = CONF.get('quick_layouts', 'active')
 
         if len(active) == 0:
             return
@@ -2006,11 +2004,9 @@ class MainWindow(QMainWindow):
         self.quick_layout_switch(layout_index[new_index])
 
     def quick_layout_set_menu(self):
-        """ """
-        get = CONF.get
-        names = get('quick_layouts', 'names')
-        order = get('quick_layouts', 'order')
-        active = get('quick_layouts', 'active')
+        names = CONF.get('quick_layouts', 'names')
+        order = CONF.get('quick_layouts', 'order')
+        active = CONF.get('quick_layouts', 'active')
 
         ql_actions = []
 
@@ -2070,11 +2066,9 @@ class MainWindow(QMainWindow):
 
     def quick_layout_save(self):
         """Save layout dialog"""
-        get = CONF.get
-        set_ = CONF.set
-        names = get('quick_layouts', 'names')
-        order = get('quick_layouts', 'order')
-        active = get('quick_layouts', 'active')
+        names = CONF.get('quick_layouts', 'names')
+        order = CONF.get('quick_layouts', 'order')
+        active = CONF.get('quick_layouts', 'active')
 
         dlg = self.dialog_layout_save(self, names)
 
@@ -2082,11 +2076,13 @@ class MainWindow(QMainWindow):
             name = dlg.combo_box.currentText()
 
             if name in names:
-                answer = QMessageBox.warning(self, _("Warning"),
-                                             _("Layout <b>%s</b> will be \
-                                               overwritten. Do you want to \
-                                               continue?") % name,
-                                             QMessageBox.Yes | QMessageBox.No)
+                answer = QMessageBox.warning(
+                    self,
+                    _("Warning"),
+                    _("<b>%s</b> will be overwritten. Do you want to "
+                      "continue?") % name,
+                    QMessageBox.Yes | QMessageBox.No
+                )
                 index = order.index(name)
             else:
                 answer = True
@@ -2106,27 +2102,23 @@ class MainWindow(QMainWindow):
             if answer:
                 self.save_current_window_settings('layout_{}/'.format(index),
                                                   section='quick_layouts')
-                set_('quick_layouts', 'names', names)
-                set_('quick_layouts', 'order', order)
-                set_('quick_layouts', 'active', active)
+                CONF.set('quick_layouts', 'names', names)
+                CONF.set('quick_layouts', 'order', order)
+                CONF.set('quick_layouts', 'active', active)
                 self.quick_layout_set_menu()
 
     def quick_layout_settings(self):
         """Layout settings dialog"""
-        get = CONF.get
-        set_ = CONF.set
-
         section = 'quick_layouts'
-
-        names = get(section, 'names')
-        order = get(section, 'order')
-        active = get(section, 'active')
+        names = CONF.get(section, 'names')
+        order = CONF.get(section, 'order')
+        active = CONF.get(section, 'active')
 
         dlg = self.dialog_layout_settings(self, names, order, active)
         if dlg.exec_():
-            set_(section, 'names', dlg.names)
-            set_(section, 'order', dlg.order)
-            set_(section, 'active', dlg.active)
+            CONF.set(section, 'names', dlg.names)
+            CONF.set(section, 'order', dlg.order)
+            CONF.set(section, 'active', dlg.active)
             self.quick_layout_set_menu()
 
     def quick_layout_switch(self, index):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1578,7 +1578,7 @@ class MainWindow(QMainWindow):
         if current_width < width or current_height < height:
             pos = CONF.get_default(section, prefix + 'position')
 
-        is_maximized =  get_func(section, prefix + 'is_maximized')
+        is_maximized = get_func(section, prefix + 'is_maximized')
         is_fullscreen = get_func(section, prefix + 'is_fullscreen')
         return (hexstate, window_size, prefs_dialog_size, pos, is_maximized,
                 is_fullscreen)
@@ -1654,7 +1654,8 @@ class MainWindow(QMainWindow):
         pos = self.pos()
         prefs_size = self.prefs_dialog_size
 
-        CONF.set(section, prefix + 'size', (win_size.width(), win_size.height()))
+        CONF.set(section, prefix + 'size',
+                 (win_size.width(), win_size.height()))
         CONF.set(section, prefix + 'prefs_dialog_size',
                  (prefs_size.width(), prefs_size.height()))
         CONF.set(section, prefix + 'is_maximized', self.isMaximized())

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1549,18 +1549,24 @@ class MainWindow(QMainWindow):
                   ) % missing_deps, QMessageBox.Ok)
 
     def load_window_settings(self, prefix, default=False, section='main'):
-        """Load window layout settings from userconfig-based configuration
-        with *prefix*, under *section*
-        default: if True, do not restore inner layout"""
+        """
+        Load window layout settings from userconfig-based configuration
+        with `prefix`, under `section`.
+
+        Parameters
+        ----------
+        default: bool
+            If True, do not restore inner layout.
+        """
         get_func = CONF.get_default if default else CONF.get
-        window_size = get_func(section, prefix+'size')
-        prefs_dialog_size = get_func(section, prefix+'prefs_dialog_size')
+        window_size = get_func(section, prefix + 'size')
+        prefs_dialog_size = get_func(section, prefix + 'prefs_dialog_size')
         if default:
             hexstate = None
         else:
-            hexstate = get_func(section, prefix+'state', None)
+            hexstate = get_func(section, prefix + 'state', None)
 
-        pos = get_func(section, prefix+'position')
+        pos = get_func(section, prefix + 'position')
 
         # It's necessary to verify if the window/position value is valid
         # with the current screen. See spyder-ide/spyder#3748.
@@ -1570,16 +1576,19 @@ class MainWindow(QMainWindow):
         current_width = screen_shape.width()
         current_height = screen_shape.height()
         if current_width < width or current_height < height:
-            pos = CONF.get_default(section, prefix+'position')
+            pos = CONF.get_default(section, prefix + 'position')
 
-        is_maximized =  get_func(section, prefix+'is_maximized')
-        is_fullscreen = get_func(section, prefix+'is_fullscreen')
-        return hexstate, window_size, prefs_dialog_size, pos, is_maximized, \
-               is_fullscreen
+        is_maximized =  get_func(section, prefix + 'is_maximized')
+        is_fullscreen = get_func(section, prefix + 'is_fullscreen')
+        return (hexstate, window_size, prefs_dialog_size, pos, is_maximized,
+                is_fullscreen)
 
     def get_window_settings(self):
-        """Return current window settings
-        Symetric to the 'set_window_settings' setter"""
+        """
+        Return current window settings.
+
+        Symmetric to the 'set_window_settings' setter.
+        """
         window_size = (self.window_size.width(), self.window_size.height())
         is_fullscreen = self.isFullScreen()
         if is_fullscreen:
@@ -1595,8 +1604,11 @@ class MainWindow(QMainWindow):
 
     def set_window_settings(self, hexstate, window_size, prefs_dialog_size,
                             pos, is_maximized, is_fullscreen):
-        """Set window settings
-        Symetric to the 'get_window_settings' accessor"""
+        """
+        Set window settings.
+
+        Symmetric to the 'get_window_settings' accessor.
+        """
         self.setUpdatesEnabled(False)
         self.window_size = QSize(window_size[0], window_size[1]) # width,height
         self.prefs_dialog_size = QSize(prefs_dialog_size[0],
@@ -1632,26 +1644,28 @@ class MainWindow(QMainWindow):
 
     def save_current_window_settings(self, prefix, section='main',
                                      none_state=False):
-        """Save current window settings with *prefix* in
-        the userconfig-based configuration, under *section*"""
+        """
+        Save current window settings with `prefix` in
+        the userconfig-based configuration, under `section`.
+        """
         win_size = self.window_size
         prefs_size = self.prefs_dialog_size
 
-        CONF.set(section, prefix+'size', (win_size.width(), win_size.height()))
-        CONF.set(section, prefix+'prefs_dialog_size',
+        CONF.set(section, prefix + 'size', (win_size.width(), win_size.height()))
+        CONF.set(section, prefix + 'prefs_dialog_size',
                  (prefs_size.width(), prefs_size.height()))
-        CONF.set(section, prefix+'is_maximized', self.isMaximized())
-        CONF.set(section, prefix+'is_fullscreen', self.isFullScreen())
+        CONF.set(section, prefix + 'is_maximized', self.isMaximized())
+        CONF.set(section, prefix + 'is_fullscreen', self.isFullScreen())
         pos = self.window_position
-        CONF.set(section, prefix+'position', (pos.x(), pos.y()))
+        CONF.set(section, prefix + 'position', (pos.x(), pos.y()))
         self.maximize_dockwidget(restore=True)# Restore non-maximized layout
         if none_state:
             CONF.set(section, prefix + 'state', None)
         else:
             qba = self.saveState()
             CONF.set(section, prefix + 'state', qbytearray_to_str(qba))
-        CONF.set(section, prefix+'statusbar',
-                    not self.statusBar().isHidden())
+        CONF.set(section, prefix + 'statusbar',
+                 not self.statusBar().isHidden())
 
     def tabify_plugins(self, first, second):
         """Tabify plugin dockwigdets"""
@@ -2131,7 +2145,7 @@ class MainWindow(QMainWindow):
             (hexstate, window_size, prefs_dialog_size, pos, is_maximized,
              is_fullscreen) = settings
 
-            # The defaults layouts will always be regenerated unless there was
+            # The default layouts will always be regenerated unless there was
             # an overwrite, either by rewriting with same name, or by deleting
             # and then creating a new one
             if hexstate is None:
@@ -2152,9 +2166,6 @@ class MainWindow(QMainWindow):
                                  _("Quick switch layout #%s has not yet "
                                    "been defined.") % str(index))
             return
-            # TODO: is there any real use in calling the previous layout
-            # setting?
-            # self.previous_layout_settings = self.get_window_settings()
         self.set_window_settings(*settings)
         self.current_quick_layout = index
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1648,7 +1648,10 @@ class MainWindow(QMainWindow):
         Save current window settings with `prefix` in
         the userconfig-based configuration, under `section`.
         """
-        win_size = self.window_size
+        # Use current size and position when saving window settings.
+        # Fixes spyder-ide/spyder#13882
+        win_size = self.size()
+        pos = self.pos()
         prefs_size = self.prefs_dialog_size
 
         CONF.set(section, prefix + 'size', (win_size.width(), win_size.height()))
@@ -1656,7 +1659,6 @@ class MainWindow(QMainWindow):
                  (prefs_size.width(), prefs_size.height()))
         CONF.set(section, prefix + 'is_maximized', self.isMaximized())
         CONF.set(section, prefix + 'is_fullscreen', self.isFullScreen())
-        pos = self.window_position
         CONF.set(section, prefix + 'position', (pos.x(), pos.y()))
         self.maximize_dockwidget(restore=True)# Restore non-maximized layout
         if none_state:

--- a/spyder/app/tour.py
+++ b/spyder/app/tour.py
@@ -1265,6 +1265,7 @@ class AnimatedTour(QWidget):
                     self.spy_window.windowState()
                     & (~ Qt.WindowFullScreen))
         return False
+
     def start_tour(self):
         """ """
         self.spy_window.setUpdatesEnabled(False)


### PR DESCRIPTION
This PR also does the following:

* Improve the style and docstrings of several layout related methods. Those were really bad, so I took the opportunity to improve them while I was reviewing how their code works.
* Improve how git displays diffs for Python files. That's something I just found on [this page](https://tekin.co.uk/2020/10/better-git-diff-output-for-ruby-python-elixir-and-more) and it was useful while reviewing the diffs generated by my changes.

@juanis2112, could you review if this PR fixes the problem you reported? It does on my manual tests.
