### PR TITLE
PR: Get rid of QDarkStyleSheet deprecation warning

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -574,7 +574,8 @@ class MainWindow(QMainWindow):
                 # Set style proxy to fix combobox popup on mac and qdark
                 qapp = QApplication.instance()
                 qapp.setStyle(self._proxy_style)
-            dark_qss = qdarkstyle.load_stylesheet_from_environment()
+            dark_qss = qdarkstyle.load_stylesheet(
+                        qt_api=os.environ.get('QT_API', None))
             self.setStyleSheet(dark_qss)
             self.statusBar().setStyleSheet(dark_qss)
             css_path = DARK_CSS_PATH
@@ -584,7 +585,8 @@ class MainWindow(QMainWindow):
                     # Set style proxy to fix combobox popup on mac and qdark
                     qapp = QApplication.instance()
                     qapp.setStyle(self._proxy_style)
-                dark_qss = qdarkstyle.load_stylesheet_from_environment()
+                dark_qss = qdarkstyle.load_stylesheet(
+                            qt_api=os.environ.get('QT_API', None))
                 self.setStyleSheet(dark_qss)
                 self.statusBar().setStyleSheet(dark_qss)
                 css_path = DARK_CSS_PATH

--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -127,7 +127,8 @@ class PluginWindow(QMainWindow):
 
         # Setting interface theme
         if is_dark_interface():
-            self.setStyleSheet(qdarkstyle.load_stylesheet_from_environment())
+            self.setStyleSheet(qdarkstyle.load_stylesheet(
+                qt_api=os.environ.get('QT_API', None)))
 
     def closeEvent(self, event):
         """Reimplement Qt method."""

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -3375,7 +3375,8 @@ class EditorMainWindow(QMainWindow):
 
         # Setting interface theme
         if is_dark_interface():
-            self.setStyleSheet(qdarkstyle.load_stylesheet_from_environment())
+            self.setStyleSheet(qdarkstyle.load_stylesheet(
+                qt_api=os.environ.get('QT_API', None)))
 
         # Give focus to current editor to update/show all status bar widgets
         editorstack = self.editorwidget.editorsplitter.editorstack

--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -236,7 +236,8 @@ class PathComboBox(EditableComboBox):
 
         completer = QCompleter(opts, self)
         if is_dark_interface():
-            dark_qss = qdarkstyle.load_stylesheet_from_environment()
+            dark_qss = qdarkstyle.load_stylesheet(
+                        qt_api=os.environ.get('QT_API', None))
             completer.popup().setStyleSheet(dark_qss)
         self.setCompleter(completer)
 
@@ -351,7 +352,8 @@ class FileComboBox(PathComboBox):
 
         completer = QCompleter(opts, self)
         if is_dark_interface():
-            dark_qss = qdarkstyle.load_stylesheet_from_environment()
+            dark_qss = qdarkstyle.load_stylesheet(
+                        qt_api=os.environ.get('QT_API', None))
             completer.popup().setStyleSheet(dark_qss)
         self.setCompleter(completer)
 

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -136,7 +136,8 @@ class BaseEditMixin(object):
         self._styled_widgets.add(id(widget))
 
         if is_dark_interface():
-            css = qdarkstyle.load_stylesheet(qt_api='')
+            css = qdarkstyle.load_stylesheet(
+                    qt_api=os.environ.get('QT_API', None))
             widget.setStyleSheet(css)
             palette = widget.palette()
             background = palette.color(palette.Window).lighter(150).name()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Removed the following deprecation warnings:
```
spyder/app/tests/test_mainwindow.py::test_single_instance_and_edit_magic
spyder/app/tests/test_mainwindow.py::test_default_plugin_actions
spyder/app/tests/test_mainwindow.py::test_edidorstack_open_symbolfinder_dlg
spyder/app/tests/test_mainwindow.py::test_run_static_code_analysis
spyder/app/tests/test_mainwindow.py::test_ordering_lsp_requests_at_startup
spyder/app/tests/test_mainwindow.py::test_update_outline
  /usr/share/miniconda/envs/test/lib/python3.7/site-packages/qdarkstyle/__init__.py:385: DeprecationWarning: This function will be deprecated in v3.0.
  Please, set the wanted binding by using QtPy environment variable QT_API,
  then use load_stylesheet() or use load_stylesheet()
  passing the argument qt_api='wanted_binding'.
    warnings.warn(DEPRECATION_MSG, DeprecationWarning)
```

Also modified a `load_stylesheet` to actually look at the environment variable. Not sure if it has any implications, but I assume that there may be odd cases where the original code didn't work.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: oscargus

<!--- Thanks for your help making Spyder better for everyone! --->
