### PR TITLE
PR: Don't try to reload analysis for the currently displayed file (Code Analysis)

### DIFF
--- a/spyder/plugins/pylint/widgets/pylintgui.py
+++ b/spyder/plugins/pylint/widgets/pylintgui.py
@@ -265,6 +265,13 @@ class PylintWidget(QWidget):
     def set_filename(self, filename):
         """Set filename without performing code analysis."""
         filename = to_text_string(filename)  # filename is a QString instance
+
+        # Don't try to reload saved analysis for filename, if filename
+        # is the one currently displayed.
+        # Fixes spyder-ide/spyder#13347
+        if self.get_filename() == filename:
+            return
+
         self.kill_if_running()
         index, _data = self.get_data(filename)
         is_parent = self.parent is not None


### PR DESCRIPTION
This avoids collapsing the results tree after pressing in one of its entries.

Fixes #13347 
