### PR TITLE
PR: Check that we can get symbols in a file not part of a Python module

### DIFF
--- a/external-deps/python-language-server/.gitrepo
+++ b/external-deps/python-language-server/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/palantir/python-language-server.git
-	branch = develop
-	commit = 1425f75b59e5eba8ba1e1ad250e05502657370af
-	parent = e4925362e2e3263377c811e3b424d296628a1663
+	branch = symbols-no-init
+	commit = 7edf85b1e8faa03460b87f0b3583727716678f0f
+	parent = 613fbd5f45939c9359d40ec2dc1bed765bc1a4f1
 	method = merge
 	cmdver = 0.4.1

--- a/external-deps/python-language-server/.gitrepo
+++ b/external-deps/python-language-server/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/ccordoba12/python-language-server.git
-	branch = symbols-no-init
-	commit = 4bde52e7cd6775a66abe17ae0eea21fcd3c5f10f
-	parent = fbc65e2f9b5328576bdfbfb114fdac7ce1197acb
+	remote = https://github.com/palantir/python-language-server.git
+	branch = develop
+	commit = cf59b8f558cc8121c5fe2de6db70ab91560e2da8
+	parent = c043cbdf8f2edb184e637ec584c1512cda6d396b
 	method = merge
 	cmdver = 0.4.1

--- a/external-deps/python-language-server/.gitrepo
+++ b/external-deps/python-language-server/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ccordoba12/python-language-server.git
 	branch = symbols-no-init
-	commit = 7edf85b1e8faa03460b87f0b3583727716678f0f
-	parent = 613fbd5f45939c9359d40ec2dc1bed765bc1a4f1
+	commit = 4bde52e7cd6775a66abe17ae0eea21fcd3c5f10f
+	parent = fbc65e2f9b5328576bdfbfb114fdac7ce1197acb
 	method = merge
 	cmdver = 0.4.1

--- a/external-deps/python-language-server/.gitrepo
+++ b/external-deps/python-language-server/.gitrepo
@@ -4,7 +4,7 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/palantir/python-language-server.git
+	remote = https://github.com/ccordoba12/python-language-server.git
 	branch = symbols-no-init
 	commit = 7edf85b1e8faa03460b87f0b3583727716678f0f
 	parent = 613fbd5f45939c9359d40ec2dc1bed765bc1a4f1

--- a/external-deps/python-language-server/pyls/plugins/symbols.py
+++ b/external-deps/python-language-server/pyls/plugins/symbols.py
@@ -1,5 +1,7 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import logging
+import os
+
 from pyls import hookimpl
 from pyls.lsp import SymbolKind
 
@@ -15,7 +17,13 @@ def pyls_document_symbols(config, document):
     symbols_settings = config.plugin_settings('jedi_symbols')
     all_scopes = symbols_settings.get('all_scopes', True)
     add_import_symbols = symbols_settings.get('include_import_symbols', True)
-    definitions = document.jedi_names(all_scopes=all_scopes)
+
+    use_document_path = False
+    document_dir = os.path.dirname(document.path)
+    if not os.path.isfile(os.path.join(document_dir, '__init__.py')):
+        use_document_path = True
+
+    definitions = document.jedi_names(use_document_path, all_scopes=all_scopes)
     module_name = document.dot_path
     symbols = []
     exclude = set({})

--- a/external-deps/python-language-server/pyls/plugins/symbols.py
+++ b/external-deps/python-language-server/pyls/plugins/symbols.py
@@ -19,7 +19,7 @@ def pyls_document_symbols(config, document):
     add_import_symbols = symbols_settings.get('include_import_symbols', True)
 
     use_document_path = False
-    document_dir = os.path.dirname(document.path)
+    document_dir = os.path.normpath(os.path.dirname(document.path))
     if not os.path.isfile(os.path.join(document_dir, '__init__.py')):
         use_document_path = True
 

--- a/external-deps/python-language-server/pyls/workspace.py
+++ b/external-deps/python-language-server/pyls/workspace.py
@@ -263,7 +263,7 @@ class Document(object):
 
         # Extend sys_path with document's path if requested
         if use_document_path:
-            sys_path += [os.path.dirname(self.path)]
+            sys_path += [os.path.normpath(os.path.dirname(self.path))]
 
         kwargs = {
             'code': self.source,

--- a/external-deps/python-language-server/pyls/workspace.py
+++ b/external-deps/python-language-server/pyls/workspace.py
@@ -234,8 +234,8 @@ class Document(object):
         return m_start[0] + m_end[-1]
 
     @lock
-    def jedi_names(self, all_scopes=False, definitions=True, references=False):
-        script = self.jedi_script()
+    def jedi_names(self, use_document_path, all_scopes=False, definitions=True, references=False):
+        script = self.jedi_script(use_document_path=use_document_path)
         return script.get_names(all_scopes=all_scopes, definitions=definitions,
                                 references=references)
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -3727,5 +3727,29 @@ def test_continue_first_line(main_window, qtbot):
     assert "b = 9" in shell._control.toPlainText()
 
 
+@pytest.mark.slow
+@flaky(max_runs=3)
+@pytest.mark.use_introspection
+@pytest.mark.skipif(os.name == 'nt', reason="Fails on Windows")
+def test_outline_no_init(main_window, qtbot):
+    # Open file in one of our directories without an __init__ file
+    spy_dir = osp.dirname(get_module_path('spyder'))
+    main_window.editor.load(osp.join(spy_dir, 'tools', 'rm_whitespace.py'))
+
+    # Show outline explorer
+    outline_explorer = main_window.outlineexplorer
+    outline_explorer._toggle_view_action.setChecked(True)
+
+    # Wait a bit for trees to be filled
+    qtbot.wait(5000)
+
+    # Get tree length
+    treewidget = outline_explorer.explorer.treewidget
+    editor_id = list(treewidget.editor_ids.values())[1]
+
+    # Assert symbols in the file are detected and shown
+    assert len(treewidget.editor_tree_cache[editor_id]) > 0
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -16,13 +16,10 @@ import os
 import os.path as osp
 import re
 import shutil
+import sys
 import tempfile
 from textwrap import dedent
-try:
-    from unittest.mock import Mock, MagicMock
-except ImportError:
-    from mock import Mock, MagicMock  # Python 2
-import sys
+from unittest.mock import Mock, MagicMock
 import uuid
 
 # Third party imports
@@ -36,11 +33,11 @@ from numpy.testing import assert_array_equal
 import pylint
 import pytest
 from qtpy import PYQT5, PYQT_VERSION
-from qtpy.QtCore import Qt, QTimer, QEvent, QPoint, QUrl
+from qtpy.QtCore import Qt, QTimer, QUrl
 from qtpy.QtTest import QTest
 from qtpy.QtGui import QImage
 from qtpy.QtWidgets import (QAction, QApplication, QFileDialog, QLineEdit,
-                            QTabBar, QToolTip, QWidget)
+                            QTabBar, QWidget)
 from qtpy.QtWebEngineWidgets import WEBENGINE
 
 # Local imports
@@ -49,7 +46,6 @@ from spyder.app import start
 from spyder.app.mainwindow import MainWindow  # Tests fail without this import
 from spyder.config.base import get_home_dir, get_conf_path, get_module_path
 from spyder.config.manager import CONF
-from spyder.widgets.dock import TabFilter
 from spyder.preferences.runconfig import RunConfiguration
 from spyder.plugins.base import PluginWindow
 from spyder.plugins.help.widgets import ObjectComboBox
@@ -58,15 +54,7 @@ from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec
 from spyder.plugins.projects.projecttypes import EmptyProject
 from spyder.py3compat import PY2, to_text_string
 from spyder.utils.misc import remove_backslashes
-from spyder.utils.programs import is_module_installed
 from spyder.widgets.dock import DockTitleBar
-
-# For testing various Spyder urls
-if not PY2:
-    from urllib.request import urlopen
-    from urllib.error import URLError
-else:
-    from urllib2 import urlopen, URLError
 
 
 # =============================================================================
@@ -1610,8 +1598,6 @@ def test_c_and_n_pdb_commands(main_window, qtbot):
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
 def test_stop_dbg(main_window, qtbot):
     """Test that we correctly stop a debugging session."""
-    nsb = main_window.variableexplorer.get_focus_widget()
-
     # Wait until the window is fully up
     shell = main_window.ipyconsole.get_current_shellwidget()
     qtbot.waitUntil(lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
@@ -2580,7 +2566,6 @@ def test_go_to_definition(main_window, qtbot, capsys):
 
     # Create new editor with code and wait until LSP is ready
     main_window.editor.new(text=code_def)
-    n_editors = len(main_window.editor.get_filenames())
     code_editor = main_window.editor.get_focus_widget()
     with qtbot.waitSignal(code_editor.lsp_response_signal, timeout=30000):
         code_editor.document_did_open()
@@ -2657,7 +2642,6 @@ def test_runcell(main_window, qtbot, tmpdir, debug):
     # Execute runcell
     with qtbot.waitSignal(shell.executed):
         shell.execute(function + u"(0, r'{}')".format(to_text_string(p)))
-    control = main_window.ipyconsole.get_focus_widget()
 
     if debug:
         # Reach the 'name' input
@@ -3371,7 +3355,6 @@ def test_varexp_cleared_after_kernel_restart(main_window, qtbot):
     Test that the variable explorer is cleared after a kernel restart.
     """
     shell = main_window.ipyconsole.get_current_shellwidget()
-    control = main_window.ipyconsole.get_focus_widget()
     qtbot.waitUntil(lambda: shell._prompt_html is not None,
                     timeout=SHELL_TIMEOUT)
 
@@ -3401,7 +3384,6 @@ def test_varexp_cleared_after_reset(main_window, qtbot):
     reset in the IPython console and variable explorer panes.
     """
     shell = main_window.ipyconsole.get_current_shellwidget()
-    control = main_window.ipyconsole.get_focus_widget()
     qtbot.waitUntil(lambda: shell._prompt_html is not None,
                     timeout=SHELL_TIMEOUT)
 

--- a/tools/rm_whitespace.py
+++ b/tools/rm_whitespace.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# -----------------------------------------------------------------------------
 # Copyright (c) 2009- Spyder Project Contributors
 #
 # Distributed under the terms of the MIT License
 # (see spyder/__init__.py for details)
-# -----------------------------------------------------------------------------
 
 """Script and functions to automatically remove trailing spaces from files."""
 


### PR DESCRIPTION
This was an important regression after moving the Outline to use the LSP symbols information.

Depends on palantir/python-language-server#882
Fixes #13928.