### PR TITLE
PR: Add search paths to PATH in is_program_installed

### DIFF
--- a/spyder/utils/conda.py
+++ b/spyder/utils/conda.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 
 from spyder.config.base import running_in_mac_app, get_home_dir
-from spyder.utils.programs import find_program
+from spyder.utils.programs import find_program, run_shell_command
 
 
 WINDOWS = os.name == 'nt'
@@ -110,12 +110,9 @@ def get_list_conda_envs():
     if conda is None:
         return env_list
 
+    cmdstr = ' '.join([conda, 'env', 'list', '--json'])
     try:
-        out, err = subprocess.Popen(
-            [conda, 'env', 'list', '--json'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        ).communicate()
+        out, err = run_shell_command(cmdstr, env={}).communicate()
         out = out.decode()
         err = err.decode()
         out = json.loads(out)

--- a/spyder/utils/conda.py
+++ b/spyder/utils/conda.py
@@ -105,27 +105,14 @@ def get_conda_env_path(pyexec, quote=False):
 
 def get_list_conda_envs():
     """Return the list of all conda envs found in the system."""
-    conda_list = ['conda', 'env', 'list', '--json']
-    if running_in_mac_app():
-        # set PATHs for finding conda
-        old_path = os.environ['PATH']
-        home = get_home_dir()
-        os.environ['PATH'] = os.pathsep.join([
-            old_path,
-            os.path.join(home, 'opt', 'anaconda3', 'condabin'),
-            # could have miniconda
-            os.path.join(home, 'opt', 'miniconda3', 'condabin'),
-            # could be installed for all users
-            os.path.join('/opt', 'anaconda3', 'condabin'),
-            os.path.join('/opt', 'miniconda3', 'condabin')
-        ])
-        conda_path = find_program('conda')
-        os.environ['PATH'] = old_path  # restore PATH
-        if conda_path:
-            conda_list = [conda_path, 'env', 'list', '--json']
+    env_list = {}
+    conda = find_program('conda')
+    if conda is None:
+        return env_list
+
     try:
         out, err = subprocess.Popen(
-            conda_list,
+            [conda, 'env', 'list', '--json'],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         ).communicate()
@@ -135,7 +122,6 @@ def get_list_conda_envs():
     except Exception:
         out = {'envs': []}
         err = ''
-    env_list = {}
     for env in out['envs']:
         name = env.split('/')[-1]
         try:

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -73,8 +73,8 @@ def is_program_installed(basename):
     Return program absolute path if installed in PATH.
     Otherwise, return None.
 
-    Temporarily adds specific platform dependent paths to PATH if not already
-    present. This permits general use without assuming user profiles are
+    Also searches specific platform dependent paths that are not already in
+    PATH. This permits general use without assuming user profiles are
     sourced (e.g. .bash_Profile), such as when login shells are not used to
     launch Spyder.
 
@@ -114,20 +114,10 @@ def is_program_installed(basename):
         # TODO: what are the possible pyenv paths?
         pass
 
-    # Temporarily add required paths
-    old_path = os.environ['PATH']
-    for path in req_paths:
-        if path not in old_path:
-            os.environ['PATH'] += os.pathsep + path
-
-    abspath = None
-    for path in os.environ["PATH"].split(os.pathsep):
+    for path in os.environ['PATH'].split(os.pathsep) + req_paths:
         abspath = osp.join(path, basename)
         if osp.isfile(abspath):
-            break
-    os.environ['PATH'] = old_path  # retore PATH
-
-    return abspath
+            return abspath
 
 
 def find_program(basename):

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -1069,14 +1069,11 @@ def get_pyenv_path(name):
 
 def get_list_pyenv_envs():
     """Return the list of all pyenv envs found in the system."""
-    pyenv = 'pyenv'
-    if running_in_mac_app():
-        old_path = os.environ['PATH']
-        os.environ['PATH'] = os.pathsep.join([old_path, '/usr/local/bin'])
-        pyenv_path = find_program('pyenv')
-        os.environ['PATH'] = old_path  # restore PATH
-        if pyenv_path:
-            pyenv = pyenv_path
+    env_list = {}
+    pyenv = find_program('pyenv')
+    if pyenv is None:
+        return env_list
+
     try:
         out, err = subprocess.Popen(
             [pyenv, 'versions', '--bare', '--skip-aliases'],
@@ -1089,7 +1086,6 @@ def get_list_pyenv_envs():
         out = ''
         err = ''
     out = out.split('\n')
-    env_list = {}
     for env in out:
         data = env.split('/')
         path = get_pyenv_path(data[-1])

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -189,6 +189,11 @@ def alter_subprocess_kwargs_by_platform(**kwargs):
                         break  # don't risk multiple values
                 if sys_root_key is not None:
                     kwargs['env'].update({sys_root_key: os.environ[sys_root_key]})
+    else:
+        # linux and macOS
+        if kwargs.get('env') is not None:
+            if 'HOME' not in kwargs['env']:
+                kwargs['env'].update({'HOME': get_home_dir()})
 
     return kwargs
 
@@ -1064,12 +1069,9 @@ def get_list_pyenv_envs():
     if pyenv is None:
         return env_list
 
+    cmdstr = ' '.join([pyenv, 'versions', '--bare', '--skip-aliases'])
     try:
-        out, err = subprocess.Popen(
-            [pyenv, 'versions', '--bare', '--skip-aliases'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        ).communicate()
+        out, err = run_shell_command(cmdstr, env={}).communicate()
         out = out.decode()
         err = err.decode()
     except Exception:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Temporarily add required paths to `sys.environ['PATH']` in `spyder.utils.programs.is_program_installed`.


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->
By adding platform dependent paths to `os.environ['PATH']`, developers will not have to consider macOS application cases when using `find_program`. Additionally, developers will not have to consider cases in which Spyder is not launched from login shells (i.e. user profiles are not sourced).

Since `PATH` is only temporarily modified to locate a given program, it should not affect the behavior of Spyder or Consoles.

Developers should update the `req_paths` in the respective platform control sequence to include paths in the search for programs.

### Issues Resolved
Fixes #14136 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
mrclary
<!--- Thanks for your help making Spyder better for everyone! --->
