### PR TITLE
PR: Set column width automatically after changing autoformatter

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -509,7 +509,7 @@ DEFAULTS = [
               'preload_modules': PRELOAD_MDOULES,
               'pyflakes': True,
               'mccabe': False,
-              'formatting': 'black',
+              'formatting': 'autopep8',
               'format_on_save': False,
               'pycodestyle': False,
               'pycodestyle/filename': '',
@@ -647,4 +647,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '61.1.0'
+CONF_VERSION = '61.2.0'

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -942,13 +942,11 @@ class LanguageServerConfigPage(GeneralConfigPage):
                 self.get_option('pycodestyle/max_line_length') == 79):
             self.set_option('pycodestyle/max_line_length', 88)
             self.code_style_max_line_length.spinbox.setValue(88)
-            self.set_option('edge_line_columns', 88, section='editor')
 
         if(self.get_option('formatting') != 'black' and
                 self.get_option('pycodestyle/max_line_length') == 88):
             self.set_option('pycodestyle/max_line_length', 79)
             self.code_style_max_line_length.spinbox.setValue(79)
-            self.set_option('edge_line_columns', 79, section='editor')
 
         # Update entries in the source menu
         for name, action in self.main.editor.checkable_actions.items():
@@ -985,7 +983,8 @@ class LanguageServerConfigPage(GeneralConfigPage):
                 'editor', 'automatic_completions_after_chars'),
             'set_automatic_completions_after_ms': (
                 'editor', 'automatic_completions_after_ms'),
-            'set_edgeline_columns': ('editor', 'edge_line_columns'),
+            'set_edgeline_columns': (self.CONF_SECTION,
+                                     'pycodestyle/max_line_length'),
             'set_edgeline_enabled': ('editor', 'edge_line'),
         }
         for editorstack in editor.editorstacks:

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -72,8 +72,6 @@ class LanguageServerConfigPage(GeneralConfigPage):
             'automatic_completions_after_ms', min_=0, max_=5000, step=10,
             tip=_("Default is 300"), section='editor')
         code_snippets_box = newcb(_("Enable code snippets"), 'code_snippets')
-        vertical_line_box = newcb(_("Show vertical line"), 'edge_line',
-                                  section='editor')
 
         completion_layout = QGridLayout()
         completion_layout.addWidget(self.completion_box, 0, 0)
@@ -90,7 +88,6 @@ class LanguageServerConfigPage(GeneralConfigPage):
         completion_layout.addWidget(self.completions_after_ms.plabel, 5, 0)
         completion_layout.addWidget(self.completions_after_ms.spinbox, 5, 1)
         completion_layout.addWidget(code_snippets_box, 6, 0)
-        completion_layout.addWidget(vertical_line_box, 7, 0)
         completion_layout.setColumnStretch(2, 6)
         completion_widget = QWidget()
         completion_widget.setLayout(completion_layout)
@@ -215,6 +212,10 @@ class LanguageServerConfigPage(GeneralConfigPage):
             'pycodestyle/max_line_length', min_=10, max_=500, step=1,
             tip=_("Default is 79"))
 
+        vertical_line_box = newcb(
+            _("Show vertical line at maximum allowed length"), 'edge_line',
+            section='editor')
+
         # Code style layout
         code_style_g_layout = QGridLayout()
         code_style_g_layout.addWidget(
@@ -243,6 +244,7 @@ class LanguageServerConfigPage(GeneralConfigPage):
         code_style_layout.addWidget(code_style_label)
         code_style_layout.addWidget(self.code_style_check)
         code_style_layout.addWidget(code_style_g_widget)
+        code_style_layout.addWidget(vertical_line_box)
 
         code_style_widget = QWidget()
         code_style_widget.setLayout(code_style_layout)

--- a/spyder/plugins/completion/languageserver/confpage.py
+++ b/spyder/plugins/completion/languageserver/confpage.py
@@ -72,6 +72,8 @@ class LanguageServerConfigPage(GeneralConfigPage):
             'automatic_completions_after_ms', min_=0, max_=5000, step=10,
             tip=_("Default is 300"), section='editor')
         code_snippets_box = newcb(_("Enable code snippets"), 'code_snippets')
+        vertical_line_box = newcb(_("Show vertical line"), 'edge_line',
+                                  section='editor')
 
         completion_layout = QGridLayout()
         completion_layout.addWidget(self.completion_box, 0, 0)
@@ -88,6 +90,7 @@ class LanguageServerConfigPage(GeneralConfigPage):
         completion_layout.addWidget(self.completions_after_ms.plabel, 5, 0)
         completion_layout.addWidget(self.completions_after_ms.spinbox, 5, 1)
         completion_layout.addWidget(code_snippets_box, 6, 0)
+        completion_layout.addWidget(vertical_line_box, 7, 0)
         completion_layout.setColumnStretch(2, 6)
         completion_widget = QWidget()
         completion_widget.setLayout(completion_layout)
@@ -207,7 +210,7 @@ class LanguageServerConfigPage(GeneralConfigPage):
             _("Ignore the following errors or warnings:"),
             'pycodestyle/ignore', alignment=Qt.Horizontal, word_wrap=False,
             placeholder=_("Example codes: E201, E303"))
-        code_style_max_line_length = self.create_spinbox(
+        self.code_style_max_line_length = self.create_spinbox(
             _("Maximum allowed line length:"), None,
             'pycodestyle/max_line_length', min_=10, max_=500, step=1,
             tip=_("Default is 79"))
@@ -224,9 +227,10 @@ class LanguageServerConfigPage(GeneralConfigPage):
         code_style_g_layout.addWidget(code_style_select.textbox, 3, 1)
         code_style_g_layout.addWidget(code_style_ignore.label, 4, 0)
         code_style_g_layout.addWidget(code_style_ignore.textbox, 4, 1)
-        code_style_g_layout.addWidget(code_style_max_line_length.plabel, 5, 0)
         code_style_g_layout.addWidget(
-            code_style_max_line_length.spinbox, 5, 1)
+            self.code_style_max_line_length.plabel, 5, 0)
+        code_style_g_layout.addWidget(
+            self.code_style_max_line_length.spinbox, 5, 1)
 
         # Set Code style options enabled/disabled
         code_style_g_widget = QWidget()
@@ -265,7 +269,6 @@ class LanguageServerConfigPage(GeneralConfigPage):
         code_fmt_provider = self.create_combobox(
             _("Choose the code formatting provider: "),
             (("autopep8", 'autopep8'),
-             ("yapf", 'yapf'),
              ("black", 'black')),
             'formatting')
 
@@ -933,6 +936,18 @@ class LanguageServerConfigPage(GeneralConfigPage):
         self.table.save_servers()
         self.snippets_proxy.save_snippets()
 
+        if(self.get_option('formatting') == 'black' and
+                self.get_option('pycodestyle/max_line_length') == 79):
+            self.set_option('pycodestyle/max_line_length', 88)
+            self.code_style_max_line_length.spinbox.setValue(88)
+            self.set_option('edge_line_columns', 88, section='editor')
+
+        if(self.get_option('formatting') != 'black' and
+                self.get_option('pycodestyle/max_line_length') == 88):
+            self.set_option('pycodestyle/max_line_length', 79)
+            self.code_style_max_line_length.spinbox.setValue(79)
+            self.set_option('edge_line_columns', 79, section='editor')
+
         # Update entries in the source menu
         for name, action in self.main.editor.checkable_actions.items():
             if name in options:
@@ -968,6 +983,8 @@ class LanguageServerConfigPage(GeneralConfigPage):
                 'editor', 'automatic_completions_after_chars'),
             'set_automatic_completions_after_ms': (
                 'editor', 'automatic_completions_after_ms'),
+            'set_edgeline_columns': ('editor', 'edge_line_columns'),
+            'set_edgeline_enabled': ('editor', 'edge_line'),
         }
         for editorstack in editor.editorstacks:
             for method_name, (sec, opt) in editor_method_sec_opts.items():

--- a/spyder/plugins/completion/languageserver/plugin.py
+++ b/spyder/plugins/completion/languageserver/plugin.py
@@ -662,6 +662,9 @@ class LanguageServerPlugin(SpyderCompletionPlugin):
             for fmt in formatters
         }
 
+        if formatter == 'pyls_black':
+            formatter_options['pyls_black']['line_length'] = cs_max_line_length
+
         # PyLS-Spyder configuration
         group_cells = self.get_option(
             'group_cells',

--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -49,19 +49,6 @@ class EditorConfigPage(PluginConfigPage):
         scroll_past_end_box = newcb(_("Scroll past the end"),
                                     'scroll_past_end')
 
-        edgeline_box = newcb(_("Show vertical lines at"), 'edge_line')
-        edgeline_edit = self.create_lineedit(
-            "",
-            'edge_line_columns',
-            tip=("Enter values separated by commas"),
-            alignment=Qt.Horizontal,
-            regex="[0-9]+(,[0-9]+)*")
-        edgeline_edit_label = QLabel(_("characters"))
-        edgeline_box.toggled.connect(edgeline_edit.setEnabled)
-        edgeline_box.toggled.connect(edgeline_edit_label.setEnabled)
-        edgeline_edit.setEnabled(self.get_option('edge_line'))
-        edgeline_edit_label.setEnabled(self.get_option('edge_line'))
-
         occurrence_box = newcb(_("Highlight occurrences after"),
                                'occurrence_highlighting')
         occurrence_spin = self.create_spinbox(
@@ -76,12 +63,9 @@ class EditorConfigPage(PluginConfigPage):
                 self.get_option('occurrence_highlighting'))
 
         display_g_layout = QGridLayout()
-        display_g_layout.addWidget(edgeline_box, 0, 0)
-        display_g_layout.addWidget(edgeline_edit.textbox, 0, 1)
-        display_g_layout.addWidget(edgeline_edit_label, 0, 2)
-        display_g_layout.addWidget(occurrence_box, 1, 0)
-        display_g_layout.addWidget(occurrence_spin.spinbox, 1, 1)
-        display_g_layout.addWidget(occurrence_spin.slabel, 1, 2)
+        display_g_layout.addWidget(occurrence_box, 0, 0)
+        display_g_layout.addWidget(occurrence_spin.spinbox, 0, 1)
+        display_g_layout.addWidget(occurrence_spin.slabel, 0, 2)
 
         display_h_layout = QHBoxLayout()
         display_h_layout.addLayout(display_g_layout)

--- a/spyder/plugins/editor/panels/edgeline.py
+++ b/spyder/plugins/editor/panels/edgeline.py
@@ -52,7 +52,7 @@ class EdgeLine(Panel):
         """Set edge line columns values."""
         if isinstance(columns, tuple):
             self.columns = columns
-        else:
+        elif columns:
             columns = str(columns)
             self.columns = tuple(int(e) for e in columns.split(','))
 

--- a/spyder/plugins/editor/panels/edgeline.py
+++ b/spyder/plugins/editor/panels/edgeline.py
@@ -52,7 +52,8 @@ class EdgeLine(Panel):
         """Set edge line columns values."""
         if isinstance(columns, tuple):
             self.columns = columns
-        elif is_text_string(columns):
+        else:
+            columns = str(columns)
             self.columns = tuple(int(e) for e in columns.split(','))
 
         self.update()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Enhance the UI of the autoformatter options in the completion engine.

- [x] If people select Black, we should set 88 as the value of Completion and linting > Code style > Maximum allowed length. And this value should be 79 if people select Autopep8 or Yapf.
- [x] When using Black, we should set 88 as the value of Editor > Display > Show vertical lines at. And this value should be 79 if people select Autopep8 or Yapf.
- [x] If people manually set the value of Completion and linting > Code style > Maximum allowed length, we should tell the current formatter to use that value instead of the one they used by default. And if people select another formatter, that option needs to be passed to the new formatter too.
- [x] Remove the option from `Editor > Display > Show vertical lines at` and create a new one in the codestyle preferences that is called `Show vertical lines`

![image](https://user-images.githubusercontent.com/20992645/98177630-11c03100-1ec9-11eb-8256-246f187abaa7.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14082


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
