### PR TITLE
PR: Fix some strings for translation

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -135,16 +135,17 @@ class CollectionsDelegate(QItemDelegate):
                     message.format(val_type=val_type, module=module))
                 return
             else:
-                message = _("Spyder is unable to show the variable you're"
-                            " trying to view because the module "
-                            "<tt>{module}</tt> is not ")
                 if running_in_mac_app():
-                    message += _("supported in the Spyder MacOS "
-                                 "application.<br>")
+                    message = _("Spyder is unable to show the variable you're"
+                                " trying to view because the module "
+                                "<tt>{module}</tt> is not supported in the "
+                                "Spyder MacOS application.<br>")
                 else:
-                    message += _("found in your Spyder environment. Please "
-                                 "install this package in your Spyder "
-                                 "environment.<br>")
+                    message = _("Spyder is unable to show the variable you're"
+                                " trying to view because the module "
+                                "<tt>{module}</tt> is not found in your "
+                                "Spyder environment. Please install this "
+                                "package in your Spyder environment.<br>")
                 QMessageBox.critical(self.parent(), _("Error"),
                                      message.format(module=module))
                 return

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -135,17 +135,17 @@ class CollectionsDelegate(QItemDelegate):
                     message.format(val_type=val_type, module=module))
                 return
             else:
-                if running_in_mac_app():
+                if running_in_mac_app() or is_pynsist():
                     message = _("Spyder is unable to show the variable you're"
                                 " trying to view because the module "
                                 "<tt>{module}</tt> is not supported in the "
-                                "Spyder MacOS application.<br>")
+                                "Spyder Lite application.<br>")
                 else:
                     message = _("Spyder is unable to show the variable you're"
                                 " trying to view because the module "
                                 "<tt>{module}</tt> is not found in your "
                                 "Spyder environment. Please install this "
-                                "package in your Spyder environment.<br>")
+                                "package in this environment.<br>")
                 QMessageBox.critical(self.parent(), _("Error"),
                                      message.format(module=module))
                 return

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -20,7 +20,7 @@ from qtpy.QtWidgets import (QAbstractItemDelegate, QDateEdit, QDateTimeEdit,
                             QItemDelegate, QLineEdit, QMessageBox, QTableView)
 
 # Local imports
-from spyder.config.base import _, running_in_mac_app
+from spyder.config.base import _, is_pynsist, running_in_mac_app
 from spyder.config.fonts import DEFAULT_SMALL_DELTA
 from spyder.config.gui import get_font
 from spyder_kernels.utils.nsview import (

--- a/spyder/widgets/about.py
+++ b/spyder/widgets/about.py
@@ -46,7 +46,7 @@ class AboutDialog(QDialog):
         if sys.platform == 'darwin':
             font_size -= 2
 
-        self.label = QLabel(_(
+        self.label = QLabel((
             """
             <div style='font-family: "{font_family}";
                         font-size: {font_size}pt;


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

The text in the warning for variable explorer was separated which didn't allow translations
<img width="726" alt="Screenshot 2020-11-05 at 3 09 57 PM" src="https://user-images.githubusercontent.com/18587879/98295759-f7955a00-1f7f-11eb-8eea-92b4aac7bd61.png">

I created two separated messages to allow translations
<img width="643" alt="Screenshot 2020-11-05 at 3 58 33 PM" src="https://user-images.githubusercontent.com/18587879/98295742-f401d300-1f7f-11eb-893f-1835712ee9b9.png">




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

Juanis2112

<!--- Thanks for your help making Spyder better for everyone! --->
