### PR TITLE
PR: Prevent code snippet search from picking the root text node

### DIFF
--- a/spyder/plugins/editor/extensions/snippets.py
+++ b/spyder/plugins/editor/extensions/snippets.py
@@ -675,16 +675,19 @@ class SnippetsExtension(EditorExtension):
         point = (line, col) * 2
         node_numbers = list(self.index.intersection(point))
         current_node, nearest_text, nearest_snippet = None, None, None
+
         if len(node_numbers) > 0:
             for node_number in node_numbers:
                 current_node = self.node_position[node_number][-1]
                 if isinstance(current_node, nodes.SnippetASTNode):
                     nearest_snippet = current_node
                 elif isinstance(current_node, nodes.TextNode):
-                    nearest_text = current_node
+                    if node_number != 0:
+                        nearest_text = current_node
                 elif isinstance(current_node, nodes.LeafNode):
                     if current_node.name == 'EPSILON':
                         break
+
         if nearest_text is not None:
             node_id = id(current_node)
             text_ids = set([id(token) for token in nearest_text.tokens])


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR fixes a corner case with indented code snippets where the root TextNode was picked instead of the nearest one.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

![Peek 05-11-2020 20-34](https://user-images.githubusercontent.com/1878982/98315573-7c936a00-1fa6-11eb-96f3-feb2631a79fa.gif)



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14125


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @andfoy

<!--- Thanks for your help making Spyder better for everyone! --->
