### PR TITLE
PR: Fix conda environment list on Windows application

### DIFF
--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -179,16 +179,14 @@ def alter_subprocess_kwargs_by_platform(**kwargs):
 
         # ensure Windows subprocess environment has SYSTEMROOT
         if kwargs.get('env') is not None:
-            # Is SYSTEMROOT in env? case insensitive
-            if 'SYSTEMROOT' not in map(str.upper, kwargs['env'].keys()):
-                # Add SYSTEMROOT from os.environ
-                sys_root_key = None
-                for k, v in os.environ.items():
-                    if 'SYSTEMROOT' == k.upper():
-                        sys_root_key = k
-                        break  # don't risk multiple values
-                if sys_root_key is not None:
-                    kwargs['env'].update({sys_root_key: os.environ[sys_root_key]})
+            # Is SYSTEMROOT, SYSTEMDRIVE in env? case insensitive
+            for env_var in ['SYSTEMROOT', 'SYSTEMDRIVE']:
+                if env_var not in map(str.upper, kwargs['env'].keys()):
+                    # Add from os.environ
+                    for k, v in os.environ.items():
+                        if env_var == k.upper():
+                            kwargs['env'].update({k: v})
+                            break  # don't risk multiple values
     else:
         # linux and macOS
         if kwargs.get('env') is not None:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
* add SYSTEMDRIVE to required environment variables on Windows for `alter_subprocess_kwargs_by_platform`
* fixes issue where interpreter environments are not found
* fixes issue "pywintypes.com_error: (-2147024893, 'The system cannot find the path specified.', None, None)"

<!--- Remember that an image/animation is worth a thousand words! --->


<!--- Explain what you've done and why --->
Upon testing the Windows installer for 4.2.0 release, I discovered that external conda environments were not found.
Further investigation from the internal console revealed the following traceback.
```python
Traceback (most recent call last):
  File "C:\Users\rclary\Anaconda3\Scripts\conda-env-script.py", line 5, in <module>
    from conda_env.cli.main import main
  File "C:\Users\rclary\Anaconda3\lib\site-packages\conda_env\cli\main.py", line 44, in <module>
    from . import main_create
  File "C:\Users\rclary\Anaconda3\lib\site-packages\conda_env\cli\main_create.py", line 19, in <module>
    from .. import exceptions, specs
  File "C:\Users\rclary\Anaconda3\lib\site-packages\conda_env\specs\__init__.py", line 8, in <module>
    from .binstar import BinstarSpec
  File "C:\Users\rclary\Anaconda3\lib\site-packages\conda_env\specs\binstar.py", line 11, in <module>
    from binstar_client import errors
  File "C:\Users\rclary\Anaconda3\lib\site-packages\binstar_client\__init__.py", line 17, in <module>
    from .utils import compute_hash, jencode, pv
  File "C:\Users\rclary\Anaconda3\lib\site-packages\binstar_client\utils\__init__.py", line 17, in <module>
    from .config import (get_server_api, dirs, load_token, store_token,
  File "C:\Users\rclary\Anaconda3\lib\site-packages\binstar_client\utils\config.py", line 81, in <module>
    dirs.site_data_dir,
  File "C:\Users\rclary\Anaconda3\lib\site-packages\binstar_client\utils\appdirs.py", line 250, in site_data_dir
    version=self.version)
  File "C:\Users\rclary\Anaconda3\lib\site-packages\binstar_client\utils\appdirs.py", line 107, in site_data_dir
    path = os.path.join(_get_win_folder("CSIDL_COMMON_APPDATA"),
  File "C:\Users\rclary\Anaconda3\lib\site-packages\binstar_client\utils\appdirs.py", line 285, in _get_win_folder_with_pywin32
    dir = shell.SHGetFolderPath(0, getattr(shellcon, csidl_name), 0, 0)
pywintypes.com_error: (-2147024893, 'The system cannot find the path specified.', None, None)
```
Subsequent investigation revealed that the Windows environment variable `SYSTEMDRIVE` was required for successful `run_shell_command` execution.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary
<!--- Thanks for your help making Spyder better for everyone! --->
