### PR TITLE
PR: Pin NumPy version to prevent RuntimeError - sanity check on Windows installer (Windows 10)

### DIFF
--- a/installers/Windows/req-extras-pull-request.txt
+++ b/installers/Windows/req-extras-pull-request.txt
@@ -10,7 +10,8 @@ rope
 yapf
 
 # Scientific packages (for Same as Spyder)
-numpy
+# Ping NumPy version to 1.19.3 do message error on Windows
+numpy==1.19.3
 scipy
 pandas
 matplotlib

--- a/installers/Windows/req-extras-release.txt
+++ b/installers/Windows/req-extras-release.txt
@@ -10,7 +10,8 @@ rope
 yapf
 
 # Scientific packages (for Same as Spyder)
-numpy
+# Ping NumPy version to 1.19.3 do message error on Windows
+numpy==1.19.3
 scipy
 pandas
 matplotlib


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Prevent an error when importing NumPy:

```
RuntimeError: The current Numpy installation ('C:\\Users\\Daniel\\AppData\\Local\\Programs\\Spyder\\pkgs\\numpy\\__init__.py') fails to pass a sanity check due to a bug in the windows runtime. See this issue for more information: https://tinyurl.com/y3dm3h86
```


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
