### PR TITLE
PR: Simplify creation of main application and splash screen

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3410,10 +3410,10 @@ class MainWindow(QMainWindow):
 
 
 #==============================================================================
-# Utilities to create the 'main' function
+# Utilities for the 'main' function below
 #==============================================================================
-def initialize():
-    """Initialize Qt, patching sys.exit and eventually setting up ETS"""
+def create_application():
+    """Create application, patch sys.exit and set up ETS."""
     # Our QApplication
     app = qapplication()
 
@@ -3461,7 +3461,7 @@ def initialize():
     return app
 
 
-def run_spyder(app, splash, options, args):
+def create_window(app, splash, options, args):
     """
     Create and show Spyder's main window and start QApplication event loop.
     """
@@ -3524,8 +3524,8 @@ def main(options, args):
             option = CONF.get('main', 'opengl')
             set_opengl_implementation(option)
 
-        app = initialize()
-        window = run_spyder(app, options, None)
+        app = create_application()
+        window = create_window(app, options, None)
         return window
 
     # **** Handle hide_console option ****
@@ -3553,7 +3553,7 @@ def main(options, args):
             set_opengl_implementation(option)
 
     # **** Set high DPI scaling ****
-    # This attibute must be set before creating the application.
+    # This attribute must be set before creating the application.
     if hasattr(Qt, 'AA_EnableHighDpiScaling'):
         QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling,
                                       CONF.get('main', 'high_dpi_scaling'))
@@ -3562,7 +3562,7 @@ def main(options, args):
     setup_logging(options)
 
     # **** Create the application ****
-    app = initialize()
+    app = create_application()
 
     # **** Create splash screen ****
     splash = create_splash_screen()
@@ -3608,9 +3608,9 @@ def main(options, args):
             import faulthandler
             with open(faulthandler_file, 'w') as f:
                 faulthandler.enable(file=f)
-                mainwindow = run_spyder(app, splash, options, args)
+                mainwindow = create_window(app, splash, options, args)
         else:
-            mainwindow = run_spyder(app, splash, options, args)
+            mainwindow = create_window(app, splash, options, args)
     except FontError as fontError:
         QMessageBox.information(None, "Spyder",
                 "Spyder was unable to load the <i>Spyder 3</i> "

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -80,7 +80,7 @@ from spyder import dependencies
 from spyder.app import tour
 from spyder.app.utils import (create_splash_screen, delete_lsp_log_files,
                               get_python_doc_path, qt_message_handler,
-                              setup_logging, set_opengl_implementation)
+                              setup_logging, set_opengl_implementation, Spy)
 from spyder.config.base import (_, DEV, get_conf_path, get_debug_level,
                                 get_home_dir, get_image_path, get_module_path,
                                 get_module_source_path, get_safe_mode,
@@ -3461,24 +3461,6 @@ def initialize():
     return app
 
 
-class Spy(object):
-    """
-    Inspect Spyder internals
-
-    Attributes:
-        app       Reference to main QApplication object
-        window    Reference to spyder.MainWindow widget
-    """
-    def __init__(self, app, window):
-        self.app = app
-        self.window = window
-    def __dir__(self):
-        return list(self.__dict__.keys()) +\
-                 [x for x in dir(self.__class__) if x[0] != '_']
-    def versions(self):
-        return get_versions()
-
-
 def run_spyder(app, splash, options, args):
     """
     Create and show Spyder's main window and start QApplication event loop.
@@ -3499,8 +3481,8 @@ def run_spyder(app, splash, options, args):
     main.post_visible_setup()
 
     if main.console:
-        main.console.shell.interpreter.namespace['spy'] = \
-                                                    Spy(app=app, window=main)
+        internal_intrepreter = main.console.shell.interpreter
+        internal_intrepreter.namespace['spy'] = Spy(app=app, window=main)
 
     # Don't show icons in menus for Mac
     if sys.platform == 'darwin':

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3518,7 +3518,7 @@ def main(options, args):
             set_opengl_implementation(option)
 
         app = create_application()
-        window = create_window(app, options, None)
+        window = create_window(app, None, options, None)
         return window
 
     # **** Handle hide_console option ****

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -3413,7 +3413,7 @@ class MainWindow(QMainWindow):
 # Utilities for the 'main' function below
 #==============================================================================
 def create_application():
-    """Create application, patch sys.exit and set up ETS."""
+    """Create application and patch sys.exit."""
     # Our QApplication
     app = qapplication()
 
@@ -3450,13 +3450,6 @@ def create_application():
 
     # Removing arguments from sys.argv as in standard Python interpreter
     sys.argv = ['']
-
-    # Selecting Qt4 backend for Enthought Tool Suite (if installed)
-    try:
-        from enthought.etsconfig.api import ETSConfig
-        ETSConfig.toolkit = 'qt4'
-    except ImportError:
-        pass
 
     return app
 

--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -17,9 +17,12 @@ import sys
 # Third-party imports
 import psutil
 from qtpy.QtCore import QCoreApplication, Qt
+from qtpy.QtGui import QPixmap
+from qtpy.QtWidgets import QSplashScreen
 
 # Local imports
-from spyder.config.base import DEV, get_conf_path, get_debug_level
+from spyder.config.base import (DEV, get_conf_path, get_debug_level,
+                                get_image_path, running_under_pytest)
 from spyder.utils.qthelpers import file_uri
 from spyder.utils.external.dafsa.dafsa import DAFSA
 
@@ -148,3 +151,16 @@ def qt_message_handler(msg_type, msg_log_context, msg_string):
     ]
     if DEV or msg_string not in BLACKLIST:
         print(msg_string)  # spyder: test-skip
+
+
+def create_splash_screen():
+    """Create splash screen."""
+    if not running_under_pytest():
+        splash = QSplashScreen(QPixmap(get_image_path('splash.svg')))
+        splash_font = splash.font()
+        splash_font.setPixelSize(10)
+        splash.setFont(splash_font)
+    else:
+        splash = None
+
+    return splash

--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -38,6 +38,24 @@ FILTER_NAMES = os.environ.get('SPYDER_FILTER_LOG', "").split(',')
 FILTER_NAMES = [f.strip() for f in FILTER_NAMES]
 
 
+class Spy:
+    """
+    This is used to inject a 'spy' object in the internal console
+    namespace to inspect Spyder internals.
+
+    Attributes:
+        app       Reference to main QApplication object
+        window    Reference to spyder.MainWindow widget
+    """
+    def __init__(self, app, window):
+        self.app = app
+        self.window = window
+
+    def __dir__(self):
+        return (list(self.__dict__.keys()) +
+                [x for x in dir(self.__class__) if x[0] != '_'])
+
+
 def get_python_doc_path():
     """
     Return Python documentation path


### PR DESCRIPTION
After PR #12926, I noticed we could simplify those two things a lot.

Benefits:
* It helps to make the code way more readable
* It avoids the hacks of using constants for the app and splash screen that need to be passed around in several places.