### PR TITLE
PR: Improve startup time a bit

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1402,7 +1402,13 @@ class MainWindow(QMainWindow):
 
         # Show dialog with missing dependencies
         if not running_under_pytest():
-            self.report_missing_dependencies()
+            # This avoids computing missing deps before the window is fully up
+            timer_report_deps = QTimer(self)
+            timer_report_deps.setInterval(2000)
+            timer_report_deps.setSingleShot(True)
+            timer_report_deps.timeout.connect(
+                self.report_missing_dependencies)
+            timer_report_deps.start()
 
         # Raise the menuBar to the top of the main window widget's stack
         # Fixes spyder-ide/spyder#3887.
@@ -1521,6 +1527,7 @@ class MainWindow(QMainWindow):
         self.base_title = title
         self.setWindowTitle(self.base_title)
 
+    @Slot()
     def report_missing_dependencies(self):
         """Show a QMessageBox with a list of missing hard dependencies"""
         # Declare dependencies before trying to detect the missing ones

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -388,7 +388,7 @@ def missing_dependencies():
     """Return the status of missing dependencies (if any)"""
     missing_deps = []
     for dependency in DEPENDENCIES:
-        if not dependency.check() and dependency.kind != OPTIONAL:
+        if dependency.kind != OPTIONAL and not dependency.check():
             missing_deps.append(dependency)
 
     if missing_deps:

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -929,6 +929,10 @@ def is_module_installed(module_name, version=None, interpreter=None):
             # Module is not installed
             return False
 
+        # This can happen if a package was not uninstalled correctly
+        if module_version is None:
+            return False
+
     if version is None:
         return True
     else:


### PR DESCRIPTION
This improves startup time a bit by doing the following:

* Delaying computation of missing dependencies 2 seconds after the window is up.
* Not running the check for optional dependencies when computing missing deps.

It also fixes a bug in `is_module_installed` that was making Spyder crash at startup if a module was not uninstalled correctly.