### PR TITLE
PR: Fix issues with expanded symbols when cursor is not being followed up

### DIFF
--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -877,8 +877,9 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         self.activated(item)
 
     def selection_switched(self, current_item, previous_item):
-        current_ref = current_item.ref
-        current_ref.selected = True
+        if current_item is not None:
+            current_ref = current_item.ref
+            current_ref.selected = True
         if previous_item is not None:
             previous_ref = previous_item.ref
             previous_ref.selected = False


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR fixes some issues where symbols were collapsed when the `Follow cursor` option is disabled.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
![Peek 16-11-2020 18-14](https://user-images.githubusercontent.com/1878982/99319484-9733d180-2837-11eb-8bfc-59b8db0399cd.gif)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14152


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
