### PR TITLE
PR: Set base permission to 0o666 minus umask for files when saving

### DIFF
--- a/spyder/utils/encoding.py
+++ b/spyder/utils/encoding.py
@@ -262,7 +262,9 @@ def write(text, filename, encoding='utf-8', mode='wb'):
             # Creating a new file, emulate what os.open() does
             umask = os.umask(0)
             os.umask(umask)
-            original_mode = 0o777 & ~umask
+            # Set base permission of a file to standard permissions.
+            # See #spyder-ide/spyder#14112.
+            original_mode = 0o666 & ~umask
             creation = time.time()
         try:
             # fixes issues with scripts in Dropbox leaving


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Set default permission without execution 


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14112 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
