### PR TITLE
PR: Use signals to connects plugins to ipyconsole

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -890,6 +890,12 @@ class MainWindow(QMainWindow):
         self.ipyconsole = IPythonConsole(self, css_path=css_path)
         self.ipyconsole.register_plugin()
 
+        self.variableexplorer.connect_ipyconsole(self.ipyconsole)
+        self.plots.connect_ipyconsole(self.ipyconsole)
+        if self.help:
+            self.help.connect_ipyconsole(self.ipyconsole)
+
+
         # Explorer
         if CONF.get('explorer', 'enable'):
             self.set_splash(_("Loading file explorer..."))

--- a/spyder/plugins/plots/plugin.py
+++ b/spyder/plugins/plots/plugin.py
@@ -43,6 +43,23 @@ class Plots(SpyderPluginWidget):
         layout = QGridLayout(self)
         layout.addWidget(self.stack)
 
+    def connect_ipyconsole(self, ipyconsole):
+        """Connect to ipyconsole plugin."""
+        ipyconsole.sig_new_shellwidget.connect(
+            self.handle_new_shellwiget)
+        ipyconsole.sig_del_shellwidget.connect(
+            self.remove_shellwidget)
+        ipyconsole.sig_switch_shellwidget.connect(
+            self.set_shellwidget_from_id)
+
+    def handle_new_shellwiget(self, shellwidget, external):
+        """Add a new shellwidget if it is a spyder kernels."""
+        if external:
+            shellwidget.sig_is_spykernel.connect(
+                lambda sw=shellwidget: self.add_shellwidget(sw))
+        else:
+            self.add_shellwidget(shellwidget)
+
     def get_settings(self):
         """Retrieve all Plots configuration settings."""
         return {name: self.get_option(name) for name in

--- a/spyder/plugins/variableexplorer/plugin.py
+++ b/spyder/plugins/variableexplorer/plugin.py
@@ -43,6 +43,27 @@ class VariableExplorer(SpyderPluginWidget):
         layout.addWidget(self.stack)
         self.setLayout(layout)
 
+    def connect_ipyconsole(self, ipyconsole):
+        """Connect to ipyconsole plugin."""
+        ipyconsole.sig_new_shellwidget.connect(
+            self.handle_new_shellwiget)
+        ipyconsole.sig_del_shellwidget.connect(
+            self.remove_shellwidget)
+        ipyconsole.sig_switch_shellwidget.connect(
+            self.set_shellwidget_from_id)
+
+    def handle_new_shellwiget(self, shellwidget, external):
+        """Add a new shellwidget if it is a spyder kernels."""
+        if external:
+            shellwidget.sig_is_spykernel.connect(
+                lambda sw=shellwidget: self.add_shellwidget(sw))
+            shellwidget.sig_is_spykernel.connect(
+                shellwidget.set_namespace_view_settings)
+            shellwidget.sig_is_spykernel.connect(
+                shellwidget.refresh_namespacebrowser)
+        else:
+            self.add_shellwidget(shellwidget)
+
     def get_settings(self):
         """
         Retrieve all Variable Explorer configuration settings.


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
The help, variable explorer, plots, as well as PR #14199 and #11186 needs to be notified when a shellwidget is opened, closed, or switched. This is now hardcoded in the ipyconsole plugin. This PR proposes a way of using signals to communicate between  these plugins to increase the code separation.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
