### PR TITLE
PR: Replace Jaro-Wrinkler distance by normalized Jaccard index (Folding)

### DIFF
--- a/spyder/plugins/editor/panels/utils.py
+++ b/spyder/plugins/editor/panels/utils.py
@@ -151,7 +151,7 @@ def merge_folding(ranges, current_tree, root):
     while deleted_entry is not None and changed_entry is not None:
         deleted_entry_i = deleted_entry.data
         changed_entry_i = changed_entry.data
-        dist = textdistance.jaro_winkler.normalized_similarity(
+        dist = textdistance.jaccard.normalized_similarity(
             deleted_entry_i.text, changed_entry_i.text)
 
         if dist >= 0.80:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR replaces Jaro-Wrinkler distance by the Jaccard index distance used to compare text among folding regions. The former metric was causing significant delays on the editor updates.


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14309


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
