### PR TITLE
PR: Fix variable explorer sort by size bug

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -285,7 +285,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
             except:
                 pass
         elif column == 2:
-            self.keys[:self.rows_loaded] = sort_against(self.keys, self.sizes)
+            self.keys[:self.rows_loaded] = sort_against(self.keys, self.sizes, reverse=reverse)
             self.types = sort_against(self.types, self.sizes, reverse=reverse)
             try:
                 self.sizes.sort(reverse=reverse)

--- a/spyder/plugins/variableexplorer/widgets/collectionseditor.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionseditor.py
@@ -285,7 +285,9 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
             except:
                 pass
         elif column == 2:
-            self.keys[:self.rows_loaded] = sort_against(self.keys, self.sizes, reverse=reverse)
+            self.keys[:self.rows_loaded] = sort_against(self.keys,
+                                                        self.sizes,
+                                                        reverse=reverse)
             self.types = sort_against(self.types, self.sizes, reverse=reverse)
             try:
                 self.sizes.sort(reverse=reverse)


### PR DESCRIPTION
### Description of Changes
This PR fixes a bug where columns in the variable explorer could get out of sync when sorting on size.

### Issue(s) Resolved
Fixes #14155 

### Affirmation
By submitting this Pull Request and typing my username below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: hengin
