### PR TITLE
PR: Update view after applying filters if filters are on (Files)

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -37,12 +37,13 @@ jobs:
           if [[ ${GITHUB_EVENT_NAME} == 'pull_request' ]]; then
               INSTALL_FLAGS+=(${SPK_REPO} ${PLS_REPO})
           fi
-          pip3 install -c req-const.txt -r req-build.txt "${INSTALL_FLAGS[@]}" ${GITHUB_WORKSPACE}
-          pip3 uninstall -q -y spyder
+          brew link python@3.9
+          python3.9 -m pip install -c req-const.txt -r req-build.txt "${INSTALL_FLAGS[@]}" ${GITHUB_WORKSPACE}
+          python3.9 -m pip uninstall -q -y spyder
       - name: Build Application Bundle
-        run: python3 setup.py ${LITE_FLAG} --dist-dir ${DISTDIR}
+        run: python3.9 setup.py ${LITE_FLAG} --dist-dir ${DISTDIR}
       - name: Build Disk Image
-        run: python3 setup.py ${LITE_FLAG} --dist-dir ${DISTDIR} --dmg --no-app
+        run: python3.9 setup.py ${LITE_FLAG} --dist-dir ${DISTDIR} --dmg --no-app
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:

--- a/installers/macOS/req-const.txt
+++ b/installers/macOS/req-const.txt
@@ -1,3 +1,4 @@
+
 # Spyder build environment constraints
 setuptools >= 50.3.2  # versions >44.0.0 and <50.3.2 cause problems for app bundle
-pyobjc >= 6.2.2  # 6.2.1 will not build; required by applaunchservices
+pyobjc == 6.2.2  # 6.2.1 will not build; required by applaunchservices. 7.0 doesn't have wheels for some frameworks in Python 3.9

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -154,6 +154,7 @@ class DirView(QTreeView):
     sig_new_file = Signal(str)
     sig_open_interpreter = Signal(str)
     redirect_stdio = Signal(bool)
+    sig_update_filters = Signal()
 
     def __init__(self, parent=None):
         super(DirView, self).__init__(parent)
@@ -416,6 +417,7 @@ class DirView(QTreeView):
             self.parent_widget.sig_option_changed.emit(
                 'name_filters', filter_text)
             self.set_name_filters(filter_text)
+            self.sig_update_filters.emit()
             dialog.accept()
 
         def handle_reset():
@@ -1786,6 +1788,7 @@ class ExplorerWidget(QWidget):
         self.treewidget.set_previous_enabled.connect(
                                                previous_action.setEnabled)
         self.treewidget.set_next_enabled.connect(next_action.setEnabled)
+        self.treewidget.sig_update_filters.connect(self.filter_files)
         self.sig_option_changed.connect(self.refresh_actions)
 
     def change_filter_state(self):
@@ -1796,6 +1799,11 @@ class ExplorerWidget(QWidget):
             _("Deactivate filename filters") if self.filter_on else _(
                 "Activate filename filters"))
         self.filter_button.setToolTip(tip_message)
+        self.filter_files()
+
+    @Slot()
+    def filter_files(self):
+        """Update filters in the tree widget."""
         self.treewidget.filter_files(self.filter_on)
 
     def refresh_actions(self, option, value):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

This updates the Files view if the filter button is on and the user changed its filters.

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

We now emit a signal (`sig_update_filters`) after the filters dialog is closed. This signal is connected to a new method in the tree widget called `filter_files`, which is in charge of filterting the view.

*Note*: I took the opportunity to fix a minor issue with the Mac installer caused by a new version of `pyobjc`. The solution was simply to pin that package to version `6.2.2` (the one that it's currently working).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14328


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
