### PR TITLE
PR: Fix error when opening array of boolean arrays in Variable Explorer

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -392,7 +392,10 @@ class ArrayDelegate(QItemDelegate):
         """Create editor widget"""
         model = index.model()
         value = model.get_value(index)
-        if model._data.dtype.name == "bool":
+        if type(value) == np.ndarray or model.readonly:
+            # The editor currently cannot properly handle this case
+            return
+        elif model._data.dtype.name == "bool":
             value = not value
             model.setData(index, to_qvariant(value))
             return


### PR DESCRIPTION
## Description of Changes

In the Array Editor, when editing boolean values, they toggle instead of opening an actual editor. However, the logic to detect boolean values could not distinguish between booleans and arrays of booleans. This caused errors to be raised in the latter case.

This pull request adds an extra clause to detect this case and prevent errors. As a bonus, it prevents a QLineEdit from being created when the view is readonly. This is the case for object arrays such as `np.array([1, 'abc', [3,2,1]])`. Previously, the creation of a QLineEdit gave the user the impression that editing was possible; even though all such edit attempts would silently fail when the QLineEdit was closed.

### Issue(s) Resolved

Fixes #12877 

### Affirmation

By submitting this Pull Request and typing my username below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: hengin