### PR TITLE
PR: Use a single tooltip for the Files filter button

### DIFF
--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -1795,10 +1795,7 @@ class ExplorerWidget(QWidget):
         """Handle the change of the filter state."""
         self.filter_on = not self.filter_on
         self.filter_button.setChecked(self.filter_on)
-        tip_message = (
-            _("Deactivate filename filters") if self.filter_on else _(
-                "Activate filename filters"))
-        self.filter_button.setToolTip(tip_message)
+        self.filter_button.setToolTip(_("Filter filenames"))
         self.filter_files()
 
     @Slot()

--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -15,10 +15,7 @@ import os
 import shutil
 import os.path as osp
 import sys
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock  # Python 2
+from unittest.mock import Mock
 
 # Third party imports
 import pytest
@@ -344,6 +341,7 @@ def test_project_explorer_tree_root(projects, tmpdir, qtbot):
 
 
 @flaky(max_runs=5)
+@pytest.mark.skipif(sys.platform == 'darwin', reason="Fails on Mac")
 def test_filesystem_notifications(qtbot, projects, tmpdir):
     """
     Test that filesystem notifications are emitted when creating,


### PR DESCRIPTION
## Description of Changes

We were using a different tooltip if the button was pushed or not, which was really confusing.

* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

![Selección_048](https://user-images.githubusercontent.com/365293/100940834-ac129500-34c6-11eb-82e3-c25b74cbaf9c.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14329


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
