### PR TITLE
PR: Fix env status widget that prevent Spyder to launch

### DIFF
--- a/spyder/widgets/status.py
+++ b/spyder/widgets/status.py
@@ -364,6 +364,7 @@ class InterpreterStatus(BaseTimerStatus):
         path = path.lower() if os.name == 'nt' else path
         try:
             name = self.path_to_env[path]
+            __, version = self.envs[name]
         except KeyError:
             win_app_path = osp.join(
                 'AppData', 'Local', 'Programs', 'spyder')
@@ -378,7 +379,6 @@ class InterpreterStatus(BaseTimerStatus):
             version = get_interpreter_info(path)
             self.path_to_env[path] = name
             self.envs[name] = (path, version)
-        __, version = self.envs[name]
         return f'{name} ({version})'
 
     def get_tooltip(self):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what ou've done and why --->

After PR #14332, Spyder fails to launch with the following tracebacks:

```
  File "/home/Public/spyder/spyder/widgets/status.py", line 336, in update_envs
    self.update_interpreter()
  File "/home/Public/spyder/spyder/widgets/status.py", line 392, in update_interpreter
    self.value = self._get_env_info(self._interpreter)
  File "/home/Public/spyder/spyder/widgets/status.py", line 381, in _get_env_info
    __, version = self.envs[name]
KeyError: 'custom'
```
```
  File "bootstrap.py", line 239, in <module>
    start.main()
  File "/home/Public/spyder/spyder/app/start.py", line 227, in main
    mainwindow.main(options, args)
  File "/home/Public/spyder/spyder/app/mainwindow.py", line 4084, in main
    mainwindow = create_window(app, splash, options, args)
  File "/home/Public/spyder/spyder/app/mainwindow.py", line 3941, in create_window
    main.setup()
  File "/home/Public/spyder/spyder/app/mainwindow.py", line 1535, in setup
    self.apply_statusbar_settings()
  File "/home/Public/spyder/spyder/app/mainwindow.py", line 3498, in apply_statusbar_settings
    self.interpreter_status.update_interpreter(interpreter)
  File "/home/Public/spyder/spyder/widgets/status.py", line 392, in update_interpreter
    self.value = self._get_env_info(self._interpreter)
  File "/home/Public/spyder/spyder/widgets/status.py", line 381, in _get_env_info
    __, version = self.envs[name]
KeyError: 'custom'
```

As you probably notice from tracebacks, I have a custom environment. 
While I debug `_get_env_info` and the envs dict, I see that envs was cleared (probably by [this](https://github.com/spyder-ide/spyder/blob/f7d8c435e0eda455421415a8e96b206b40665a10/spyder/widgets/status.py#L328)).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->
None


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: trollodel

<!--- Thanks for your help making Spyder better for everyone! --->
