### PR TITLE
PR: Add Rtree and other fixes for the macOS app

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -37,6 +37,7 @@ jobs:
           if [[ ${GITHUB_EVENT_NAME} == 'pull_request' ]]; then
               INSTALL_FLAGS+=(${SPK_REPO} ${PLS_REPO})
           fi
+          brew install spatialindex
           brew link python@3.9
           python3.9 -m pip install -c req-const.txt -r req-build.txt "${INSTALL_FLAGS[@]}" ${GITHUB_WORKSPACE}
           python3.9 -m pip uninstall -q -y spyder

--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -26,21 +26,28 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Update System
+        run: |
+          brew install spatialindex
+          brew link python@3.9
       - name: Install Dependencies
         run: |
-          SPK_REPO=${GITHUB_WORKSPACE}/external-deps/spyder-kernels
-          PLS_REPO=${GITHUB_WORKSPACE}/external-deps/python-language-server
           INSTALL_FLAGS=()
           if [[ -z ${LITE_FLAG} ]]; then
               INSTALL_FLAGS+=('-r' 'req-scientific.txt')
           fi
-          if [[ ${GITHUB_EVENT_NAME} == 'pull_request' ]]; then
-              INSTALL_FLAGS+=(${SPK_REPO} ${PLS_REPO})
-          fi
-          brew install spatialindex
-          brew link python@3.9
           python3.9 -m pip install -c req-const.txt -r req-build.txt -r req-extras.txt "${INSTALL_FLAGS[@]}" ${GITHUB_WORKSPACE}
           python3.9 -m pip uninstall -q -y spyder
+      - name: Install Subrepos
+        if: ${{github.event_name == 'pull_request'}}
+        run: |
+          SPK_REPO=${GITHUB_WORKSPACE}/external-deps/spyder-kernels
+          PLS_REPO=${GITHUB_WORKSPACE}/external-deps/python-language-server
+          SITE_PACKAGES=`python3.9 -c 'import site; print(site.getsitepackages()[0])'`
+          python3.9 -m pip uninstall -q -y spyder-kernels python-language-server
+          python3.9 -m pip install --no-deps ${SPK_REPO}
+          cd ${PLS_REPO}
+          python3.9 setup.py develop --no-deps --install-dir ${SITE_PACKAGES}
       - name: Build Application Bundle
         run: python3.9 setup.py ${LITE_FLAG} --dist-dir ${DISTDIR}
       - name: Build Disk Image

--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -32,14 +32,14 @@ jobs:
           PLS_REPO=${GITHUB_WORKSPACE}/external-deps/python-language-server
           INSTALL_FLAGS=()
           if [[ -z ${LITE_FLAG} ]]; then
-              INSTALL_FLAGS+=('-r' 'req-extras.txt')
+              INSTALL_FLAGS+=('-r' 'req-scientific.txt')
           fi
           if [[ ${GITHUB_EVENT_NAME} == 'pull_request' ]]; then
               INSTALL_FLAGS+=(${SPK_REPO} ${PLS_REPO})
           fi
           brew install spatialindex
           brew link python@3.9
-          python3.9 -m pip install -c req-const.txt -r req-build.txt "${INSTALL_FLAGS[@]}" ${GITHUB_WORKSPACE}
+          python3.9 -m pip install -c req-const.txt -r req-build.txt -r req-extras.txt "${INSTALL_FLAGS[@]}" ${GITHUB_WORKSPACE}
           python3.9 -m pip uninstall -q -y spyder
       - name: Build Application Bundle
         run: python3.9 setup.py ${LITE_FLAG} --dist-dir ${DISTDIR}

--- a/installers/macOS/req-extras.txt
+++ b/installers/macOS/req-extras.txt
@@ -7,12 +7,5 @@ pydocstyle
 pyflakes
 pyxdg
 rope
+rtree
 yapf
-
-# Scientific packages (for Same as Spyder)
-numpy
-scipy
-pandas
-matplotlib
-cython
-sympy

--- a/installers/macOS/req-scientific.txt
+++ b/installers/macOS/req-scientific.txt
@@ -1,0 +1,7 @@
+# Scientific packages (for Same as Spyder)
+numpy
+scipy
+pandas
+matplotlib
+cython
+sympy

--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -123,15 +123,17 @@ def make_app_bundle(dist_dir, make_lite=False):
         python38.zip/spyder/app/mac_stylesheet.qss'
     spyder_kernels :
         No module named spyder_kernels.console.__main__
-
-   """
+    textdistance :
+        NotADirectoryError: [Errno 20] Not a directory: '<path>/Resources/lib/
+        python39.zip/textdistance/libraries.json'
+    """
     build_type = 'lite' if make_lite else 'full'
     logger.info('Creating %s app bundle...', build_type)
 
     PACKAGES = ['alabaster', 'astroid', 'blib2to3', 'ipykernel', 'IPython',
                 'jedi', 'jinja2', 'keyring', 'parso', 'pygments', 'pylint',
                 'pyls', 'pyls_black', 'pyls_spyder', 'qtawesome', 'setuptools',
-                'sphinx', 'spyder', 'spyder_kernels']
+                'sphinx', 'spyder', 'spyder_kernels', 'textdistance']
 
     if make_lite:
         INCLUDES = []

--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -149,6 +149,9 @@ def make_app_bundle(dist_dir, make_lite=False):
 
     EDIT_EXT = [ext[1:] for ext in _get_extensions(EDIT_FILETYPES)]
 
+    FRAMEWORKS = ['/usr/local/lib/libspatialindex.dylib',
+                  '/usr/local/lib/libspatialindex_c.dylib']  # for rtree
+
     OPTIONS = {
         'optimize': 0,
         'packages': PACKAGES,
@@ -156,6 +159,7 @@ def make_app_bundle(dist_dir, make_lite=False):
         'excludes': EXCLUDES,
         'iconfile': ICONFILE,
         'dist_dir': dist_dir,
+        'frameworks': FRAMEWORKS,
         'plist': {
             'CFBundleDocumentTypes': [{'CFBundleTypeExtensions': EDIT_EXT,
                                        'CFBundleTypeName': 'Text File',

--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -13,13 +13,8 @@ $ python setup.py
 
 import os
 import sys
-import shutil
-import argparse
-import pkg_resources
 from logging import getLogger, StreamHandler, Formatter
 from setuptools import setup
-from dmgbuild import build_dmg
-from dmgbuild.core import DMGError
 
 # Setup logger
 fmt = Formatter('%(asctime)s [%(levelname)s] [%(name)s] -> %(message)s')
@@ -29,18 +24,14 @@ logger = getLogger('spyder-macOS')
 logger.addHandler(h)
 logger.setLevel('INFO')
 
-# Setup paths
+# Define paths
 HERE = os.path.abspath(__file__)
 THISDIR = os.path.dirname(HERE)
 SPYREPO = os.path.realpath(os.path.join(THISDIR, '..', '..'))
 ICONFILE = os.path.join(SPYREPO, 'img_src', 'spyder.icns')
-
 SPYLINK = os.path.join(THISDIR, 'spyder')
-os.symlink(os.path.join(SPYREPO, 'spyder'), SPYLINK)
 
-from spyder import __version__ as SPYVER                         # noqa
-from spyder.config.utils import EDIT_FILETYPES, _get_extensions  # noqa
-from spyder.config.base import MAC_APP_NAME                      # noqa
+sys.path.append(SPYREPO)
 
 # Python version
 PYVER = [sys.version_info.major, sys.version_info.minor,
@@ -127,6 +118,13 @@ def make_app_bundle(dist_dir, make_lite=False):
         NotADirectoryError: [Errno 20] Not a directory: '<path>/Resources/lib/
         python39.zip/textdistance/libraries.json'
     """
+    import shutil
+    import pkg_resources
+
+    from spyder import __version__ as SPYVER
+    from spyder.config.utils import EDIT_FILETYPES, _get_extensions
+    from spyder.config.base import MAC_APP_NAME
+
     build_type = 'lite' if make_lite else 'full'
     logger.info('Creating %s app bundle...', build_type)
 
@@ -175,9 +173,11 @@ def make_app_bundle(dist_dir, make_lite=False):
     shutil.copy2(os.path.join(SPYREPO, 'scripts', 'spyder'), app_script_path)
 
     try:
+        os.symlink(os.path.join(SPYREPO, 'spyder'), SPYLINK)
         setup(app=[app_script_path], options={'py2app': OPTIONS})
     finally:
         os.remove(app_script_path)
+        os.remove(SPYLINK)
 
     # Copy egg info from site-packages: fixes pkg_resources issue for pyls
     dest_dir = os.path.join(dist_dir, MAC_APP_NAME, 'Contents', 'Resources',
@@ -210,6 +210,11 @@ def make_disk_image(dist_dir, make_lite=False):
     """
     logger.info('Creating disk image...')
 
+    from dmgbuild import build_dmg
+    from dmgbuild.core import DMGError
+    from spyder import __version__ as SPYVER
+    from spyder.config.base import MAC_APP_NAME
+
     volume_name = '{}-{} Py-{}.{}.{}'.format(MAC_APP_NAME[:-4], SPYVER, *PYVER)
     dmgfile = os.path.join(dist_dir, 'Spyder')
     if make_lite:
@@ -240,6 +245,7 @@ def make_disk_image(dist_dir, make_lite=False):
 
 
 if __name__ == '__main__':
+    import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('-n', '--no-app', dest='make_app',
                         action='store_false', default=True,
@@ -259,15 +265,12 @@ if __name__ == '__main__':
 
     dist_dir = os.path.abspath(args.dist_dir)
 
-    try:
-        if args.make_app:
-            make_app_bundle(dist_dir, make_lite=args.make_lite)
-        else:
-            logger.info('Skipping app bundle.')
+    if args.make_app:
+        make_app_bundle(dist_dir, make_lite=args.make_lite)
+    else:
+        logger.info('Skipping app bundle.')
 
-        if args.make_dmg:
-            make_disk_image(dist_dir, make_lite=args.make_lite)
-        else:
-            logger.info('Skipping disk image.')
-    finally:
-        os.remove(SPYLINK)
+    if args.make_dmg:
+        make_disk_image(dist_dir, make_lite=args.make_lite)
+    else:
+        logger.info('Skipping disk image.')

--- a/spyder/utils/pyenv.py
+++ b/spyder/utils/pyenv.py
@@ -43,21 +43,17 @@ def get_list_pyenv_envs():
     cmdstr = ' '.join([pyenv, 'versions', '--bare', '--skip-aliases'])
     try:
         out, __ = run_shell_command(cmdstr, env={}).communicate()
-        out = out.decode()
+        out = out.decode().strip()
     except Exception:
-        out = ''
+        return env_list
 
-    out = out.split('\n')
+    out = out.split('\n') if out else []
     for env in out:
         data = env.split(osp.sep)
         path = get_pyenv_path(data[-1])
 
-        if data[-1] == '':
-            name = 'internal' if running_in_mac_app(path) else 'system'
-        else:
-            name = 'pyenv: {}'.format(data[-1])
-        version = (
-            'Python 2.7' if data[-1] == '' else 'Python {}'.format(data[0]))
+        name = f'pyenv: {data[-1]}'
+        version = f'Python {data[0]}'
         env_list[name] = (path, version)
 
     PYENV_ENV_LIST_CACHE = env_list

--- a/spyder/utils/tests/test_pyenv.py
+++ b/spyder/utils/tests/test_pyenv.py
@@ -21,7 +21,7 @@ from spyder.utils.pyenv import (
 @pytest.mark.skipif(os.name == 'nt', reason="Doesn't work on Windows")
 def test_get_list_pyenv_envs():
     output = get_list_pyenv_envs()
-    expected_envs = ['pyenv: 3.8.1', 'system']
+    expected_envs = ['pyenv: 3.8.1']
     assert set(expected_envs) == set(output.keys())
 
 

--- a/spyder/widgets/status.py
+++ b/spyder/widgets/status.py
@@ -325,7 +325,7 @@ class InterpreterStatus(BaseTimerStatus):
 
     def update_envs(self, worker, output, error):
         """Update the list of environments in the system."""
-        self.envs = output
+        self.envs.update(**output)
         for env in list(self.envs.keys()):
             path, version = self.envs[env]
             # Save paths in lowercase on Windows to avoid issues with
@@ -379,7 +379,7 @@ class InterpreterStatus(BaseTimerStatus):
             self.path_to_env[path] = name
             self.envs[name] = (path, version)
         __, version = self.envs[name]
-        return '{env} ({version})'.format(env=name, version=version)
+        return f'{name} ({version})'
 
     def get_tooltip(self):
         """Override api method."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->
Snippets are now fully functional in the macOS application. It turns out that we don't need a wheel for Rtree, but just need to include the `spatialindex` libraries in the `py2app` setup file.

Also fixed issue (since PR #14332) where macOS app and bootstrap (non-conda) fail to launch with error
```python
Traceback (most recent call last):
  File "/Users/rclary/Documents/Python/spyder/installers/macOS/dist/Spyder.app/Contents/Resources/lib/python3.9/spyder/widgets/status.py", line 336, in update_envs
    self.update_interpreter()
  File "/Users/rclary/Documents/Python/spyder/installers/macOS/dist/Spyder.app/Contents/Resources/lib/python3.9/spyder/widgets/status.py", line 398, in update_interpreter
    self.value = self._get_env_info(self._interpreter)
  File "/Users/rclary/Documents/Python/spyder/installers/macOS/dist/Spyder.app/Contents/Resources/lib/python3.9/spyder/widgets/status.py", line 386, in _get_env_info
    import pdb; pdb.set_trace()
KeyError: 'internal'
```


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14243


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary
<!--- Thanks for your help making Spyder better for everyone! --->
