### PR TITLE
PR: Don't apply asyncio patch for Tornado 6.1+ (IPython console)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -71,9 +71,11 @@ conda create -n spytest-ž -q -y python=3.6 spyder-kernels
 conda list -n spytest-ž
 
 # Install pyenv
-if [ "$OS" != "win" ]; then
-    curl https://pyenv.run | bash
-    $HOME/.pyenv/bin/pyenv install 3.8.1
+if [ "$RUN_SLOW" = "false" ]; then
+    if [ "$OS" != "win" ]; then
+        curl https://pyenv.run | bash
+        $HOME/.pyenv/bin/pyenv install 3.8.1
+    fi
 fi
 
 # Coverage

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -56,7 +56,6 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/checkout@v2
       - name: Fetch branches
-        if: github.event_name == 'pull_request'
         run: git fetch --prune --unshallow
       - name: Check build skips
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -56,7 +56,6 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/checkout@v2
       - name: Fetch branches
-        if: github.event_name == 'pull_request'
         run: git fetch --prune --unshallow
       - name: Check build skips
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -56,7 +56,6 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/checkout@v2
       - name: Fetch branches
-        if: github.event_name == 'pull_request'
         run: git fetch --prune --unshallow
       - name: Check build skips
         if: github.event_name == 'pull_request'

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -1589,19 +1589,22 @@ class IPythonConsole(SpyderPluginWidget):
     #------ Private API -------------------------------------------------------
     def _init_asyncio_patch(self):
         """
-        Same workaround fix as https://github.com/ipython/ipykernel/pull/456
-        Set default asyncio policy to be compatible with tornado
-        Tornado 6 (at least) is not compatible with the default
-        asyncio implementation on Windows
-        Pick the older SelectorEventLoopPolicy on Windows
-        if the known-incompatible default policy is in use.
-        Do this as early as possible to make it a low priority and overrideable
-        ref: https://github.com/tornadoweb/tornado/issues/2608
-        FIXME: if/when tornado supports the defaults in asyncio,
-               remove and bump tornado requirement for py38
-        Based on: jupyter/qtconsole#406
+        - This was fixed in Tornado 6.1!
+        - Same workaround fix as ipython/ipykernel#564
+        - ref: tornadoweb/tornado#2608
+        - On Python 3.8+, Tornado 6.0 is not compatible with the default
+          asyncio implementation on Windows. Pick the older
+          SelectorEventLoopPolicy if the known-incompatible default policy is
+          in use.
+        - Do this as early as possible to make it a low priority and
+          overrideable.
         """
         if os.name == 'nt' and PY38_OR_MORE:
+            # Tests on Linux hang if we don't leave this import here.
+            import tornado
+            if tornado.version_info >= (6, 1):
+                return
+
             import asyncio
             try:
                 from asyncio import (


### PR DESCRIPTION
## Description of Changes

- This is not necessary anymore with Tornado 6.1+, released a couple of weeks ago.
- This PR also fixes an error when running our tests after merging and don't install pyenv in our slow slots.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14404


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
