### PR TITLE
PR: Show a warning telling people how to get out of the pager (IPython console)

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -43,10 +43,9 @@ from qtpy.QtWebEngineWidgets import WEBENGINE
 # Local imports
 from spyder import __trouble_url__, __project_url__
 from spyder.app import start
-from spyder.app.mainwindow import MainWindow  # Tests fail without this import
+from spyder.app.mainwindow import MainWindow
 from spyder.config.base import get_home_dir, get_conf_path, get_module_path
 from spyder.config.manager import CONF
-from spyder.preferences.runconfig import RunConfiguration
 from spyder.plugins.base import PluginWindow
 from spyder.plugins.help.widgets import ObjectComboBox
 from spyder.plugins.help.tests.test_plugin import check_text
@@ -724,6 +723,7 @@ def test_move_to_first_breakpoint(main_window, qtbot, debugcell):
 @pytest.mark.skipif(os.name == 'nt', reason='Fails on windows!')
 def test_runconfig_workdir(main_window, qtbot, tmpdir):
     """Test runconfig workdir options."""
+    from spyder.preferences.runconfig import RunConfiguration
     CONF.set('run', 'configurations', [])
 
     # ---- Load test file ----
@@ -780,6 +780,8 @@ def test_runconfig_workdir(main_window, qtbot, tmpdir):
                     reason="It's failing there")
 def test_dedicated_consoles(main_window, qtbot):
     """Test running code in dedicated consoles."""
+    from spyder.preferences.runconfig import RunConfiguration
+
     # ---- Load test file ----
     test_file = osp.join(LOCATION, 'script.py')
     main_window.editor.load(test_file)

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -941,7 +941,7 @@ class IPythonConsole(SpyderPluginWidget):
                                       is_pylab=is_pylab, is_sympy=is_sympy)
         if client.shellwidget.kernel_manager is None:
             return
-        self.register_client(client)
+        self.register_client(client, give_focus=give_focus)
 
     def create_pylab_client(self):
         """Force creation of Pylab client"""
@@ -1127,7 +1127,6 @@ class IPythonConsole(SpyderPluginWidget):
         # Local vars
         shellwidget = client.shellwidget
         control = shellwidget._control
-        page_control = shellwidget._page_control
 
         # Create new clients with Ctrl+T shortcut
         shellwidget.new_client.connect(self.create_new_client)
@@ -1176,18 +1175,11 @@ class IPythonConsole(SpyderPluginWidget):
         # Set font for client
         client.set_font(self.get_font())
 
-        # Connect focus signal to client's control widget
-        control.focus_changed.connect(lambda: self.focus_changed.emit())
-
-        shellwidget.sig_change_cwd.connect(self.set_working_directory)
-
         # Set editor for the find widget
         self.find_widget.set_editor(control)
 
-        page_control.focus_changed.connect(lambda: self.focus_changed.emit())
-        control.visibility_changed.connect(self.refresh_plugin)
-        page_control.visibility_changed.connect(self.refresh_plugin)
-        page_control.show_find_widget.connect(self.find_widget.show)
+        # Connect to working directory
+        shellwidget.sig_change_cwd.connect(self.set_working_directory)
 
     def close_client(self, index=None, client=None, force=False):
         """Close client tab from index or widget (or close current tab)"""

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -154,10 +154,7 @@ class IPythonConsole(SpyderPluginWidget):
         layout.addWidget(self.infowidget)
 
         # Label to inform users how to get out of the pager
-        self.pager_label = QLabel(
-            _("You are in the pager now. Press <b>Q</b> to get out of it"),
-            self
-        )
+        self.pager_label = QLabel(_("Press <b>Q</b> to exit pager"), self)
         self.pager_label.setStyleSheet(
             "background-color: #3775A9;"
             "margin: 0px 4px 4px 4px;"

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -1107,6 +1107,7 @@ class IPythonConsole(SpyderPluginWidget):
         # Local vars
         shellwidget = client.shellwidget
         control = shellwidget._control
+        page_control = shellwidget._page_control
 
         # Create new clients with Ctrl+T shortcut
         shellwidget.new_client.connect(self.create_new_client)
@@ -1162,6 +1163,11 @@ class IPythonConsole(SpyderPluginWidget):
 
         # Set editor for the find widget
         self.find_widget.set_editor(control)
+
+        page_control.focus_changed.connect(lambda: self.focus_changed.emit())
+        control.visibility_changed.connect(self.refresh_plugin)
+        page_control.visibility_changed.connect(self.refresh_plugin)
+        page_control.show_find_widget.connect(self.find_widget.show)
 
     def close_client(self, index=None, client=None, force=False):
         """Close client tab from index or widget (or close current tab)"""

--- a/spyder/plugins/ipythonconsole/widgets/__init__.py
+++ b/spyder/plugins/ipythonconsole/widgets/__init__.py
@@ -11,7 +11,7 @@
 Widgets for the IPython Console.
 """
 
-from .control import ControlWidget
+from .control import ControlWidget, PageControlWidget
 from .debugging import DebuggingWidget
 from .help import HelpWidget
 from .namespacebrowser import NamepaceBrowserWidget

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -419,7 +419,12 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
     def get_control(self):
         """Return the text widget (or similar) to give focus to"""
-        return self.shellwidget._control
+        # page_control is the widget used for paging
+        page_control = self.shellwidget._page_control
+        if page_control and page_control.isVisible():
+            return page_control
+        else:
+            return self.shellwidget._control
 
     def get_kernel(self):
         """Get kernel associated with this client"""

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -125,6 +125,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         self.stderr_dir = None
         self.is_error_shown = False
         self.restart_thread = None
+        self.give_focus = True
 
         if css_path is None:
             self.css_path = CSS_PATH
@@ -267,11 +268,10 @@ class ClientWidget(QWidget, SaveHistoryMixin):
 
     def configure_shellwidget(self, give_focus=True):
         """Configure shellwidget after kernel is connected."""
+        self.give_focus = give_focus
+
         # Make sure the kernel sends the comm config over
         self.shellwidget.call_kernel()._send_comm_config()
-
-        if give_focus:
-            self.get_control().setFocus()
 
         # Set exit callback
         self.shellwidget.set_exit_callback()
@@ -346,6 +346,13 @@ class ClientWidget(QWidget, SaveHistoryMixin):
             self._when_prompt_is_ready)
         self.shellwidget.sig_remote_execute.disconnect(
             self._when_prompt_is_ready)
+
+        # It's necessary to do this at this point to avoid giving
+        # focus to _control at startup.
+        self._connect_control_signals()
+
+        if self.give_focus:
+            self.shellwidget._control.setFocus()
 
     def enable_stop_button(self):
         self.stop_button.setEnabled(True)
@@ -869,3 +876,16 @@ class ClientWidget(QWidget, SaveHistoryMixin):
             return True
         else:
             return False
+
+    def _connect_control_signals(self):
+        """Connect signals of control widgets."""
+        control = self.shellwidget._control
+        page_control = self.shellwidget._page_control
+
+        control.focus_changed.connect(
+            lambda: self.plugin.focus_changed.emit())
+        page_control.focus_changed.connect(
+            lambda: self.plugin.focus_changed.emit())
+        control.visibility_changed.connect(self.plugin.refresh_plugin)
+        page_control.visibility_changed.connect(self.plugin.refresh_plugin)
+        page_control.show_find_widget.connect(self.plugin.find_widget.show)

--- a/spyder/plugins/ipythonconsole/widgets/control.py
+++ b/spyder/plugins/ipythonconsole/widgets/control.py
@@ -69,3 +69,40 @@ class ControlWidget(TracebackLinksMixin, GetHelpMixin,
         """Reimplement Qt method to send focus change notification"""
         self.focus_changed.emit()
         return super(ControlWidget, self).focusOutEvent(event)
+
+
+class PageControlWidget(QTextEdit, BaseEditMixin):
+    """
+    Subclass of QTextEdit with features from Spyder's mixins.BaseEditMixin to
+    use as the paging widget for IPython widgets
+    """
+    QT_CLASS = QTextEdit
+    visibility_changed = Signal(bool)
+    show_find_widget = Signal()
+    focus_changed = Signal()
+
+    def __init__(self, parent=None):
+        QTextEdit.__init__(self, parent)
+        BaseEditMixin.__init__(self)
+        self.found_results = []
+
+    def showEvent(self, event):
+        """Reimplement Qt Method"""
+        self.visibility_changed.emit(True)
+
+    def keyPressEvent(self, event):
+        """Reimplement Qt Method - Basic keypress event handler"""
+        event, text, key, ctrl, shift = restore_keyevent(event)
+
+        if key == Qt.Key_Slash and self.isVisible():
+            self.show_find_widget.emit()
+
+    def focusInEvent(self, event):
+        """Reimplement Qt method to send focus change notification"""
+        self.focus_changed.emit()
+        return super(PageControlWidget, self).focusInEvent(event)
+
+    def focusOutEvent(self, event):
+        """Reimplement Qt method to send focus change notification"""
+        self.focus_changed.emit()
+        return super(PageControlWidget, self).focusOutEvent(event)

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -29,7 +29,7 @@ from spyder.widgets.helperwidgets import MessageCheckBox
 from spyder.plugins.ipythonconsole.comms.kernelcomm import KernelComm
 from spyder.plugins.ipythonconsole.widgets import (
         ControlWidget, DebuggingWidget, FigureBrowserWidget,
-        HelpWidget, NamepaceBrowserWidget)
+        HelpWidget, NamepaceBrowserWidget, PageControlWidget)
 
 
 class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
@@ -73,6 +73,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
                  external_kernel, *args, **kw):
         # To override the Qt widget used by RichJupyterWidget
         self.custom_control = ControlWidget
+        self.custom_page_control = PageControlWidget
         self.custom_edit = True
         self.spyder_kernel_comm = KernelComm()
         self.spyder_kernel_comm.sig_exception_occurred.connect(

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -267,11 +267,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
             self._cwd = dirname
 
     def update_cwd(self):
-        """Update current working directory.
-
-        Retrieve the cwd and emit a signal connected to the working directory
-        widget. (see: handle_exec_method())
-        """
+        """Update current working directory in the kernel."""
         if self.kernel_client is None:
             return
         self.call_kernel(callback=self.remote_set_cwd).get_cwd()


### PR DESCRIPTION
## Description of Changes

The IPython console has a pager to show long texts in a separate widget to not overflow it with them. It was deactivated by default, but I removed that option with PR #14056 because I thought the pager was broken.

However, our users quickly found out that was not the case and @OverLordGoldDragon suggested we should add a warning to tell people how to get out of the pager. And that's what I've done in this PR.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

![pager](https://user-images.githubusercontent.com/365293/102030338-684e4400-3d80-11eb-8437-0300bc60902b.gif)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14192.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
