### PR TITLE
PR: Fix validation for incorrectly uninstalled packages in is_module_installed

### DIFF
--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -944,9 +944,14 @@ def is_module_installed(module_name, version=None, interpreter=None):
             # Module is not installed
             return False
 
-        # This can happen if a package was not uninstalled correctly
-        if module_version is None:
-            return False
+        # This can happen if a package was not uninstalled correctly. For
+        # instance, if it's __pycache__ main directory is left behind.
+        try:
+            mod = __import__(module_name)
+            if not getattr(mod, '__file__', None):
+                return False
+        except Exception:
+            pass
 
     if version is None:
         return True


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

- This fixes the Profiler, which requires the presence of some modules to work.
- The previous validation was incorrect because a module can be present and don't have a version. That was precisely the case for the modules requested by the Profiler.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
