### PR TITLE
PR: Remove option to set max number of lines (History)

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -241,7 +241,6 @@ DEFAULTS = [
             ('historylog',
              {
               'enable': True,
-              'max_entries': 100,
               'wrap': True,
               'go_to_eof': True,
               'line_numbers': False,
@@ -647,4 +646,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '61.2.0'
+CONF_VERSION = '63.0.0'

--- a/spyder/plugins/console/widgets/shell.py
+++ b/spyder/plugins/console/widgets/shell.py
@@ -40,6 +40,10 @@ from spyder.widgets.mixins import (GetHelpMixin, SaveHistoryMixin,
 from spyder.plugins.console.widgets.console import ConsoleBaseWidget
 
 
+# Maximum number of lines to load
+MAX_LINES = 1000
+
+
 class ShellBaseWidget(ConsoleBaseWidget, SaveHistoryMixin,
                       BrowseHistoryMixin):
     """
@@ -504,7 +508,7 @@ class ShellBaseWidget(ConsoleBaseWidget, SaveHistoryMixin,
                    if line and not line.startswith('#')]
 
         # Truncating history to X entries:
-        while len(history) >= CONF.get('historylog', 'max_entries'):
+        while len(history) >= MAX_LINES:
             del history[0]
             while rawhistory[0].startswith('#'):
                 del rawhistory[0]

--- a/spyder/plugins/history/confpage.py
+++ b/spyder/plugins/history/confpage.py
@@ -24,22 +24,12 @@ class HistoryConfigPage(PluginConfigPage):
 
     def setup_page(self):
         """Setup config page widgets and options."""
-        settings_group = QGroupBox(_("Settings"))
-        hist_spin = self.create_spinbox(
-                            _("History depth: "), _(" entries"),
-                            'max_entries', min_=10, max_=10000, step=10,
-                            tip=_("Set maximum line count"))
-
-        sourcecode_group = QGroupBox(_("Source code"))
+        sourcecode_group = QGroupBox(_("Display"))
         wrap_mode_box = self.create_checkbox(_("Wrap lines"), 'wrap')
         linenumbers_mode_box = self.create_checkbox(_("Show line numbers"),
                                                     'line_numbers')
         go_to_eof_box = self.create_checkbox(
                         _("Scroll automatically to last entry"), 'go_to_eof')
-
-        settings_layout = QVBoxLayout()
-        settings_layout.addWidget(hist_spin)
-        settings_group.setLayout(settings_layout)
 
         sourcecode_layout = QVBoxLayout()
         sourcecode_layout.addWidget(wrap_mode_box)
@@ -48,7 +38,6 @@ class HistoryConfigPage(PluginConfigPage):
         sourcecode_group.setLayout(sourcecode_layout)
 
         vlayout = QVBoxLayout()
-        vlayout.addWidget(settings_group)
         vlayout.addWidget(sourcecode_group)
         vlayout.addStretch(1)
         self.setLayout(vlayout)

--- a/spyder/plugins/history/tests/test_plugin.py
+++ b/spyder/plugins/history/tests/test_plugin.py
@@ -76,27 +76,6 @@ def historylog_with_tab(historylog, mocker, monkeypatch):
 #==============================================================================
 # Tests
 #==============================================================================
-def test_max_entries(historylog, tmpdir):
-    """Test that history is truncated at max_entries."""
-    max_entries = historylog.get_option('max_entries')
-
-    # Write more than max entries in a test file
-    history = ''
-    for i in range(max_entries + 1):
-        history = history + '{}\n'.format(i)
-
-    history_file = tmpdir.join('history.py')
-    history_file.write(history)
-
-    # Load test file in plugin
-    historylog.add_history(to_text_string(history_file))
-
-    # Assert that we have max_entries after loading history and
-    # that there's no 0 in the first line
-    assert len(history_file.readlines()) == max_entries
-    assert '0' not in history_file.readlines()[0]
-
-
 def test_init(historylog):
     """Test HistoryLog.__init__.
 
@@ -106,8 +85,8 @@ def test_init(historylog):
     hl = historylog
     assert hl.editors == []
     assert hl.filenames == []
-    assert len(hl._plugin_actions) == 5
-    assert len(hl.tabwidget.cornerWidget().menu().actions()) == 5
+    assert len(hl._plugin_actions) == 4
+    assert len(hl.tabwidget.cornerWidget().menu().actions()) == 4
 
 
 def test_add_history(historylog, mocker, monkeypatch):
@@ -209,30 +188,6 @@ def test_append_to_history(historylog_with_tab, mocker):
     assert hl.editors[0].toPlainText() == 'import re\na = r"[a-z]"\n'
     # Cursor not at end.
     assert not hl.editors[0].is_cursor_at_end()
-
-
-def test_change_history_depth(historylog_with_tab, mocker):
-    """Test the change_history_depth method.
-
-    Modify the 'Maximum history entries' values to test the config action.
-    """
-    hl = historylog_with_tab
-    action = hl.history_action
-    # Mock dialog.
-    mocker.patch.object(history.QInputDialog, 'getInt')
-
-    # Starts with default.
-    assert hl.get_option('max_entries') == 100
-
-    # Invalid data.
-    history.QInputDialog.getInt.return_value = (10, False)
-    action.trigger()
-    assert hl.get_option('max_entries') == 100  # No change.
-
-    # Valid data.
-    history.QInputDialog.getInt.return_value = (475, True)
-    action.trigger()
-    assert hl.get_option('max_entries') == 475
 
 
 def test_toggle_wrap_mode(historylog_with_tab):


### PR DESCRIPTION
## Description of Changes

While writing docs for this pane, @juanis2112, @CAM-Gerlach and I came to the conclusion that this option doesn't add much value and it's also hard to understand because it's not applied instantly but when Spyder is restarted.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

Preferences for history now look like this

![Selección_067](https://user-images.githubusercontent.com/365293/102405773-a41f1e80-3fb7-11eb-93b5-8cc65707c39f.png)

Before they looked like this

![Selección_068](https://user-images.githubusercontent.com/365293/102405903-cc0e8200-3fb7-11eb-8804-cb132b8594a6.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ccordoba12



<!--- Thanks for your help making Spyder better for everyone! --->
