### PR TITLE
PR: Add .pyt and .pyi as extension recognized as Python files (Editor)

### DIFF
--- a/spyder/plugins/editor/utils/languages.py
+++ b/spyder/plugins/editor/utils/languages.py
@@ -9,7 +9,7 @@ Language utilities
 """
 
 ALL_LANGUAGES = {
-    'Python': ('py', 'pyw', 'python'),
+    'Python': ('py', 'pyw', 'python', 'pyt', 'pyi'),
     'IPython': ('ipy', 'ipython'),
     'Cython': ('pyx', 'pxi', 'pxd'),
     'Enaml': ('enaml',),

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -258,7 +258,9 @@ class CodeEditor(TextEditBaseWidget):
         'None': (sh.TextSH, '', None),
     }
 
-    TAB_ALWAYS_INDENTS = ('py', 'pyw', 'python', 'ipy', 'c', 'cpp', 'cl', 'h')
+    TAB_ALWAYS_INDENTS = (
+        'py', 'pyw', 'python', 'ipy', 'c', 'cpp', 'cl', 'h', 'pyt', 'pyi'
+    )
 
     # Custom signal to be emitted upon completion of the editor's paintEvent
     painted = Signal(QPaintEvent)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

This was requested in https://github.com/spyder-ide/spyder/issues/638#issuecomment-719724646. According to the user, ArcGIS uses `pyt` as the extension for its Python scripts.

Also, `pyi` files are very becoming common in compiled libraries (e.g. Numpy).

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

![Selección_069](https://user-images.githubusercontent.com/365293/102413808-8061d580-3fc3-11eb-82e0-83974d567b9f.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
