### PR TITLE
PR: Show Kite's on-boarding dialog the third time Spyder is started

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -546,6 +546,7 @@ DEFAULTS = [
               'show_installation_dialog': True,
               'show_onboarding': True,
               'show_installation_error_message': True,
+              'spyder_runs': 1
              }),
             ]
 

--- a/spyder/plugins/completion/kite/plugin.py
+++ b/spyder/plugins/completion/kite/plugin.py
@@ -77,7 +77,7 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
             self.set_status)
         self.status_widget.sig_clicked.connect(
             self.show_installation_dialog)
-        # self.main.sig_setup_finished.connect(self.mainwindow_setup_finished)
+        self.main.sig_setup_finished.connect(self.mainwindow_setup_finished)
 
         # Config
         self.update_configuration()
@@ -92,16 +92,22 @@ class KiteCompletionPlugin(SpyderCompletionPlugin):
     @Slot()
     def mainwindow_setup_finished(self):
         """
-        This is called after the main window setup finishes to show Kite's
-        installation dialog and onboarding if necessary.
+        This is called after the main window setup finishes, and the
+        third time Spyder is started, to show Kite's installation dialog
+        and onboarding if necessary.
         """
-        self._kite_onboarding()
+        spyder_runs = self.get_option('spyder_runs')
+        if spyder_runs == 3:
+            self._kite_onboarding()
 
-        show_dialog = self.get_option('show_installation_dialog')
-        if show_dialog:
-            # Only show the dialog once at startup
-            self.set_option('show_installation_dialog', False)
-            self.show_installation_dialog()
+            show_dialog = self.get_option('show_installation_dialog')
+            if show_dialog:
+                # Only show the dialog once at startup
+                self.set_option('show_installation_dialog', False)
+                self.show_installation_dialog()
+        else:
+            if spyder_runs < 3:
+                self.set_option('spyder_runs', spyder_runs + 1)
 
     @Slot(str)
     @Slot(dict)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

We had an interesting call with Adam Smith (Kite's CEO) yesterday about this. He understood our rationale for showing the tour's dialog the first time Spyder is started. And we agreed to show Kite's on-boarding dialog again, but this time the third time Spyder is started.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
