### PR TITLE
PR: Preserve custom interpreters introduced manually (Main interpreter)

### DIFF
--- a/spyder/preferences/maininterpreter.py
+++ b/spyder/preferences/maininterpreter.py
@@ -42,10 +42,11 @@ class MainInterpreterConfigPage(GeneralConfigPage):
         conda_env = get_list_conda_envs_cache()
         pyenv_env = get_list_pyenv_envs_cache()
         envs = {**conda_env, **pyenv_env}
-        valid_custom_list = []
+        valid_custom_list = self.get_option('custom_interpreters_list')
         for env in envs.keys():
             path, _ = envs[env]
-            valid_custom_list.append(path)
+            if path not in valid_custom_list:
+                valid_custom_list.append(path)
         self.set_option('custom_interpreters_list', valid_custom_list)
 
         # Python executable selection (initializing default values as well)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

This preserves custom interpreters introduced manually in Preferences after reopening them again and across different Spyder sessions.

This was something we missed when implemented these changes in 4.2.0

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

![Selección_073](https://user-images.githubusercontent.com/365293/102559622-49142700-409e-11eb-9620-96d5ca70266b.png)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
