### PR TITLE
PR: Limit call rate document_did_change

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1299,6 +1299,7 @@ class CodeEditor(TextEditBaseWidget):
     @request(method=LSPRequestTypes.DOCUMENT_COMPLETION)
     def do_completion(self, automatic=False):
         """Trigger completion."""
+        self._document_did_change()
         cursor = self.textCursor()
         current_word = self.get_current_word(
             completion=True,
@@ -1414,6 +1415,7 @@ class CodeEditor(TextEditBaseWidget):
     @request(method=LSPRequestTypes.DOCUMENT_SIGNATURE)
     def request_signature(self):
         """Ask for signature."""
+        self._document_did_change()
         self.document_did_change('')
         line, column = self.get_cursor_line_column()
         offset = self.get_position('cursor')
@@ -1467,6 +1469,7 @@ class CodeEditor(TextEditBaseWidget):
     # ------------- LSP: Hover/Mouse ---------------------------------------
     @request(method=LSPRequestTypes.DOCUMENT_CURSOR_EVENT)
     def request_cursor_event(self):
+        self._document_did_change()
         text = self.toPlainText()
         cursor = self.textCursor()
         params = {
@@ -1482,6 +1485,7 @@ class CodeEditor(TextEditBaseWidget):
     @request(method=LSPRequestTypes.DOCUMENT_HOVER)
     def request_hover(self, line, col, offset, show_hint=True, clicked=True):
         """Request hover information."""
+        self._document_did_change()
         params = {
             'file': self.filename,
             'line': line,
@@ -1536,7 +1540,7 @@ class CodeEditor(TextEditBaseWidget):
         if (not self.go_to_definition_enabled or
                 self.in_comment_or_string()):
             return
-
+        self._document_did_change()
         if cursor is None:
             cursor = self.textCursor()
 
@@ -1591,7 +1595,7 @@ class CodeEditor(TextEditBaseWidget):
     def format_document(self):
         if not self.formatting_enabled:
             return
-
+        self._document_did_change()
         using_spaces = self.indent_chars != '\t'
         tab_size = (len(self.indent_chars) if using_spaces else
                     self.tab_stop_width_spaces)
@@ -1619,7 +1623,7 @@ class CodeEditor(TextEditBaseWidget):
     def format_document_range(self):
         if not self.range_formatting_enabled or not self.has_selected_text():
             return
-
+        self._document_did_change()
         start, end = self.get_selection_start_end()
         start_line, start_col = start
         end_line, end_col = end
@@ -1778,6 +1782,7 @@ class CodeEditor(TextEditBaseWidget):
         """Request folding."""
         if not self.folding_supported or not self.code_folding:
             return
+        self._document_did_change()
         params = {'file': self.filename}
         return params
 
@@ -1822,6 +1827,7 @@ class CodeEditor(TextEditBaseWidget):
              requires_response=False)
     def notify_save(self):
         """Send save request."""
+        self._document_did_change()
         params = {'file': self.filename}
         if self.save_include_text:
             params['text'] = self.toPlainText()
@@ -1832,6 +1838,7 @@ class CodeEditor(TextEditBaseWidget):
     def notify_close(self):
         """Send close request."""
         if self.completions_available:
+            self._document_did_change()
             params = {
                 'file': self.filename,
                 'codeeditor': self


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
document_did_change is called on each keystroke, producing a small lag. This is visible if a lot of text is typed quickly in a large file. This limits the calls to document_did_change to 1 per second, as having sub-second accuracy on linting is not necessary (And the server takes a while to answer anyway).

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
