### PR TITLE
PR: Fix two typos in Contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,8 +124,8 @@ To start working on a new PR, you need to execute these commands, filling in the
 
 ```bash
 $ git checkout <SPYDER-BASE-BRANCH>
-$ git pull upstream <SPYDER-BASE-BRANC>
-$ git checkout -b NAME-NEW-BRANCH
+$ git pull upstream <SPYDER-BASE-BRANCH>
+$ git checkout -b <NAME-NEW-BRANCH>
 ```
 
 


### PR DESCRIPTION
* `## Spyder Branches` : Added `H` to `<SPYDER-BASE-BRANC>`
* `## Spyder Branches` : Added `<>` around `NAME-NEW-BRANCH`
