### PR TITLE
Add color scheme import and export

### DIFF
--- a/spyder/config/user.py
+++ b/spyder/config/user.py
@@ -36,6 +36,45 @@ class NoDefault:
     pass
 
 
+class TypedConfig(cp.ConfigParser):
+    """
+    A wrapper around cp.ConfigParser that support types.
+    """
+
+    def get(self, section, option, type_=str, default=NoDefault, **kwargs):
+        """
+        Get an option value that is converted to the desired type.
+        """
+        try:
+            value = super().get(section, option, **kwargs)
+        except cp.NoOptionError:
+            if default is NoDefault:
+                raise
+            value = default
+        if issubclass(type_, bool):
+            value = ast.literal_eval(value)
+        elif issubclass(type_, float):
+            value = float(value)
+        elif issubclass(type_, int):
+            value = int(value)
+        elif issubclass(type_, str):
+            # Do nothing
+            pass
+        else:
+            try:
+                # Lists, tuples, ...
+                value = ast.literal_eval(value)
+            except (SyntaxError, ValueError):
+                pass
+
+        return value
+
+    def set(self, section, option, value):
+        if not isinstance(value, str):
+            value = repr(value)
+        super().set(section, option, value)
+
+
 # ============================================================================
 # Defaults class
 # ============================================================================


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
![image](https://user-images.githubusercontent.com/33117082/103152148-4774ee00-4785-11eb-8516-8c7ef8e637a7.png)

Allows custom schemes to be imported and exported.
Exported schemes are saved into an INI file and the scheme is saved into the `spyder-syntax-highlighting` section.

Update:
This PR adds a new ConfigParser wrapper to use and store option values in the UserConfig format.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1493


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: trollodel

<!--- Thanks for your help making Spyder better for everyone! --->
