### PR TITLE
PR: remove unnecessary wdir from runfile

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 1.x
-	commit = 893d54cfd142937d42df9743ca6666d8ad47c362
-	parent = 4477ab9c55561bce5dd3048b7e86214906567f96
+	branch = remove_wdir
+	commit = 2ffc798fd9a611fbab36fcf1f7c7a89e3a882e32
+	parent = 9706ee7c357ebbec370a4434b6e55251ea73f0e4
 	method = merge
-	cmdver = 0.4.3
+	cmdver = 0.4.1

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = remove_wdir
-	commit = 2ffc798fd9a611fbab36fcf1f7c7a89e3a882e32
-	parent = 9706ee7c357ebbec370a4434b6e55251ea73f0e4
+	commit = d41e2198f44883f3733743abd7523ea2a4422adb
+	parent = 088675070c4ae69be05694e9134d4dd34a682493
 	method = merge
 	cmdver = 0.4.1

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
@@ -496,7 +496,7 @@ def get_file_code(filename, save_all=True):
 
 
 def runfile(filename=None, args=None, wdir=None, namespace=None,
-            post_mortem=False, current_namespace=False):
+            post_mortem=False, current_namespace=False, file_dir=True):
     """
     Run filename
     args: command line arguments (string)
@@ -504,6 +504,7 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
     namespace: namespace for execution
     post_mortem: boolean, whether to enter post-mortem mode on error
     current_namespace: if true, run the file in the current namespace
+    file_dir: if wdir is None, should the file directory be used?
     """
     # Tell IPython to hide this frame (>7.16)
     __tracebackhide__ = True
@@ -549,27 +550,27 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
         if args is not None:
             for arg in shlex.split(args):
                 sys.argv.append(arg)
-        if wdir is None:
+        if wdir is None and file_dir:
             wdir = os.path.dirname(filename)
-        else:
-            if PY2:
-                try:
-                    wdir = wdir.decode('utf-8')
-                except (UnicodeError, TypeError):
-                    # UnicodeError, TypeError --> eventually raised in Python 2
-                    pass
-        if os.path.isdir(wdir):
-            os.chdir(wdir)
-            # See https://github.com/spyder-ide/spyder/issues/13632
-            if "multiprocessing.process" in sys.modules:
-                try:
-                    import multiprocessing.process
-                    multiprocessing.process.ORIGINAL_DIR = os.path.abspath(
-                        wdir)
-                except Exception:
-                    pass
-        else:
-            _print("Working directory {} doesn't exist.\n".format(wdir))
+        elif PY2 and wdir is not None:
+            try:
+                wdir = wdir.decode('utf-8')
+            except (UnicodeError, TypeError):
+                # UnicodeError, TypeError --> eventually raised in Python 2
+                pass
+        if wdir is not None:
+            if os.path.isdir(wdir):
+                os.chdir(wdir)
+                # See https://github.com/spyder-ide/spyder/issues/13632
+                if "multiprocessing.process" in sys.modules:
+                    try:
+                        import multiprocessing.process
+                        multiprocessing.process.ORIGINAL_DIR = os.path.abspath(
+                            wdir)
+                    except Exception:
+                        pass
+            else:
+                _print("Working directory {} doesn't exist.\n".format(wdir))
 
         if __umr__.has_cython:
             # Cython files

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
@@ -549,25 +549,27 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
         if args is not None:
             for arg in shlex.split(args):
                 sys.argv.append(arg)
-        if wdir is not None:
+        if wdir is None:
+            wdir = os.path.dirname(filename)
+        else:
             if PY2:
                 try:
                     wdir = wdir.decode('utf-8')
                 except (UnicodeError, TypeError):
                     # UnicodeError, TypeError --> eventually raised in Python 2
                     pass
-            if os.path.isdir(wdir):
-                os.chdir(wdir)
-                # See https://github.com/spyder-ide/spyder/issues/13632
-                if "multiprocessing.process" in sys.modules:
-                    try:
-                        import multiprocessing.process
-                        multiprocessing.process.ORIGINAL_DIR = os.path.abspath(
-                            wdir)
-                    except Exception:
-                        pass
-            else:
-                _print("Working directory {} doesn't exist.\n".format(wdir))
+        if os.path.isdir(wdir):
+            os.chdir(wdir)
+            # See https://github.com/spyder-ide/spyder/issues/13632
+            if "multiprocessing.process" in sys.modules:
+                try:
+                    import multiprocessing.process
+                    multiprocessing.process.ORIGINAL_DIR = os.path.abspath(
+                        wdir)
+                except Exception:
+                    pass
+        else:
+            _print("Working directory {} doesn't exist.\n".format(wdir))
 
         if __umr__.has_cython:
             # Cython files

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -676,7 +676,7 @@ class IPythonConsole(SpyderPluginWidget):
                                     norm(filename))
                 if args:
                     line += ", args='%s'" % norm(args)
-                if wdir:
+                if wdir and wdir != os.path.dirname(filename):
                     line += ", wdir='%s'" % norm(wdir)
                 if post_mortem:
                     line += ", post_mortem=True"

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -676,8 +676,11 @@ class IPythonConsole(SpyderPluginWidget):
                                     norm(filename))
                 if args:
                     line += ", args='%s'" % norm(args)
-                if wdir and wdir != os.path.dirname(filename):
-                    line += ", wdir='%s'" % norm(wdir)
+                if wdir:
+                    if wdir != os.path.dirname(filename):
+                        line += ", wdir='%s'" % norm(wdir)
+                else:
+                    line += ", file_dir=False"
                 if post_mortem:
                     line += ", post_mortem=True"
                 if console_namespace:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

depends on https://github.com/spyder-ide/spyder-kernels/pull/273
* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
When running a file in spyder, the `runfile` function in the python console usually specifies the working directory, which is almost always the file directory. This changes so that when calling runfile without giving the wdir, it uses the file directory.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Probably mitigates #2254


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
