### PR TITLE
PR: Don't open script that starts Spyder at startup on macOS

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -2806,12 +2806,18 @@ class MainWindow(QMainWindow):
         Open external files that can be handled either by the Editor or the
         variable explorer inside Spyder.
         """
+        # Check that file exists
         fname = encoding.to_unicode_from_fs(fname)
         if osp.exists(osp.join(CWD, fname)):
             fpath = osp.join(CWD, fname)
         elif osp.exists(fname):
             fpath = fname
         else:
+            return
+
+        # Don't open script that starts Spyder at startup.
+        # Fixes issue spyder-ide/spyder#14483
+        if sys.platform == 'darwin' and 'bin/spyder' in fname:
             return
 
         if osp.isfile(fpath):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

After PR #14229, we were opening the script that starts Spyder at each startup (but only in Anaconda and Mac). The changes in this PR prevent that.

The idea is simply to not open a filename that contains `bin/spyder` as part of its name (which is the ending of our start script in Mac).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14483

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
