### PR TITLE
PR: Remove PYTHONEXECUTABLE from env vars passed to the kernel

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -189,10 +189,15 @@ class SpyderKernelSpec(KernelSpec):
             env_vars['SPY_SYMPY_O'] = False
             env_vars['SPY_RUN_CYTHON'] = True
 
-        # macOS app considerations
+        # App considerations
         if (running_in_mac_app() or is_pynsist()) and not default_interpreter:
             env_vars.pop('PYTHONHOME', None)
             env_vars.pop('PYTHONPATH', None)
+
+        # Remove this variable because it prevents starting kernels for
+        # external interpreters when present.
+        # Fixes spyder-ide/spyder#13252
+        env_vars.pop('PYTHONEXECUTABLE', None)
 
         # Making all env_vars strings
         clean_env_vars = clean_env(env_vars)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

- That variable was preventing kernel creation for custom interpreters in Anaconda and macOS.
- That's because Anaconda's `pythonw` Bash script exports `PYTHONEXECUTABLE` as part of it.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13252 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
