### PR TITLE
PR: Fix issues with docstring generation

### DIFF
--- a/spyder/plugins/editor/extensions/docstring.py
+++ b/spyder/plugins/editor/extensions/docstring.py
@@ -931,16 +931,15 @@ class FunctionInfo(object):
         self.func_indent = get_indent(text)
 
         text = text.strip()
-        text = text.replace('\r\n', '')
-        text = text.replace('\n', '')
-        text = text.replace("\\", "")
 
         return_type_re = re.search(
             r'->[ ]*([\"\'a-zA-Z0-9_,()\[\] ]*):$', text)
         if return_type_re:
             self.return_type_annotated = return_type_re.group(1).strip(" ()\\")
             if is_touple_strings(self.return_type_annotated):
-                self.return_type_annotated = "(" + self.return_type_annotated + ")"
+                self.return_type_annotated = ("("
+                                              + self.return_type_annotated
+                                              + ")")
             text_end = text.rfind(return_type_re.group(0))
         else:
             self.return_type_annotated = None

--- a/spyder/plugins/editor/extensions/docstring.py
+++ b/spyder/plugins/editor/extensions/docstring.py
@@ -52,7 +52,7 @@ def is_in_scope_forward(text):
     """Check if the next empty line could be part of the definition."""
     text = text.replace(r"\"", "").replace(r"\'", "")
     scopes = ["'''", '"""', "'", '"']
-    indices = [10**6]*4  # Limits function def length to 10**6
+    indices = [10**6] * 4  # Limits function def length to 10**6
     for i in range(len(scopes)):
         if scopes[i] in text:
             indices[i] = text.index(scopes[i])
@@ -102,34 +102,34 @@ class DocstringWriterExtension(object):
 
         return False
 
-    def is_end_of_function_definition(self, text, lineNumber):
+    def is_end_of_function_definition(self, text, line_number):
         """Return True if text is the end of the function definition."""
-        textWithoutWhitespace = "".join(text.split())
-        if (textWithoutWhitespace.endswith("):") or
-            textWithoutWhitespace.endswith("]:") or
-            (textWithoutWhitespace.endswith(":") and
-             "->" in textWithoutWhitespace)):
+        text_without_whitespace = "".join(text.split())
+        if (text_without_whitespace.endswith("):") or
+            text_without_whitespace.endswith("]:") or
+            (text_without_whitespace.endswith(":") and
+             "->" in text_without_whitespace)):
             return True
-        elif textWithoutWhitespace.endswith(":") and lineNumber > 1:
-            completeText = textWithoutWhitespace
+        elif text_without_whitespace.endswith(":") and line_number > 1:
+            complete_text = text_without_whitespace
             document = self.code_editor.document()
             cursor = QTextCursor(
-                document.findBlockByNumber(lineNumber - 2))  # previous line
-            for i in range(lineNumber - 2, -1, -1):
+                document.findBlockByNumber(line_number - 2))  # previous line
+            for i in range(line_number - 2, -1, -1):
                 txt = "".join(to_text_string(cursor.block().text()).split())
-                if (txt.endswith("\\") or is_in_scope_backward(completeText)):
+                if (txt.endswith("\\") or is_in_scope_backward(complete_text)):
                     if txt.endswith("\\"):
                         txt = txt[:-1]
-                    completeText = txt+completeText
+                    complete_text = txt + complete_text
                 else:
                     break
                 if i != 0:
                     cursor.movePosition(QTextCursor.PreviousBlock)
-            if is_start_of_function(completeText):
-                return (completeText.endswith("):") or
-                        completeText.endswith("]:") or
-                        (completeText.endswith(":") and
-                         "->" in completeText))
+            if is_start_of_function(complete_text):
+                return (complete_text.endswith("):") or
+                        complete_text.endswith("]:") or
+                        (complete_text.endswith(":") and
+                         "->" in complete_text))
             else:
                 return False
         else:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
There are expressions, that are syntactically valid, but don't get recognized by the docstring generator.
This should allow it to work with more kinds of line breaks, handle empty lines in brackets and allows for string literal metadata in returned annotated.
This is mostly done by changing the way an end of a function definition is detected. It now, does not just search for a line ending with ":" but it now searches backwards in lines ignoring whitespace and skipping over empty lines if they are in brackets until a line end is found. A line end is defined by it ending with "):" or "]:" or ending with ":" and containing "->"

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14520
Fixes #14521


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Richardk2n
<!--- Thanks for your help making Spyder better for everyone! --->
