### PR TITLE
Update plugin.py

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1825,6 +1825,7 @@ class Editor(SpyderPluginWidget):
                 VARS = {
                     'date': time.ctime(),
                     'username': username,
+                    'section': '%%',
                 }
                 try:
                     text = text % VARS


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

To have sections in the template as a section variable, I have just edited the plugin.py file from Anaconda3\Lib\site-packages\spyder\plugins\editor\widgets at line 1825 where the Dictionary Variable VARS will hold 3 keys instead of two.


<!--- Explain what you've done and why --->

To add the ability to have sections in the template file, I have added a new variable names section in addition of date and username. To have this new variable replaced to #%% I had to edit the plugin.py file where the VARS dict holds one extra key now for this section variable in the template

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11426 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
