### PR TITLE
PR: Remove highlight matches button from find widget

### DIFF
--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -118,17 +118,11 @@ class FindReplace(QWidget):
         self.words_button.setCheckable(True)
         self.words_button.toggled.connect(lambda state: self.find())
 
-        self.highlight_button = create_toolbutton(self,
-                                              icon=get_icon("highlight.png"),
-                                              tip=_("Highlight matches"))
-        self.highlight_button.setCheckable(True)
-        self.highlight_button.toggled.connect(self.toggle_highlighting)
-
         hlayout = QHBoxLayout()
         self.widgets = [self.close_button, self.search_text,
                         self.number_matches_text, self.previous_button,
                         self.next_button, self.re_button, self.case_button,
-                        self.words_button, self.highlight_button]
+                        self.words_button]
         for widget in self.widgets[1:]:
             hlayout.addWidget(widget)
         glayout.addLayout(hlayout, 0, 1)
@@ -353,7 +347,6 @@ class FindReplace(QWidget):
         self.re_button.setVisible(not isinstance(editor, QWebEngineView))
         from spyder.plugins.editor.widgets.codeeditor import CodeEditor
         self.is_code_editor = isinstance(editor, CodeEditor)
-        self.highlight_button.setVisible(self.is_code_editor)
         if refresh:
             self.refresh()
         if self.isHidden() and editor is not None:
@@ -385,7 +378,7 @@ class FindReplace(QWidget):
 
     def highlight_matches(self):
         """Highlight found results"""
-        if self.is_code_editor and self.highlight_button.isChecked():
+        if self.is_code_editor:
             text = self.search_text.currentText()
             case = self.case_button.isChecked()
             word = self.words_button.isChecked()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Remove highlight matches button from find widget so now the matches will be highlighted by default with a new color settled with the palette. 
<img width="1280" alt="Screenshot 2021-01-21 at 5 44 15 PM" src="https://user-images.githubusercontent.com/18587879/105421564-4a41f200-5c10-11eb-8d4d-b3896443b644.png">

(I'll post an updated screenshot when the color is changed)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes https://github.com/spyder-ide/ux-improvements/issues/26


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Juanis2112

<!--- Thanks for your help making Spyder better for everyone! --->
