### PR TITLE
PR: Add flag to prevent adding initial empty QAction on Mac for non-migrated menus

### DIFF
--- a/spyder/api/widgets/menus.py
+++ b/spyder/api/widgets/menus.py
@@ -41,7 +41,7 @@ class SpyderMenu(QMenu):
     """
     MENUS = []
 
-    def __init__(self, parent=None, title=None):
+    def __init__(self, parent=None, title=None, dynamic=True):
         self._parent = parent
         self._title = title
         self._sections = []
@@ -55,7 +55,7 @@ class SpyderMenu(QMenu):
             super().__init__(title, parent)
 
         self.MENUS.append((parent, title, self))
-        if sys.platform == 'darwin':
+        if sys.platform == 'darwin' and dynamic:
             # Needed to enable the dynamic population of actions in menus
             # in the aboutToShow signal
             # See spyder-ide/spyder#14612

--- a/spyder/plugins/mainmenu/plugin.py
+++ b/spyder/plugins/mainmenu/plugin.py
@@ -54,16 +54,20 @@ class MainMenu(SpyderPluginV2):
         # Reference holder dict for the menus
         self._APPLICATION_MENUS = OrderedDict()
         # Create Application menus using plugin public API
+        # FIXME: Migrated menus need to have 'dynamic=True' (default value) to
+        # work on Mac. Remove the 'dynamic' kwarg when migrating a menu!
         create_app_menu = self.create_application_menu
-        create_app_menu(ApplicationMenus.File, _("&File"))
-        create_app_menu(ApplicationMenus.Edit, _("&Edit"))
-        create_app_menu(ApplicationMenus.Search, _("&Search"))
-        create_app_menu(ApplicationMenus.Source, _("Sour&ce"))
-        create_app_menu(ApplicationMenus.Run, _("&Run"))
-        create_app_menu(ApplicationMenus.Debug, _("&Debug"))
-        create_app_menu(ApplicationMenus.Consoles, _("C&onsoles"))
-        create_app_menu(ApplicationMenus.Projects, _("&Projects"))
-        create_app_menu(ApplicationMenus.Tools, _("&Tools"))
+        create_app_menu(ApplicationMenus.File, _("&File"), dynamic=False)
+        create_app_menu(ApplicationMenus.Edit, _("&Edit"), dynamic=False)
+        create_app_menu(ApplicationMenus.Search, _("&Search"), dynamic=False)
+        create_app_menu(ApplicationMenus.Source, _("Sour&ce"), dynamic=False)
+        create_app_menu(ApplicationMenus.Run, _("&Run"), dynamic=False)
+        create_app_menu(ApplicationMenus.Debug, _("&Debug"), dynamic=False)
+        create_app_menu(
+            ApplicationMenus.Consoles, _("C&onsoles"), dynamic=False)
+        create_app_menu(
+            ApplicationMenus.Projects, _("&Projects"), dynamic=False)
+        create_app_menu(ApplicationMenus.Tools, _("&Tools"), dynamic=False)
         create_app_menu(ApplicationMenus.View, _("&View"))
         create_app_menu(ApplicationMenus.Help, _("&Help"))
 
@@ -180,7 +184,7 @@ class MainMenu(SpyderPluginV2):
 
     # --- Public API
     # ------------------------------------------------------------------------
-    def create_application_menu(self, menu_id, title):
+    def create_application_menu(self, menu_id, title, dynamic=True):
         """
         Create a Spyder application menu.
 
@@ -195,7 +199,7 @@ class MainMenu(SpyderPluginV2):
             raise SpyderAPIError(
                 'Menu with id "{}" already added!'.format(menu_id))
 
-        menu = ApplicationMenu(self.main, title)
+        menu = ApplicationMenu(self.main, title, dynamic=dynamic)
         menu.menu_id = menu_id
         self._APPLICATION_MENUS[menu_id] = menu
         self.main.menuBar().addMenu(menu)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Flag to preserve UI even with a mix of migrated and non-migrated menus

Preview:
![menuMac](https://user-images.githubusercontent.com/16781833/106644824-e3b3c100-658b-11eb-83c5-4c06acb4af95.gif)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14661 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
