### PR TITLE
PR: Improve DPI change detection 

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1332,7 +1332,6 @@ class MainWindow(QMainWindow):
         # Fixes spyder-ide/spyder#3887.
         self.menuBar().raise_()
 
-        # Handle DPI scale and window changes to show a restart message
         # Handle DPI scale and window changes to show a restart message.
         # Don't activate this functionality on macOS because it's being
         # triggered in the wrong situations.
@@ -1361,11 +1360,10 @@ class MainWindow(QMainWindow):
 
     def show_dpi_change_message(self, dpi):
         """Show message to restart Spyder since the DPI scale changed."""
-        screen = self.window().windowHandle().screen()
         if not self.show_dpi_message:
             return
 
-        if self.current_dpi != dpi and screen is not None:
+        if self.current_dpi != dpi:
             # Check the window state to not show the message if the window
             # is in fullscreen mode.
             window = self.window().windowHandle()
@@ -1374,7 +1372,8 @@ class MainWindow(QMainWindow):
                 return
 
             dismiss_box = QCheckBox(
-                _("Hide this message during the current session")
+                _("Hide this message during the current session"),
+                self
             )
 
             msgbox = QMessageBox(self)
@@ -1394,7 +1393,7 @@ class MainWindow(QMainWindow):
                 _('Dismiss'), QMessageBox.NoRole)
             msgbox.setCheckBox(dismiss_box)
             msgbox.setDefaultButton(dismiss_button)
-            msgbox.exec_()
+            msgbox.show()
 
             if dismiss_box.isChecked():
                 self.show_dpi_message = False
@@ -1410,6 +1409,7 @@ class MainWindow(QMainWindow):
                 # Reconnect DPI scale changes to show a restart message
                 # also update current dpi for future checks
                 self.current_dpi = dpi
+                screen = self.window().windowHandle().screen()
                 screen.logicalDotsPerInchChanged.connect(
                     self.show_dpi_change_message)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Try to simplify the logic to handle the DPI change to trigger a restart of Spyder if needed (Monitor scale change message). ~Use `show` instead of `exec` to prevent crashing when no painting device is found.~ Actually `open` needs to be use and also connect to the finished signal of the dialog to handle the result.

Needs manual testing on Mac and Linux and also in a setup using a secondary screen (connecting/disconnecting, changing scale/DPI settings, etc)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14273 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
