### PR TITLE
PR: Fix commenting/uncommenting to not change leading whitespaces

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -2374,43 +2374,20 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
 
     def __remove_prefix(self, prefix, cursor, line_text):
         """Handle the removal of the prefix for a single line."""
-        start_with_space = line_text.startswith(' ')
-        if start_with_space:
-            left_spaces = self.__even_number_of_spaces(line_text)
-        else:
-            left_spaces = False
-        if start_with_space:
-            right_number_spaces = self.__number_of_spaces(line_text, group=1)
-        else:
-            right_number_spaces = self.__number_of_spaces(line_text)
+        cursor.movePosition(QTextCursor.Right,
+                            QTextCursor.MoveAnchor,
+                            line_text.find(prefix))
         # Handle prefix remove for comments with spaces
         if (prefix.strip() and line_text.lstrip().startswith(prefix + ' ')
                 or line_text.startswith(prefix + ' ') and '#' in prefix):
             cursor.movePosition(QTextCursor.Right,
-                                QTextCursor.MoveAnchor,
-                                line_text.find(prefix))
-            if (right_number_spaces == 1
-                    and (left_spaces or not start_with_space)
-                    or (not start_with_space and right_number_spaces % 2 != 0)
-                    or (left_spaces and right_number_spaces % 2 != 0)):
-                # Handle inserted '# ' with the count of the number of spaces
-                # at the right and left of the prefix.
-                cursor.movePosition(QTextCursor.Right,
-                                    QTextCursor.KeepAnchor, len(prefix + ' '))
-            else:
-                # Handle manual insertion of '#'
-                cursor.movePosition(QTextCursor.Right,
-                                    QTextCursor.KeepAnchor, len(prefix))
-            cursor.removeSelectedText()
+                                QTextCursor.KeepAnchor, len(prefix + ' '))
         # Check for prefix without space
         elif (prefix.strip() and line_text.lstrip().startswith(prefix)
                 or line_text.startswith(prefix)):
             cursor.movePosition(QTextCursor.Right,
-                                QTextCursor.MoveAnchor,
-                                line_text.find(prefix))
-            cursor.movePosition(QTextCursor.Right,
                                 QTextCursor.KeepAnchor, len(prefix))
-            cursor.removeSelectedText()
+        cursor.removeSelectedText()
 
     def __even_number_of_spaces(self, line_text, group=0):
         """

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_comments.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_comments.py
@@ -62,21 +62,21 @@ def test_single_line_comment(codeeditor):
     # Toggle comment with space at the right of prefix but manually inserted
     text = toggle_comment(editor, start_line=2)
     assert text == ("class a():\n"
-                    "    self.b = 1\n"
+                    "   self.b = 1\n"
                     " #   print(self.b)\n"
                     "#    \n"
                     )
     # Toggle comment with space insertion
     text = toggle_comment(editor, start_line=2)
     assert text == ("class a():\n"
-                    "    # self.b = 1\n"
+                    "   # self.b = 1\n"
                     " #   print(self.b)\n"
                     "#    \n"
                     )
     # Toggle comment deleting inserted space
     text = toggle_comment(editor, start_line=2)
     assert text == ("class a():\n"
-                    "    self.b = 1\n"
+                    "   self.b = 1\n"
                     " #   print(self.b)\n"
                     "#    \n"
                     )
@@ -84,8 +84,8 @@ def test_single_line_comment(codeeditor):
     # but manually inserted
     text = toggle_comment(editor, start_line=3)
     assert text == ("class a():\n"
-                    "    self.b = 1\n"
-                    "    print(self.b)\n"
+                    "   self.b = 1\n"
+                    "   print(self.b)\n"
                     "#    \n"
                     )
 
@@ -102,23 +102,23 @@ def test_selection_comment(codeeditor):
     # Toggle manually commented code
     text = toggle_comment(editor, single_line=False)
     assert text == ("class a():\n"
-                    "    self.b = 1\n"
-                    "    print(self.b)\n"
-                    "    \n"
+                    "   self.b = 1\n"
+                    "   print(self.b)\n"
+                    "   \n"
                     )
     # Toggle comment inserting prefix and space
     text = toggle_comment(editor, single_line=False)
     assert text == ("# class a():\n"
-                    "#     self.b = 1\n"
-                    "#     print(self.b)\n"
-                    "    \n"
+                    "#    self.b = 1\n"
+                    "#    print(self.b)\n"
+                    "   \n"
                     )
     # Toggle comment deleting inserted prefix and space
     text = toggle_comment(editor, single_line=False)
     assert text == ("class a():\n"
-                    "    self.b = 1\n"
-                    "    print(self.b)\n"
-                    "    \n"
+                    "   self.b = 1\n"
+                    "   print(self.b)\n"
+                    "   \n"
                     )
     # Test compatibility with Spyder 3 commenting structure
     text = ("#class a():\n"
@@ -130,9 +130,9 @@ def test_selection_comment(codeeditor):
     # Toggle comment deleting inserted prefix (without space)
     text = toggle_comment(editor, single_line=False)
     assert text == ("class a():\n"
-                    "    self.b = 1\n"
-                    "    print(self.b)\n"
-                    "    \n"
+                    "   self.b = 1\n"
+                    "   print(self.b)\n"
+                    "   \n"
                     )
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

This PR changes the way spyder uncomments code and fixes an issue where toggling comments on and off over lines with an uneven number of leading whitespaces would add an extra whitespace (regardless of indentation level).
Example:
```python
from pprint import pprint
x = [1,
     2]
y=[1,
   2]
def f(x, y):
    pprint(x,
           y)
```

Commenting (Ctrl+1) then uncommenting (Ctrl+1), before:
```python
from pprint import pprint
x = [1,
      2]
y=[1,
    2]
def f(x, y):
    pprint(x,
            y)
```

Commenting (Ctrl+1) then uncommenting (Ctrl+1), after:
```python
from pprint import pprint
x = [1,
     2]
y=[1,
   2]
def f(x, y):
    pprint(x,
           y)
```

This PR breaks compatibility with spyder 3: commenting with spyder 3 and uncommenting with spyder 4 with break indentation but that should not be happening much.

This PR also break toggling comments on manually commented lines (prefixing `'#'` instead of `'# '`) but that should be expected and other IDE behave the same (at least VSCode and Atom do).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14326

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: remisalmon

<!--- Thanks for your help making Spyder better for everyone! --->
