### PR TITLE
PR: Several fixes to load external plugins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -267,34 +267,25 @@ extras_require = {
 
 spyder_plugins_entry_points = [
     'appearance = spyder.plugins.appearance.plugin:Appearance',
+    'application = spyder.plugins.application.plugin:Application',
     'breakpoints = spyder.plugins.breakpoints.plugin:Breakpoints',
-    ('code_completion = spyder.plugins.completion.manager.plugin:'
-     'CompletionManager'),
-    'editor = spyder.plugins.editor.plugin:Editor',
     'explorer = spyder.plugins.explorer.plugin:Explorer',
-    ('fallback_completion = spyder.plugins.completion.fallback.plugin:'
-     'FallbackPlugin'),
     'find_in_files = spyder.plugins.findinfiles.plugin:FindInFiles',
     'help = spyder.plugins.help.plugin:Help',
     'historylog = spyder.plugins.history.plugin:HistoryLog',
-    'ipython_console = spyder.plugins.ipythonconsole.plugin:IPythonConsole',
-    ('kite_completion = spyder.plugins.completion.kite.plugin:'
-     'KiteCompletionPlugin'),
+    'internal_console = spyder.plugins.console.plugin:Console',
+    'main_interpreter = spyder.plugins.maininterpreter.plugin:MainInterpreter',
+    'mainmenu = spyder.plugins.mainmenu.plugin:MainMenu',
     'onlinehelp = spyder.plugins.onlinehelp.plugin:OnlineHelp',
-    'outline_explorer = spyder.plugins.outlineexplorer.plugin:OutlineExplorer',
     'plots = spyder.plugins.plots.plugin:Plots',
     'preferences = spyder.plugins.preferences.plugin:Preferences',
     'profiler = spyder.plugins.profiler.plugin:Profiler',
-    'project_explorer = spyder.plugins.projects.plugin:Projects',
     'pylint = spyder.plugins.pylint.plugin:Pylint',
-    ('lsp_completion = spyder.plugins.completion.languageserver.plugin:'
-     'LanguageServerPlugin'),
-    'python = spyder.plugins.python.plugin:Python',
+    'run = spyder.plugins.run.plugin:Run',
     'statusbar = spyder.plugins.statusbar.plugin:StatusBar',
-    ('variable_explorer = spyder.plugins.variableexplorer.plugin:'
-     'VariableExplorer'),
-    ('workingdir = spyder.plugins.workingdirectory.plugin:'
-     'WorkingDirectory'),
+    'shortcuts = spyder.plugins.shortcuts.plugin:Shortcuts',
+    'toolbar = spyder.plugins.toolbar.plugin:Toolbar',
+    'workingdir = spyder.plugins.workingdirectory.plugin:WorkingDirectory',
 ]
 
 

--- a/spyder/api/plugins.py
+++ b/spyder/api/plugins.py
@@ -574,7 +574,6 @@ class Plugins:
     """
     Application = 'application'
     Breakpoints = 'breakpoints'
-    CodeAnalysis = 'code_analysis'
     CodeCompletion = 'code_completion'
     KiteCompletion = 'kite'
     FallBackCompletion = 'fallback'

--- a/spyder/api/utils.py
+++ b/spyder/api/utils.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2009- Spyder Project Contributors
+#
+# Distributed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+API utilities.
+"""
+
+def get_class_values(cls):
+    """
+    Get the attribute values for the class enumerations used in our
+    API.
+    """
+    return [v for (k,v) in cls.__dict__.items() if k[:1] != '_']

--- a/spyder/api/utils.py
+++ b/spyder/api/utils.py
@@ -9,9 +9,13 @@
 API utilities.
 """
 
+
 def get_class_values(cls):
     """
     Get the attribute values for the class enumerations used in our
     API.
+
+    Idea from:
+    https://stackoverflow.com/a/17249228/438386
     """
-    return [v for (k,v) in cls.__dict__.items() if k[:1] != '_']
+    return [v for (k, v) in cls.__dict__.items() if k[:1] != '_']

--- a/spyder/api/widgets/toolbars.py
+++ b/spyder/api/widgets/toolbars.py
@@ -150,10 +150,6 @@ class ApplicationToolbar(SpyderToolbar):
     This is used by Qt to be able to save and restore the state of widgets.
     """
 
-    def _check_interface(self):
-        if self.ID is None:
-            raise SpyderAPIError("Toolbar must define an ID attribute.")
-
 
 class MainWidgetToolbar(SpyderToolbar):
     """

--- a/spyder/app/solver.py
+++ b/spyder/app/solver.py
@@ -166,6 +166,9 @@ def solve_plugin_dependencies(plugins):
         plugin._OPTIONAL = plugin.OPTIONAL.copy()
 
     plugin_names = {plugin.NAME: plugin for plugin in plugins}
+    # TODO: Remove the next line once the migration is finished (it
+    # shouldn't be necessary)
+    plugin_names.update(find_internal_plugins())
     dependencies_dict = {}
 
     # Prune plugins based on required dependencies

--- a/spyder/app/solver.py
+++ b/spyder/app/solver.py
@@ -168,7 +168,8 @@ def solve_plugin_dependencies(plugins):
     plugin_names = {plugin.NAME: plugin for plugin in plugins}
     # TODO: Remove the next line once the migration is finished (it
     # shouldn't be necessary)
-    plugin_names.update(find_internal_plugins())
+    internal_plugins = find_internal_plugins()
+    plugin_names.update(internal_plugins)
     dependencies_dict = {}
 
     # Prune plugins based on required dependencies
@@ -199,6 +200,10 @@ def solve_plugin_dependencies(plugins):
     deps = toposort_flatten(dependencies_dict)
 
     # Convert back from names to plugins
-    plugin_deps = [plugin_names[name] for name in deps]
+    # TODO: Remove the if part when the migration is done!
+    plugin_deps = [
+        plugin_names[name] for name in deps
+        if name not in internal_plugins.keys()
+    ]
 
     return plugin_deps

--- a/spyder/app/solver.py
+++ b/spyder/app/solver.py
@@ -95,14 +95,8 @@ def find_internal_plugins():
 
         # TODO: Remove after migration is finished
         internal_plugins["editor"] = None
-        internal_plugins["explorer"] = None
         internal_plugins["project_explorer"] = None
-        internal_plugins["code_completion"] = None
-        internal_plugins["kite"] = None
-        internal_plugins["fallback"] = None
         internal_plugins["ipython_console"] = None
-        internal_plugins["lsp"] = None
-        internal_plugins["pylint"] = None
         internal_plugins["variable_explorer"] = None
         internal_plugins["outline_explorer"] = None
 
@@ -114,16 +108,6 @@ def find_external_plugins():
     Find available internal plugins based on setuptools entry points.
     """
     internal_plugins = find_internal_plugins()
-    new_plugins = [
-        "appearance",
-        "code_completion",
-        "console",
-        "core",
-        "fallback_completion",
-        "kite_completion",
-        "lsp_completion",
-        "python",
-    ]
     plugins = [
         entry_point for entry_point
         in pkg_resources.iter_entry_points("spyder.plugins")
@@ -132,7 +116,7 @@ def find_external_plugins():
     external_plugins = {}
     for entry_point in plugins:
         name = entry_point.name
-        if name not in internal_plugins and name not in new_plugins:
+        if name not in internal_plugins:
             try:
                 class_name = entry_point.attrs[0]
                 mod = importlib.import_module(entry_point.module_name)
@@ -170,8 +154,6 @@ def solve_plugin_dependencies(plugins):
         dependencies.
     * Sort with toposort algorithm.
     """
-    plugin_names = [plugin.NAME for plugin in plugins]
-
     # Back up dependencies
     for plugin in plugins:
         if plugin.REQUIRES is None:

--- a/spyder/app/tests/test_solver.py
+++ b/spyder/app/tests/test_solver.py
@@ -119,4 +119,4 @@ def test_solve_plugin_dependencies_3():
 
 def test_find_internal_plugins():
     internal = find_internal_plugins()
-    assert len(internal) == 22
+    assert len(internal) == 20

--- a/spyder/plugins/appearance/__init__.py
+++ b/spyder/plugins/appearance/__init__.py
@@ -3,3 +3,15 @@
 # Copyright © Spyder Project Contributors
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
+
+"""
+spyder.plugins.appearance
+=========================
+
+Appearance Plugin.
+"""
+
+from spyder.plugins.appearance.plugin import Appearance
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [Appearance]

--- a/spyder/plugins/application/__init__.py
+++ b/spyder/plugins/application/__init__.py
@@ -5,5 +5,13 @@
 # (see spyder/__init__.py for details)
 
 """
-Application plugin.
+spyder.plugins.application
+==========================
+
+Application Plugin.
 """
+
+from spyder.plugins.application.plugin import Application
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [Application]

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -35,9 +35,8 @@ _ = get_translation('spyder')
 
 class Application(SpyderPluginV2):
     NAME = 'application'
-    REQUIRES = [Plugins.Console]
-    OPTIONAL = [Plugins.Help, Plugins.MainMenu, Plugins.Preferences,
-                Plugins.Shortcuts]
+    REQUIRES = [Plugins.Console, Plugins.Preferences]
+    OPTIONAL = [Plugins.Help, Plugins.MainMenu, Plugins.Shortcuts]
     CONTAINER_CLASS = ApplicationContainer
     CONF_SECTION = 'main'
     CONF_FILE = False

--- a/spyder/plugins/explorer/__init__.py
+++ b/spyder/plugins/explorer/__init__.py
@@ -10,3 +10,8 @@ spyder.plugins.explorer
 
 Files and Directories Explorer Plugin.
 """
+
+from spyder.plugins.explorer.plugin import Explorer
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [Explorer]

--- a/spyder/plugins/maininterpreter/__init__.py
+++ b/spyder/plugins/maininterpreter/__init__.py
@@ -3,3 +3,15 @@
 # Copyright © Spyder Project Contributors
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
+
+"""
+spyder.plugins.maininterpreter
+==============================
+
+Main interpreter Plugin.
+"""
+
+from spyder.plugins.maininterpreter.plugin import MainInterpreter
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [MainInterpreter]

--- a/spyder/plugins/mainmenu/__init__.py
+++ b/spyder/plugins/mainmenu/__init__.py
@@ -5,5 +5,13 @@
 # (see spyder/__init__.py for details)
 
 """
-Main menu plugin.
+spyder.plugins.mainmenu
+=======================
+
+Main Menu Plugin.
 """
+
+from spyder.plugins.mainmenu.plugin import MainMenu
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [MainMenu]

--- a/spyder/plugins/preferences/__init__.py
+++ b/spyder/plugins/preferences/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+spyder.plugins.preferences
+==========================
+
+Preferences plugin
+"""
+
+from spyder.plugins.preferences.plugin import Preferences
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [Preferences]

--- a/spyder/plugins/pylint/__init__.py
+++ b/spyder/plugins/pylint/__init__.py
@@ -1,9 +1,17 @@
 # -*- coding: utf-8 -*-
-# -----------------------------------------------------------------------------
-# Copyright (c) 2009- Spyder Project Contributors
 #
-# Distributed under the terms of the MIT License
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
-# -----------------------------------------------------------------------------
 
-from spyder.plugins.pylint.plugin import Pylint as PLUGIN_CLASS
+"""
+spyder.plugins.pylint
+=====================
+
+Pylint Plugin.
+"""
+
+from spyder.plugins.pylint.plugin import Pylint
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [Pylint]

--- a/spyder/plugins/run/__init__.py
+++ b/spyder/plugins/run/__init__.py
@@ -1,7 +1,17 @@
 # -*- coding: utf-8 -*-
-# -----------------------------------------------------------------------------
-# Copyright (c) 2009- Spyder Project Contributors
 #
-# Distributed under the terms of the MIT License
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
-# -----------------------------------------------------------------------------
+
+"""
+spyder.plugins.run
+==================
+
+Run Plugin.
+"""
+
+from spyder.plugins.run.plugin import Run
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [Run]

--- a/spyder/plugins/shortcuts/__init__.py
+++ b/spyder/plugins/shortcuts/__init__.py
@@ -4,4 +4,14 @@
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
 
-"""Shortcut Plugin."""
+"""
+spyder.plugins.shortcuts
+========================
+
+Shortcuts Plugin.
+"""
+
+from spyder.plugins.shortcuts.plugin import Shortcuts
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [Shortcuts]

--- a/spyder/plugins/shortcuts/plugin.py
+++ b/spyder/plugins/shortcuts/plugin.py
@@ -44,7 +44,8 @@ class Shortcuts(SpyderPluginV2):
 
     NAME = 'shortcuts'
     # TODO: Fix requires to reflect the desired order in the preferences
-    OPTIONAL = [Plugins.Preferences, Plugins.MainMenu]
+    REQUIRES = [Plugins.Preferences]
+    OPTIONAL = [Plugins.MainMenu]
     CONF_WIDGET_CLASS = ShortcutsConfigPage
     CONF_SECTION = NAME
     CONF_FILE = False

--- a/spyder/plugins/toolbar/__init__.py
+++ b/spyder/plugins/toolbar/__init__.py
@@ -5,5 +5,13 @@
 # (see spyder/__init__.py for details)
 
 """
-Toolbar plugin.
+spyder.plugins.toolbar
+======================
+
+Toolbar Plugin.
 """
+
+from spyder.plugins.toolbar.plugin import Toolbar
+
+# The following statement is required to be able to grab internal plugins.
+PLUGIN_CLASSES = [Toolbar]

--- a/spyder/plugins/toolbar/container.py
+++ b/spyder/plugins/toolbar/container.py
@@ -19,6 +19,7 @@ from qtpy.QtWidgets import QMenu, QToolBar
 from spyder.api.exceptions import SpyderAPIError
 from spyder.api.translations import get_translation
 from spyder.api.widgets import PluginMainContainer
+from spyder.api.utils import get_class_values
 from spyder.api.widgets.toolbars import ApplicationToolbar
 from spyder.plugins.toolbar.api import ApplicationToolbars
 
@@ -300,13 +301,7 @@ class ToolbarContainer(PluginMainContainer):
         """
         main_section = ToolbarsMenuSections.Main
         secondary_section = ToolbarsMenuSections.Secondary
-        default_toolbars = [
-            ApplicationToolbars.File,
-            ApplicationToolbars.Run,
-            ApplicationToolbars.Debug,
-            ApplicationToolbars.Main,
-            ApplicationToolbars.WorkingDirectory
-        ]
+        default_toolbars = get_class_values(ApplicationToolbars)
 
         for toolbar_id, toolbar in self._ADDED_TOOLBARS.items():
             if toolbar:

--- a/spyder/plugins/toolbar/container.py
+++ b/spyder/plugins/toolbar/container.py
@@ -149,7 +149,6 @@ class ToolbarContainer(PluginMainContainer):
         toolbar.ID = toolbar_id
         toolbar.setObjectName(toolbar_id)
         self._APPLICATION_TOOLBARS[toolbar_id] = toolbar
-        self._toolbarslist.append(toolbar)
 
         return toolbar
 
@@ -164,8 +163,18 @@ class ToolbarContainer(PluginMainContainer):
         mainwindow: QMainWindow
             The main application window.
         """
+        # Check toolbar class
+        if not isinstance(toolbar, ApplicationToolbar):
+            raise SpyderAPIError(
+                'Any toolbar must subclass ApplicationToolbar!'
+            )
+
+        # Check ID
         toolbar_id = toolbar.ID
-        toolbar._check_interface()
+        if toolbar_id is None:
+            raise SpyderAPIError(
+                f"Toolbar `{repr(toolbar)}` doesn't have an identifier!"
+            )
 
         if toolbar_id in self._ADDED_TOOLBARS:
             raise SpyderAPIError(
@@ -289,31 +298,27 @@ class ToolbarContainer(PluginMainContainer):
         """
         Populate the toolbars menu inside the view application menu.
         """
-        # TODO: This is hardcoding an order and assuming the working
-        # directory toolbar plugin exists. This should probably just
-        # use the order of creation as the order, or even sort
-        # alphabetically.
-        order = [
+        main_section = ToolbarsMenuSections.Main
+        secondary_section = ToolbarsMenuSections.Secondary
+        default_toolbars = [
             ApplicationToolbars.File,
             ApplicationToolbars.Run,
             ApplicationToolbars.Debug,
             ApplicationToolbars.Main,
-            "working_directory_toolbar",
-            None,
+            ApplicationToolbars.WorkingDirectory
         ]
 
-        section = 0
-        for toolbar_id in order:
-            if toolbar_id is None:
-                section += 1
-                continue
-
-            toolbar = self._ADDED_TOOLBARS.get(toolbar_id)
+        for toolbar_id, toolbar in self._ADDED_TOOLBARS.items():
             if toolbar:
                 action = toolbar.toggleViewAction()
+                section = (
+                    main_section
+                    if toolbar_id in default_toolbars
+                    else secondary_section
+                )
 
-            self.add_item_to_menu(
-                action,
-                menu=self.toolbars_menu,
-                section=str(section),
-            )
+                self.add_item_to_menu(
+                    action,
+                    menu=self.toolbars_menu,
+                    section=section,
+                )

--- a/spyder/plugins/toolbar/plugin.py
+++ b/spyder/plugins/toolbar/plugin.py
@@ -51,9 +51,9 @@ class Toolbar(SpyderPluginV2):
 
         # TODO: Until all core plugins are migrated, this is needed.
         ACTION_MAP = {
-            ApplicationToolbars.File: self.main.file_toolbar_actions,
-            ApplicationToolbars.Debug: self.main.debug_toolbar_actions,
-            ApplicationToolbars.Run: self.main.run_toolbar_actions,
+            ApplicationToolbars.File: self._main.file_toolbar_actions,
+            ApplicationToolbars.Debug: self._main.debug_toolbar_actions,
+            ApplicationToolbars.Run: self._main.run_toolbar_actions,
         }
         for toolbar in container.get_application_toolbars():
             toolbar_id = toolbar.ID
@@ -115,7 +115,7 @@ class Toolbar(SpyderPluginV2):
         toolbar: spyder.api.widgets.toolbars.ApplicationToolbar
             The application toolbar to add to the main window.
         """
-        self.get_container().add_application_toolbar(toolbar, self.main)
+        self.get_container().add_application_toolbar(toolbar, self._main)
 
     def add_item_to_application_toolbar(self, item, toolbar=None,
                                         toolbar_id=None, section=None,


### PR DESCRIPTION
## Description of Changes

This PR fixes several problems we discovered in 5.0 alpha4 when loading external plugins:

- Add missing entry_points and fix init files for new plugins added in alpha3 and alpha4.
- Fix solving list of required plugins for external plugins.
- Fix adding third-party toolbars to the toolbars menu.
- Make Preferences a required plugin for a couple of plugins that had it as optional.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
