### PR TITLE
PR: Constrain Watchdog to be less than 2.0.0

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -45,7 +45,7 @@ dependencies:
 - spyder-kernels
 - textdistance >=4.2.0
 - three-merge >=0.1.1
-- watchdog >=0.10.3
+- watchdog >=0.10.3,<2.0.0
 
 # We can not refer to an environment.yml file from another
 # So to get performant launches on mybinder.org, we have copied

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -41,4 +41,4 @@ sphinx >=0.6.6
 spyder-kernels
 textdistance >=4.2.0
 three-merge >=0.1.1
-watchdog >=0.10.3
+watchdog >=0.10.3,<2.0.0

--- a/setup.py
+++ b/setup.py
@@ -226,7 +226,7 @@ install_requires = [
     'spyder-kernels>=1.10.1,<1.11.0',
     'textdistance>=4.2.0',
     'three-merge>=0.1.1',
-    'watchdog>=0.10.3'
+    'watchdog>=0.10.3,<2.0.0'
 ]
 
 extras_require = {

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -66,7 +66,7 @@ TEXTDISTANCE_REQVER = '>=4.2.0'
 THREE_MERGE_REQVER = '>=0.1.1'
 # None for pynsist install for now
 # (check way to add dist.info/egg.info from packages without wheels available)
-WATCHDOG_REQVER = None if is_pynsist() else '>=0.10.3'
+WATCHDOG_REQVER = None if is_pynsist() else '>=0.10.3;<2.0.0'
 
 
 # Optional dependencies


### PR DESCRIPTION
## Description of Changes

This fixes an error in macOS when switching projects.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14779.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
