### PR TITLE
PR: Remove "No such comm" warning

### DIFF
--- a/spyder/plugins/ipythonconsole/comms/kernelcomm.py
+++ b/spyder/plugins/ipythonconsole/comms/kernelcomm.py
@@ -126,6 +126,12 @@ class KernelComm(CommBase, QObject):
             super(KernelComm, self)._set_call_return_value(
                 call_dict, data, is_error)
 
+    def remove(self, comm_id=None):
+        """Remove the comm without notifying the other side."""
+        id_list = self.get_comm_id_list(comm_id)
+        for comm_id in id_list:
+            del self._comms[comm_id]
+
     def open_comm(self, kernel_client):
         """Open comm through the kernel client."""
         self.kernel_client = kernel_client

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -660,7 +660,7 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         else:
             # Reset Pdb state and reopen comm
             sw._pdb_in_loop = False
-            sw.spyder_kernel_comm.close()
+            sw.spyder_kernel_comm.remove()
             sw.spyder_kernel_comm.open_comm(sw.kernel_client)
 
             # Start autorestart mechanism


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
When the kernel restarts, it will close the comm and reopen it. THis doesn't make sense to close it as the comm is not open at this point.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
