### PR TITLE
PR: Add options to include user's local PYTHONPATH and environment variables

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2683,7 +2683,7 @@ def test_preferences_change_interpreter(qtbot, main_window):
     config = lsp.generate_python_config()
     jedi = config['configurations']['pylsp']['plugins']['jedi']
     assert jedi['environment'] is None
-    assert jedi['extra_paths'] == []
+    assert jedi['extra_paths'] == os.environ.get('PYTHONPATH', '').split(os.pathsep)
 
     # Change main interpreter on preferences
     dlg, index, page = preferences_dialog_helper(qtbot, main_window,
@@ -2698,7 +2698,7 @@ def test_preferences_change_interpreter(qtbot, main_window):
     config = lsp.generate_python_config()
     jedi = config['configurations']['pylsp']['plugins']['jedi']
     assert jedi['environment'] == sys.executable
-    assert jedi['extra_paths'] == []
+    assert jedi['extra_paths'] == os.environ.get('PYTHONPATH', '').split(os.pathsep)
 
 
 @pytest.mark.slow

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2683,7 +2683,7 @@ def test_preferences_change_interpreter(qtbot, main_window):
     config = lsp.generate_python_config()
     jedi = config['configurations']['pylsp']['plugins']['jedi']
     assert jedi['environment'] is None
-    assert jedi['extra_paths'] == os.environ.get('PYTHONPATH', '').split(os.pathsep)
+    assert jedi['extra_paths'] == []
 
     # Change main interpreter on preferences
     dlg, index, page = preferences_dialog_helper(qtbot, main_window,
@@ -2698,7 +2698,7 @@ def test_preferences_change_interpreter(qtbot, main_window):
     config = lsp.generate_python_config()
     jedi = config['configurations']['pylsp']['plugins']['jedi']
     assert jedi['environment'] == sys.executable
-    assert jedi['extra_paths'] == os.environ.get('PYTHONPATH', '').split(os.pathsep)
+    assert jedi['extra_paths'] == []
 
 
 @pytest.mark.slow

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -369,7 +369,7 @@ def test_single_instance_and_edit_magic(main_window, qtbot, tmpdir):
     p = tmpdir.mkdir("foo").join("bar.py")
     p.write(lock_code)
 
-    with qtbot.waitSignal(shell.executed):
+    with qtbot.waitSignal(shell.executed, timeout=2000):
         shell.execute('%edit {}'.format(to_text_string(p)))
 
     qtbot.wait(3000)

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -129,6 +129,8 @@ DEFAULTS = [
               'umr/namelist': [],
               'custom_interpreters_list': [],
               'custom_interpreter': '',
+              'system_pythonpath': False,
+              'system_env_variables': False,
               }),
             ('ipython_console',
              {

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -578,7 +578,8 @@ class LanguageServerProvider(SpyderCompletionProvider):
         self.update_lsp_configuration(python_only=True)
 
     @on_conf_change(section='main_interpreter',
-                    option=['default', 'custom_interpreter'])
+                    option=['default', 'custom_interpreter',
+                            'system_pythonpath'])
     def on_main_interpreter_change(self, option, value):
         if running_under_pytest():
             if not os.environ.get('SPY_TEST_USE_INTROSPECTION'):

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -23,7 +23,7 @@ from qtpy.QtWidgets import QMessageBox
 # Local imports
 from spyder.api.config.decorators import on_conf_change
 from spyder.config.base import (_, get_conf_path, running_under_pytest,
-                                running_in_mac_app)
+                                running_in_mac_app, is_pynsist)
 from spyder.config.lsp import PYTHON_CONFIG
 from spyder.config.manager import CONF
 from spyder.utils.misc import check_connection_port
@@ -35,6 +35,7 @@ from spyder.plugins.completion.providers.languageserver.conftabs import TABS
 from spyder.plugins.completion.providers.languageserver.widgets import (
     ClientStatus, LSPStatusWidget, ServerDisabledMessageBox)
 from spyder.utils.introspection.module_completion import PREFERRED_MODULES
+from spyder.utils.programs import get_user_env_variables
 
 # Modules to be preloaded for Rope and Jedi
 PRELOAD_MDOULES = ', '.join(PREFERRED_MODULES)
@@ -787,8 +788,13 @@ class LanguageServerProvider(SpyderCompletionProvider):
         if not self.get_conf('default', section='main_interpreter'):
             environment = self.get_conf('custom_interpreter',
                                         section='main_interpreter')
-            if running_in_mac_app():
+
+        if running_in_mac_app():
+            if not self.get_conf('default', section='main_interpreter'):
                 env_vars.pop('PYTHONHOME', None)
+
+            if CONF.get('main_interpreter', 'system_pythonpath', False):
+                pythonpath = get_user_env_variables().get('PYTHONPATH', '')
 
         # PYTHONPATH must be added to extra_paths
         extra_paths.extend(pythonpath.split(os.pathsep))

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -23,7 +23,7 @@ from qtpy.QtWidgets import QMessageBox
 # Local imports
 from spyder.api.config.decorators import on_conf_change
 from spyder.config.base import (_, get_conf_path, running_under_pytest,
-                                running_in_mac_app, is_pynsist)
+                                running_in_mac_app)
 from spyder.config.lsp import PYTHON_CONFIG
 from spyder.config.manager import CONF
 from spyder.utils.misc import check_connection_port
@@ -35,7 +35,8 @@ from spyder.plugins.completion.providers.languageserver.conftabs import TABS
 from spyder.plugins.completion.providers.languageserver.widgets import (
     ClientStatus, LSPStatusWidget, ServerDisabledMessageBox)
 from spyder.utils.introspection.module_completion import PREFERRED_MODULES
-from spyder.utils.programs import get_user_env_variables
+from spyder.utils.programs import (get_user_env_variables,
+                                   get_required_env_variables)
 
 # Modules to be preloaded for Rope and Jedi
 PRELOAD_MDOULES = ', '.join(PREFERRED_MODULES)
@@ -796,10 +797,9 @@ class LanguageServerProvider(SpyderCompletionProvider):
             extra_paths.extend(pythonpath.split(os.pathsep))
 
         # - environment variables
-        env_vars = os.environ.copy()  # user environment variables
-        if (running_in_mac_app()
-                and not self.get_conf('default', section='main_interpreter')):
-            env_vars.pop('PYTHONHOME', None)
+        env_vars = get_required_env_variables()
+        if running_in_mac_app(environment):
+            env_vars['PYTHONHOME'] = os.environ.get('PYTHONHOME')
 
         jedi = {
             'environment': environment,

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -778,22 +778,24 @@ class LanguageServerProvider(SpyderCompletionProvider):
         }
 
         # Jedi configuration
-        if self.get_conf('default', section='main_interpreter'):
-            environment = None
-            env_vars = None
-        else:
+        environment = None
+        extra_paths = self.get_conf('spyder_pythonpath',
+                                    section='main', default=[])
+        env_vars = os.environ.copy()
+        pythonpath = os.environ.get('PYTHONPATH', '')
+
+        if not self.get_conf('default', section='main_interpreter'):
             environment = self.get_conf('custom_interpreter',
                                         section='main_interpreter')
-            env_vars = os.environ.copy()
-            # external interpreter should not use internal PYTHONPATH
-            env_vars.pop('PYTHONPATH', None)
             if running_in_mac_app():
                 env_vars.pop('PYTHONHOME', None)
 
+        # PYTHONPATH must be added to extra_paths
+        extra_paths.extend(pythonpath.split(os.pathsep))
+
         jedi = {
             'environment': environment,
-            'extra_paths': self.get_conf('spyder_pythonpath',
-                                         section='main', default=[]),
+            'extra_paths': extra_paths,
             'env_vars': env_vars,
         }
         jedi_completion = {

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1760,9 +1760,9 @@ def test_pdb_eventloop(ipyconsole, qtbot, backend):
     """Check if pdb works with every backend. (only testing 3)."""
     # Skip failing tests
     if backend == 'tk' and (os.name == 'nt' or PY2):
-        return
+        pytest.skip()
     if backend == 'osx' and (sys.platform != "darwin" or PY2):
-        return
+        pytest.skip()
 
     shell = ipyconsole.get_current_shellwidget()
     qtbot.waitUntil(lambda: shell._prompt_html is not None,

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -134,8 +134,10 @@ class SpyderKernelSpec(KernelSpec):
             repo_path = osp.normpath(osp.join(HERE, '..', '..', '..', '..'))
             subrepo_path = osp.join(repo_path, 'external-deps',
                                     'spyder-kernels')
-
-            env_vars.update({'PYTHONPATH': subrepo_path})
+            pythonpath = env_vars.get('PYTHONPATH', '') if DEV else ''
+            env_vars.update(
+                {'PYTHONPATH': os.pathsep.join([subrepo_path, pythonpath])}
+            )
 
         # App considerations
         if (running_in_mac_app() or is_pynsist()):
@@ -146,11 +148,13 @@ class SpyderKernelSpec(KernelSpec):
 
             user_env_vars = get_user_env_variables()
             if CONF.get('main_interpreter', 'system_pythonpath', False):
+                # Only get PYTHONPATH
                 pythonpath = user_env_vars.get('PYTHONPATH', None)
                 if pythonpath is not None:
                     env_vars.update({'PYTHONPATH': pythonpath})
 
             if CONF.get('main_interpreter', 'system_env_variables', False):
+                # Get all but PYTHONPATH
                 user_env_vars.pop('PYTHONPATH', None)
                 env_vars.update(user_env_vars)
 

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -125,7 +125,10 @@ class SpyderKernelSpec(KernelSpec):
         default_interpreter = CONF.get('main_interpreter', 'default')
         user_env_vars = get_user_env_variables()
 
-        env_vars = {}
+        req_vars = []
+        if os.name == 'nt':
+            req_vars.extend(['PATH', 'SYSTEMROOT', 'USERPROFILE'])
+        env_vars = {k: v for k, v in os.environ.items() if k in req_vars}
 
         if running_in_mac_app() and default_interpreter:
             env_vars.update({'PYTHONHOME': os.environ['PYTHONHOME']})

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -141,6 +141,7 @@ class SpyderKernelSpec(KernelSpec):
             subrepo_path = osp.join(repo_path, 'external-deps',
                                     'spyder-kernels')
             pythonpath.update(dict.fromkeys([subrepo_path]))
+            env_vars.update({'SPYDER_PYTEST': os.environ.get('SPYDER_PYTEST')})
 
         # Paths in PYTHONPATH Manager plus project's path
         pypath_manager = CONF.get('main', 'spyder_pythonpath', default=[])

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -18,14 +18,16 @@ import sys
 from jupyter_client.kernelspec import KernelSpec
 
 # Local imports
-from spyder.config.base import (DEV, is_pynsist, running_under_pytest,
-                                get_safe_mode, running_in_mac_app)
+from spyder.config.base import (DEV, running_under_pytest, get_safe_mode,
+                                running_in_mac_app)
 from spyder.config.manager import CONF
 from spyder.utils.conda import (add_quotes, get_conda_activation_script,
                                 get_conda_env_path, is_conda_env)
 from spyder.utils.environ import clean_env
 from spyder.utils.misc import get_python_executable
-from spyder.utils.programs import is_python_interpreter, get_user_env_variables
+from spyder.utils.programs import (is_python_interpreter,
+                                   get_user_env_variables,
+                                   get_required_env_variables)
 
 # Constants
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -125,13 +127,10 @@ class SpyderKernelSpec(KernelSpec):
         default_interpreter = CONF.get('main_interpreter', 'default')
         user_env_vars = get_user_env_variables()
 
-        req_vars = []
-        if os.name == 'nt':
-            req_vars.extend(['PATH', 'SYSTEMROOT', 'USERPROFILE'])
-        env_vars = {k: v for k, v in os.environ.items() if k in req_vars}
+        env_vars = get_required_env_variables()
 
         if running_in_mac_app() and default_interpreter:
-            env_vars.update({'PYTHONHOME': os.environ['PYTHONHOME']})
+            env_vars['PYTHONHOME'] = os.environ.get('PYTHONHOME')
 
         # PYTHONPATH heirarchy:
         # subrepo, pypath manager, user systerm pypath, spyder runtime pypath

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -134,10 +134,13 @@ class SpyderKernelSpec(KernelSpec):
             repo_path = osp.normpath(osp.join(HERE, '..', '..', '..', '..'))
             subrepo_path = osp.join(repo_path, 'external-deps',
                                     'spyder-kernels')
-            pythonpath = env_vars.get('PYTHONPATH', '') if DEV else ''
-            env_vars.update(
-                {'PYTHONPATH': os.pathsep.join([subrepo_path, pythonpath])}
-            )
+            sys_pythonpath = env_vars.get('PYTHONPATH', '')
+            if DEV and sys_pythonpath:
+                # If DEV, don't clobber PYTHONPATH
+                pythonpath = os.pathsep.join([subrepo_path, sys_pythonpath])
+            else:
+                pythonpath = subrepo_path
+            env_vars.update({'PYTHONPATH': pythonpath})
 
         # App considerations
         if (running_in_mac_app() or is_pynsist()):

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -150,8 +150,6 @@ class SpyderKernelSpec(KernelSpec):
         if CONF.get('main_interpreter', 'system_pythonpath', False):
             pythonpath.update(dict.fromkeys(user_pypath))
 
-        env_vars.update({'PYTHONPATH': os.pathsep.join(pythonpath)})
-
         # Use user environment variables
         if CONF.get('main_interpreter', 'system_env_variables', False):
             env_vars.update(user_env_vars)
@@ -187,7 +185,7 @@ class SpyderKernelSpec(KernelSpec):
             'SPY_SYMPY_O': CONF.get('ipython_console', 'symbolic_math'),
             'SPY_TESTING': running_under_pytest() or get_safe_mode(),
             'SPY_HIDE_CMD': CONF.get('ipython_console', 'hide_cmd_windows'),
-            'SPY_PYTHONPATH': ''  # obsolete
+            'SPY_PYTHONPATH': os.pathsep.join(pythonpath)
         })
 
         if self.is_pylab is True:

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -138,13 +138,17 @@ class SpyderKernelSpec(KernelSpec):
         user_pypath = user_env_vars.pop('PYTHONPATH', '').split(os.pathsep)
         pythonpath = {}  # dictionary preserves uniqueness and order
 
-        # Add spyder-kernels subrepo path to front of PYTHONPATH
+        # Add spyder-kernels subrepo path to front of sys.path
         if DEV or running_under_pytest():
             repo_path = osp.normpath(osp.join(HERE, '..', '..', '..', '..'))
             subrepo_path = osp.join(repo_path, 'external-deps',
                                     'spyder-kernels')
             pythonpath.update(dict.fromkeys([subrepo_path]))
+
+        if running_under_pytest():
+            # Test environment must have these variables
             env_vars.update({'SPYDER_PYTEST': os.environ.get('SPYDER_PYTEST')})
+            env_vars.update({'PYTHONPATH': subrepo_path})
 
         # Paths in PYTHONPATH Manager plus project's path
         pypath_manager = CONF.get('main', 'spyder_pythonpath', default=[])

--- a/spyder/plugins/maininterpreter/confpage.py
+++ b/spyder/plugins/maininterpreter/confpage.py
@@ -125,10 +125,9 @@ class MainInterpreterConfigPage(PluginConfigPage):
 
         # ENV Group
         pyenv_group = QGroupBox(_("Environment variables"))
-        pyenv_label = QLabel(_("For standalone Spyder applications "
-                               "(macOS, Windows), select whether to add user "
-                               "environment variables to the Python "
-                               "interpreter environment."))
+        pyenv_label = QLabel(_("Select whether to include system environment "
+                               "variables to the Python interpreter "
+                               "environment."))
         pyenv_label.setWordWrap(True)
         system_pythonpath = newcb(
             _("Use system PYTHONPATH"),
@@ -146,10 +145,6 @@ class MainInterpreterConfigPage(PluginConfigPage):
             tip=_("For standalone applications, use your "
                   "system environment variables")
         )
-        if not running_in_mac_app() and not is_pynsist():
-            # Disable preference if not a standalone application
-            system_pythonpath.setEnabled(False)
-            system_env_variables.setEnabled(False)
 
         pyenv_layout = QVBoxLayout()
         pyenv_layout.addWidget(pyenv_label)

--- a/spyder/plugins/maininterpreter/confpage.py
+++ b/spyder/plugins/maininterpreter/confpage.py
@@ -23,6 +23,7 @@ from spyder.utils import programs
 from spyder.utils.conda import get_list_conda_envs_cache
 from spyder.utils.misc import get_python_executable
 from spyder.utils.pyenv import get_list_pyenv_envs_cache
+from spyder.config.base import is_pynsist, running_in_mac_app
 
 # Localization
 _ = get_translation('spyder')
@@ -123,6 +124,7 @@ class MainInterpreterConfigPage(PluginConfigPage):
             'system_pythonpath',
             msg_info=_("Please note that these changes will "
                        "be applied only to new consoles"),
+            tip=_("For standalone applications, use your system PYTHONPATH")
         )
         pyexec_layout.addWidget(system_pythonpath)
         system_env_variables = newcb(
@@ -130,8 +132,14 @@ class MainInterpreterConfigPage(PluginConfigPage):
             'system_env_variables',
             msg_info=_("Please note that these changes will "
                        "be applied only to new consoles"),
+            tip=_("For standalone applications, use your "
+                  "system environment variables")
         )
         pyexec_layout.addWidget(system_env_variables)
+        if not running_in_mac_app() and not is_pynsist():
+            # Disable preference if not a standalone application
+            system_pythonpath.setEnabled(False)
+            system_env_variables.setEnabled(False)
 
         pyexec_group.setLayout(pyexec_layout)
 

--- a/spyder/plugins/maininterpreter/confpage.py
+++ b/spyder/plugins/maininterpreter/confpage.py
@@ -119,6 +119,17 @@ class MainInterpreterConfigPage(PluginConfigPage):
         self.cus_exec_radio.toggled.connect(self.cus_exec_combo.setEnabled)
         pyexec_layout.addWidget(self.cus_exec_combo)
 
+        pyexec_group.setLayout(pyexec_layout)
+
+        self.pyexec_edit = self.cus_exec_combo.combobox.lineEdit()
+
+        # ENV Group
+        pyenv_group = QGroupBox(_("Environment variables"))
+        pyenv_label = QLabel(_("For standalone Spyder applications "
+                               "(macOS, Windows), select whether to add user "
+                               "environment variables to the Python "
+                               "interpreter environment."))
+        pyenv_label.setWordWrap(True)
         system_pythonpath = newcb(
             _("Use system PYTHONPATH"),
             'system_pythonpath',
@@ -127,7 +138,6 @@ class MainInterpreterConfigPage(PluginConfigPage):
                        "and immediately to completions"),
             tip=_("For standalone applications, use your system PYTHONPATH")
         )
-        pyexec_layout.addWidget(system_pythonpath)
         system_env_variables = newcb(
             _("Use system environment variables"),
             'system_env_variables',
@@ -136,15 +146,16 @@ class MainInterpreterConfigPage(PluginConfigPage):
             tip=_("For standalone applications, use your "
                   "system environment variables")
         )
-        pyexec_layout.addWidget(system_env_variables)
         if not running_in_mac_app() and not is_pynsist():
             # Disable preference if not a standalone application
             system_pythonpath.setEnabled(False)
             system_env_variables.setEnabled(False)
 
-        pyexec_group.setLayout(pyexec_layout)
-
-        self.pyexec_edit = self.cus_exec_combo.combobox.lineEdit()
+        pyenv_layout = QVBoxLayout()
+        pyenv_layout.addWidget(pyenv_label)
+        pyenv_layout.addWidget(system_pythonpath)
+        pyenv_layout.addWidget(system_env_variables)
+        pyenv_group.setLayout(pyenv_layout)
 
         # UMR Group
         umr_group = QGroupBox(_("User Module Reloader (UMR)"))
@@ -193,6 +204,7 @@ class MainInterpreterConfigPage(PluginConfigPage):
 
         vlayout = QVBoxLayout()
         vlayout.addWidget(pyexec_group)
+        vlayout.addWidget(pyenv_group)
         vlayout.addWidget(umr_group)
         vlayout.addStretch(1)
         self.setLayout(vlayout)

--- a/spyder/plugins/maininterpreter/confpage.py
+++ b/spyder/plugins/maininterpreter/confpage.py
@@ -117,6 +117,22 @@ class MainInterpreterConfigPage(PluginConfigPage):
         self.def_exec_radio.toggled.connect(self.cus_exec_combo.setDisabled)
         self.cus_exec_radio.toggled.connect(self.cus_exec_combo.setEnabled)
         pyexec_layout.addWidget(self.cus_exec_combo)
+
+        system_pythonpath = newcb(
+            _("Use system PYTHONPATH"),
+            'system_pythonpath',
+            msg_info=_("Please note that these changes will "
+                       "be applied only to new consoles"),
+        )
+        pyexec_layout.addWidget(system_pythonpath)
+        system_env_variables = newcb(
+            _("Use system environment variables"),
+            'system_env_variables',
+            msg_info=_("Please note that these changes will "
+                       "be applied only to new consoles"),
+        )
+        pyexec_layout.addWidget(system_env_variables)
+
         pyexec_group.setLayout(pyexec_layout)
 
         self.pyexec_edit = self.cus_exec_combo.combobox.lineEdit()

--- a/spyder/plugins/maininterpreter/confpage.py
+++ b/spyder/plugins/maininterpreter/confpage.py
@@ -123,7 +123,8 @@ class MainInterpreterConfigPage(PluginConfigPage):
             _("Use system PYTHONPATH"),
             'system_pythonpath',
             msg_info=_("Please note that these changes will "
-                       "be applied only to new consoles"),
+                       "be applied only to new consoles but "
+                       "and immediately to completions"),
             tip=_("For standalone applications, use your system PYTHONPATH")
         )
         pyexec_layout.addWidget(system_pythonpath)

--- a/spyder/plugins/maininterpreter/container.py
+++ b/spyder/plugins/maininterpreter/container.py
@@ -51,7 +51,8 @@ class MainInterpreterContainer(PluginMainContainer):
     def update_actions(self):
         pass
 
-    @on_conf_change(option=['default', 'custom_interpreter', 'custom'])
+    @on_conf_change(option=['default', 'custom_interpreter', 'custom',
+                            'system_pythonpath'])
     def section_conf_update(self, option, value):
         if option in ['default', 'custom_interpreter', 'custom'] and value:
             self._update_status()

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -40,6 +40,13 @@ from spyder.utils.misc import get_python_executable
 
 HERE = osp.abspath(osp.dirname(__file__))
 
+# Minimum environment variables required for subprocesses
+REQ_ENV_VARS = []
+if os.name == 'nt':
+    REQ_ENV_VARS.extend(['PATH', 'SYSTEMROOT', 'SYSTEMDRIVE', 'USERPROFILE'])
+else:
+    REQ_ENV_VARS.extend(['HOME'])
+
 
 class ProgramError(Exception):
     pass
@@ -184,19 +191,22 @@ def alter_subprocess_kwargs_by_platform(**kwargs):
 
         # ensure Windows subprocess environment has SYSTEMROOT
         if kwargs.get('env') is not None:
-            # Is SYSTEMROOT, SYSTEMDRIVE in env? case insensitive
-            for env_var in ['SYSTEMROOT', 'SYSTEMDRIVE']:
-                if env_var not in map(str.upper, kwargs['env'].keys()):
+            # case insensitive
+            for req_var in REQ_ENV_VARS:
+                if req_var not in map(str.upper, kwargs['env'].keys()):
                     # Add from os.environ
                     for k, v in os.environ.items():
-                        if env_var == k.upper():
+                        if req_var == k.upper():
                             kwargs['env'].update({k: v})
                             break  # don't risk multiple values
     else:
         # linux and macOS
         if kwargs.get('env') is not None:
-            if 'HOME' not in kwargs['env']:
-                kwargs['env'].update({'HOME': get_home_dir()})
+            req_dict = {k: os.environ.get(k) for k in REQ_ENV_VARS}
+            req_dict.update(kwargs['env'])
+            if req_dict['HOME'] is None:
+                req_dict['HOME'] = get_home_dir()
+            kwargs['env'] = req_dict
 
     return kwargs
 
@@ -1091,3 +1101,10 @@ def get_user_env_variables():
             env_vars.update([item.split('=')])
 
     return env_vars
+
+
+def get_required_env_variables():
+    """Get the required environment variables"""
+    kwargs = alter_subprocess_kwargs_by_platform(env={})
+
+    return kwargs['env']

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -45,7 +45,7 @@ REQ_ENV_VARS = []
 if os.name == 'nt':
     REQ_ENV_VARS.extend(['PATH', 'SYSTEMROOT', 'SYSTEMDRIVE', 'USERPROFILE'])
 elif sys.platform.startswith('linux'):
-    REQ_ENV_VARS.extend(['HOME', 'DISPLAY'])
+    REQ_ENV_VARS.extend(['HOME', 'DISPLAY', 'XAUTHORITY'])
 elif sys.platform == 'darwin':
     REQ_ENV_VARS.extend(['HOME'])
 

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -45,9 +45,9 @@ REQ_ENV_VARS = []
 if os.name == 'nt':
     REQ_ENV_VARS.extend(['PATH', 'SYSTEMROOT', 'SYSTEMDRIVE', 'USERPROFILE'])
 elif sys.platform.startswith('linux'):
-    REQ_ENV_VARS.extend(['HOME', 'DISPLAY', 'XAUTHORITY'])
+    REQ_ENV_VARS.extend(['PATH', 'HOME', 'DISPLAY', 'XAUTHORITY'])
 elif sys.platform == 'darwin':
-    REQ_ENV_VARS.extend(['HOME'])
+    REQ_ENV_VARS.extend(['PATH', 'HOME'])
 
 
 class ProgramError(Exception):

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -1069,6 +1069,7 @@ def find_git():
 
 
 def get_user_env_variables():
+    """Return local environment variables"""
     cmdstr = ''
     if sys.platform == 'darwin':
         cmdstr = ('[[ -e /etc/profile ]] && source /etc/profile; '

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -1066,3 +1066,23 @@ def find_git():
         return find_program('git')
     else:
         return find_program('git')
+
+
+def get_user_env_variables():
+    cmdstr = ''
+    if sys.platform == 'darwin':
+        cmdstr = ('[[ -e /etc/profile ]] && source /etc/profile; '
+                  '[[ -e ~/.bash_profile ]] && source ~/.bash_profile; '
+                  'printenv')
+    elif sys.platform.startswith('linux'):
+        pass
+    elif os.name == 'nt':
+        pass
+
+    out, err = run_shell_command(cmdstr, env={}).communicate()
+
+    env_vars = {}
+    for item in out.decode().strip().split('\n'):
+        env_vars.update([item.split('=')])
+
+    return env_vars

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -44,7 +44,9 @@ HERE = osp.abspath(osp.dirname(__file__))
 REQ_ENV_VARS = []
 if os.name == 'nt':
     REQ_ENV_VARS.extend(['PATH', 'SYSTEMROOT', 'SYSTEMDRIVE', 'USERPROFILE'])
-else:
+elif sys.platform.startswith('linux'):
+    REQ_ENV_VARS.extend(['HOME', 'DISPLAY'])
+elif sys.platform == 'darwin':
     REQ_ENV_VARS.extend(['HOME'])
 
 

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -1098,7 +1098,7 @@ def get_user_env_variables():
                   'printenv')
         out, err = run_shell_command(cmdstr, env={}).communicate()
         for item in out.decode().strip().split('\n'):
-            env_vars.update([item.split('=')])
+            env_vars.update([item.split('=', 1)])
 
     return env_vars
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Added preference to the Python Interpreter section allowing all platforms and launch methods to select whether a user's system `PYTHONPATH` and environment variables are used for Consoles.

Spyder's PYTHONPATH Manager list behavior is unchanged. 

Fixes #14843

<img width="936" alt="Screen Shot 2021-05-31 at 4 02 16 PM" src="https://user-images.githubusercontent.com/9618975/120247835-bfaa7880-c229-11eb-9f1f-17098ad3d82d.png">


### New Behavior
* If "Use system PYTHONPATH" is deselected: paths in PYTHONPATH Manager are appended to the Console's `sys.path`
* If "Use system PYTHONPATH" is selected: in addition to the above, the paths in the user's local `PYTHONPATH` environment variable are appended to the Console's `sys.path`. On macOS and Linux, the user's local `PYTHONPATH` is determined by `/etc/profile`, `~/.bash_profile`, `~/.bash_login`, and `~/.profile`. On Windows, the user's local `PYTHONPATH` is extracted from the registry query `reg query HKEY_CURRENT_USER\Environment`.
* If "Use system environment variables" is deselected: only the following variables are passed to the Console's `os.environ`.
  * `PATH` and `HOME` on macOS
  * `PATH`, `HOME`, `DISPLAY` and `XAUTHORITY` on Linux
  * 'PATH', 'SYSTEMROOT', 'SYSTEMDRIVE', and 'USERPROFILE' on Windows
* If "Use system environment variables" is selected, all of the user's local environment variables, except `PYTHONPATH`, are passed to the Console's `os.environ`. On macOS and Linux, these are determined by `/etc/profile`, `~/.bash_profile`, `~/.bash_login`, and `~/.profile`. On Windows these are determined by the registry query `reg query HKEY_CURRENT_USER\Environment`

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary 
<!--- Thanks for your help making Spyder better for everyone! --->
