### PR TITLE
PR: Add lsp to spyder.completions entry-points

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -38,6 +38,8 @@ jobs:
           fi
           python3.9 -m pip install -c req-const.txt -r req-build.txt -r req-extras.txt "${INSTALL_FLAGS[@]}" ${GITHUB_WORKSPACE}
           python3.9 -m pip uninstall -q -y spyder
+          cd ${GITHUB_WORKSPACE}
+          python3.9 setup.py develop egg_info
       - name: Install Subrepos
         if: ${{github.event_name == 'pull_request'}}
         run: |
@@ -45,9 +47,10 @@ jobs:
           PLS_REPO=${GITHUB_WORKSPACE}/external-deps/python-language-server
           SITE_PACKAGES=`python3.9 -c 'import site; print(site.getsitepackages()[0])'`
           python3.9 -m pip uninstall -q -y spyder-kernels python-language-server
-          python3.9 -m pip install --no-deps ${SPK_REPO}
+          cd ${SPK_REPO}
+          python3.9 setup.py develop --no-deps --install-dir=${SITE_PACKAGES}
           cd ${PLS_REPO}
-          python3.9 setup.py develop --no-deps --install-dir ${SITE_PACKAGES}
+          python3.9 setup.py develop --no-deps --install-dir=${SITE_PACKAGES}
       - name: Build Application Bundle
         run: python3.9 setup.py ${LITE_FLAG} --dist-dir ${DISTDIR}
       - name: Build Disk Image

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -32,7 +32,6 @@ import time
 
 time_start = time.time()
 
-
 # --- Parse command line
 
 parser = argparse.ArgumentParser(
@@ -43,20 +42,20 @@ symbol (example: `python bootstrap.py -- --hide-console`).
 Type `python bootstrap.py -- --help` to read about Spyder
 options.""")
 parser.add_argument('--gui', default=None,
-                  help="GUI toolkit: pyqt5 (for PyQt5), pyqt (for PyQt4) or "
-                       "pyside (for PySide, deprecated)")
+                    help="GUI toolkit: pyqt5 (for PyQt5), pyqt (for PyQt4) or "
+                    "pyside (for PySide, deprecated)")
 parser.add_argument('--show-console', action='store_true', default=False,
-                  help="(Deprecated) Does nothing, now the default behavior "
-                  "is to show the console")
-parser.add_argument('--hide-console', action='store_true',
-                  default=False, help="Hide parent console window (Windows only)")
+                    help="(Deprecated) Does nothing, now the default behavior "
+                    "is to show the console")
+parser.add_argument('--hide-console', action='store_true', default=False,
+                    help="Hide parent console window (Windows only)")
 parser.add_argument('--safe-mode', dest="safe_mode",
                     action='store_true', default=False,
                     help="Start Spyder with a clean configuration directory")
-parser.add_argument('--no-apport', action='store_true',
-                    default=False, help="Disable Apport exception hook (Ubuntu)")
+parser.add_argument('--no-apport', action='store_true', default=False,
+                    help="Disable Apport exception hook (Ubuntu)")
 parser.add_argument('--debug', action='store_true',
-                  default=False, help="Run Spyder in debug mode")
+                    default=False, help="Run Spyder in debug mode")
 parser.add_argument('--filter-log', default='',
                     help="Comma-separated module name hierarchies whose log "
                          "messages should be shown. e.g., "
@@ -103,16 +102,16 @@ except UnicodeDecodeError:
 # Warn if we're running under 3rd party exception hook, such as
 # apport_python_hook.py from Ubuntu
 if sys.excepthook != sys.__excepthook__:
-   if sys.excepthook.__name__ != 'apport_excepthook':
-     print("WARNING: 3rd party Python exception hook is active: '%s'"
-            % sys.excepthook.__name__)
-   else:
-     if not args.no_apport:
-       print("WARNING: Ubuntu Apport exception hook is detected")
-       print("         Use --no-apport option to disable it")
-     else:
-       sys.excepthook = sys.__excepthook__
-       print("NOTICE: Ubuntu Apport exception hook is disabed")
+    if sys.excepthook.__name__ != 'apport_excepthook':
+        print("WARNING: 3rd party Python exception hook is active: '%s'"
+              % sys.excepthook.__name__)
+    else:
+        if not args.no_apport:
+            print("WARNING: Ubuntu Apport exception hook is detected")
+            print("         Use --no-apport option to disable it")
+        else:
+            sys.excepthook = sys.__excepthook__
+            print("NOTICE: Ubuntu Apport exception hook is disabed")
 
 
 # --- Continue
@@ -216,7 +215,6 @@ d._ep_map = {
 # Add the fake distribution to the global working_set
 pkg_resources.working_set.add(d, 'spyder')
 
-
 # Selecting the GUI toolkit: PyQt5 if installed
 if args.gui is None:
     try:
@@ -226,7 +224,7 @@ if args.gui is None:
     except ImportError:
         sys.exit("ERROR: No PyQt5 detected!")
 else:
-    print ("*. Skipping GUI toolkit detection")
+    print("*. Skipping GUI toolkit detection")
     os.environ['QT_API'] = args.gui
 
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -24,7 +24,6 @@ import atexit
 import argparse
 import os
 import os.path as osp
-import pkg_resources
 import shutil
 import subprocess
 import sys
@@ -178,42 +177,8 @@ subprocess.check_output(
 
 atexit.register(remove_pyls_installation)
 
-print("*. Declaring completion providers")
-# Register completion providers
-fallback = pkg_resources.EntryPoint.parse(
-    'fallback = spyder.plugins.completion.providers.fallback.provider:'
-    'FallbackProvider')
-
-snippets = pkg_resources.EntryPoint.parse(
-    'snippets = spyder.plugins.completion.providers.snippets.provider:'
-    'SnippetsProvider'
-)
-
-lsp = pkg_resources.EntryPoint.parse(
-    'lsp = spyder.plugins.completion.providers.languageserver.provider:'
-    'LanguageServerProvider'
-)
-
-kite = pkg_resources.EntryPoint.parse(
-    'kite = spyder.plugins.completion.providers.kite.provider:'
-    'KiteProvider'
-)
-
-# Create a fake Spyder distribution
-d = pkg_resources.Distribution(__file__)
-
-# Add the providers to the fake EntryPoint
-d._ep_map = {
-    'spyder.completions': {
-        'fallback': fallback,
-        'snippets': snippets,
-        'lsp': lsp,
-        'kite': kite
-    }
-}
-
-# Add the fake distribution to the global working_set
-pkg_resources.working_set.add(d, 'spyder')
+subprocess.check_output([sys.executable, '-W', 'ignore',
+                         'setup.py', 'egg_info'])
 
 # Selecting the GUI toolkit: PyQt5 if installed
 if args.gui is None:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -24,6 +24,7 @@ import atexit
 import argparse
 import os
 import os.path as osp
+import pkg_resources
 import shutil
 import subprocess
 import sys
@@ -177,8 +178,44 @@ subprocess.check_output(
 
 atexit.register(remove_pyls_installation)
 
-subprocess.check_output([sys.executable, '-W', 'ignore',
-                         'setup.py', 'egg_info'])
+print("*. Declaring completion providers")
+
+# Register completion providers
+fallback = pkg_resources.EntryPoint.parse(
+    'fallback = spyder.plugins.completion.providers.fallback.provider:'
+    'FallbackProvider')
+
+snippets = pkg_resources.EntryPoint.parse(
+    'snippets = spyder.plugins.completion.providers.snippets.provider:'
+    'SnippetsProvider'
+)
+
+lsp = pkg_resources.EntryPoint.parse(
+    'lsp = spyder.plugins.completion.providers.languageserver.provider:'
+    'LanguageServerProvider'
+)
+
+kite = pkg_resources.EntryPoint.parse(
+    'kite = spyder.plugins.completion.providers.kite.provider:'
+    'KiteProvider'
+)
+
+# Create a fake Spyder distribution
+d = pkg_resources.Distribution(__file__)
+
+# Add the providers to the fake EntryPoint
+d._ep_map = {
+    'spyder.completions': {
+        'fallback': fallback,
+        'snippets': snippets,
+        'lsp': lsp,
+        'kite': kite
+    }
+}
+
+# Add the fake distribution to the global working_set
+pkg_resources.working_set.add(d, 'spyder')
+
 
 # Selecting the GUI toolkit: PyQt5 if installed
 if args.gui is None:

--- a/setup.py
+++ b/setup.py
@@ -301,6 +301,8 @@ spyder_completions_entry_points = [
      'SnippetsProvider'),
     ('kite = spyder.plugins.completion.providers.kite.provider:'
      'KiteProvider'),
+    ('lsp = spyder.plugins.completion.providers.languageserver.provider:'
+     'LanguageServerProvider'),
 ]
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

The LSP server was not starting for macOS applications, and apparently bootstrap worked around the same issue some time ago by explicitly adding the spyder.completions entry-points in `bootstrap.py`. However, this is not necessary if `lsp` is added in `setup.py`.
* Added `lsp` to `spyder.completions` entry-points; this resolves issue with LSP not starting for macOS application.
* With `lsp` added to entry-points, the entry-point patching in `bootstrap.py` is not needed (in fact causes an error); instead just create Spyder's egg-info


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14923


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary
<!--- Thanks for your help making Spyder better for everyone! --->
