### PR TITLE
PR: Remove unmaintained pytest-ordering package

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -64,7 +64,7 @@ dependencies:
 - pytest-cov
 - pytest-lazy-fixture
 - pytest-mock
-- pytest-ordering
+- pytest-order
 - pytest-qt
 - pytest-xvfb
 - pyyaml

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,9 +24,6 @@ markers =
     change_directory
     use_startup_wdir: Test startup workingdir CONF
     preload_project: Preload a project on the main window
-    first
-    second
-    third
     no_xvfb
     external_interpreter
     test_environment_interpreter

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -13,7 +13,7 @@ pytest <6.0
 pytest-cov
 pytest-lazy-fixture
 pytest-mock
-pytest-ordering
+pytest-order
 pytest-qt
 pyyaml
 scipy

--- a/setup.py
+++ b/setup.py
@@ -256,7 +256,7 @@ extras_require = {
         'pytest-cov',
         'pytest-lazy-fixture',
         'pytest-mock',
-        'pytest-ordering',
+        'pytest-order',
         'pytest-qt',
         'pyyaml',
         'scipy',

--- a/spyder/app/tests/test_cli_options.py
+++ b/spyder/app/tests/test_cli_options.py
@@ -11,7 +11,7 @@ import pytest
 from spyder.app import cli_options
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 def test_get_options():
     getopt = cli_options.get_options
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -316,7 +316,7 @@ def cleanup(request):
 # ---- Tests
 # =============================================================================
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.single_instance
 @pytest.mark.skipif(os.environ.get('CI', None) is None,
                     reason="It's not meant to be run outside of CIs")
@@ -387,7 +387,7 @@ def test_lock_action(main_window):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(os.name == 'nt' and PY2, reason="Fails on win and py2")
 def test_default_plugin_actions(main_window, qtbot):
     """Test the effect of dock, undock, close and toggle view actions."""
@@ -964,7 +964,7 @@ def test_connection_to_external_kernel(main_window, qtbot):
     kc.stop_channels()
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It times out sometimes on Windows")
@@ -2615,7 +2615,7 @@ def test_preferences_shortcut_reset_regression(main_window, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 def test_preferences_change_interpreter(qtbot, main_window):
     """Test that on main interpreter change signal is emitted."""
     # Check original pyls configuration

--- a/spyder/plugins/completion/providers/kite/utils/tests/test_install.py
+++ b/spyder/plugins/completion/providers/kite/utils/tests/test_install.py
@@ -27,7 +27,7 @@ INSTALL_TIMEOUT = 360000
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skip(reason="Fail on CIs and it's too heavy to run locally")
 def test_kite_install(qtbot):
     """Test the correct execution of the installation process of kite."""

--- a/spyder/plugins/completion/providers/languageserver/tests/test_client.py
+++ b/spyder/plugins/completion/providers/languageserver/tests/test_client.py
@@ -34,7 +34,7 @@ def lsp_client_and_completion(request):
 
 
 @pytest.mark.slow
-@pytest.mark.third
+@pytest.mark.order(3)
 def test_didOpen(lsp_client_and_completion, qtbot):
     client, completion = lsp_client_and_completion
 
@@ -60,7 +60,7 @@ def test_didOpen(lsp_client_and_completion, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.third
+@pytest.mark.order(3)
 def test_get_signature(lsp_client_and_completion, qtbot):
     client, completion = lsp_client_and_completion
 
@@ -99,7 +99,7 @@ def test_get_signature(lsp_client_and_completion, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.third
+@pytest.mark.order(3)
 def test_get_completions(lsp_client_and_completion, qtbot):
     client, completion = lsp_client_and_completion
 
@@ -139,7 +139,7 @@ def test_get_completions(lsp_client_and_completion, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.third
+@pytest.mark.order(3)
 def test_go_to_definition(lsp_client_and_completion, qtbot):
     client, completion = lsp_client_and_completion
 
@@ -179,7 +179,7 @@ def test_go_to_definition(lsp_client_and_completion, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.third
+@pytest.mark.order(3)
 def test_local_signature(lsp_client_and_completion, qtbot):
     client, completion = lsp_client_and_completion
 
@@ -224,7 +224,7 @@ def test_local_signature(lsp_client_and_completion, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.third
+@pytest.mark.order(3)
 def test_send_workspace_folders_change(lsp_client_and_completion, qtbot):
     client, completion = lsp_client_and_completion
     folder = '/tmp/'

--- a/spyder/plugins/completion/tests/test_plugin.py
+++ b/spyder/plugins/completion/tests/test_plugin.py
@@ -165,7 +165,7 @@ def test_provider_detection(completion_plugin_all):
 
 
 @pytest.mark.slow
-# @pytest.mark.third
+# @pytest.mark.order(3)
 def test_plugin_completion_gather(qtbot_module, completion_receiver):
     completion, receiver = completion_receiver
 
@@ -215,7 +215,7 @@ def test_plugin_completion_gather(qtbot_module, completion_receiver):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 def test_plugin_first_response_request(qtbot_module, completion_receiver):
     completion, receiver = completion_receiver
 

--- a/spyder/plugins/editor/widgets/tests/test_classfunc_selector.py
+++ b/spyder/plugins/editor/widgets/tests/test_classfunc_selector.py
@@ -42,7 +42,7 @@ class SomeOtherObject:
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @flaky(max_runs=5)
 def test_class_func_selector(completions_codeeditor, qtbot):
     code_editor, _ = completions_codeeditor

--- a/spyder/plugins/editor/widgets/tests/test_completions_hide.py
+++ b/spyder/plugins/editor/widgets/tests/test_completions_hide.py
@@ -14,7 +14,7 @@ from qtpy.QtCore import Qt
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @flaky(max_runs=5)
 def test_automatic_completions_hide_complete(completions_codeeditor, qtbot):
     """Test on-the-fly completion closing when already complete.
@@ -86,7 +86,7 @@ def test_automatic_completions_hide_complete(completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @flaky(max_runs=5)
 def test_automatic_completions_widget_visible(completions_codeeditor, qtbot):
     """

--- a/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
@@ -287,7 +287,7 @@ def test_toggle_on_show_all_files(editorstack, outlineexplorer, test_files):
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 def test_editor_outlineexplorer(qtbot, completions_codeeditor_outline):
     """Tests that the outline explorer reacts to editor changes."""
     code_editor, outlineexplorer = completions_codeeditor_outline
@@ -403,7 +403,7 @@ def test_editor_outlineexplorer(qtbot, completions_codeeditor_outline):
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 def test_empty_file(qtbot, completions_codeeditor_outline):
     """
     Test that the outline explorer is updated correctly when

--- a/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
+++ b/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
@@ -396,7 +396,7 @@ def test_set_layout_settings_goto(editor_splitter_layout_bot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(os.name == 'nt',
                     reason="Makes other tests fail on Windows")
 def test_lsp_splitter_close(editor_splitter_lsp):

--- a/spyder/plugins/editor/widgets/tests/test_folding.py
+++ b/spyder/plugins/editor/widgets/tests/test_folding.py
@@ -57,7 +57,7 @@ responses = {
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @flaky(max_runs=5)
 def test_folding(completions_codeeditor, qtbot):
     code_editor, _ = completions_codeeditor
@@ -81,7 +81,7 @@ def test_folding(completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @flaky(max_runs=5)
 @pytest.mark.skipif(os.name == 'nt', reason="Hangs on Windows")
 def test_unfold_when_searching(search_codeeditor, qtbot):
@@ -110,7 +110,7 @@ def test_unfold_when_searching(search_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @flaky(max_runs=5)
 @pytest.mark.skipif(os.name == 'nt', reason="Hangs on Windows")
 def test_unfold_goto(search_codeeditor, qtbot):

--- a/spyder/plugins/editor/widgets/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/tests/test_formatting.py
@@ -38,7 +38,7 @@ def get_formatter_values(formatter, range_fmt=False):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.parametrize('formatter', ['autopep8', 'yapf', 'black'])
 def test_document_formatting(formatter, completions_codeeditor, qtbot):
     """Validate text autoformatting via autopep8, yapf or black."""
@@ -71,7 +71,7 @@ def test_document_formatting(formatter, completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.parametrize('formatter', ['autopep8', 'yapf', 'black'])
 def test_document_range_formatting(formatter, completions_codeeditor, qtbot):
     """Validate text range autoformatting."""

--- a/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
+++ b/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
@@ -32,7 +32,7 @@ some_function""".format(SIG=TEST_SIG, DOC=TEST_DOCSTRING)
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @pytest.mark.skipif(sys.platform == 'darwin' and PY2,
                     reason='Fails on Mac and Python 2')
 def test_hide_calltip(completions_codeeditor, qtbot):
@@ -64,7 +64,7 @@ def test_hide_calltip(completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @pytest.mark.skipif(
     os.name == 'nt' and PY2,
     reason='Fails on Win',
@@ -131,7 +131,7 @@ def test_get_calltips(qtbot, completions_codeeditor, params):
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @pytest.mark.skipif(sys.platform == 'darwin', reason='Fails on Mac')
 @pytest.mark.parametrize('params', [
             # Parameter, Expected Output
@@ -173,7 +173,7 @@ def test_get_hints(qtbot, completions_codeeditor, params, capsys):
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @pytest.mark.skipif(sys.platform == 'darwin', reason='Fails on Mac')
 def test_get_hints_not_triggered(qtbot, completions_codeeditor):
     """Test that the editor is not returning hover hints for empty docs."""

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -59,7 +59,7 @@ def set_executable_config_helper(executable=None):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(not sys.platform.startswith('linux') or PY2,
                     reason='Only works on Linux and Python 3')
 @flaky(max_runs=5)
@@ -139,7 +139,7 @@ def test_fallback_completions(completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 def test_space_completion(completions_codeeditor, qtbot):
     """Validate completion's space character handling."""
     code_editor, _ = completions_codeeditor
@@ -175,7 +175,7 @@ def test_space_completion(completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @flaky(max_runs=5)
 @pytest.mark.skipif(bool(os.environ.get('CI', None)), reason='Fails on CI!')
 def test_hide_widget_completion(completions_codeeditor, qtbot):
@@ -223,7 +223,7 @@ def test_hide_widget_completion(completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @flaky(max_runs=5)
 def test_automatic_completions(completions_codeeditor, qtbot):
     """Test on-the-fly completions."""
@@ -314,7 +314,7 @@ def test_automatic_completions(completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @flaky(max_runs=5)
 def test_automatic_completions_tab_bug(completions_codeeditor, qtbot):
     """
@@ -349,7 +349,7 @@ def test_automatic_completions_tab_bug(completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @flaky(max_runs=5)
 def test_automatic_completions_space_bug(completions_codeeditor, qtbot):
     """Test that completions are not invoked when pressing the space key."""
@@ -439,7 +439,7 @@ def test_automatic_completions_parens_bug(completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @flaky(max_runs=5)
 def test_completions(completions_codeeditor, qtbot):
     """Exercise code completion in several ways."""
@@ -687,7 +687,7 @@ def test_completions(completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(not rtree_available or PY2 or os.name == 'nt',
                     reason='Only works if rtree is installed')
 def test_code_snippets(completions_codeeditor, qtbot):
@@ -1003,7 +1003,7 @@ def test_kite_code_snippets(kite_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @flaky(max_runs=5)
 def test_completion_order(completions_codeeditor, qtbot):
     code_editor, _ = completions_codeeditor
@@ -1045,7 +1045,7 @@ def test_completion_order(completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @flaky(max_runs=5)
 def test_text_snippet_completions(completions_codeeditor, qtbot):
     code_editor, _ = completions_codeeditor
@@ -1072,7 +1072,7 @@ def test_text_snippet_completions(completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @flaky(max_runs=5)
 def test_kite_textEdit_completions(mock_completions_codeeditor, qtbot):
     """Test textEdit completions such as those returned by the Kite provider.
@@ -1121,7 +1121,7 @@ def test_kite_textEdit_completions(mock_completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @flaky(max_runs=5)
 @pytest.mark.skipif(os.name == 'nt', reason='Hangs on Windows')
 def test_completions_extra_paths(completions_codeeditor, qtbot, tmpdir):
@@ -1175,7 +1175,7 @@ def spam():
 
 
 @pytest.mark.slow
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(os.environ.get('CI') is None,
                     reason='Run tests only on CI.')
 @flaky(max_runs=5)

--- a/spyder/plugins/editor/widgets/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/tests/test_warnings.py
@@ -62,7 +62,7 @@ def completions_codeeditor_linting(request, qtbot, completions_codeeditor):
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @flaky(max_runs=5)
 def test_ignore_warnings(qtbot, completions_codeeditor_linting):
     """Test that the editor is ignoring some warnings."""
@@ -114,7 +114,7 @@ def test_ignore_warnings(qtbot, completions_codeeditor_linting):
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @flaky(max_runs=5)
 def test_adding_warnings(qtbot, completions_codeeditor_linting):
     """Test that warnings are saved in the editor blocks."""
@@ -149,7 +149,7 @@ def test_adding_warnings(qtbot, completions_codeeditor_linting):
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @flaky(max_runs=5)
 def test_move_warnings(qtbot, completions_codeeditor_linting):
     """Test that moving to next/previous warnings is working."""
@@ -185,7 +185,7 @@ def test_move_warnings(qtbot, completions_codeeditor_linting):
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @flaky(max_runs=5)
 def test_get_warnings(qtbot, completions_codeeditor_linting):
     """Test that the editor is returning the right list of warnings."""
@@ -218,7 +218,7 @@ def test_get_warnings(qtbot, completions_codeeditor_linting):
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @flaky(max_runs=5)
 def test_update_warnings_after_delete_line(qtbot, completions_codeeditor_linting):
     """
@@ -257,7 +257,7 @@ def test_update_warnings_after_delete_line(qtbot, completions_codeeditor_linting
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @flaky(max_runs=5)
 def test_update_warnings_after_closequotes(qtbot, completions_codeeditor_linting):
     """
@@ -294,7 +294,7 @@ def test_update_warnings_after_closequotes(qtbot, completions_codeeditor_linting
 
 
 @pytest.mark.slow
-@pytest.mark.second
+@pytest.mark.order(2)
 @flaky(max_runs=5)
 def test_update_warnings_after_closebrackets(qtbot, completions_codeeditor_linting):
     """

--- a/spyder/plugins/explorer/widgets/tests/test_explorer.py
+++ b/spyder/plugins/explorer/widgets/tests/test_explorer.py
@@ -229,7 +229,7 @@ def test_single_click_to_open(qtbot, file_explorer):
     run_test_helper(single_click=False, initial_index=initial_index)
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 def test_get_common_file_associations(qtbot, file_explorer_associations):
     widget = file_explorer_associations.explorer.treewidget
     associations = widget.get_common_file_associations(
@@ -247,7 +247,7 @@ def test_get_common_file_associations(qtbot, file_explorer_associations):
     assert associations[0][-1] == '/some/fake/some_app_1' + ext
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 def test_get_file_associations(qtbot, file_explorer_associations):
     widget = file_explorer_associations.explorer.treewidget
     associations = widget.get_file_associations('/some/path/file.txt')
@@ -260,7 +260,7 @@ def test_get_file_associations(qtbot, file_explorer_associations):
     assert associations[0][-1] == '/some/fake/some_app_1' + ext
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 def test_create_file_manager_actions(qtbot, file_explorer_associations,
                                      tmp_path):
     widget = file_explorer_associations.explorer.treewidget
@@ -290,7 +290,7 @@ def test_create_file_manager_actions(qtbot, file_explorer_associations,
     assert not action_texts
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 def test_clicked(qtbot, file_explorer_associations, tmp_path):
     widget = file_explorer_associations.explorer.treewidget
     some_dir = tmp_path / 'some_dir'
@@ -322,7 +322,7 @@ def test_clicked(qtbot, file_explorer_associations, tmp_path):
     qtbot.keyClick(widget, Qt.Key_Return)
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 def test_check_launch_error_codes(qtbot, file_explorer_associations):
     widget = file_explorer_associations.explorer.treewidget
 
@@ -353,7 +353,7 @@ def test_check_launch_error_codes(qtbot, file_explorer_associations):
     assert not res
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 def test_open_association(qtbot, file_explorer_associations, tmp_path):
     widget = file_explorer_associations.explorer.treewidget
     some_dir = tmp_path / 'some_dir'
@@ -373,7 +373,7 @@ def test_open_association(qtbot, file_explorer_associations, tmp_path):
     widget.open_association('some-app')
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 def test_update_filters(file_explorer, qtbot):
     """
     Test that view is updated if the filter button is activated and

--- a/spyder/plugins/explorer/widgets/tests/test_fileassociations.py
+++ b/spyder/plugins/explorer/widgets/tests/test_fileassociations.py
@@ -23,7 +23,7 @@ from spyder.plugins.explorer.widgets.fileassociations import (
 from spyder.py3compat import PY2
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(os.name == 'nt' and PY2, reason='Fails on win and py2!')
 def test_input_text_dialog(qtbot):
     widget = InputTextDialog()
@@ -55,7 +55,7 @@ def test_input_text_dialog(qtbot):
     widget.validate()
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(os.name == 'nt' and PY2, reason='Fails on win and py2!')
 def test_apps_dialog(qtbot, tmp_path):
     widget = ApplicationsDialog()
@@ -144,7 +144,7 @@ def create_timer(func, interval=500):
     return timer
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(os.name == 'nt' and PY2, reason='Fails on win and py2!')
 def test_file_assoc_widget(file_assoc_widget):
     qtbot, widget = file_assoc_widget

--- a/spyder/plugins/findinfiles/tests/test_plugin.py
+++ b/spyder/plugins/findinfiles/tests/test_plugin.py
@@ -38,7 +38,7 @@ def findinfiles(qtbot):
 
 
 # ---- Tests for FindInFiles plugin
-@pytest.mark.first
+@pytest.mark.order(1)
 def test_closing_plugin(findinfiles, qtbot, mocker):
     """
     Test that the external paths listed in the combobox are saved and loaded

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1574,7 +1574,7 @@ def test_calltip(ipyconsole, qtbot):
 
 
 @flaky(max_runs=3)
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.test_environment_interpreter
 def test_conda_env_activation(ipyconsole, qtbot):
     """

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -99,7 +99,7 @@ def png_to_qimage(png):
 # =============================================================================
 # ---- Tests
 # =============================================================================
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.parametrize("fmt, fext",
                          [('image/png', '.png'), ('image/svg+xml', '.svg')])
 def test_handle_new_figures(figbrowser, tmpdir, fmt, fext):

--- a/spyder/utils/tests/test_encoding.py
+++ b/spyder/utils/tests/test_encoding.py
@@ -23,7 +23,7 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(),
                                              os.path.dirname(__file__)))
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(os.name == 'nt' and PY2, reason='Fails on Win!')
 def test_symlinks(tmpdir):
     """

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -97,7 +97,7 @@ def test_run_python_script_in_terminal(scriptpath, qtbot):
 
 
 @flaky(max_runs=3)
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(
     os.environ.get('CI', None) is None or os.name == 'nt',
     reason='Only on CI and not on windows!',
@@ -121,7 +121,7 @@ def test_run_python_script_in_terminal_blank_wdir(scriptpath_with_blanks,
 
 
 @flaky(max_runs=3)
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(
     os.environ.get('CI', None) is None or os.name == 'nt',
     reason='Only on CI and not on windows!',
@@ -145,19 +145,19 @@ def test_run_python_script_in_terminal_with_wdir_empty(scriptpath, qtbot):
     assert res == 'done'
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(os.environ.get('CI', None) is None, reason='Only on CI!')
 def test_is_valid_interpreter():
     assert is_python_interpreter(VALID_INTERPRETER)
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(os.environ.get('CI', None) is None, reason='Only on CI!')
 def test_is_invalid_interpreter():
     assert not is_python_interpreter(INVALID_INTERPRETER)
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 @pytest.mark.skipif(os.environ.get('CI', None) is None, reason='Only on CI!')
 def test_is_valid_interpreter_name():
     names = ['python', 'pythonw', 'python2.7', 'python3.5', 'python.exe', 'pythonw.exe']


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

pytest-ordering is not maintained and broken:
https://github.com/ftobia/pytest-ordering/issues/73

This PR removes it. Tests should be written in a way that they are independent of each other.

Alternatively, if the order of tests is really needed, you may consider using forked and maintained https://github.com/pytest-dev/pytest-order with more concise mark names.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: bnavigator

<!--- Thanks for your help making Spyder better for everyone! --->