### PR TITLE
PR: Add missing recursive_notification argument to set_option calls in old API preference pages

### DIFF
--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1339,6 +1339,7 @@ def test_remove_old_stderr_files(ipyconsole, qtbot):
     assert not osp.isfile(osp.join(tmpdir, 'foo.stderr'))
 
 
+@flaky(max_runs=10)
 @pytest.mark.use_startup_wdir
 def test_console_working_directory(ipyconsole, qtbot):
     """Test for checking the working directory."""

--- a/spyder/plugins/preferences/api.py
+++ b/spyder/plugins/preferences/api.py
@@ -46,9 +46,11 @@ class ConfigAccessMixin(object):
     """Namespace for methods that access config storage"""
     CONF_SECTION = None
 
-    def set_option(self, option, value, section=None):
+    def set_option(self, option, value, section=None,
+                   recursive_notification=False):
         section = self.CONF_SECTION if section is None else section
-        CONF.set(section, option, value, recursive_notification=False)
+        CONF.set(section, option, value,
+                 recursive_notification=recursive_notification)
 
     def get_option(self, option, default=NoDefault, section=None):
         section = self.CONF_SECTION if section is None else section


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This change fixes some exceptions caused due to a missing argument to calls to `set_option` in some old API preference pages, such as Appearance.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @andfoy

<!--- Thanks for your help making Spyder better for everyone! --->
