### PR TITLE
PR: Move actions to open preferences and reset to defaults to the Preferences plugin

### DIFF
--- a/spyder/app/tests/test_solver.py
+++ b/spyder/app/tests/test_solver.py
@@ -134,4 +134,6 @@ def test_solve_internal_plugins():
     assert solve_plugin_dependencies(internal, testing=False) == []
 
     # Test that solver doesn't crash and returns all available plugins
-    assert len(solve_plugin_dependencies(internal, testing=True)) == 26
+    solved_dependencies = solve_plugin_dependencies(internal, testing=True)
+    print(solved_dependencies)
+    assert len(solved_dependencies) == 26

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -356,12 +356,10 @@ DEFAULTS = [
               '_/lock unlock panes': "Shift+Ctrl+F5",
               '_/use next layout': "Shift+Alt+PgDown",
               '_/use previous layout': "Shift+Alt+PgUp",
-              '_/preferences': "Ctrl+Alt+Shift+P",
               '_/maximize pane': "Ctrl+Alt+Shift+M",
               '_/fullscreen mode': "F11",
               '_/save current layout': "Shift+Alt+S",
               '_/layout preferences': "Shift+Alt+P",
-              '_/show toolbars': "Alt+Shift+T",
               '_/spyder documentation': "F1",
               '_/restart': "Shift+Alt+R",
               '_/quit': "Ctrl+Q",
@@ -624,4 +622,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '67.0.0'
+CONF_VERSION = '68.0.0'

--- a/spyder/plugins/mainmenu/api.py
+++ b/spyder/plugins/mainmenu/api.py
@@ -83,6 +83,7 @@ class ProjectsMenuSections:
 
 class ToolsMenuSections:
     Tools = 'tools_section'
+    Extras = 'extras_section'
 
 
 class ViewMenuSections:

--- a/spyder/plugins/preferences/widgets/container.py
+++ b/spyder/plugins/preferences/widgets/container.py
@@ -5,15 +5,29 @@
 # (see spyder/__init__.py for details)
 
 # Third party imports
-from qtpy.QtCore import Signal
+from qtpy.QtCore import Qt, Signal
 
 # Local imports
-from spyder.plugins.preferences.widgets.configdialog import ConfigDialog
+from spyder.api.translations import get_translation
 from spyder.api.widgets import PluginMainContainer
+from spyder.plugins.preferences.widgets.configdialog import ConfigDialog
+
+
+# Localization
+_ = get_translation('spyder')
+
+
+class PreferencesActions:
+    Show = 'show_action'
+    Reset = 'reset_action'
 
 
 class PreferencesContainer(PluginMainContainer):
-    sig_reset_spyder = Signal()
+    sig_reset_preferences_requested = Signal()
+    """Request a reset of preferences."""
+
+    sig_show_preferences_requested = Signal()
+    """Request showing preferences."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -71,15 +85,30 @@ class PreferencesContainer(PluginMainContainer):
         """Preference page index has changed."""
         self.dialog_index = index
 
-    def reset_spyder(self):
-        self.sig_reset_spyder.emit()
+    def reset(self):
+        self.sig_reset_preferences_requested.emit()
 
     def is_dialog_open(self):
         return self.dialog is not None and self.dialog.isVisible()
 
+    def show_preferences(self):
+        """Show preferences."""
+        self.sig_show_preferences_requested.emit()
+
     # ---- PluginMainContainer API
     def setup(self):
-        pass
+        self.show_action = self.create_action(
+            PreferencesActions.Show,
+            _("Preferences"),
+            icon=self.create_icon('configure'),
+            triggered=self.show_preferences
+        )
+
+        self.reset_action = self.create_action(
+            PreferencesActions.Reset,
+            _("Reset Spyder to factory defaults"),
+            triggered=self.reset
+        )
 
     def update_actions(self):
         pass

--- a/spyder/plugins/toolbar/container.py
+++ b/spyder/plugins/toolbar/container.py
@@ -94,10 +94,7 @@ class ToolbarContainer(PluginMainContainer):
         self.show_toolbars_action = self.create_action(
             ToolbarActions.ShowToolbars,
             text=_("Show toolbars"),
-            triggered=self._show_toolbars,
-            context=Qt.ApplicationShortcut,
-            shortcut_context="_",
-            register_shortcut=True
+            triggered=self._show_toolbars
         )
 
         self.toolbars_menu = self.create_menu(


### PR DESCRIPTION
## Description of Changes

This also solves the circular dependency between Preferences and Shortcuts reported by @dalthviz. What I did was to remove shortcuts to open Preferences and show toolbars because those plugins need to be loaded before Shortcuts.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
