### PR TITLE
PR: Update hexstate handling to fallback to default layout when moving from Spyder 5 to Spyder 4

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1540,8 +1540,17 @@ class MainWindow(QMainWindow):
 
         # Window layout
         if hexstate:
-            self.restoreState( QByteArray().fromHex(
-                    str(hexstate).encode('utf-8')) )
+            hexstate_valid = self.restoreState(
+                QByteArray().fromHex(str(hexstate).encode('utf-8')))
+
+            # Check layout validity. Spyder 4 uses the default version 0 state
+            # whereas Spyder 5 will use version 1 state. For more info see the
+            # version argument for QMainWindow.restoreState:
+            # https://doc.qt.io/qt-5/qmainwindow.html#restoreState
+            if not hexstate_valid:
+                self.setUpdatesEnabled(True)
+                self.setup_layout(default=True)
+                return
             # Workaround for spyder-ide/spyder#880.
             # QDockWidget objects are not painted if restored as floating
             # windows, so we must dock them before showing the mainwindow.


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->


Use the version argument of `QMainWindow.restoreState` to validate the hexstate that will be loaded

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #13629


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
