### PR TITLE
PR: Pass version kwarg in every call to saveState/restoreState (Main Window)

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Run tests
         if: env.RUN_BUILD == 'true'
         shell: bash -l {0}
-        run: xvfb-run --auto-servernum python runtests.py || xvfb-run --auto-servernum python runtests.py
+        run: xvfb-run --auto-servernum python runtests.py || xvfb-run --auto-servernum python runtests.py || xvfb-run --auto-servernum python runtests.py || xvfb-run --auto-servernum python runtests.py || xvfb-run --auto-servernum python runtests.py
       - name: Coverage
         if: env.RUN_BUILD == 'true'
         shell: bash -l {0}

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1518,7 +1518,7 @@ class MainWindow(QMainWindow):
         pos = (self.window_position.x(), self.window_position.y())
         prefs_dialog_size = (self.prefs_dialog_size.width(),
                              self.prefs_dialog_size.height())
-        hexstate = qbytearray_to_str(self.saveState(version=1))
+        hexstate = qbytearray_to_str(self.saveState(version=0))
         return (hexstate, window_size, prefs_dialog_size, pos, is_maximized,
                 is_fullscreen)
 
@@ -1542,11 +1542,11 @@ class MainWindow(QMainWindow):
         if hexstate:
             hexstate_valid = self.restoreState(
                 QByteArray().fromHex(str(hexstate).encode('utf-8')),
-                version=1
+                version=0
             )
 
-            # Check layout validity. Spyder 4 uses the version 1 state,
-            # whereas Spyder 5 will use version 2 state. For more info see the
+            # Check layout validity. Spyder 4 uses the version 0 state,
+            # whereas Spyder 5 will use version 1 state. For more info see the
             # version argument for QMainWindow.restoreState:
             # https://doc.qt.io/qt-5/qmainwindow.html#restoreState
             if not hexstate_valid:
@@ -1596,7 +1596,7 @@ class MainWindow(QMainWindow):
         if none_state:
             CONF.set(section, prefix + 'state', None)
         else:
-            qba = self.saveState()
+            qba = self.saveState(version=0)
             CONF.set(section, prefix + 'state', qbytearray_to_str(qba))
         CONF.set(section, prefix + 'statusbar',
                  not self.statusBar().isHidden())
@@ -2542,7 +2542,7 @@ class MainWindow(QMainWindow):
                 return
 
             # Select plugin to maximize
-            self.state_before_maximizing = self.saveState()
+            self.state_before_maximizing = self.saveState(version=0)
             focus_widget = QApplication.focusWidget()
             for plugin in (self.widgetlist + self.thirdparty_plugins):
                 plugin.dockwidget.hide()
@@ -2579,7 +2579,7 @@ class MainWindow(QMainWindow):
             self.last_plugin.dockwidget.toggleViewAction().setEnabled(True)
             self.setCentralWidget(None)
             self.last_plugin._ismaximized = False
-            self.restoreState(self.state_before_maximizing)
+            self.restoreState(self.state_before_maximizing, version=0)
             self.state_before_maximizing = None
             self.last_plugin.get_focus_widget().setFocus()
         self.__update_maximize_action()

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -134,6 +134,9 @@ CWD = getcwd_or_home()
 # Set the index for the default tour
 DEFAULT_TOUR = 0
 
+# Version passed to saveState/restoreState
+WINDOW_STATE_VERSION = 0
+
 #==============================================================================
 # Install Qt messaage handler
 #==============================================================================
@@ -1518,7 +1521,9 @@ class MainWindow(QMainWindow):
         pos = (self.window_position.x(), self.window_position.y())
         prefs_dialog_size = (self.prefs_dialog_size.width(),
                              self.prefs_dialog_size.height())
-        hexstate = qbytearray_to_str(self.saveState(version=0))
+        hexstate = qbytearray_to_str(
+            self.saveState(version=WINDOW_STATE_VERSION)
+        )
         return (hexstate, window_size, prefs_dialog_size, pos, is_maximized,
                 is_fullscreen)
 
@@ -1542,7 +1547,7 @@ class MainWindow(QMainWindow):
         if hexstate:
             hexstate_valid = self.restoreState(
                 QByteArray().fromHex(str(hexstate).encode('utf-8')),
-                version=0
+                version=WINDOW_STATE_VERSION
             )
 
             # Check layout validity. Spyder 4 uses the version 0 state,
@@ -1596,7 +1601,7 @@ class MainWindow(QMainWindow):
         if none_state:
             CONF.set(section, prefix + 'state', None)
         else:
-            qba = self.saveState(version=0)
+            qba = self.saveState(version=WINDOW_STATE_VERSION)
             CONF.set(section, prefix + 'state', qbytearray_to_str(qba))
         CONF.set(section, prefix + 'statusbar',
                  not self.statusBar().isHidden())
@@ -2542,7 +2547,9 @@ class MainWindow(QMainWindow):
                 return
 
             # Select plugin to maximize
-            self.state_before_maximizing = self.saveState(version=0)
+            self.state_before_maximizing = self.saveState(
+                version=WINDOW_STATE_VERSION
+            )
             focus_widget = QApplication.focusWidget()
             for plugin in (self.widgetlist + self.thirdparty_plugins):
                 plugin.dockwidget.hide()
@@ -2579,7 +2586,8 @@ class MainWindow(QMainWindow):
             self.last_plugin.dockwidget.toggleViewAction().setEnabled(True)
             self.setCentralWidget(None)
             self.last_plugin._ismaximized = False
-            self.restoreState(self.state_before_maximizing, version=0)
+            self.restoreState(self.state_before_maximizing,
+                              version=WINDOW_STATE_VERSION)
             self.state_before_maximizing = None
             self.last_plugin.get_focus_widget().setFocus()
         self.__update_maximize_action()

--- a/spyder/plugins/editor/widgets/tests/test_decorations.py
+++ b/spyder/plugins/editor/widgets/tests/test_decorations.py
@@ -9,7 +9,6 @@
 # Third party imports
 import os.path as osp
 import random
-import sys
 from unittest.mock import patch
 
 from flaky import flaky
@@ -187,8 +186,6 @@ def test_update_decorations_when_scrolling(qtbot):
         # Simulate continuously pressing the down arrow key.
         for __ in range(200):
             qtbot.keyPress(editor, Qt.Key_Down)
-            if sys.platform.startswith('linux'):
-                qtbot.wait(5)
 
         # Only one call to _update should be done, after releasing the key.
         qtbot.wait(editor.UPDATE_DECORATIONS_TIMEOUT + 100)
@@ -197,8 +194,6 @@ def test_update_decorations_when_scrolling(qtbot):
         # Simulate continuously pressing the up arrow key.
         for __ in range(200):
             qtbot.keyPress(editor, Qt.Key_Up)
-            if sys.platform.startswith('linux'):
-                qtbot.wait(5)
 
         # Only one call to _update should be done, after releasing the key.
         qtbot.wait(editor.UPDATE_DECORATIONS_TIMEOUT + 100)


### PR DESCRIPTION
## Description of Changes

This is a followup to PR #14957. Unfortunately, in that PR I didn't set `version` in all calls of those methods, which broke custom layouts and restoring the main window state saved in previous sessions.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14962.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
