### PR TITLE
PR: Fix for search/find close button error (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -490,11 +490,10 @@ class VariableExplorerWidget(PluginMainWidget):
             self.layout().addWidget(self.finder)
         else:
             # Just update references to the same text_finder (Custom QLineEdit)
-            # widget to the new current NamespaceBrowser
+            # widget to the new current NamespaceBrowser and save current
+            # finder state in the previous NamespaceBrowser
             if old_nsb is not None:
-                last_find = self.text_finder.text()
-                finder_visibility = self.finder.isVisible()
-                old_nsb.save_finder_state(last_find, finder_visibility)
+                self.save_finder_state(old_nsb)
             self.text_finder.update_parent(
                 nsb.editor,
                 callback=nsb.editor.set_regex,
@@ -578,6 +577,7 @@ class VariableExplorerWidget(PluginMainWidget):
             if checked:
                 self.finder.text_finder.setText(nsb.last_find)
             else:
+                self.save_finder_state(nsb)
                 self.finder.text_finder.setText('')
             self.finder.setVisible(checked)
             if self.finder.isVisible():
@@ -589,7 +589,19 @@ class VariableExplorerWidget(PluginMainWidget):
     def hide_finder(self):
         action = self.get_action(VariableExplorerWidgetActions.Search)
         action.setChecked(False)
+        nsb = self.current_widget()
+        self.save_finder_state(nsb)
         self.finder.text_finder.setText('')
+
+    def save_finder_state(self, nsb):
+        """
+        Save finder state (last input text and visibility).
+
+        The values are saved in the given NamespaceBrowser.
+        """
+        last_find = self.text_finder.text()
+        finder_visibility = self.finder.isVisible()
+        nsb.save_finder_state(last_find, finder_visibility)
 
     def refresh_table(self):
         if self.count():

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -59,7 +59,6 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
         super().__init__(parent=parent, class_parent=parent)
 
         # Attributes
-        self.is_visible = True
         self.filename = None
         self.text_finder = None
         self.last_find = ''
@@ -131,13 +130,12 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
         self.finder_is_visible = finder_visibility
 
     def refresh_table(self):
-        """Refresh variable table"""
-        if self.is_visible and self.isVisible():
-            self.shellwidget.refresh_namespacebrowser()
-            try:
-                self.editor.resizeRowToContents()
-            except TypeError:
-                pass
+        """Refresh variable table."""
+        self.shellwidget.refresh_namespacebrowser()
+        try:
+            self.editor.resizeRowToContents()
+        except TypeError:
+            pass
 
     def process_remote_view(self, remote_view):
         """Process remote view"""

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -126,7 +126,7 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
 
     def save_finder_state(self, last_find, finder_visibility):
         """Save last finder/search text input and finder visibility."""
-        if last_find:
+        if last_find and finder_visibility:
             self.last_find = last_find
         self.finder_is_visible = finder_visibility
 

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -63,6 +63,7 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
         self.filename = None
         self.text_finder = None
         self.last_find = ''
+        self.finder_is_visible = False
 
         # Widgets
         self.editor = None
@@ -115,11 +116,19 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
         shellwidget.set_namespacebrowser(self)
 
     def set_text_finder(self, text_finder):
-        """Binder NamespaceBrowsersFinder to namespace browser."""
+        """Bind NamespaceBrowsersFinder to namespace browser."""
         self.text_finder = text_finder
-        self.text_finder.setText(self.last_find)
-
+        if self.finder_is_visible:
+            self.text_finder.setText(self.last_find)
         self.editor.finder = text_finder
+
+        return self.finder_is_visible
+
+    def save_finder_state(self, last_find, finder_visibility):
+        """Save last finder/search text input and finder visibility."""
+        if last_find:
+            self.last_find = last_find
+        self.finder_is_visible = finder_visibility
 
     def refresh_table(self):
         """Refresh variable table"""

--- a/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
@@ -24,7 +24,7 @@ from qtpy.QtCore import Qt, QPoint, QModelIndex
 
 # Local imports
 from spyder.plugins.variableexplorer.widgets.namespacebrowser import (
-    NamespaceBrowser)
+    NamespaceBrowser, NamespacesBrowserFinder, VALID_VARIABLE_CHARS)
 from spyder.py3compat import PY2
 from spyder.widgets.collectionseditor import ROWS_TO_LOAD
 from spyder.widgets.tests.test_collectioneditor import data, data_table
@@ -153,6 +153,12 @@ def test_filtering_with_large_rows(qtbot):
     qtbot.addWidget(browser)
     browser.set_shellwidget(Mock())
     browser.setup()
+    text_finder = NamespacesBrowserFinder(
+        browser.editor,
+        callback=browser .editor.set_regex,
+        main=browser,
+        regex_base=VALID_VARIABLE_CHARS)
+    browser.set_text_finder(text_finder)
 
     # Create data
     variables = {}
@@ -174,15 +180,15 @@ def test_filtering_with_large_rows(qtbot):
     assert data(model, 49, 0) == 'e49'
 
     # Assert we can filter variables not loaded yet.
-    qtbot.keyClicks(browser.finder.text_finder, "t19")
+    qtbot.keyClicks(text_finder, "t19")
     assert model.rowCount() == 10
 
     # Assert all variables effectively start with 't19'.
     for i in range(10):
         assert data(model, i, 0) == 't19{}'.format(i)
 
-    # Hide finder widget in order to reset it.
-    browser.show_finder(set_visible=False)
+    # Reset text_finder widget.
+    text_finder.setText('')
 
     # Create a new variable that starts with a different letter than
     # the rest.
@@ -196,7 +202,7 @@ def test_filtering_with_large_rows(qtbot):
     browser.process_remote_view(new_variables)
 
     # Assert that can find 'z' among the declared variables.
-    qtbot.keyClicks(browser.finder.text_finder, "z")
+    qtbot.keyClicks(text_finder, "z")
     assert model.rowCount() == 1
 
 

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -1408,6 +1408,7 @@ class RemoteCollectionsEditorTableView(BaseTableView):
         self.dictfilter = None
         self.delegate = None
         self.readonly = False
+        self.finder = None
 
         self.source_model = CollectionsModel(
             self, data, names=True,
@@ -1528,7 +1529,7 @@ class RemoteCollectionsEditorTableView(BaseTableView):
 
     def set_regex(self, regex=None, reset=False):
         """Update the regex text for the variable finder."""
-        if reset or not self.finder.text():
+        if reset or self.finder is None or not self.finder.text():
             text = ''
         else:
             text = self.finder.text().replace(' ', '').lower()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Multiple instances of the finder (close button + line edit) were being created. The main problem was not related to creating the whole finder element multiple times but the close button (which was like declaring the same action multiple times).

Now only one instance of the finder is created.

#### TODO:

- [x] How to keep text input and the visibility of the search bar for the different Name Space Browser (i.e one could have the search visible while another one could have it invisible, also one could have some text in it while the other is blank)

#### Preview

![vefinder](https://user-images.githubusercontent.com/16781833/112721455-1fbc3000-8f04-11eb-9368-d2e394e54e72.gif)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15010


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
