### PR TITLE
PR: Fix a segfault with the intro tour

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -3700,8 +3700,6 @@ def test_ordering_lsp_requests_at_startup(main_window, qtbot):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
-@pytest.mark.skipif(sys.platform == 'darwin',
-                    reason="Fails sometimes on macOS")
 @pytest.mark.parametrize(
     'main_window',
     [{'spy_config': ('main', 'show_tour_message', 2)}],

--- a/spyder/app/tour.py
+++ b/spyder/app/tour.py
@@ -459,9 +459,12 @@ class FadingCanvas(FadingDialog):
         self.parent = parent
         self.tour = tour
 
-        self.color = color              # Canvas color
-        self.color_decoration = SpyderPalette.COLOR_ERROR_2 # Decoration color
-        self.stroke_decoration = 2      # width in pixels for decoration
+        # Canvas color
+        self.color = color
+        # Decoration color
+        self.color_decoration = QColor(SpyderPalette.COLOR_ERROR_2)
+        # Width in pixels for decoration
+        self.stroke_decoration = 2
 
         self.region_mask = None
         self.region_subtract = None


### PR DESCRIPTION
## Description of Changes

Not passing a `QColor` to `QPen` was causing a segfault when trying to display the tour. 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
