### PR TITLE
PR: Set right roles for some actions on macOS menu bar

### DIFF
--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -12,10 +12,11 @@ Holds references for base actions in the Application of Spyder.
 
 # Standard library imports
 import os
+import sys
 
 # Third party imports
 from qtpy.QtCore import Qt, QThread, Slot
-from qtpy.QtWidgets import QMessageBox
+from qtpy.QtWidgets import QMessageBox, QAction
 
 # Local imports
 from spyder import (
@@ -114,6 +115,8 @@ class ApplicationContainer(PluginMainContainer):
             _("About %s...") % "Spyder",
             icon=self.create_icon('MessageBoxInformation'),
             triggered=self.show_about)
+        if sys.platform == 'darwin':
+            self.about_action.setMenuRole(QAction.AboutRole)
 
         # Tools actions
         if WinUserEnvDialog is not None:

--- a/spyder/plugins/preferences/widgets/container.py
+++ b/spyder/plugins/preferences/widgets/container.py
@@ -4,8 +4,12 @@
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
 
+# Standard library imports
+import sys
+
 # Third party imports
 from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QAction
 
 # Local imports
 from spyder.api.translations import get_translation
@@ -103,6 +107,9 @@ class PreferencesContainer(PluginMainContainer):
             icon=self.create_icon('configure'),
             triggered=self.show_preferences
         )
+
+        if sys.platform == 'darwin':
+            self.show_action.setMenuRole(QAction.PreferencesRole)
 
         self.reset_action = self.create_action(
             PreferencesActions.Reset,


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Add Qt Roles for About and Preferences main menu actions for adding the actions in the applications menu

![image](https://user-images.githubusercontent.com/20992645/112904067-05be5100-90ae-11eb-868d-bf83deb56720.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14917 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
