### PR TITLE
PR: Prevent setting negative sizes in the Plots pane

### DIFF
--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -212,7 +212,8 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
             The available splitter width.
         """
         min_sb_width = self.thumbnails_sb._min_scrollbar_width
-        self.splitter.setSizes([base_width - min_sb_width, min_sb_width])
+        if base_width - min_sb_width > 0:
+            self.splitter.setSizes([base_width - min_sb_width, min_sb_width])
 
     def show_fig_outline_in_viewer(self, state):
         """Draw a frame around the figure viewer if state is True."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
This fixes the error of the thumbnail section in the plots pane to occupy all the space afer restarting Spyder,

![image](https://user-images.githubusercontent.com/20992645/112909182-897c3b80-90b6-11eb-85df-d7c1af1d25fb.png)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Steff456

<!--- Thanks for your help making Spyder better for everyone! --->
