### PR TITLE
PR: Send snippets provider completion results to last

### DIFF
--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -648,8 +648,7 @@ class CompletionPlugin(SpyderPluginV2):
 
         for request in COMPLETION_REQUESTS:
             request_priorities = source_priorities.get(request, {})
-            if provider_name not in request_priorities:
-                request_priorities[provider_name] = provider_priority - 1
+            request_priorities[provider_name] = provider_priority - 1
             source_priorities[request] = request_priorities
 
         self.source_priority = source_priorities

--- a/spyder/plugins/completion/providers/fallback/provider.py
+++ b/spyder/plugins/completion/providers/fallback/provider.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 class FallbackProvider(SpyderCompletionProvider):
     COMPLETION_PROVIDER_NAME = 'fallback'
-    DEFAULT_ORDER = 3
+    DEFAULT_ORDER = 2
 
     def __init__(self, parent, config):
         SpyderCompletionProvider.__init__(self, parent, config)

--- a/spyder/plugins/completion/providers/snippets/actor.py
+++ b/spyder/plugins/completion/providers/snippets/actor.py
@@ -104,7 +104,7 @@ class SnippetsActor(QObject):
                                 'kind': CompletionItemKind.SNIPPET,
                                 'insertText': text,
                                 'label': f'{trigger} ({description})',
-                                'sortText': trigger,
+                                'sortText': f'zzz{trigger}',
                                 'filterText': trigger,
                                 'documentation': '',
                                 'provider': SNIPPETS_COMPLETION,

--- a/spyder/plugins/completion/providers/snippets/provider.py
+++ b/spyder/plugins/completion/providers/snippets/provider.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 class SnippetsProvider(SpyderCompletionProvider):
     COMPLETION_PROVIDER_NAME = 'snippets'
-    DEFAULT_ORDER = 2
+    DEFAULT_ORDER = 3
     CONF_DEFAULTS = [(lang, SNIPPETS[lang]) for lang in SNIPPETS]
     CONF_VERSION = "0.1.0"
     CONF_TABS = [SnippetsConfigTab]

--- a/spyder/plugins/completion/providers/snippets/tests/test_snippets.py
+++ b/spyder/plugins/completion/providers/snippets/tests/test_snippets.py
@@ -35,7 +35,7 @@ def test_snippet_completions(qtbot_module, snippets_completions, trigger):
             'kind': CompletionItemKind.SNIPPET,
             'insertText': text,
             'label': f'{trigger} ({description})',
-            'sortText': trigger,
+            'sortText': f'zzz{trigger}',
             'filterText': trigger,
             'documentation': '',
             'provider': 'Snippets',


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR prevents snippet completion results to appear before fallback ones.

![Peek 30-03-2021 11-31](https://user-images.githubusercontent.com/1878982/113023750-95660d00-914b-11eb-92de-eee9b4fc5ef9.gif)


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @andfoy

<!--- Thanks for your help making Spyder better for everyone! --->
