### PR TITLE
PR: Prevent completion timeouts when a single slow provider is up

### DIFF
--- a/spyder/plugins/completion/api.py
+++ b/spyder/plugins/completion/api.py
@@ -858,6 +858,10 @@ class SpyderCompletionProvider(QObject, CompletionConfigurationObserver):
     # Status: Required
     DEFAULT_ORDER = -1
 
+    # Define if the provider response time is not constant and may take
+    # a long time for some requests.
+    SLOW = False
+
     # Define configuration options for the provider.
     # List of tuples with the first item being the option name and the second
     # one its default value.

--- a/spyder/plugins/completion/api.py
+++ b/spyder/plugins/completion/api.py
@@ -966,6 +966,11 @@ class SpyderCompletionProvider(QObject, CompletionConfigurationObserver):
             }
         req_id: int
             Request identifier for response
+
+        Notes
+        -----
+        A completion client should always reply to the
+        `textDocument/completion` request, even if the answer is empty.
         """
         pass
 

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -217,6 +217,9 @@ class CompletionPlugin(SpyderPluginV2):
         # Completion request priority
         self.source_priority = {}
 
+        # Completion provider speed: slow or fast
+        self.provider_speed = {}
+
         # Timeout limit for a response to be received
         self.wait_for_ms = self.get_conf('completions_wait_for_ms')
 
@@ -650,6 +653,7 @@ class CompletionPlugin(SpyderPluginV2):
             request_priorities = source_priorities.get(request, {})
             if provider_name not in request_priorities:
                 request_priorities[provider_name] = provider_priority - 1
+            self.provider_speed[provider_name] = Provider.SLOW
             source_priorities[request] = request_priorities
 
         self.source_priority = source_priorities
@@ -863,8 +867,14 @@ class CompletionPlugin(SpyderPluginV2):
             'timed_out': False,
         }
 
+        # Check if there are two or more slow completion providers
+        # in order to start the timeout counter.
+        providers = self.available_providers_for_language(language.lower())
+        slow_provider_count = sum([self.provider_speed[p] for p in providers])
+
+
         # Start the timer on this request
-        if req_type in self.AGGREGATE_RESPONSES:
+        if req_type in self.AGGREGATE_RESPONSES and slow_provider_count > 2:
             if self.wait_for_ms > 0:
                 QTimer.singleShot(self.wait_for_ms,
                                   lambda: self.receive_timeout(req_id))
@@ -872,7 +882,6 @@ class CompletionPlugin(SpyderPluginV2):
                 self.requests[req_id]['timed_out'] = True
 
         # Send request to all running completion providers
-        providers = self.available_providers_for_language(language.lower())
         for provider_name in providers:
             provider_info = self.providers[provider_name]
             provider_info['instance'].send_request(

--- a/spyder/plugins/completion/providers/kite/provider.py
+++ b/spyder/plugins/completion/providers/kite/provider.py
@@ -41,6 +41,7 @@ class KiteProviderActions:
 class KiteProvider(SpyderCompletionProvider):
     COMPLETION_PROVIDER_NAME = 'kite'
     DEFAULT_ORDER = 1
+    SLOW = True
     CONF_DEFAULTS = [
         ('spyder_runs', 1),
         ('show_installation_dialog', True),

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -46,6 +46,7 @@ class LanguageServerProvider(SpyderCompletionProvider):
     """Language Server Protocol manager."""
     COMPLETION_PROVIDER_NAME = 'lsp'
     DEFAULT_ORDER = 1
+    SLOW = True
     CONF_DEFAULTS = [
         ('enable_hover_hints', True),
         ('show_lsp_down_warning', True),

--- a/spyder/plugins/completion/providers/snippets/actor.py
+++ b/spyder/plugins/completion/providers/snippets/actor.py
@@ -88,6 +88,8 @@ class SnippetsActor(QObject):
             snippets = []
 
             if current_word is None:
+                snippets = {'params': snippets}
+                self.sig_snippets_response.emit(_id, snippets)
                 return
 
             if language in self.language_snippets:

--- a/spyder/plugins/editor/widgets/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/tests/conftest.py
@@ -158,6 +158,7 @@ def completions_codeeditor(completion_plugin_all_started, qtbot_module,
 
     CONF.set('completions', 'enable_code_snippets', False)
     completion_plugin.after_configuration_update([])
+    CONF.notify_section_all_observers('completions')
 
     # Redirect editor LSP requests to lsp_manager
     editor.sig_perform_completion_request.connect(


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR prevents starting the completion timeout timer when only a single slow completion provider (e.g., lsp and kite) is running. 

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

![Peek 30-03-2021 11-54](https://user-images.githubusercontent.com/1878982/113026815-12df4c80-914f-11eb-8ee6-f14cedd7635a.gif)


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
