### PR TITLE
PR: Fix issue with the report dialog that prevented to click on the traceback error

### DIFF
--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -412,7 +412,8 @@ class ConsoleWidget(PluginMainWidget):
                     self.get_conf('selected', section='appearance'))
                 self.error_dlg.close_btn.clicked.connect(self.close_error_dlg)
                 self.error_dlg.rejected.connect(self.remove_error_dlg)
-                self.error_dlg.details.go_to_error.connect(self.go_to_error)
+                self.error_dlg.details.sig_go_to_error_requested.connect(
+                    self.go_to_error)
 
             # Set the report repository
             self.error_dlg.set_github_repo_org(repo)

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -111,7 +111,7 @@ class DescriptionWidget(SimpleCodeEditor):
 class ShowErrorWidget(TracebackLinksMixin, ConsoleBaseWidget, BaseEditMixin):
     """Widget to show errors as they appear in the Internal console."""
     QT_CLASS = QPlainTextEdit
-    go_to_error = Signal(str)
+    sig_go_to_error_requested = Signal(str)
 
     def __init__(self, parent=None):
         ConsoleBaseWidget.__init__(self, parent)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR fixed the regression where the report error dialog did not react to clicks to go to the position where a traceback had occurred.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

![Peek 30-03-2021 12-35](https://user-images.githubusercontent.com/1878982/113031778-ba12b280-9154-11eb-9206-0f02b456b85f.gif)
<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
