### PR TITLE
PR: Use group colors for objects in the Variable Explorer

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = master
-	commit = b4d07e00dd2da5a0bb23f444e2919d2b6e9642d5
-	parent = ecca3fa403fd634ea634e1b4b9f2953f1b025021
+	branch = add-numpy-types-to-nsview
+	commit = ce1acbdc77629024ae6a43fc54a3099c3a10c760
+	parent = 0af96f64e6f0ac8a6c3f8dfb4648eda1ff1078a7
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = add-numpy-types-to-nsview
-	commit = ce1acbdc77629024ae6a43fc54a3099c3a10c760
-	parent = 0af96f64e6f0ac8a6c3f8dfb4648eda1ff1078a7
+	branch = master
+	commit = 4c647fe543e3c641e6be228cc220b949a2386ef0
+	parent = 6efe1f0302712a5e72eb321e2156699b71898eb9
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -135,13 +135,25 @@ class SpyderKernel(IPythonKernel):
 
         This is a dictionary with the following structure
 
-        {'a': {'color': '#800000', 'size': 1, 'type': 'str', 'view': '1'}}
+        {'a':
+            {
+                'type': 'str',
+                'size': 1,
+                'view': '1',
+                'python_type': 'int',
+                'numpy_type': 'Unknown'
+            }
+        }
 
         Here:
-        * 'a' is the variable name
-        * 'color' is the color used to show it
-        * 'size' and 'type' are self-evident
-        * and'view' is its value or the text shown in the last column
+        * 'a' is the variable name.
+        * 'type' and 'size' are self-evident.
+        * 'view' is its value or its repr computed with
+          `value_to_display`.
+        * 'python_type' is its Python type computed with
+          `get_type_string`.
+        * 'numpy_type' is its Numpy type (if any) computed with
+          `get_numpy_type_string`.
         """
         from spyder_kernels.utils.nsview import make_remote_view
 

--- a/external-deps/spyder-kernels/spyder_kernels/console/tests/test_console_kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/tests/test_console_kernel.py
@@ -182,8 +182,13 @@ def test_get_namespace_view(kernel):
     assert "'a':" in nsview
     assert "'type': 'int'" in nsview or "'type': u'int'" in nsview
     assert "'size': 1" in nsview
-    assert "'color': '#0000ff'" in nsview
     assert "'view': '1'" in nsview
+    assert "'numpy_type': 'Unknown'" in nsview
+
+    if PY3:
+        assert "'python_type': 'int'" in nsview
+    else:
+        assert "'python_type': u'int'" in nsview
 
 
 def test_get_var_properties(kernel):

--- a/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
@@ -73,6 +73,17 @@ def get_numpy_dtype(obj):
                 return
 
 
+def get_numpy_type_string(value):
+    """Get the type of a Numpy object as a string."""
+    np_dtype = get_numpy_dtype(value)
+    if np_dtype is None or not hasattr(value, 'size'):
+        return 'Unknown'
+    elif value.size == 1:
+        return 'Scalar'
+    else:
+        return 'Array'
+
+
 #==============================================================================
 # Pandas support
 #==============================================================================
@@ -210,48 +221,8 @@ def str_to_timedelta(value):
 
 
 #==============================================================================
-# Background colors for supported types
+# Supported types
 #==============================================================================
-ARRAY_COLOR = "#00ff00"
-SCALAR_COLOR = "#0000ff"
-COLORS = {
-          bool:               "#ff00ff",
-          NUMERIC_TYPES:      SCALAR_COLOR,
-          list:               "#ffff00",
-          set:                "#008000",
-          dict:               "#00ffff",
-          tuple:              "#c0c0c0",
-          TEXT_TYPES:         "#800000",
-          (ndarray,
-           MaskedArray,
-           matrix,
-           DataFrame,
-           Series,
-           Index):            ARRAY_COLOR,
-          Image:              "#008000",
-          datetime.date:      "#808000",
-          datetime.timedelta: "#808000",
-          }
-CUSTOM_TYPE_COLOR = "#7755aa"
-UNSUPPORTED_COLOR = "#ffffff"
-
-def get_color_name(value):
-    """Return color name depending on value type"""
-    if not is_known_type(value):
-        return CUSTOM_TYPE_COLOR
-    for typ, name in list(COLORS.items()):
-        if isinstance(value, typ):
-            return name
-    else:
-        np_dtype = get_numpy_dtype(value)
-        if np_dtype is None or not hasattr(value, 'size'):
-            return UNSUPPORTED_COLOR
-        elif value.size == 1:
-            return SCALAR_COLOR
-        else:
-            return ARRAY_COLOR
-
-
 def is_editable_type(value):
     """
     Return True if data type is editable with a standard GUI-based editor,
@@ -745,9 +716,9 @@ def make_remote_view(data, settings, more_excluded_names=None):
         remote[key] = {
             'type':  get_human_readable_type(value),
             'size':  get_size(value),
-            'color': get_color_name(value),
             'view':  view,
-            'python_type': get_type_string(value)
+            'python_type': get_type_string(value),
+            'numpy_type': get_numpy_type_string(value)
         }
 
     return remote

--- a/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_nsview.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_nsview.py
@@ -22,10 +22,11 @@ import PIL.Image
 
 # Local imports
 from spyder_kernels.py3compat import PY2
-from spyder_kernels.utils.nsview import (sort_against, is_supported,
-                                         value_to_display, get_size,
-                                         get_supported_types, get_type_string,
-                                         is_editable_type)
+from spyder_kernels.utils.nsview import (
+    sort_against, is_supported, value_to_display, get_size,
+    get_supported_types, get_type_string, get_numpy_type_string,
+    is_editable_type)
+
 
 def generate_complex_object():
     """Taken from issue #4221."""
@@ -419,6 +420,30 @@ def test_is_editable_type():
 
     my_instance = MyClass()
     assert not is_editable_type(my_instance)
+
+
+def test_get_numpy_type():
+    """Test for get_numpy_type_string."""
+    # Numpy objects
+    assert get_numpy_type_string(np.array([1, 2, 3])) == 'Array'
+
+    matrix = np.matrix([[1, 2], [3, 4]])
+    assert get_numpy_type_string(matrix) == 'Array'
+
+    assert get_numpy_type_string(np.int32(1)) == 'Scalar'
+
+    # Regular Python objects
+    assert get_numpy_type_string(1.5) == 'Unknown'
+    assert get_numpy_type_string([1, 2, 3]) == 'Unknown'
+    assert get_numpy_type_string({1: 2}) == 'Unknown'
+
+    # PIL images
+    img = PIL.Image.new('RGB', (256,256))
+    assert get_numpy_type_string(img) == 'Unknown'
+
+    # Pandas objects
+    df = pd.DataFrame([1, 2, 3])
+    assert get_numpy_type_string(df) == 'Unknown'
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/variableexplorer/widgets/importwizard.py
+++ b/spyder/plugins/variableexplorer/widgets/importwizard.py
@@ -37,6 +37,7 @@ from spyder.utils import programs
 from spyder.utils.icon_manager import ima
 from spyder.utils.qthelpers import add_actions, create_action
 from spyder.plugins.variableexplorer.widgets.basedialog import BaseDialog
+from spyder.utils.palette import SpyderPalette
 
 
 def try_to_parse(value):
@@ -86,16 +87,16 @@ def datestr_to_datetime(value, dayfirst=True):
 
 #----Background colors for supported types
 COLORS = {
-          bool: Qt.magenta,
-          tuple([float] + list(INT_TYPES)): Qt.blue,
-          list: Qt.yellow,
-          set: Qt.darkGreen,
-          dict: Qt.cyan,
-          tuple: Qt.lightGray,
-          TEXT_TYPES: Qt.darkRed,
-          ndarray: Qt.green,
-          datetime.date: Qt.darkYellow,
-          }
+    bool: SpyderPalette.GROUP_1,
+    tuple([float] + list(INT_TYPES)): SpyderPalette.GROUP_2,
+    TEXT_TYPES: SpyderPalette.GROUP_3,
+    datetime.date: SpyderPalette.GROUP_4,
+    list: SpyderPalette.GROUP_5,
+    set: SpyderPalette.GROUP_6,
+    tuple: SpyderPalette.GROUP_7,
+    dict: SpyderPalette.GROUP_8,
+    ndarray: SpyderPalette.GROUP_9,
+}
 
 def get_color(value, alpha):
     """Return color depending on value type"""
@@ -296,7 +297,8 @@ class PreviewTableModel(QAbstractTableModel):
         if role == Qt.DisplayRole:
             return self._display_data(index)
         elif role == Qt.BackgroundColorRole:
-            return to_qvariant(get_color(self._data[index.row()][index.column()], .2))
+            return to_qvariant(get_color(
+                self._data[index.row()][index.column()], 0.5))
         elif role == Qt.TextAlignmentRole:
             return to_qvariant(int(Qt.AlignRight|Qt.AlignVCenter))
         return to_qvariant()

--- a/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
@@ -39,7 +39,8 @@ def test_automatic_column_width(qtbot):
 
     col_width = [browser.editor.columnWidth(i) for i in range(4)]
     browser.set_data({'a_variable':
-            {'type': 'int', 'size': 1, 'color': '#0000ff', 'view': '1'}})
+        {'type': 'int', 'size': 1, 'view': '1', 'python_type': 'int',
+         'numpy_type': 'Unknown'}})
     new_col_width = [browser.editor.columnWidth(i) for i in range(4)]
     assert browser.editor.automatic_column_width
     assert col_width != new_col_width  # Automatic col width is on
@@ -47,7 +48,8 @@ def test_automatic_column_width(qtbot):
     browser.editor.setColumnWidth(0, 100)  # Simulate user changing col width
     assert browser.editor.automatic_column_width == False
     browser.set_data({'a_lengthy_variable_name_which_should_change_width':
-            {'type': 'int', 'size': 1, 'color': '#0000ff', 'view': '1'}})
+        {'type': 'int', 'size': 1, 'view': '1', 'python_type': 'int',
+         'numpy_type': 'Unknown'}})
     assert browser.editor.columnWidth(0) == 100  # Automatic col width is off
 
 
@@ -63,9 +65,11 @@ def test_sort_by_column(qtbot):
 
     browser.set_data(
         {'a_variable':
-            {'type': 'int', 'size': 1, 'color': '#0000ff', 'view': '1'},
+            {'type': 'int', 'size': 1, 'view': '1', 'python_type': 'int',
+             'numpy_type': 'Unknown'},
          'b_variable':
-            {'type': 'int', 'size': 1, 'color': '#0000ff', 'view': '2'}}
+            {'type': 'int', 'size': 1, 'view': '2', 'python_type': 'int',
+             'numpy_type': 'Unknown'}}
     )
 
     header = browser.editor.horizontalHeader()
@@ -109,7 +113,8 @@ def test_keys_sorted_and_sort_with_large_rows(qtbot):
     # Create variables.
     variables = {}
     variables['i'] = (
-        {'type': 'int', 'size': 1, 'color': '#0000ff', 'view': '1'}
+        {'type': 'int', 'size': 1, 'view': '1', 'python_type': 'int',
+         'numpy_type': 'Unknown'}
     )
 
     for i in range(100):
@@ -118,7 +123,8 @@ def test_keys_sorted_and_sort_with_large_rows(qtbot):
         else:
             var = 'd_' + str(i)
         variables[var] = (
-            {'type': 'int', 'size': 1, 'color': '#0000ff', 'view': '1'}
+            {'type': 'int', 'size': 1, 'view': '1', 'python_type': 'int',
+             'numpy_type': 'Unknown'}
         )
 
     # Set data
@@ -163,7 +169,8 @@ def test_filtering_with_large_rows(qtbot):
         letter = string.ascii_lowercase[i // 10]
         var = letter + str(i)
         variables[var] = (
-            {'type': 'int', 'size': 1, 'color': '#0000ff', 'view': '1'}
+            {'type': 'int', 'size': 1, 'view': '1', 'python_type': 'int',
+             'numpy_type': 'Unknown'}
         )
 
     # Set data
@@ -191,7 +198,8 @@ def test_filtering_with_large_rows(qtbot):
     # the rest.
     new_variables = variables.copy()
     new_variables['z'] = (
-        {'type': 'int', 'size': 1, 'color': '#0000ff', 'view': '1'}
+        {'type': 'int', 'size': 1, 'view': '1', 'python_type': 'int',
+         'numpy_type': 'Unknown'}
     )
 
     # Emulate the process of loading those variables after the

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -37,8 +37,8 @@ from qtpy.QtWidgets import (QAbstractItemView, QApplication, QDialog,
                             QWidget)
 from spyder_kernels.utils.misc import fix_reference_name
 from spyder_kernels.utils.nsview import (
-    DataFrame, display_to_value, FakeObject,
-    get_color_name, get_human_readable_type, get_size, Image,
+    DataFrame, display_to_value, FakeObject, get_human_readable_type,
+    get_numpy_type_string, get_size, get_type_string, Image,
     MaskedArray, ndarray, np_savetxt, Series, sort_against,
     try_to_eval, unsorted_unique, value_to_display, get_object_attrs,
     get_type_string, NUMERIC_NUMPY_TYPES)
@@ -59,6 +59,8 @@ from spyder.plugins.variableexplorer.widgets.collectionsdelegate import (
 from spyder.plugins.variableexplorer.widgets.importwizard import ImportWizard
 from spyder.widgets.helperwidgets import CustomSortFilterProxy
 from spyder.plugins.variableexplorer.widgets.basedialog import BaseDialog
+from spyder.utils.palette import SpyderPalette
+
 
 # Maximum length of a serialized variable to be set in the kernel
 MAX_SERIALIZED_LENGHT = 1e6
@@ -468,18 +470,59 @@ class CollectionsModel(ReadOnlyCollectionsModel):
         self.types[index.row()] = get_human_readable_type(value)
         self.sig_setting_data.emit()
 
+    def type_to_color(self, python_type, numpy_type):
+        """Get the color that corresponds to a Python type."""
+        # Color for unknown types
+        color = SpyderPalette.GROUP_12
+
+        if numpy_type != 'Unknown':
+            if numpy_type == 'Array':
+                color = SpyderPalette.GROUP_9
+            elif numpy_type == 'Scalar':
+                color = SpyderPalette.GROUP_2
+        elif python_type == 'bool':
+            color = SpyderPalette.GROUP_1
+        elif python_type in ['int', 'float', 'complex']:
+            color = SpyderPalette.GROUP_2
+        elif python_type in ['str', 'unicode']:
+            color = SpyderPalette.GROUP_3
+        elif 'datetime' in python_type:
+            color = SpyderPalette.GROUP_4
+        elif python_type == 'list':
+            color = SpyderPalette.GROUP_5
+        elif python_type == 'set':
+            color = SpyderPalette.GROUP_6
+        elif python_type == 'tuple':
+            color = SpyderPalette.GROUP_7
+        elif python_type == 'dict':
+            color = SpyderPalette.GROUP_8
+        elif python_type in ['MaskedArray', 'Matrix', 'NDArray']:
+            color = SpyderPalette.GROUP_9
+        elif (python_type in ['DataFrame', 'Series'] or
+                'Index' in python_type):
+            color = SpyderPalette.GROUP_10
+        elif python_type == 'PIL.Image.Image':
+            color = SpyderPalette.GROUP_11
+        else:
+            color = SpyderPalette.GROUP_12
+
+        return color
+
     def get_bgcolor(self, index):
-        """Background color depending on value"""
+        """Background color depending on value."""
         value = self.get_value(index)
         if index.column() < 3:
             color = ReadOnlyCollectionsModel.get_bgcolor(self, index)
         else:
             if self.remote:
-                color_name = value['color']
+                python_type = value['python_type']
+                numpy_type = value['numpy_type']
             else:
-                color_name = get_color_name(value)
+                python_type = get_type_string(value)
+                numpy_type = get_numpy_type_string(value)
+            color_name = self.type_to_color(python_type, numpy_type)
             color = QColor(color_name)
-            color.setAlphaF(.2)
+            color.setAlphaF(0.5)
         return color
 
     def setData(self, index, value, role=Qt.EditRole):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

This uses the group colors defined in the new Spyder palette to represent different kinds of objects in the Variable Explorer.

![imagen](https://user-images.githubusercontent.com/365293/113258303-68237700-9291-11eb-9d7d-b0eb640421fc.png)

![imagen](https://user-images.githubusercontent.com/365293/113257535-5d1c1700-9290-11eb-880f-495a63bbc3c7.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes spyder-ide/ux-improvements#7

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
