### PR TITLE
PR: Fix OutlineExplorerWidget creation on separate editor window

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1644,10 +1644,8 @@ class Editor(SpyderPluginWidget):
             super(Editor, self).switch_to_plugin()
 
     def create_new_window(self):
-        oe_options = self.outlineexplorer.get_widget().get_options()
         window = EditorMainWindow(
-            self, self.stack_menu_actions, self.toolbar_list, self.menu_list,
-            outline_explorer_options=oe_options)
+            self, self.stack_menu_actions, self.toolbar_list, self.menu_list)
         window.add_toolbars_to_menu("&View", window.get_toolbars())
         window.load_toolbars()
         window.resize(self.size())

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -3102,7 +3102,8 @@ class EditorWidget(QSplitter):
         self.outlineexplorer = OutlineExplorerWidget(
             'outline_explorer',
             plugin,
-            self
+            self,
+            context=f'editor_window_{str(id(self))}'
         )
         self.outlineexplorer.edit_goto.connect(
                      lambda filenames, goto, word:

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -3069,7 +3069,7 @@ class EditorSplitter(QSplitter):
 
 
 class EditorWidget(QSplitter):
-    def __init__(self, parent, plugin, menu_actions, outline_explorer_options):
+    def __init__(self, parent, plugin, menu_actions):
         QSplitter.__init__(self, parent)
         self.setAttribute(Qt.WA_DeleteOnClose)
 
@@ -3093,15 +3093,14 @@ class EditorWidget(QSplitter):
         self.find_widget = FindReplace(self, enable_replace=True)
         self.plugin.register_widget_shortcuts(self.find_widget)
         self.find_widget.hide()
+
+        # TODO: Check this initialization once the editor is migrated to the
+        # new API
         self.outlineexplorer = OutlineExplorerWidget(
-            self,
-            show_fullpath=outline_explorer_options['show_fullpath'],
-            show_all_files=outline_explorer_options['show_all_files'],
-            group_cells=outline_explorer_options['group_cells'],
-            show_comments=outline_explorer_options['show_comments'],
-            sort_files_alphabetically=outline_explorer_options[
-                'sort_files_alphabetically'],
-            )
+            'outline_explorer',
+            plugin,
+            self
+        )
         self.outlineexplorer.edit_goto.connect(
                      lambda filenames, goto, word:
                      plugin.load(filenames=filenames, goto=goto, word=word,
@@ -3144,9 +3143,6 @@ class EditorWidget(QSplitter):
                      self.cursorpos_status.update_cursor_position)
         editorstack.sig_refresh_eol_chars.connect(self.eol_status.update_eol)
         self.plugin.register_editorstack(editorstack)
-        oe_btn = create_toolbutton(self)
-        oe_btn.setDefaultAction(self.outlineexplorer.visibility_action)
-        editorstack.add_corner_widgets_to_tabbar([5, oe_btn])
 
     def __print_editorstacks(self):
         logger.debug("%d editorstack(s) in editorwidget:" %
@@ -3162,16 +3158,14 @@ class EditorWidget(QSplitter):
 
 
 class EditorMainWindow(QMainWindow):
-    def __init__(self, plugin, menu_actions, toolbar_list, menu_list,
-                 outline_explorer_options):
+    def __init__(self, plugin, menu_actions, toolbar_list, menu_list):
         QMainWindow.__init__(self)
         self.setAttribute(Qt.WA_DeleteOnClose)
 
         self.plugin = plugin
         self.window_size = None
 
-        self.editorwidget = EditorWidget(self, plugin, menu_actions,
-                                         outline_explorer_options)
+        self.editorwidget = EditorWidget(self, plugin, menu_actions)
         self.setCentralWidget(self.editorwidget)
 
         # Setting interface theme

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -60,7 +60,8 @@ from spyder.widgets.tabs import BaseTabs
 from spyder.plugins.explorer.widgets.explorer import (
     show_in_external_file_explorer)
 from spyder.plugins.outlineexplorer.api import cell_name
-from spyder.utils.stylesheet import PANES_TABBAR_STYLESHEET
+from spyder.utils.stylesheet import (
+    APP_TOOLBAR_STYLESHEET, PANES_TABBAR_STYLESHEET)
 
 
 logger = logging.getLogger(__name__)
@@ -3069,6 +3070,8 @@ class EditorSplitter(QSplitter):
 
 
 class EditorWidget(QSplitter):
+    CONF_SECTION = 'editor'
+
     def __init__(self, parent, plugin, menu_actions):
         QSplitter.__init__(self, parent)
         self.setAttribute(Qt.WA_DeleteOnClose)
@@ -3185,6 +3188,8 @@ class EditorMainWindow(QMainWindow):
             for title, object_name, actions in toolbar_list:
                 toolbar = self.addToolBar(title)
                 toolbar.setObjectName(object_name)
+                toolbar.setStyleSheet(str(APP_TOOLBAR_STYLESHEET))
+                toolbar.setMovable(False)
                 add_actions(toolbar, actions)
                 self.toolbars.append(toolbar)
         if menu_list:

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -3217,6 +3217,7 @@ class EditorMainWindow(QMainWindow):
         # Six is the position of the view menu in menus list
         # that you can find in plugins/editor.py setup_other_windows.
         view_menu = self.menus[6]
+        view_menu.setObjectName('checkbox-padding')
         if actions == self.toolbars and view_menu:
             toolbars = []
             for toolbar in self.toolbars:

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -297,6 +297,9 @@ class OutlineExplorerTreeWidget(OneColumnTree):
     CONF_SECTION = 'outline_explorer'
 
     def __init__(self, parent):
+        if hasattr(parent, 'CONTEXT_NAME'):
+            self.CONTEXT_NAME = parent.CONTEXT_NAME
+
         self.show_fullpath = self.get_conf('show_fullpath')
         self.show_all_files = self.get_conf('show_all_files')
         self.group_cells = self.get_conf('group_cells')
@@ -888,7 +891,10 @@ class OutlineExplorerWidget(PluginMainWidget):
     ENABLE_SPINNER = True
     CONF_SECTION = 'outline_explorer'
 
-    def __init__(self, name, plugin, parent=None):
+    def __init__(self, name, plugin, parent=None, context=None):
+        if context is not None:
+            self.CONTEXT_NAME = context
+
         super().__init__(name, plugin, parent)
 
         self.treewidget = OutlineExplorerTreeWidget(self)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR fixes some issues where some invalid keywords were passed to initialize the outline explorer on the separate editor main window.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15104 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @andfoy

<!--- Thanks for your help making Spyder better for everyone! --->
