### PR TITLE
PR: Sync spyder-kernels subrepo with the 2.x branch

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = master
-	commit = 4c647fe543e3c641e6be228cc220b949a2386ef0
-	parent = 6efe1f0302712a5e72eb321e2156699b71898eb9
+	branch = 2.x
+	commit = 126c46c79223b62d675099c595594a54b8a0cac2
+	parent = 5244ef9021757ed74e500d3f2f1c02b3b8386922
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/CHANGELOG.md
+++ b/external-deps/spyder-kernels/CHANGELOG.md
@@ -1,5 +1,41 @@
 # History of changes
 
+## Version 2.0.1 (2021-04-02)
+
+* This release also contains all fixes present in version 1.10.3
+
+
+----
+
+
+## Version 2.0.0 (2021-04-01)
+
+### New features
+* Color handling in namespace view was moved to Spyder.
+
+### Pull Requests Merged
+
+* [PR 284](https://github.com/spyder-ide/spyder-kernels/pull/284) - PR: Remove handling of colors for object types, by [@ccordoba12](https://github.com/ccordoba12)
+* [PR 279](https://github.com/spyder-ide/spyder-kernels/pull/279) - PR: Add Python types to namespace view, by [@ccordoba12](https://github.com/ccordoba12)
+
+In this release 2 pull requests were closed.
+
+
+----
+
+
+## Version 1.10.3 (2021-04-02)
+
+### Pull Requests Merged
+
+* [PR 285](https://github.com/spyder-ide/spyder-kernels/pull/285) - PR: Add a new dependency on decorator to fix the Cython magic, by [@ccordoba12](https://github.com/ccordoba12)
+
+In this release 1 pull request was closed.
+
+
+----
+
+
 ## Version 1.10.2 (2021-02-21)
 
 ### Pull Requests Merged

--- a/external-deps/spyder-kernels/RELEASE.md
+++ b/external-deps/spyder-kernels/RELEASE.md
@@ -2,9 +2,9 @@ To release a new version of spyder-kernels on PyPI:
 
 * Close the respective milestone on Github
 
-* git checkout 1.x
+* git checkout 2.x
 
-* git fetch upstream && get merge upstream/1.x
+* git fetch upstream && get merge upstream/2.x
 
 * git clean -xfdi
 
@@ -30,10 +30,10 @@ To release a new version of spyder-kernels on PyPI:
 
 * git checkout master
 
-* git merge 1.x
+* git merge 2.x
 
 * git push upstream master
 
-* git push upstream 1.x
+* git push upstream 2.x
 
 * git push upstream --tags

--- a/external-deps/spyder-kernels/setup.py
+++ b/external-deps/spyder-kernels/setup.py
@@ -37,6 +37,7 @@ def get_version(module='spyder_kernels'):
 
 REQUIREMENTS = [
     'cloudpickle',
+    'decorator<5',  # Higher versions break the Cython magic
     'ipykernel<5; python_version<"3"',
     'ipykernel>=5.3.0; python_version>="3"',
     'ipython<6; python_version<"3"',

--- a/external-deps/spyder-kernels/spyder_kernels/_version.py
+++ b/external-deps/spyder-kernels/spyder_kernels/_version.py
@@ -8,5 +8,5 @@
 
 """Version File."""
 
-VERSION_INFO = (2, 0, 0, 'dev0')
+VERSION_INFO = (2, 1, 0, 'dev0')
 __version__ = '.'.join(map(str, VERSION_INFO))


### PR DESCRIPTION
## Description of Changes

- This syncs our 5.x branch with the new 2.x branch in spyder-kernels.
- This is also necessary to avoid showing our Dependencies dialog when running Spyder from `bootstrap.py`.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
