### PR TITLE
PR: Increase padding in checkboxes for old PyQt versions

### DIFF
--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -14,10 +14,14 @@ import sys
 import qdarkstyle
 import qstylizer
 from qstylizer.parser import parse as parse_stylesheet
+from qtpy import PYQT_VERSION
 
 # Local imports
 from spyder.utils.palette import QStylePalette
+from spyder.utils import programs
 
+
+OLD_PYQT = programs.check_version(PYQT_VERSION, "5.12", "<")
 
 # =============================================================================
 # ---- Base stylesheet class
@@ -132,7 +136,7 @@ class AppStylesheet(SpyderStyleSheet):
             # iconSize='0.8em'
         )
 
-        if sys.platform == 'darwin':
+        if OLD_PYQT:
             css["QMenu::item"].setValues(
                 padding='4px 24px 4px 28px',
             )


### PR DESCRIPTION
## Description of Changes

We thought this problem only happened on macOS, but it was really caused by old PyQt versions (i.e. less than 5.12).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15116.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
