### PR TITLE
PR: Improve the style of tabs

### DIFF
--- a/spyder/plugins/history/widgets.py
+++ b/spyder/plugins/history/widgets.py
@@ -313,8 +313,21 @@ class HistoryWidget(PluginMainWidget):
         """
         tabs_stylesheet = PANES_TABBAR_STYLESHEET.get_copy()
         css = tabs_stylesheet.get_stylesheet()
-        css['QTabBar::tab'].setValues(padding='4px')
-        return tabs_stylesheet.to_string()
+
+        css['QTabBar::tab'].setValues(
+            marginTop='1.0em',
+            padding='4px'
+        )
+
+        css['QTabWidget::left-corner'].setValues(
+            left='0px',
+        )
+
+        css['QTabWidget::right-corner'].setValues(
+            right='0px'
+        )
+
+        return str(tabs_stylesheet)
 
 
 def test():

--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -249,7 +249,7 @@ PANES_TOOLBAR_STYLESHEET = PanesToolbarStyleSheet()
 class PanesTabBarStyleSheet(PanesToolbarStyleSheet):
     """Stylesheet for pane tabbars"""
 
-    # TODO: This needs to be changed to 0.9em when the IPython console
+    # TODO: This needs to be changed to 1.0em when the IPython console
     # and the Editor are migrated.
     TOP_MARGIN = '0.8em'
 

--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -259,7 +259,7 @@ class PanesTabBarStyleSheet(PanesToolbarStyleSheet):
         is_macos = sys.platform == 'darwin'
 
         # QTabBar forces the corner widgets to be smaller than they should.
-        # The top margin added allows the toolbuttons to expand to their
+        # be. The added top margin allows the toolbuttons to expand to their
         # normal size.
         # See: spyder-ide/spyder#13600
         css['QTabBar::tab'].setValues(
@@ -275,6 +275,24 @@ class PanesTabBarStyleSheet(PanesToolbarStyleSheet):
         # more.
         css['QTabBar::close-button'].setValues(
             paddingBottom='-5px' if is_macos else '-6px',
+        )
+
+        # Remove border between selected tab and pane below
+        css['QTabWidget::pane'].setValues(
+            borderTop='0px',
+        )
+
+        # Adjust margins of corner widgets
+        css['QTabWidget::left-corner'].setValues(
+            top='-1px',
+            bottom='-2px',
+            left='1px',
+        )
+
+        css['QTabWidget::right-corner'].setValues(
+            top='-1px',
+            bottom='-2px',
+            right='1px'
         )
 
     def to_string(self):


### PR DESCRIPTION
## Description of Changes

- Remove top border around corner widgets for the Editor and IPython console.
- Remove 1px border between tabbar and pane for selected tabs in those panes too.

**Before**

![imagen](https://user-images.githubusercontent.com/365293/113650840-8228d500-9656-11eb-8442-e824c9adeead.png)

**After**

![imagen](https://user-images.githubusercontent.com/365293/113650448-d41d2b00-9655-11eb-8a57-e39f89cd48dd.png)

- Make corner widgets in History to have the right height

**Before**

![imagen](https://user-images.githubusercontent.com/365293/113650946-b56b6400-9656-11eb-869e-ae450b39099b.png)

**After**

![imagen](https://user-images.githubusercontent.com/365293/113650533-f9aa3480-9655-11eb-8d17-06e8b01147f6.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
