### PR TITLE
PR: Fix a crash at startup when switching screens

### DIFF
--- a/.github/scripts/modules_test.sh
+++ b/.github/scripts/modules_test.sh
@@ -47,7 +47,10 @@ for f in spyder/*/*.py; do
         continue
     fi
     if [[ $f == spyder/widgets/about.py ]]; then
-    continue
+        continue
+    fi
+    if [[ $f == spyder/api/__init__.py ]]; then
+        continue
     fi
     python "$f"
     if [ $? -ne 0 ]; then

--- a/spyder/api/__init__.py
+++ b/spyder/api/__init__.py
@@ -8,9 +8,11 @@
 spyder.api
 ==========
 
-This package contains bases classes that can be used it to create
-third-party plugins to extend Spyder.
+This package contains base classes, mixins and widgets that can be used
+to create third-party plugins to extend Spyder.
 
 This API should be considered pre-release and is subject to change
-The final API version will be released in Spyder 4.0
+before its version reaches 1.0.
 """
+
+from ._version import __version__

--- a/spyder/api/_version.py
+++ b/spyder/api/_version.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""Spyder API Version."""
+
+VERSION_INFO = (0, 1, 0)
+__version__ = '.'.join(map(str, VERSION_INFO))

--- a/spyder/api/config/mixins.py
+++ b/spyder/api/config/mixins.py
@@ -128,6 +128,28 @@ class SpyderConfigurationAccessor:
             )
         CONF.remove_option(section, option)
 
+    def get_conf_default(self,
+                         option: ConfigurationKey,
+                         section: Optional[str] = None):
+        """
+        Get an option default value in the Spyder configuration system.
+
+        Parameters
+        ----------
+        option: ConfigurationKey
+            Name/Tuple path of the option to remove its value.
+        section: Optional[str]
+            Section in the configuration system, e.g. `shortcuts`. If None,
+            then the value of `CONF_SECTION` is used.
+        """
+        section = self.CONF_SECTION if section is None else section
+        if section is None:
+            raise AttributeError(
+                'A SpyderConfigurationAccessor must define a `CONF_SECTION` '
+                'class attribute!'
+            )
+        return CONF.get_default(section, option)
+
 
 class SpyderConfigurationObserver(SpyderConfigurationAccessor):
     """

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -348,7 +348,7 @@ class Layout(SpyderPluginV2):
         *prefix*, under *section* default: if True, do not restore inner
         layout.
         """
-        get_func = self.get_conf
+        get_func = self.get_conf_default if default else self.get_conf
         window_size = get_func(prefix + 'size', section=section)
         prefs_dialog_size = get_func(
             prefix + 'prefs_dialog_size', section=section)
@@ -371,7 +371,7 @@ class Layout(SpyderPluginV2):
         current_width = screen_shape.width()
         current_height = screen_shape.height()
         if current_width < width or current_height < height:
-            pos = get_func(prefix + 'position', section)
+            pos = self.get_conf_default(prefix + 'position', section)
 
         is_maximized = get_func(prefix + 'is_maximized', section=section)
         is_fullscreen = get_func(prefix + 'is_fullscreen', section=section)

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -214,7 +214,7 @@ class Layout(SpyderPluginV2):
             # default layouts.
             # Order and name of the default layouts is found in config.py
             section = 'quick_layouts'
-            get_func = self.get_conf
+            get_func = self.get_conf_default if default else self.get_conf
             order = get_func(section, 'order')
 
             # Restore the original defaults if reset layouts is called
@@ -460,10 +460,13 @@ class Layout(SpyderPluginV2):
         """
         Save current window settings.
 
-        Takes config form *prefix* in the userconfig-based configuration,
-        under *section*.
+        It saves config with *prefix* in the userconfig-based,
+        configuration under *section*.
         """
-        win_size = self.window_size
+        # Use current size and position when saving window settings.
+        # Fixes spyder-ide/spyder#13882
+        win_size = self.main.size()
+        pos = self.main.pos()
         prefs_size = self.prefs_dialog_size
 
         self.set_conf(
@@ -486,8 +489,6 @@ class Layout(SpyderPluginV2):
             self.main.isFullScreen(),
             section=section,
         )
-
-        pos = self.window_position
         self.set_conf(
             prefix + 'position',
             (pos.x(), pos.y()),

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -148,7 +148,6 @@ class Layout(SpyderPluginV2):
         -------
         SpyderDockablePlugin
             The last focused dockable plugin.
-
         """
         return self._last_plugin
 
@@ -162,7 +161,6 @@ class Layout(SpyderPluginV2):
         -------
         bool
             True is the mainwindow is in fullscreen. False otherwise.
-
         """
         return self._fullscreen_flag
 
@@ -192,7 +190,6 @@ class Layout(SpyderPluginV2):
         -------
         Instance of a spyder.plugins.layout.api.BaseGridLayoutType subclass
             Layout.
-
         """
         return self.get_container().get_layout(layout_id)
 
@@ -345,8 +342,12 @@ class Layout(SpyderPluginV2):
     def load_window_settings(self, prefix, default=False, section='main'):
         """
         Load window layout settings from userconfig-based configuration with
-        *prefix*, under *section* default: if True, do not restore inner
-        layout.
+        *prefix*, under *section*.
+
+        Parameters
+        ----------
+        default: bool
+            if True, do not restore inner layout.
         """
         get_func = self.get_conf_default if default else self.get_conf
         window_size = get_func(prefix + 'size', section=section)
@@ -398,7 +399,8 @@ class Layout(SpyderPluginV2):
                              self.prefs_dialog_size.height())
 
         hexstate = qbytearray_to_str(
-            self.main.saveState(version=WINDOW_STATE_VERSION))
+            self.main.saveState(version=WINDOW_STATE_VERSION)
+        )
         return (hexstate, window_size, prefs_dialog_size, pos, is_maximized,
                 is_fullscreen)
 
@@ -423,9 +425,10 @@ class Layout(SpyderPluginV2):
         if hexstate:
             hexstate_valid = self.main.restoreState(
                 QByteArray().fromHex(str(hexstate).encode('utf-8')),
-                version=WINDOW_STATE_VERSION)
+                version=WINDOW_STATE_VERSION
+            )
 
-            # Check layout validity. Spyder 4 and below uses the version 0
+            # Check layout validity. Spyder 4 and below use the version 0
             # state (default), whereas Spyder 5 will use version 1 state.
             # For more info see the version argument for
             # QMainWindow.restoreState:
@@ -553,7 +556,8 @@ class Layout(SpyderPluginV2):
 
             # Select plugin to maximize
             self._state_before_maximizing = self.main.saveState(
-                version=WINDOW_STATE_VERSION)
+                version=WINDOW_STATE_VERSION
+            )
             focus_widget = QApplication.focusWidget()
 
             for plugin in self.get_dockable_plugins():
@@ -585,7 +589,6 @@ class Layout(SpyderPluginV2):
             except AttributeError:
                 # Old API
                 self.main.setCentralWidget(self._last_plugin)
-
             self._last_plugin._ismaximized = True
 
             # Workaround to solve an issue with editor's outline explorer:
@@ -616,7 +619,6 @@ class Layout(SpyderPluginV2):
             except AttributeError:
                 # Old API
                 self._last_plugin.dockwidget.setWidget(self._last_plugin)
-
             self._last_plugin.dockwidget.toggleViewAction().setEnabled(True)
             self.main.setCentralWidget(None)
 
@@ -628,7 +630,8 @@ class Layout(SpyderPluginV2):
                 self._last_plugin._ismaximized = False
 
             self.main.restoreState(
-                self._state_before_maximizing, version=WINDOW_STATE_VERSION)
+                self._state_before_maximizing, version=WINDOW_STATE_VERSION
+            )
             self._state_before_maximizing = None
             try:
                 # New API
@@ -648,11 +651,6 @@ class Layout(SpyderPluginV2):
     def toggle_fullscreen(self):
         """
         Toggle option to show the mainwindow in fullscreen or windowed.
-
-        Returns
-        -------
-        None.
-
         """
         main = self.main
         if self._fullscreen_flag:


### PR DESCRIPTION
## Description of Changes

- Fix crash at startup when Spyder is closed in a secondary screen, that screen is unplugged and then Spyder is opened in the primary screen.
- Add `get_conf_default` method to `SpyderConfigurationAccessor` to make that fix easier.
- Start to version our API to let developers know about additions or removals.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
