### PR TITLE
PR: Add maximize_dockwidget method for old API compatibility (mainwindow)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -30,6 +30,9 @@ if [ "$USE_CONDA" = "true" ]; then
     # Remove packages we have subrepos for
     conda remove spyder-kernels --force -q -y
     conda remove python-language-server --force -q -y
+
+    # Provisional change to prevent error from jupyter_client 6.1.13
+    conda install jupyter_client=6.1.12
 else
     # Update pip and setuptools
     pip install -U pip setuptools
@@ -52,6 +55,9 @@ else
     # Remove packages we have subrepos for
     pip uninstall spyder-kernels -q -y
     pip uninstall python-language-server -q -y
+
+    # Provisional change to prevent error from jupyter_client 6.1.13
+    pip install jupyter_client==6.1.12
 fi
 
 # This is necessary only for Windows (don't know why).

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -344,6 +344,25 @@ class MainWindow(QMainWindow):
         # spyder/plugins/base::_switch_to_plugin
         return self.layouts.get_last_plugin()
 
+    def maximize_dockwidget(self, restore=False):
+        """
+        Maximize current dockwidget or restore it.
+
+        Parameters
+        ----------
+        restore : bool, optional
+            If the current dockwidget needs to be restored to its unmaximized
+            state. The default is False.
+
+        Returns
+        -------
+        None.
+
+        """
+        # Needed to prevent errors with the old API at
+        # spyder/plugins/base::_switch_to_plugin. See #spyder-ide/spyder#15164
+        self.layouts.maximize_dockwidget(restore=False)
+
     def switch_to_plugin(self, plugin, force_focus=None):
         """
         Switch to this plugin.

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -346,7 +346,7 @@ class MainWindow(QMainWindow):
 
     def maximize_dockwidget(self, restore=False):
         """
-        Needed to prevent errors with the old API at
+        This is needed to prevent errors with the old API at
         spyder/plugins/base::_switch_to_plugin.
 
         See spyder-ide/spyder#15164
@@ -356,11 +356,6 @@ class MainWindow(QMainWindow):
         restore : bool, optional
             If the current dockwidget needs to be restored to its unmaximized
             state. The default is False.
-
-        Returns
-        -------
-        None.
-
         """
         self.layouts.maximize_dockwidget(restore=restore)
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -346,7 +346,10 @@ class MainWindow(QMainWindow):
 
     def maximize_dockwidget(self, restore=False):
         """
-        Maximize current dockwidget or restore it.
+        Needed to prevent errors with the old API at
+        spyder/plugins/base::_switch_to_plugin.
+
+        See spyder-ide/spyder#15164
 
         Parameters
         ----------
@@ -359,8 +362,6 @@ class MainWindow(QMainWindow):
         None.
 
         """
-        # Needed to prevent errors with the old API at
-        # spyder/plugins/base::_switch_to_plugin. See #spyder-ide/spyder#15164
         self.layouts.maximize_dockwidget(restore=False)
 
     def switch_to_plugin(self, plugin, force_focus=None):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -362,7 +362,7 @@ class MainWindow(QMainWindow):
         None.
 
         """
-        self.layouts.maximize_dockwidget(restore=False)
+        self.layouts.maximize_dockwidget(restore=restore)
 
     def switch_to_plugin(self, plugin, force_focus=None):
         """


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

The old API plugins call the mainwindow instance to provide the switch to plugin functionality, maximize/restore panes


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15164 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
