### PR TITLE
PR: More style fixes

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -71,8 +71,8 @@ from spyder import __version__
 from spyder import dependencies
 from spyder.app import tour
 from spyder.app.utils import (create_splash_screen, delete_lsp_log_files,
-                              qt_message_handler, setup_logging,
-                              set_opengl_implementation, Spy)
+                              qt_message_handler, set_links_color,
+                              setup_logging, set_opengl_implementation, Spy)
 from spyder.config.base import (_, DEV, get_conf_path, get_debug_level,
                                 get_home_dir, get_module_source_path,
                                 get_safe_mode, is_pynsist, running_in_mac_app,
@@ -2288,6 +2288,9 @@ def main(options, args):
         except Exception:
             pass
     CONF.set('main', 'previous_crash', previous_crash)
+
+    # **** Set color for links ****
+    set_links_color(app)
 
     # **** Create main window ****
     mainwindow = None

--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -17,7 +17,7 @@ import sys
 # Third-party imports
 import psutil
 from qtpy.QtCore import QCoreApplication, Qt
-from qtpy.QtGui import QPixmap
+from qtpy.QtGui import QColor, QPalette, QPixmap
 from qtpy.QtWidgets import QSplashScreen
 
 # Local imports
@@ -26,6 +26,7 @@ from spyder.config.base import (DEV, get_conf_path, get_debug_level,
 from spyder.utils.image_path_manager import get_image_path
 from spyder.utils.qthelpers import file_uri
 from spyder.utils.external.dafsa.dafsa import DAFSA
+from spyder.utils.stylesheet import QStylePalette
 
 # For spyder-ide/spyder#7447.
 try:
@@ -183,3 +184,17 @@ def create_splash_screen():
         splash = None
 
     return splash
+
+
+def set_links_color(app):
+    """
+    Fix color for links.
+
+    This is taken from QDarkstyle, which is MIT licensed.
+    """
+    color = QStylePalette.COLOR_ACCENT_3
+    qcolor = QColor(color)
+
+    app_palette = app.palette()
+    app_palette.setColor(QPalette.Normal, QPalette.Link, qcolor)
+    app.setPalette(app_palette)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -3195,7 +3195,7 @@ class EditorMainWindow(QMainWindow):
                 self.toolbars.append(toolbar)
         if menu_list:
             quit_action = create_action(self, _("Close window"),
-                                        icon="close_panel",
+                                        icon=ima.icon("close_pane"),
                                         tip=_("Close this window"),
                                         triggered=self.close)
             self.menus = []

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -34,8 +34,8 @@ from spyder.plugins.variableexplorer.widgets.objectexplorer import (
     DEFAULT_ATTR_COLS, DEFAULT_ATTR_DETAILS, ToggleColumnTreeView,
     TreeItem, TreeModel, TreeProxyModel)
 from spyder.utils.icon_manager import ima
-from spyder.utils.qthelpers import (add_actions, create_plugin_layout,
-                                    create_toolbutton, qapplication)
+from spyder.utils.qthelpers import add_actions, create_toolbutton, qapplication
+from spyder.utils.stylesheet import PANES_TOOLBAR_STYLESHEET
 from spyder.widgets.simplecodeeditor import SimpleCodeEditor
 
 
@@ -185,6 +185,7 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor):
             toggled=self._toggle_show_callable_attributes_action)
         callable_attributes.setCheckable(True)
         callable_attributes.setChecked(show_callable_attributes)
+        callable_attributes.setStyleSheet(str(PANES_TOOLBAR_STYLESHEET))
         self.tools_layout.addWidget(callable_attributes)
 
         special_attributes = create_toolbutton(
@@ -193,20 +194,21 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor):
             toggled=self._toggle_show_special_attributes_action)
         special_attributes.setCheckable(True)
         special_attributes.setChecked(show_special_attributes)
+        special_attributes.setStyleSheet(str(PANES_TOOLBAR_STYLESHEET))
+        self.tools_layout.addSpacing(5)
         self.tools_layout.addWidget(special_attributes)
 
         self.tools_layout.addStretch()
 
         self.options_button = create_toolbutton(
                 self, text=_('Options'), icon=ima.icon('tooloptions'))
+        self.options_button.setStyleSheet(str(PANES_TOOLBAR_STYLESHEET))
         self.options_button.setPopupMode(QToolButton.InstantPopup)
 
         self.show_cols_submenu = QMenu(self)
+        self.show_cols_submenu.setObjectName('checkbox-padding')
         self.options_button.setMenu(self.show_cols_submenu)
-        # Don't show menu arrow and remove padding
-        self.options_button.setStyleSheet(
-            ("QToolButton::menu-indicator{image: none;}\n"
-             "QToolButton{padding: 3px;}"))
+        self.show_cols_submenu.setStyleSheet(str(PANES_TOOLBAR_STYLESHEET))
         self.tools_layout.addWidget(self.options_button)
 
     @Slot()
@@ -226,9 +228,13 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor):
 
     def _setup_views(self):
         """Creates the UI widgets."""
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        layout.addLayout(self.tools_layout)
         self.central_splitter = QSplitter(self, orientation=Qt.Vertical)
-        layout = create_plugin_layout(self.tools_layout,
-                                      self.central_splitter)
+        layout.addWidget(self.central_splitter)
         self.setLayout(layout)
 
         # Stretch last column?

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -184,7 +184,7 @@ class IconManager():
             'editcut':                 [('mdi.content-cut',), {'color': self.MAIN_FG_COLOR}],
             'editclear':               [('mdi.delete',), {'color': self.MAIN_FG_COLOR}],
             'selectall':               [('mdi.select-all',), {'color': self.MAIN_FG_COLOR}],
-            'exit':                    [('mdi.power',), {'color': SpyderPalette.COLOR_ERROR_1}],
+            'exit':                    [('mdi.power',), {'color': self.MAIN_FG_COLOR}],
             'advanced':                [('mdi.package-variant',), {'color': self.MAIN_FG_COLOR}],
             'bug':                     [('mdi.bug',), {'color': self.MAIN_FG_COLOR}],
             'window_nofullscreen':     [('mdi.arrow-collapse-all',), {'color': self.MAIN_FG_COLOR}],


### PR DESCRIPTION
## Description of Changes

- Make style of Object Explorer tool buttons match the one of pane toolbars:

    ![imagen](https://user-images.githubusercontent.com/365293/113941965-b2db4c80-97c5-11eb-854b-6e92fb33f3be.png)

- Add padding to checkboxes in Object Explorer options menu, so they don't overlap the text:

    ![imagen](https://user-images.githubusercontent.com/365293/113942109-ef0ead00-97c5-11eb-8f74-96904c6b2da2.png)

- Use QDarkstyle palette for the color of links

    ![imagen](https://user-images.githubusercontent.com/365293/113942407-59275200-97c6-11eb-8f1f-394aa7de52e9.png)

- Change color of `exit` icon to main color so it has more contrast in the dark theme:

    ![imagen](https://user-images.githubusercontent.com/365293/113942272-27ae8680-97c6-11eb-8b77-0b2de9c25bfb.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15148 
Fixes #15146

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
