### PR TITLE
PR: Fix style of the tabbar scroller buttons

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -36,17 +36,6 @@ from spyder.config.base import _, running_under_pytest
 from spyder.config.manager import CONF
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
                                  get_filter, is_kde_desktop, is_anaconda)
-from spyder.py3compat import qbytearray_to_str, to_text_string
-from spyder.utils.icon_manager import ima
-from spyder.utils import encoding, sourcecode, syntaxhighlighters
-from spyder.utils.qthelpers import (add_actions, create_action,
-                                    create_toolbutton, MENU_SEPARATOR,
-                                    mimedata2url, set_menu_icons,
-                                    create_waitspinner)
-from spyder.utils.stylesheet import APP_STYLESHEET
-from spyder.plugins.outlineexplorer.widgets import OutlineExplorerWidget
-from spyder.plugins.outlineexplorer.editor import OutlineExplorerProxyEditor
-from spyder.widgets.findreplace import FindReplace
 from spyder.plugins.editor.utils.autosave import AutosaveForStack
 from spyder.plugins.editor.utils.editor import get_file_language
 from spyder.plugins.editor.utils.switcher import EditorSwitcherManager
@@ -56,12 +45,22 @@ from spyder.plugins.editor.widgets.editorstack_helpers import (
 from spyder.plugins.editor.widgets.status import (CursorPositionStatus,
                                                   EncodingStatus, EOLStatus,
                                                   ReadWriteStatus, VCSStatus)
-from spyder.widgets.tabs import BaseTabs
 from spyder.plugins.explorer.widgets.explorer import (
     show_in_external_file_explorer)
+from spyder.plugins.outlineexplorer.widgets import OutlineExplorerWidget
+from spyder.plugins.outlineexplorer.editor import OutlineExplorerProxyEditor
 from spyder.plugins.outlineexplorer.api import cell_name
+from spyder.py3compat import qbytearray_to_str, to_text_string
+from spyder.utils import encoding, sourcecode, syntaxhighlighters
+from spyder.utils.icon_manager import ima
+from spyder.utils.qthelpers import (add_actions, create_action,
+                                    create_toolbutton, MENU_SEPARATOR,
+                                    mimedata2url, set_menu_icons,
+                                    create_waitspinner)
 from spyder.utils.stylesheet import (
-    APP_TOOLBAR_STYLESHEET, PANES_TABBAR_STYLESHEET)
+    APP_STYLESHEET, APP_TOOLBAR_STYLESHEET, PANES_TABBAR_STYLESHEET)
+from spyder.widgets.findreplace import FindReplace
+from spyder.widgets.tabs import BaseTabs
 
 
 logger = logging.getLogger(__name__)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -21,6 +21,7 @@ import functools
 import unicodedata
 
 # Third party imports
+import qstylizer
 from qtpy.compat import getsavefilename
 from qtpy.QtCore import (QByteArray, QFileInfo, QPoint, QSize, Qt, QTimer,
                          Signal, Slot)
@@ -53,6 +54,7 @@ from spyder.plugins.outlineexplorer.api import cell_name
 from spyder.py3compat import qbytearray_to_str, to_text_string
 from spyder.utils import encoding, sourcecode, syntaxhighlighters
 from spyder.utils.icon_manager import ima
+from spyder.utils.palette import QStylePalette
 from spyder.utils.qthelpers import (add_actions, create_action,
                                     create_toolbutton, MENU_SEPARATOR,
                                     mimedata2url, set_menu_icons,
@@ -2891,6 +2893,8 @@ class EditorSplitter(QSplitter):
         if not running_under_pytest():
             self.editorstack.set_color_scheme(plugin.get_color_scheme())
 
+        self.setStyleSheet(self._stylesheet)
+
     def closeEvent(self, event):
         """Override QWidget closeEvent().
 
@@ -3066,6 +3070,14 @@ class EditorSplitter(QSplitter):
         if editor is not None:
             editor.clearFocus()
             editor.setFocus()
+
+    @property
+    def _stylesheet(self):
+        css = qstylizer.style.StyleSheet()
+        css.QSplitter.setValues(
+            background=QStylePalette.COLOR_BACKGROUND_1
+        )
+        return css.toString()
 
 
 class EditorWidget(QSplitter):

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -684,7 +684,6 @@ class EditorStack(QWidget):
         corner_widgets = {Qt.TopRightCorner: [menu_btn]}
         self.tabs = BaseTabs(self, menu=self.menu, menu_use_tooltips=True,
                              corner_widgets=corner_widgets)
-        self.tabs.tabBar().setObjectName('plugin-tab')
         self.tabs.set_close_function(self.close_file)
         self.tabs.tabBar().tabMoved.connect(self.move_editorstack_data)
         self.tabs.setMovable(True)

--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -277,6 +277,28 @@ class PanesTabBarStyleSheet(PanesToolbarStyleSheet):
             paddingBottom='-5px' if is_macos else '-6px',
         )
 
+        # Set style for scroller buttons
+        css['QTabBar#pane-tabbar QToolButton'].setValues(
+            background=QStylePalette.COLOR_BACKGROUND_1,
+            borderRadius='0px',
+            borderRight=f'0.3em solid {QStylePalette.COLOR_BACKGROUND_1}'
+        )
+
+        for state in ['hover', 'pressed', 'checked', 'checked:hover']:
+            if state == 'hover':
+                color = QStylePalette.COLOR_BACKGROUND_2
+            else:
+                color = QStylePalette.COLOR_BACKGROUND_3
+            css[f'QTabBar#pane-tabbar QToolButton:{state}'].setValues(
+                background=color
+            )
+
+        # This makes one button huge and the other very small in PyQt 5.9
+        if not OLD_PYQT:
+            css['QTabBar::scroller'].setValues(
+                width='4.0em',
+            )
+
         # Remove border between selected tab and pane below
         css['QTabWidget::pane'].setValues(
             borderTop='0px',

--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -141,10 +141,7 @@ class TabBar(QTabBar):
                  split_index=0):
         QTabBar.__init__(self, parent)
         self.ancestor = ancestor
-
-        # To style tabs on Mac
-        if sys.platform == 'darwin':
-            self.setObjectName('plugin-tab')
+        self.setObjectName('pane-tabbar')
 
         # Dragging tabs
         self.__drag_start_pos = QPoint()
@@ -249,10 +246,7 @@ class BaseTabs(QTabWidget):
                  corner_widgets=None, menu_use_tooltips=False):
         QTabWidget.__init__(self, parent)
         self.setUsesScrollButtons(True)
-
-        # To style tabs on Mac
-        if sys.platform == 'darwin':
-            self.setObjectName('plugin-tab')
+        self.tabBar().setObjectName('pane-tabbar')
 
         self.corner_widgets = {}
         self.menu_use_tooltips = menu_use_tooltips


### PR DESCRIPTION
## Description of Changes

- Move editor's spinner to be next to the filename label. This gives more space in the tabbar for 

    ![imagen](https://user-images.githubusercontent.com/365293/114289027-43ba5e00-9a3a-11eb-8f82-17b36036e160.png)

- Fix tabbar scroller buttons style:

    **After**

    ![imagen](https://user-images.githubusercontent.com/365293/114289075-a01d7d80-9a3a-11eb-9981-360da0ab9b2b.png)

    **Before**

    ![imagen](https://user-images.githubusercontent.com/365293/114289109-030f1480-9a3b-11eb-9d89-c08a8f6ef5d8.png)

- Fix ordering of imports in `plugins/editor/widgets/editor.py`

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
