### PR TITLE
PR: Fix traceback links in the IPython console

### DIFF
--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -1199,7 +1199,7 @@ class IPythonConsole(SpyderPluginWidget):
         shellwidget.new_client.connect(self.create_new_client)
 
         # For tracebacks
-        control.go_to_error.connect(self.go_to_error)
+        control.sig_go_to_error_requested.connect(self.go_to_error)
 
         # For help requests
         control.sig_help_requested.connect(self.sig_help_requested)

--- a/spyder/plugins/ipythonconsole/widgets/control.py
+++ b/spyder/plugins/ipythonconsole/widgets/control.py
@@ -22,7 +22,7 @@ class ControlWidget(TracebackLinksMixin, GetHelpMixin,
     """
     QT_CLASS = QTextEdit
     visibility_changed = Signal(bool)
-    go_to_error = Signal(str)
+    sig_go_to_error_requested = Signal(str)
     focus_changed = Signal()
 
     sig_help_requested = Signal(dict)

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -1015,9 +1015,8 @@ class BaseTableView(QTableView, SpyderConfigurationAccessor):
             try:
                 if 'matplotlib' not in sys.modules:
                     import matplotlib
-                    matplotlib.use("Qt4Agg")
                 return True
-            except:
+            except Exception:
                 QMessageBox.warning(self, _("Import error"),
                                     _("Please install <b>matplotlib</b>"
                                       " or <b>guiqwt</b>."))


### PR DESCRIPTION
## Description of Changes

- Restore the ability to go the error line in the editor after clicking on the corresponding line in a console traceback.
- Don't use Qt4Agg as Matplotlib backend in the Variable Explorer.

### Issue(s) Resolved

Fixes #15166.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
