### PR TITLE
PR: Remove most small white dots around toolbuttons in tabwidgets

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -162,6 +162,39 @@ Files covered:
 Source Code
 ===========
 
+QDarkStyleSheet
+---------------
+
+
+Copyright (c) 2013- Colin Duquesnoy and others (see QDarkStyleSheet/AUTHORS.rst)
+
+
+Author: Colin Duquesnoy and others | colin.duquesnoy@gmail.com
+https://github.com/ColinDuquesnoy/QDarkStyleSheet/graphs/contributors
+Site: https://github.com/ColinDuquesnoy/QDarkStyleSheet/
+Source: https://github.com/ColinDuquesnoy/QDarkStyleSheet
+License: MIT (Expat) License | https://opensource.org/licenses/MIT
+
+Modifications made to adapt each file to Spyder.
+
+
+See below for the full text of the MIT License.
+
+The current QDarkStyleSheet license can be viewed at:
+https://github.com/ColinDuquesnoy/QDarkStyleSheet/blob/master/LICENSE.rst
+
+The current versions of the original files can be viewed at:
+https://github.com/ColinDuquesnoy/QDarkStyleSheet/blob/master/qdarkstyle/__init__.py
+
+
+Files covered:
+
+spyder/app/utils.py
+
+
+-------------------------------------------------------------------------------
+
+
 
 MathJax 2.0
 -----------

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1376,8 +1376,9 @@ class MainWindow(QMainWindow):
                  "We recommend restarting Spyder to ensure that it's properly "
                  "displayed. If you don't want to do that, please be sure to "
                  "activate the option<br><br><tt>Enable auto high DPI scaling"
-                 "</tt><br><br>in <tt>Preferences > General > Interface</tt>, "
-                 "in case Spyder is not displayed correctly.<br><br>"
+                 "</tt><br><br>in <tt>Preferences > Application > "
+                 "Interface</tt>, in case Spyder is not displayed "
+                 "correctly.<br><br>"
                  "Do you want to restart Spyder?"))
             msgbox.addButton(_('Restart now'), QMessageBox.NoRole)
             dismiss_button = msgbox.addButton(

--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -190,7 +190,7 @@ def set_links_color(app):
     """
     Fix color for links.
 
-    This is taken from QDarkstyle, which is MIT licensed.
+    This was taken from QDarkstyle, which is MIT licensed.
     """
     color = QStylePalette.COLOR_ACCENT_3
     qcolor = QColor(color)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -664,7 +664,7 @@ class EditorStack(QWidget):
 
     def setup_editorstack(self, parent, layout):
         """Setup editorstack's layout"""
-        layout.setSpacing(1)
+        layout.setSpacing(0)
 
         # Create filename label, spinner and the toolbar that contains them
         self.create_top_widgets()

--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -329,6 +329,13 @@ class BaseTabs(QTabWidget):
         for corner, widgets in list(self.corner_widgets.items()):
             cwidget = QWidget()
             cwidget.hide()
+
+            # This removes some white dots in our tabs (not all but most).
+            # See spyder-ide/spyder#15081
+            cwidget.setObjectName('corner-widget')
+            cwidget.setStyleSheet(
+                "QWidget#corner-widget {border-radius: '0px'}")
+
             prev_widget = self.cornerWidget(corner)
             if prev_widget:
                 prev_widget.close()


### PR DESCRIPTION
## Description of Changes

- Remove most small white dots around toolbuttons in tabwidgets:

    **Before**

    ![image](https://user-images.githubusercontent.com/5084939/113331805-c0d92b00-92f6-11eb-98d5-da8b8adc0547.png)

    **After**

    ![imagen](https://user-images.githubusercontent.com/365293/114331819-7cc20380-9b0a-11eb-97f1-a390cd5b4413.png)

- Remove 1px margin between new top toolbar in the editor and tabwidget.
- Add entry in `NOTICE.txt` about the code we're using from QDarkstyle
- Update message we show when the screen DPI changes.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
