### PR TITLE
PR: Remove usage of distutils

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ filterwarnings =
     ignore:.*You passed a bytestring as `filenames`.*:DeprecationWarning
     ignore:.*zmq.eventloop.ioloop is deprecated in pyzmq 17.*:DeprecationWarning
     ignore:.*Session._session_changed is deprecated in traitlets.*:DeprecationWarning
+    ignore:.*There already exists a reference.*with id.*under the context:UserWarning
 
 markers =
     slow: Marks tests as slow

--- a/scripts/spyder_win_post_install.py
+++ b/scripts/spyder_win_post_install.py
@@ -134,8 +134,7 @@ def install():
     if not osp.exists(script): # if not installed to the site scripts dir
         script = osp.abspath(osp.join(osp.dirname(osp.abspath(__file__)), 'spyder'))
     workdir = "%HOMEDRIVE%%HOMEPATH%"
-    import distutils.sysconfig
-    lib_dir = distutils.sysconfig.get_python_lib(plat_specific=1)
+    lib_dir = sysconfig.get_path("platlib")
     ico_dir = osp.join(lib_dir, 'spyder', 'windows')
     # if user is running -install manually then icons are in Scripts/
     if not osp.isdir(ico_dir):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -862,6 +862,8 @@ class MainWindow(QMainWindow):
                     Plugins.Projects]:
                 if plugin_name == Plugins.IPythonConsole:
                     plugin_instance = plugin_class(self, css_path=css_path)
+                    plugin_instance.sig_exception_occurred.connect(
+                        self.handle_exception)
                 else:
                     plugin_instance = plugin_class(self)
                 plugin_instance.register_plugin()

--- a/spyder/app/solver.py
+++ b/spyder/app/solver.py
@@ -33,6 +33,7 @@ def find_internal_plugins():
     In DEV mode we parse the `setup.py` file directly.
     """
     internal_plugins = {}
+
     # If DEV, look for entry points in setup.py file for internal plugins
     # and then look on the system for the rest
     HERE = os.path.abspath(os.path.dirname(__file__))
@@ -59,7 +60,6 @@ def find_internal_plugins():
                     end = idx + 1
                     break
 
-        internal_plugins = {}
         entry_points_list = "[" + "\n".join(lines[start:end])
         spyder_plugin_entry_points = ast.literal_eval(entry_points_list)
         for entry_point in spyder_plugin_entry_points:

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -11,10 +11,8 @@ Tests for the main window.
 """
 
 # Standard library imports
-from distutils.version import LooseVersion
 import os
 import os.path as osp
-import pkg_resources
 import re
 import shutil
 import sys
@@ -31,6 +29,8 @@ from matplotlib.testing.compare import compare_images
 import nbconvert
 import numpy as np
 from numpy.testing import assert_array_equal
+import pkg_resources
+from pkg_resources import parse_version
 import pylint
 import pytest
 from qtpy import PYQT5, PYQT_VERSION
@@ -1064,7 +1064,7 @@ def test_change_cwd_explorer(main_window, qtbot, tmpdir, test_directory):
 @flaky(max_runs=3)
 @pytest.mark.skipif(
     (os.name == 'nt' or sys.platform == 'darwin' or
-     LooseVersion(ipy_release.version) == LooseVersion('7.11.0')),
+     parse_version(ipy_release.version) == parse_version('7.11.0')),
     reason="Hard to test on Windows and macOS and fails for IPython 7.11.0")
 def test_run_cython_code(main_window, qtbot):
     """Test all the different ways we have to run Cython code"""
@@ -2139,8 +2139,8 @@ def test_run_static_code_analysis(main_window, qtbot):
     result_content = treewidget.results
     assert result_content['C:']
 
-    pylint_version = LooseVersion(pylint.__version__)
-    if pylint_version < LooseVersion('2.5.0'):
+    pylint_version = parse_version(pylint.__version__)
+    if pylint_version < parse_version('2.5.0'):
         number_of_conventions = 5
     else:
         number_of_conventions = 3

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -6,15 +6,17 @@
 
 """Module checking Spyder runtime dependencies"""
 
-
+# Standard library imports
 import os
+import os.path as osp
 import sys
 
 # Local imports
-from spyder.utils import programs
-from spyder.config.base import _, is_pynsist
+from spyder.config.base import _, DEV, is_pynsist, running_under_pytest
 from spyder.config.utils import is_anaconda
+from spyder.utils import programs
 
+HERE = osp.dirname(osp.abspath(__file__))
 
 # =============================================================================
 # Kind of dependency
@@ -401,6 +403,14 @@ def missing_dependencies():
     """Return the status of missing dependencies (if any)"""
     missing_deps = []
     for dependency in DEPENDENCIES:
+        # Skip checking dependencies for which we have subrepos
+        if DEV or running_under_pytest():
+            repo_path = osp.normpath(osp.join(HERE, '..'))
+            subrepos_path = osp.join(repo_path, 'external-deps')
+            subrepos = os.listdir(subrepos_path)
+            if dependency.package_name in subrepos:
+                continue
+
         if dependency.kind != OPTIONAL and not dependency.check():
             missing_deps.append(dependency)
 

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -685,6 +685,9 @@ class CompletionPlugin(SpyderPluginV2):
     def _instantiate_and_register_provider(
             self, Provider: SpyderCompletionProvider):
         provider_name = Provider.COMPLETION_PROVIDER_NAME
+        if provider_name in self._available_providers:
+            return
+
         self._available_providers[provider_name] = Provider
 
         logger.debug("Completion plugin: Registering {0}".format(

--- a/spyder/plugins/console/tests/test_plugin.py
+++ b/spyder/plugins/console/tests/test_plugin.py
@@ -152,5 +152,19 @@ ZeroDivisionError: division by zero
     console_plugin.set_conf('previous_crash', '', section='main')
 
 
+def test_handle_warnings(console_plugin):
+    """Test that we don't show warnings in our error dialog."""
+    widget = console_plugin.get_widget()
+    shell = widget.shell
+
+    # Write warning in the console
+    warning = ("/home/foo/bar.py:1926: UserWarning: baz\n"
+               "  warnings.warn('baz')")
+    shell.append_text_to_shell(warning, error=True, prompt=False)
+
+    # Make sure the error dialog was not generated.
+    assert widget.error_dlg is None
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/plugins/console/tests/test_plugin.py
+++ b/spyder/plugins/console/tests/test_plugin.py
@@ -194,7 +194,7 @@ def test_report_external_repo(console_plugin, mocker):
     mocker.patch.object(SpyderErrorDialog, 'set_github_repo_org')
 
     # Error data (repo is added later)
-    error_data= {
+    error_data = {
         "text": 'UserError',
         "is_traceback": True,
         "title": 'My plugin error',

--- a/spyder/plugins/console/tests/test_plugin.py
+++ b/spyder/plugins/console/tests/test_plugin.py
@@ -11,7 +11,7 @@ Tests for the console plugin.
 """
 
 # Standard library imports
-from unittest.mock import Mock
+from unittest.mock import call, Mock
 
 # Third party imports
 from qtpy.QtCore import Qt
@@ -20,8 +20,19 @@ import pytest
 from flaky import flaky
 
 # Local imports
+from spyder.api.exceptions import SpyderAPIError
+from spyder.api.plugins import SpyderPluginV2
 from spyder.config.manager import CONF
 from spyder.plugins.console.plugin import Console
+from spyder.widgets.reporterror import SpyderErrorDialog
+
+
+# =============================================================================
+# Auxiliary classes
+# =============================================================================
+class MyPlugin(SpyderPluginV2):
+    NAME = 'my-plugin'
+    CONF_SECTION = 'my_plugin'
 
 
 # =============================================================================
@@ -163,6 +174,61 @@ def test_handle_warnings(console_plugin):
 
     # Make sure the error dialog was not generated.
     assert widget.error_dlg is None
+
+
+def test_report_external_repo(console_plugin, mocker):
+    """
+    Test that we use an external Github repo to report errors for
+    external plugins.
+    """
+    widget = console_plugin.get_widget()
+    my_plugin = MyPlugin(None)
+
+    # Avoid showing the error dialog.
+    mocker.patch('spyder.widgets.reporterror.SpyderErrorDialog.show',
+                 return_value=None)
+
+    # To get the external repo
+    mocker.patch.object(SpyderErrorDialog, 'set_github_repo_org')
+
+    # Error data (repo is added later)
+    error_data= {
+        "text": 'UserError',
+        "is_traceback": True,
+        "title": 'My plugin error',
+        "label": '',
+        "steps": '',
+    }
+
+    # Check that we throw an error if error_data doesn't contain repo
+    with pytest.raises(SpyderAPIError) as excinfo:
+        widget.handle_exception(error_data, sender=my_plugin)
+        assert "does not define 'repo'" in str(excinfo.value)
+
+    # Check that we don't allow our main repo in external plugins
+    error_data['repo'] = 'spyder-ide/spyder'
+    with pytest.raises(SpyderAPIError) as excinfo:
+        widget.handle_exception(error_data, sender=my_plugin)
+        assert "needs to be different from" in str(excinfo.value)
+
+    # Make sure the error dialog is generated with the right repo
+    error_data['repo'] = 'my-plugin-org/my-plugin'
+    widget.handle_exception(error_data, sender=my_plugin)
+    assert widget.error_dlg is not None
+
+    # Assert we called the method that sets the repo in SpyderErrorDialog
+    call_args = SpyderErrorDialog.set_github_repo_org.call_args
+    assert call_args == call(error_data['repo'])
+
+    # Assert repo is not necessary for internal plugins
+    error_data.pop('repo')
+    widget.error_dlg = None
+    widget.handle_exception(error_data, sender=console_plugin)
+    assert widget.error_dlg is not None
+
+    # Assert we use our main repo for internal plugins
+    call_args = SpyderErrorDialog.set_github_repo_org.call_args
+    assert call_args == call('spyder-ide/spyder')
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/console/tests/test_plugin.py
+++ b/spyder/plugins/console/tests/test_plugin.py
@@ -97,8 +97,7 @@ def test_handle_exception(console_plugin, mocker):
 
     # --- Test internal errors in Spyder
     # Write error in the console
-    error = """
-Traceback (most recent call last):
+    error = """Traceback (most recent call last):
   File "/home/foo/miniconda3/envs/py37/lib/python3.7/code.py", line 90, in runcode
     exec(code, self.locals)
   File "<console>", line 2, in <module>

--- a/spyder/plugins/console/tests/test_plugin.py
+++ b/spyder/plugins/console/tests/test_plugin.py
@@ -169,6 +169,8 @@ def test_handle_warnings(console_plugin):
 
     # Write warning in the console
     warning = ("/home/foo/bar.py:1926: UserWarning: baz\n"
+               "Line 1\n"
+               "Line 2\n"
                "  warnings.warn('baz')")
     shell.append_text_to_shell(warning, error=True, prompt=False)
 

--- a/spyder/plugins/console/widgets/console.py
+++ b/spyder/plugins/console/widgets/console.py
@@ -241,21 +241,21 @@ class ConsoleBaseWidget(TextEditBaseWidget):
 
         if error:
             is_traceback = False
+            is_warning = False
             for line in text.splitlines(True):
-                is_warning = False
                 if (line.startswith('  File')
                         and not line.startswith('  File "<')):
                     is_traceback = True
+                    is_warning = False
                     # Show error links in blue underlined text
                     cursor.insertText('  ', self.default_style.format)
                     cursor.insertText(line[2:],
                                       self.traceback_link_style.format)
                 else:
                     # Detect if line is a warning.
-                    is_warning = (
-                        re.findall('[A-Z].*Warning', line) != [] or
-                        'warnings.warn' in line
-                    )
+                    if (re.findall('[A-Z].*Warning', line) != [] or
+                            'warnings.warn' in line):
+                        is_warning = True
 
                     # Show error/warning messages in red
                     cursor.insertText(line, self.error_style.format)

--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -25,6 +25,7 @@ from qtpy.QtCore import Qt, Signal, Slot
 from qtpy.QtWidgets import QInputDialog, QLineEdit, QVBoxLayout
 
 # Local imports
+from spyder.api.exceptions import SpyderAPIError
 from spyder.api.translations import get_translation
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.api.config.decorators import on_conf_change
@@ -377,32 +378,38 @@ class ConsoleWidget(PluginMainWidget):
                 or self.dismiss_error):
             return
 
+        # Get internal plugin names
         if internal_plugins is None:
             internal_plugins = find_internal_plugins()
 
-        if internal_plugins:
-            internal_plugin_names = []
-            for __, val in internal_plugins.items():
-                name = getattr(val, 'NAME', getattr(val, 'CONF_SECTION'))
-                internal_plugin_names.append(name)
+        internal_plugin_names = []
+        for __, val in internal_plugins.items():
+            name = getattr(val, 'NAME', getattr(val, 'CONF_SECTION'))
+            internal_plugin_names.append(name)
 
-            sender_name = getattr(val, 'NAME', getattr(val, 'CONF_SECTION'))
+        # Get if sender is internal or not
+        is_internal_plugin = True
+        if sender is not None:
+            sender_name = getattr(
+                sender, 'NAME', getattr(sender, 'CONF_SECTION'))
             is_internal_plugin = sender_name in internal_plugin_names
-        else:
-            is_internal_plugin = False
 
+        # Set repo
         repo = "spyder-ide/spyder"
-        if sender is not None and not is_internal_plugin:
+        if not is_internal_plugin:
             repo = error_data.get("repo", None)
-            try:
-                plugin_name = sender.NAME
-            except Exception:
-                plugin_name = sender.CONF_SECTION
 
             if repo is None:
-                raise Exception(
-                    'External plugin "{}" does not define "repo" key in '
-                    'the "error_data" dictionary!'.format(plugin_name)
+                raise SpyderAPIError(
+                    f"External plugin '{sender_name}' does not define 'repo' "
+                     "key in the 'error_data' dictionary in the form "
+                     "my-org/my-repo (only Github is supported)."
+                )
+
+            if repo == 'spyder-ide/spyder':
+                raise SpyderAPIError(
+                    f"External plugin '{sender_name}' 'repo' key needs to be "
+                     "different from the main Spyder repo."
                 )
 
         if self.get_conf('show_internal_errors', section='main'):

--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -402,14 +402,14 @@ class ConsoleWidget(PluginMainWidget):
             if repo is None:
                 raise SpyderAPIError(
                     f"External plugin '{sender_name}' does not define 'repo' "
-                     "key in the 'error_data' dictionary in the form "
-                     "my-org/my-repo (only Github is supported)."
+                    "key in the 'error_data' dictionary in the form "
+                    "my-org/my-repo (only Github is supported)."
                 )
 
             if repo == 'spyder-ide/spyder':
                 raise SpyderAPIError(
                     f"External plugin '{sender_name}' 'repo' key needs to be "
-                     "different from the main Spyder repo."
+                    "different from the main Spyder repo."
                 )
 
         if self.get_conf('show_internal_errors', section='main'):

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -156,6 +156,9 @@ class IPythonConsole(SpyderPluginWidget):
         The new working directory path.
     """
 
+    # Remove when this plugin is migrated
+    sig_exception_occurred = Signal(dict)
+
     # Error messages
     permission_error_msg = _("The directory {} is not writable and it is "
                              "required to create IPython consoles. Please "
@@ -1063,7 +1066,7 @@ class IPythonConsole(SpyderPluginWidget):
         shellwidget = client.shellwidget
         shellwidget.set_kernel_client_and_manager(kc, km)
         shellwidget.sig_exception_occurred.connect(
-            self.main.console.handle_exception)
+            self.sig_exception_occurred)
 
     @Slot(object, object)
     def edit_file(self, filename, line):
@@ -1852,7 +1855,7 @@ class IPythonConsole(SpyderPluginWidget):
         shellwidget.set_kernel_client_and_manager(
             kernel_client, kernel_manager)
         shellwidget.sig_exception_occurred.connect(
-            self.main.console.handle_exception)
+            self.sig_exception_occurred)
 
         if external_kernel:
             shellwidget.sig_is_spykernel.connect(

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -12,7 +12,6 @@ Tests for the IPython console plugin.
 
 # Standard library imports
 import codecs
-from distutils.version import LooseVersion
 import os
 import os.path as osp
 import shutil
@@ -26,6 +25,7 @@ import IPython
 from IPython.core import release as ipy_release
 from IPython.core.application import get_ipython_dir
 from flaky import flaky
+from pkg_resources import parse_version
 from pygments.token import Name
 import pytest
 from qtpy import PYQT5
@@ -373,7 +373,7 @@ def test_sympy_client(ipyconsole, qtbot):
 @pytest.mark.cython_client
 @pytest.mark.skipif(
     (not sys.platform.startswith('linux') or
-     LooseVersion(ipy_release.version) == LooseVersion('7.11.0')),
+     parse_version(ipy_release.version) == parse_version('7.11.0')),
     reason="It only works reliably on Linux and fails for IPython 7.11.0")
 def test_cython_client(ipyconsole, qtbot):
     """Test that the Cython console is working correctly."""

--- a/spyder/requirements.py
+++ b/spyder/requirements.py
@@ -6,9 +6,12 @@
 
 """Module checking Spyder installation requirements"""
 
+# Standard library imports
 import sys
 import os.path as osp
-from distutils.version import LooseVersion
+
+# Third-party imports
+from pkg_resources import parse_version
 
 
 def show_warning(message):
@@ -41,7 +44,7 @@ def check_qt():
         import qtpy
         package_name, required_ver = qt_infos[qtpy.API]
         actual_ver = qtpy.PYQT_VERSION
-        if LooseVersion(actual_ver) < LooseVersion(required_ver):
+        if parse_version(actual_ver) < parse_version(required_ver):
             show_warning("Please check Spyder installation requirements:\n"
                          "%s %s+ is required (found v%s)."
                          % (package_name, required_ver, actual_ver))
@@ -60,7 +63,7 @@ def check_spyder_kernels():
         import spyder_kernels
         required_ver = '1.0.0'
         actual_ver = spyder_kernels.__version__
-        if LooseVersion(actual_ver) < LooseVersion(required_ver):
+        if parse_version(actual_ver) < parse_version(required_ver):
             show_warning("Please check Spyder installation requirements:\n"
                          "spyder-kernels >= 1.0 is required (found %s)."
                          % actual_ver)

--- a/spyder/requirements.py
+++ b/spyder/requirements.py
@@ -61,13 +61,13 @@ def check_spyder_kernels():
     """Check spyder-kernel requirement."""
     try:
         import spyder_kernels
-        required_ver = '1.0.0'
+        required_ver = '2.0.0'
         actual_ver = spyder_kernels.__version__
         if parse_version(actual_ver) < parse_version(required_ver):
             show_warning("Please check Spyder installation requirements:\n"
-                         "spyder-kernels >= 1.0 is required (found %s)."
+                         "spyder-kernels >= 2.0 is required (found %s)."
                          % actual_ver)
     except ImportError:
         show_warning("Failed to import spyder-kernels.\n"
                      "Please check Spyder installation requirements:\n\n"
-                     "spyder-kernels >= 1.0 is required")
+                     "spyder-kernels >= 2.0 is required")

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -10,7 +10,6 @@ from __future__ import print_function
 
 # Standard library imports
 from ast import literal_eval
-from distutils.version import LooseVersion
 from getpass import getuser
 from textwrap import dedent
 import glob
@@ -27,6 +26,7 @@ import time
 
 # Third party imports
 import pkg_resources
+from pkg_resources import parse_version
 import psutil
 
 # Local imports
@@ -827,26 +827,17 @@ def check_version(actver, version, cmp_op):
     if isinstance(actver, tuple):
         actver = '.'.join([str(i) for i in actver])
 
-    # Hacks needed so that LooseVersion understands that (for example)
-    # version = '3.0.0' is in fact bigger than actver = '3.0.0rc1'
-    if is_stable_version(version) and not is_stable_version(actver) and \
-      actver.startswith(version) and version != actver:
-        version = version + 'zz'
-    elif is_stable_version(actver) and not is_stable_version(version) and \
-      version.startswith(actver) and version != actver:
-        actver = actver + 'zz'
-
     try:
         if cmp_op == '>':
-            return LooseVersion(actver) > LooseVersion(version)
+            return parse_version(actver) > parse_version(version)
         elif cmp_op == '>=':
-            return LooseVersion(actver) >= LooseVersion(version)
+            return parse_version(actver) >= parse_version(version)
         elif cmp_op == '=':
-            return LooseVersion(actver) == LooseVersion(version)
+            return parse_version(actver) == parse_version(version)
         elif cmp_op == '<':
-            return LooseVersion(actver) < LooseVersion(version)
+            return parse_version(actver) < parse_version(version)
         elif cmp_op == '<=':
-            return LooseVersion(actver) <= LooseVersion(version)
+            return parse_version(actver) <= parse_version(version)
         else:
             return False
     except TypeError:


### PR DESCRIPTION
## Description of Changes

- Remove usage of `distutils` except in our `setup.py`.
- Don't register completion providers with the same name several times. That will avoid people replacing our current providers for theirs.
- Update check of spyder-kernels version
- Avoid showing warnings in our error report dialog.
- Fix reporting errors to external repos for external plugins.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15093.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
