### PR TITLE
PR: Add base plugin actions to validation (to not disable them) - Plots

### DIFF
--- a/spyder/plugins/plots/widgets/main_widget.py
+++ b/spyder/plugins/plots/widgets/main_widget.py
@@ -320,7 +320,10 @@ class PlotsWidget(PluginMainWidget):
         for __, action in self.get_actions().items():
             if action and action not in [self.mute_action,
                                          self.outline_action,
-                                         self.fit_action]:
+                                         self.fit_action,
+                                         self.undock_action,
+                                         self.close_action,
+                                         self.dock_action]:
                 action.setEnabled(value)
 
                 # IMPORTANT: Since we are defining the main actions in here


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Plots uses some logic to disable actions when no plot is available. In the validation to enable/disable actions base actions need to be skipped.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
