### PR TITLE
PR: Minor layout improvements to the cornet widget of the panes toolbar

### DIFF
--- a/spyder/api/widgets/auxiliary_widgets.py
+++ b/spyder/api/widgets/auxiliary_widgets.py
@@ -9,8 +9,8 @@ Spyder API auxiliary widgets.
 """
 
 # Third party imports
-from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QHBoxLayout, QMainWindow, QWidget
+from qtpy.QtCore import Signal, QSize
+from qtpy.QtWidgets import QMainWindow, QSizePolicy, QToolBar, QWidget
 
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
@@ -44,23 +44,20 @@ class SpyderWindowWidget(QMainWindow):
         self.sig_closed.emit()
 
 
-class MainCornerWidget(QWidget):
+class MainCornerWidget(QToolBar):
     """
     Corner widget to hold options menu, spinner and additional options.
     """
 
     def __init__(self, parent, name):
         super().__init__(parent)
+        self._icon_size = QSize(16, 16)
+        self.setIconSize(self._icon_size)
 
         self._widgets = {}
+        self._actions = []
         self.setObjectName(name)
 
-        self._layout = QHBoxLayout()
-        self.setLayout(self._layout)
-
-        # left, top, right, bottom
-        self._layout.setContentsMargins(0, 0, 0, 0)
-        self.setContentsMargins(0, 0, 0, 0)
 
     def add_widget(self, widget_id, widget):
         """
@@ -74,7 +71,10 @@ class MainCornerWidget(QWidget):
 
         widget.ID = widget_id
         self._widgets[widget_id] = widget
-        self._layout.insertWidget(0, widget)
+        if len(self._actions):
+            self._actions.append(self.insertWidget(self._actions[-1], widget))
+        else:
+            self._actions.append(self.addWidget(widget))
 
     def get_widget(self, widget_id):
         """

--- a/spyder/api/widgets/auxiliary_widgets.py
+++ b/spyder/api/widgets/auxiliary_widgets.py
@@ -58,6 +58,13 @@ class MainCornerWidget(QToolBar):
         self._actions = []
         self.setObjectName(name)
 
+        # We add an strut widget here so that there is a spacing
+        # between the first item of the corner widget and the last
+        # item of the MainWidgetToolbar.
+        self._strut = QWidget()
+        self._strut.setFixedWidth(0)
+        self._strut.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.addWidget(self._strut)
 
     def add_widget(self, widget_id, widget):
         """

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -36,7 +36,8 @@ from spyder.api.widgets.toolbars import MainWidgetToolbar
 from spyder.utils.qthelpers import create_waitspinner, set_menu_icons
 from spyder.utils.registries import (
     ACTION_REGISTRY, TOOLBAR_REGISTRY, MENU_REGISTRY)
-from spyder.utils.stylesheet import APP_STYLESHEET, PANES_TABBAR_STYLESHEET
+from spyder.utils.stylesheet import (
+    APP_STYLESHEET, PANES_TABBAR_STYLESHEET, PANES_TOOLBAR_STYLESHEET)
 from spyder.widgets.dock import SpyderDockWidget
 from spyder.widgets.tabs import Tabs
 
@@ -374,6 +375,7 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
                 toolbar=self._corner_toolbar,
                 section="corner",
             )
+            self._corner_widget.setStyleSheet(str(PANES_TOOLBAR_STYLESHEET))
 
         # Update title
         self.setWindowTitle(self.get_title())


### PR DESCRIPTION
## Description of Changes

In this PR, I propose that we make `MainCornerWidget` inherit from `QToolBar` instead of `QWidget` so that we can set more easily a style that is consistent with that of the `MainWidgetToolbar` .

I also suggest to add a strut to the corner widget so that there is a space between the last item of the `MainWidgetToolbar` and the first item of the corner widget.

## Before
- there is no space to the left of the spinner
- the space to the right of the spinner is too large (though it is very subtle)

![spinner_spacing_nok](https://user-images.githubusercontent.com/10170372/115447369-6e4ca980-a1e6-11eb-9a45-aeee6acdfe1e.gif)

## After
![spinner_spacing_ok](https://user-images.githubusercontent.com/10170372/115447388-73a9f400-a1e6-11eb-921a-a4d6175b7703.gif)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jean-Sébastien Gosselin

<!--- Thanks for your help making Spyder better for everyone! --->
