### PR TITLE
PR: Add passphrase to the text expected by ssh tunnels (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/ssh.py
+++ b/spyder/plugins/ipythonconsole/utils/ssh.py
@@ -59,7 +59,10 @@ def openssh_tunnel(self, lport, rport, server, remoteip='127.0.0.1',
     failed = False
     while True:
         try:
-            i = tunnel.expect([ssh_newkey, '[Pp]assword:'], timeout=.1)
+            i = tunnel.expect(
+                [ssh_newkey, '[Pp]assword:', '[Pp]assphrase'],
+                timeout=.1
+            )
             if i == 0:
                 host = server.split('@')[-1]
                 question = _("The authenticity of host <b>%s</b> can't be "


### PR DESCRIPTION
## Description of Changes

Spyder was freezing if the other end of the tunnel asks for a passphrase instead of a password.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15388.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
