### PR TITLE
online help fix & no-inherit pydoc option

### DIFF
--- a/spyder/plugins/onlinehelp/pydoc_patch.py
+++ b/spyder/plugins/onlinehelp/pydoc_patch.py
@@ -24,6 +24,15 @@ from spyder.config.base import _, DEV
 from spyder.config.gui import is_dark_interface, get_font
 from spyder.py3compat import PY2, to_text_string
 
+_document_parent_class = True
+def setParentClassDocMode(value):
+    """
+    Sets the mode used for display of classes: if True,
+    methods from parent classes (etc) are included in the output
+    """
+    global _document_parent_class
+    _document_parent_class = value
+
 if not PY2:
     from pydoc import (
         classname, classify_class_attrs, describe, Doc, format_exception_only,
@@ -478,8 +487,17 @@ if not PY2:
                                          lambda t: t[1] == 'data descriptor')
                 attrs = spilldata('Data and other attributes %s' % tag, attrs,
                                   lambda t: t[1] == 'data')
-                assert attrs == []
-                attrs = inherited
+
+                # At this point attrs should be empty. If not, the remaining
+                # items will not be documented. Perhaps this should be noted
+                # as a console message or a note in the documentation
+                #assert attrs == []
+
+                # report on inherited items only when option allows
+                if _document_parent_class:
+                    attrs = inherited
+                else:
+                    break
 
             contents = ''.join(contents)
 

--- a/spyder/plugins/onlinehelp/pydoc_patch.py
+++ b/spyder/plugins/onlinehelp/pydoc_patch.py
@@ -25,6 +25,8 @@ from spyder.config.gui import is_dark_interface, get_font
 from spyder.py3compat import PY2, to_text_string
 
 _document_parent_class = True
+
+
 def setParentClassDocMode(value):
     """
     Sets the mode used for display of classes: if True,
@@ -491,7 +493,8 @@ if not PY2:
                 # At this point attrs should be empty. If not, the remaining
                 # items will not be documented. Perhaps this should be noted
                 # as a console message or a note in the documentation
-                #assert attrs == []
+                #
+                # assert attrs == []
 
                 # report on inherited items only when option allows
                 if _document_parent_class:

--- a/spyder/plugins/onlinehelp/widgets.py
+++ b/spyder/plugins/onlinehelp/widgets.py
@@ -42,7 +42,7 @@ PORT = 30128
 class PydocBrowserActions:
     # Toggles
     ToggleIncludeParentClass = 'toggle_include__parent_class_docs'
-    
+
     # Triggers
     Home = 'home_action'
     Find = 'find_action'
@@ -51,9 +51,10 @@ class PydocBrowserActions:
 class PydocBrowserMainToolbarSections:
     Main = 'main_section'
 
+
 class PydocBrowserOptionsMenuSections:
     Other = 'other_section'
-    
+
 
 # =============================================================================
 # Pydoc adjustments
@@ -254,13 +255,13 @@ class PydocBrowser(PluginMainWidget):
                 self.webview.addAction(action)
 
         self.sig_toggle_view_changed.connect(self.initialize)
-        
+
     @on_conf_change(option='include_parent_docs')
     def on_include_parent_docs(self, value):
         # Set the mode in pydoc_patch and redisplay the current page
         setParentClassDocMode(value)
         self.reload()
-        
+
     def update_actions(self):
         stop_action = self.get_action(WebViewActions.Stop)
         refresh_action = self.get_action(WebViewActions.Refresh)


### PR DESCRIPTION
fix online help w/class items not in pydoc; add option to not show inherited class info

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Online help gives a display with only the following three lines:

> Error 
> <module name>.html
> AssertionError

for modules where there are classes with items that are not displayed in the pydoc (these include readonly items). 

Also, subclassed classes display with all the parent info, which can be huge and unwanted. An option has been added for this. 

### Issue(s) Resolved

Fixes #15396


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
brian@toby@anl.gov

<!--- Thanks for your help making Spyder better for everyone! --->
