### PR TITLE
PR: Put the sys.prefix in the config search path

### DIFF
--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -252,6 +252,10 @@ def get_conf_paths():
             '{}/etc/spyder'.format(CONDA_PREFIX),
         )
 
+    SEARCH_PATH += (
+        '{}/etc/spyder'.format(sys.prefix),
+    )
+
     if running_under_pytest():
         search_paths = []
         tmpfolder = str(tempfile.gettempdir())


### PR DESCRIPTION
## Description of Changes

This change puts ``sys.prefix`` on the config search path. With this change we have the option of providing a centrally managed spyder installation which can be pre-configured without setting global (machine-wide) config.

The use case that this comes from:

 > I want to be able to provide a spyder installation to a large number of users (200+) who have all got a specific NFS drive mounted on their Linux (Centos) machines. I therefore cannot setup a config in ``/etc/``, and cannot control the user's ``~/.config``; I therefore want to be able to put a config in ``{sys.prefix}/etc/spyder/spyder.ini`` and it affect the global config (which can be overridden by the user config, should a user so choose).

In my case, I wanted to provide a spyder installation which is pre-configured to use a specific interpreter by default (different from the spyder interpreter). I therefore put the following config file in place:

```
$ which spyder
/home/pelson/github/spyder/spyder/env/bin/spyder

$ cat /home/pelson/github/spyder/spyder/env/etc/spyder/spyder.ini 
[main_interpreter]
custom_interpreter = /tmp/spyder-kernel-env/bin/python
executable = /tmp/spyder-kernel-env/bin/python
default = False
custom = True

$ rm -rf ~/.config/spyder-py*

$ spyder   # correctly uses the configured environment (/tmp/spyder-kernel-env/bin/python)
```


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.


I certify the above statement is true and correct:

@pelson

