### PR TITLE
PR: Fix issues with empty responses for non-aggregated completion requests

### DIFF
--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -874,7 +874,6 @@ class CompletionPlugin(SpyderPluginV2):
         providers = self.available_providers_for_language(language.lower())
         slow_provider_count = sum([self.provider_speed[p] for p in providers])
 
-
         # Start the timer on this request
         if req_type in self.AGGREGATE_RESPONSES and slow_provider_count > 2:
             if self.wait_for_ms > 0:
@@ -1046,12 +1045,13 @@ class CompletionPlugin(SpyderPluginV2):
         language = request_responses['language'].lower()
         req_type = request_responses['req_type']
 
+        available_providers = self.available_providers_for_language(
+            language)
+        sorted_providers = self.sort_providers_for_request(
+            available_providers, req_type)
+
         if req_type in self.AGGREGATE_RESPONSES:
             # Wait only for the available providers for the given request
-            available_providers = self.available_providers_for_language(
-                language)
-            sorted_providers = self.sort_providers_for_request(
-                available_providers, req_type)
             timed_out = request_responses['timed_out']
             all_returned = all(source in request_responses['sources']
                                for source in sorted_providers)
@@ -1066,7 +1066,14 @@ class CompletionPlugin(SpyderPluginV2):
                 if all_returned or any_nonempty:
                     self.skip_and_reply(req_id)
         else:
-            self.skip_and_reply(req_id)
+            # Any empty response will be discarded and the completion
+            # loop will wait for the next non-empty response.
+            # This should fix the scenario where Kite may does not have a
+            # response for a non-aggregated request but the LSP does.
+            any_nonempty = any(request_responses['sources'].get(source)
+                               for source in sorted_providers)
+            if any_nonempty:
+                self.skip_and_reply(req_id)
 
     def skip_and_reply(self, req_id: int):
         """

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -1068,7 +1068,7 @@ class CompletionPlugin(SpyderPluginV2):
         else:
             # Any empty response will be discarded and the completion
             # loop will wait for the next non-empty response.
-            # This should fix the scenario where Kite may does not have a
+            # This should fix the scenario where Kite does not have a
             # response for a non-aggregated request but the LSP does.
             any_nonempty = any(request_responses['sources'].get(source)
                                for source in sorted_providers)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR checks that a response for a non-aggregated completion request (e.g., folding, symbols, etc) is not empty.

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15139 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @andfoy

<!--- Thanks for your help making Spyder better for everyone! --->
