### PR TITLE
PR: Only switch to Plots when inline plotting is muted

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -23,6 +23,7 @@ import uuid
 
 # Third party imports
 from flaky import flaky
+import ipykernel
 from IPython.core import release as ipy_release
 from jupyter_client.manager import KernelManager
 from matplotlib.testing.compare import compare_images
@@ -1867,7 +1868,10 @@ def test_plots_plugin(main_window, qtbot, tmpdir, mocker):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
-@pytest.mark.skipif(PY2, reason="It times out sometimes")
+@pytest.mark.skipif(
+    (parse_version(ipy_release.version) >= parse_version('7.23.0') and
+     parse_version(ipykernel.__version__) <= parse_version('5.5.3')),
+    reason="Fails due to a bug in the %matplotlib magic")
 def test_tight_layout_option_for_inline_plot(main_window, qtbot, tmpdir):
     """
     Test that the option to set bbox_inches to 'tight' or 'None' is

--- a/spyder/plugins/plots/plugin.py
+++ b/spyder/plugins/plots/plugin.py
@@ -71,6 +71,14 @@ class Plots(SpyderDockablePlugin):
         ipyconsole.sig_shellwidget_id_process_finished.disconnect(
             self.remove_shellwidget_from_id)
 
+    def switch_to_plugin(self, force_focus=False):
+        # Only switch when inline plotting is muted. This avoids
+        # showing the plugin when users want to only see plots in
+        # the IPython console.
+        # Fixes spyder-ide/spyder#15467
+        if self.get_conf('mute_inline_plotting'):
+            super().switch_to_plugin(force_focus=force_focus)
+
     # --- Public API
     # ------------------------------------------------------------------------
     def current_widget(self):


### PR DESCRIPTION
## Description of Changes

- Don't switch to Plots automatically when the `Mute inline plotting` option is deactivated.
- Skip a test that fails for IPython 7.23 and ipykernel 5.5.3. I'll submit a PR to ipykernel to fix it.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15467.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
