### PR TITLE
PR: Remove rtree wheel from Windows installer extra packages

### DIFF
--- a/installers/Windows/req-extras-pull-request.txt
+++ b/installers/Windows/req-extras-pull-request.txt
@@ -22,9 +22,5 @@ sympy
 ./external-deps/spyder-kernels
 ./external-deps/qdarkstyle
 
-# Dependencies without wheels in PyPI
-# Rtree
-./installers/Windows/assets/rtree/Rtree-0.9.4-cp37-cp37m-win_amd64.whl
-
 # There are no wheels for version 3.3
 cryptography==3.2.1

--- a/installers/Windows/req-extras-release.txt
+++ b/installers/Windows/req-extras-release.txt
@@ -18,9 +18,5 @@ matplotlib
 cython
 sympy
 
-# Dependencies without wheels in PyPI
-# Rtree
-./installers/Windows/assets/rtree/Rtree-0.9.4-cp37-cp37m-win_amd64.whl
-
 # There are no wheels for version 3.3
 cryptography==3.2.1

--- a/installers/Windows/req-pull-request.txt
+++ b/installers/Windows/req-pull-request.txt
@@ -2,8 +2,5 @@
 ./external-deps/spyder-kernels
 ./external-deps/qdarkstyle
 
-# Rtree from external wheel
-./installers/Windows/assets/rtree/Rtree-0.9.4-cp37-cp37m-win_amd64.whl
-
 # There are no wheels for version 3.3
 cryptography==3.2.1

--- a/installers/Windows/req-release.txt
+++ b/installers/Windows/req-release.txt
@@ -1,6 +1,2 @@
-# Dependencies without wheels in PyPI
-# Rtree
-./installers/Windows/assets/rtree/Rtree-0.9.4-cp37-cp37m-win_amd64.whl
-
 # There are no wheels for version 3.3
 cryptography==3.2.1


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

`rtree >= 0.9.7` has proper wheels in PyPI

Depends on https://github.com/spyder-ide/spyder/pull/14496


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of https://github.com/spyder-ide/windows-installer-assets/issues/1


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
