### PR TITLE
PR: Scroll pager content with keys (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -237,7 +237,7 @@ class IPythonConsole(SpyderPluginWidget):
         self.pager_label.setStyleSheet(
             f"background-color: {QStylePalette.COLOR_ACCENT_2};"
             f"color: {QStylePalette.COLOR_TEXT_1};"
-            "margin: 0px 4px 4px 4px;"
+            "margin: 0px 1px 4px 1px;"
             "padding: 5px;"
             "qproperty-alignment: AlignCenter;"
         )

--- a/spyder/plugins/ipythonconsole/widgets/control.py
+++ b/spyder/plugins/ipythonconsole/widgets/control.py
@@ -104,6 +104,9 @@ class PageControlWidget(QTextEdit, BaseEditMixin):
 
         if key == Qt.Key_Slash and self.isVisible():
             self.show_find_widget.emit()
+        else:
+            # Let the parent widget handle the key press event
+            QTextEdit.keyPressEvent(self, event)
 
     def focusInEvent(self, event):
         """Reimplement Qt method to send focus change notification"""

--- a/spyder/plugins/ipythonconsole/widgets/control.py
+++ b/spyder/plugins/ipythonconsole/widgets/control.py
@@ -61,8 +61,8 @@ class ControlWidget(TracebackLinksMixin, GetHelpMixin,
     def keyPressEvent(self, event):
         """Reimplement Qt Method - Basic keypress event handler"""
         event, text, key, ctrl, shift = restore_keyevent(event)
-        if key == Qt.Key_ParenLeft and not self.has_selected_text() \
-          and self.help_enabled and not self.parent()._reading:
+        if (key == Qt.Key_ParenLeft and not self.has_selected_text()
+                and self.help_enabled and not self.parent()._reading):
             self._key_paren_left(text)
         else:
             # Let the parent widget handle the key press event


### PR DESCRIPTION
## Description of Changes

It was not possible to scroll the pager content using Page up/down or the up/down arrow keys.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
