### PR TITLE
PR: Fix extraneous reloading documents on project switching

### DIFF
--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -101,18 +101,21 @@ class Projects(SpyderDockablePlugin):
 
     Parameters
     ----------
-    project_packages: object
-        Package to install. Currently not in use.
+    project_path: object
+        Loaded project path.
     """
 
-    sig_project_closed = Signal(object)
+    sig_project_closed = Signal((object,), (bool,))
     """
     This signal is emitted when a project is closed.
 
     Parameters
     ----------
-    project_packages: object
-        Package to install. Currently not in use.
+    project_path: object
+        Closed project path (signature 1).
+    close_project: bool
+        This is emitted only when closing a project but not when switching
+        between projects (signature 2).
     """
 
     sig_pythonpath_changed = Signal()
@@ -220,7 +223,7 @@ class Projects(SpyderDockablePlugin):
                                   update_kind=WorkspaceUpdateKind.DELETION,
                                   instance=self))
         if self.editor:
-            self.sig_project_closed.connect(
+            self.sig_project_closed[bool].connect(
                 lambda v: self.editor.setup_open_files())
         if outline_explorer:
             self.sig_project_closed.connect(
@@ -513,6 +516,7 @@ class Projects(SpyderDockablePlugin):
             self.setup_menu_actions()
 
             self.sig_project_closed.emit(path)
+            self.sig_project_closed[bool].emit(True)
             self.sig_pythonpath_changed.emit()
 
             # Hide pane.

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -391,7 +391,6 @@ class Projects(SpyderDockablePlugin):
 
             self._create_project(root_path, project_type_id=project_type)
             self.sig_pythonpath_changed.emit()
-            self.restart_consoles()
             dlg.close()
 
     def _create_project(self, root_path, project_type_id=EmptyProject.ID,

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -390,7 +390,6 @@ class Projects(SpyderDockablePlugin):
                 self.sig_project_closed.emit(active_project.root_path)
 
             self._create_project(root_path, project_type_id=project_type)
-            self.sig_pythonpath_changed.emit()
             dlg.close()
 
     def _create_project(self, root_path, project_type_id=EmptyProject.ID,

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -370,7 +370,6 @@ class Projects(SpyderDockablePlugin):
     def create_new_project(self):
         """Create new project."""
         self.unmaximize()
-        active_project = self.current_active_project
         dlg = ProjectDialog(self.get_widget(),
                             project_types=self.get_project_types())
         result = dlg.exec_()
@@ -379,11 +378,6 @@ class Projects(SpyderDockablePlugin):
         project_type = data.get("project_type", EmptyProject.ID)
 
         if result:
-            # A project was not open before
-            if active_project is None:
-                if self.get_conf('visible_if_project_open'):
-                    self.show_explorer()
-
             self._create_project(root_path, project_type_id=project_type)
             dlg.close()
 

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -25,7 +25,6 @@ from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QInputDialog, QMessageBox
 
 # Local imports
-from spyder.api.config.decorators import on_conf_change
 from spyder.api.exceptions import SpyderAPIError
 from spyder.api.translations import get_translation
 from spyder.api.plugins import Plugins, SpyderDockablePlugin

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -383,11 +383,6 @@ class Projects(SpyderDockablePlugin):
             if active_project is None:
                 if self.get_conf('visible_if_project_open'):
                     self.show_explorer()
-            else:
-                # We are switching projects.
-                # TODO: Don't emit sig_project_closed when we support
-                # multiple workspaces.
-                self.sig_project_closed.emit(active_project.root_path)
 
             self._create_project(root_path, project_type_id=project_type)
             dlg.close()

--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -466,11 +466,6 @@ def test_loaded_and_closed_signals(create_projects, tmpdir, mocker, qtbot):
             [projects.sig_project_loaded, projects.sig_project_closed]):
         projects.open_project(path=path2)
 
-    # Create new project with an active one. This must emit
-    # sig_project_closed!
-    with qtbot.waitSignal(projects.sig_project_closed):
-        projects.create_new_project()
-
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* When switching projects, project close emit will call `editor.setup_open_files` only when not switching projects.
* Removed redundant code in `create_new_project`. This lead to multiple unnecessary calls to `sig_project_closed.emit` and `restart_consoles`.
* Removed unnecessary test for project close signal on create new project. This test fails because a project `root_path` is not set in the mocked dialogue window so a project is not _actually_ created and the active project is not closed. This test is unnecessary since `create_new_project` should not send `sig_project_closed.emit`, which is sent in `open_project` (if switching projects) or the `close_project` and is already tested.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14787

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary 
<!--- Thanks for your help making Spyder better for everyone! --->
