### PR TITLE
PR: Force reading of path stored in Spyder configuration folder as utf-8

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1858,12 +1858,14 @@ class MainWindow(QMainWindow):
     def load_python_path(self):
         """Load path stored in Spyder configuration folder."""
         if osp.isfile(self.SPYDER_PATH):
-            path, _x = encoding.readlines(self.SPYDER_PATH)
+            with open(self.SPYDER_PATH, 'r', encoding='utf-8') as f:
+                path = f.read().splitlines()
             self.path = tuple(name for name in path if osp.isdir(name))
 
         if osp.isfile(self.SPYDER_NOT_ACTIVE_PATH):
-            not_active_path, _x = encoding.readlines(
-                self.SPYDER_NOT_ACTIVE_PATH)
+            with open(self.SPYDER_NOT_ACTIVE_PATH, 'r',
+                      encoding='utf-8') as f:
+                not_active_path = f.read().splitlines()
             self.not_active_path = tuple(name for name in not_active_path
                                          if osp.isdir(name))
 


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
See issue #15692 for description.
The `path` file in the spyder configuration directory, which holds the user provided paths added with the PYTHONPATH manager is not read with correct encoding, and thus not allowing for unicode characters in the paths (e.g. 'ö'). The current read functionality is handled by `encoding.readlines()`, with subsequent calls to `encoding.read()`,` encoding.decode()`, `encoding.get_coding()` which finally calls `chardet.UniversalDetector()`. `chardet` returns (at least sometimes) the wrong encoding as per issue #15692. 

Other fixes were considered
- write BOM to the path file to make sure `chardet` detects utf-8. Using BOM with utf-8 appears, however, to be generally discourages (https://stackoverflow.com/questions/2223882/whats-the-difference-between-utf-8-and-utf-8-without-bom/2223926#2223926)
- rewrite functions in `encoding.py` to allow for defining the encoding when reading a file (note that `read`/`readlines `has a kw encoding, but this is ignored and not used). However, would require more changes, and considered unnecessary complicated and more likely to break other parts of the code due to the extensive use of the `read()` function in `utils/encoding.py`

The proposed and simple solution in this PR simply reads the file with encoding set to utf-8. The `path` file is written by `encoding.write()` and `encoding.encode()` should encode the text using utf-8. 


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15692

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Reinert Huseby Karlsen

<!--- Thanks for your help making Spyder better for everyone! --->
