### PR TITLE
PR: Catch another KeyError when trying to highlight a folding block (Editor)

### DIFF
--- a/spyder/plugins/editor/utils/editor.py
+++ b/spyder/plugins/editor/utils/editor.py
@@ -158,7 +158,13 @@ class DelayJobRunner(object):
     def _exec_requested_job(self):
         """Execute the requested job after the timer has timeout."""
         self._timer.stop()
-        self._job(*self._args, **self._kwargs)
+
+        try:
+            self._job(*self._args, **self._kwargs)
+        except KeyError:
+            # Catching the KeyError above is necessary to avoid
+            # issue spyder-ide/spyder#15712.
+            pass
 
 
 class TextHelper(object):


### PR DESCRIPTION
## Description of Changes

This shows up after editing some text and then trying to highlight the block.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15712

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
