### PR TITLE
PR: Avoid showing "No such comms" warning when restarting the kernel (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.github/workflows/linux-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/linux-tests.yml
@@ -45,6 +45,7 @@ jobs:
           conda install nomkl -y -q
           conda install --file requirements/tests.txt -y -q
           if [ "$PYTHON_VERSION" != "2.7" ]; then conda install -y -q jedi=0.17.2; fi
+          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install -y -q click=7; fi
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/external-deps/spyder-kernels/.github/workflows/macos-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/macos-tests.yml
@@ -41,6 +41,7 @@ jobs:
           conda install nomkl -y -q
           conda install --file requirements/tests.txt -y -q
           if [ "$PYTHON_VERSION" != "2.7" ]; then conda install -y -q jedi=0.17.2; fi
+          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install -y -q click=7; fi
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = no-comms-warning
-	commit = eb4d88a65e5243e2efec84f4acba2be100a0b1a5
-	parent = 001b5b750f8ef36ee41c1ae5a1b417b3e319e593
+	branch = 2.x
+	commit = dcaca9b60f16fb34b8cbac8ff1e6141989af7db8
+	parent = 72b9a13151be68bd18a4916ca854b1ea0f861d8f
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 2.x
-	commit = 5cbae424e7d5608faa85c85661a2eb3db511ebe2
-	parent = 89e3e00f33f7b9db1c9a30e83fccb7300a01b341
+	branch = no-comms-warning
+	commit = eb4d88a65e5243e2efec84f4acba2be100a0b1a5
+	parent = 001b5b750f8ef36ee41c1ae5a1b417b3e319e593
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -64,6 +64,7 @@ class SpyderKernel(IPythonKernel):
     def __init__(self, *args, **kwargs):
         super(SpyderKernel, self).__init__(*args, **kwargs)
 
+        self.comm_manager.get_comm = self._get_comm
         self.frontend_comm = FrontendComm(self)
 
         # All functions that can be called through the comm
@@ -839,3 +840,16 @@ class SpyderKernel(IPythonKernel):
                 get_ipython().run_line_magic('reload_ext', 'wurlitzer')
             except Exception:
                 pass
+
+    def _get_comm(self, comm_id):
+        """
+        We need to redefine this method from ipykernel.comm_manager to
+        avoid showing a warning when the comm corresponding to comm_id
+        is not present.
+
+        Fixes spyder-ide/spyder#15498
+        """
+        try:
+            return self.comm_manager.comms[comm_id]
+        except KeyError:
+            pass

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spyderpdb.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spyderpdb.py
@@ -511,7 +511,19 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         argument (which is an arbitrary expression or statement to be
         executed in the current environment).
         """
-        super(SpyderPdb, self).do_debug(arg)
+        try:
+            super(SpyderPdb, self).do_debug(arg)
+        except Exception:
+            if PY2:
+                t, v = sys.exc_info()[:2]
+                if type(t) == type(''):
+                    exc_type_name = t
+                else: exc_type_name = t.__name__
+                print >>self.stdout, '***', exc_type_name + ':', v
+            else:
+                exc_info = sys.exc_info()[:2]
+                self.error(
+                    traceback.format_exception_only(*exc_info)[-1].strip())
         kernel = get_ipython().kernel
         kernel._register_pdb_session(self)
 


### PR DESCRIPTION
## Description of Changes

I decided to override a comms method in our kernel to not show that warning once and for all.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15498.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12.

<!--- Thanks for your help making Spyder better for everyone! --->
