### PR TITLE
PR: Add environment of custom interpreter to Pylint plugin

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -26,6 +26,7 @@ dependencies:
 - psutil >=5.3
 - pygments >=2.0
 - pylint >=2.5.0,<3.0
+- pylint-venv >=2.1.1
 - pyls-spyder >=0.4.0
 - pyqt <5.16
 - pyqtwebengine <5.16

--- a/installers/macOS/packages.py
+++ b/installers/macOS/packages.py
@@ -22,6 +22,8 @@ pkg_resources:
     packager of your distribution.
 pygments:
     ModuleNotFoundError: No module named 'pygments.formatters.latex'
+pylint_venv:
+    Mandatory: pylint_venv >=2.1.1 : None (NOK)
 pyls_spyder :
     Mandatory: pyls_spyder >=0.1.1 : None (NOK)
 pylsp_black :
@@ -42,6 +44,7 @@ PACKAGES = [
     'humanfriendly',
     'pkg_resources',
     'pygments',
+    'pylint_venv',
     'pyls_spyder',
     'pylsp_black',
     'setuptools',

--- a/installers/macOS/test_app.sh
+++ b/installers/macOS/test_app.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-timeout=60
+timeout=90
 interval=1
 delay=10
 

--- a/requirements/main.yml
+++ b/requirements/main.yml
@@ -24,6 +24,7 @@ dependencies:
   - psutil >=5.3
   - pygments >=2.0
   - pylint >=2.5.0,<3.0
+  - pylint-venv >=2.1.1
   - pyls-spyder >=0.4.0
   - pyqt <5.16
   - pyqtwebengine <5.16

--- a/setup.py
+++ b/setup.py
@@ -224,6 +224,7 @@ install_requires = [
     'psutil>=5.3',
     'pygments>=2.0',
     'pylint>=2.5.0,<3.0',
+    'pylint-venv>=2.1.1',
     'python-lsp-black>=1.2.0',
     'pyls-spyder>=0.4.0',
     'pyqt5<5.16',

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -52,6 +52,7 @@ PICKLESHARE_REQVER = '>=0.4'
 PSUTIL_REQVER = '>=5.3'
 PYGMENTS_REQVER = '>=2.0'
 PYLINT_REQVER = '>=2.5.0;<3.0'
+PYLINT_VENV_REQVER = '>=2.1.1'
 PYLSP_REQVER = '>=1.5.0;<1.6.0'
 PYLSP_BLACK_REQVER = '>=1.2.0'
 PYLS_SPYDER_REQVER = '>=0.4.0'
@@ -178,6 +179,11 @@ DESCRIPTIONS = [
      'package_name': "pylint",
      'features': _("Static code analysis"),
      'required_version': PYLINT_REQVER},
+    {'modname': "pylint_venv",
+     'package_name': "pylint_venv",
+     'features': _("Use the same Pylint installation with different virtual"
+                   " environments"),
+     'required_version': PYLINT_VENV_REQVER},
     {'modname': 'pylsp',
      'package_name': 'python-lsp-server',
      'features': _("Code completion and linting for the Editor"),

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -180,7 +180,7 @@ DESCRIPTIONS = [
      'features': _("Static code analysis"),
      'required_version': PYLINT_REQVER},
     {'modname': "pylint_venv",
-     'package_name': "pylint_venv",
+     'package_name': "pylint-venv",
      'features': _("Use the same Pylint installation with different virtual"
                    " environments"),
      'required_version': PYLINT_VENV_REQVER},

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -28,7 +28,6 @@ from qtpy.QtWidgets import (QInputDialog, QLabel, QMessageBox, QTreeWidgetItem,
                             QVBoxLayout)
 
 # Local imports
-from spyder.config.manager import CONF
 from spyder.api.config.decorators import on_conf_change
 from spyder.api.translations import get_translation
 from spyder.api.widgets.main_widget import PluginMainWidget
@@ -882,10 +881,14 @@ class PylintWidget(PluginMainWidget):
         Check if custom interpreter is active and if so, return path from
         this interpreter
         """
-        custom_interpreter = osp.normpath(CONF.get('main_interpreter',
-                                                   'custom_interpreter'))
-        if CONF.get('main_interpreter', 'default') or \
-                get_python_executable() == custom_interpreter:
+        custom_interpreter = osp.normpath(
+            self.get_conf('executable', section='main_interpreter')
+        )
+
+        if (
+            self.get_conf('default', section='main_interpreter')
+            or get_python_executable() == custom_interpreter
+        ):
             path_of_custom_interpreter = None
         else:
             # Check if custom interpreter is still present

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -885,8 +885,8 @@ class PylintWidget(PluginMainWidget):
         custom_interpreter = osp.normpath(CONF.get('main_interpreter',
                                                    'custom_interpreter'))
         if CONF.get('main_interpreter', 'default') or \
-            get_python_executable() == custom_interpreter:
-                path_of_custom_interpreter = None
+        get_python_executable() == custom_interpreter:
+            path_of_custom_interpreter = None
         else:
             # Check if custom interpreter is still present
             if osp.isfile(custom_interpreter):
@@ -916,8 +916,9 @@ class PylintWidget(PluginMainWidget):
                              'import pylint_venv; \
                                  pylint_venv.inithook(\'{}\',\
                                  force_venv_activation=True)'.format(
-                             path_of_custom_interpreter.replace("\\", 
-                                                                "\\\\")), ]
+                                 path_of_custom_interpreter.replace("\\",
+                                 "\\\\")),
+            ]
 
         pylintrc_path = self.get_pylintrc_path(filename=filename)
         if pylintrc_path is not None:

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -882,11 +882,11 @@ class PylintWidget(PluginMainWidget):
         Check if custom interpreter is active and if so, return path from
         this interpreter
         """
-        custom_interpreter = osp.normpath(CONF.get('main_interpreter', \
+        custom_interpreter = osp.normpath(CONF.get('main_interpreter',
                                                    'custom_interpreter'))
         if CONF.get('main_interpreter', 'default') or \
             get_python_executable() == custom_interpreter:
-            path_of_custom_interpreter = None
+                path_of_custom_interpreter = None
         else:
             # Check if custom interpreter is still present
             if osp.isfile(custom_interpreter):
@@ -913,9 +913,11 @@ class PylintWidget(PluginMainWidget):
         path_of_custom_interpreter = self.test_for_custom_interpreter()
         if path_of_custom_interpreter is not None:
             command_args += ["--init-hook="
-                'import pylint_venv; pylint_venv.inithook(\'{}\',\
-                    force_venv_activation=True)'.format( \
-                             path_of_custom_interpreter.replace("\\", "\\\\")),]
+                             'import pylint_venv; \
+                                 pylint_venv.inithook(\'{}\',\
+                                 force_venv_activation=True)'.format(
+                             path_of_custom_interpreter.replace("\\", 
+                                                                "\\\\")), ]
 
         pylintrc_path = self.get_pylintrc_path(filename=filename)
         if pylintrc_path is not None:

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -885,7 +885,7 @@ class PylintWidget(PluginMainWidget):
         custom_interpreter = osp.normpath(CONF.get('main_interpreter',
                                                    'custom_interpreter'))
         if CONF.get('main_interpreter', 'default') or \
-        get_python_executable() == custom_interpreter:
+            get_python_executable() == custom_interpreter:
             path_of_custom_interpreter = None
         else:
             # Check if custom interpreter is still present
@@ -917,7 +917,7 @@ class PylintWidget(PluginMainWidget):
                                  pylint_venv.inithook(\'{}\',\
                                  force_venv_activation=True)'.format(
                                  path_of_custom_interpreter.replace("\\",
-                                 "\\\\")),
+                                                                    "\\\\")),
             ]
 
         pylintrc_path = self.get_pylintrc_path(filename=filename)

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -885,7 +885,7 @@ class PylintWidget(PluginMainWidget):
         custom_interpreter = osp.normpath(CONF.get('main_interpreter',
                                                    'custom_interpreter'))
         if CONF.get('main_interpreter', 'default') or \
-            get_python_executable() == custom_interpreter:
+                get_python_executable() == custom_interpreter:
             path_of_custom_interpreter = None
         else:
             # Check if custom interpreter is still present
@@ -912,12 +912,12 @@ class PylintWidget(PluginMainWidget):
 
         path_of_custom_interpreter = self.test_for_custom_interpreter()
         if path_of_custom_interpreter is not None:
-            command_args += ["--init-hook="
-                             'import pylint_venv; \
-                                 pylint_venv.inithook(\'{}\',\
-                                 force_venv_activation=True)'.format(
-                                 path_of_custom_interpreter.replace("\\",
-                                                                    "\\\\")),
+            command_args += [
+                "--init-hook="
+                'import pylint_venv; \
+                    pylint_venv.inithook(\'{}\',\
+                    force_venv_activation=True)'.format(
+                        path_of_custom_interpreter.replace("\\", "\\\\")),
             ]
 
         pylintrc_path = self.get_pylintrc_path(filename=filename)

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -878,8 +878,8 @@ class PylintWidget(PluginMainWidget):
 
     def test_for_custom_interpreter(self):
         """
-        Check if custom interpreter is active and if so, return path from
-        this interpreter
+        Check if custom interpreter is active and if so, return path for the
+        environment that contains it.
         """
         custom_interpreter = osp.normpath(
             self.get_conf('executable', section='main_interpreter')
@@ -893,7 +893,16 @@ class PylintWidget(PluginMainWidget):
         else:
             # Check if custom interpreter is still present
             if osp.isfile(custom_interpreter):
-                path_of_custom_interpreter = osp.dirname(custom_interpreter)
+                # Pylint-venv requires the root path to a virtualenv, but what
+                # we save in Preferences is the path to its Python interpreter.
+                # So, we need to make the following adjustments here to get the
+                # right path to pass to it.
+                if os.name == 'nt':
+                    path_of_custom_interpreter = osp.dirname(
+                        custom_interpreter)
+                else:
+                    path_of_custom_interpreter = osp.dirname(osp.dirname(
+                        custom_interpreter))
             else:
                 path_of_custom_interpreter = None
 

--- a/spyder/plugins/pylint/tests/test_pylint.py
+++ b/spyder/plugins/pylint/tests/test_pylint.py
@@ -28,9 +28,13 @@ if QApplication.instance() is None:
 
 # Local imports
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
+from spyder.config.base import running_in_ci
 from spyder.config.manager import CONF
+from spyder.config.utils import is_anaconda
 from spyder.plugins.pylint.plugin import Pylint
 from spyder.plugins.pylint.utils import get_pylintrc_path
+from spyder.utils.conda import get_list_conda_envs
+from spyder.utils.misc import get_python_executable
 
 # pylint: disable=redefined-outer-name
 
@@ -91,6 +95,11 @@ def pylint_plugin(mocker, qtbot):
     plugin = Pylint(parent=main_window, configuration=CONF)
     plugin._register()
     plugin.set_conf("history_filenames", [])
+
+    # This avoids possible errors in our tests for not being available while
+    # running them.
+    plugin.set_conf('executable', get_python_executable(),
+                    section='main_interpreter')
 
     widget = plugin.get_widget()
     widget.resize(640, 480)
@@ -280,6 +289,49 @@ def test_pylint_max_history_conf(pylint_plugin, pylint_test_scripts):
 
     assert pylint_widget.filecombo.count() == 1
     assert 'test_script_2.py' in pylint_widget.curr_filenames[0]
+
+
+@flaky(max_runs=3)
+@pytest.mark.parametrize("custom_interpreter", [True, False])
+@pytest.mark.skipif(not is_anaconda(), reason='Only works with Anaconda')
+@pytest.mark.skipif(not running_in_ci(), reason='Only works on CIs')
+def test_custom_interpreter(pylint_plugin, tmp_path, qtbot,
+                            custom_interpreter):
+    """Test that the plugin works as expected with custom interpreters."""
+    # Get conda env to use
+    conda_env = [
+        env[0] for env in get_list_conda_envs().values()
+        if 'jedi-test-env' in env[0]
+    ][0]
+
+    # Set custom interpreter
+    if custom_interpreter:
+        pylint_plugin.set_conf('default', False, section='main_interpreter')
+        pylint_plugin.set_conf('executable', conda_env,
+                               section='main_interpreter')
+    else:
+        pylint_plugin.set_conf('default', True, section='main_interpreter')
+        pylint_plugin.set_conf('executable', get_python_executable(),
+                               section='main_interpreter')
+
+    # Write test code to file
+    file_path = tmp_path / 'test_custom_interpreter.py'
+    file_path.write_text('import flask')
+
+    # Run analysis and get its data
+    pylint_widget = pylint_plugin.get_widget()
+    pylint_plugin.start_code_analysis(filename=str(file_path))
+    qtbot.waitUntil(
+        lambda: pylint_widget.get_data(file_path)[1] is not None,
+        timeout=5000)
+    pylint_data = pylint_widget.get_data(filename=str(file_path))
+
+    # Assert no import errors are reported for custom interpreters
+    errors = pylint_data[1][3]["E:"]
+    if custom_interpreter:
+        assert not errors
+    else:
+        assert errors
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Added a function to get the path of the custom interpreter if one is active. Then activating the custom environment in pylint via an init-hook and the pylint_venv package.

Open question: Where pylint_venv should be added in the requirements (only available in pip)?

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15709


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: mwawra

<!--- Thanks for your help making Spyder better for everyone! --->
