### PR TITLE
PR: Add restriction to pytest-qt to be < 4.0

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -65,7 +65,7 @@ dependencies:
 - pytest-lazy-fixture
 - pytest-mock
 - pytest-order
-- pytest-qt
+- pytest-qt <4.0
 - pytest-xvfb
 - pyyaml
 - scipy

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -13,7 +13,7 @@ pytest-cov
 pytest-lazy-fixture
 pytest-mock
 pytest-order
-pytest-qt
+pytest-qt <4.0
 pyyaml
 scipy
 sympy

--- a/setup.py
+++ b/setup.py
@@ -258,7 +258,7 @@ extras_require = {
         'pytest-lazy-fixture',
         'pytest-mock',
         'pytest-order',
-        'pytest-qt',
+        'pytest-qt<4.0',
         'pyyaml',
         'scipy',
         'sympy',


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

`pytest-qt` 4.0.0 makes the test fail


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->



### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
