### PR TITLE
PR: Bump CONF_VERSION after move to pylsp server (Completions)

### DIFF
--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -87,7 +87,7 @@ class LanguageServerProvider(SpyderCompletionProvider):
     #    want to *rename* options, then you need to do a MAJOR update in
     #    version, e.g. from 0.1.0 to 1.0.0
     # 3. You don't need to touch this value if you're just adding a new option
-    CONF_VERSION = "0.1.0"
+    CONF_VERSION = "0.2.0"
     CONF_TABS = TABS
 
     STOPPED = 'stopped'


### PR DESCRIPTION
## Description of Changes

This was missing in PR #15657. Without it Spyder was trying to load the previous `pyls` server when moving from a 5.0.4 settings to 5.x, master or the upcoming 5.1.0.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
