### PR TITLE
PR: Make IPython Console widgets and other elements to use the SpyderConfigurationAccessor

### DIFF
--- a/spyder/api/config/mixins.py
+++ b/spyder/api/config/mixins.py
@@ -13,7 +13,11 @@ import logging
 from typing import Any, Union, Optional
 import warnings
 
+# Third-party imports
+from qtpy.QtWidgets import QAction, QWidget
+
 # Local imports
+from spyder.config.gui import Shortcut
 from spyder.config.manager import CONF
 from spyder.config.types import ConfigurationKey
 from spyder.config.user import NoDefault
@@ -200,6 +204,38 @@ class SpyderConfigurationAccessor:
         """
         context = self.CONF_SECTION if context is None else context
         return CONF.get_shortcut(context, name)
+    
+    def config_shortcut(
+            self, action: QAction, name: str, parent: QWidget,
+            context: Optional[str] = None) -> Shortcut:
+        """
+        Create a Shortcut namedtuple for a widget.
+
+        The data contained in this tuple will be registered in our shortcuts
+        preferences page.
+
+        Parameters
+        ----------
+        action: QAction
+            Action that will use the shortcut.
+        name: str
+            Key identifier under which the shortcut is stored.
+        parent: QWidget
+            Parent widget for the shortcut.
+        context: Optional[str]
+            Name of the context (plugin) where the shortcut was defined.
+        
+
+        Returns
+        -------
+        shortcut: Shortcut
+            Namedtuple with the information of the shortcut as used for the
+            shortcuts preferences page.
+
+        """
+        shortcut_context = self.CONF_SECTION if context is None else context
+        return  CONF.config_shortcut(action, shortcut_context, name, parent)
+        
 
 
 class SpyderConfigurationObserver(SpyderConfigurationAccessor):

--- a/spyder/api/config/mixins.py
+++ b/spyder/api/config/mixins.py
@@ -230,7 +230,6 @@ class SpyderConfigurationAccessor:
         shortcut: Shortcut
             Namedtuple with the information of the shortcut as used for the
             shortcuts preferences page.
-
         """
         shortcut_context = self.CONF_SECTION if context is None else context
         return CONF.config_shortcut(action, shortcut_context, name, parent)

--- a/spyder/api/config/mixins.py
+++ b/spyder/api/config/mixins.py
@@ -204,7 +204,7 @@ class SpyderConfigurationAccessor:
         """
         context = self.CONF_SECTION if context is None else context
         return CONF.get_shortcut(context, name)
-    
+
     def config_shortcut(
             self, action: QAction, name: str, parent: QWidget,
             context: Optional[str] = None) -> Shortcut:
@@ -224,7 +224,6 @@ class SpyderConfigurationAccessor:
             Parent widget for the shortcut.
         context: Optional[str]
             Name of the context (plugin) where the shortcut was defined.
-        
 
         Returns
         -------
@@ -234,8 +233,7 @@ class SpyderConfigurationAccessor:
 
         """
         shortcut_context = self.CONF_SECTION if context is None else context
-        return  CONF.config_shortcut(action, shortcut_context, name, parent)
-        
+        return CONF.config_shortcut(action, shortcut_context, name, parent)
 
 
 class SpyderConfigurationObserver(SpyderConfigurationAccessor):

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -493,6 +493,9 @@ DEFAULTS = [
               'ipython_console/new tab': "Ctrl+T",
               'ipython_console/reset namespace': "Ctrl+Alt+R",
               'ipython_console/restart kernel': "Ctrl+.",
+              'ipython_console/inspect current object': "Ctrl+I",
+              'ipython_console/clear shell': "Ctrl+L",
+              'ipython_console/clear line': "Shift+Escape",
               # ---- In widgets/arraybuider.py ----
               'array_builder/enter array inline': "Ctrl+Alt+M",
               'array_builder/enter array table': "Ctrl+M",

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -84,7 +84,7 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderConfigurationAccessor):
 
     sig_append_to_history_requested = Signal(str, str)
 
-    CONF_SECTION = 'inspect current object'
+    CONF_SECTION = 'ipython_console'
     SEPARATOR = '{0}## ---({1})---'.format(os.linesep*2, time.ctime())
     INITHISTORY = ['# -*- coding: utf-8 -*-',
                    '# *** Spyder Python Console History Log ***',]
@@ -530,8 +530,7 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderConfigurationAccessor):
         reset_namespace_action = create_action(
             self,
             _("Remove all variables"),
-            QKeySequence(self.get_shortcut('reset namespace',
-                                           context='ipython_console')),
+            QKeySequence(self.get_shortcut('reset namespace')),
             icon=ima.icon('editdelete'),
             triggered=self.reset_namespace)
 

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -31,9 +31,9 @@ from qtpy.QtWidgets import (QHBoxLayout, QLabel, QMenu, QMessageBox,
                             QToolButton, QVBoxLayout, QWidget)
 
 # Local imports
+from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.config.base import (_, get_module_source_path,
                                 running_under_pytest)
-from spyder.config.manager import CONF
 from spyder.utils.icon_manager import ima
 from spyder.utils import sourcecode
 from spyder.utils.image_path_manager import get_image_path
@@ -74,7 +74,7 @@ except AttributeError:
 #-----------------------------------------------------------------------------
 # Client widget
 #-----------------------------------------------------------------------------
-class ClientWidget(QWidget, SaveHistoryMixin):
+class ClientWidget(QWidget, SaveHistoryMixin, SpyderConfigurationAccessor):
     """
     Client widget for the IPython Console
 
@@ -82,11 +82,12 @@ class ClientWidget(QWidget, SaveHistoryMixin):
     plugin and each shell widget.
     """
 
+    sig_append_to_history_requested = Signal(str, str)
+
+    CONF_SECTION = 'inspect current object'
     SEPARATOR = '{0}## ---({1})---'.format(os.linesep*2, time.ctime())
     INITHISTORY = ['# -*- coding: utf-8 -*-',
                    '# *** Spyder Python Console History Log ***',]
-
-    sig_append_to_history_requested = Signal(str, str)
 
     def __init__(self, plugin, id_,
                  history_filename, config_options,
@@ -516,29 +517,28 @@ class ClientWidget(QWidget, SaveHistoryMixin):
         inspect_action = create_action(
             self,
             _("Inspect current object"),
-            QKeySequence(CONF.get_shortcut('console',
-                                           'inspect current object')),
+            QKeySequence(self.get_shortcut('inspect current object')),
             icon=ima.icon('MessageBoxInformation'),
             triggered=self.inspect_object)
 
         clear_line_action = create_action(
             self,
             _("Clear line or block"),
-            QKeySequence(CONF.get_shortcut('console', 'clear line')),
+            QKeySequence(self.get_shortcut('clear line')),
             triggered=self.clear_line)
 
         reset_namespace_action = create_action(
             self,
             _("Remove all variables"),
-            QKeySequence(CONF.get_shortcut('ipython_console',
-                                           'reset namespace')),
+            QKeySequence(self.get_shortcut('reset namespace',
+                                           context='ipython_console')),
             icon=ima.icon('editdelete'),
             triggered=self.reset_namespace)
 
         clear_console_action = create_action(
             self,
             _("Clear console"),
-            QKeySequence(CONF.get_shortcut('console', 'clear shell')),
+            QKeySequence(self.get_shortcut('clear shell')),
             triggered=self.clear_console)
 
         quit_action = create_action(

--- a/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
@@ -21,12 +21,14 @@ from qtpy.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox, QGridLayout,
                             QVBoxLayout)
 
 # Local imports
+from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.config.base import _, get_home_dir
-from spyder.config.manager import CONF
 
 
-class KernelConnectionDialog(QDialog):
+class KernelConnectionDialog(QDialog, SpyderConfigurationAccessor):
     """Dialog to connect to existing kernels (either local or remote)."""
+
+    CONF_SECTION = 'existing-kernel'
 
     def __init__(self, parent=None):
         super(KernelConnectionDialog, self).__init__(parent)
@@ -164,7 +166,7 @@ class KernelConnectionDialog(QDialog):
 
     def load_connection_settings(self):
         """Load the user's previously-saved kernel connection settings."""
-        existing_kernel = CONF.get("existing-kernel", "settings", {})
+        existing_kernel = self.get_conf("settings", {})
 
         connection_file_path = existing_kernel.get("json_file_path", "")
         is_remote = existing_kernel.get("is_remote", False)
@@ -216,7 +218,7 @@ class KernelConnectionDialog(QDialog):
             "is_ssh_keyfile": is_ssh_key,
             "ssh_key_file_path": self.kf.text()
         }
-        CONF.set("existing-kernel", "settings", connection_settings)
+        self.set_conf("settings", connection_settings)
 
         try:
             import keyring

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -19,9 +19,9 @@ from qtpy.QtCore import Signal, QThread
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports
+from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.config.base import (
     _, is_pynsist, running_in_mac_app, running_under_pytest)
-from spyder.config.manager import CONF
 from spyder.py3compat import to_text_string
 from spyder.utils.palette import SpyderPalette
 from spyder.utils import programs, encoding
@@ -40,7 +40,7 @@ MODULES_FAQ_URL = (
 
 
 class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
-                  FigureBrowserWidget):
+                  FigureBrowserWidget, SpyderConfigurationAccessor):
     """
     Shell widget for the IPython Console
 
@@ -75,6 +75,8 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
 
     # For printing internal errors
     sig_exception_occurred = Signal(dict)
+
+    CONF_SECTION = 'ipython_console'
 
     def __init__(self, ipyclient, additional_options, interpreter_versions,
                  external_kernel, *args, **kw):
@@ -450,7 +452,7 @@ the sympy module (e.g. plot)
         self._reading = False
 
     def _reset_namespace(self):
-        warning = CONF.get('ipython_console', 'show_reset_namespace_warning')
+        warning = self.get_conf('show_reset_namespace_warning')
         self.reset_namespace(warning=warning)
 
     def reset_namespace(self, warning=False, message=False):
@@ -485,8 +487,8 @@ the sympy module (e.g. plot)
             answer = box.exec_()
 
             # Update checkbox based on user interaction
-            CONF.set('ipython_console', 'show_reset_namespace_warning',
-                     not box.is_checked())
+            self.set_conf(
+                'show_reset_namespace_warning', not box.is_checked())
             self.ipyclient.reset_warning = not box.is_checked()
 
             if answer != QMessageBox.Yes:
@@ -530,49 +532,49 @@ the sympy module (e.g. plot)
 
     def create_shortcuts(self):
         """Create shortcuts for ipyconsole."""
-        inspect = CONF.config_shortcut(
+        inspect = self.config_shortcut(
             self._control.inspect_current_object,
             context='Console',
             name='Inspect current object',
             parent=self)
 
-        clear_console = CONF.config_shortcut(
+        clear_console = self.config_shortcut(
             self.clear_console,
             context='Console',
             name='Clear shell',
             parent=self)
 
-        restart_kernel = CONF.config_shortcut(
+        restart_kernel = self.config_shortcut(
             self.ipyclient.restart_kernel,
             context='ipython_console',
             name='Restart kernel',
             parent=self)
 
-        new_tab = CONF.config_shortcut(
+        new_tab = self.config_shortcut(
             lambda: self.new_client.emit(),
             context='ipython_console',
             name='new tab',
             parent=self)
 
-        reset_namespace = CONF.config_shortcut(
+        reset_namespace = self.config_shortcut(
             lambda: self._reset_namespace(),
             context='ipython_console',
             name='reset namespace',
             parent=self)
 
-        array_inline = CONF.config_shortcut(
+        array_inline = self.config_shortcut(
             self._control.enter_array_inline,
             context='array_builder',
             name='enter array inline',
             parent=self)
 
-        array_table = CONF.config_shortcut(
+        array_table = self.config_shortcut(
             self._control.enter_array_table,
             context='array_builder',
             name='enter array table',
             parent=self)
 
-        clear_line = CONF.config_shortcut(
+        clear_line = self.config_shortcut(
             self.ipyclient.clear_line,
             context='console',
             name='clear line',
@@ -764,7 +766,8 @@ the sympy module (e.g. plot)
         Bytes are returned instead of str to support non utf-8 files.
         """
         editorstack = self.get_editorstack()
-        if save_all and CONF.get('editor', 'save_all_before_run', True):
+        if save_all and self.get_conf(
+                'save_all_before_run', default=True, section='editor'):
             editorstack.save_all(save_new_files=False)
         editor = self.get_editor(filename)
 

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -19,7 +19,6 @@ from qtpy.QtCore import Signal, QThread
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports
-from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.config.base import (
     _, is_pynsist, running_in_mac_app, running_under_pytest)
 from spyder.py3compat import to_text_string
@@ -40,7 +39,7 @@ MODULES_FAQ_URL = (
 
 
 class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
-                  FigureBrowserWidget, SpyderConfigurationAccessor):
+                  FigureBrowserWidget):
     """
     Shell widget for the IPython Console
 
@@ -75,8 +74,6 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
 
     # For printing internal errors
     sig_exception_occurred = Signal(dict)
-
-    CONF_SECTION = 'ipython_console'
 
     def __init__(self, ipyclient, additional_options, interpreter_versions,
                  external_kernel, *args, **kw):

--- a/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
@@ -14,7 +14,6 @@ import os
 import pytest
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QDialogButtonBox
-import time
 
 # Local imports
 from spyder.plugins.ipythonconsole.widgets.kernelconnect import (

--- a/spyder/plugins/shortcuts/tests/test_shortcuts.py
+++ b/spyder/plugins/shortcuts/tests/test_shortcuts.py
@@ -96,7 +96,7 @@ def test_shortcuts_filtering(shortcut_table):
     assert not shortcut_table.isSortingEnabled()
     # Six hits (causes a bit of an issue to hardcode it like this if new
     # shortcuts are added...)
-    assert shortcut_table.model().rowCount() == 7
+    assert shortcut_table.model().rowCount() == 10
     # Remove filter text
     shortcut_table.finder = FilterTextMock('')
     shortcut_table.set_regex()

--- a/spyder/plugins/shortcuts/tests/test_shortcuts.py
+++ b/spyder/plugins/shortcuts/tests/test_shortcuts.py
@@ -96,7 +96,7 @@ def test_shortcuts_filtering(shortcut_table):
     assert not shortcut_table.isSortingEnabled()
     # Six hits (causes a bit of an issue to hardcode it like this if new
     # shortcuts are added...)
-    assert shortcut_table.model().rowCount() == 10
+    assert shortcut_table.model().rowCount() == 7
     # Remove filter text
     shortcut_table.finder = FilterTextMock('')
     shortcut_table.set_regex()
@@ -120,9 +120,9 @@ def test_shortcut_filtering_context(shortcut_table):
     # Filter by "console"
     shortcut_table.finder = FilterTextMock('console')
     shortcut_table.set_regex()
-    # Verify the number of entries after the regex are 7
+    # Verify the number of entries after the regex are 10
     # If a new shortcut is added to console, this needs to be changed
-    assert shortcut_table.model().rowCount() == 7
+    assert shortcut_table.model().rowCount() == 10
 
     # Filter by "pylint"
     shortcut_table.finder = FilterTextMock('pylint')

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -56,7 +56,6 @@ from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.config.base import _
 from spyder.config.fonts import DEFAULT_SMALL_DELTA
 from spyder.config.gui import get_font
-from spyder.config.manager import CONF
 from spyder.py3compat import (io, is_text_string, is_type_text_string, PY2,
                               to_text_string, perf_counter)
 from spyder.utils.icon_manager import ima
@@ -513,7 +512,7 @@ class DataFrameModel(QAbstractTableModel):
         self.endResetModel()
 
 
-class DataFrameView(QTableView):
+class DataFrameView(QTableView, SpyderConfigurationAccessor):
     """
     Data Frame view class.
 
@@ -525,6 +524,8 @@ class DataFrameView(QTableView):
     sig_sort_by_column = Signal()
     sig_fetch_more_columns = Signal()
     sig_fetch_more_rows = Signal()
+
+    CONF_SECTION = 'variable_explorer'
 
     def __init__(self, parent, model, header, hscroll, vscroll):
         """Constructor."""
@@ -539,11 +540,7 @@ class DataFrameView(QTableView):
         self.header_class = header
         self.header_class.sectionClicked.connect(self.sortByColumn)
         self.menu = self.setup_menu()
-        CONF.config_shortcut(
-            self.copy,
-            context='variable_explorer',
-            name='copy',
-            parent=self)
+        self.config_shortcut(self.copy, 'copy', self)
         self.horizontalScrollBar().valueChanged.connect(
             self._load_more_columns)
         self.verticalScrollBar().valueChanged.connect(self._load_more_rows)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Move IPython Console widgets and other components to use the `SpyderConfigurationAccessor` instead of using `CONF` directly


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
