### PR TITLE
PR: Fix Wrong EOL in  LSP Requests text

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1085,7 +1085,7 @@ class CodeEditor(TextEditBaseWidget):
     def document_did_open(self):
         """Send textDocument/didOpen request to the server."""
         cursor = self.textCursor()
-        text = self.toPlainText()
+        text = self.get_text_with_eol()
         if self.is_ipython():
             # Send valid python text to LSP as it doesn't support IPython
             text = self.ipython_to_python(text)
@@ -1134,7 +1134,7 @@ class CodeEditor(TextEditBaseWidget):
     def document_did_change(self, text=None):
         """Send textDocument/didChange request to the server."""
         self.text_version += 1
-        text = self.toPlainText()
+        text = self.get_text_with_eol()
         if self.is_ipython():
             # Send valid python text to LSP
             text = self.ipython_to_python(text)
@@ -1460,7 +1460,7 @@ class CodeEditor(TextEditBaseWidget):
     # ------------- LSP: Hover/Mouse ---------------------------------------
     @request(method=CompletionRequestTypes.DOCUMENT_CURSOR_EVENT)
     def request_cursor_event(self):
-        text = self.toPlainText()
+        text = self.get_text_with_eol()
         cursor = self.textCursor()
         params = {
             'file': self.filename,
@@ -1692,7 +1692,7 @@ class CodeEditor(TextEditBaseWidget):
         if edits is None:
             return
 
-        text = self.toPlainText()
+        text = self.get_text_with_eol()
         text_tokens = list(text)
         merged_text = None
         for edit in edits:
@@ -1833,7 +1833,7 @@ class CodeEditor(TextEditBaseWidget):
         """Send save request."""
         params = {'file': self.filename}
         if self.save_include_text:
-            params['text'] = self.toPlainText()
+            params['text'] = self.get_text_with_eol()
         return params
 
     @request(method=CompletionRequestTypes.DOCUMENT_DID_CLOSE,

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1799,7 +1799,7 @@ class EditorStack(QWidget):
         Returns:
             int: computed hash.
         """
-        txt = fileinfo.editor.get_text_with_eol()
+        txt = to_text_string(fileinfo.editor.get_text_with_eol())
         return hash(txt)
 
     def _write_to_file(self, fileinfo, filename):
@@ -1812,7 +1812,7 @@ class EditorStack(QWidget):
         This is a low-level function that only saves the text to file in the
         correct encoding without doing any error handling.
         """
-        txt = fileinfo.editor.get_text_with_eol()
+        txt = to_text_string(fileinfo.editor.get_text_with_eol())
         fileinfo.encoding = encoding.write(txt, filename, fileinfo.encoding)
 
     def save(self, index=None, force=False, save_new_files=True):

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -692,12 +692,14 @@ class BaseEditMixin(object):
             return os.linesep
 
     def get_text_with_eol(self):
-        """Same as 'toPlainText', replace '\n'
-        by correct end-of-line characters"""
-        utext = self.toPlainText()
+        """
+        Same as 'toPlainText', replacing '\n' by correct end-of-line
+        characters.
+        """
+        text = self.toPlainText()
         linesep = self.get_line_separator()
-        utext.replace('\n', linesep)
-        return utext
+        text.replace('\n', linesep)
+        return text
 
     #------Positions, coordinates (cursor, EOF, ...)
     def get_position(self, subject):

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -694,14 +694,9 @@ class BaseEditMixin(object):
     def get_text_with_eol(self):
         """Same as 'toPlainText', replace '\n'
         by correct end-of-line characters"""
-        utext = to_text_string(self.toPlainText())
+        utext = self.toPlainText()
         linesep = self.get_line_separator()
-        if linesep != '\n':
-            lines = utext.splitlines()
-            txt = linesep.join(lines)
-            if utext.endswith('\n'):
-                txt += linesep
-            return txt
+        utext.replace('\n', linesep)
         return utext
 
     #------Positions, coordinates (cursor, EOF, ...)

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -695,12 +695,14 @@ class BaseEditMixin(object):
         """Same as 'toPlainText', replace '\n'
         by correct end-of-line characters"""
         utext = to_text_string(self.toPlainText())
-        lines = utext.splitlines()
         linesep = self.get_line_separator()
-        txt = linesep.join(lines)
-        if utext.endswith('\n'):
-            txt += linesep
-        return txt
+        if linesep != '\n':
+            lines = utext.splitlines()
+            txt = linesep.join(lines)
+            if utext.endswith('\n'):
+                txt += linesep
+            return txt
+        return utext
 
     #------Positions, coordinates (cursor, EOF, ...)
     def get_position(self, subject):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Replace the ``toPlainText`` method used to get the text to use in LSP Requests  with ``get_text_with_eol`` that corrects the ``toPlainText`` EOL. This fixes the wrong position returned by the Language Servers when a document has line endings different from line feed.
Modify ``get_text_with_eol`` to replace LF with correct document EOL and keep the same string encoding as ``toPlainText``.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15900


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @hlouzada

<!--- Thanks for your help making Spyder better for everyone! --->
