### PR TITLE
PR: Add border around WebView widgets

### DIFF
--- a/.github/workflows/test-files.yml
+++ b/.github/workflows/test-files.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 5.x
+      - 5.*
       - 4.x
     paths:
       - '.github/scripts/*.sh'
@@ -18,7 +18,7 @@ on:
   pull_request:
     branches:
       - master
-      - 5.x
+      - 5.*
       - 4.x
     paths:
       - '.github/scripts/*.sh'

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 5.x
+      - 5.*
       - 4.x
     paths:
       - '.github/scripts/*.sh'
@@ -18,7 +18,7 @@ on:
   pull_request:
     branches:
       - master
-      - 5.x
+      - 5.*
       - 4.x
     paths:
       - '.github/scripts/*.sh'

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 5.x
+      - 5.*
       - 4.x
     paths:
       - '.github/scripts/*.sh'
@@ -18,7 +18,7 @@ on:
   pull_request:
     branches:
       - master
-      - 5.x
+      - 5.*
       - 4.x
     paths:
       - '.github/scripts/*.sh'

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 5.x
+      - 5.*
       - 4.x
     paths:
       - '.github/scripts/*.sh'
@@ -18,7 +18,7 @@ on:
   pull_request:
     branches:
       - master
-      - 5.x
+      - 5.*
       - 4.x
     paths:
       - '.github/scripts/*.sh'

--- a/spyder/config/gui.py
+++ b/spyder/config/gui.py
@@ -18,6 +18,7 @@ Important note regarding shortcuts:
 from collections import namedtuple
 
 # Third party imports
+from qtpy import PYQT_VERSION
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QFont, QFontDatabase, QKeySequence
 from qtpy.QtWidgets import QShortcut
@@ -25,6 +26,7 @@ from qtpy.QtWidgets import QShortcut
 # Local imports
 from spyder.config.manager import CONF
 from spyder.py3compat import to_text_string
+from spyder.utils import programs
 from spyder.utils import syntaxhighlighters as sh
 
 # Third-party imports
@@ -36,6 +38,9 @@ Shortcut = namedtuple('Shortcut', 'data')
 
 # Stylesheet to remove the indicator that appears on tool buttons with a menu.
 STYLE_BUTTON_CSS = "QToolButton::menu-indicator{image: none;}"
+
+# Check for old PyQt versions
+OLD_PYQT = programs.check_version(PYQT_VERSION, "5.12", "<")
 
 
 def font_is_installed(font):

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -57,7 +57,7 @@ from spyder.utils.misc import get_error_match, remove_backslashes
 from spyder.utils.palette import QStylePalette
 from spyder.utils.programs import get_temp_dir
 from spyder.utils.qthelpers import MENU_SEPARATOR, add_actions, create_action
-from spyder.widgets.browser import WebView
+from spyder.widgets.browser import FrameWebView
 from spyder.widgets.findreplace import FindReplace
 from spyder.widgets.tabs import Tabs
 
@@ -226,7 +226,7 @@ class IPythonConsole(SpyderPluginWidget):
             layout.addWidget(self.tabwidget)
 
         # Info widget
-        self.infowidget = WebView(self)
+        self.infowidget = FrameWebView(self)
         if WEBENGINE:
             self.infowidget.page().setBackgroundColor(QColor(MAIN_BG_COLOR))
         else:

--- a/spyder/plugins/onlinehelp/widgets.py
+++ b/spyder/plugins/onlinehelp/widgets.py
@@ -23,7 +23,7 @@ from qtpy.QtWidgets import QApplication, QLabel, QVBoxLayout
 from spyder.api.translations import get_translation
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.plugins.onlinehelp.pydoc_patch import _start_server, _url_handler
-from spyder.widgets.browser import WebView, WebViewActions
+from spyder.widgets.browser import FrameWebView, WebViewActions
 from spyder.widgets.comboboxes import UrlComboBox
 from spyder.widgets.findreplace import FindReplace
 
@@ -142,8 +142,10 @@ class PydocBrowser(PluginMainWidget):
         # Widgets
         self.label = QLabel(_("Package:"))
         self.url_combo = UrlComboBox(self)
-        self.webview = WebView(self,
-                               handle_links=self.get_conf('handle_links'))
+        self.webview = FrameWebView(
+            self,
+            handle_links=self.get_conf('handle_links')
+        )
         self.find_widget = FindReplace(self)
 
         # Setup

--- a/spyder/plugins/onlinehelp/widgets.py
+++ b/spyder/plugins/onlinehelp/widgets.py
@@ -159,12 +159,10 @@ class PydocBrowser(PluginMainWidget):
         self.webview.set_zoom_factor(self.get_conf('zoom_factor'))
 
         # Layout
-        spacing = 10
         layout = QVBoxLayout()
         layout.addWidget(self.webview)
-        layout.addSpacing(spacing)
+        layout.addSpacing(1)
         layout.addWidget(self.find_widget)
-        layout.addSpacing(int(spacing / 2))
         self.setLayout(layout)
 
         # Signals

--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -14,14 +14,11 @@ import sys
 import qdarkstyle
 import qstylizer
 from qstylizer.parser import parse as parse_stylesheet
-from qtpy import PYQT_VERSION
 
 # Local imports
+from spyder.config.gui import OLD_PYQT
 from spyder.utils.palette import QStylePalette
-from spyder.utils import programs
 
-
-OLD_PYQT = programs.check_version(PYQT_VERSION, "5.12", "<")
 
 # =============================================================================
 # ---- Base stylesheet class

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -531,10 +531,14 @@ class FrameWebView(QFrame):
     """
     linkClicked = Signal(QUrl)
 
-    def __init__(self, parent):
+    def __init__(self, parent, handle_links=True):
         super().__init__(parent)
 
-        self._webview = WebView(self, class_parent=parent)
+        self._webview = WebView(
+            self,
+            handle_links=handle_links,
+            class_parent=parent
+        )
         self._webview.sig_focus_in_event.connect(
             lambda: self._apply_stylesheet(focus=True))
         self._webview.sig_focus_out_event.connect(
@@ -546,10 +550,11 @@ class FrameWebView(QFrame):
         self.setLayout(layout)
         self._apply_stylesheet()
 
-        if WEBENGINE:
-            self._webview.page().linkClicked.connect(self.linkClicked)
-        else:
-            self._webview.linkClicked.connect(self.linkClicked)
+        if handle_links:
+            if WEBENGINE:
+                self._webview.page().linkClicked.connect(self.linkClicked)
+            else:
+                self._webview.linkClicked.connect(self.linkClicked)
 
     def __getattr__(self, name):
         if name == '_webview':

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -23,6 +23,7 @@ from qtpy.QtWidgets import QFrame, QHBoxLayout, QLabel, QProgressBar, QWidget
 from spyder.api.translations import get_translation
 from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.config.base import DEV
+from spyder.config.gui import OLD_PYQT
 from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils.icon_manager import ima
 from spyder.utils.palette import QStylePalette
@@ -353,9 +354,11 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
         https://bugreports.qt.io/browse/QTBUG-52999
         """
         if WEBENGINE:
-            self.setEnabled(False)
+            if OLD_PYQT:
+                self.setEnabled(False)
             super(WebView, self).setHtml(html, baseUrl)
-            self.setEnabled(True)
+            if OLD_PYQT:
+                self.setEnabled(True)
         else:
             super(WebView, self).setHtml(html, baseUrl)
 

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -12,7 +12,8 @@ import sre_constants
 import sys
 
 # Third party imports
-from qtpy.QtCore import Qt, QUrl, Signal, Slot
+import qstylizer
+from qtpy.QtCore import QEvent, Qt, QUrl, Signal, Slot
 from qtpy.QtGui import QFontInfo
 from qtpy.QtWebEngineWidgets import (WEBENGINE, QWebEnginePage,
                                      QWebEngineSettings, QWebEngineView)
@@ -24,6 +25,7 @@ from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.config.base import DEV
 from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils.icon_manager import ima
+from spyder.utils.palette import QStylePalette
 from spyder.utils.qthelpers import (action2button, create_plugin_layout,
                                     create_toolbutton)
 from spyder.widgets.comboboxes import UrlComboBox
@@ -86,6 +88,15 @@ class WebPage(QWebEnginePage):
 class WebView(QWebEngineView, SpyderWidgetMixin):
     """
     Web view.
+    """
+    sig_focus_in_event = Signal()
+    """
+    This signal is emitted when the widget receives focus.
+    """
+
+    sig_focus_out_event = Signal()
+    """
+    This signal is emitted when the widget loses focus.
     """
 
     def __init__(self, parent, handle_links=True, class_parent=None):
@@ -348,6 +359,34 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
         else:
             super(WebView, self).setHtml(html, baseUrl)
 
+        # The event filter needs to be installed every time html is set
+        # because the proxy changes with new content.
+        self.focusProxy().installEventFilter(self)
+
+    def load(self, url):
+        """
+        Load url.
+
+        This is reimplemented to install our event filter after the
+        url is loaded.
+        """
+        super().load(url)
+        self.focusProxy().installEventFilter(self)
+
+    def eventFilter(self, widget, event):
+        """
+        Handle events that affect the view.
+
+        All events (e.g. focus in/out) reach the focus proxy, not this
+        widget itself. That's why this event filter is necessary.
+        """
+        if self.focusProxy() is widget:
+            if event.type() == QEvent.FocusIn:
+                self.sig_focus_in_event.emit()
+            elif event.type() == QEvent.FocusOut:
+                self.sig_focus_out_event.emit()
+        return super().eventFilter(widget, event)
+
 
 class WebBrowser(QWidget):
     """
@@ -488,7 +527,7 @@ class WebBrowser(QWidget):
 
 class FrameWebView(QFrame):
     """
-    Framed QWebEngineView for UI consistency in Spyder.
+    Framed WebView for UI consistency in Spyder.
     """
     linkClicked = Signal(QUrl)
 
@@ -496,13 +535,16 @@ class FrameWebView(QFrame):
         super().__init__(parent)
 
         self._webview = WebView(self, class_parent=parent)
+        self._webview.sig_focus_in_event.connect(
+            lambda: self._apply_stylesheet(focus=True))
+        self._webview.sig_focus_out_event.connect(
+            lambda: self._apply_stylesheet(focus=False))
 
         layout = QHBoxLayout()
         layout.addWidget(self._webview)
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
-
-        self.setFrameStyle(QFrame.StyledPanel | QFrame.Sunken)
+        self._apply_stylesheet()
 
         if WEBENGINE:
             self._webview.page().linkClicked.connect(self.linkClicked)
@@ -521,6 +563,23 @@ class FrameWebView(QFrame):
     @property
     def web_widget(self):
         return self._webview
+
+    def _apply_stylesheet(self, focus=False):
+        """Apply stylesheet according to the current focus."""
+        if focus:
+            border_color = QStylePalette.COLOR_ACCENT_3
+        else:
+            border_color = QStylePalette.COLOR_BACKGROUND_4
+
+        css = qstylizer.style.StyleSheet()
+        css.QFrame.setValues(
+            border=f'1px solid {border_color}',
+            margin='0px 1px 0px 1px',
+            padding='0px 0px 1px 0px',
+            borderRadius='3px'
+        )
+
+        self.setStyleSheet(css.toString())
 
 
 def test():


### PR DESCRIPTION
## Description of Changes

We were not drawing borders around WebView widgets such as the ones used in Help and Online Help.

**Before**

![imagen](https://user-images.githubusercontent.com/365293/123000173-d8afd080-d374-11eb-86e1-a6ef35dde79a.png)

**After**

![imagen](https://user-images.githubusercontent.com/365293/123000081-b3bb5d80-d374-11eb-949a-326b799cd071.png)

Other changes include:

* Paint the border with an accent color when it has focus.
* Fix layout for Online Help main widget.
* Prevent to give focus to WebView widgets only for old PyQt versions (5.12+ doesn't have this problem).
* Make tests run for any `5.*` branch.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
