### PR TITLE
PR: Don't add linting messages to block data for cloned editors (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1282,7 +1282,13 @@ class CodeEditor(TextEditBaseWidget):
                                              data._selection(),
                                              underline_color=block.color)
             else:
-                data.code_analysis.append((source, code, severity, message))
+                # Don't append messages to data for cloned editors to avoid
+                # showing them twice or more times on hover.
+                # Fixes spyder-ide/spyder#15618
+                if not self.is_cloned:
+                    data.code_analysis.append(
+                        (source, code, severity, message)
+                    )
                 block.setUserData(data)
 
     # ------------- LSP: Completion ---------------------------------------


### PR DESCRIPTION
## Description of Changes

This avoids displaying those message several times on hover.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15618.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
