### PR TITLE
PR: Restore ability to ignore linting messages with inline comments (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -95,9 +95,10 @@ except Exception:
 logger = logging.getLogger(__name__)
 
 
+# Regexp to detect noqa inline comments.
+NOQA_INLINE_REGEXP = re.compile(r"#?noqa", re.IGNORECASE)
 
 
-# %% This line is for cell execution testing
 @class_register
 class CodeEditor(TextEditBaseWidget):
     """Source Code Editor Widget based exclusively on Qt"""
@@ -1260,6 +1261,17 @@ class CodeEditor(TextEditBaseWidget):
 
             block = document.findBlockByNumber(start['line'])
             data = block.userData()
+
+            # Skip messages according to certain criteria.
+            # This one works for any programming language
+            if 'analysis:ignore' in block.text():
+                continue
+
+            # This only works for Python.
+            if self.language == 'Python':
+                if NOQA_INLINE_REGEXP.search(block.text()) is not None:
+                    continue
+
             if not data:
                 data = BlockUserData(self)
 

--- a/spyder/plugins/editor/widgets/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/tests/test_warnings.py
@@ -329,3 +329,42 @@ def test_update_warnings_after_closebrackets(qtbot, completions_codeeditor_linti
     qtbot.wait(2000)
     expected = [['D100: Missing docstring in public module', 1]]
     assert editor.get_current_warnings() == expected
+
+
+@pytest.mark.slow
+@pytest.mark.order(2)
+@flaky(max_runs=5)
+@pytest.mark.parametrize(
+    'ignore_comment', ['#noqa', '# NOQA', '# analysis:ignore', '# no-work']
+)
+def test_ignore_warnings_with_comments(
+    qtbot, completions_codeeditor_linting, ignore_comment
+):
+    """
+    Test that ignoring linting messages with inline comments works as
+    expected.
+    """
+    editor, _ = completions_codeeditor_linting
+    editor.textCursor().insertText(
+        f"foo {ignore_comment}\n"
+        "bar\n"
+    )
+
+    if ignore_comment == '# no-work':
+        expected = [
+            ["undefined name 'foo'", 1],
+            ['D100: Missing docstring in public module', 1],
+            ['E261 at least two spaces before inline comment', 1],
+            ["undefined name 'bar'", 2]
+        ]
+    else:
+        expected = [["undefined name 'bar'", 2]]
+
+    # Notify changes.
+    with qtbot.waitSignal(editor.completions_response_signal, timeout=30000):
+        editor.document_did_change()
+
+    # Wait for linting info to arrive
+    qtbot.wait(2000)
+
+    assert editor.get_current_warnings() == expected


### PR DESCRIPTION
## Description of Changes

`# noqa`, `# NOQA` and `# analysis:ignore` inline comments are supported now.

**Before**

![imagen](https://user-images.githubusercontent.com/365293/123167111-c51b6d00-d43b-11eb-8bb5-c0c4364869fb.png)

**After**

![imagen](https://user-images.githubusercontent.com/365293/123166556-28f16600-d43b-11eb-838c-b8bbbf02e256.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11033.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
