### PR TITLE
PR: Fix asking for restart when changing interface theme options (Appearance)

### DIFF
--- a/spyder/config/gui.py
+++ b/spyder/config/gui.py
@@ -18,6 +18,7 @@ Important note regarding shortcuts:
 from collections import namedtuple
 
 # Third party imports
+from qtconsole.styles import dark_color
 from qtpy import PYQT_VERSION
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QFont, QFontDatabase, QKeySequence
@@ -29,8 +30,6 @@ from spyder.py3compat import to_text_string
 from spyder.utils import programs
 from spyder.utils import syntaxhighlighters as sh
 
-# Third-party imports
-from qtconsole.styles import dark_color
 
 # To save metadata about widget shortcuts (needed to build our
 # preferences page)

--- a/spyder/plugins/appearance/confpage.py
+++ b/spyder/plugins/appearance/confpage.py
@@ -6,6 +6,7 @@
 
 """Appearance entry in Preferences."""
 
+from qtconsole.styles import dark_color
 from qtpy.QtCore import Slot
 from qtpy.QtWidgets import (QApplication, QDialog, QFontComboBox,
                             QGridLayout, QGroupBox, QMessageBox,
@@ -19,6 +20,7 @@ from spyder.config.manager import CONF
 from spyder.config.utils import is_gtk_desktop
 from spyder.plugins.appearance.widgets import SchemeEditor
 from spyder.utils import syntaxhighlighters
+from spyder.utils.palette import QStylePalette
 from spyder.widgets.simplecodeeditor import SimpleCodeEditor
 
 # Localization
@@ -172,11 +174,14 @@ class AppearanceConfigPage(PluginConfigPage):
     def apply_settings(self):
         self.set_option('selected', self.current_scheme)
         color_scheme = self.get_option('selected')
+
+        # A dark color scheme is characterized by a light font and viceversa
+        is_dark_color_scheme = not is_dark_font_color(color_scheme)
         ui_theme = self.get_option('ui_theme')
-        style_sheet = self.main.styleSheet()
+
         if ui_theme == 'automatic':
-            if ((not is_dark_font_color(color_scheme) and not style_sheet)
-                    or (is_dark_font_color(color_scheme) and style_sheet)):
+            if ((self.is_dark_interface() and not is_dark_color_scheme) or
+                    (not self.is_dark_interface() and is_dark_color_scheme)):
                 self.changed_options.add('ui_theme')
             elif 'ui_theme' in self.changed_options:
                 self.changed_options.remove('ui_theme')
@@ -199,8 +204,8 @@ class AppearanceConfigPage(PluginConfigPage):
                 self.update_preview()
         else:
             if 'ui_theme' in self.changed_options:
-                if (style_sheet and ui_theme == 'dark' or
-                        not style_sheet and ui_theme == 'light'):
+                if ((self.is_dark_interface() and ui_theme == 'dark') or
+                    (not self.is_dark_interface() and ui_theme == 'light')):
                     self.changed_options.remove('ui_theme')
 
             if 'ui_theme' not in self.changed_options:
@@ -425,3 +430,13 @@ class AppearanceConfigPage(PluginConfigPage):
                 self.set_option(option, value)
 
             self.load_from_conf()
+
+    def is_dark_interface(self):
+        """
+        Check if our interface is dark independently from our config
+        system.
+
+        We need to do this because when applying settings we can't
+        detect correctly the current theme.
+        """
+        return dark_color(QStylePalette.COLOR_BACKGROUND_1)


### PR DESCRIPTION
## Description of Changes

The detection of the current interface theme was broken after the release of Spyder 5, so we couldn't ask for a restart when needed.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15904.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
