### PR TITLE
PR: Move check for possible updates after the main window is visible (Application)

### DIFF
--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -24,7 +24,6 @@ from spyder import (
 from spyder import dependencies
 from spyder.api.translations import get_translation
 from spyder.api.widgets.main_container import PluginMainContainer
-from spyder.config.base import DEV
 from spyder.config.utils import is_anaconda
 from spyder.utils.qthelpers import start_file, DialogManager
 from spyder.widgets.about import AboutDialog
@@ -142,11 +141,6 @@ class ApplicationContainer(PluginMainContainer):
             shortcut_context="_",
             register_shortcut=True)
 
-        # Initialize
-        if DEV is None and self.get_conf('check_updates_on_startup'):
-            self.give_updates_feedback = False
-            self.check_updates(startup=True)
-
     def update_actions(self):
         pass
 
@@ -255,7 +249,7 @@ class ApplicationContainer(PluginMainContainer):
         # while loading.
         # Fixes spyder-ide/spyder#15839
         updates_timer = QTimer(self)
-        updates_timer.setInterval(15000)
+        updates_timer.setInterval(3000)
         updates_timer.setSingleShot(True)
         updates_timer.timeout.connect(self.thread_updates.start)
         updates_timer.start()

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -92,9 +92,10 @@ class Application(SpyderPluginV2):
 
     def on_mainwindow_visible(self):
         """Actions after the mainwindow in visible."""
+        container = self.get_container()
+
         # Show dialog with missing dependencies
         if not running_under_pytest():
-            container = self.get_container()
             self.dependencies_thread.run = container.compute_dependencies
             self.dependencies_thread.finished.connect(
                 container.report_missing_dependencies)
@@ -105,6 +106,11 @@ class Application(SpyderPluginV2):
             dependencies_timer.setSingleShot(True)
             dependencies_timer.timeout.connect(self.dependencies_thread.start)
             dependencies_timer.start()
+
+        # Check for updates
+        if DEV is None and self.get_conf('check_updates_on_startup'):
+            container.give_updates_feedback = False
+            container.check_updates(startup=True)
 
     # --- Private methods
     # ------------------------------------------------------------------------

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -480,7 +480,7 @@ the sympy module (e.g. plot)
             box.set_check_visible(True)
             box.setText(warn_str)
 
-            answer = box.exec_()
+            answer = box.show()
 
             # Update checkbox based on user interaction
             self.set_conf(

--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -67,7 +67,8 @@ class MessageCheckBox(QMessageBox):
     def __init__(self, *args, **kwargs):
         super(MessageCheckBox, self).__init__(*args, **kwargs)
 
-        self._checkbox = QCheckBox()
+        self.setWindowModality(Qt.NonModal)
+        self._checkbox = QCheckBox(self)
 
         # Set layout to include checkbox
         size = 9


### PR DESCRIPTION
## Description of Changes

* Move that check to the `on_mainwindow_visible` method of the Application plugin.
* Add a small delay before running that check to prevent showing it before the window is really up.
* Make all usages of `MessageCheckBox` to be non-modal to avoid interrupting users as much as possible.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15839

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
