### PR TITLE
PR: Catch error in snippets extension (Editor)

### DIFF
--- a/spyder/plugins/editor/extensions/snippets.py
+++ b/spyder/plugins/editor/extensions/snippets.py
@@ -363,7 +363,7 @@ class SnippetsExtension(EditorExtension):
             self._remove_selection(start, end)
             line, column = start
         node, snippet, text_node = self._find_node_by_position(line, column)
-        if node is None:
+        if node is None or text_node is None:
             self.reset()
             return
         tokens = tokenize(text)


### PR DESCRIPTION
## Description of Changes

This simply avoids inserting snippets when a necessary variable for them is `None`.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15960

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
