### PR TITLE
PR: Fix compatibility with pytest-qt >= 4

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -66,7 +66,7 @@ dependencies:
 - pytest-lazy-fixture
 - pytest-mock
 - pytest-order
-- pytest-qt <4.0
+- pytest-qt
 - pytest-xvfb
 - pyyaml
 - scipy

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -13,7 +13,7 @@ pytest-cov
 pytest-lazy-fixture
 pytest-mock
 pytest-order
-pytest-qt <4.0
+pytest-qt
 pyyaml
 scipy
 sympy

--- a/setup.py
+++ b/setup.py
@@ -258,7 +258,7 @@ extras_require = {
         'pytest-lazy-fixture',
         'pytest-mock',
         'pytest-order',
-        'pytest-qt<4.0',
+        'pytest-qt',
         'pyyaml',
         'scipy',
         'sympy',

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2286,9 +2286,7 @@ def test_custom_layouts(main_window, qtbot):
             layout = mw.layouts.setup_default_layouts(
                 layout_idx, settings=settings)
 
-            with qtbot.waitSignal(None, timeout=500, raising=False):
-                # Add a wait to see changes
-                pass
+            qtbot.wait(500)
 
             for area in layout._areas:
                 if area['visible']:
@@ -2322,9 +2320,7 @@ def test_programmatic_custom_layouts(main_window, qtbot):
     with qtbot.waitSignal(mw.sig_layout_setup_ready, timeout=5000):
         mw.layouts.quick_layout_switch(layout_id)
 
-        with qtbot.waitSignal(None, timeout=500, raising=False):
-            # Add a wait to see changes
-            pass
+        qtbot.wait(500)
 
         for area in layout._areas:
             if area['visible']:

--- a/spyder/plugins/completion/providers/fallback/tests/conftest.py
+++ b/spyder/plugins/completion/providers/fallback/tests/conftest.py
@@ -25,8 +25,6 @@ class CompletionManagerMock(QObject):
 def fallback_completions(qtbot_module, request):
     fallback = FallbackProvider(None, {})
     completions = CompletionManagerMock(None)
-    qtbot_module.addWidget(fallback)
-    qtbot_module.addWidget(completions)
 
     with qtbot_module.waitSignal(fallback.sig_provider_ready, timeout=30000):
         fallback.start()

--- a/spyder/plugins/completion/providers/languageserver/tests/conftest.py
+++ b/spyder/plugins/completion/providers/languageserver/tests/conftest.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, MagicMock
 from qtpy.QtCore import QObject, Signal, Slot
 from qtpy.QtWidgets import QWidget
 import pytest
-from pytestqt.plugin import QtBot
+from pytestqt.qtbot import QtBot
 
 from spyder.config.manager import CONF
 from spyder.plugins.completion.api import SERVER_CAPABILITES

--- a/spyder/plugins/completion/providers/snippets/tests/conftest.py
+++ b/spyder/plugins/completion/providers/snippets/tests/conftest.py
@@ -31,8 +31,6 @@ def snippets_completions(qtbot_module, request):
 
     snippets = SnippetsProvider(None, dict(SnippetsProvider.CONF_DEFAULTS))
     completions = CompletionManagerMock(None)
-    qtbot_module.addWidget(snippets)
-    qtbot_module.addWidget(completions)
 
     with qtbot_module.waitSignal(snippets.sig_provider_ready, timeout=30000):
         snippets.start()

--- a/spyder/plugins/completion/tests/conftest.py
+++ b/spyder/plugins/completion/tests/conftest.py
@@ -27,7 +27,7 @@ app = qapplication()
 
 # PyTest imports
 import pytest
-from pytestqt.plugin import QtBot
+from pytestqt.qtbot import QtBot
 
 
 class MainWindowMock(QMainWindow):

--- a/spyder/plugins/findinfiles/tests/test_plugin.py
+++ b/spyder/plugins/findinfiles/tests/test_plugin.py
@@ -32,7 +32,7 @@ def findinfiles(qtbot):
 
     # qtbot wants to close the widget
     findinfiles_plugin.close = lambda: True
-    qtbot.addWidget(findinfiles_plugin)
+    qtbot.addWidget(findinfiles_plugin.get_widget())
 
     return findinfiles_plugin
 

--- a/spyder/plugins/history/tests/test_plugin.py
+++ b/spyder/plugins/history/tests/test_plugin.py
@@ -39,7 +39,7 @@ def historylog(qtbot, monkeypatch):
     """
     historylog = history.HistoryLog(None, configuration=CONF)
     historylog.close = lambda: True
-    qtbot.addWidget(historylog)
+    qtbot.addWidget(historylog.get_widget())
     historylog.get_widget().show()
     yield historylog
     historylog.on_close()

--- a/spyder/plugins/workingdirectory/tests/test_workingdirectory.py
+++ b/spyder/plugins/workingdirectory/tests/test_workingdirectory.py
@@ -19,7 +19,7 @@ NEW_DIR = 'new_workingdir'
 
 
 @pytest.fixture
-def setup_workingdirectory(qtbot, request):
+def setup_workingdirectory(request):
     """Setup working directory plugin."""
     CONF.reset_to_defaults()
     use_startup_wdir = request.node.get_closest_marker('use_startup_wdir')
@@ -36,14 +36,13 @@ def setup_workingdirectory(qtbot, request):
 
     workingdirectory = WorkingDirectory(None, configuration=CONF)
     workingdirectory.close = lambda: True
-    qtbot.addWidget(workingdirectory)
 
-    return workingdirectory, qtbot
+    return workingdirectory
 
 
 def test_basic_initialization(setup_workingdirectory):
     """Test Working Directory plugin initialization."""
-    workingdirectory, qtbot = setup_workingdirectory
+    workingdirectory = setup_workingdirectory
 
     # Assert that workingdirectory exists
     assert workingdirectory is not None
@@ -51,7 +50,7 @@ def test_basic_initialization(setup_workingdirectory):
 
 def test_get_workingdir(setup_workingdirectory):
     """Test the method that defines the working directory at home."""
-    workingdirectory, qtbot = setup_workingdirectory
+    workingdirectory = setup_workingdirectory
     # Start the working directory on the home directory
     act_wdir = workingdirectory.get_workdir()
     assert act_wdir == get_home_dir()
@@ -60,7 +59,7 @@ def test_get_workingdir(setup_workingdirectory):
 @pytest.mark.use_startup_wdir
 def test_get_workingdir_startup(setup_workingdirectory):
     """Test the method that defines the working directory at home."""
-    workingdirectory, qtbot = setup_workingdirectory
+    workingdirectory = setup_workingdirectory
     # Start the working directory on the home directory
     act_wdir = workingdirectory.get_workdir()
     folders = osp.split(act_wdir)


### PR DESCRIPTION
This reverts #15782 and fixes the reason why pytest-qt was pinned: qtbot.addWidget() expects a widget as argument, but a few plugins were not widgets.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @bnavigator

<!--- Thanks for your help making Spyder better for everyone! --->
