### PR TITLE
PR: Fix getting text with end-of-lines (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/tests/conftest.py
@@ -43,6 +43,7 @@ def codeeditor_factory():
                         automatic_completions_after_chars=1,
                         automatic_completions_after_ms=200,
                         folding=False)
+    editor.eol_chars = '\n'
     editor.resize(640, 480)
     return editor
 

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -697,9 +697,12 @@ class BaseEditMixin(object):
         characters.
         """
         text = self.toPlainText()
+        lines = text.splitlines()
         linesep = self.get_line_separator()
-        text.replace('\n', linesep)
-        return text
+        text_with_eol = linesep.join(lines)
+        if text.endswith('\n'):
+            text_with_eol += linesep
+        return text_with_eol
 
     #------Positions, coordinates (cursor, EOF, ...)
     def get_position(self, subject):


### PR DESCRIPTION
## Description of Changes

- We were not preserving EOLs when saving files.
- This was broken after PR #15903

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
