### PR TITLE
PR: Move create_application and create_window to utils (Main window)

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -72,13 +72,12 @@ from spyder import dependencies
 from spyder.app.utils import (
     create_application, create_splash_screen, create_window,
     delete_lsp_log_files, qt_message_handler, set_links_color, setup_logging,
-    set_opengl_implementation, Spy)
+    set_opengl_implementation)
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
 from spyder.config.base import (_, DEV, get_conf_path, get_debug_level,
                                 get_home_dir, get_module_source_path,
-                                get_safe_mode, is_pynsist, running_in_mac_app,
+                                is_pynsist, running_in_mac_app,
                                 running_under_pytest, STDERR)
-from spyder.utils.image_path_manager import get_image_path
 from spyder.config.gui import is_dark_font_color
 from spyder.config.main import OPEN_FILES_PORT
 from spyder.config.manager import CONF
@@ -961,10 +960,8 @@ class MainWindow(QMainWindow):
         # Menus
         # TODO: Remove when all menus are migrated to use the Main Menu Plugin
         logger.info("Creating Menus...")
-        from spyder.api.widgets.menus import SpyderMenu
         from spyder.plugins.mainmenu.api import (
-            ApplicationMenus, HelpMenuSections, ToolsMenuSections,
-            FileMenuSections)
+            ApplicationMenus, ToolsMenuSections, FileMenuSections)
         mainmenu = self.mainmenu
         self.edit_menu = mainmenu.get_application_menu("edit_menu")
         self.search_menu = mainmenu.get_application_menu("search_menu")

--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -217,24 +217,26 @@ def create_application():
     if hasattr(app, 'setDesktopFileName'):
         app.setDesktopFileName('spyder')
 
-    #----Monkey patching QApplication
+    # ---- Monkey patching QApplication
     class FakeQApplication(QApplication):
         """Spyder's fake QApplication"""
         def __init__(self, args):
             self = app  # analysis:ignore
+
         @staticmethod
         def exec_():
             """Do nothing because the Qt mainloop is already running"""
             pass
+
     from qtpy import QtWidgets
     QtWidgets.QApplication = FakeQApplication
 
-    # ----Monkey patching sys.exit
+    # ---- Monkey patching sys.exit
     def fake_sys_exit(arg=[]):
         pass
     sys.exit = fake_sys_exit
 
-    # ----Monkey patching sys.excepthook to avoid crashes in PyQt 5.5+
+    # ---- Monkey patching sys.excepthook to avoid crashes in PyQt 5.5+
     def spy_excepthook(type_, value, tback):
         sys.__excepthook__(type_, value, tback)
     sys.excepthook = spy_excepthook


### PR DESCRIPTION
## Description of Changes

This is a small refactoring that moves those self-contained functions out of `mainwindow.py`

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
