### PR TITLE
PR: Only switch to Plots plugin once per session

### DIFF
--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -203,7 +203,7 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
 
     def update_splitter_widths(self, base_width):
         """
-        Update the widths to provide the scrollbar with a fixed minimumwidth.
+        Update the widths to provide the scrollbar with a fixed minimum width.
 
         Parameters
         ----------

--- a/spyder/plugins/plots/widgets/main_widget.py
+++ b/spyder/plugins/plots/widgets/main_widget.py
@@ -173,7 +173,11 @@ class PlotsWidget(PluginMainWidget):
         self._stack.sig_save_dir_changed.connect(
             lambda val: self.set_conf('save_dir', val))
 
-    # --- PluginMainWidget API
+        # Resize to a huge width to get the right size of the thumbnail
+        # scrollbar at startup.
+        self.resize(50000, self.height())
+
+    # ---- PluginMainWidget API
     # ------------------------------------------------------------------------
     def get_title(self):
         return _('Plots')
@@ -359,7 +363,7 @@ class PlotsWidget(PluginMainWidget):
                 widget.setup({option: value})
                 self.update_actions()
 
-    # --- Public API:
+    # ---- Public API:
     # ------------------------------------------------------------------------
     def set_current_widget(self, fig_browser):
         """


### PR DESCRIPTION
## Description of Changes

- This avoids raising the plugin when users have focus on other plugins.
- It also fixes the issue with the thumbnail scrollbar size not being correctly at startup.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15705

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
