### PR TITLE
PR: Don't try to display hovers when there's no content to display (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1531,12 +1531,15 @@ class CodeEditor(TextEditBaseWidget):
         try:
             content = contents['params']
 
-            if isinstance(content, list):
-                # Prevent sporious errors when a client return a list
+            # - Don't display hover if there's no content to display.
+            # - Prevent spurious errors when a client returns a list.
+            if not content or isinstance(content, list):
                 return
 
-            self.sig_display_object_info.emit(content,
-                                              self._request_hover_clicked)
+            self.sig_display_object_info.emit(
+                content,
+                self._request_hover_clicked
+            )
             if content is not None and self._show_hint and self._last_point:
                 # This is located in spyder/widgets/mixins.py
                 word = self._last_hover_word

--- a/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
+++ b/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
@@ -134,12 +134,12 @@ def test_get_calltips(qtbot, completions_codeeditor, params):
 @pytest.mark.order(2)
 @pytest.mark.skipif(sys.platform == 'darwin', reason='Fails on Mac')
 @pytest.mark.parametrize('params', [
-            # Parameter, Expected Output
-            ('"".format', '-> str'),
-            ('import math', 'module'),
-            (TEST_TEXT, TEST_DOCSTRING)
-        ]
-    )
+        # Parameter, Expected Output
+        ('"".format', '-> str'),
+        ('import math', 'module'),
+        (TEST_TEXT, TEST_DOCSTRING)
+    ]
+)
 def test_get_hints(qtbot, completions_codeeditor, params, capsys):
     """Test that the editor is returning hover hints."""
     code_editor, _ = completions_codeeditor
@@ -185,19 +185,27 @@ def test_get_hints(qtbot, completions_codeeditor, params, capsys):
 @pytest.mark.slow
 @pytest.mark.order(2)
 @pytest.mark.skipif(sys.platform == 'darwin', reason='Fails on Mac')
-def test_get_hints_not_triggered(qtbot, completions_codeeditor):
+@pytest.mark.parametrize('text', [
+        'def test():\n    pass\n\ntest',
+        '# a comment',
+        '"a string"',
+    ]
+)
+def test_get_hints_not_triggered(qtbot, completions_codeeditor, text):
     """Test that the editor is not returning hover hints for empty docs."""
     code_editor, _ = completions_codeeditor
 
     # Set text in editor
-    code_editor.set_text('def test():\n    pass\n\ntest')
+    code_editor.set_text(text)
 
     # Move mouse to another position.
     qtbot.mouseMove(code_editor, QPoint(400, 400))
 
     # Get cursor coordinates
     code_editor.moveCursor(QTextCursor.End)
-    qtbot.keyPress(code_editor, Qt.Key_Left)
+
+    for _ in range(3):
+        qtbot.keyPress(code_editor, Qt.Key_Left)
 
     # Wait a bit in case the window manager repositions the window.
     qtbot.wait(1000)

--- a/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
+++ b/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
@@ -145,15 +145,25 @@ def test_get_hints(qtbot, completions_codeeditor, params, capsys):
     code_editor, _ = completions_codeeditor
     param, expected_output_text = params
 
+    # Move mouse to another position to be sure the hover is displayed when
+    # the cursor is put on top of the tested word.
+    qtbot.mouseMove(code_editor, QPoint(400, 400))
+
     # Set text in editor
     code_editor.set_text(param)
 
     # Get cursor coordinates
     code_editor.moveCursor(QTextCursor.End)
     qtbot.keyPress(code_editor, Qt.Key_Left)
+
+    # Wait a bit in case the window manager repositions the window.
+    qtbot.wait(1000)
+
+    # Position cursor on top of word we want the hover for.
     x, y = code_editor.get_coordinates('cursor')
     point = code_editor.calculate_real_position(QPoint(x, y))
 
+    # Get hover and compare
     with qtbot.waitSignal(code_editor.sig_display_object_info,
                           timeout=30000) as blocker:
         qtbot.mouseMove(code_editor, point)
@@ -182,13 +192,23 @@ def test_get_hints_not_triggered(qtbot, completions_codeeditor):
     # Set text in editor
     code_editor.set_text('def test():\n    pass\n\ntest')
 
+    # Move mouse to another position.
+    qtbot.mouseMove(code_editor, QPoint(400, 400))
+
     # Get cursor coordinates
     code_editor.moveCursor(QTextCursor.End)
     qtbot.keyPress(code_editor, Qt.Key_Left)
+
+    # Wait a bit in case the window manager repositions the window.
+    qtbot.wait(1000)
+
+    # Position cursor on top of word we want the hover for.
     x, y = code_editor.get_coordinates('cursor')
     point = code_editor.calculate_real_position(QPoint(x, y))
 
-    with qtbot.waitSignal(code_editor.sig_display_object_info, timeout=30000):
+    # Check that no hover was generated.
+    with qtbot.waitSignal(code_editor.completions_response_signal,
+                          timeout=30000):
         qtbot.mouseMove(code_editor, point)
         qtbot.mouseClick(code_editor, Qt.LeftButton, pos=point)
         qtbot.wait(1000)


### PR DESCRIPTION
## Description of Changes

- Hovers were displayed with no content at all, which was very annoying.
- I think this was a regression after the migration to the new API, which was not caught by our tests.

### Issue(s) Resolved

Fixes #16079.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
