### PR TITLE
PR: Support Rich and Colorama in the IPython console

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = feat/isatty
-	commit = 0fce2342d30fde27389bb3f319cfc5b9d7f8c448
-	parent = 12eebb38342da80377478f31c9db58765de10d57
+	branch = patch-terminal-size
+	commit = c262584b37a8ca541d3d30f1e50e03162f253fd6
+	parent = 1de9716e79de75bbf670a034dd1ed74c1940c5dc
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 2.x
-	commit = 52ccb1b1ac7d360dcb99ad1d5dc827131c78ec0f
-	parent = 09fd9d2184b0777ffeca2858ca287ba3ba777b2a
+	branch = feat/isatty
+	commit = 0fce2342d30fde27389bb3f319cfc5b9d7f8c448
+	parent = 12eebb38342da80377478f31c9db58765de10d57
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = patch-terminal-size
-	commit = c262584b37a8ca541d3d30f1e50e03162f253fd6
-	parent = 1de9716e79de75bbf670a034dd1ed74c1940c5dc
+	branch = 2.x
+	commit = 786edcae4b3df5994e94cf775e4672b79bd8f308
+	parent = 839d46123c907b000df62e2c5ee781a322be2a0a
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/README.md
+++ b/external-deps/spyder-kernels/README.md
@@ -13,10 +13,10 @@ Python session, and allow for interactive or file-based execution of Python
 code inside Spyder.
 
 To learn about creating, connecting to and using these kernels with the Spyder
-console, please read our [documentation](https://docs.spyder-ide.org/ipythonconsole.html).
+console, please read our [documentation](https://docs.spyder-ide.org/current/panes/ipythonconsole.html).
 
-For advice on managing packages and environments with `spyder-kernels`, please visit
-our [wiki](https://github.com/spyder-ide/spyder/wiki/Working-with-packages-and-environments-in-Spyder).
+For advice on managing packages and environments with `spyder-kernels`, please read this
+[FAQ](http://docs.spyder-ide.org/current/faq.html#using-existing-environment) in our docs.
 
 
 ## Installation

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -107,7 +107,6 @@ class SpyderKernel(IPythonKernel):
         self.namespace_view_settings = {}
         self._pdb_obj = None
         self._pdb_step = None
-        self._do_publish_pdb_state = True
         self._mpl_backend_error = None
         self._running_namespace = None
         self._pdb_input_line = None
@@ -201,7 +200,6 @@ class SpyderKernel(IPythonKernel):
     def get_value(self, name):
         """Get the value of a variable"""
         ns = self._get_current_namespace()
-        self._do_publish_pdb_state = False
         return ns[name]
 
     def set_value(self, name, value):
@@ -286,16 +284,12 @@ class SpyderKernel(IPythonKernel):
         return self._do_complete(code, cursor_pos)
 
     def publish_pdb_state(self):
-        """
-        Publish Variable Explorer state and Pdb step through
-        send_spyder_msg.
-        """
-        if self._pdb_obj and self._do_publish_pdb_state:
+        """Publish Pdb state."""
+        if self._pdb_obj:
             state = dict(namespace_view = self.get_namespace_view(),
                          var_properties = self.get_var_properties(),
                          step = self._pdb_step)
             self.frontend_call(blocking=False).pdb_state(state)
-        self._do_publish_pdb_state = True
 
     def set_spyder_breakpoints(self, breakpoints):
         """

--- a/external-deps/spyder-kernels/spyder_kernels/console/outstream.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/outstream.py
@@ -16,6 +16,7 @@ from ipykernel.iostream import OutStream
 class TTYOutStream(OutStream):
     """Subclass of OutStream that represents a TTY."""
 
-    def __init__(self, session, pub_thread, name, pipe=None, echo=None, *, watchfd=True):
+    def __init__(self, session, pub_thread, name, pipe=None, echo=None, *,
+                 watchfd=True):
         super().__init__(session, pub_thread, name, pipe,
                          echo=echo, watchfd=watchfd, isatty=True)

--- a/external-deps/spyder-kernels/spyder_kernels/console/outstream.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/outstream.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2009- Spyder Kernels Contributors
+#
+# Licensed under the terms of the MIT License
+# (see spyder_kernels/__init__.py for details)
+# -----------------------------------------------------------------------------
+
+"""
+Custom Spyder Outstream class.
+"""
+
+from ipykernel.iostream import OutStream
+
+
+class TTYOutStream(OutStream):
+    """Subclass of OutStream that represents a TTY."""
+
+    def __init__(self, session, pub_thread, name, pipe=None, echo=None, *, watchfd=True):
+        super().__init__(session, pub_thread, name, pipe,
+                         echo=echo, watchfd=watchfd, isatty=True)

--- a/external-deps/spyder-kernels/spyder_kernels/console/start.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/start.py
@@ -17,6 +17,9 @@ import os.path as osp
 import sys
 import site
 
+from traitlets import DottedObjectName
+import ipykernel
+
 # Local imports
 from spyder_kernels.utils.misc import is_module_installed
 from spyder_kernels.utils.mpl import (
@@ -24,6 +27,8 @@ from spyder_kernels.utils.mpl import (
 
 
 PY2 = sys.version[0] == '2'
+IPYKERNEL_6 = ipykernel.__version__[0] >= '6'
+
 
 
 def import_spydercustomize():
@@ -269,6 +274,10 @@ def main():
     from spyder_kernels.console.kernel import SpyderKernel
 
     class SpyderKernelApp(IPKernelApp):
+
+        if IPYKERNEL_6:
+            outstream_class = DottedObjectName(
+                'spyder_kernels.console.outstream.TTYOutStream')
 
         def init_pdb(self):
             """

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
@@ -109,6 +109,7 @@ if os.name == 'nt' and HIDE_CMD_WINDOWS:
 
     subprocess.Popen = SubprocessPopen
 
+
 # =============================================================================
 # Importing user's sitecustomize
 # =============================================================================
@@ -184,6 +185,7 @@ try:
     QtGui.QApplication = SpyderQApplication
 except Exception:
     pass
+
 
 # =============================================================================
 # IPython adjustments
@@ -309,6 +311,16 @@ if not PY2:
         multiprocessing.spawn.get_preparation_data = _patched_preparation_data
     except Exception:
         pass
+
+
+# =============================================================================
+# os adjustments
+# =============================================================================
+# This is necessary to have better support for Rich and Colorama.
+def _patched_get_terminal_size(fd=None):
+    return os.terminal_size((80, 30))
+
+os.get_terminal_size = _patched_get_terminal_size
 
 
 # =============================================================================


### PR DESCRIPTION
## Description of Changes

- This makes the `isatty` attribute of the `OutStream` instance in our kernel to return `True`, which adds out of the box support for Rich and Colorama in our consoles.
- It also makes `os.get_terminal_size` to return a proper value in our consoles.

Associated PRs:

- Depends on spyder-ide/spyder-kernels#306
- Depends on spyder-ide/spyder-kernels#305

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1917.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
