### PR TITLE
PR: Make go-to-defintion and hover work for files when no project is active or outside of it (Completions)

### DIFF
--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/python-lsp/python-lsp-server.git
-	branch = develop
-	commit = 58b229b520b7cb78196115d0366e94596242dc4c
-	parent = f8e5f56cc0515580006c349ebe4fe7e16b411284
+	branch = fix-goto-def
+	commit = a99d51c702540bdd9b66dece5991e7e34dfb79b8
+	parent = f44cb727436fbd81858a824c9d92c03dea549194
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/python-lsp/python-lsp-server.git
-	branch = fix-goto-def
-	commit = a99d51c702540bdd9b66dece5991e7e34dfb79b8
-	parent = f44cb727436fbd81858a824c9d92c03dea549194
+	branch = develop
+	commit = 32bbc067f4a0f97ddabe69bc80059fa7481d622e
+	parent = bb30c7cb3dd40c963a50d3b6730b0f6479e56187
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/CONFIGURATION.md
+++ b/external-deps/python-lsp-server/CONFIGURATION.md
@@ -4,6 +4,16 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 | **Configuration Key** | **Type** | **Description** | **Default** 
 |----|----|----|----|
 | `pylsp.configurationSources` | `array`  of unique `string` items | List of configuration sources to use. | `["pycodestyle"]` |
+| `pylsp.plugins.flake8.config` | `string` | Path to the config file that will be the authoritative config source. | `null` |
+| `pylsp.plugins.flake8.enabled` | `boolean` | Enable or disable the plugin. | `false` |
+| `pylsp.plugins.flake8.exclude` | `array`  | List of files or directories to exclude. | `null` |
+| `pylsp.plugins.flake8.executable` | `string` | Path to the flake8 executable. | `"flake8"` |
+| `pylsp.plugins.flake8.filename` | `string` | Only check for filenames matching the patterns in this list. | `null` |
+| `pylsp.plugins.flake8.hangClosing` | `boolean` | Hang closing bracket instead of matching indentation of opening bracket's line. | `null` |
+| `pylsp.plugins.flake8.ignore` | `array`  | List of errors and warnings to ignore (or skip). | `null` |
+| `pylsp.plugins.flake8.maxLineLength` | `integer` | Maximum allowed line length for the entirety of this run. | `null` |
+| `pylsp.plugins.flake8.perFileIgnores` | `array`  | A pairing of filenames and violation codes that defines which violations to ignore in a particular file, for example: `["file_path.py:W305,W304"]`). | `null` |
+| `pylsp.plugins.flake8.select` | `array`  | List of errors and warnings to enable. | `null` |
 | `pylsp.plugins.jedi.extra_paths` | `array`  | Define extra paths for jedi.Script. | `[]` |
 | `pylsp.plugins.jedi.env_vars` | `object` | Define environment variables for jedi.Script and Jedi.names. | `null` |
 | `pylsp.plugins.jedi.environment` | `string` | Define environment for jedi.Script and Jedi.names. | `null` |

--- a/external-deps/python-lsp-server/pylsp/config/schema.json
+++ b/external-deps/python-lsp-server/pylsp/config/schema.json
@@ -14,6 +14,56 @@
       },
       "uniqueItems": true
     },
+    "pylsp.plugins.flake8.config": {
+      "type": "string",
+      "default": null,
+      "description": "Path to the config file that will be the authoritative config source."
+    },
+    "pylsp.plugins.flake8.enabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable or disable the plugin."
+    },
+    "pylsp.plugins.flake8.exclude": {
+      "type": "array",
+      "default": null,
+      "description": "List of files or directories to exclude."
+    },
+    "pylsp.plugins.flake8.executable": {
+      "type": "string",
+      "default": "flake8",
+      "description": "Path to the flake8 executable."
+    },
+    "pylsp.plugins.flake8.filename": {
+      "type": "string",
+      "default": null,
+      "description": "Only check for filenames matching the patterns in this list."
+    },
+    "pylsp.plugins.flake8.hangClosing": {
+      "type": "boolean",
+      "default": null,
+      "description": "Hang closing bracket instead of matching indentation of opening bracket's line."
+    },
+    "pylsp.plugins.flake8.ignore": {
+      "type": "array",
+      "default": null,
+      "description": "List of errors and warnings to ignore (or skip)."
+    },
+    "pylsp.plugins.flake8.maxLineLength": {
+      "type": "integer",
+      "default": null,
+      "description": "Maximum allowed line length for the entirety of this run."
+    },
+    "pylsp.plugins.flake8.perFileIgnores": {
+      "type": "array",
+      "default": null,
+      "description": "A pairing of filenames and violation codes that defines which violations to ignore in a particular file, for example: `[\"file_path.py:W305,W304\"]`)."
+    },
+    "pylsp.plugins.flake8.select": {
+      "type": "array",
+      "default": null,
+      "description": "List of errors and warnings to enable."
+    },
     "pylsp.plugins.jedi.extra_paths": {
       "type": "array",
       "default": [],

--- a/external-deps/python-lsp-server/pylsp/plugins/definition.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/definition.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 def pylsp_definitions(config, document, position):
     settings = config.plugin_settings('jedi_definition')
     code_position = _utils.position_to_jedi_linecolumn(document, position)
-    definitions = document.jedi_script().goto(
+    definitions = document.jedi_script(use_document_path=True).goto(
         follow_imports=settings.get('follow_imports', True),
         follow_builtin_imports=settings.get('follow_builtin_imports', True),
         **code_position)

--- a/external-deps/python-lsp-server/pylsp/plugins/hover.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/hover.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 @hookimpl
 def pylsp_hover(document, position):
     code_position = _utils.position_to_jedi_linecolumn(document, position)
-    definitions = document.jedi_script().infer(**code_position)
+    definitions = document.jedi_script(use_document_path=True).infer(**code_position)
     word = document.word_at_position(position)
 
     # Find first exact matching definition

--- a/external-deps/python-lsp-server/test/plugins/test_definitions.py
+++ b/external-deps/python-lsp-server/test/plugins/test_definitions.py
@@ -1,6 +1,8 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
+import os
+
 from pylsp import uris
 from pylsp.plugins.definition import pylsp_definitions
 from pylsp.workspace import Document
@@ -57,3 +59,36 @@ def test_assignment(config, workspace):
 
     doc = Document(DOC_URI, workspace, DOC)
     assert [{'uri': DOC_URI, 'range': def_range}] == pylsp_definitions(config, doc, cursor_pos)
+
+
+def test_document_path_definitions(config, workspace_other_root_path, tmpdir):
+    # Create a dummy module out of the workspace's root_path and try to get
+    # a definition on it in another file placed next to it.
+    module_content = '''
+def foo():
+    pass
+'''
+
+    p = tmpdir.join("mymodule.py")
+    p.write(module_content)
+
+    # Content of doc to test definition
+    doc_content = """from mymodule import foo"""
+    doc_path = str(tmpdir) + os.path.sep + 'myfile.py'
+    doc_uri = uris.from_fs_path(doc_path)
+    doc = Document(doc_uri, workspace_other_root_path, doc_content)
+
+    # The range where is defined in mymodule.py
+    def_range = {
+        'start': {'line': 1, 'character': 4},
+        'end': {'line': 1, 'character': 7}
+    }
+
+    # The position where foo is called in myfile.py
+    cursor_pos = {'line': 0, 'character': 24}
+
+    # The uri for mymodule.py
+    module_path = str(p)
+    module_uri = uris.from_fs_path(module_path)
+
+    assert [{'uri': module_uri, 'range': def_range}] == pylsp_definitions(config, doc, cursor_pos)

--- a/external-deps/python-lsp-server/test/test_language_server.py
+++ b/external-deps/python-lsp-server/test/test_language_server.py
@@ -75,6 +75,7 @@ def client_exited_server():
     assert client_server_pair.process.is_alive() is False
 
 
+@pytest.mark.skipif(sys.platform == 'darwin', reason='Too flaky on Mac')
 def test_initialize(client_server):  # pylint: disable=redefined-outer-name
     response = client_server._endpoint.request('initialize', {
         'rootPath': os.path.dirname(__file__),


### PR DESCRIPTION
## Description of Changes

- Those features were broken since we migrated to the LSP architecture.
- Depends on python-lsp/python-lsp-server#62

### Issue(s) Resolved

Fixes #15400
Fixes #13358

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
