### PR TITLE
PR: Fix setting filters in Files

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -18,7 +18,6 @@ import sys
 from spyder.config.base import CHECK_ALL, EXCLUDED_NAMES
 from spyder.config.fonts import MEDIUM, SANS_SERIF
 from spyder.config.utils import IMPORT_EXT
-from spyder.config.snippets import SNIPPETS
 from spyder.config.appearance import APPEARANCE
 from spyder.plugins.editor.utils.findtasks import TASKS_PATTERN
 from spyder.utils.introspection.module_completion import PREFERRED_MODULES
@@ -31,7 +30,8 @@ from spyder.utils.introspection.module_completion import PREFERRED_MODULES
 EXCLUDE_PATTERNS = ['*.csv, *.dat, *.log, *.tmp, *.bak, *.orig']
 
 # Extensions that should be visible in Spyder's file/project explorers
-SHOW_EXT = ['.py', '.ipynb', '.dat', '.pdf', '.png', '.svg']
+SHOW_EXT = ['.py', '.ipynb', '.dat', '.pdf', '.png', '.svg', '.md', '.yml',
+            '.yaml']
 
 # Extensions supported by Spyder (Editor or Variable explorer)
 USEFUL_EXT = IMPORT_EXT + SHOW_EXT

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -293,6 +293,10 @@ DEFAULTS = [
               'visible_if_project_open': True,
               'date_column': False,
               'single_click_to_open': False,
+              'show_hidden': False,
+              'size_column': False,
+              'type_column': False,
+              'date_column': False
               }),
             ('explorer',
              {
@@ -300,7 +304,9 @@ DEFAULTS = [
               'name_filters': NAME_FILTERS,
               'show_hidden': False,
               'single_click_to_open': False,
-              'file_associations': {},
+              'size_column': False,
+              'type_column': False,
+              'date_column': True
               }),
             ('find_in_files',
              {
@@ -628,4 +634,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '69.1.0'
+CONF_VERSION = '70.0.0'

--- a/spyder/plugins/explorer/confpage.py
+++ b/spyder/plugins/explorer/confpage.py
@@ -75,7 +75,7 @@ class ExplorerConfigPage(PluginConfigPage):
         file_associations = FileAssociationsWidget()
 
         # Widget setup
-        file_associations.load_values(self.get_option('file_associations'))
+        file_associations.load_values(self.get_option('file_associations', {}))
         # The actual config data is stored on this text edit set to invisible
         self.edit_file_associations.setVisible(False)
 

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -281,9 +281,6 @@ class DirView(QTreeView, SpyderWidgetMixin):
     def setup(self):
         self.setup_view()
 
-        self.set_name_filters(self.get_conf('name_filters', []))
-        self.set_name_filters(self.get_conf('file_associations', {}))
-
         # New actions
         new_file_action = self.create_action(
             DirViewActions.NewFile,

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -411,7 +411,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             DirViewActions.ToggleHiddenFiles,
             text=_("Show hidden files"),
             toggled=True,
-            initial=self.get_conf('show_hidden', False),
+            initial=self.get_conf('show_hidden'),
             option='show_hidden'
         )
 
@@ -426,7 +426,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             DirViewActions.ToggleSingleClick,
             text=_("Single click to open"),
             toggled=True,
-            initial=self.get_conf('single_click_to_open', False),
+            initial=self.get_conf('single_click_to_open'),
             option='single_click_to_open'
         )
 
@@ -459,7 +459,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             DirViewActions.ToggleSizeColumn,
             text=_('Size'),
             toggled=True,
-            initial=self.get_conf('size_column', False),
+            initial=self.get_conf('size_column'),
             register_shortcut=False,
             option='size_column'
         )
@@ -467,7 +467,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             DirViewActions.ToggleTypeColumn,
             text=_('Type') if sys.platform == 'darwin' else _('Type'),
             toggled=True,
-            initial=self.get_conf('type_column', False),
+            initial=self.get_conf('type_column'),
             register_shortcut=False,
             option='type_column'
         )
@@ -475,7 +475,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             DirViewActions.ToggleDateColumn,
             text=_("Date modified"),
             toggled=True,
-            initial=self.get_conf('date_column', True),
+            initial=self.get_conf('date_column'),
             register_shortcut=False,
             option='date_column'
         )
@@ -754,7 +754,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
     def mouseReleaseEvent(self, event):
         """Reimplement Qt method."""
         super().mouseReleaseEvent(event)
-        if self.get_conf('single_click_to_open', False):
+        if self.get_conf('single_click_to_open'):
             self.clicked()
 
     def dragEnterEvent(self, event):
@@ -879,21 +879,21 @@ class DirView(QTreeView, SpyderWidgetMixin):
               'want to show, separated by commas.'))
         description_label.setOpenExternalLinks(True)
         description_label.setWordWrap(True)
-        filters = QTextEdit(", ".join(self.get_conf('name_filters', [])))
+        filters = QTextEdit(", ".join(self.get_conf('name_filters')),
+                            parent=self)
         layout = QVBoxLayout()
         layout.addWidget(description_label)
         layout.addWidget(filters)
 
         def handle_ok():
             filter_text = filters.toPlainText()
-            filter_text = [
-                f.strip() for f in str(filter_text).split(',')]
+            filter_text = [f.strip() for f in str(filter_text).split(',')]
             self.set_name_filters(filter_text)
             dialog.accept()
 
         def handle_reset():
             self.set_name_filters(NAME_FILTERS)
-            filters.setPlainText(", ".join(self.get_conf('name_filters', [])))
+            filters.setPlainText(", ".join(self.get_conf('name_filters')))
 
         # Dialog buttons
         button_box = QDialogButtonBox(QDialogButtonBox.Reset |
@@ -1372,7 +1372,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
     def filter_files(self, name_filters=None):
         """Filter files given the defined list of filters."""
         if name_filters is None:
-            name_filters = self.get_conf('name_filters', [])
+            name_filters = self.get_conf('name_filters')
 
         if self.filter_on:
             self.fsmodel.setNameFilters(name_filters)
@@ -1555,7 +1555,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
 
     def set_name_filters(self, name_filters):
         """Set name filters"""
-        if self.get_conf('name_filters', []) == ['']:
+        if self.get_conf('name_filters') == ['']:
             self.set_conf('name_filters', [])
         else:
             if running_under_pytest():


### PR DESCRIPTION
## Description of Changes

- Filters were blank since Spyder 5.0 due to a wrong `set_conf` call that made them like so.
- This also avoids setting default values for other options in Files and Projects, which will prevent us from changing those values in the future.

### Issue(s) Resolved

Fixes #15459.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
