### PR TITLE
PR: Add a timeout when doing a request to Kite url installers

### DIFF
--- a/spyder/plugins/completion/providers/kite/utils/status.py
+++ b/spyder/plugins/completion/providers/kite/utils/status.py
@@ -116,7 +116,7 @@ def check_kite_installers_availability():
 
     available = False
     try:
-        req = requests.head(url)
+        req = requests.head(url, timeout=0.2)
         available = req.ok
         if req.ok:
             if req.is_redirect:


### PR DESCRIPTION
## Description of Changes

This prevents Spyder from hanging when that url can't be accessed for some reason.

### Issue(s) Resolved

Fixes #16064.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
