### PR TITLE
PR: Fix several issues with the Outline

### DIFF
--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/python-lsp/python-lsp-server.git
 	branch = fix-symbols
-	commit = 9f69edc242f34e3c0ac52baf409f38aecea61e4e
-	parent = 30c4de3c55dfbe267a73abf3e9544ded94e4173b
+	commit = c4cfd1643437df77d3a667882bc68ff1b05e0b29
+	parent = 19271485a130e190b6b2af1721045416493e2ffb
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/python-lsp/python-lsp-server.git
-	branch = develop
-	commit = 32bbc067f4a0f97ddabe69bc80059fa7481d622e
-	parent = bb30c7cb3dd40c963a50d3b6730b0f6479e56187
+	branch = fix-symbols
+	commit = 9f69edc242f34e3c0ac52baf409f38aecea61e4e
+	parent = 30c4de3c55dfbe267a73abf3e9544ded94e4173b
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/python-lsp/python-lsp-server.git
-	branch = fix-symbols
-	commit = c4cfd1643437df77d3a667882bc68ff1b05e0b29
-	parent = 19271485a130e190b6b2af1721045416493e2ffb
+	branch = develop
+	commit = 03ab6efdec1d53b9d2359caa376ef12269b81cb5
+	parent = 1a0510697d444347aa5244bf9bb68531a796470f
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/CONFIGURATION.md
+++ b/external-deps/python-lsp-server/CONFIGURATION.md
@@ -32,6 +32,7 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 | `pylsp.plugins.jedi_signature_help.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.jedi_symbols.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.jedi_symbols.all_scopes` | `boolean` | If True lists the names of all scopes instead of only the module namespace. | `true` |
+| `pylsp.plugins.jedi_symbols.include_import_symbols` | `boolean` | If True includes symbols imported from other libraries. | `true` |
 | `pylsp.plugins.mccabe.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.mccabe.threshold` | `number`  | The minimum threshold that triggers warnings about cyclomatic complexity. | `15` |
 | `pylsp.plugins.preload.enabled` | `boolean` | Enable or disable the plugin. | `true` |

--- a/external-deps/python-lsp-server/pylsp/config/schema.json
+++ b/external-deps/python-lsp-server/pylsp/config/schema.json
@@ -157,6 +157,11 @@
       "default": true,
       "description": "If True lists the names of all scopes instead of only the module namespace."
     },
+    "pylsp.plugins.jedi_symbols.include_import_symbols": {
+      "type": "boolean",
+      "default": true,
+      "description": "If True includes symbols imported from other libraries."
+    },
     "pylsp.plugins.mccabe.enabled": {
       "type": "boolean",
       "default": true,

--- a/external-deps/python-lsp-server/pylsp/python_lsp.py
+++ b/external-deps/python-lsp-server/pylsp/python_lsp.py
@@ -383,7 +383,8 @@ class PythonLSPServer(MethodDispatcher):
         return self.signature_help(textDocument['uri'], position)
 
     def m_workspace__did_change_configuration(self, settings=None):
-        self.config.update((settings or {}).get('pylsp', {}))
+        if self.config is not None:
+            self.config.update((settings or {}).get('pylsp', {}))
         for workspace in self.workspaces.values():
             workspace.update_config(settings)
             for doc_uri in workspace.documents:

--- a/external-deps/python-lsp-server/pylsp/workspace.py
+++ b/external-deps/python-lsp-server/pylsp/workspace.py
@@ -239,8 +239,8 @@ class Document:
         return m_start[0] + m_end[-1]
 
     @lock
-    def jedi_names(self, use_document_path, all_scopes=False, definitions=True, references=False):
-        script = self.jedi_script(use_document_path=use_document_path)
+    def jedi_names(self, all_scopes=False, definitions=True, references=False):
+        script = self.jedi_script()
         return script.get_names(all_scopes=all_scopes, definitions=definitions,
                                 references=references)
 

--- a/external-deps/python-lsp-server/test/test_language_server.py
+++ b/external-deps/python-lsp-server/test/test_language_server.py
@@ -7,6 +7,7 @@ import multiprocessing
 import sys
 from threading import Thread
 
+from flaky import flaky
 from pylsp_jsonrpc.exceptions import JsonRpcMethodNotFound
 import pytest
 
@@ -75,6 +76,7 @@ def client_exited_server():
     assert client_server_pair.process.is_alive() is False
 
 
+@flaky(max_runs=10, min_passes=1)
 @pytest.mark.skipif(sys.platform == 'darwin', reason='Too flaky on Mac')
 def test_initialize(client_server):  # pylint: disable=redefined-outer-name
     response = client_server._endpoint.request('initialize', {

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -248,17 +248,28 @@ def main_window(request, tmpdir):
     if preload_project:
         # Create project
         project = tmpdir.mkdir('test_project')
-        subdir = project.mkdir('subdir')
+        project_subdir = project.mkdir('subdir')
+
+        # Create directories out of the project
+        out_of_project_1 = tmpdir.mkdir('out_of_project_1')
+        out_of_project_2 = tmpdir.mkdir('out_of_project_2')
+        out_of_project_1_subdir = out_of_project_1.mkdir('subdir')
+        out_of_project_2_subdir = out_of_project_2.mkdir('subdir')
 
         project_path = str(project)
         spy_project = EmptyProject(project_path)
         CONF.set('project_explorer', 'current_project_path', project_path)
 
-        # Add some files to project
+        # Add some files to project. This is necessary to test that we get
+        # symgbols for all these files.
         abs_filenames = []
         filenames_to_create = {
             project: ['file1.py', 'file2.py', 'file3.txt', '__init__.py'],
-            subdir: ['subdir_file1.py', '__init__.py']
+            project_subdir: ['a.py', '__init__.py'],
+            out_of_project_1: ['b.py'],
+            out_of_project_2: ['c.py', '__init__.py'],
+            out_of_project_1_subdir: ['d.py', '__init__.py'],
+            out_of_project_2_subdir: ['e.py']
         }
 
         for path in filenames_to_create.keys():
@@ -3823,7 +3834,8 @@ def test_tour_message(main_window, qtbot):
 @flaky(max_runs=3)
 @pytest.mark.use_introspection
 @pytest.mark.preload_project
-@pytest.mark.skipif(os.name == 'nt', reason="Fails on Windows")
+@pytest.mark.skipif(not sys.platform.startswith('linux'),
+                    reason="Only works on Linux")
 def test_update_outline(main_window, qtbot, tmpdir):
     """
     Test that files in the Outline pane are updated at startup and
@@ -3841,7 +3853,7 @@ def test_update_outline(main_window, qtbot, tmpdir):
     ]
 
     # Wait a bit for trees to be filled
-    qtbot.wait(5000)
+    qtbot.wait(20000)
 
     # Assert all Python editors are filled
     assert all(

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -247,25 +247,23 @@ def main_window(request, tmpdir):
 
     if preload_project:
         # Create project
-        project_path = str(tmpdir.mkdir('test_project'))
-        project = EmptyProject(project_path)
+        project = tmpdir.mkdir('test_project')
+        project_path = str(project)
+        spy_project = EmptyProject(project_path)
         CONF.set('project_explorer', 'current_project_path', project_path)
 
         # Add some files to project
-        filenames = [
-            osp.join(project_path, f) for f in
-            ['file1.py', 'file2.py', 'file3.txt']
-        ]
+        abs_filenames = []
+        for filename in ['file1.py', 'file2.py', 'file3.txt']:
+            f = project.join(filename)
+            abs_filenames.append(str(f))
+            if osp.splitext(filename)[1] == '.py':
+                f.write("def f(x):\n"
+                        "    return x\n")
+            else:
+                f.write("Hello world!")
 
-        for filename in filenames:
-            with open(filename, 'w') as f:
-                if osp.splitext(filename)[1] == '.py':
-                    f.write("def f(x):\n"
-                            "    return x\n")
-                else:
-                    f.write("Hello world!")
-
-        project.set_recent_files(filenames)
+        spy_project.set_recent_files(abs_filenames)
     else:
         CONF.set('project_explorer', 'current_project_path', None)
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -278,8 +278,17 @@ def main_window(request, tmpdir):
                 f = path.join(filename)
                 abs_filenames.append(str(f))
                 if osp.splitext(filename)[1] == '.py':
-                    f.write("def f(x):\n"
-                            "    return x\n")
+                    code = dedent(
+                        """
+                        from math import cos
+                        from numpy import (
+                           linspace)
+
+                        def f(x):
+                            return x
+                        """
+                    )
+                    f.write(code)
                 else:
                     f.write("Hello world!")
 
@@ -3858,7 +3867,7 @@ def test_update_outline(main_window, qtbot, tmpdir):
     # Assert all Python editors are filled
     assert all(
         [
-            len(treewidget.editor_tree_cache[editor.get_id()]) > 0
+            len(treewidget.editor_tree_cache[editor.get_id()]) == 1
             for editor in editors_py
         ]
     )

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -248,20 +248,29 @@ def main_window(request, tmpdir):
     if preload_project:
         # Create project
         project = tmpdir.mkdir('test_project')
+        subdir = project.mkdir('subdir')
+
         project_path = str(project)
         spy_project = EmptyProject(project_path)
         CONF.set('project_explorer', 'current_project_path', project_path)
 
         # Add some files to project
         abs_filenames = []
-        for filename in ['file1.py', 'file2.py', 'file3.txt']:
-            f = project.join(filename)
-            abs_filenames.append(str(f))
-            if osp.splitext(filename)[1] == '.py':
-                f.write("def f(x):\n"
-                        "    return x\n")
-            else:
-                f.write("Hello world!")
+        filenames_to_create = {
+            project: ['file1.py', 'file2.py', 'file3.txt', '__init__.py'],
+            subdir: ['subdir_file1.py', '__init__.py']
+        }
+
+        for path in filenames_to_create.keys():
+            filenames = filenames_to_create[path]
+            for filename in filenames:
+                f = path.join(filename)
+                abs_filenames.append(str(f))
+                if osp.splitext(filename)[1] == '.py':
+                    f.write("def f(x):\n"
+                            "    return x\n")
+                else:
+                    f.write("Hello world!")
 
         spy_project.set_recent_files(abs_filenames)
     else:

--- a/spyder/plugins/completion/providers/languageserver/client.py
+++ b/spyder/plugins/completion/providers/languageserver/client.py
@@ -15,6 +15,7 @@ communicate with a v3.0 Language Server Protocol server.
 import logging
 import os
 import os.path as osp
+import pathlib
 import signal
 import sys
 import time
@@ -26,6 +27,7 @@ import zmq
 import psutil
 
 # Local imports
+from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.config.base import (DEV, get_conf_path, get_debug_level,
                                 running_under_pytest)
 from spyder.plugins.completion.api import (
@@ -38,14 +40,8 @@ from spyder.plugins.completion.providers.languageserver.transport import (
     MessageKind)
 from spyder.plugins.completion.providers.languageserver.providers import (
     LSPMethodProviderMixIn)
-from spyder.py3compat import PY2
 from spyder.utils.misc import getcwd_or_home, select_port
 
-# Conditional imports
-if PY2:
-    import pathlib2 as pathlib
-else:
-    import pathlib
 
 # Main constants
 LOCATION = osp.realpath(osp.join(os.getcwd(),
@@ -63,7 +59,7 @@ logger = logging.getLogger(__name__)
 
 
 @class_register
-class LSPClient(QObject, LSPMethodProviderMixIn):
+class LSPClient(QObject, LSPMethodProviderMixIn, SpyderConfigurationAccessor):
     """Language Server Protocol v3.0 client implementation."""
     #: Signal to inform the editor plugin that the client has
     #  started properly and it's ready to be used.
@@ -161,6 +157,26 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
             os.makedirs(osp.dirname(location))
 
         return location
+
+    def _clean_sys_path(self):
+        """
+        Remove from sys.path entries that come from our config system.
+
+        They will be passed to the server in the extra_paths option
+        and are not needed for the transport layer.
+        """
+        spyder_pythonpath = self.get_conf(
+            'spyder_pythonpath',
+            section='main',
+            default=[]
+        )
+
+        sys_path = sys.path[:]
+        for path in spyder_pythonpath:
+            if path in sys_path:
+                sys_path.remove(path)
+
+        return sys_path
 
     @property
     def server_log_file(self):
@@ -265,7 +281,8 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         if DEV or running_under_pytest():
             running_in_ci = bool(os.environ.get('CI'))
             if os.name != 'nt' or os.name == 'nt' and not running_in_ci:
-                env.insert('PYTHONPATH', os.pathsep.join(sys.path)[:])
+                sys_path = self._clean_sys_path()
+                env.insert('PYTHONPATH', os.pathsep.join(sys_path)[:])
 
         # Adjustments for the Python language server.
         if self.language == 'python':
@@ -326,10 +343,11 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         # Modifying PYTHONPATH to run transport in development mode or
         # tests
         if DEV or running_under_pytest():
+            sys_path = self._clean_sys_path()
             if running_under_pytest():
-                env.insert('PYTHONPATH', os.pathsep.join(sys.path)[:])
+                env.insert('PYTHONPATH', os.pathsep.join(sys_path)[:])
             else:
-                env.insert('PYTHONPATH', os.pathsep.join(sys.path)[1:])
+                env.insert('PYTHONPATH', os.pathsep.join(sys_path)[1:])
             self.transport.setProcessEnvironment(env)
 
         # Set up transport

--- a/spyder/plugins/completion/providers/languageserver/client.py
+++ b/spyder/plugins/completion/providers/languageserver/client.py
@@ -433,6 +433,10 @@ class LSPClient(QObject, LSPMethodProviderMixIn):
         if self.is_down():
             return
 
+        # Don't send requests to the server before it's been initialized.
+        if not self.initialized and method != 'initialize':
+            return
+
         if ClientConstants.CANCEL in params:
             return
         _id = self.request_seq

--- a/spyder/plugins/outlineexplorer/plugin.py
+++ b/spyder/plugins/outlineexplorer/plugin.py
@@ -79,8 +79,3 @@ class OutlineExplorer(SpyderDockablePlugin):
         """Disable LSP symbols functionality."""
         explorer = self.get_widget()
         explorer.stop_symbol_services(language)
-
-    def update_all_editors(self):
-        """Update all editors with an associated LSP server."""
-        explorer = self.get_widget()
-        explorer.update_all_editors()

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -561,14 +561,13 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         if items is None:
             return
 
-        plugin_base = self.parent().parent()
         if editor is None:
             editor = self.current_editor
         editor_id = editor.get_id()
         language = editor.get_language()
         update = self.update_tree(items, editor_id, language)
 
-        if getattr(plugin_base, "_isvisible", True) and update:
+        if update:
             self.save_expanded_state()
             self.restore_expanded_state()
             self.do_follow_cursor()

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -375,13 +375,13 @@ class OutlineExplorerTreeWidget(OneColumnTree):
     def toggle_show_comments(self, state):
         self.show_comments = state
         self.sig_update_configuration.emit()
-        self.update_all_editors(reset_info=True)
+        self.update_editors(language='python')
 
     @on_conf_change(option='group_cells')
     def toggle_group_cells(self, state):
         self.group_cells = state
         self.sig_update_configuration.emit()
-        self.update_all_editors(reset_info=True)
+        self.update_editors(language='python')
 
     @on_conf_change(option='display_variables')
     def toggle_variables(self, state):
@@ -550,12 +550,6 @@ class OutlineExplorerTreeWidget(OneColumnTree):
                 except KeyError:
                     pass
                 self.editors_to_update[language].remove(editor)
-            self.update_timers[language].start()
-
-    def update_all_editors(self, reset_info=False):
-        """Update all editors with LSP support."""
-        for language in self._languages:
-            self.set_editors_to_update(language, reset_info=reset_info)
             self.update_timers[language].start()
 
     @Slot(list)
@@ -1027,7 +1021,3 @@ class OutlineExplorerWidget(PluginMainWidget):
     def stop_symbol_services(self, language):
         """Disable LSP symbols functionality."""
         self.treewidget.stop_symbol_services(language)
-
-    def update_all_editors(self):
-        """Update all editors with an associated LSP server."""
-        self.treewidget.update_all_editors()

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -489,7 +489,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
 
         # Update tree with currently stored info or require symbols if
         # necessary.
-        if (editor.get_language() in self._languages and
+        if (editor.get_language().lower() in self._languages and
                 len(self.editor_tree_cache[editor_id]) == 0):
             if editor.info is not None:
                 self.update_editor(editor.info)

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -76,7 +76,7 @@ class Projects(SpyderDockablePlugin):
     CONF_FILE = False
     REQUIRES = []
     OPTIONAL = [Plugins.Completions, Plugins.IPythonConsole, Plugins.Editor,
-                Plugins.OutlineExplorer, Plugins.MainMenu]
+                Plugins.MainMenu]
     WIDGET_CLASS = ProjectExplorerWidget
 
     # Signals
@@ -211,7 +211,7 @@ class Projects(SpyderDockablePlugin):
         #     lambda settings, language:
         #         self.start_workspace_services())
         self.completions.sig_stop_completions.connect(
-                self.stop_workspace_services)
+            self.stop_workspace_services)
         self.sig_project_loaded.connect(
             functools.partial(self.completions.project_path_update,
                               update_kind=WorkspaceUpdateKind.ADDITION,
@@ -235,14 +235,6 @@ class Projects(SpyderDockablePlugin):
                 fname, osp.dirname(fname), '', False, False, False, True,
                 False)
         )
-
-    @on_plugin_available(plugin=Plugins.OutlineExplorer)
-    def on_outline_explorer_available(self):
-        outline_explorer = self.get_plugin(Plugins.OutlineExplorer)
-        self.sig_project_loaded.connect(
-            lambda v: outline_explorer.update_all_editors())
-        self.sig_project_closed.connect(
-            lambda v: outline_explorer.update_all_editors())
 
     @on_plugin_available(plugin=Plugins.MainMenu)
     def on_main_menu_available(self):


### PR DESCRIPTION
## Description of Changes

- Symbols were not shown for files in projects when an `__init__.py` file is present at the root of the project.
- Symbols were not updated when switching projects.
- Don't send requests to the LSP server before it's been initialized (this was not compliant with the LSP protocol).
- Remove from `sys.path` entries that come from our config system when passed to the LSP server and transport layer, and Spyder is running in dev or testing modes. That allows us to better test things in those modes.
- Depends on python-lsp/python-lsp-server#53

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15648 
Fixes #14871

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
