### PR TITLE
PR: Pre-render menus when main window is visible on macOS

### DIFF
--- a/spyder/api/widgets/mixins.py
+++ b/spyder/api/widgets/mixins.py
@@ -351,7 +351,7 @@ class SpyderActionMixin:
                       context=Qt.WidgetWithChildrenShortcut, initial=None,
                       register_shortcut=False, section=None, option=None,
                       parent=None, register_action=True, overwrite=False,
-                      context_name=None):
+                      context_name=None, menurole=None):
         """
         name: str
             unique identifiable name for the action
@@ -400,7 +400,9 @@ class SpyderActionMixin:
             Name of the context that holds the action in case of registration.
             The combination of `name` and `context_name` is unique so trying
             to register an action with the same `name` and `context_name` will
-            cause a warning unless `overwrite` is set to `True`
+            cause a warning unless `overwrite` is set to `True`.
+        menurole: QAction.MenuRole, optional
+            Menu role for the action (it only has effect on macOS).
 
         Notes
         -----
@@ -444,7 +446,8 @@ class SpyderActionMixin:
             context_name=(
                 self.CONTEXT_NAME if context_name is None else context_name),
             register_action=register_action,
-            overwrite=overwrite
+            overwrite=overwrite,
+            menurole=menurole
         )
         action.name = name
         if icon_text:

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1052,8 +1052,7 @@ class MainWindow(QMainWindow):
             _("PYTHONPATH manager"),
             None, icon=ima.icon('pythonpath'),
             triggered=self.show_path_manager,
-            tip=_("PYTHONPATH manager"),
-            menurole=QAction.ApplicationSpecificRole)
+            tip=_("PYTHONPATH manager"))
         from spyder.plugins.application.plugin import (
             ApplicationActions, WinUserEnvDialog)
         winenv_action = None

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -118,9 +118,8 @@ class ApplicationContainer(PluginMainContainer):
             ApplicationActions.SpyderAbout,
             _("About %s...") % "Spyder",
             icon=self.create_icon('MessageBoxInformation'),
-            triggered=self.show_about)
-        if sys.platform == 'darwin':
-            self.about_action.setMenuRole(QAction.AboutRole)
+            triggered=self.show_about,
+            menurole=QAction.AboutRole)
 
         # Tools actions
         if WinUserEnvDialog is not None:

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -125,66 +125,64 @@ class Application(SpyderPluginV2):
     # ------------------------------------------------------------------------
     def _populate_file_menu(self):
         mainmenu = self.get_plugin(Plugins.MainMenu)
-        if mainmenu:
-            mainmenu.add_item_to_application_menu(
-                self.restart_action,
-                menu_id=ApplicationMenus.File,
-                section=FileMenuSections.Restart)
+        mainmenu.add_item_to_application_menu(
+            self.restart_action,
+            menu_id=ApplicationMenus.File,
+            section=FileMenuSections.Restart)
 
     def _populate_tools_menu(self):
         """Add base actions and menus to the Tools menu."""
         mainmenu = self.get_plugin(Plugins.MainMenu)
-        if mainmenu:
-            if WinUserEnvDialog is not None:
-                mainmenu.add_item_to_application_menu(
-                    self.winenv_action,
-                    menu_id=ApplicationMenus.Tools,
-                    section=ToolsMenuSections.Tools)
+        if WinUserEnvDialog is not None:
+            mainmenu.add_item_to_application_menu(
+                self.winenv_action,
+                menu_id=ApplicationMenus.Tools,
+                section=ToolsMenuSections.Tools)
 
     def _populate_help_menu(self):
         """Add base actions and menus to the Help menu."""
-        mainmenu = self.get_plugin(Plugins.MainMenu)
-        self._populate_help_menu_documentation_section(mainmenu)
-        self._populate_help_menu_support_section(mainmenu)
-        self._populate_help_menu_about_section(mainmenu)
+        self._populate_help_menu_documentation_section()
+        self._populate_help_menu_support_section()
+        self._populate_help_menu_about_section()
 
-    def _populate_help_menu_documentation_section(self, mainmenu):
+    def _populate_help_menu_documentation_section(self):
         """Add base Spyder documentation actions to the Help main menu."""
-        if mainmenu:
-            shortcuts = self.get_plugin(Plugins.Shortcuts)
-            shortcuts_summary_action = None
-            if shortcuts:
-                from spyder.plugins.shortcuts.plugin import ShortcutActions
-                shortcuts_summary_action = shortcuts.get_action(
-                    ShortcutActions.ShortcutSummaryAction)
-            for documentation_action in [
-                    self.documentation_action, self.video_action]:
-                mainmenu.add_item_to_application_menu(
-                    documentation_action,
-                    menu_id=ApplicationMenus.Help,
-                    section=HelpMenuSections.Documentation,
-                    before=shortcuts_summary_action,
-                    before_section=HelpMenuSections.Support)
+        mainmenu = self.get_plugin(Plugins.MainMenu)
+        shortcuts = self.get_plugin(Plugins.Shortcuts)
+        shortcuts_summary_action = None
 
-    def _populate_help_menu_support_section(self, mainmenu):
-        """Add Spyder base support actions to the Help main menu."""
-        if mainmenu:
-            for support_action in [
-                    self.trouble_action, self.dependencies_action,
-                    self.check_updates_action, self.support_group_action]:
-                mainmenu.add_item_to_application_menu(
-                    support_action,
-                    menu_id=ApplicationMenus.Help,
-                    section=HelpMenuSections.Support,
-                    before_section=HelpMenuSections.ExternalDocumentation)
-
-    def _populate_help_menu_about_section(self, mainmenu):
-        """Create Spyder base about actions."""
-        if mainmenu:
+        if shortcuts:
+            from spyder.plugins.shortcuts.plugin import ShortcutActions
+            shortcuts_summary_action = shortcuts.get_action(
+                ShortcutActions.ShortcutSummaryAction)
+        for documentation_action in [
+                self.documentation_action, self.video_action]:
             mainmenu.add_item_to_application_menu(
-                self.about_action,
+                documentation_action,
                 menu_id=ApplicationMenus.Help,
-                section=HelpMenuSections.About)
+                section=HelpMenuSections.Documentation,
+                before=shortcuts_summary_action,
+                before_section=HelpMenuSections.Support)
+
+    def _populate_help_menu_support_section(self):
+        """Add Spyder base support actions to the Help main menu."""
+        mainmenu = self.get_plugin(Plugins.MainMenu)
+        for support_action in [
+                self.trouble_action, self.dependencies_action,
+                self.check_updates_action, self.support_group_action]:
+            mainmenu.add_item_to_application_menu(
+                support_action,
+                menu_id=ApplicationMenus.Help,
+                section=HelpMenuSections.Support,
+                before_section=HelpMenuSections.ExternalDocumentation)
+
+    def _populate_help_menu_about_section(self):
+        """Create Spyder base about actions."""
+        mainmenu = self.get_plugin(Plugins.MainMenu)
+        mainmenu.add_item_to_application_menu(
+            self.about_action,
+            menu_id=ApplicationMenus.Help,
+            section=HelpMenuSections.About)
 
     # ---- Public API
     # ------------------------------------------------------------------------

--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -22,7 +22,7 @@ import sys
 # Third party imports
 from qtpy.compat import getopenfilename
 from qtpy.QtCore import Qt, Signal, Slot
-from qtpy.QtWidgets import QInputDialog, QLineEdit, QVBoxLayout
+from qtpy.QtWidgets import QAction, QInputDialog, QLineEdit, QVBoxLayout
 
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
@@ -169,7 +169,8 @@ class ConsoleWidget(PluginMainWidget):
             triggered=self.sig_quit_requested,
             context=Qt.ApplicationShortcut,
             shortcut_context="_",
-            register_shortcut=True
+            register_shortcut=True,
+            menurole=QAction.QuitRole
         )
         run_action = self.create_action(
             ConsoleWidgetActions.Run,

--- a/spyder/plugins/mainmenu/plugin.py
+++ b/spyder/plugins/mainmenu/plugin.py
@@ -62,9 +62,17 @@ class MainMenu(SpyderPluginV2):
         create_app_menu(ApplicationMenus.View, _("&View"))
         create_app_menu(ApplicationMenus.Help, _("&Help"))
 
-    # --- Private methods
-    # ------------------------------------------------------------------------
+    def on_mainwindow_visible(self):
+        # Pre-render menus so actions with menu roles (like "About Spyder"
+        # and "Preferences") are located in the right place in Mac's menu
+        # bar.
+        # Fixes spyder-ide/spyder#14917
+        if sys.platform == 'darwin':
+            for menu in self._APPLICATION_MENUS.values():
+                menu._render()
 
+    # ---- Private methods
+    # ------------------------------------------------------------------------
     def _show_shortcuts(self, menu):
         """
         Show action shortcuts in menu.
@@ -139,7 +147,7 @@ class MainMenu(SpyderPluginV2):
                         lambda menu=menu: set_menu_icons(menu, False))
                     menu.aboutToShow.connect(self._hide_options_menus)
 
-    # --- Public API
+    # ---- Public API
     # ------------------------------------------------------------------------
     def create_application_menu(self, menu_id, title, dynamic=True):
         """

--- a/spyder/plugins/preferences/widgets/container.py
+++ b/spyder/plugins/preferences/widgets/container.py
@@ -105,11 +105,9 @@ class PreferencesContainer(PluginMainContainer):
             PreferencesActions.Show,
             _("Preferences"),
             icon=self.create_icon('configure'),
-            triggered=self.show_preferences
+            triggered=self.show_preferences,
+            menurole=QAction.PreferencesRole
         )
-
-        if sys.platform == 'darwin':
-            self.show_action.setMenuRole(QAction.PreferencesRole)
 
         self.reset_action = self.create_action(
             PreferencesActions.Reset,


### PR DESCRIPTION
## Description of Changes

- This correctly positions actions with a menu role in Mac's menu bar.
- Also, add a `menurole` kwarg to the `create_action` method of `SpyderActionMixin`.
- Remove unnecessary check for MainMenu in Application.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14917

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
