### PR TITLE
PR: Fix loading internal plugins and run tests as if the package were installed in our CIs

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -62,8 +62,11 @@ do
 done
 
 # Install Spyder to test it as if it was properly installed
+# Note: `python setup.py egg_info` doesn't work here but it
+# does locally.
 pip uninstall spyder -q -y
-python setup.py egg_info
+python setup.py bdist_wheel
+pip install --no-deps dist/spyder*.whl
 
 # To check our manifest
 pip install check-manifest

--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -24,9 +24,10 @@ if [ "$USE_CONDA" = "true" ]; then
         conda install pyzmq=19
     fi
 
-    # Remove packages we have subrepos for
+    # Remove packages we have subrepos for.
     conda remove spyder-kernels --force -q -y
     conda remove python-lsp-server --force -q -y
+    conda remove qdarkstyle --force -q -y
 else
     # Update pip and setuptools
     pip install -U pip setuptools
@@ -49,16 +50,21 @@ else
     # Remove packages we have subrepos for
     pip uninstall spyder-kernels -q -y
     pip uninstall python-lsp-server -q -y
-
+    pip uninstall qdarkstyle -q -y
 fi
 
-# This is necessary only for Windows (don't know why).
-if [ "$OS" = "win" ]; then
-    # Install python-lsp-server from our subrepo
-    pushd external-deps/python-lsp-server
+# Install subrepos in development mode
+for dep in $(ls external-deps)
+do
+    pushd external-deps/$dep
     pip install --no-deps -q -e .
     popd
-fi
+done
+
+# Install Spyder to test it as if it was properly installed
+pip uninstall spyder -q -y
+python setup.py bdist_wheel
+pip install --no-deps dist/spyder*.whl
 
 # To check our manifest
 pip install check-manifest

--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -63,8 +63,7 @@ done
 
 # Install Spyder to test it as if it was properly installed
 pip uninstall spyder -q -y
-python setup.py bdist_wheel
-pip install --no-deps dist/spyder*.whl
+python setup.py egg_info
 
 # To check our manifest
 pip install check-manifest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,6 @@
 [check-manifest]
 ignore =
-    .circleci/*
     .codecov.yml
-    .circleci
     .codecov.yml
     .coveragerc
     .pep8speaks.yml
@@ -12,14 +10,9 @@ ignore =
     RELEASE.md
     TROUBLESHOOTING.md
     MAINTENANCE.md
-    azure-pipelines.yml
-    binder
     binder/**
     conftest.py
-    continuous_integration
-    continuous_integration/**
     crowdin.yml
-    external-deps
     external-deps/**
     img_src/*.svg
     img_src/*.png
@@ -29,13 +22,10 @@ ignore =
     img_src/*.icns
     installers/**
     pytest.ini
-    requirements
     requirements/**
-    rope_profiling
     rope_profiling/**
     runtests.py
     *tests/**
-    tools
     tools/**
     branding/**
 ignore-bad-ideas =

--- a/spyder/app/find_plugins.py
+++ b/spyder/app/find_plugins.py
@@ -19,7 +19,8 @@ from spyder.api.exceptions import SpyderAPIError
 from spyder.api.plugins import (
     SpyderDockablePlugin, SpyderPluginWidget, Plugins)
 from spyder.api.utils import get_class_values
-from spyder.config.base import DEV, STDERR, running_under_pytest
+from spyder.config.base import (
+    DEV, STDERR, running_in_ci, running_under_pytest)
 
 
 logger = logging.getLogger(__name__)
@@ -39,8 +40,7 @@ def find_internal_plugins():
     base_path = os.path.dirname(os.path.dirname(HERE))
     setup_path = os.path.join(base_path, "setup.py")
 
-    if (DEV is not None or running_under_pytest()
-            and os.path.isfile(setup_path)):
+    if (DEV or running_under_pytest()) and not running_in_ci():
         if not os.path.isfile(setup_path):
             raise Exception(
                 'No "setup.py" file found and running in DEV mode!')

--- a/spyder/app/find_plugins.py
+++ b/spyder/app/find_plugins.py
@@ -18,9 +18,8 @@ import pkg_resources
 from spyder.api.exceptions import SpyderAPIError
 from spyder.api.plugins import (
     SpyderDockablePlugin, SpyderPluginWidget, Plugins)
+from spyder.api.utils import get_class_values
 from spyder.config.base import DEV, STDERR, running_under_pytest
-from spyder.utils.external.toposort import (CircularDependencyError,
-                                            toposort_flatten)
 
 
 logger = logging.getLogger(__name__)
@@ -28,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 def find_internal_plugins():
     """
-    Find available plugins based on setup.py entry points.
+    Find internal plugins based on setup.py entry points.
 
     In DEV mode we parse the `setup.py` file directly.
     """
@@ -39,6 +38,7 @@ def find_internal_plugins():
     HERE = os.path.abspath(os.path.dirname(__file__))
     base_path = os.path.dirname(os.path.dirname(HERE))
     setup_path = os.path.join(base_path, "setup.py")
+
     if (DEV is not None or running_under_pytest()
             and os.path.isfile(setup_path)):
         if not os.path.isfile(setup_path):
@@ -80,38 +80,40 @@ def find_internal_plugins():
             except (ModuleNotFoundError, ImportError) as e:
                 raise e
     else:
-        import spyder.plugins as plugin_mod
+        entry_points = list(pkg_resources.iter_entry_points("spyder.plugins"))
+        internal_names = get_class_values(Plugins)
 
-        plugins_path = os.path.dirname(plugin_mod.__file__)
-        for folder in os.listdir(plugins_path):
-            plugin_path = os.path.join(plugins_path, folder)
-            init_path = os.path.join(plugin_path, "__init__.py")
-            if (os.path.isdir(plugin_path) and os.path.isfile(init_path)
-                    and not folder.startswith("io_")):
-                spec = importlib.util.spec_from_file_location(folder,
-                                                              init_path)
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-                for plugin_class in getattr(module, "PLUGIN_CLASSES", []):
-                    internal_plugins[plugin_class.NAME] = plugin_class
+        for entry_point in entry_points:
+            name = entry_point.name
+            if name not in internal_names:
+                continue
+
+            class_name = entry_point.attrs[0]
+            mod = importlib.import_module(entry_point.module_name)
+            plugin_class = getattr(mod, class_name, None)
+            internal_plugins[name] = plugin_class
+
+        # FIXME: This shouldn't be necessary but it's just to be sure
+        # plugins are sorted in alphabetical order. We need to remove it
+        # in a later version.
+        internal_plugins = {
+            key: value for key, value in sorted(internal_plugins.items())
+        }
 
     return internal_plugins
 
 
 def find_external_plugins():
     """
-    Find available internal plugins based on setuptools entry points.
+    Find available external plugins based on setuptools entry points.
     """
-    internal_plugins = find_internal_plugins()
-    plugins = [
-        entry_point for entry_point
-        in pkg_resources.iter_entry_points("spyder.plugins")
-    ]
-
+    internal_names = get_class_values(Plugins)
+    plugins = list(pkg_resources.iter_entry_points("spyder.plugins"))
     external_plugins = {}
+
     for entry_point in plugins:
         name = entry_point.name
-        if name not in internal_plugins:
+        if name not in internal_names:
             try:
                 class_name = entry_point.attrs[0]
                 mod = importlib.import_module(entry_point.module_name)

--- a/spyder/app/tests/test_find_plugins.py
+++ b/spyder/app/tests/test_find_plugins.py
@@ -7,7 +7,7 @@
 # -----------------------------------------------------------------------------
 
 """
-Tests for the finding plugins.
+Tests for finding plugins.
 """
 
 from spyder.api.plugins import Plugins
@@ -25,7 +25,7 @@ def test_find_internal_plugins():
     # Dictionary of internal plugins
     internal_plugins = find_internal_plugins()
 
-    # Lenghts must be the same
+    # Lengths must be the same
     assert len(expected_names) == len(internal_plugins.values())
 
     # Names must be the same

--- a/spyder/app/tests/test_find_plugins.py
+++ b/spyder/app/tests/test_find_plugins.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+# -----------------------------------------------------------------------------
+
+"""
+Tests for the finding plugins.
+"""
+
+from spyder.api.plugins import Plugins
+from spyder.api.utils import get_class_values
+from spyder.app.find_plugins import find_internal_plugins
+
+
+def test_find_internal_plugins():
+    """Test that we return all internal plugins available."""
+    # We don't take the 'All' plugin into account here because it's not
+    # really a plugin.
+    expected_names = get_class_values(Plugins)
+    expected_names.remove(Plugins.All)
+
+    # Dictionary of internal plugins
+    internal_plugins = find_internal_plugins()
+
+    # Lenghts must be the same
+    assert len(expected_names) == len(internal_plugins.values())
+
+    # Names must be the same
+    assert sorted(expected_names) == sorted(list(internal_plugins.keys()))

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -55,12 +55,17 @@ def get_safe_mode():
 
 def running_under_pytest():
     """
-    Return True if currently running under py.test.
+    Return True if currently running under pytest.
 
     This function is used to do some adjustment for testing. The environment
     variable SPYDER_PYTEST is defined in conftest.py.
     """
     return bool(os.environ.get('SPYDER_PYTEST'))
+
+
+def running_in_ci():
+    """Return True if currently running under CI."""
+    return bool(os.environ.get('CI'))
 
 
 def is_stable_version(version):

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -12,7 +12,8 @@ import os.path as osp
 import sys
 
 # Local imports
-from spyder.config.base import _, DEV, is_pynsist, running_under_pytest
+from spyder.config.base import (
+    _, DEV, is_pynsist, running_in_ci, running_under_pytest)
 from spyder.config.utils import is_anaconda
 from spyder.utils import programs
 
@@ -403,7 +404,7 @@ def missing_dependencies():
     missing_deps = []
     for dependency in DEPENDENCIES:
         # Skip checking dependencies for which we have subrepos
-        if DEV or running_under_pytest():
+        if (DEV or running_under_pytest()) and not running_in_ci():
             repo_path = osp.normpath(osp.join(HERE, '..'))
             subrepos_path = osp.join(repo_path, 'external-deps')
             subrepos = os.listdir(subrepos_path)

--- a/spyder/plugins/completion/providers/languageserver/client.py
+++ b/spyder/plugins/completion/providers/languageserver/client.py
@@ -28,8 +28,8 @@ import psutil
 
 # Local imports
 from spyder.api.config.mixins import SpyderConfigurationAccessor
-from spyder.config.base import (DEV, get_conf_path, get_debug_level,
-                                running_under_pytest)
+from spyder.config.base import (
+    DEV, get_conf_path, get_debug_level, running_in_ci, running_under_pytest)
 from spyder.plugins.completion.api import (
     CLIENT_CAPABILITES, SERVER_CAPABILITES,
     TEXT_DOCUMENT_SYNC_OPTIONS, CompletionRequestTypes,
@@ -278,11 +278,9 @@ class LSPClient(QObject, LSPMethodProviderMixIn, SpyderConfigurationAccessor):
         env = self.server.processEnvironment()
 
         # Use local PyLS instead of site-packages one.
-        if DEV or running_under_pytest():
-            running_in_ci = bool(os.environ.get('CI'))
-            if os.name != 'nt' or os.name == 'nt' and not running_in_ci:
-                sys_path = self._clean_sys_path()
-                env.insert('PYTHONPATH', os.pathsep.join(sys_path)[:])
+        if (DEV or running_under_pytest()) and not running_in_ci():
+            sys_path = self._clean_sys_path()
+            env.insert('PYTHONPATH', os.pathsep.join(sys_path)[:])
 
         # Adjustments for the Python language server.
         if self.language == 'python':
@@ -342,7 +340,7 @@ class LSPClient(QObject, LSPMethodProviderMixIn, SpyderConfigurationAccessor):
 
         # Modifying PYTHONPATH to run transport in development mode or
         # tests
-        if DEV or running_under_pytest():
+        if (DEV or running_under_pytest()) and not running_in_ci():
             sys_path = self._clean_sys_path()
             if running_under_pytest():
                 env.insert('PYTHONPATH', os.pathsep.join(sys_path)[:])

--- a/spyder/plugins/editor/panels/tests/__init__.py
+++ b/spyder/plugins/editor/panels/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+
+"""Tests for the Editor panels."""

--- a/spyder/plugins/editor/utils/tests/__init__.py
+++ b/spyder/plugins/editor/utils/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+
+"""Tests for the Editor utils."""

--- a/spyder/plugins/editor/widgets/tests/assets/autopep8_range.py
+++ b/spyder/plugins/editor/widgets/tests/assets/autopep8_range.py
@@ -10,13 +10,11 @@ import os;import sys
 
 # %% functions
 def d():
-    def inner():
-        return 2
-
+    def inner(): return 2
     return inner
-
-
 # ---- func 1 and 2
+
+
 def func1():
     for i in range(3):
         print(i)
@@ -25,9 +23,9 @@ def func1():
 def func2():
     if True:
         pass
-
-
 # ---- other functions
+
+
 def a():
     pass
 

--- a/spyder/plugins/editor/widgets/tests/assets/autopep8_result.py
+++ b/spyder/plugins/editor/widgets/tests/assets/autopep8_result.py
@@ -11,13 +11,11 @@ import sys
 
 # %% functions
 def d():
-    def inner():
-        return 2
-
+    def inner(): return 2
     return inner
-
-
 # ---- func 1 and 2
+
+
 def func1():
     for i in range(3):
         print(i)
@@ -26,9 +24,9 @@ def func1():
 def func2():
     if True:
         pass
-
-
 # ---- other functions
+
+
 def a():
     pass
 

--- a/spyder/plugins/explorer/tests/__init__.py
+++ b/spyder/plugins/explorer/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+
+"""Tests for Files."""

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -33,7 +33,7 @@ from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
 from spyder.api.config.decorators import on_conf_change
 from spyder.api.translations import get_translation
 from spyder.api.widgets.mixins import SpyderWidgetMixin
-from spyder.config.base import get_home_dir, running_under_pytest
+from spyder.config.base import get_home_dir
 from spyder.config.main import NAME_FILTERS
 from spyder.plugins.explorer.widgets.utils import (
     create_script, fixpath, IconProvider, show_in_external_file_explorer)
@@ -1558,10 +1558,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
         if self.get_conf('name_filters') == ['']:
             self.set_conf('name_filters', [])
         else:
-            if running_under_pytest():
-                self.set_conf('name_filters', name_filters)
-            else:
-                self.set_conf('name_filters', name_filters)
+            self.set_conf('name_filters', name_filters)
 
     def set_show_hidden(self, state):
         """Toggle 'show hidden files' state"""

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -19,8 +19,9 @@ from jupyter_client.kernelspec import KernelSpec
 
 # Local imports
 from spyder.api.config.mixins import SpyderConfigurationAccessor
-from spyder.config.base import (DEV, is_pynsist, running_under_pytest,
-                                get_safe_mode, running_in_mac_app)
+from spyder.config.base import (
+    DEV, get_safe_mode, is_pynsist, running_in_ci, running_in_mac_app,
+    running_under_pytest)
 from spyder.utils.conda import (add_quotes, get_conda_activation_script,
                                 get_conda_env_path, is_conda_env)
 from spyder.utils.environ import clean_env
@@ -133,7 +134,7 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
         env_vars.pop('VIRTUAL_ENV', None)
 
         # Add spyder-kernels subrepo path to PYTHONPATH
-        if DEV or running_under_pytest():
+        if (DEV or running_under_pytest()) and not running_in_ci():
             repo_path = osp.normpath(osp.join(HERE, '..', '..', '..', '..'))
             subrepo_path = osp.join(repo_path, 'external-deps',
                                     'spyder-kernels')

--- a/spyder/plugins/ipythonconsole/utils/tests/test_spyder_kernel.py
+++ b/spyder/plugins/ipythonconsole/utils/tests/test_spyder_kernel.py
@@ -11,16 +11,18 @@ Tests for the Spyder kernel
 import os
 import pytest
 
+from spyder.config.base import running_in_ci
 from spyder.config.manager import CONF
+from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec
 from spyder.py3compat import PY2, is_binary_string, to_text_string
 from spyder.utils.encoding import to_fs_from_unicode
-from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec
 
 
 @pytest.mark.parametrize('default_interpreter', [True, False])
-def test_dont_preserve_pypath(tmpdir, default_interpreter):
+@pytest.mark.skipif(not running_in_ci(), reason="Only works in CI")
+def test_preserve_pypath(tmpdir, default_interpreter):
     """
-    Test that PYTHONPATH is not preserved in the env vars passed to the kernel
+    Test that PYTHONPATH is preserved in the env vars passed to the kernel
     when an external interpreter is used or not.
 
     Regression test for spyder-ide/spyder#8681.
@@ -32,9 +34,9 @@ def test_dont_preserve_pypath(tmpdir, default_interpreter):
     pypath = to_text_string(tmpdir.mkdir('test-pypath'))
     os.environ['PYTHONPATH'] = pypath
 
-    # Check that PYTHONPATH is not the same as in our kernelspec
+    # Check that PYTHONPATH is in our kernelspec
     kernel_spec = SpyderKernelSpec()
-    assert pypath not in kernel_spec.env['PYTHONPATH']
+    assert pypath in kernel_spec.env['PYTHONPATH']
 
     # Restore default value
     CONF.set('main_interpreter', 'default', True)

--- a/spyder/plugins/ipythonconsole/widgets/tests/__init__.py
+++ b/spyder/plugins/ipythonconsole/widgets/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+
+"""Tests for the IPython console widgets."""

--- a/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/tests/test_kernelconnect.py
@@ -10,12 +10,12 @@
 
 # Third party imports
 import sys
-import os
 import pytest
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QDialogButtonBox
 
 # Local imports
+from spyder.config.base import running_in_ci
 from spyder.plugins.ipythonconsole.widgets.kernelconnect import (
     KernelConnectionDialog)
 from spyder.config.manager import CONF
@@ -129,8 +129,7 @@ def test_connection_dialog_remembers_input_with_ssh_passphrase(
     assert new_dlg.un.text() == pytest.un
     assert new_dlg.pn.text() == str(pytest.pn)
     assert new_dlg.kf.text() == pytest.kf
-    if (sys.platform == 'darwin' or
-            not os.environ.get('CI') is not None):
+    if not running_in_ci():
         assert new_dlg.kfp.text() == pytest.kfp
 
 
@@ -157,8 +156,7 @@ def test_connection_dialog_doesnt_remember_input_with_ssh_passphrase(
     assert new_dlg.un.text() == ""
     assert new_dlg.pn.text() == "22"
     assert new_dlg.kf.text() == ""
-    if (sys.platform == 'darwin' or
-            not os.environ.get('CI') is not None):
+    if not running_in_ci():
         assert new_dlg.kfp.text() == ""
 
 
@@ -183,8 +181,7 @@ def test_connection_dialog_remembers_input_with_password(
     assert new_dlg.hn.text() == pytest.hn
     assert new_dlg.un.text() == pytest.un
     assert new_dlg.pn.text() == str(pytest.pn)
-    if (sys.platform == 'darwin' or
-            not os.environ.get('CI') is not None):
+    if not running_in_ci():
         assert new_dlg.pw.text() == pytest.pw
 
 
@@ -210,8 +207,7 @@ def test_connection_dialog_doesnt_remember_input_with_password(
     assert new_dlg.hn.text() == ""
     assert new_dlg.un.text() == ""
     assert new_dlg.pn.text() == "22"
-    if (sys.platform == 'darwin' or
-            not os.environ.get('CI') is not None):
+    if not running_in_ci():
         assert new_dlg.pw.text() == ""
 
 

--- a/spyder/plugins/onlinehelp/tests/__init__.py
+++ b/spyder/plugins/onlinehelp/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+
+"""Tests for the Online help."""

--- a/spyder/plugins/outlineexplorer/tests/__init__.py
+++ b/spyder/plugins/outlineexplorer/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+
+"""Tests for the Outline explorer."""

--- a/spyder/plugins/plots/widgets/tests/__init__.py
+++ b/spyder/plugins/plots/widgets/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+
+"""Tests for the Plots widgets."""

--- a/spyder/plugins/pylint/tests/__init__.py
+++ b/spyder/plugins/pylint/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+
+"""Tests for Pylint plugin."""

--- a/spyder/plugins/variableexplorer/tests/__init__.py
+++ b/spyder/plugins/variableexplorer/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+
+"""Tests for the Variable Explorer."""

--- a/spyder/widgets/github/tests/test_github_backend.py
+++ b/spyder/widgets/github/tests/test_github_backend.py
@@ -19,6 +19,7 @@ import sys
 
 import pytest
 
+from spyder.config.base import running_in_ci
 from spyder.config.manager import CONF
 from spyder.py3compat import PY2
 from spyder.widgets.github import backend
@@ -100,9 +101,7 @@ def test_get_credentials_from_settings():
     assert remember_token is True
 
 
-@pytest.mark.skipif((os.environ.get('CI', None) is not None and
-                     not sys.platform == 'darwin'),
-                    reason="Only work on macOS and our CIs")
+@pytest.mark.skipif(running_in_ci(), reason="Only works locally")
 def test_store_user_credentials():
     b = get_backend()
     b._store_token('token', True)

--- a/spyder/workers/tests/__init__.py
+++ b/spyder/workers/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+
+"""Tests for workers."""


### PR DESCRIPTION
## Description of Changes

- Internal plugins were not detected correctly when the package was not installed but running from git.
- This generated a crash at startup that went undetected before releasing 5.1.0.
- That's why I also took the opportunity to make the necessary changes to run our tests as if the package were installed. That way we can be sure this won't happen again.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16136
Fixes #16117

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
