### PR TITLE
PR: Improve how we handle responses of completion item resolution (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1431,7 +1431,20 @@ class CodeEditor(TextEditBaseWidget):
 
     @handles(CompletionRequestTypes.COMPLETION_RESOLVE)
     def handle_completion_item_resolution(self, response):
-        self.completion_widget.augment_completion_info(response['params'])
+        try:
+            response = response['params']
+
+            if not response:
+                return
+
+            self.completion_widget.augment_completion_info(response)
+        except RuntimeError:
+            # This is triggered when a codeeditor instance was removed
+            # before the response can be processed.
+            return
+        except Exception:
+            self.log_lsp_handle_errors(
+                "Error when handling completion item resolution")
 
     # ------------- LSP: Signature Hints ------------------------------------
     @request(method=CompletionRequestTypes.DOCUMENT_SIGNATURE)


### PR DESCRIPTION
## Description of Changes

- Now we pass on empty responses, instead of passing them to the completion widget.
- We also catch the usual errors that can happen with any response.

### Issue(s) Resolved

Fixes #16125 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
