### PR TITLE
PR: Use running_in_ci instead of checking for the 'CI' env var directly

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -25,7 +25,7 @@ import pytest
 
 
 # To run our slow tests only in our CIs
-CI = os.environ.get('CI', None) is not None
+CI = bool(os.environ.get('CI', None))
 RUN_SLOW = os.environ.get('RUN_SLOW', None) == 'true'
 
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -49,7 +49,8 @@ from spyder.api.widgets.auxiliary_widgets import SpyderWindowWidget
 from spyder.api.plugins import Plugins
 from spyder.app import start
 from spyder.app.mainwindow import MainWindow
-from spyder.config.base import get_home_dir, get_conf_path, get_module_path
+from spyder.config.base import (
+    get_home_dir, get_conf_path, get_module_path, running_in_ci)
 from spyder.config.manager import CONF
 from spyder.plugins.base import PluginWindow
 from spyder.plugins.help.widgets import ObjectComboBox
@@ -371,8 +372,8 @@ def cleanup(request):
 @pytest.mark.slow
 @pytest.mark.order(1)
 @pytest.mark.single_instance
-@pytest.mark.skipif(os.environ.get('CI', None) is None,
-                    reason="It's not meant to be run outside of CIs")
+@pytest.mark.skipif(
+    not running_in_ci(), reason="It's not meant to be run outside of CIs")
 def test_single_instance_and_edit_magic(main_window, qtbot, tmpdir):
     """Test single instance mode and %edit magic."""
     editorstack = main_window.editor.get_current_editorstack()
@@ -659,8 +660,8 @@ def test_get_help_ipython_console_special_characters(
 
 @pytest.mark.slow
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.name == 'nt' and os.environ.get('CI') is not None,
-                    reason="Times out on AppVeyor")
+@pytest.mark.skipif(os.name == 'nt' and running_in_ci(),
+                    reason="Times out on Windows")
 def test_get_help_ipython_console(main_window, qtbot):
     """Test that Help works when called from the IPython console."""
     shell = main_window.ipyconsole.get_current_shellwidget()
@@ -1535,10 +1536,9 @@ def test_run_cell_copy(main_window, qtbot, tmpdir):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.name == 'nt' or os.environ.get('CI', None) is None or PYQT5,
-                    reason="It times out sometimes on Windows, it's not "
-                           "meant to be run outside of a CI and it segfaults "
-                           "too frequently in PyQt5")
+@pytest.mark.skipif(os.name == 'nt' or not running_in_ci(),
+                    reason="It times out sometimes on Windows and it's not "
+                           "meant to be run outside of CIs")
 def test_open_files_in_new_editor_window(main_window, qtbot):
     """
     This tests that opening files in a new editor window
@@ -1603,8 +1603,7 @@ def test_maximize_minimize_plugins(main_window, qtbot):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
-@pytest.mark.skipif((os.name == 'nt' or
-                     os.environ.get('CI', None) is not None and PYQT_VERSION >= '5.9'),
+@pytest.mark.skipif(os.name == 'nt' or running_in_ci() and PYQT_VERSION >= '5.9',
                     reason="It times out on Windows and segfaults in our CIs with PyQt >= 5.9")
 def test_issue_4066(main_window, qtbot):
     """

--- a/spyder/plugins/editor/panels/tests/test_scrollflag.py
+++ b/spyder/plugins/editor/panels/tests/test_scrollflag.py
@@ -14,6 +14,7 @@ from qtpy.QtCore import QPoint, Qt
 from qtpy.QtGui import QFont
 
 # Local imports
+from spyder.config.base import running_in_ci
 from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 
 
@@ -147,8 +148,7 @@ def test_flag_painting(editor_bot, qtbot):
         editor.setTextCursor(cursor)
 
 
-@pytest.mark.skipif(os.environ.get('CI', None) is not None,
-                    reason="It fails on CIs")
+@pytest.mark.skipif(running_in_ci(), reason="Fails on CIs")
 def test_range_indicator_visible_on_hover_only(editor_bot, qtbot):
     """Test that the slider range indicator is visible only when hovering
     over the scrollflag area when the editor vertical scrollbar is visible.
@@ -196,8 +196,7 @@ def test_range_indicator_visible_on_hover_only(editor_bot, qtbot):
     qtbot.waitUntil(lambda: not sfa._range_indicator_is_visible)
 
 
-@pytest.mark.skipif(os.environ.get('CI', None) is not None,
-                    reason="It fails on CIs")
+@pytest.mark.skipif(running_in_ci(), reason="Fails on CIs")
 def test_range_indicator_alt_modifier_response(editor_bot, qtbot):
     """Test that the slider range indicator is visible while the alt key is
     held down while the cursor is over the editor, but outside of the

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -21,7 +21,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtGui import QTextCursor
 
 # Local imports
-from spyder.config.base import get_conf_path
+from spyder.config.base import get_conf_path, running_in_ci
 from spyder.plugins.editor.widgets.editor import EditorStack
 from spyder.widgets.findreplace import FindReplace
 from spyder.py3compat import PY2
@@ -642,8 +642,7 @@ def test_tab_moves_focus_from_search_to_replace(editor_find_replace_bot,
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.environ.get('CI', None) is not None,
-                    reason="It fails on CIs")
+@pytest.mark.skipif(running_in_ci(), reason="Fails on CIs")
 def test_tab_copies_find_to_replace(editor_find_replace_bot, qtbot):
     """Check that text in the find box is copied to the replace box on tab
     keypress. Regression test spyder-ide/spyder#4482."""

--- a/spyder/plugins/editor/widgets/tests/test_goto.py
+++ b/spyder/plugins/editor/widgets/tests/test_goto.py
@@ -16,6 +16,7 @@ from qtpy.QtWidgets import QMessageBox
 import pytest
 
 # Local imports
+from spyder.config.base import running_in_ci
 from spyder.plugins.editor.widgets.tests.test_codeeditor import editorbot
 from spyder.utils.vcs import get_git_remotes
 
@@ -29,7 +30,7 @@ TEST_FILE_ABS = TEST_FILES[0].replace(' ', '%20')
 TEST_FILE_REL = 'conftest.py'
 
 
-@pytest.mark.skipif(bool(os.environ.get('CI', None)), reason='Fails on CI!')
+@pytest.mark.skipif(running_in_ci(), reason='Fails on CI!')
 @pytest.mark.parametrize('params', [
             # Parameter, expected output 1, full file path, expected output 2
             # ----------------------------------------------------------------

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -17,17 +17,12 @@ import sys
 from flaky import flaky
 import pytest
 import pytestqt
-
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QTextCursor
-
-try:
-    from rtree import index
-    rtree_available = True
-except Exception:
-    rtree_available = False
+from rtree import index
 
 # Local imports
+from spyder.config.base import running_in_ci
 from spyder.plugins.completion.api import (
     CompletionRequestTypes, CompletionItemKind)
 from spyder.plugins.completion.providers.kite.providers.document import (
@@ -177,7 +172,7 @@ def test_space_completion(completions_codeeditor, qtbot):
 @pytest.mark.slow
 @pytest.mark.order(1)
 @flaky(max_runs=5)
-@pytest.mark.skipif(bool(os.environ.get('CI', None)), reason='Fails on CI!')
+@pytest.mark.skipif(running_in_ci(), reason='Fails on CI!')
 def test_hide_widget_completion(completions_codeeditor, qtbot):
     """Validate hiding completion widget after a delimeter or operator."""
     code_editor, _ = completions_codeeditor
@@ -688,10 +683,8 @@ def test_completions(completions_codeeditor, qtbot):
 
 @pytest.mark.slow
 @pytest.mark.order(1)
-@pytest.mark.skipif(not rtree_available or PY2 or os.name == 'nt',
-                    reason='Only works if rtree is installed')
+@pytest.mark.skipif(os.name == 'nt', reason='Fails on Windows')
 def test_code_snippets(completions_codeeditor, qtbot):
-    assert rtree_available
     code_editor, completion_plugin = completions_codeeditor
     completion = code_editor.completion_widget
     snippets = code_editor.editor_extensions.get('SnippetsExtension')
@@ -917,11 +910,9 @@ def test_code_snippets(completions_codeeditor, qtbot):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif((not rtree_available
-                     or not check_if_kite_installed()
+@pytest.mark.skipif((not check_if_kite_installed()
                      or not check_if_kite_running()),
-                    reason="Only works if rtree is installed."
-                           "It's not meant to be run without kite installed "
+                    reason="It's not meant to be run without kite installed "
                            "and running")
 def test_kite_code_snippets(kite_codeeditor, qtbot):
     """
@@ -929,7 +920,6 @@ def test_kite_code_snippets(kite_codeeditor, qtbot):
 
     See spyder-ide/spyder#10971
     """
-    assert rtree_available
     code_editor, kite = kite_codeeditor
     completion = code_editor.completion_widget
     snippets = code_editor.editor_extensions.get('SnippetsExtension')
@@ -1176,8 +1166,7 @@ def spam():
 
 @pytest.mark.slow
 @pytest.mark.order(1)
-@pytest.mark.skipif(os.environ.get('CI') is None,
-                    reason='Run tests only on CI.')
+@pytest.mark.skipif(not running_in_ci(), reason='Run tests only on CI.')
 @flaky(max_runs=5)
 def test_completions_environment(completions_codeeditor, qtbot, tmpdir):
     """Exercise code completion when adding extra paths."""

--- a/spyder/plugins/editor/widgets/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/tests/test_shortcuts.py
@@ -19,6 +19,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication
 
 # Local imports
+from spyder.config.base import running_in_ci
 from spyder.plugins.editor.widgets.codeeditor_widgets import GoToLineDialog
 from spyder.plugins.editor.widgets.editor import EditorStack
 from spyder.config.manager import CONF
@@ -73,7 +74,7 @@ def test_default_keybinding_values():
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    sys.platform.startswith('linux') and running_in_ci(),
     reason="It fails on Linux due to the lack of a proper X server.")
 def test_start_and_end_of_document_shortcuts(editor_bot):
     """
@@ -96,7 +97,7 @@ def test_start_and_end_of_document_shortcuts(editor_bot):
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    sys.platform.startswith('linux') and running_in_ci(),
     reason="It fails on Linux due to the lack of a proper X server.")
 def test_del_undo_redo_shortcuts(editor_bot):
     """
@@ -127,7 +128,7 @@ def test_del_undo_redo_shortcuts(editor_bot):
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    sys.platform.startswith('linux') and running_in_ci(),
     reason="It fails on Linux due to the lack of a proper X server.")
 def test_copy_cut_paste_shortcuts(editor_bot):
     """
@@ -161,7 +162,7 @@ def test_copy_cut_paste_shortcuts(editor_bot):
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    sys.platform.startswith('linux') and running_in_ci(),
     reason="It fails on Linux due to the lack of a proper X server.")
 def test_select_all_shortcut(editor_bot):
     """
@@ -177,7 +178,7 @@ def test_select_all_shortcut(editor_bot):
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    sys.platform.startswith('linux') and running_in_ci(),
     reason="It fails on Linux due to the lack of a proper X server.")
 @pytest.mark.no_xvfb
 def test_delete_line_shortcut(editor_bot):
@@ -195,7 +196,7 @@ def test_delete_line_shortcut(editor_bot):
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    sys.platform.startswith('linux') and running_in_ci(),
     reason="It fails on Linux due to the lack of a proper X server.")
 @pytest.mark.no_xvfb
 def test_go_to_line_shortcut(editor_bot, mocker):
@@ -215,7 +216,7 @@ def test_go_to_line_shortcut(editor_bot, mocker):
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    sys.platform.startswith('linux') and running_in_ci(),
     reason="It fails on Linux due to the lack of a proper X server.")
 @pytest.mark.no_xvfb
 def test_transform_to_lowercase_shortcut(editor_bot):
@@ -233,7 +234,7 @@ def test_transform_to_lowercase_shortcut(editor_bot):
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    sys.platform.startswith('linux') and running_in_ci(),
     reason="It fails on Linux due to the lack of a proper X server.")
 @pytest.mark.no_xvfb
 def test_transform_to_uppercase_shortcut(editor_bot):
@@ -252,7 +253,7 @@ def test_transform_to_uppercase_shortcut(editor_bot):
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    sys.platform.startswith('linux') and running_in_ci(),
     reason="It fails on Linux due to the lack of a proper X server.")
 @pytest.mark.no_xvfb
 def test_next_and_previous_word_shortcuts(editor_bot):

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -35,7 +35,7 @@ from qtpy.QtWidgets import QMessageBox, QMainWindow
 import sympy
 
 # Local imports
-from spyder.config.base import get_home_dir
+from spyder.config.base import get_home_dir, running_in_ci
 from spyder.config.gui import get_color_scheme
 from spyder.config.manager import CONF
 from spyder.py3compat import PY2, to_text_string
@@ -855,8 +855,8 @@ def test_read_stderr(ipyconsole, qtbot):
 
 @flaky(max_runs=10)
 @pytest.mark.no_xvfb
-@pytest.mark.skipif(os.environ.get('CI', None) is not None and os.name == 'nt',
-                    reason="It times out on AppVeyor.")
+@pytest.mark.skipif(running_in_ci() and os.name == 'nt',
+                    reason="Times out on Windows")
 @pytest.mark.skipif(PY2, reason="It times out in Python 2.")
 def test_values_dbg(ipyconsole, qtbot):
     """
@@ -1028,8 +1028,7 @@ def test_mpl_backend_change(ipyconsole, qtbot):
 
 
 @flaky(max_runs=10)
-@pytest.mark.skipif(os.environ.get('CI', None) is not None or PYQT5,
-                    reason="It fails frequently in PyQt5 and our CIs")
+@pytest.mark.skipif(running_in_ci(), reason="Fails frequently in CI")
 def test_ctrl_c_dbg(ipyconsole, qtbot):
     """
     Test that Ctrl+C works while debugging

--- a/spyder/plugins/maininterpreter/widgets/tests/test_status.py
+++ b/spyder/plugins/maininterpreter/widgets/tests/test_status.py
@@ -16,12 +16,12 @@ import pytest
 
 
 # Local imports
+from spyder.config.base import running_in_ci
 from spyder.plugins.statusbar.widgets.tests.test_status import status_bar
 from spyder.plugins.maininterpreter.widgets.status import InterpreterStatus
 
 
-@pytest.mark.skipif(not bool(os.environ.get('CI')),
-                    reason="Only meant for CIs")
+@pytest.mark.skipif(not running_in_ci(), reason="Only meant for CIs")
 def test_status_bar_conda_interpreter_status(status_bar, qtbot):
     """Test status bar message with conda interpreter."""
     # We patch where the method is used not where it is imported from

--- a/spyder/plugins/shortcuts/tests/test_shortcuts.py
+++ b/spyder/plugins/shortcuts/tests/test_shortcuts.py
@@ -14,9 +14,10 @@ import sys
 
 # Third party imports
 import pytest
-
 from qtpy.QtCore import Qt
+
 # Local imports
+from spyder.config.base import running_in_ci
 from spyder.config.manager import CONF
 from spyder.plugins.shortcuts.widgets.table import (
     INVALID_KEY, NO_WARNING, SEQUENCE_CONFLICT, SEQUENCE_EMPTY,
@@ -58,7 +59,7 @@ class FilterTextMock():
 
 # ---- Tests ShortcutsTable
 @pytest.mark.skipif(
-    sys.platform.startswith('linux') and os.environ.get('CI') is not None,
+    sys.platform.startswith('linux') and running_in_ci(),
     reason="It fails on Linux due to the lack of a proper X server.")
 def test_shortcuts(shortcut_table):
     """Run shortcuts table."""

--- a/spyder/utils/tests/test_conda.py
+++ b/spyder/utils/tests/test_conda.py
@@ -15,10 +15,10 @@ import time
 import pytest
 
 # Local imports
+from spyder.config.base import running_in_ci
 from spyder.utils.conda import (
     add_quotes, find_conda, get_conda_activation_script, get_conda_env_path,
-    get_conda_root_prefix, get_list_conda_envs, get_list_conda_envs_cache
-)
+    get_conda_root_prefix, get_list_conda_envs, get_list_conda_envs_cache)
 
 
 if os.name == 'nt':
@@ -61,14 +61,12 @@ def test_get_conda_root_prefix():
     assert 'envs' not in get_conda_root_prefix(sys.executable)
 
 
-@pytest.mark.skipif(not bool(os.environ.get('CI')),
-                    reason="Only meant for CIs")
+@pytest.mark.skipif(not running_in_ci(), reason="Only meant for CIs")
 def test_find_conda():
     assert find_conda()
 
 
-@pytest.mark.skipif(not bool(os.environ.get('CI')),
-                    reason="Only meant for CIs")
+@pytest.mark.skipif(not running_in_ci(), reason="Only meant for CIs")
 def test_get_list_conda_envs():
     output = get_list_conda_envs()
     expected_envs = ['base', 'test', 'jedi-test-env', 'spytest-ž']
@@ -77,8 +75,7 @@ def test_get_list_conda_envs():
     assert set(expected_envs) == set(output.keys())
 
 
-@pytest.mark.skipif(not bool(os.environ.get('CI')),
-                    reason="Only meant for CIs")
+@pytest.mark.skipif(not running_in_ci(), reason="Only meant for CIs")
 def test_get_list_conda_envs_cache():
     time0 = time.time()
     output = get_list_conda_envs_cache()

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -14,6 +14,7 @@ from flaky import flaky
 import pytest
 
 # Local imports
+from spyder.config.base import running_in_ci
 from spyder.utils.programs import (_clean_win_application_path, check_version,
                                    find_program, get_application_icon,
                                    get_installed_applications, get_temp_dir,
@@ -70,8 +71,7 @@ def scriptpath_with_blanks(tmpdir):
 # =============================================================================
 # ---- Tests
 # =============================================================================
-@pytest.mark.skipif((sys.platform.startswith('linux') or
-                     os.environ.get('CI', None) is None),
+@pytest.mark.skipif(sys.platform.startswith('linux') or not running_in_ci(),
                     reason='It only runs in CI services and '
                            'Linux does not have pythonw executables.')
 def test_is_valid_w_interpreter():
@@ -79,7 +79,7 @@ def test_is_valid_w_interpreter():
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(bool(os.environ.get('CI', None)), reason='Only on CI!')
+@pytest.mark.skipif(not running_in_ci(), reason='Only on CI!')
 def test_run_python_script_in_terminal(scriptpath, qtbot):
     """
     Test running a Python script in an external terminal when specifying
@@ -99,7 +99,7 @@ def test_run_python_script_in_terminal(scriptpath, qtbot):
 @flaky(max_runs=3)
 @pytest.mark.order(1)
 @pytest.mark.skipif(
-    os.environ.get('CI', None) is None or os.name == 'nt',
+    not running_in_ci() or os.name == 'nt',
     reason='Only on CI and not on windows!',
 )
 def test_run_python_script_in_terminal_blank_wdir(scriptpath_with_blanks,
@@ -123,7 +123,7 @@ def test_run_python_script_in_terminal_blank_wdir(scriptpath_with_blanks,
 @flaky(max_runs=3)
 @pytest.mark.order(1)
 @pytest.mark.skipif(
-    os.environ.get('CI', None) is None or os.name == 'nt',
+    not running_in_ci() or os.name == 'nt',
     reason='Only on CI and not on windows!',
 )
 def test_run_python_script_in_terminal_with_wdir_empty(scriptpath, qtbot):
@@ -146,19 +146,19 @@ def test_run_python_script_in_terminal_with_wdir_empty(scriptpath, qtbot):
 
 
 @pytest.mark.order(1)
-@pytest.mark.skipif(os.environ.get('CI', None) is None, reason='Only on CI!')
+@pytest.mark.skipif(not running_in_ci(), reason='Only on CI!')
 def test_is_valid_interpreter():
     assert is_python_interpreter(VALID_INTERPRETER)
 
 
 @pytest.mark.order(1)
-@pytest.mark.skipif(os.environ.get('CI', None) is None, reason='Only on CI!')
+@pytest.mark.skipif(not running_in_ci(), reason='Only on CI!')
 def test_is_invalid_interpreter():
     assert not is_python_interpreter(INVALID_INTERPRETER)
 
 
 @pytest.mark.order(1)
-@pytest.mark.skipif(os.environ.get('CI', None) is None, reason='Only on CI!')
+@pytest.mark.skipif(not running_in_ci(), reason='Only on CI!')
 def test_is_valid_interpreter_name():
     names = ['python', 'pythonw', 'python2.7', 'python3.5', 'python.exe', 'pythonw.exe']
     assert all([is_python_interpreter_valid_name(n) for n in names])

--- a/spyder/utils/tests/test_pyenv.py
+++ b/spyder/utils/tests/test_pyenv.py
@@ -11,13 +11,12 @@ import time
 
 import pytest
 
+from spyder.config.base import running_in_ci
 from spyder.utils.pyenv import (
-    get_list_pyenv_envs, get_list_pyenv_envs_cache
-)
+    get_list_pyenv_envs, get_list_pyenv_envs_cache)
 
 
-@pytest.mark.skipif(not bool(os.environ.get('CI')),
-                    reason="Only meant for CIs")
+@pytest.mark.skipif(not running_in_ci(), reason="Only meant for CIs")
 @pytest.mark.skipif(os.name == 'nt', reason="Doesn't work on Windows")
 def test_get_list_pyenv_envs():
     output = get_list_pyenv_envs()
@@ -25,8 +24,7 @@ def test_get_list_pyenv_envs():
     assert set(expected_envs) == set(output.keys())
 
 
-@pytest.mark.skipif(not bool(os.environ.get('CI')),
-                    reason="Only meant for CIs")
+@pytest.mark.skipif(not running_in_ci(), reason="Only meant for CIs")
 @pytest.mark.skipif(os.name == 'nt', reason="Doesn't work on Windows")
 def test_get_list_pyenv_envs_cache():
     time0 = time.time()

--- a/spyder/utils/tests/test_vcs.py
+++ b/spyder/utils/tests/test_vcs.py
@@ -18,6 +18,7 @@ from spyder.utils import programs
 import pytest
 
 # Local imports
+from spyder.config.base import running_in_ci
 from spyder.utils.vcs import (ActionToolNotFound, get_git_refs,
                               get_git_remotes, get_git_revision, get_vcs_root,
                               remote_to_url, run_vcs_tool)
@@ -30,8 +31,7 @@ skipnogit = pytest.mark.skipif(not(get_vcs_root(HERE)),
 
 
 @skipnogit
-@pytest.mark.skipif(os.environ.get('CI', None) is None,
-                    reason="Not to be run outside of CIs")
+@pytest.mark.skipif(running_in_ci(), reason="Not to be run outside of CIs")
 def test_vcs_tool():
     if not os.name == 'nt':
         with pytest.raises(ActionToolNotFound):
@@ -49,8 +49,6 @@ def test_vcs_root(tmpdir):
 
 
 @skipnogit
-@pytest.mark.skipif(os.name == 'nt' and os.environ.get('AZURE') is not None,
-                    reason="Fails on Windows/Azure")
 def test_git_revision():
     root = get_vcs_root(osp.dirname(__file__))
     assert get_git_revision(osp.dirname(__file__)) == (None, None)

--- a/spyder/widgets/tests/test_pathmanager.py
+++ b/spyder/widgets/tests/test_pathmanager.py
@@ -18,8 +18,8 @@ from qtpy.QtWidgets import QMessageBox, QPushButton
 
 # Local imports
 from spyder.py3compat import PY3
-from spyder.widgets import pathmanager as pathmanager_mod
 from spyder.utils.programs import is_module_installed
+from spyder.widgets import pathmanager as pathmanager_mod
 
 
 @pytest.fixture
@@ -224,35 +224,6 @@ def test_add_repeated_item(qtbot, pathmanager, tmpdir):
     assert pathmanager.count() == 3
     assert list(pathmanager.get_path_dict().keys())[0] == dir2
     assert all(pathmanager.get_path_dict().values())
-
-
-@pytest.mark.skipif(PY3 or (os.environ.get('CI') is not None and sys.platform.startswith('linux')),
-                    reason=('This tests only applies to Python 2.'
-                            'It is failing on Linux CI. Works locally!'))
-@pytest.mark.parametrize('pathmanager',
-                         [(('/spam', '/bar'), ('/foo', ), ('/bar', ))],
-                         indirect=True)
-def test_add_invalid_path(qtbot, pathmanager):
-    """Checks for unicode on python 2."""
-    pathmanager.show()
-    count = pathmanager.count()
-
-    def interact_message_box():
-        qtbot.wait(500)
-        messagebox = pathmanager.findChild(QMessageBox)
-        button = messagebox.findChild(QPushButton)
-        qtbot.mouseClick(button, Qt.LeftButton)
-
-    timer = QTimer()
-    timer.setSingleShot(True)
-    timer.timeout.connect(interact_message_box)
-    timer.start(500)
-    pathmanager.add_path('/foo/bar/測試')
-    qtbot.wait(500)
-
-    # Back to main thread
-    assert len(pathmanager.get_path_dict()) == 2
-    assert len(pathmanager.get_path_dict(True)) == 3
 
 
 @pytest.mark.skipif(os.name != 'nt' or not is_module_installed('win32con'),


### PR DESCRIPTION
## Description of Changes

- This just helps us to simplify code around.
- I also removed a test that only applied to Python 2.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
