### PR TITLE
PR: Allow to set a custom configuration directory through the command line

### DIFF
--- a/spyder/app/cli_options.py
+++ b/spyder/app/cli_options.py
@@ -142,6 +142,13 @@ def get_options(argv=None):
         default=False,
         help="Report segmentation fault to Github."
     )
+    parser.add_argument(
+        '--conf-dir',
+        type=str,
+        dest="conf_dir",
+        default=None,
+        help="Choose a configuration directory to use for Spyder."
+    )
 
     parser.add_argument('files', nargs='*')
     options = parser.parse_args(argv)

--- a/spyder/app/start.py
+++ b/spyder/app/start.py
@@ -59,6 +59,9 @@ else:
 if CLI_OPTIONS.safe_mode:
     os.environ['SPYDER_SAFE_MODE'] = 'True'
 
+if CLI_OPTIONS.conf_dir:
+    os.environ['SPYDER_CONFDIR'] = CLI_OPTIONS.conf_dir
+
 
 def send_args_to_spyder(args):
     """

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -204,12 +204,31 @@ def get_clean_conf_dir():
     return conf_dir
 
 
+def get_custom_conf_dir():
+    """
+    Use a custom configuration directory, passed through our command
+    line options or by setting the env var below.
+    """
+    custom_dir = os.environ.get('SPYDER_CONFDIR')
+    if custom_dir:
+        custom_dir = osp.abspath(custom_dir)
+
+        # Set env var to not lose its value in future calls when the cwd
+        # is changed by Spyder.
+        os.environ['SPYDER_CONFDIR'] = custom_dir
+        return custom_dir
+
+
 def get_conf_path(filename=None):
     """Return absolute path to the config file with the specified filename."""
     # Define conf_dir
     if running_under_pytest() or get_safe_mode():
         # Use clean config dir if running tests or the user requests it.
         conf_dir = get_clean_conf_dir()
+    elif get_custom_conf_dir():
+        # Use a custom directory if the user decided to do it through
+        # our command line options.
+        conf_dir = get_custom_conf_dir()
     elif sys.platform.startswith('linux'):
         # This makes us follow the XDG standard to save our settings
         # on Linux, as it was requested on spyder-ide/spyder#2629.
@@ -226,7 +245,7 @@ def get_conf_path(filename=None):
 
     # Create conf_dir
     if not osp.isdir(conf_dir):
-        if running_under_pytest() or get_safe_mode():
+        if running_under_pytest() or get_safe_mode() or get_custom_conf_dir():
             os.makedirs(conf_dir)
         else:
             os.mkdir(conf_dir)


### PR DESCRIPTION
## Description of Changes

- This is useful to set different configuration directories according to your needs.
- It works like this

      spyder --conf-dir <abs-path-or-relative-path>

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15551 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
