### PR TITLE
PR: Fix double clicks when single-click mode is active

### DIFF
--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -747,9 +747,10 @@ class DirView(QTreeView, SpyderWidgetMixin):
             QTreeView.keyPressEvent(self, event)
 
     def mouseDoubleClickEvent(self, event):
-        """Handle single clicks."""
+        """Handle double clicks."""
         super().mouseDoubleClickEvent(event)
-        self.clicked(index=self.indexAt(event.pos()))
+        if not self.get_conf('single_click_to_open'):
+            self.clicked(index=self.indexAt(event.pos()))
 
     def mousePressEvent(self, event):
         """

--- a/spyder/plugins/projects/widgets/projectexplorer.py
+++ b/spyder/plugins/projects/widgets/projectexplorer.py
@@ -31,13 +31,24 @@ _ = get_translation('spyder')
 class ProxyModel(QSortFilterProxyModel):
     """Proxy model to filter tree view."""
 
-    DEFAULTS_PATHS_TO_HIDE = [
+    PATHS_TO_HIDE = [
+        # Useful paths
         '.spyproject',
         '__pycache__',
         '.ipynb_checkpoints',
+        # VCS paths
+        '.git',
+        '.hg',
+        '.svn',
+        # Others
+        '.pytest_cache',
         '.DS_Store',
         'Thumbs.db',
         '.directory'
+    ]
+
+    PATHS_TO_SHOW = [
+        '.github'
     ]
 
     def __init__(self, parent):
@@ -80,8 +91,11 @@ class ProxyModel(QSortFilterProxyModel):
         else:
             for p in [osp.normcase(p) for p in self.path_list]:
                 if path == p or path.startswith(p + os.sep):
-                    if any([d in path for d in self.DEFAULTS_PATHS_TO_HIDE]):
-                        return False
+                    if not any([d in path for d in self.PATHS_TO_SHOW]):
+                        if any([d in path for d in self.PATHS_TO_HIDE]):
+                            return False
+                        else:
+                            return True
                     else:
                         return True
             else:


### PR DESCRIPTION
## Description of Changes

- Double clicking on a file when single-click mode is active opened it several times.
- That was a regression introduced by #16182. Unfortunately, I only noticed it after that PR was merged.
- Also, don't show VCS directories in Projects.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
