### PR TITLE
Add PYTHONHOME to shell environment when executing in external terminal from macOS app

### DIFF
--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -31,12 +31,11 @@ import psutil
 
 # Local imports
 from spyder.config.base import (is_stable_version, running_under_pytest,
-                                get_home_dir)
+                                get_home_dir, running_in_mac_app)
 from spyder.config.utils import is_anaconda
 from spyder.py3compat import PY2, is_text_string, to_text_string
 from spyder.utils import encoding
 from spyder.utils.misc import get_python_executable
-
 
 HERE = osp.abspath(osp.dirname(__file__))
 
@@ -794,6 +793,8 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
                                         delete=False)
         if wdir:
             f.write('cd {}\n'.format(wdir))
+        if running_in_mac_app() and executable == get_python_executable():
+            f.write(f'export PYTHONHOME={os.environ["PYTHONPATH"]}\n')
         f.write(' '.join(p_args))
         f.close()
         os.chmod(f.name, 0o777)


### PR DESCRIPTION
## Description of Changes

Added `PYTHONHOME` environment variable to the shell environment when executing a Python script with "Execute in an external system terminal" is selected and using the macOS application.

Environment variables cannot be inherited by the shell environment in the Terminal application, so `PYTHONHOME` must be explicitly set in the executed shell script.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16185


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary 
<!--- Thanks for your help making Spyder better for everyone! --->
