### PR TITLE
PR: Use menu and item identifiers to add items to the main menu plugin

### DIFF
--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -556,10 +556,9 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
             )
 
         menu = MainWidgetMenu(parent=self, title=title, menu_id=menu_id)
-        menu.ID = menu_id
 
         MENU_REGISTRY.register_reference(
-            menu, menu.ID, self.PLUGIN_NAME, self.CONTEXT_NAME)
+            menu, menu_id, self.PLUGIN_NAME, self.CONTEXT_NAME)
 
         if icon is not None:
             menu.menuAction().setIconVisibleInMenu(True)

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -555,7 +555,7 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
                 'Menu name "{}" already in use!'.format(menu_id)
             )
 
-        menu = MainWidgetMenu(parent=self, title=title)
+        menu = MainWidgetMenu(parent=self, title=title, menu_id=menu_id)
         menu.ID = menu_id
 
         MENU_REGISTRY.register_reference(

--- a/spyder/api/widgets/menus.py
+++ b/spyder/api/widgets/menus.py
@@ -9,7 +9,6 @@ Spyder API menu widgets.
 """
 
 # Standard library imports
-from spyder.api.exceptions import SpyderAPIError
 import sys
 from typing import Optional, Union, TypeVar
 

--- a/spyder/api/widgets/mixins.py
+++ b/spyder/api/widgets/mixins.py
@@ -254,7 +254,7 @@ class SpyderMenuMixin:
         """
         from spyder.api.widgets.menus import SpyderMenu
 
-        menu = SpyderMenu(parent=self, title=text)
+        menu = SpyderMenu(parent=self, title=text, menu_id=name)
         if icon is not None:
             menu.menuAction().setIconVisibleInMenu(True)
             menu.setIcon(icon)

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -31,6 +31,7 @@ import shutil
 import signal
 import socket
 import glob
+from spyder.api.widgets.menus import SpyderMenu
 import sys
 import threading
 import traceback
@@ -975,7 +976,8 @@ class MainWindow(QMainWindow):
                                     icon=ima.icon('filelist'),
                                     tip=_('Fast switch between files'),
                                     triggered=self.open_switcher,
-                                    context=Qt.ApplicationShortcut)
+                                    context=Qt.ApplicationShortcut,
+                                    id_='file_switcher')
         self.register_shortcut(self.file_switcher_action, context="_",
                                name="File switcher")
         self.symbol_finder_action = create_action(
@@ -983,7 +985,8 @@ class MainWindow(QMainWindow):
                                     icon=ima.icon('symbol_find'),
                                     tip=_('Fast symbol search in file'),
                                     triggered=self.open_symbolfinder,
-                                    context=Qt.ApplicationShortcut)
+                                    context=Qt.ApplicationShortcut,
+                                    id_='symbol_finder')
         self.register_shortcut(self.symbol_finder_action, context="_",
                                name="symbol finder", add_shortcut_to_tip=True)
 
@@ -1046,7 +1049,8 @@ class MainWindow(QMainWindow):
             _("PYTHONPATH manager"),
             None, icon=ima.icon('pythonpath'),
             triggered=self.show_path_manager,
-            tip=_("PYTHONPATH manager"))
+            tip=_("PYTHONPATH manager"),
+            id_='spyder_path_action')
         from spyder.plugins.application.plugin import (
             ApplicationActions, WinUserEnvDialog)
         winenv_action = None
@@ -1060,7 +1064,8 @@ class MainWindow(QMainWindow):
             before=winenv_action
         )
         if get_debug_level() >= 3:
-            self.menu_lsp_logs = QMenu(_("LSP logs"))
+            self.menu_lsp_logs = SpyderMenu(
+                title=_("LSP logs"), menu_id='lsp_logs_menu')
             self.menu_lsp_logs.aboutToShow.connect(self.update_lsp_logs)
             mainmenu.add_item_to_application_menu(
                 self.menu_lsp_logs,

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -31,7 +31,6 @@ import shutil
 import signal
 import socket
 import glob
-from spyder.api.widgets.menus import SpyderMenu
 import sys
 import threading
 import traceback
@@ -70,6 +69,7 @@ from qtawesome.iconic_font import FontError
 #==============================================================================
 from spyder import __version__
 from spyder import dependencies
+from spyder.api.widgets.menus import SpyderMenu
 from spyder.app.utils import (
     create_application, create_splash_screen, create_window,
     delete_lsp_log_files, qt_message_handler, set_links_color, setup_logging,

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1055,8 +1055,7 @@ class MainWindow(QMainWindow):
             ApplicationActions, WinUserEnvDialog)
         winenv_action = None
         if WinUserEnvDialog:
-            winenv_action = self.application.get_action(
-                ApplicationActions.SpyderWindowsEnvVariables)
+            winenv_action = ApplicationActions.SpyderWindowsEnvVariables
         mainmenu.add_item_to_application_menu(
             spyder_path_action,
             menu_id=ApplicationMenus.Tools,

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -136,8 +136,7 @@ class Application(SpyderPluginV2):
 
         if shortcuts:
             from spyder.plugins.shortcuts.plugin import ShortcutActions
-            shortcuts_summary_action = shortcuts.get_action(
-                ShortcutActions.ShortcutSummaryAction)
+            shortcuts_summary_action = ShortcutActions.ShortcutSummaryAction
         for documentation_action in [
                 self.documentation_action, self.video_action]:
             mainmenu.add_item_to_application_menu(

--- a/spyder/plugins/breakpoints/plugin.py
+++ b/spyder/plugins/breakpoints/plugin.py
@@ -137,8 +137,8 @@ class Breakpoints(SpyderDockablePlugin):
     def on_main_menu_available(self):
         mainmenu = self.get_plugin(Plugins.MainMenu)
         list_action = self.get_action(BreakpointsActions.ListBreakpoints)
-        debug_menu = mainmenu.get_application_menu(ApplicationMenus.Debug)
-        mainmenu.add_item_to_application_menu(list_action, debug_menu)
+        mainmenu.add_item_to_application_menu(
+            list_action, menu_id=ApplicationMenus.Debug)
 
     # --- Private API
     # ------------------------------------------------------------------------

--- a/spyder/plugins/completion/api.py
+++ b/spyder/plugins/completion/api.py
@@ -1332,7 +1332,7 @@ class SpyderCompletionProvider(QObject, CompletionConfigurationObserver):
         self.main.add_item_to_menu(
             action_or_menu, menu, section=section, before=before)
 
-    def add_item_to_application_menu(self, item, menu=None, menu_id=None,
+    def add_item_to_application_menu(self, item, menu_id=None,
                                      section=None, before=None,
                                      before_section=None):
         """
@@ -1348,7 +1348,7 @@ class SpyderCompletionProvider(QObject, CompletionConfigurationObserver):
             The application menu unique string identifier.
         section: str or None
             The section id in which to insert the `item` on the `menu`.
-        before: SpyderAction/SpyderMenu or None
+        before: str or None
             Make the item appear before another given item.
         before_section: Section or None
             Make the item section (if provided) appear before another
@@ -1359,5 +1359,5 @@ class SpyderCompletionProvider(QObject, CompletionConfigurationObserver):
         Must provide a `menu` or a `menu_id`.
         """
         self.main.add_item_to_application_menu(
-            item, menu=menu, menu_id=menu_id, section=section,
+            item, menu_id=menu_id, section=section,
             before=before, before_section=before_section)

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -985,7 +985,8 @@ class Editor(SpyderPluginWidget):
             self.new_action,
             menu_id=ApplicationMenus.File,
             section=FileMenuSections.New,
-            before_section=FileMenuSections.Restart)
+            before_section=FileMenuSections.Restart,
+            omit_id=True)
         # Open section
         open_actions = [
             self.open_action,
@@ -997,7 +998,8 @@ class Editor(SpyderPluginWidget):
                 open_action,
                 menu_id=ApplicationMenus.File,
                 section=FileMenuSections.Open,
-                before_section=FileMenuSections.Restart)
+                before_section=FileMenuSections.Restart,
+                omit_id=True)
         # Save section
         save_actions = [
             self.save_action,
@@ -1011,7 +1013,8 @@ class Editor(SpyderPluginWidget):
                 save_action,
                 menu_id=ApplicationMenus.File,
                 section=FileMenuSections.Save,
-                before_section=FileMenuSections.Restart)
+                before_section=FileMenuSections.Restart,
+                omit_id=True)
         # Print
         print_actions = [
             print_preview_action,
@@ -1022,7 +1025,8 @@ class Editor(SpyderPluginWidget):
                 print_action,
                 menu_id=ApplicationMenus.File,
                 section=FileMenuSections.Print,
-                before_section=FileMenuSections.Restart)
+                before_section=FileMenuSections.Restart,
+                omit_id=True)
         # Close
         close_actions = [
             self.close_action,
@@ -1033,14 +1037,16 @@ class Editor(SpyderPluginWidget):
                 close_action,
                 menu_id=ApplicationMenus.File,
                 section=FileMenuSections.Close,
-                before_section=FileMenuSections.Restart)
+                before_section=FileMenuSections.Restart,
+                omit_id=True)
         # Navigation
         if sys.platform == 'darwin':
             self.main.mainmenu.add_item_to_application_menu(
                 self.tab_navigation_actions,
                 menu_id=ApplicationMenus.File,
                 section=FileMenuSections.Navigation,
-                before_section=FileMenuSections.Restart)
+                before_section=FileMenuSections.Restart,
+                omit_id=True)
 
         file_toolbar_actions = ([self.new_action, self.open_action,
                                 self.save_action, self.save_all_action] +

--- a/spyder/plugins/findinfiles/plugin.py
+++ b/spyder/plugins/findinfiles/plugin.py
@@ -87,10 +87,9 @@ class FindInFiles(SpyderDockablePlugin):
         mainmenu = self.get_plugin(Plugins.MainMenu)
         findinfiles_action = self.get_action(FindInFilesActions.FindInFiles)
 
-        menu = mainmenu.get_application_menu(ApplicationMenus.Search)
         mainmenu.add_item_to_application_menu(
             findinfiles_action,
-            menu=menu,
+            menu_id=ApplicationMenus.Search,
         )
 
     def on_close(self, cancelable=False):

--- a/spyder/plugins/help/plugin.py
+++ b/spyder/plugins/help/plugin.py
@@ -177,8 +177,7 @@ class Help(SpyderDockablePlugin):
         shortcuts_summary_action = None
         if shortcuts:
             from spyder.plugins.shortcuts.plugin import ShortcutActions
-            shortcuts_summary_action = shortcuts.get_action(
-                ShortcutActions.ShortcutSummaryAction)
+            shortcuts_summary_action = ShortcutActions.ShortcutSummaryAction
         if mainmenu:
             from spyder.plugins.mainmenu.api import (
                 ApplicationMenus, HelpMenuSections)

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -673,12 +673,14 @@ class IPythonConsole(SpyderPluginWidget):
             self.main.mainmenu.add_item_to_application_menu(
                 console_new_action,
                 menu_id=ApplicationMenus.Consoles,
-                section=ConsolesMenuSections.New)
+                section=ConsolesMenuSections.New,
+                omit_id=True)
         for console_restart_connect_action in restart_connect_consoles_actions:
             self.main.mainmenu.add_item_to_application_menu(
                 console_restart_connect_action,
                 menu_id=ApplicationMenus.Consoles,
-                section=ConsolesMenuSections.Restart)
+                section=ConsolesMenuSections.Restart,
+                omit_id=True)
 
         # IPython documentation
         self.ipython_menu = SpyderMenu(
@@ -703,7 +705,8 @@ class IPythonConsole(SpyderPluginWidget):
             self.ipython_menu,
             menu_id=ApplicationMenus.Help,
             section=HelpMenuSections.ExternalDocumentation,
-            before_section=HelpMenuSections.About)
+            before_section=HelpMenuSections.About,
+            omit_id=True)
 
         # Plugin actions
         self.menu_actions = [create_client_action, special_console_menu,

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -735,6 +735,7 @@ class Layout(SpyderPluginV2):
             except AttributeError:
                 # Old API
                 action = plugin._toggle_view_action
+                action.action_id = f'switch to {plugin.CONF_SECTION}'
 
             if action:
                 action.setChecked(plugin.dockwidget.isVisible())

--- a/spyder/plugins/mainmenu/plugin.py
+++ b/spyder/plugins/mainmenu/plugin.py
@@ -32,7 +32,7 @@ _ = get_translation('spyder')
 # Extended typing definitions
 ItemType = Union[SpyderAction, SpyderMenu]
 ItemSectionBefore = Tuple[
-    ItemType, str, Optional[str], Optional[str], Optional[str]]
+    ItemType, Optional[str], Optional[str], Optional[str]]
 ItemQueue = Dict[str, List[ItemSectionBefore]]
 
 
@@ -196,15 +196,15 @@ class MainMenu(SpyderPluginV2):
         if menu_id in self._ITEM_QUEUE:
             pending_items = self._ITEM_QUEUE.pop(menu_id)
             for pending in pending_items:
-                (item, item_id, section,
+                (item, section,
                  before_item, before_section) = pending
                 self.add_item_to_application_menu(
-                    item, item_id, menu_id=menu_id, section=section,
+                    item, menu_id=menu_id, section=section,
                     before=before_item, before_section=before_section)
 
         return menu
 
-    def add_item_to_application_menu(self, item: ItemType, item_id: str,
+    def add_item_to_application_menu(self, item: ItemType,
                                      menu_id: Optional[str] = None,
                                      section: Optional[str] = None,
                                      before: Optional[str] = None,
@@ -216,8 +216,6 @@ class MainMenu(SpyderPluginV2):
         ----------
         item: SpyderAction or SpyderMenu
             The item to add to the `menu`.
-        item_id: str
-            The identifier under which the item will be stored.
         menu_id: str or None
             The application menu unique string identifier.
         section: str or None
@@ -232,6 +230,10 @@ class MainMenu(SpyderPluginV2):
         -----
         Must provide a `menu` or a `menu_id`.
         """
+        if not isinstance(item, (SpyderAction, SpyderMenu)):
+            raise SpyderAPIError('A menu only accepts items objects of type '
+                                 'SpyderAction or SpyderMenu')
+
         # TODO: For now just add the item to the bottom for non-migrated menus.
         #       Temporal solution while migration is complete
         app_menu_actions = {
@@ -249,12 +251,12 @@ class MainMenu(SpyderPluginV2):
         else:
             if menu_id not in self._APPLICATION_MENUS:
                 pending_menu_items = self._ITEM_QUEUE.get(menu_id, [])
-                pending_menu_items.append((item, item_id, section, before,
+                pending_menu_items.append((item, section, before,
                                            before_section))
                 self._ITEM_QUEUE[menu_id] = pending_menu_items
             else:
                 menu = self.get_application_menu(menu_id)
-                menu.add_action(item, item_id, section=section, before=before,
+                menu.add_action(item, section=section, before=before,
                                 before_section=before_section)
 
     def get_application_menu(self, menu_id: str) -> SpyderMenu:

--- a/spyder/plugins/mainmenu/plugin.py
+++ b/spyder/plugins/mainmenu/plugin.py
@@ -10,6 +10,7 @@ Main menu Plugin.
 
 # Standard library imports
 from collections import OrderedDict
+from email.mime.nonmultipart import MIMENonMultipart
 import sys
 from typing import Dict, List, Tuple, Optional, Union
 
@@ -208,7 +209,8 @@ class MainMenu(SpyderPluginV2):
                                      menu_id: Optional[str] = None,
                                      section: Optional[str] = None,
                                      before: Optional[str] = None,
-                                     before_section: Optional[str] = None):
+                                     before_section: Optional[str] = None,
+                                     omit_id: bool = False):
         """
         Add action or widget `item` to given application menu `section`.
 
@@ -225,12 +227,16 @@ class MainMenu(SpyderPluginV2):
         before_section: Section or None
             Make the item section (if provided) appear before another
             given section.
+        omit_id: bool
+            If True, then the menu will check if the item to add declares an
+            id, False otherwise. This flag exists only for items added on
+            Spyder 4 plugins. Default: False
 
         Notes
         -----
         Must provide a `menu` or a `menu_id`.
         """
-        if not isinstance(item, (SpyderAction, SpyderMenu)):
+        if not isinstance(item, (SpyderAction, SpyderMenu)) and not omit_id:
             raise SpyderAPIError('A menu only accepts items objects of type '
                                  'SpyderAction or SpyderMenu')
 
@@ -257,7 +263,7 @@ class MainMenu(SpyderPluginV2):
             else:
                 menu = self.get_application_menu(menu_id)
                 menu.add_action(item, section=section, before=before,
-                                before_section=before_section)
+                                before_section=before_section, omit_id=omit_id)
 
     def get_application_menu(self, menu_id: str) -> SpyderMenu:
         """

--- a/spyder/plugins/mainmenu/plugin.py
+++ b/spyder/plugins/mainmenu/plugin.py
@@ -11,6 +11,7 @@ Main menu Plugin.
 # Standard library imports
 from collections import OrderedDict
 import sys
+from typing import Dict, List, Tuple, Optional, Union
 
 # Third party imports
 from qtpy.QtGui import QKeySequence
@@ -20,13 +21,19 @@ from qtpy.QtWidgets import QMenu
 from spyder.api.exceptions import SpyderAPIError
 from spyder.api.plugins import Plugins, SpyderPluginV2, SpyderDockablePlugin
 from spyder.api.translations import get_translation
-from spyder.api.widgets.menus import MENU_SEPARATOR
+from spyder.api.widgets.menus import MENU_SEPARATOR, SpyderMenu
 from spyder.plugins.mainmenu.api import (
     ApplicationMenu, ApplicationMenus, HelpMenuSections)
-from spyder.utils.qthelpers import add_actions, set_menu_icons
+from spyder.utils.qthelpers import add_actions, set_menu_icons, SpyderAction
 
 # Localization
 _ = get_translation('spyder')
+
+# Extended typing definitions
+ItemType = Union[SpyderAction, SpyderMenu]
+ItemSectionBefore = Tuple[
+    ItemType, str, Optional[str], Optional[str], Optional[str]]
+ItemQueue = Dict[str, List[ItemSectionBefore]]
 
 
 class MainMenu(SpyderPluginV2):
@@ -46,6 +53,11 @@ class MainMenu(SpyderPluginV2):
     def on_initialize(self):
         # Reference holder dict for the menus
         self._APPLICATION_MENUS = OrderedDict()
+
+        # Queue that contain items that are pending to add to a non-existing
+        # menu
+        self._ITEM_QUEUE = {}  # type: ItemQueue
+
         # Create Application menus using plugin public API
         # FIXME: Migrated menus need to have 'dynamic=True' (default value) to
         # work on Mac. Remove the 'dynamic' kwarg when migrating a menu!
@@ -149,7 +161,8 @@ class MainMenu(SpyderPluginV2):
 
     # ---- Public API
     # ------------------------------------------------------------------------
-    def create_application_menu(self, menu_id, title, dynamic=True):
+    def create_application_menu(self, menu_id: str, title: str,
+                                dynamic: bool = True):
         """
         Create a Spyder application menu.
 
@@ -180,11 +193,22 @@ class MainMenu(SpyderPluginV2):
                 lambda menu=menu: set_menu_icons(menu, False))
             menu.aboutToShow.connect(self._hide_options_menus)
 
+        if menu_id in self._ITEM_QUEUE:
+            pending_items = self._ITEM_QUEUE.pop(menu_id)
+            for pending in pending_items:
+                (item, item_id, section,
+                 before_item, before_section) = pending
+                self.add_item_to_application_menu(
+                    item, item_id, menu_id=menu_id, section=section,
+                    before=before_item, before_section=before_section)
+
         return menu
 
-    def add_item_to_application_menu(self, item, menu=None, menu_id=None,
-                                     section=None, before=None,
-                                     before_section=None):
+    def add_item_to_application_menu(self, item: ItemType, item_id: str,
+                                     menu_id: Optional[str] = None,
+                                     section: Optional[str] = None,
+                                     before: Optional[str] = None,
+                                     before_section: Optional[str] = None):
         """
         Add action or widget `item` to given application menu `section`.
 
@@ -192,8 +216,8 @@ class MainMenu(SpyderPluginV2):
         ----------
         item: SpyderAction or SpyderMenu
             The item to add to the `menu`.
-        menu: ApplicationMenu or None
-            Instance of a Spyder application menu.
+        item_id: str
+            The identifier under which the item will be stored.
         menu_id: str or None
             The application menu unique string identifier.
         section: str or None
@@ -208,18 +232,6 @@ class MainMenu(SpyderPluginV2):
         -----
         Must provide a `menu` or a `menu_id`.
         """
-        if menu and menu_id:
-            raise SpyderAPIError('Must provide only menu or menu_id!')
-
-        if menu is None and menu_id is None:
-            raise SpyderAPIError('Must provide at least menu or menu_id!')
-
-        if menu and not isinstance(menu, ApplicationMenu):
-            raise SpyderAPIError('Not an `ApplicationMenu`!')
-
-        if menu_id and menu_id not in self._APPLICATION_MENUS:
-            raise SpyderAPIError('{} is not a valid menu_id'.format(menu_id))
-
         # TODO: For now just add the item to the bottom for non-migrated menus.
         #       Temporal solution while migration is complete
         app_menu_actions = {
@@ -230,18 +242,22 @@ class MainMenu(SpyderPluginV2):
             ApplicationMenus.Debug: self._main.debug_menu_actions,
         }
 
-        menu_id = menu_id if menu_id else menu.menu_id
-        menu = menu if menu else self.get_application_menu(menu_id)
-
         if menu_id in app_menu_actions:
             actions = app_menu_actions[menu_id]
             actions.append(MENU_SEPARATOR)
             actions.append(item)
         else:
-            menu.add_action(item, section=section, before=before,
-                            before_section=before_section)
+            if menu_id not in self._APPLICATION_MENUS:
+                pending_menu_items = self._ITEM_QUEUE.get(menu_id, [])
+                pending_menu_items.append((item, item_id, section, before,
+                                           before_section))
+                self._ITEM_QUEUE[menu_id] = pending_menu_items
+            else:
+                menu = self.get_application_menu(menu_id)
+                menu.add_action(item, item_id, section=section, before=before,
+                                before_section=before_section)
 
-    def get_application_menu(self, menu_id):
+    def get_application_menu(self, menu_id: str) -> SpyderMenu:
         """
         Return an application menu by menu unique id.
 

--- a/spyder/plugins/mainmenu/plugin.py
+++ b/spyder/plugins/mainmenu/plugin.py
@@ -10,7 +10,6 @@ Main menu Plugin.
 
 # Standard library imports
 from collections import OrderedDict
-from email.mime.nonmultipart import MIMENonMultipart
 import sys
 from typing import Dict, List, Tuple, Optional, Union
 
@@ -222,8 +221,8 @@ class MainMenu(SpyderPluginV2):
             The application menu unique string identifier.
         section: str or None
             The section id in which to insert the `item` on the `menu`.
-        before: SpyderAction/SpyderMenu or None
-            Make the item appear before another given item.
+        before: str
+            Make the item appear before the given object identifier.
         before_section: Section or None
             Make the item section (if provided) appear before another
             given section.

--- a/spyder/plugins/profiler/plugin.py
+++ b/spyder/plugins/profiler/plugin.py
@@ -102,8 +102,8 @@ class Profiler(SpyderDockablePlugin):
         mainmenu = self.get_plugin(Plugins.MainMenu)
         run_action = self.get_action(ProfilerActions.ProfileCurrentFile)
 
-        run_menu = mainmenu.get_application_menu(ApplicationMenus.Run)
-        mainmenu.add_item_to_application_menu(run_action, menu=run_menu)
+        mainmenu.add_item_to_application_menu(
+            run_action, menu_id=ApplicationMenus.Run)
 
     # --- Public API
     # ------------------------------------------------------------------------

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -248,19 +248,19 @@ class Projects(SpyderDockablePlugin):
 
         main_menu.add_item_to_application_menu(
             new_project_action,
-            menu=projects_menu,
+            menu_id=ApplicationMenus.Projects,
             section=ProjectsMenuSections.New)
 
         for item in [open_project_action, self.close_project_action,
                      self.delete_project_action]:
             main_menu.add_item_to_application_menu(
                 item,
-                menu=projects_menu,
+                menu_id=ApplicationMenus.Projects,
                 section=ProjectsMenuSections.Open)
 
         main_menu.add_item_to_application_menu(
             self.recent_project_menu,
-            menu=projects_menu,
+            menu_id=ApplicationMenus.Projects,
             section=ProjectsMenuSections.Extras)
 
     def setup(self):

--- a/spyder/plugins/pylint/plugin.py
+++ b/spyder/plugins/pylint/plugin.py
@@ -126,9 +126,8 @@ class Pylint(SpyderDockablePlugin):
         mainmenu = self.get_plugin(Plugins.MainMenu)
 
         pylint_act = self.get_action(PylintActions.AnalyzeCurrentFile)
-        source_menu = mainmenu.get_application_menu(
-            ApplicationMenus.Source)
-        mainmenu.add_item_to_application_menu(pylint_act, menu=source_menu)
+        mainmenu.add_item_to_application_menu(
+            pylint_act, menu_id=ApplicationMenus.Source)
 
     # --- Private API
     # ------------------------------------------------------------------------

--- a/spyder/plugins/shortcuts/plugin.py
+++ b/spyder/plugins/shortcuts/plugin.py
@@ -91,10 +91,9 @@ class Shortcuts(SpyderPluginV2):
             ShortcutActions.ShortcutSummaryAction)
 
         # Add to Help menu.
-        help_menu = mainmenu.get_application_menu(ApplicationMenus.Help)
         mainmenu.add_item_to_application_menu(
             shortcuts_action,
-            help_menu,
+            menu_id=ApplicationMenus.Help,
             section=HelpMenuSections.Documentation,
         )
 

--- a/spyder/plugins/toolbar/container.py
+++ b/spyder/plugins/toolbar/container.py
@@ -43,6 +43,7 @@ class ToolbarActions:
 
 
 class QActionID(QAction):
+    """Wrapper class around QAction that allows to set/get an identifier."""
     @property
     def action_id(self):
         return self._action_id
@@ -50,6 +51,7 @@ class QActionID(QAction):
     @action_id.setter
     def action_id(self, act):
         self._action_id = act
+
 
 class ToolbarContainer(PluginMainContainer):
     def __init__(self, name, plugin, parent=None):

--- a/spyder/plugins/toolbar/container.py
+++ b/spyder/plugins/toolbar/container.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 
 # Third party imports
 from qtpy.QtCore import QSize, Slot
+from qtpy.QtWidgets import QAction
 
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
@@ -40,6 +41,15 @@ class ToolbarsMenuSections:
 class ToolbarActions:
     ShowToolbars = "show toolbars"
 
+
+class QActionID(QAction):
+    @property
+    def action_id(self):
+        return self._action_id
+
+    @action_id.setter
+    def action_id(self, act):
+        self._action_id = act
 
 class ToolbarContainer(PluginMainContainer):
     def __init__(self, name, plugin, parent=None):
@@ -296,6 +306,8 @@ class ToolbarContainer(PluginMainContainer):
         for toolbar_id, toolbar in self._ADDED_TOOLBARS.items():
             if toolbar:
                 action = toolbar.toggleViewAction()
+                action.__class__ = QActionID
+                action.action_id = f'toolbar_{toolbar_id}'
                 section = (
                     main_section
                     if toolbar_id in default_toolbars

--- a/spyder/plugins/tours/plugin.py
+++ b/spyder/plugins/tours/plugin.py
@@ -58,15 +58,11 @@ class Tours(SpyderPluginV2):
     def on_main_menu_available(self):
         mainmenu = self.get_plugin(Plugins.MainMenu)
 
-        docs_action = self.get_action(
-            ApplicationActions.SpyderDocumentationAction,
-            plugin=Plugins.Application)
-
         mainmenu.add_item_to_application_menu(
             self.get_container().tour_action,
             menu_id=ApplicationMenus.Help,
             section=HelpMenuSections.Documentation,
-            before=docs_action)
+            before=ApplicationActions.SpyderDocumentationAction)
 
     def on_mainwindow_visible(self):
         self.show_tour_message()

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -311,7 +311,7 @@ def create_action(parent, text, shortcut=None, icon=None, tip=None,
                   id_=None, plugin=None, context_name=None,
                   register_action=False, overwrite=False):
     """Create a QAction"""
-    action = SpyderAction(text, parent)
+    action = SpyderAction(text, parent, action_id=id_)
     if triggered is not None:
         action.triggered.connect(triggered)
     if toggled is not None:
@@ -552,9 +552,10 @@ def get_filetype_icon(fname):
 class SpyderAction(QAction):
     """Spyder QAction class wrapper to handle cross platform patches."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, action_id=None, **kwargs):
         """Spyder QAction class wrapper to handle cross platform patches."""
         super(SpyderAction, self).__init__(*args, **kwargs)
+        self.action_id = action_id
         if sys.platform == "darwin":
             self.setIconVisibleInMenu(False)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
This PR updates the Main Menu plugin methods to exclusively use string identifiers as opposed to using object references when adding items to a specific menu and/or before a given menu item. This is a breaking API change.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @andfoy

<!--- Thanks for your help making Spyder better for everyone! --->
