### PR TITLE
PR: Add option to per-file run configuration to use default run configuration

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -966,6 +966,7 @@ def test_runconfig_workdir(main_window, qtbot, tmpdir):
 
     # --- Use cwd for this file ---
     rc = RunConfiguration().get()
+    rc['default'] = False
     rc['file_dir'] = False
     rc['cw_dir'] = True
     config_entry = (test_file, rc)
@@ -1022,8 +1023,8 @@ def test_dedicated_consoles(main_window, qtbot):
 
     # --- Set run options for this file ---
     rc = RunConfiguration().get()
-    # A dedicated console is used when these two options are False
-    rc['current'] = rc['systerm'] = False
+    # A dedicated console is used when these three options are False
+    rc['default'] = rc['current'] = rc['systerm'] = False
     config_entry = (test_file, rc)
     CONF.set('run', 'configurations', [config_entry])
 

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -58,8 +58,8 @@ from spyder.plugins.editor.widgets.status import (CursorPositionStatus,
                                                   EncodingStatus, EOLStatus,
                                                   ReadWriteStatus, VCSStatus)
 from spyder.plugins.run.widgets import (ALWAYS_OPEN_FIRST_RUN_OPTION,
-                                        get_run_configuration, RunConfigDialog,
-                                        RunConfiguration, RunConfigOneDialog)
+                                        get_run_configuration,
+                                        RunConfigDialog, RunConfigOneDialog)
 from spyder.plugins.mainmenu.api import ApplicationMenus
 
 
@@ -2928,10 +2928,6 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             if show_dlg and not dialog.exec_():
                 return
             runconf = dialog.get_configuration()
-
-        if runconf.default:
-            # use global run preferences settings
-            runconf = RunConfiguration()
 
         args = runconf.get_arguments()
         python_args = runconf.get_python_arguments()

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -58,8 +58,8 @@ from spyder.plugins.editor.widgets.status import (CursorPositionStatus,
                                                   EncodingStatus, EOLStatus,
                                                   ReadWriteStatus, VCSStatus)
 from spyder.plugins.run.widgets import (ALWAYS_OPEN_FIRST_RUN_OPTION,
-                                        get_run_configuration,
-                                        RunConfigDialog, RunConfigOneDialog)
+                                        get_run_configuration, RunConfigDialog,
+                                        RunConfiguration, RunConfigOneDialog)
 from spyder.plugins.mainmenu.api import ApplicationMenus
 
 
@@ -2928,6 +2928,10 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             if show_dlg and not dialog.exec_():
                 return
             runconf = dialog.get_configuration()
+
+        if runconf.default:
+            # use global run preferences settings
+            runconf = RunConfiguration()
 
         args = runconf.get_arguments()
         python_args = runconf.get_python_arguments()

--- a/spyder/plugins/run/widgets.py
+++ b/spyder/plugins/run/widgets.py
@@ -28,6 +28,8 @@ from spyder.utils.qthelpers import create_toolbutton
 # Localization
 _ = get_translation("spyder")
 
+RUN_DEFAULT_CONFIG = _("Run file with default configuration")
+RUN_CUSTOM_CONFIG = _("Run file with custom configuration")
 CURRENT_INTERPRETER = _("Execute in current console")
 DEDICATED_INTERPRETER = _("Execute in a dedicated console")
 SYSTERM_INTERPRETER = _("Execute in an external system terminal")
@@ -58,6 +60,7 @@ class RunConfiguration(object):
     """Run configuration"""
 
     def __init__(self, fname=None):
+        self.default = None
         self.args = None
         self.args_enabled = None
         self.wdir = None
@@ -78,6 +81,7 @@ class RunConfiguration(object):
         self.set(CONF.get('run', 'defaultconfiguration', default={}))
 
     def set(self, options):
+        self.default = options.get('default', True)
         self.args = options.get('args', '')
         self.args_enabled = options.get('args/enabled', False)
         self.current = options.get('current',
@@ -104,6 +108,7 @@ class RunConfiguration(object):
 
     def get(self):
         return {
+                'default': self.default,
                 'args/enabled': self.args_enabled,
                 'args': self.args,
                 'workdir/enabled': self.wdir_enabled,
@@ -173,8 +178,22 @@ class RunConfigOptions(QWidget):
         self.runconf = RunConfiguration()
         firstrun_o = CONF.get('run', ALWAYS_OPEN_FIRST_RUN_OPTION, False)
 
+        # --- Run settings ---
+        run_group = QGroupBox(_("Run settings"))
+        run_layout = QVBoxLayout(run_group)
+
+        self.run_default_config_radio = QRadioButton(RUN_DEFAULT_CONFIG)
+        run_layout.addWidget(self.run_default_config_radio)
+
+        self.run_custom_config_radio = QRadioButton(RUN_CUSTOM_CONFIG)
+        run_layout.addWidget(self.run_custom_config_radio)
+
         # --- Interpreter ---
         interpreter_group = QGroupBox(_("Console"))
+        interpreter_group.setDisabled(True)
+
+        self.run_custom_config_radio.toggled.connect(interpreter_group.setEnabled)
+
         interpreter_layout = QVBoxLayout(interpreter_group)
 
         self.current_radio = QRadioButton(CURRENT_INTERPRETER)
@@ -188,6 +207,10 @@ class RunConfigOptions(QWidget):
 
         # --- General settings ----
         common_group = QGroupBox(_("General settings"))
+        common_group.setDisabled(True)
+
+        self.run_custom_config_radio.toggled.connect(common_group.setEnabled)
+
         common_layout = QGridLayout(common_group)
 
         self.clear_var_cb = QCheckBox(CLEAR_ALL_VARIABLES)
@@ -208,6 +231,10 @@ class RunConfigOptions(QWidget):
 
         # --- Working directory ---
         wdir_group = QGroupBox(_("Working directory settings"))
+        wdir_group.setDisabled(True)
+
+        self.run_custom_config_radio.toggled.connect(wdir_group.setEnabled)
+
         wdir_layout = QVBoxLayout(wdir_group)
 
         self.file_dir_radio = QRadioButton(FILE_DIR)
@@ -236,6 +263,8 @@ class RunConfigOptions(QWidget):
         external_group = QGroupBox(_("External system terminal"))
         external_group.setDisabled(True)
 
+        self.run_custom_config_radio.toggled.connect(lambda x:
+            external_group.setEnabled(x and self.systerm_radio.isChecked()))
         self.systerm_radio.toggled.connect(external_group.setEnabled)
 
         external_layout = QGridLayout()
@@ -259,6 +288,7 @@ class RunConfigOptions(QWidget):
         self.firstrun_cb.setChecked(firstrun_o)
 
         layout = QVBoxLayout(self)
+        layout.addWidget(run_group)
         layout.addWidget(interpreter_group)
         layout.addWidget(common_group)
         layout.addWidget(wdir_group)
@@ -278,6 +308,10 @@ class RunConfigOptions(QWidget):
 
     def set(self, options):
         self.runconf.set(options)
+        if self.runconf.default:
+            self.run_default_config_radio.setChecked(True)
+        else:
+            self.run_custom_config_radio.setChecked(True)
         self.clo_cb.setChecked(self.runconf.args_enabled)
         self.clo_edit.setText(self.runconf.args)
         if self.runconf.current:
@@ -299,6 +333,7 @@ class RunConfigOptions(QWidget):
         self.wd_edit.setText(self.dir)
 
     def get(self):
+        self.runconf.default = self.run_default_config_radio.isChecked()
         self.runconf.args_enabled = self.clo_cb.isChecked()
         self.runconf.args = str(self.clo_edit.text())
         self.runconf.current = self.current_radio.isChecked()

--- a/spyder/plugins/run/widgets.py
+++ b/spyder/plugins/run/widgets.py
@@ -364,8 +364,6 @@ class BaseRunConfigDialog(QDialog):
         bbox = QDialogButtonBox(stdbtns)
         run_btn = bbox.addButton(_("Run"), QDialogButtonBox.AcceptRole)
         run_btn.clicked.connect(self.run_btn_clicked)
-        remove_btn = bbox.addButton(_("Remove"), QDialogButtonBox.ResetRole)
-        remove_btn.clicked.connect(self.remove_btn_clicked)
         bbox.accepted.connect(self.accept)
         bbox.rejected.connect(self.reject)
         btnlayout = QHBoxLayout()
@@ -383,10 +381,6 @@ class BaseRunConfigDialog(QDialog):
 
     def run_btn_clicked(self):
         """Run button was just clicked"""
-        pass
-
-    def remove_btn_clicked(self):
-        """Reset button was just clicked"""
         pass
 
     def setup(self, fname):
@@ -443,12 +437,6 @@ class RunConfigDialog(BaseRunConfigDialog):
     def run_btn_clicked(self):
         """Run button was just clicked"""
         self.file_to_run = str(self.combo.currentText())
-
-    def remove_btn_clicked(self):
-        """Reset button was just clicked"""
-        index = self.combo.currentIndex()
-        self.stack.removeWidget(self.stack.currentWidget())
-        self.combo.removeItem(index)
 
     def setup(self, fname):
         """Setup Run Configuration dialog with filename *fname*"""

--- a/spyder/plugins/run/widgets.py
+++ b/spyder/plugins/run/widgets.py
@@ -179,14 +179,8 @@ class RunConfigOptions(QWidget):
         firstrun_o = CONF.get('run', ALWAYS_OPEN_FIRST_RUN_OPTION, False)
 
         # --- Run settings ---
-        run_group = QGroupBox(_("Run settings"))
-        run_layout = QVBoxLayout(run_group)
-
         self.run_default_config_radio = QRadioButton(RUN_DEFAULT_CONFIG)
-        run_layout.addWidget(self.run_default_config_radio)
-
         self.run_custom_config_radio = QRadioButton(RUN_CUSTOM_CONFIG)
-        run_layout.addWidget(self.run_custom_config_radio)
 
         # --- Interpreter ---
         interpreter_group = QGroupBox(_("Console"))
@@ -291,7 +285,8 @@ class RunConfigOptions(QWidget):
         self.firstrun_cb.setChecked(firstrun_o)
 
         layout = QVBoxLayout(self)
-        layout.addWidget(run_group)
+        layout.addWidget(self.run_default_config_radio)
+        layout.addWidget(self.run_custom_config_radio)
         layout.addWidget(interpreter_group)
         layout.addWidget(common_group)
         layout.addWidget(wdir_group)

--- a/spyder/plugins/run/widgets.py
+++ b/spyder/plugins/run/widgets.py
@@ -364,6 +364,8 @@ class BaseRunConfigDialog(QDialog):
         bbox = QDialogButtonBox(stdbtns)
         run_btn = bbox.addButton(_("Run"), QDialogButtonBox.AcceptRole)
         run_btn.clicked.connect(self.run_btn_clicked)
+        remove_btn = bbox.addButton(_("Remove"), QDialogButtonBox.ResetRole)
+        remove_btn.clicked.connect(self.remove_btn_clicked)
         bbox.accepted.connect(self.accept)
         bbox.rejected.connect(self.reject)
         btnlayout = QHBoxLayout()
@@ -381,6 +383,10 @@ class BaseRunConfigDialog(QDialog):
 
     def run_btn_clicked(self):
         """Run button was just clicked"""
+        pass
+
+    def remove_btn_clicked(self):
+        """Reset button was just clicked"""
         pass
 
     def setup(self, fname):
@@ -437,6 +443,12 @@ class RunConfigDialog(BaseRunConfigDialog):
     def run_btn_clicked(self):
         """Run button was just clicked"""
         self.file_to_run = str(self.combo.currentText())
+
+    def remove_btn_clicked(self):
+        """Reset button was just clicked"""
+        index = self.combo.currentIndex()
+        self.stack.removeWidget(self.stack.currentWidget())
+        self.combo.removeItem(index)
 
     def setup(self, fname):
         """Setup Run Configuration dialog with filename *fname*"""

--- a/spyder/plugins/run/widgets.py
+++ b/spyder/plugins/run/widgets.py
@@ -192,7 +192,8 @@ class RunConfigOptions(QWidget):
         interpreter_group = QGroupBox(_("Console"))
         interpreter_group.setDisabled(True)
 
-        self.run_custom_config_radio.toggled.connect(interpreter_group.setEnabled)
+        self.run_custom_config_radio.toggled.connect(
+            interpreter_group.setEnabled)
 
         interpreter_layout = QVBoxLayout(interpreter_group)
 
@@ -263,8 +264,10 @@ class RunConfigOptions(QWidget):
         external_group = QGroupBox(_("External system terminal"))
         external_group.setDisabled(True)
 
-        self.run_custom_config_radio.toggled.connect(lambda x:
-            external_group.setEnabled(x and self.systerm_radio.isChecked()))
+        self.run_custom_config_radio.toggled.connect(
+            lambda x: external_group.setEnabled(
+                x and self.systerm_radio.isChecked())
+            )
         self.systerm_radio.toggled.connect(external_group.setEnabled)
 
         external_layout = QGridLayout()

--- a/spyder/plugins/run/widgets.py
+++ b/spyder/plugins/run/widgets.py
@@ -28,7 +28,6 @@ from spyder.utils.qthelpers import create_toolbutton
 # Localization
 _ = get_translation("spyder")
 
-USE_DEFAULT_CONFIG = _("Use default run settings")
 CURRENT_INTERPRETER = _("Execute in current console")
 DEDICATED_INTERPRETER = _("Execute in a dedicated console")
 SYSTERM_INTERPRETER = _("Execute in an external system terminal")
@@ -59,7 +58,6 @@ class RunConfiguration(object):
     """Run configuration"""
 
     def __init__(self, fname=None):
-        self.default = None
         self.args = None
         self.args_enabled = None
         self.wdir = None
@@ -80,7 +78,6 @@ class RunConfiguration(object):
         self.set(CONF.get('run', 'defaultconfiguration', default={}))
 
     def set(self, options):
-        self.default = options.get('default', False)
         self.args = options.get('args', '')
         self.args_enabled = options.get('args/enabled', False)
         self.current = options.get('current',
@@ -107,7 +104,6 @@ class RunConfiguration(object):
 
     def get(self):
         return {
-                'default': self.default,
                 'args/enabled': self.args_enabled,
                 'args': self.args,
                 'workdir/enabled': self.wdir_enabled,
@@ -176,9 +172,6 @@ class RunConfigOptions(QWidget):
         self.dir = None
         self.runconf = RunConfiguration()
         firstrun_o = CONF.get('run', ALWAYS_OPEN_FIRST_RUN_OPTION, False)
-
-        self.use_default_cb = QCheckBox(USE_DEFAULT_CONFIG)
-        self.use_default_cb.setChecked(self.runconf.default)
 
         # --- Interpreter ---
         interpreter_group = QGroupBox(_("Console"))
@@ -266,7 +259,6 @@ class RunConfigOptions(QWidget):
         self.firstrun_cb.setChecked(firstrun_o)
 
         layout = QVBoxLayout(self)
-        layout.addWidget(self.use_default_cb)
         layout.addWidget(interpreter_group)
         layout.addWidget(common_group)
         layout.addWidget(wdir_group)
@@ -286,7 +278,6 @@ class RunConfigOptions(QWidget):
 
     def set(self, options):
         self.runconf.set(options)
-        self.use_default_cb.setChecked(self.runconf.default)
         self.clo_cb.setChecked(self.runconf.args_enabled)
         self.clo_edit.setText(self.runconf.args)
         if self.runconf.current:
@@ -308,7 +299,6 @@ class RunConfigOptions(QWidget):
         self.wd_edit.setText(self.dir)
 
     def get(self):
-        self.runconf.default = self.use_default_cb.isChecked()
         self.runconf.args_enabled = self.clo_cb.isChecked()
         self.runconf.args = str(self.clo_edit.text())
         self.runconf.current = self.current_radio.isChecked()

--- a/spyder/plugins/run/widgets.py
+++ b/spyder/plugins/run/widgets.py
@@ -28,6 +28,7 @@ from spyder.utils.qthelpers import create_toolbutton
 # Localization
 _ = get_translation("spyder")
 
+USE_DEFAULT_CONFIG = _("Use default run settings")
 CURRENT_INTERPRETER = _("Execute in current console")
 DEDICATED_INTERPRETER = _("Execute in a dedicated console")
 SYSTERM_INTERPRETER = _("Execute in an external system terminal")
@@ -58,6 +59,7 @@ class RunConfiguration(object):
     """Run configuration"""
 
     def __init__(self, fname=None):
+        self.default = None
         self.args = None
         self.args_enabled = None
         self.wdir = None
@@ -78,6 +80,7 @@ class RunConfiguration(object):
         self.set(CONF.get('run', 'defaultconfiguration', default={}))
 
     def set(self, options):
+        self.default = options.get('default', False)
         self.args = options.get('args', '')
         self.args_enabled = options.get('args/enabled', False)
         self.current = options.get('current',
@@ -104,6 +107,7 @@ class RunConfiguration(object):
 
     def get(self):
         return {
+                'default': self.default,
                 'args/enabled': self.args_enabled,
                 'args': self.args,
                 'workdir/enabled': self.wdir_enabled,
@@ -172,6 +176,9 @@ class RunConfigOptions(QWidget):
         self.dir = None
         self.runconf = RunConfiguration()
         firstrun_o = CONF.get('run', ALWAYS_OPEN_FIRST_RUN_OPTION, False)
+
+        self.use_default_cb = QCheckBox(USE_DEFAULT_CONFIG)
+        self.use_default_cb.setChecked(self.runconf.default)
 
         # --- Interpreter ---
         interpreter_group = QGroupBox(_("Console"))
@@ -259,6 +266,7 @@ class RunConfigOptions(QWidget):
         self.firstrun_cb.setChecked(firstrun_o)
 
         layout = QVBoxLayout(self)
+        layout.addWidget(self.use_default_cb)
         layout.addWidget(interpreter_group)
         layout.addWidget(common_group)
         layout.addWidget(wdir_group)
@@ -278,6 +286,7 @@ class RunConfigOptions(QWidget):
 
     def set(self, options):
         self.runconf.set(options)
+        self.use_default_cb.setChecked(self.runconf.default)
         self.clo_cb.setChecked(self.runconf.args_enabled)
         self.clo_edit.setText(self.runconf.args)
         if self.runconf.current:
@@ -299,6 +308,7 @@ class RunConfigOptions(QWidget):
         self.wd_edit.setText(self.dir)
 
     def get(self):
+        self.runconf.default = self.use_default_cb.isChecked()
         self.runconf.args_enabled = self.clo_cb.isChecked()
         self.runconf.args = str(self.clo_edit.text())
         self.runconf.current = self.current_radio.isChecked()

--- a/spyder/plugins/run/widgets.py
+++ b/spyder/plugins/run/widgets.py
@@ -200,6 +200,27 @@ class RunConfigOptions(QWidget):
         self.systerm_radio = QRadioButton(SYSTERM_INTERPRETER)
         interpreter_layout.addWidget(self.systerm_radio)
 
+        # --- System terminal ---
+        external_group = QWidget()
+        external_group.setDisabled(True)
+        self.systerm_radio.toggled.connect(external_group.setEnabled)
+
+        external_layout = QGridLayout()
+        external_group.setLayout(external_layout)
+        self.interact_cb = QCheckBox(INTERACT)
+        external_layout.addWidget(self.interact_cb, 1, 0, 1, -1)
+
+        self.pclo_cb = QCheckBox(_("Command line options:"))
+        external_layout.addWidget(self.pclo_cb, 3, 0)
+        self.pclo_edit = QLineEdit()
+        self.pclo_cb.toggled.connect(self.pclo_edit.setEnabled)
+        self.pclo_edit.setEnabled(False)
+        self.pclo_edit.setToolTip(_("<b>-u</b> is added to the "
+                                    "other options you set here"))
+        external_layout.addWidget(self.pclo_edit, 3, 1)
+
+        interpreter_layout.addWidget(external_group)
+
         # --- General settings ----
         common_group = QGroupBox(_("General settings"))
         common_group.setDisabled(True)
@@ -254,30 +275,6 @@ class RunConfigOptions(QWidget):
         fixed_dir_layout.addWidget(browse_btn)
         wdir_layout.addLayout(fixed_dir_layout)
 
-        # --- System terminal ---
-        external_group = QGroupBox(_("External system terminal"))
-        external_group.setDisabled(True)
-
-        self.run_custom_config_radio.toggled.connect(
-            lambda x: external_group.setEnabled(
-                x and self.systerm_radio.isChecked())
-            )
-        self.systerm_radio.toggled.connect(external_group.setEnabled)
-
-        external_layout = QGridLayout()
-        external_group.setLayout(external_layout)
-        self.interact_cb = QCheckBox(INTERACT)
-        external_layout.addWidget(self.interact_cb, 1, 0, 1, -1)
-
-        self.pclo_cb = QCheckBox(_("Command line options:"))
-        external_layout.addWidget(self.pclo_cb, 3, 0)
-        self.pclo_edit = QLineEdit()
-        self.pclo_cb.toggled.connect(self.pclo_edit.setEnabled)
-        self.pclo_edit.setEnabled(False)
-        self.pclo_edit.setToolTip(_("<b>-u</b> is added to the "
-                                    "other options you set here"))
-        external_layout.addWidget(self.pclo_edit, 3, 1)
-
         # Checkbox to preserve the old behavior, i.e. always open the dialog
         # on first run
         self.firstrun_cb = QCheckBox(ALWAYS_OPEN_FIRST_RUN % _("this dialog"))
@@ -290,7 +287,6 @@ class RunConfigOptions(QWidget):
         layout.addWidget(interpreter_group)
         layout.addWidget(common_group)
         layout.addWidget(wdir_group)
-        layout.addWidget(external_group)
         layout.addWidget(self.firstrun_cb)
         layout.addStretch(100)
 

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -731,11 +731,16 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
     if executable is None:
         executable = get_python_executable()
 
-    # If fname or python_exe contains spaces, it can't be ran on Windows, so we
+    # If fname or wdir has spaces, must be enclosed in quotes (all platforms)
+    if ' ' in fname:
+        fname = '"' + fname + '"'
+    if ' ' in wdir:
+        wdir = '"' + wdir + '"'
+
+    # If python_exe contains spaces, it can't be ran on Windows, so we
     # have to enclose them in quotes. Also wdir can come with / as os.sep, so
     # we need to take care of it.
     if os.name == 'nt':
-        fname = '"' + fname + '"'
         wdir = wdir.replace('/', '\\')
         executable = '"' + executable + '"'
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->

* Added option to use default run configuration in the per-file run configuration
* Moved external terminal elements moved to the console group
* Behavior is unchanged except that when this option is selected the file-specific run configuration is ignored and the default run configuration takes priority.
* Note: all other file-specific run configuration options are not modified. This will allow toggling the run configuration without requiring the user to re-establish file run configuration.
* Fixed an issue with running in an external terminal if path and/or script name had spaces.

<img width="400" alt="Screen Shot 2022-03-15 at 6 28 37 PM" src="https://user-images.githubusercontent.com/9618975/158539750-a063454e-c9cf-4588-91ea-887b19b79485.png"><img width="400" alt="Screen Shot 2022-03-15 at 6 29 09 PM" src="https://user-images.githubusercontent.com/9618975/158539780-b83ab8f5-5713-46d1-a919-de3f63bf7093.png">

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16207

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary 
<!--- Thanks for your help making Spyder better for everyone! --->
