### PR TITLE
PR: Solves pasting of one line + newline into the editor

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2833,10 +2833,12 @@ class CodeEditor(TextEditBaseWidget):
                 preceding_text)
 
             # Make sure the code is not flattened
-            max_dedent = min(
-                [self.get_line_indentation(line)
-                 for line in remaining_lines if line.strip() != ""])
-            lines_adjustment = max(lines_adjustment, -max_dedent)
+            indentations = [
+                self.get_line_indentation(line)
+                for line in remaining_lines if line.strip() != ""]
+            if indentations:
+                max_dedent = min(indentations)
+                lines_adjustment = max(lines_adjustment, -max_dedent)
     
             # Get new text
             remaining_lines = [


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

PR #16164 fixed bug #16159, where the indentation of code pasted into the editor was lost.

This failed the border case, when just one line + newline is pasted (https://github.com/spyder-ide/spyder/issues/16159#issuecomment-898484641 ff). This PR solves this by calculating the list of indentation and then only uses this list, if it is not empty.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fix an issue found after merging PR #16164.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
sphh

<!--- Thanks for your help making Spyder better for everyone! --->
