### PR TITLE
PR: Use toPlainText to get the file's text when applying formatting (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1747,7 +1747,11 @@ class CodeEditor(TextEditBaseWidget):
         if edits is None:
             return
 
-        text = self.get_text_with_eol()
+        # We need to use here toPlainText and not get_text_with_eol to
+        # to not mess up the code when applying formatting.
+        # See spyder-ide/spyder#16180
+        text = self.toPlainText()
+
         text_tokens = list(text)
         merged_text = None
         for edit in edits:


### PR DESCRIPTION
## Description of Changes

Code formatting with Autopep8 or Black was introducing errors for files with line endings other than LF.

### Issue(s) Resolved

Fixes #16180.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
