### PR TITLE
PR: Fix splash screen when restarting Spyder

### DIFF
--- a/spyder/app/restart.py
+++ b/spyder/app/restart.py
@@ -120,6 +120,12 @@ class Restarter(QWidget):
         self._show_message(text)
         self.timer_ellipsis.start(500)
 
+        # Wait 1.2 seconds so we can give feedback to users that a
+        # restart is happening.
+        for __ in range(40):
+            time.sleep(0.03)
+            QApplication.processEvents()
+
     def launch_error_message(self, error_type, error=None):
         """Launch a message box with a predefined error message.
 

--- a/spyder/app/restart.py
+++ b/spyder/app/restart.py
@@ -21,12 +21,12 @@ import sys
 import time
 
 # Third party imports
-from qtpy import PYQT5
 from qtpy.QtCore import Qt, QTimer
-from qtpy.QtGui import QColor, QPixmap, QIcon
-from qtpy.QtWidgets import QApplication, QMessageBox, QSplashScreen, QWidget
+from qtpy.QtGui import QColor, QIcon
+from qtpy.QtWidgets import QApplication, QMessageBox, QWidget
 
 # Local imports
+from spyder.app.utils import create_splash_screen
 from spyder.config.base import _
 from spyder.utils.image_path_manager import get_image_path
 from spyder.utils.encoding import to_unicode
@@ -92,15 +92,10 @@ class Restarter(QWidget):
 
         # Widgets
         self.timer_ellipsis = QTimer(self)
-        self.splash = QSplashScreen(QPixmap(get_image_path('splash'),
-                                    'svg'))
+        self.splash = create_splash_screen()
 
         # Widget setup
         self.setVisible(False)
-
-        font = self.splash.font()
-        font.setPixelSize(10)
-        self.splash.setFont(font)
         self.splash.show()
 
         self.timer_ellipsis.timeout.connect(self.animate_ellipsis)

--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -25,10 +25,10 @@ from spyder.config.base import (
     DEV, get_conf_path, get_debug_level, running_in_mac_app,
     running_under_pytest)
 from spyder.config.manager import CONF
-from spyder.utils.image_path_manager import get_image_path
-from spyder.utils.qthelpers import file_uri, qapplication
 from spyder.utils.external.dafsa.dafsa import DAFSA
-from spyder.utils.stylesheet import QStylePalette
+from spyder.utils.image_path_manager import get_image_path
+from spyder.utils.palette import QStylePalette
+from spyder.utils.qthelpers import file_uri, qapplication
 
 # For spyder-ide/spyder#7447.
 try:


### PR DESCRIPTION
## Description of Changes

* Wait for a bit when showing the screen so users know that a restart is happening (before the screen was practically not shown).
* Use `create_splash_screen` from `app/utils.py` to show the same screen when starting and restarting.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
