### PR TITLE
PR: Create main_widget module for the Outline plugin

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -47,7 +47,7 @@ from spyder.plugins.editor.widgets.status import (CursorPositionStatus,
                                                   ReadWriteStatus, VCSStatus)
 from spyder.plugins.explorer.widgets.explorer import (
     show_in_external_file_explorer)
-from spyder.plugins.outlineexplorer.widgets import OutlineExplorerWidget
+from spyder.plugins.outlineexplorer.main_widget import OutlineExplorerWidget
 from spyder.plugins.outlineexplorer.editor import OutlineExplorerProxyEditor
 from spyder.plugins.outlineexplorer.api import cell_name
 from spyder.py3compat import qbytearray_to_str, to_text_string

--- a/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
@@ -24,8 +24,8 @@ import pytest
 
 # Local imports
 from spyder.plugins.editor.widgets import editor
-from spyder.plugins.outlineexplorer.widgets import OutlineExplorerWidget
 from spyder.plugins.outlineexplorer.editor import OutlineExplorerProxyEditor
+from spyder.plugins.outlineexplorer.main_widget import OutlineExplorerWidget
 
 
 HERE = osp.dirname(osp.abspath(__file__))

--- a/spyder/plugins/editor/widgets/tests/test_save.py
+++ b/spyder/plugins/editor/widgets/tests/test_save.py
@@ -18,7 +18,7 @@ import pytest
 # Local imports
 from spyder.plugins.editor.panels import DebuggerPanel
 from spyder.plugins.editor.widgets import editor
-from spyder.plugins.outlineexplorer.widgets import OutlineExplorerWidget
+from spyder.plugins.outlineexplorer.main_widget import OutlineExplorerWidget
 
 
 # ---- Helpers

--- a/spyder/plugins/outlineexplorer/main_widget.py
+++ b/spyder/plugins/outlineexplorer/main_widget.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""Outline explorer main widget."""
+
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QHBoxLayout
+
+from spyder.api.widgets.main_widget import PluginMainWidget
+from spyder.api.translations import get_translation
+from spyder.plugins.outlineexplorer.widgets import OutlineExplorerTreeWidget
+
+_ = get_translation('spyder')
+
+
+# ---- Enums
+# -----------------------------------------------------------------------------
+class OutlineExplorerToolbuttons:
+    GoToCursor = 'go_to_cursor'
+
+
+class OutlineExplorerSections:
+    Main = 'main_section'
+    DisplayOptions = 'display_options'
+
+
+class OutlineExplorerActions:
+    GoToCursor = 'go_to_cursor'
+    ShowFullPath = 'show_fullpath'
+    ShowAllFiles = 'show_all_files'
+    ShowSpecialComments = 'show_comments'
+    GroupCodeCells = 'group_code_cells'
+    DisplayVariables = 'display_variables'
+    FollowCursor = 'follow_cursor'
+    SortFiles = 'sort_files_alphabetically'
+
+
+# ---- Main widget
+# -----------------------------------------------------------------------------
+class OutlineExplorerWidget(PluginMainWidget):
+    """Class browser"""
+    edit_goto = Signal(str, int, str)
+    edit = Signal(str)
+    is_visible = Signal()
+    sig_update_configuration = Signal()
+
+    ENABLE_SPINNER = True
+    CONF_SECTION = 'outline_explorer'
+
+    def __init__(self, name, plugin, parent=None, context=None):
+        if context is not None:
+            self.CONTEXT_NAME = context
+
+        super().__init__(name, plugin, parent)
+
+        self.treewidget = OutlineExplorerTreeWidget(self)
+        self.treewidget.sig_display_spinner.connect(self.start_spinner)
+        self.treewidget.sig_hide_spinner.connect(self.stop_spinner)
+        self.treewidget.sig_update_configuration.connect(
+            self.sig_update_configuration)
+
+        self.treewidget.header().hide()
+
+        layout = QHBoxLayout()
+        layout.addWidget(self.treewidget)
+        self.setLayout(layout)
+
+    # ---- PluginMainWidget API
+    # ------------------------------------------------------------------------
+    def get_focus_widget(self):
+        """Define the widget to focus."""
+        return self.treewidget
+
+    def get_title(self):
+        """Return the title of the plugin tab."""
+        return _("Outline")
+
+    def setup(self):
+        """Performs the setup of plugin's menu and actions."""
+        # Toolbar buttons
+        toolbar = self.get_main_toolbar()
+        fromcursor_btn = self.create_toolbutton(
+            OutlineExplorerToolbuttons.GoToCursor,
+            icon=self.create_icon('fromcursor'),
+            tip=_('Go to cursor position'),
+            triggered=self.treewidget.go_to_cursor_position)
+
+        for item in [fromcursor_btn,
+                     self.treewidget.collapse_all_action,
+                     self.treewidget.expand_all_action,
+                     self.treewidget.restore_action,
+                     self.treewidget.collapse_selection_action,
+                     self.treewidget.expand_selection_action]:
+            self.add_item_to_toolbar(item, toolbar=toolbar,
+                                     section=OutlineExplorerSections.Main)
+
+        # Actions
+        fromcursor_act = self.create_action(
+            OutlineExplorerActions.GoToCursor,
+            text=_('Go to cursor position'),
+            icon=self.create_icon('fromcursor'),
+            triggered=self.treewidget.go_to_cursor_position)
+
+        fullpath_act = self.create_action(
+            OutlineExplorerActions.ShowFullPath,
+            text=_('Show absolute path'),
+            toggled=True,
+            option='show_fullpath')
+
+        allfiles_act = self.create_action(
+            OutlineExplorerActions.ShowAllFiles,
+            text=_('Show all files'),
+            toggled=True,
+            option='show_all_files')
+
+        comment_act = self.create_action(
+            OutlineExplorerActions.ShowSpecialComments,
+            text=_('Show special comments'),
+            toggled=True,
+            option='show_comments')
+
+        group_cells_act = self.create_action(
+            OutlineExplorerActions.GroupCodeCells,
+            text=_('Group code cells'),
+            toggled=True,
+            option='group_cells')
+
+        display_variables_act = self.create_action(
+            OutlineExplorerActions.DisplayVariables,
+            text=_('Display variables and attributes'),
+            toggled=True,
+            option='display_variables'
+        )
+
+        follow_cursor_act = self.create_action(
+            OutlineExplorerActions.FollowCursor,
+            text=_('Follow cursor position'),
+            toggled=True,
+            option='follow_cursor'
+        )
+
+        sort_files_alphabetically_act = self.create_action(
+            OutlineExplorerActions.SortFiles,
+            text=_('Sort files alphabetically'),
+            toggled=True,
+            option='sort_files_alphabetically'
+        )
+
+        actions = [fullpath_act, allfiles_act, group_cells_act,
+                   display_variables_act, follow_cursor_act, comment_act,
+                   sort_files_alphabetically_act, fromcursor_act]
+
+        option_menu = self.get_options_menu()
+        for action in actions:
+            self.add_item_to_menu(
+                action,
+                option_menu,
+                section=OutlineExplorerSections.DisplayOptions,
+            )
+
+    def update_actions(self):
+        pass
+
+    # ---- Public API
+    # ------------------------------------------------------------------------
+    def set_current_editor(self, editor, update, clear):
+        if clear:
+            self.remove_editor(editor)
+        if editor is not None:
+            self.treewidget.set_current_editor(editor, update)
+
+    def remove_editor(self, editor):
+        self.treewidget.remove_editor(editor)
+
+    def register_editor(self, editor):
+        self.treewidget.register_editor(editor)
+
+    def file_renamed(self, editor, new_filename):
+        self.treewidget.file_renamed(editor, new_filename)
+
+    def start_symbol_services(self, language):
+        """Enable LSP symbols functionality."""
+        self.treewidget.start_symbol_services(language)
+
+    def stop_symbol_services(self, language):
+        """Disable LSP symbols functionality."""
+        self.treewidget.stop_symbol_services(language)
+
+    def update_all_editors(self):
+        """Update all editors with an associated LSP server."""
+        self.treewidget.update_all_editors()

--- a/spyder/plugins/outlineexplorer/plugin.py
+++ b/spyder/plugins/outlineexplorer/plugin.py
@@ -13,7 +13,7 @@ from qtpy.QtCore import Slot
 from spyder.api.plugin_registration.decorators import on_plugin_available
 from spyder.api.translations import get_translation
 from spyder.api.plugins import SpyderDockablePlugin, Plugins
-from spyder.plugins.outlineexplorer.widgets import OutlineExplorerWidget
+from spyder.plugins.outlineexplorer.main_widget import OutlineExplorerWidget
 
 # Localization
 _ = get_translation('spyder')

--- a/spyder/plugins/outlineexplorer/tests/test_widgets.py
+++ b/spyder/plugins/outlineexplorer/tests/test_widgets.py
@@ -19,9 +19,10 @@ from qtpy.QtCore import Qt
 
 # Local imports
 from spyder.plugins.outlineexplorer.editor import OutlineExplorerProxyEditor
+from spyder.plugins.outlineexplorer.main_widget import (
+    OutlineExplorerWidget, OutlineExplorerToolbuttons)
 from spyder.plugins.outlineexplorer.widgets import (
-    OutlineExplorerWidget, FileRootItem, SymbolStatus, TreeItem,
-    OutlineExplorerToolbuttons)
+    FileRootItem, SymbolStatus, TreeItem)
 from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 
 HERE = osp.abspath(osp.dirname(__file__))

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -27,6 +27,8 @@ from spyder.utils.qthelpers import set_item_user_text
 from spyder.widgets.onecolumntree import OneColumnTree
 
 
+# ---- Constants
+# -----------------------------------------------------------------------------
 SYMBOL_NAME_MAP = {
     SymbolKind.FILE: _('File'),
     SymbolKind.MODULE: _('Module'),
@@ -58,13 +60,9 @@ SYMBOL_NAME_MAP = {
     SymbolKind.BLOCK_COMMENT: _('Block comment')
 }
 
-ICON_CACHE = {}
 
-
-def line_span(position):
-    return position[1] - position[0] + 1
-
-
+# ---- Symbol status
+# -----------------------------------------------------------------------------
 class SymbolStatus:
     def __init__(self, name, kind, position, path, node=None):
         self.name = name
@@ -158,6 +156,8 @@ class SymbolStatus:
             self.position, self.name, self.id, self.status)
 
 
+# ---- Items
+# -----------------------------------------------------------------------------
 class BaseTreeItem(QTreeWidgetItem):
     def clear(self):
         self.takeChildren()
@@ -265,6 +265,8 @@ class TreeItem(QTreeWidgetItem):
         self.setup()
 
 
+# ---- Treewidget
+# -----------------------------------------------------------------------------
 class OutlineExplorerTreeWidget(OneColumnTree):
     # Used only for debug purposes
     sig_tree_updated = Signal()
@@ -621,8 +623,6 @@ class OutlineExplorerTreeWidget(OneColumnTree):
             changed_entry_i = changed_entry.data
 
             if deleted_entry_i.name == changed_entry_i.name:
-                deleted_span = line_span(deleted_entry_i.position)
-                changed_span = line_span(changed_entry_i.position)
                 # Copy symbol status
                 changed_entry_i.clone_node(deleted_entry_i)
                 deleted_entry = next(deleted_iter, None)

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -15,12 +15,10 @@ import uuid
 from intervaltree import IntervalTree
 from qtpy.compat import from_qvariant
 from qtpy.QtCore import Qt, QTimer, Signal, Slot
-from qtpy.QtWidgets import (QHBoxLayout, QTreeWidgetItem,
-                            QTreeWidgetItemIterator)
+from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidgetItemIterator
 
 # Local imports
 from spyder.api.config.decorators import on_conf_change
-from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.config.base import _
 from spyder.py3compat import to_text_string
 from spyder.utils.icon_manager import ima
@@ -65,26 +63,6 @@ ICON_CACHE = {}
 
 def line_span(position):
     return position[1] - position[0] + 1
-
-
-class OutlineExplorerToolbuttons:
-    GoToCursor = 'go_to_cursor'
-
-
-class OutlineExplorerSections:
-    Main = 'main_section'
-    DisplayOptions = 'display_options'
-
-
-class OutlineExplorerActions:
-    GoToCursor = 'go_to_cursor'
-    ShowFullPath = 'show_fullpath'
-    ShowAllFiles = 'show_all_files'
-    ShowSpecialComments = 'show_comments'
-    GroupCodeCells = 'group_code_cells'
-    DisplayVariables = 'display_variables'
-    FollowCursor = 'follow_cursor'
-    SortFiles = 'sort_files_alphabetically'
 
 
 class SymbolStatus:
@@ -878,157 +856,3 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         for editor in self.editor_ids.keys():
             if editor.get_language().lower() == language:
                 editor.info = None
-
-
-class OutlineExplorerWidget(PluginMainWidget):
-    """Class browser"""
-    edit_goto = Signal(str, int, str)
-    edit = Signal(str)
-    is_visible = Signal()
-    sig_update_configuration = Signal()
-
-    ENABLE_SPINNER = True
-    CONF_SECTION = 'outline_explorer'
-
-    def __init__(self, name, plugin, parent=None, context=None):
-        if context is not None:
-            self.CONTEXT_NAME = context
-
-        super().__init__(name, plugin, parent)
-
-        self.treewidget = OutlineExplorerTreeWidget(self)
-        self.treewidget.sig_display_spinner.connect(self.start_spinner)
-        self.treewidget.sig_hide_spinner.connect(self.stop_spinner)
-        self.treewidget.sig_update_configuration.connect(
-            self.sig_update_configuration)
-
-        self.treewidget.header().hide()
-
-        layout = QHBoxLayout()
-        layout.addWidget(self.treewidget)
-        self.setLayout(layout)
-
-    # ---- PluginMainWidget API
-    # ------------------------------------------------------------------------
-    def get_focus_widget(self):
-        """Define the widget to focus."""
-        return self.treewidget
-
-    def get_title(self):
-        """Return the title of the plugin tab."""
-        return _("Outline")
-
-    def setup(self):
-        """Performs the setup of plugin's menu and actions."""
-        # Toolbar buttons
-        toolbar = self.get_main_toolbar()
-        fromcursor_btn = self.create_toolbutton(
-            OutlineExplorerToolbuttons.GoToCursor,
-            icon=self.create_icon('fromcursor'),
-            tip=_('Go to cursor position'),
-            triggered=self.treewidget.go_to_cursor_position)
-
-        for item in [fromcursor_btn,
-                     self.treewidget.collapse_all_action,
-                     self.treewidget.expand_all_action,
-                     self.treewidget.restore_action,
-                     self.treewidget.collapse_selection_action,
-                     self.treewidget.expand_selection_action]:
-            self.add_item_to_toolbar(item, toolbar=toolbar,
-                                     section=OutlineExplorerSections.Main)
-
-        # Actions
-        fromcursor_act = self.create_action(
-            OutlineExplorerActions.GoToCursor,
-            text=_('Go to cursor position'),
-            icon=self.create_icon('fromcursor'),
-            triggered=self.treewidget.go_to_cursor_position)
-
-        fullpath_act = self.create_action(
-            OutlineExplorerActions.ShowFullPath,
-            text=_('Show absolute path'),
-            toggled=True,
-            option='show_fullpath')
-
-        allfiles_act = self.create_action(
-            OutlineExplorerActions.ShowAllFiles,
-            text=_('Show all files'),
-            toggled=True,
-            option='show_all_files')
-
-        comment_act = self.create_action(
-            OutlineExplorerActions.ShowSpecialComments,
-            text=_('Show special comments'),
-            toggled=True,
-            option='show_comments')
-
-        group_cells_act = self.create_action(
-            OutlineExplorerActions.GroupCodeCells,
-            text=_('Group code cells'),
-            toggled=True,
-            option='group_cells')
-
-        display_variables_act = self.create_action(
-            OutlineExplorerActions.DisplayVariables,
-            text=_('Display variables and attributes'),
-            toggled=True,
-            option='display_variables'
-        )
-
-        follow_cursor_act = self.create_action(
-            OutlineExplorerActions.FollowCursor,
-            text=_('Follow cursor position'),
-            toggled=True,
-            option='follow_cursor'
-        )
-
-        sort_files_alphabetically_act = self.create_action(
-            OutlineExplorerActions.SortFiles,
-            text=_('Sort files alphabetically'),
-            toggled=True,
-            option='sort_files_alphabetically'
-        )
-
-        actions = [fullpath_act, allfiles_act, group_cells_act,
-                   display_variables_act, follow_cursor_act, comment_act,
-                   sort_files_alphabetically_act, fromcursor_act]
-
-        option_menu = self.get_options_menu()
-        for action in actions:
-            self.add_item_to_menu(
-                action,
-                option_menu,
-                section=OutlineExplorerSections.DisplayOptions,
-            )
-
-    def update_actions(self):
-        pass
-
-    # ---- Public API
-    # ------------------------------------------------------------------------
-    def set_current_editor(self, editor, update, clear):
-        if clear:
-            self.remove_editor(editor)
-        if editor is not None:
-            self.treewidget.set_current_editor(editor, update)
-
-    def remove_editor(self, editor):
-        self.treewidget.remove_editor(editor)
-
-    def register_editor(self, editor):
-        self.treewidget.register_editor(editor)
-
-    def file_renamed(self, editor, new_filename):
-        self.treewidget.file_renamed(editor, new_filename)
-
-    def start_symbol_services(self, language):
-        """Enable LSP symbols functionality."""
-        self.treewidget.start_symbol_services(language)
-
-    def stop_symbol_services(self, language):
-        """Disable LSP symbols functionality."""
-        self.treewidget.stop_symbol_services(language)
-
-    def update_all_editors(self):
-        """Update all editors with an associated LSP server."""
-        self.treewidget.update_all_editors()


### PR DESCRIPTION
## Description of Changes

- Move `OutlineExplorerWidget` to be in `plugins/outlineexplorer/main_widget.py`. This is to have a uniform code layout for all dockable plugins.
- Also remove some dead code in `plugins/outlineexplorer/widgets.py`

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
