### PR TITLE
PR: Center cursor when searching for text (Editor)

### DIFF
--- a/spyder/plugins/editor/panels/linenumber.py
+++ b/spyder/plugins/editor/panels/linenumber.py
@@ -12,19 +12,14 @@ This module contains the Line Number panel
 from math import ceil
 
 # Third party imports
-from qtpy import QT_VERSION
 from qtpy.QtCore import QSize, Qt
 from qtpy.QtGui import QPainter, QColor
 
 # Local imports
 from spyder.py3compat import to_text_string
 from spyder.utils.icon_manager import ima
-from spyder.utils.programs import check_version
 from spyder.api.panel import Panel
 from spyder.plugins.completion.api import DiagnosticSeverity
-
-
-QT55_VERSION = check_version(QT_VERSION, "5.5", ">=")
 
 
 class LineNumberArea(Panel):
@@ -76,14 +71,13 @@ class LineNumberArea(Panel):
         active_line_number = active_block.blockNumber() + 1
 
         def draw_pixmap(xleft, ytop, pixmap):
-            if not QT55_VERSION:
-                pixmap_height = pixmap.height()
-            else:
-                # scale pixmap height to device independent pixels
-                pixmap_height = pixmap.height() / pixmap.devicePixelRatio()
-            painter.drawPixmap(xleft, ceil(ytop +
-                                           (font_height-pixmap_height) / 2),
-                               pixmap)
+            # Scale pixmap height to device independent pixels
+            pixmap_height = pixmap.height() / pixmap.devicePixelRatio()
+            painter.drawPixmap(
+                xleft,
+                ceil(ytop + (font_height-pixmap_height) / 2),
+                pixmap
+            )
 
         for top, line_number, block in self.editor.visible_blocks:
             if self._margin:

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -21,7 +21,7 @@ import sys
 import textwrap
 
 # Third party imports
-from qtpy.QtCore import QPoint, Qt
+from qtpy.QtCore import QPoint, QRegularExpression, Qt
 from qtpy.QtGui import QCursor, QTextCursor, QTextDocument
 from qtpy.QtWidgets import QApplication
 from qtpy import QT_VERSION
@@ -31,18 +31,11 @@ from spyder_kernels.utils.dochelpers import (getargspecfromtext, getobj,
 # Local imports
 from spyder.config.manager import CONF
 from spyder.py3compat import is_text_string, to_text_string
-from spyder.utils import encoding, sourcecode, programs
+from spyder.utils import encoding, sourcecode
 from spyder.utils import syntaxhighlighters as sh
 from spyder.utils.misc import get_error_match
-from spyder.utils.palette import QStylePalette, SpyderPalette
+from spyder.utils.palette import QStylePalette
 from spyder.widgets.arraybuilder import ArrayBuilderDialog
-
-QT55_VERSION = programs.check_version(QT_VERSION, "5.5", ">=")
-
-if QT55_VERSION:
-    from qtpy.QtCore import QRegularExpression
-else:
-    from qtpy.QtCore import QRegExp
 
 
 class BaseEditMixin(object):
@@ -1266,16 +1259,11 @@ class BaseEditMixin(object):
         else:
             text = re.escape(to_text_string(text))
 
-        if QT55_VERSION:
-            pattern = QRegularExpression(u"\\b{}\\b".format(text) if word else
-                                         text)
-            if case:
-                pattern.setPatternOptions(
-                    QRegularExpression.CaseInsensitiveOption)
-        else:
-            pattern = QRegExp(u"\\b{}\\b".format(text)
-                              if word else text, Qt.CaseSensitive if case else
-                              Qt.CaseInsensitive, QRegExp.RegExp2)
+        pattern = QRegularExpression(u"\\b{}\\b".format(text) if word else
+                                     text)
+        if case:
+            pattern.setPatternOptions(
+                QRegularExpression.CaseInsensitiveOption)
 
         for move in moves:
             cursor.movePosition(move)

--- a/spyder/widgets/simplecodeeditor.py
+++ b/spyder/widgets/simplecodeeditor.py
@@ -13,13 +13,10 @@ Adapted from:
 https://doc.qt.io/qt-5/qtwidgets-widgets-codeeditor-example.html
 """
 
-# Standard library imports
-import re
-
 # Third party imports
-from qtpy.QtCore import QRect, QSize, Qt, Signal
+from qtpy.QtCore import QPoint, QRect, QSize, Qt, Signal
 from qtpy.QtGui import QColor, QPainter, QTextCursor, QTextFormat, QTextOption
-from qtpy.QtWidgets import QApplication, QPlainTextEdit, QTextEdit, QWidget
+from qtpy.QtWidgets import QPlainTextEdit, QTextEdit, QWidget
 
 # Local imports
 import spyder.utils.syntaxhighlighters as sh
@@ -551,6 +548,14 @@ class SimpleCodeEditor(QPlainTextEdit, BaseEditMixin):
         cursor = self.textCursor()
         cursor.movePosition(QTextCursor.End)
         cursor.insertText(text)
+
+    def get_visible_block_numbers(self):
+        """Get the first and last visible block numbers."""
+        first = self.firstVisibleBlock().blockNumber()
+        bottom_right = QPoint(self.viewport().width() - 1,
+                              self.viewport().height() - 1)
+        last = self.cursorForPosition(bottom_right).blockNumber()
+        return (first, last)
 
     # --- Syntax highlighter
     # ------------------------------------------------------------------------


### PR DESCRIPTION
## Description of Changes

- Code was not centered when searching for text and the next result was out of the visible region. This fixes that.
- I tested in other editors (e.g. Sublime and VSCode) and that's also their behavior, which is nice because you can view results in context and your sight is always focused on the center of the screen.
- This also removes some dead code for unsupported Qt versions.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
