### PR TITLE
PR: Prevent slowdowns in the Variable Explorer when Numpy and Pandas are not installed

### DIFF
--- a/external-deps/spyder-kernels/.github/workflows/linux-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/linux-tests.yml
@@ -38,13 +38,14 @@ jobs:
            python-version: ${{ matrix.PYTHON_VERSION }} 
       - name: Install package dependencies
         shell: bash -l {0}
-        run: conda install --file requirements/posix.txt -y -q
+        run: |
+          conda install --file requirements/posix.txt -y -q
+          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install --file requirements/python-27.txt -y -q; fi
       - name: Install test dependencies
         shell: bash -l {0}
         run: |
           conda install nomkl -y -q
           conda install --file requirements/tests.txt -y -q
-          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install -y -q click=7; fi
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/external-deps/spyder-kernels/.github/workflows/macos-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/macos-tests.yml
@@ -34,13 +34,14 @@ jobs:
            python-version: ${{ matrix.PYTHON_VERSION }} 
       - name: Install package dependencies
         shell: bash -l {0}
-        run: conda install --file requirements/posix.txt -y -q
+        run: |
+          conda install --file requirements/posix.txt -y -q
+          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install --file requirements/python-27.txt -y -q; fi
       - name: Install test dependencies
         shell: bash -l {0}
         run: |
           conda install nomkl -y -q
           conda install --file requirements/tests.txt -y -q
-          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install -y -q click=7; fi
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 2.x
-	commit = 4a9270eda25db143c97a490786af218f169a5873
-	parent = 761b4a80357e3e381b72ea2f51bcf2de6d1d2051
+	branch = memoize-is-module-installed
+	commit = ceb76e56109a4b5869fc82470b4b5924af36a491
+	parent = ea391f765c185b22543d5da046bcef8f7a8f9b67
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = memoize-is-module-installed
-	commit = ceb76e56109a4b5869fc82470b4b5924af36a491
-	parent = ea391f765c185b22543d5da046bcef8f7a8f9b67
+	branch = 2.x
+	commit = c9c1d778755feaeaead15e836fbc649f138a2ec3
+	parent = a14659542944c3c2d71834f4a9cc0917c1d8d9a2
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/requirements/python-27.txt
+++ b/external-deps/spyder-kernels/requirements/python-27.txt
@@ -1,0 +1,2 @@
+click =7
+backports.functools_lru_cache

--- a/external-deps/spyder-kernels/setup.py
+++ b/external-deps/spyder-kernels/setup.py
@@ -36,12 +36,13 @@ def get_version(module='spyder_kernels'):
 
 
 REQUIREMENTS = [
+    'backports.functools-lru-cache; python_version<"3"',
     'cloudpickle',
     'ipykernel<5; python_version<"3"',
     'ipykernel>=5.3.0; python_version>="3"',
     'ipython<6; python_version<"3"',
     'ipython>=7.6.0; python_version>="3"',
-    'jupyter-client>=5.3.4',
+    'jupyter-client>=5.3.4,<7',
     'pyzmq>=17',
     'wurlitzer>=1.0.3;platform_system!="Windows"',
 ]
@@ -91,6 +92,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Interpreters',
     ]
 )

--- a/external-deps/spyder-kernels/spyder_kernels/py3compat.py
+++ b/external-deps/spyder-kernels/spyder_kernels/py3compat.py
@@ -258,6 +258,7 @@ if PY2:
     import string
     str_lower = string.lower
     from itertools import izip_longest as zip_longest
+    from backports.functools_lru_cache import lru_cache
 else:
     # Python 3
     getcwd = os.getcwd
@@ -265,6 +266,7 @@ else:
         return (a > b) - (a < b)
     str_lower = str.lower
     from itertools import zip_longest
+    from functools import lru_cache
 
 def qbytearray_to_str(qba):
     """Convert QByteArray object to str in a way compatible with Python 2/3"""

--- a/external-deps/spyder-kernels/spyder_kernels/utils/misc.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/misc.py
@@ -10,7 +10,10 @@
 
 import re
 
+from spyder_kernels.py3compat import lru_cache
 
+
+@lru_cache(maxsize=100)
 def is_module_installed(module_name):
     """
     Simpler version of spyder.utils.programs.is_module_installed.


### PR DESCRIPTION
## Description of Changes

- This was a regression introduced PR #15857.
- The solution was memoizing the results of `is_module_installed` in spyder-kernels, so it's only called once to determine if a module is installed.
- Depends on spyder-ide/spyder-kernels#313

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16247.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
