### PR TITLE
PR: Shift maximum character edge line to match editor characters

### DIFF
--- a/spyder/plugins/editor/panels/edgeline.py
+++ b/spyder/plugins/editor/panels/edgeline.py
@@ -36,7 +36,8 @@ class EdgeLine(Panel):
         painter.setPen(color)
 
         for column in self.columns:
-            x = self.editor.fontMetrics().width(column * '9')
+            # draw edge line at column n + 3 to account for line number margin
+            x = self.editor.fontMetrics().width(column * '9') + 3
             painter.drawLine(x, 0, x, size.height())
 
     def sizeHint(self):


### PR DESCRIPTION
## Description of Changes
The vertical line indicating the maximum characters per line (edge line) is shifted 3 units to the right so that it aligns with the characters of the editor.

Current behavior:
![Screenshot 2021-08-24 124732 - Copy](https://user-images.githubusercontent.com/2330659/130737733-39ef5c49-7f33-4228-aab9-45a1d48bdff0.png)

Shifting line to the right by 3 units:
![Screenshot 2021-08-24 125010 - Copy](https://user-images.githubusercontent.com/2330659/130737751-ac39d4a6-b455-4820-9948-422426807d85.png)

This is tested also for other font sizes (7-16) and works well, as well as other standard monospace fonts shipping with Windows.

Why shift by 3?
I tested with 3 first based on this being added to the line number margin https://github.com/spyder-ide/spyder/blob/bb2ed9a6c90df30f370f7f67413d31b363cbfe15/spyder/plugins/editor/panels/linenumber.py#L186

And it works quite well, by chance I suppose. I also tried removing the 3 from the line number margin (without shifting edge line), but this has no effect. 

An alternative solution which also appears to work quite well is to shift the line relative to the character width. Might be more robust for different (odd) fonts/resolutions. To keep this simple fix very simple I stuck with shifting 3 units as it appears to work well across sizes and fonts. Example shifting 1/3rd of a character width, an appropriate number is probably between 1/3 and 1/2.

```
char_width = self.editor.fontMetrics().width('9')
x = column * char_width + 0.33 * char_width
```

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16248


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Reinert Huseby Karlsen

<!--- Thanks for your help making Spyder better for everyone! --->
