### PR TITLE
PR: Fix error when rendering the Tools menu and Kite is not available

### DIFF
--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -13,7 +13,6 @@ subclass of PluginMainWidget.
 
 # Standard library imports
 from collections import OrderedDict
-import os
 import sys
 import textwrap
 from typing import Optional

--- a/spyder/plugins/completion/providers/kite/client.py
+++ b/spyder/plugins/completion/providers/kite/client.py
@@ -12,7 +12,6 @@ from urllib.parse import quote
 
 # Third party imports
 from qtpy.QtCore import QObject, QThread, Signal, QMutex
-from qtpy.QtWidgets import QMessageBox
 import requests
 
 # Local imports
@@ -22,8 +21,7 @@ from spyder.plugins.completion.providers.kite import (
 from spyder.plugins.completion.providers.kite.decorators import class_register
 from spyder.plugins.completion.providers.kite.providers import (
     KiteMethodProviderMixIn)
-from spyder.plugins.completion.providers.kite.utils.status import (
-    status, check_if_kite_running)
+from spyder.plugins.completion.providers.kite.utils.status import status
 from spyder.py3compat import (
     ConnectionError, ConnectionRefusedError, TEXT_TYPES)
 
@@ -135,7 +133,7 @@ class KiteClient(QObject, KiteMethodProviderMixIn):
         http_method = getattr(self.endpoint, verb)
         try:
             http_response = http_method(url, params=url_params, json=params)
-        except Exception as error:
+        except Exception:
             return False, None
         success = http_response.status_code == 200
         if success:

--- a/spyder/plugins/completion/providers/kite/provider.py
+++ b/spyder/plugins/completion/providers/kite/provider.py
@@ -21,7 +21,6 @@ from spyder.api.config.decorators import on_conf_change
 from spyder.config.base import _, running_under_pytest
 from spyder.plugins.completion.api import SpyderCompletionProvider
 from spyder.plugins.mainmenu.api import ApplicationMenus, ToolsMenuSections
-from spyder.plugins.completion.api import SpyderCompletionProvider
 from spyder.plugins.completion.providers.kite.client import KiteClient
 from spyder.plugins.completion.providers.kite.utils.status import (
     check_if_kite_running, check_if_kite_installed,

--- a/spyder/plugins/completion/providers/kite/utils/install.py
+++ b/spyder/plugins/completion/providers/kite/utils/install.py
@@ -23,7 +23,7 @@ from qtpy.QtCore import QThread, Signal
 
 # Local imports
 from spyder.config.base import _
-from spyder.py3compat import PY2, to_text_string
+from spyder.py3compat import to_text_string
 from spyder.plugins.completion.providers.kite.utils.status import (
     check_if_kite_installed, WINDOWS_URL, LINUX_URL, MAC_URL)
 

--- a/spyder/plugins/completion/providers/kite/widgets/calltoaction.py
+++ b/spyder/plugins/completion/providers/kite/widgets/calltoaction.py
@@ -131,7 +131,6 @@ class KiteCallToAction(QFrame, SpyderConfigurationAccessor):
         is_lower = ord('a') <= key <= ord('z')
         is_digit = ord('0') <= key <= ord('9')
         is_under = key == ord('_')
-        is_dot = key == ord('.')
         return is_upper or is_lower or is_digit or is_under
 
     def _dismiss_forever(self):

--- a/spyder/plugins/completion/providers/kite/widgets/install.py
+++ b/spyder/plugins/completion/providers/kite/widgets/install.py
@@ -10,8 +10,8 @@
 import sys
 
 # Third-party imports
-from qtpy.QtCore import QEvent, QObject, QSize, Qt, QUrl, Signal
-from qtpy.QtGui import QDesktopServices, QMovie, QPixmap
+from qtpy.QtCore import QEvent, QObject, Qt, Signal
+from qtpy.QtGui import QPixmap
 from qtpy.QtWidgets import (QApplication, QDialog, QHBoxLayout, QMessageBox,
                             QLabel, QProgressBar, QPushButton, QVBoxLayout,
                             QWidget)
@@ -46,7 +46,6 @@ class KiteIntegrationInfo(QWidget):
         image_path = get_image_path(icon_filename)
         image = QPixmap(image_path)
         image_label = QLabel()
-        screen = QApplication.primaryScreen()
         image_label = QLabel()
         image_height = int(image.height() * DialogStyle.IconScaleFactor)
         image_width = int(image.width() * DialogStyle.IconScaleFactor)

--- a/spyder/plugins/completion/providers/kite/widgets/messagebox.py
+++ b/spyder/plugins/completion/providers/kite/widgets/messagebox.py
@@ -7,10 +7,8 @@
 """Kite message boxes."""
 
 # Standard library imports
-import os
 
 # Third party imports
-from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports

--- a/spyder/widgets/onecolumntree.py
+++ b/spyder/widgets/onecolumntree.py
@@ -6,14 +6,13 @@
 
 # Third party imports
 from qtpy.QtCore import Slot
-from qtpy.QtWidgets import QTreeWidget, QMenu
+from qtpy.QtWidgets import QTreeWidget
 
 # Local imports
 from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.config.base import _
 from spyder.utils.icon_manager import ima
-from spyder.utils.qthelpers import (add_actions, create_action,
-                                    get_item_user_text)
+from spyder.utils.qthelpers import get_item_user_text
 
 
 class OneColumnTreeActions:


### PR DESCRIPTION
## Description of Changes

- We have to cover that special case in our API because the External menu section in the Tools menu can be empty, so we can't add another section before that one.
- The same problem can happen for external plugins, but now we raise an informative error about it.
- I also took the opportunity to remove unused imports and variables in several places.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16287 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
