### PR TITLE
PR: Fix error in runfile/debugfile with IPykernel 6.3.0

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = prevent-runfile-shadow
-	commit = 90795d9c50ca04f3353274b43c7a9dc6c4510d62
-	parent = 758fb18bce8ae3024ac2215678a16a91635abea2
+	branch = 2.x
+	commit = aaa8d2699d325ea823d95acd426fa9abc829d2c0
+	parent = db5f1fb9ca4ea812b8239963e193f8cddb2ce3f5
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 2.x
-	commit = c9c1d778755feaeaead15e836fbc649f138a2ec3
-	parent = a14659542944c3c2d71834f4a9cc0917c1d8d9a2
+	branch = prevent-runfile-shadow
+	commit = 90795d9c50ca04f3353274b43c7a9dc6c4510d62
+	parent = 758fb18bce8ae3024ac2215678a16a91635abea2
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/console/start.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/start.py
@@ -46,7 +46,7 @@ def import_spydercustomize():
 
     # Import our customizations
     site.addsitedir(customize_dir)
-    import spydercustomize
+    import spydercustomize  # noqa
 
     # Remove our customize path from sys.path
     try:
@@ -109,8 +109,17 @@ def kernel_config():
     # Spyder, to avoid deleting the sys module if users want to import
     # it through them.
     # See spyder-ide/spyder#15788
-    clear_argv = "import sys;sys.argv = [''];del sys"
+    clear_argv = "import sys; sys.argv = ['']; del sys"
     spy_cfg.IPKernelApp.exec_lines = [clear_argv]
+
+    # Set our runfile in builtins here to prevent other packages shadowing it.
+    # This started to be a problem since IPykernel 6.3.0.
+    if not PY2:
+        spy_cfg.IPKernelApp.exec_lines.append(
+            "import builtins; "
+            "builtins.runfile = builtins.spyder_runfile; "
+            "del builtins.spyder_runfile; del builtins"
+        )
 
     # Run lines of code at startup
     run_lines_o = os.environ.get('SPY_RUN_LINES_O')

--- a/external-deps/spyder-kernels/spyder_kernels/console/tests/test_console_kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/tests/test_console_kernel.py
@@ -27,7 +27,6 @@ import pytest
 from flaky import flaky
 from jupyter_core import paths
 from jupyter_client import BlockingKernelClient
-from ipython_genutils import py3compat
 import numpy as np
 
 # Local imports
@@ -77,7 +76,8 @@ def setup_kernel(cmd):
 
         if kernel.poll() is not None:
             o,e = kernel.communicate()
-            e = py3compat.cast_unicode(e)
+            if not PY3 and isinstance(e, bytes):
+                e = e.decode()
             raise IOError("Kernel failed to start:\n%s" % e)
 
         if not os.path.exists(connection_file):

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
@@ -580,7 +580,13 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
         sys.argv = ['']
 
 
-builtins.runfile = runfile
+# IPykernel 6.3.0+ shadows our runfile because it depends on the Pydev
+# debugger, which adds its own runfile to builtins. So we replace it with
+# our own using exec_lines in start.py
+if PY2:
+    builtins.runfile = runfile
+else:
+    builtins.spyder_runfile = runfile
 
 
 def debugfile(filename=None, args=None, wdir=None, post_mortem=False,


### PR DESCRIPTION
## Description of Changes

- That version adds a `runfile` function to `builtins` from the Pydev debugger that shadows our own `runfile`.
- Depends on spyder-ide/spyder-kernels#318

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16316.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
