### PR TITLE
PR: debugpy is not zip compatible (macOS app)

### DIFF
--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -68,6 +68,9 @@ def make_app_bundle(dist_dir, make_lite=False):
         File "<frozen zipimport>", line 177, in get_data
         KeyError: 'blib2to3/Users/rclary/Library/Caches/black/20.8b1/
         Grammar3.8.6.final.0.pickle'
+    debugpy :
+        NotADirectoryError: [Errno 20] Not a directory:
+        '<path>/Resources/lib/python39.zip/debugpy/_vendored'
     docutils :
         [Errno 20] Not a directory: '<path>/Resources/lib/python39.zip/
         docutils/writers/latex2e/docutils.sty'
@@ -150,6 +153,7 @@ def make_app_bundle(dist_dir, make_lite=False):
                 'pylsp', 'pylsp_black', 'pyls_spyder', 'qtawesome',
                 'setuptools', 'sphinx', 'spyder', 'spyder_kernels',
                 'textdistance',
+                'debugpy',
                 ]
     INCLUDES = ['_sitebuiltins',  # required for IPython help()
                 # required for sphinx

--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -152,8 +152,7 @@ def make_app_bundle(dist_dir, make_lite=False):
                 'jedi', 'jinja2', 'keyring', 'parso', 'pygments', 'pylint',
                 'pylsp', 'pylsp_black', 'pyls_spyder', 'qtawesome',
                 'setuptools', 'sphinx', 'spyder', 'spyder_kernels',
-                'textdistance',
-                'debugpy',
+                'textdistance', 'debugpy',
                 ]
     INCLUDES = ['_sitebuiltins',  # required for IPython help()
                 # required for sphinx


### PR DESCRIPTION
## Description of Changes

Ensured that `debugpy` is bundled outside zip folder in macOS application.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16336


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary 

<!--- Thanks for your help making Spyder better for everyone! --->
