### PR TITLE
PR: Remove indicator of popup menus in main toolbar

### DIFF
--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -380,21 +380,6 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
 
         # Update title
         self.setWindowTitle(self.get_title())
-        self._update_style()
-
-    def _update_style(self):
-        """
-        Update style of the widget.
-        """
-        qss = r"""
-            QToolButton::menu-indicator {
-                image: none;
-            }
-            QToolButton {
-                margin: 0px;
-            }
-            """
-        self._options_button.setStyleSheet(textwrap.dedent(qss))
 
     def _update_actions(self):
         """
@@ -416,7 +401,6 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
         # Widget setup
         # --------------------------------------------------------------------
         self.update_actions()
-        self._update_style()
 
     @Slot(bool)
     def _on_top_level_change(self, top_level):

--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -249,6 +249,7 @@ class PanesToolbarStyleSheet(SpyderStyleSheet):
             height=self.BUTTON_HEIGHT,
             width=self.BUTTON_WIDTH,
             border='0px',
+            margin='0px'
         )
 
         # Remove indicator for popup mode

--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -226,6 +226,11 @@ class ApplicationToolbarStylesheet(SpyderStyleSheet):
                 backgroundColor=color
             )
 
+        # Remove indicator for popup mode
+        css['QToolBar QToolButton::menu-indicator'].setValues(
+            image='none'
+        )
+
 
 class PanesToolbarStyleSheet(SpyderStyleSheet):
     """Stylesheet for pane toolbars."""
@@ -246,6 +251,7 @@ class PanesToolbarStyleSheet(SpyderStyleSheet):
             border='0px',
         )
 
+        # Remove indicator for popup mode
         css['QToolButton::menu-indicator'].setValues(
             image='none'
         )


### PR DESCRIPTION
## Description of Changes

- Adding a popup menu to a button in our main toolbar was showing an arrow to indicate the menu presence. This simply removes it.
- This also moves an style applied to pane toolbars to PanesToolbarStyleSheet.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
