### PR TITLE
PR: Set minimum and recommended sizes for the Working directory combobox 

### DIFF
--- a/spyder/plugins/workingdirectory/container.py
+++ b/spyder/plugins/workingdirectory/container.py
@@ -14,7 +14,7 @@ import os.path as osp
 
 # Third party imports
 from qtpy.compat import getexistingdirectory
-from qtpy.QtCore import Signal, Slot
+from qtpy.QtCore import QSize, Signal, Slot
 
 # Local imports
 from spyder.api.config.decorators import on_conf_change
@@ -30,7 +30,7 @@ from spyder.widgets.comboboxes import PathComboBox
 _ = get_translation('spyder')
 
 
-# --- Constants
+# ---- Constants
 # ----------------------------------------------------------------------------
 class WorkingDirectoryActions:
     Previous = 'previous_action'
@@ -46,13 +46,25 @@ class WorkingDirectoryToolbarSections:
 class WorkingDirectoryToolbarItems:
     PathComboBox = 'path_combo'
 
-# --- Widgets
+# ---- Widgets
 # ----------------------------------------------------------------------------
 class WorkingDirectoryToolbar(ApplicationToolbar):
     ID = 'working_directory_toolbar'
 
 
-# --- Container
+class WorkingDirectoryComboBox(PathComboBox):
+
+    def __init__(self, parent, adjust_to_contents=False, id_=None):
+        super().__init__(parent, adjust_to_contents, id_=id_)
+
+        # Set min width
+        self.setMinimumWidth(140)
+
+    def sizeHint(self):
+        return QSize(250, 10)
+
+
+# ---- Container
 # ----------------------------------------------------------------------------
 class WorkingDirectoryContainer(PluginMainContainer):
     """Container for the working directory toolbar."""
@@ -79,7 +91,7 @@ class WorkingDirectoryContainer(PluginMainContainer):
         # Widgets
         title = _('Current working directory')
         self.toolbar = WorkingDirectoryToolbar(self, title)
-        self.pathedit = PathComboBox(
+        self.pathedit = WorkingDirectoryComboBox(
             self,
             adjust_to_contents=self.get_conf('working_dir_adjusttocontents'),
             id_=WorkingDirectoryToolbarItems.PathComboBox
@@ -153,7 +165,7 @@ class WorkingDirectoryContainer(PluginMainContainer):
     def on_history_update(self, value):
         self.history = value
 
-    # --- API
+    # ---- API
     # ------------------------------------------------------------------------
     def get_workdir(self):
         """

--- a/spyder/plugins/workingdirectory/container.py
+++ b/spyder/plugins/workingdirectory/container.py
@@ -61,7 +61,12 @@ class WorkingDirectoryComboBox(PathComboBox):
         self.setMinimumWidth(140)
 
     def sizeHint(self):
+        """Recommended size when there are toolbars to the right."""
         return QSize(250, 10)
+
+    def enterEvent(self, event):
+        """Set current path as the tooltip of the widget on hover."""
+        self.setToolTip(self.currentText())
 
 
 # ---- Container
@@ -100,14 +105,6 @@ class WorkingDirectoryContainer(PluginMainContainer):
         # Widget Setup
         self.toolbar.setWindowTitle(title)
         self.toolbar.setObjectName(title)
-        self.pathedit.setToolTip(
-            _(
-                "This is the working directory for newly\n"
-                "opened IPython consoles, for the Files\n"
-                "and Find panes and for new files\n"
-                "created in the editor"
-            )
-        )
         self.pathedit.setMaxCount(self.get_conf('working_dir_history'))
         self.pathedit.selected_text = self.pathedit.currentText()
 


### PR DESCRIPTION
## Description of Changes

- The working directory didn't have those sizes, so when adding toolbars to its right, it looked like this

    ![imagen](https://user-images.githubusercontent.com/365293/132109981-de6300fd-b0d7-4519-ba21-c3f9bba56992.png)

    Now it looks like this

    ![imagen](https://user-images.githubusercontent.com/365293/132109958-10e93681-ff2b-4328-8531-55795ee2db38.png)

- I also changed its tooltip to show the current path

    ![imagen](https://user-images.githubusercontent.com/365293/132110026-3b969552-3a9d-4165-a11d-61ab32fe6d48.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
