### PR TITLE
PR: Restore a couple of completion options lost during the migration (Completions)

### DIFF
--- a/spyder/plugins/completion/confpage.py
+++ b/spyder/plugins/completion/confpage.py
@@ -73,6 +73,10 @@ class CompletionConfigPage(PluginConfigPage):
             _("Show automatic completions after keyboard idle (ms):"), None,
             'automatic_completions_after_ms', min_=0, max_=10000, step=10,
             tip=_("Default is 300 milliseconds"), section='editor')
+        completions_hint_after_idle = self.create_spinbox(
+            _("Show completion details after keyboard idle (ms):"), None,
+            'completions_hint_after_ms', min_=0, max_=10000, step=10,
+            tip=_("Default is 500 milliseconds"), section='editor')
 
         # ------------------- Completions group ---------------------------
         self.completions_group = QGroupBox(_('Completions'))
@@ -85,8 +89,10 @@ class CompletionConfigPage(PluginConfigPage):
         completions_layout.addWidget(completions_after_characters.spinbox, 4, 1)
         completions_layout.addWidget(completions_after_idle.plabel, 5, 0)
         completions_layout.addWidget(completions_after_idle.spinbox, 5, 1)
-        completions_layout.addWidget(completions_wait_for_ms.plabel, 6, 0)
-        completions_layout.addWidget(completions_wait_for_ms.spinbox, 6, 1)
+        completions_layout.addWidget(completions_hint_after_idle.plabel, 6, 0)
+        completions_layout.addWidget(completions_hint_after_idle.spinbox, 6, 1)
+        completions_layout.addWidget(completions_wait_for_ms.plabel, 7, 0)
+        completions_layout.addWidget(completions_wait_for_ms.spinbox, 7, 1)
         completions_layout.setColumnStretch(2, 6)
         self.completions_group.setLayout(completions_layout)
 

--- a/spyder/plugins/completion/confpage.py
+++ b/spyder/plugins/completion/confpage.py
@@ -7,11 +7,10 @@
 """Spyder completion plugin configuration page."""
 
 # Third party imports
-from qtpy.QtWidgets import QGroupBox, QVBoxLayout, QCheckBox, QGridLayout
+from qtpy.QtWidgets import QGroupBox, QVBoxLayout, QGridLayout
 
 # Local imports
 from spyder.config.base import _
-from spyder.utils.icon_manager import ima
 from spyder.api.preferences import PluginConfigPage
 
 
@@ -70,6 +69,10 @@ class CompletionConfigPage(PluginConfigPage):
             _("Notify me when Kite can provide missing completions "
               "(but is unavailable)"),
             'kite_call_to_action')
+        completions_after_idle = self.create_spinbox(
+            _("Show automatic completions after keyboard idle (ms):"), None,
+            'automatic_completions_after_ms', min_=0, max_=10000, step=10,
+            tip=_("Default is 300 milliseconds"), section='editor')
 
         # ------------------- Completions group ---------------------------
         self.completions_group = QGroupBox(_('Completions'))
@@ -80,8 +83,10 @@ class CompletionConfigPage(PluginConfigPage):
         completions_layout.addWidget(kite_cta_box, 3, 0)
         completions_layout.addWidget(completions_after_characters.plabel, 4, 0)
         completions_layout.addWidget(completions_after_characters.spinbox, 4, 1)
-        completions_layout.addWidget(completions_wait_for_ms.plabel, 5, 0)
-        completions_layout.addWidget(completions_wait_for_ms.spinbox, 5, 1)
+        completions_layout.addWidget(completions_after_idle.plabel, 5, 0)
+        completions_layout.addWidget(completions_after_idle.spinbox, 5, 1)
+        completions_layout.addWidget(completions_wait_for_ms.plabel, 6, 0)
+        completions_layout.addWidget(completions_wait_for_ms.spinbox, 6, 1)
         completions_layout.setColumnStretch(2, 6)
         self.completions_group.setLayout(completions_layout)
 


### PR DESCRIPTION
## Description of Changes

- `Show automatic completions after keyboard idle` and `Show completion details after keyboard idle` were not added to the config page of Completion and linting in Spyder 5. This PR restores them.
- This is how they look now:

    ![imagen](https://user-images.githubusercontent.com/365293/132262563-b9e9946e-9116-4ee2-96f3-e7f29c70e70f.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of issue #16342.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
