### PR TITLE
PR: Add constraint for jupyter_client version on conda based test

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -24,6 +24,10 @@ if [ "$USE_CONDA" = "true" ]; then
         conda install pyzmq=19
     fi
 
+    # Constrain jupyter_client version on conda based tests
+    # The actual dependency constrain is done in spyder-kernels since v2.1.1
+    conda install jupyter_client=6
+
     # Remove packages we have subrepos for.
     conda remove spyder-kernels --force -q -y
     conda remove python-lsp-server --force -q -y
@@ -52,8 +56,6 @@ else
     pip uninstall python-lsp-server -q -y
     pip uninstall qdarkstyle -q -y
 
-    # Install jupyter-client 6 until we release spyder-kernels 2.1.1
-    pip install jupyter-client==6.1.12
 fi
 
 # Install subrepos in development mode


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->
CI tests with conda failing due to `jupyter_client` 7.x being available in the conda main channel


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
