### PR TITLE
PR: Improve linting and folding performance (Editor)

### DIFF
--- a/spyder/plugins/editor/utils/editor.py
+++ b/spyder/plugins/editor/utils/editor.py
@@ -70,15 +70,11 @@ class BlockUserData(QTextBlockUserData):
         # Add a reference to the user data in the editor as the block won't.
         # The list should /not/ be used to list BlockUserData as the blocks
         # they refer to might not exist anymore.
-        # This prevent a segmentation fault.
+        # This prevents a segmentation fault.
         if editor is None:
             # Won't be destroyed
             self.refloop = self
             return
-        # Destroy with the editor
-        if not hasattr(editor, '_user_data_reference_list'):
-            editor._user_data_reference_list = []
-        editor._user_data_reference_list.append(self)
 
     def _selection(self):
         """

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1295,18 +1295,19 @@ class CodeEditor(TextEditBaseWidget):
                 'severity', DiagnosticSeverity.ERROR)
 
             block = document.findBlockByNumber(start['line'])
-            data = block.userData()
+            text = block.text()
 
             # Skip messages according to certain criteria.
             # This one works for any programming language
-            if 'analysis:ignore' in block.text():
+            if 'analysis:ignore' in text:
                 continue
 
             # This only works for Python.
             if self.language == 'Python':
-                if NOQA_INLINE_REGEXP.search(block.text()) is not None:
+                if NOQA_INLINE_REGEXP.search(text) is not None:
                     continue
 
+            data = block.userData()
             if not data:
                 data = BlockUserData(self)
 

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -541,6 +541,9 @@ class CodeEditor(TextEditBaseWidget):
 
         # Diagnostics
         self.update_diagnostics_thread = QThread()
+        self.update_diagnostics_thread.run = self.set_errors
+        self.update_diagnostics_thread.finished.connect(
+            self.finish_code_analysis)
         self._diagnostics = []
 
         # Editor Extensions
@@ -1210,9 +1213,6 @@ class CodeEditor(TextEditBaseWidget):
         self._diagnostics = diagnostics
 
         # Process diagnostics in a thread to improve performance.
-        self.update_diagnostics_thread.run = self.set_errors
-        self.update_diagnostics_thread.finished.connect(
-            self.finish_code_analysis)
         self.update_diagnostics_thread.start()
 
     def cleanup_code_analysis(self):

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -473,6 +473,7 @@ class CodeEditor(TextEditBaseWidget):
         # Code Folding
         self.code_folding = True
         self.update_folding_thread = QThread()
+        self.update_folding_thread.finished.connect(self.finish_code_folding)
 
         # Completions hint
         self.completions_hint = True
@@ -1888,8 +1889,6 @@ class CodeEditor(TextEditBaseWidget):
         # Update folding in a thread
         self.update_folding_thread.run = functools.partial(
             self.update_and_merge_folding, extended_ranges)
-        self.update_folding_thread.finished.connect(
-            self.finish_code_folding)
         self.update_folding_thread.start()
 
     def update_and_merge_folding(self, extended_ranges):

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -137,10 +137,10 @@ class CodeEditor(TextEditBaseWidget):
     # linting results arrive, according to the number of lines in the file.
     SYNC_SYMBOLS_AND_FOLDING_TIMEOUTS = {
         # Lines: Timeout
-        500: 500,
-        1500: 1200,
-        2500: 3200,
-        6500: 4500
+        500: 350,
+        1500: 800,
+        2500: 1200,
+        6500: 1800
     }
 
     # Custom signal to be emitted upon completion of the editor's paintEvent

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1287,6 +1287,9 @@ class CodeEditor(TextEditBaseWidget):
             them can't.
         """
         document = self.document()
+        if underline:
+            first_block, last_block = self.get_buffer_block_numbers()
+
         for diagnostic in self._diagnostics:
             if self.is_ipython() and (
                     diagnostic["message"] == "undefined name 'get_ipython'"):
@@ -1320,10 +1323,7 @@ class CodeEditor(TextEditBaseWidget):
 
             if underline:
                 block_nb = block.blockNumber()
-                first, last = self.get_buffer_block_numbers()
-
-                if (self.underline_errors_enabled and
-                        first <= block_nb <= last):
+                if first_block <= block_nb <= last_block:
                     error = severity == DiagnosticSeverity.ERROR
                     color = self.error_color if error else self.warning_color
                     color = QColor(color)
@@ -1335,7 +1335,7 @@ class CodeEditor(TextEditBaseWidget):
 
                     # Don't call highlight_selection with `update=True` so that
                     # all underline selections are updated in bulk in
-                    # finish_code_analysis or update_decorations.
+                    # underline_errors.
                     self.highlight_selection('code_analysis_underline',
                                              data._selection(),
                                              underline_color=block.color)


### PR DESCRIPTION
## Description of Changes

- Fix another serious memory leak when underlining errors.
- Stop connecting the `finished` signal of threads that update folding and linting to the same slot over and over again. That was causing a lot of delays after some time.
- Decrease time to update folding and symbols. It's not necessary to have large update times now.
- Remove a list that accumulated BlockUserData for each CodeEditor for no reason.
- Don't compute `get_buffer_block_numbers` for each decoration when underlining errors.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16384.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
