### PR TITLE
PR: Fix some issues with external plugins

### DIFF
--- a/spyder/api/panel.py
+++ b/spyder/api/panel.py
@@ -133,8 +133,7 @@ class Panel(QWidget, EditorExtension):
             painter = QPainter(self)
             painter.fillRect(event.rect(), self._background_brush)
         else:
-            raise NotImplementedError(
-                f'paintEvent method must be defined in {self}')
+            logger.debug(f'paintEvent method must be defined in {self}')
 
     def sizeHint(self):
         """

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -203,12 +203,6 @@ class MainWindow(QMainWindow):
         messageBox.setStandardButtons(QMessageBox.Ok)
         messageBox.show()
 
-    def add_plugin(self, plugin, external=False):
-        """
-        Add plugin to plugins dictionary.
-        """
-        self._PLUGINS[plugin.NAME] = plugin
-
     def register_plugin(self, plugin_name, external=False, omit_conf=False):
         """
         Register a plugin in Spyder Main Window.
@@ -258,8 +252,6 @@ class MainWindow(QMainWindow):
             if CONF.get('main', 'use_custom_margin'):
                 margin = CONF.get('main', 'custom_margin')
             plugin.update_margins(margin)
-
-        self.add_plugin(plugin, external=external)
 
         if plugin_name == Plugins.Shortcuts:
             for action, context, action_name in self.shortcut_queue:
@@ -595,7 +587,6 @@ class MainWindow(QMainWindow):
         # New API
         self._APPLICATION_TOOLBARS = OrderedDict()
         self._STATUS_WIDGETS = OrderedDict()
-        self._PLUGINS = OrderedDict()
         # Mapping of new plugin identifiers vs old attributtes
         # names given for plugins or to prevent collisions with other
         # attributes, i.e layout (Qt) vs layout (SpyderPluginV2)
@@ -1132,7 +1123,8 @@ class MainWindow(QMainWindow):
                     pass
 
         # Register custom layouts
-        for plugin, plugin_instance in self._PLUGINS.items():
+        for plugin_name in PLUGIN_REGISTRY.external_plugins:
+            plugin_instance = PLUGIN_REGISTRY.get_plugin(plugin_name)
             if hasattr(plugin_instance, 'CUSTOM_LAYOUTS'):
                 if isinstance(plugin_instance.CUSTOM_LAYOUTS, list):
                     for custom_layout in plugin_instance.CUSTOM_LAYOUTS:
@@ -1142,7 +1134,7 @@ class MainWindow(QMainWindow):
                     logger.info(
                         'Unable to load custom layouts for {}. '
                         'Expecting a list of layout classes but got {}'
-                        .format(plugin, plugin_instance.CUSTOM_LAYOUTS)
+                        .format(plugin_name, plugin_instance.CUSTOM_LAYOUTS)
                     )
         self.layouts.update_layout_menu_actions()
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -208,10 +208,6 @@ class MainWindow(QMainWindow):
         Add plugin to plugins dictionary.
         """
         self._PLUGINS[plugin.NAME] = plugin
-        if external:
-            self._EXTERNAL_PLUGINS[plugin.NAME] = plugin
-        else:
-            self._INTERNAL_PLUGINS[plugin.NAME] = plugin
 
     def register_plugin(self, plugin_name, external=False, omit_conf=False):
         """
@@ -600,8 +596,6 @@ class MainWindow(QMainWindow):
         self._APPLICATION_TOOLBARS = OrderedDict()
         self._STATUS_WIDGETS = OrderedDict()
         self._PLUGINS = OrderedDict()
-        self._EXTERNAL_PLUGINS = OrderedDict()
-        self._INTERNAL_PLUGINS = OrderedDict()
         # Mapping of new plugin identifiers vs old attributtes
         # names given for plugins or to prevent collisions with other
         # attributes, i.e layout (Qt) vs layout (SpyderPluginV2)
@@ -1112,7 +1106,8 @@ class MainWindow(QMainWindow):
         logger.info("Setting up window...")
         # Create external plugins before loading the layout to include them in
         # the window restore state after restarts.
-        for plugin, plugin_instance in self._EXTERNAL_PLUGINS.items():
+        for plugin_name in PLUGIN_REGISTRY.external_plugins:
+            plugin_instance = PLUGIN_REGISTRY.get_plugin(plugin_name)
             self.tabify_plugin(plugin_instance, Plugins.Console)
             if isinstance(plugin_instance, SpyderDockablePlugin):
                 plugin_instance.get_widget().toggle_view(False)
@@ -1536,9 +1531,10 @@ class MainWindow(QMainWindow):
                 pass
 
         # New API: External plugins
-        for plugin_name, plugin in self._EXTERNAL_PLUGINS.items():
+        for plugin_name in PLUGIN_REGISTRY.external_plugins:
+            plugin_instance = PLUGIN_REGISTRY.get_plugin(plugin_name)
             try:
-                if isinstance(plugin, SpyderDockablePlugin):
+                if isinstance(plugin_instance, SpyderDockablePlugin):
                     plugin.close_window()
 
                 if not plugin.on_close(cancelable):

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -4077,6 +4077,8 @@ def test_pdb_without_comm(main_window, qtbot):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
+@pytest.mark.skipif(not sys.platform.startswith('linux'),
+                    reason="Flaky on Mac and Windows")
 def test_print_comms(main_window, qtbot):
     """Test warning printed when comms print."""
     # Write code with a cell to a file

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -12,7 +12,7 @@ Configuration manager providing access to user/site/project configuration.
 import logging
 import os
 import os.path as osp
-from typing import Optional, Any
+from typing import Any, Dict, Optional, Set
 import weakref
 
 # Local imports

--- a/spyder/config/user.py
+++ b/spyder/config/user.py
@@ -466,6 +466,10 @@ class UserConfig(DefaultsConfig):
         for section in self.sections():
             secdict = {}
             for option, value in self.items(section, raw=self._raw):
+                try:
+                    value = ast.literal_eval(value)
+                except (SyntaxError, ValueError):
+                    pass
                 secdict[option] = value
             self.defaults.append((section, secdict))
 

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -17,7 +17,6 @@ import os.path as osp
 
 # Third-party imports
 from qtpy.QtCore import Signal, Slot, QTimer
-from qtpy.QtCore import Slot, QTimer
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports
@@ -25,7 +24,6 @@ from spyder.api.config.decorators import on_conf_change
 from spyder.config.base import (_, get_conf_path, running_under_pytest,
                                 running_in_mac_app)
 from spyder.config.lsp import PYTHON_CONFIG
-from spyder.config.manager import CONF
 from spyder.utils.misc import check_connection_port
 from spyder.plugins.completion.api import (SUPPORTED_LANGUAGES,
                                            SpyderCompletionProvider,

--- a/spyder/plugins/completion/tests/conftest.py
+++ b/spyder/plugins/completion/tests/conftest.py
@@ -41,7 +41,6 @@ class MainWindowMock(QMainWindow):
         self.thirdparty_plugins = []
         self.shortcut_data = []
         self.prefs_dialog_instance = None
-        self._PLUGINS = OrderedDict()
         self._APPLICATION_TOOLBARS = MagicMock()
 
         self.console = Mock()
@@ -63,14 +62,10 @@ class MainWindowMock(QMainWindow):
     def register_plugin(self, plugin_name, external=False):
         plugin = PLUGIN_REGISTRY.get_plugin(plugin_name)
         plugin._register()
-        self.add_plugin(plugin, external=external)
 
     def get_plugin(self, plugin_name):
         if plugin_name in PLUGIN_REGISTRY:
             return PLUGIN_REGISTRY.get_plugin(plugin_name)
-
-    def add_plugin(self, plugin, external=False):
-        self._PLUGINS[plugin.CONF_SECTION] = plugin
 
     def set_prefs_size(self, size):
         pass

--- a/spyder/plugins/completion/tests/conftest.py
+++ b/spyder/plugins/completion/tests/conftest.py
@@ -19,7 +19,7 @@ from spyder.config.base import running_in_ci
 from spyder.config.manager import CONF
 from spyder.plugins.completion.plugin import CompletionPlugin
 from spyder.plugins.completion.providers.kite.utils.status import (
-    check_if_kite_running, check_if_kite_installed)
+    check_if_kite_installed)
 
 # This is needed to avoid an error because QtAwesome
 # needs a QApplication to work correctly.
@@ -42,8 +42,6 @@ class MainWindowMock(QMainWindow):
         self.shortcut_data = []
         self.prefs_dialog_instance = None
         self._PLUGINS = OrderedDict()
-        self._EXTERNAL_PLUGINS = OrderedDict()
-        self._INTERNAL_PLUGINS = OrderedDict()
         self._APPLICATION_TOOLBARS = MagicMock()
 
         self.console = Mock()
@@ -73,10 +71,6 @@ class MainWindowMock(QMainWindow):
 
     def add_plugin(self, plugin, external=False):
         self._PLUGINS[plugin.CONF_SECTION] = plugin
-        if external:
-            self._EXTERNAL_PLUGINS[plugin.CONF_SECTION] = plugin
-        else:
-            self._INTERNAL_PLUGINS[plugin.CONF_SECTION] = plugin
 
     def set_prefs_size(self, size):
         pass

--- a/spyder/plugins/completion/tests/test_configdialog.py
+++ b/spyder/plugins/completion/tests/test_configdialog.py
@@ -7,7 +7,7 @@
 """Tests for plugin config dialog."""
 
 # Standard library imports
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock
 import pkg_resources
 
 # Test library imports
@@ -17,7 +17,6 @@ import pytest
 
 # Local imports
 from spyder.config.base import running_in_ci
-from spyder.config.manager import CONF
 from spyder.plugins.completion.plugin import CompletionPlugin
 from spyder.plugins.preferences.tests.conftest import config_dialog
 
@@ -59,7 +58,6 @@ class MainWindowMock(QMainWindow):
         super(MainWindowMock, self).__init__(None)
         self.statusbar = Mock()
         self.console = Mock()
-        self._PLUGINS = {}
 
 
 def WrappedCompletionPlugin():

--- a/spyder/plugins/console/plugin.py
+++ b/spyder/plugins/console/plugin.py
@@ -204,8 +204,7 @@ class Console(SpyderDockablePlugin):
         """
         self.get_widget().handle_exception(
             error_data,
-            sender=self.sender(),
-            internal_plugins=self._main._INTERNAL_PLUGINS,
+            sender=self.sender()
         )
 
     def quit(self):

--- a/spyder/plugins/console/tests/test_plugin.py
+++ b/spyder/plugins/console/tests/test_plugin.py
@@ -46,15 +46,12 @@ def console_plugin(qtbot):
     class MainWindowMock(QMainWindow):
         def __init__(self):
             super().__init__()
-            self._INTERNAL_PLUGINS = {'internal_console': Console}
 
         def __getattr__(self, attr):
             if attr == '_PLUGINS':
                 return {}
-            elif attr != '_INTERNAL_PLUGINS':
-                return Mock()
             else:
-                return self.__dict__[attr]
+                return Mock()
 
     window = MainWindowMock()
     console_plugin = PLUGIN_REGISTRY.register_plugin(

--- a/spyder/plugins/console/tests/test_plugin.py
+++ b/spyder/plugins/console/tests/test_plugin.py
@@ -47,12 +47,6 @@ def console_plugin(qtbot):
         def __init__(self):
             super().__init__()
 
-        def __getattr__(self, attr):
-            if attr == '_PLUGINS':
-                return {}
-            else:
-                return Mock()
-
     window = MainWindowMock()
     console_plugin = PLUGIN_REGISTRY.register_plugin(
         window, Console, external=False)

--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -336,7 +336,7 @@ class ConsoleWidget(PluginMainWidget):
         self._report_dlg.show()
 
     @Slot(dict)
-    def handle_exception(self, error_data, sender=None, internal_plugins=None):
+    def handle_exception(self, error_data, sender=None):
         """
         Exception ocurred in the internal console.
 

--- a/spyder/plugins/mainmenu/plugin.py
+++ b/spyder/plugins/mainmenu/plugin.py
@@ -18,6 +18,7 @@ from qtpy.QtGui import QKeySequence
 
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
+from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
 from spyder.api.plugins import SpyderPluginV2, SpyderDockablePlugin
 from spyder.api.translations import get_translation
 from spyder.api.widgets.menus import MENU_SEPARATOR, SpyderMenu
@@ -129,18 +130,19 @@ class MainMenu(SpyderPluginV2):
 
     def _hide_options_menus(self):
         """Hide options menu when menubar is pressed in macOS."""
-        for _plugin_id, plugin in self.main._PLUGINS.items():
-            if isinstance(plugin, SpyderDockablePlugin):
-                if plugin.CONF_SECTION == 'editor':
+        for plugin_name in PLUGIN_REGISTRY:
+            plugin_instance = PLUGIN_REGISTRY.get_plugin(plugin_name)
+            if isinstance(plugin_instance, SpyderDockablePlugin):
+                if plugin_instance.CONF_SECTION == 'editor':
                     editorstack = self.editor.get_current_editorstack()
                     editorstack.menu.hide()
                 else:
                     try:
                         # New API
-                        plugin.options_menu.hide()
+                        plugin_instance.options_menu.hide()
                     except AttributeError:
                         # Old API
-                        plugin._options_menu.hide()
+                        plugin_instance._options_menu.hide()
 
     def _setup_menus(self):
         """Setup menus."""

--- a/spyder/plugins/preferences/tests/conftest.py
+++ b/spyder/plugins/preferences/tests/conftest.py
@@ -9,8 +9,6 @@
 Testing utilities to be used with pytest.
 """
 
-from collections import OrderedDict
-import traceback
 import types
 
 from unittest.mock import Mock, MagicMock
@@ -38,7 +36,6 @@ class MainWindowMock(QMainWindow):
         self.thirdparty_plugins = []
         self.shortcut_data = []
         self.prefs_dialog_instance = None
-        self._PLUGINS = OrderedDict()
         self._APPLICATION_TOOLBARS = MagicMock()
 
         self.console = Mock()
@@ -62,14 +59,10 @@ class MainWindowMock(QMainWindow):
     def register_plugin(self, plugin_name, external=False):
         plugin = PLUGIN_REGISTRY.get_plugin(plugin_name)
         plugin._register(omit_conf=True)
-        self.add_plugin(plugin, external=external)
 
     def get_plugin(self, plugin_name):
         if plugin_name in PLUGIN_REGISTRY:
             return PLUGIN_REGISTRY.get_plugin(plugin_name)
-
-    def add_plugin(self, plugin, external=False):
-        self._PLUGINS[plugin.CONF_SECTION] = plugin
 
     def set_prefs_size(self, size):
         pass
@@ -94,23 +87,16 @@ class ConfigDialogTester:
         def register_plugin(self, plugin_name, external=False):
             plugin = PLUGIN_REGISTRY.get_plugin(plugin_name)
             plugin._register()
-            self.add_plugin(plugin, external=external)
 
         def get_plugin(self, plugin_name, error=False):
             if plugin_name in PLUGIN_REGISTRY:
                 return PLUGIN_REGISTRY.get_plugin(plugin_name)
             return None
 
-        def add_plugin(self, plugin, external=False):
-            self._PLUGINS[plugin.CONF_SECTION] = plugin
-
-        setattr(self._main, '_PLUGINS', OrderedDict())
         setattr(self._main, 'register_plugin',
                 types.MethodType(register_plugin, self._main))
         setattr(self._main, 'get_plugin',
                 types.MethodType(get_plugin, self._main))
-        setattr(self._main, 'add_plugin',
-                types.MethodType(add_plugin, self._main))
         setattr(self._main, 'reset_spyder',
                 types.MethodType(reset_spyder, self._main))
         setattr(self._main, 'set_prefs_size',
@@ -123,8 +109,8 @@ class ConfigDialogTester:
             for Plugin in plugins:
                 if hasattr(Plugin, 'CONF_WIDGET_CLASS'):
                     for required in (Plugin.REQUIRES or []):
-                        if required not in self._main._PLUGINS:
-                            self._main._PLUGINS[required] = MagicMock()
+                        if required not in PLUGIN_REGISTRY:
+                            PLUGIN_REGISTRY.plugin_registry[required] = MagicMock()
 
                     PLUGIN_REGISTRY.register_plugin(self._main, Plugin)
                 else:

--- a/spyder/plugins/preferences/tests/conftest.py
+++ b/spyder/plugins/preferences/tests/conftest.py
@@ -24,9 +24,7 @@ import pytest
 from spyder.api.plugins import Plugins
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
 from spyder.config.manager import CONF
-from spyder.plugins.preferences.api import PreferencePages
 from spyder.plugins.preferences.plugin import Preferences
-from spyder.plugins.shortcuts.widgets.table import load_shortcuts_data
 from spyder.utils.icon_manager import ima
 
 
@@ -41,8 +39,6 @@ class MainWindowMock(QMainWindow):
         self.shortcut_data = []
         self.prefs_dialog_instance = None
         self._PLUGINS = OrderedDict()
-        self._EXTERNAL_PLUGINS = OrderedDict()
-        self._INTERNAL_PLUGINS = OrderedDict()
         self._APPLICATION_TOOLBARS = MagicMock()
 
         self.console = Mock()
@@ -74,10 +70,6 @@ class MainWindowMock(QMainWindow):
 
     def add_plugin(self, plugin, external=False):
         self._PLUGINS[plugin.CONF_SECTION] = plugin
-        if external:
-            self._EXTERNAL_PLUGINS[plugin.CONF_SECTION] = plugin
-        else:
-            self._INTERNAL_PLUGINS[plugin.CONF_SECTION] = plugin
 
     def set_prefs_size(self, size):
         pass
@@ -111,14 +103,8 @@ class ConfigDialogTester:
 
         def add_plugin(self, plugin, external=False):
             self._PLUGINS[plugin.CONF_SECTION] = plugin
-            if external:
-                self._EXTERNAL_PLUGINS[plugin.CONF_SECTION] = plugin
-            else:
-                self._INTERNAL_PLUGINS[plugin.CONF_SECTION] = plugin
 
         setattr(self._main, '_PLUGINS', OrderedDict())
-        setattr(self._main, '_EXTERNAL_PLUGINS', OrderedDict())
-        setattr(self._main, '_INTERNAL_PLUGINS', OrderedDict())
         setattr(self._main, 'register_plugin',
                 types.MethodType(register_plugin, self._main))
         setattr(self._main, 'get_plugin',
@@ -139,8 +125,6 @@ class ConfigDialogTester:
                     for required in (Plugin.REQUIRES or []):
                         if required not in self._main._PLUGINS:
                             self._main._PLUGINS[required] = MagicMock()
-                            self._main._INTERNAL_PLUGINS[
-                                required] = MagicMock()
 
                     PLUGIN_REGISTRY.register_plugin(self._main, Plugin)
                 else:

--- a/spyder/plugins/pylint/tests/test_pylint.py
+++ b/spyder/plugins/pylint/tests/test_pylint.py
@@ -14,12 +14,12 @@ from unittest.mock import Mock, MagicMock
 
 # Third party imports
 import pytest
-from qtpy.QtCore import Signal, QObject
+from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QMainWindow
 
 # Local imports
+from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
 from spyder.config.manager import CONF
-from spyder.plugins.pylint.main_widget import PylintWidget
 from spyder.plugins.pylint.plugin import Pylint
 from spyder.plugins.pylint.utils import get_pylintrc_path
 
@@ -55,7 +55,6 @@ good-names=e
 
 class MainWindowMock(QMainWindow):
     sig_editor_focus_changed = Signal(str)
-    _PLUGINS = {}
 
     def __init__(self):
         super(MainWindowMock, self).__init__(None)
@@ -63,11 +62,13 @@ class MainWindowMock(QMainWindow):
         self.editor.sig_editor_focus_changed = self.sig_editor_focus_changed
         self.projects = MagicMock()
 
-        self._PLUGINS['editor'] = self.editor
-        self._PLUGINS['projects'] = self.projects
+        PLUGIN_REGISTRY.plugin_registry = {
+            'editor': self.editor,
+            'projects': self.projects
+        }
 
     def get_plugin(self, plugin_name):
-        return self._PLUGINS[plugin_name]
+        return PLUGIN_REGISTRY.get_plugin(plugin_name)
 
 
 @pytest.fixture

--- a/spyder/plugins/statusbar/widgets/tests/test_status.py
+++ b/spyder/plugins/statusbar/widgets/tests/test_status.py
@@ -7,9 +7,6 @@
 
 """Tests for status bar widgets."""
 
-# Standard library imports
-from unittest.mock import Mock
-
 # Thrid party imports
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QComboBox, QMainWindow
@@ -22,9 +19,7 @@ from spyder.plugins.statusbar.plugin import StatusBar
 
 
 class MainWindowMock(QMainWindow):
-    def __init__(self):
-        super().__init__()
-        self._PLUGINS = {'preferences': Mock()}
+    pass
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description of Changes

- Fix tabifying external plugins which are installed after Spyder was installed.
- Fix setting configuration defaults for external plugins without `CONF_DEFAULTS`.
- Remove old attributes that hold a reference to plugin instances. Now that's all handled by the new plugin registration mechanism.
- Prevent internal error when switching layouts.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16419.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
