### PR TITLE
PR: Catch error when starting watcher (Projects)

### DIFF
--- a/spyder/plugins/projects/utils/watcher.py
+++ b/spyder/plugins/projects/utils/watcher.py
@@ -125,7 +125,11 @@ class WorkspaceWatcher(QObject):
             self.observer = Observer()
             self.observer.schedule(
                 self.event_handler, workspace_folder, recursive=True)
-            self.observer.start()
+            try:
+                self.observer.start()
+            except OSError:
+                # This error happens frequently on Linux
+                logger.debug("Watcher could not be started.")
         except OSError as e:
             if u'inotify' in to_text_string(e):
                 QMessageBox.warning(


### PR DESCRIPTION
## Description of Changes

Simply catch and pass when the projects watcher can't be started due to `inotify` issues on Linux.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
