### PR TITLE
PR: Use a different icon for text completions

### DIFF
--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -273,7 +273,7 @@ class IconManager():
             'value':                   [('mdi.alpha-v-box',), {'color': SpyderPalette.ICON_5, 'scale_factor': self.BIG_ATTR_FACTOR}],
             'constant':                [('mdi.alpha-c-box',), {'color': SpyderPalette.ICON_5, 'scale_factor': self.BIG_ATTR_FACTOR}],
             'unit':                    [('mdi.alpha-u-box',), {'color': SpyderPalette.ICON_5, 'scale_factor': self.BIG_ATTR_FACTOR}],
-            'text':                    [('mdi.alpha-t-box',), {'color': SpyderPalette.GROUP_3, 'scale_factor': self.BIG_ATTR_FACTOR}],
+            'text':                    [('mdi.alphabetical',), {'color': self.MAIN_FG_COLOR, 'scale_factor': self.BIG_ATTR_FACTOR}],
             'file':                    [('mdi.file',), {'color': self.MAIN_FG_COLOR, 'scale_factor': self.SMALL_ATTR_FACTOR}],
             'snippet':                 [('mdi.alpha-s-box',), {'color': SpyderPalette.GROUP_11, 'scale_factor': self.BIG_ATTR_FACTOR}],
             'attribute':               [('mdi.alpha-a-box',), {'color': SpyderPalette.GROUP_12, 'scale_factor': self.BIG_ATTR_FACTOR}],

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -273,7 +273,7 @@ class IconManager():
             'value':                   [('mdi.alpha-v-box',), {'color': SpyderPalette.ICON_5, 'scale_factor': self.BIG_ATTR_FACTOR}],
             'constant':                [('mdi.alpha-c-box',), {'color': SpyderPalette.ICON_5, 'scale_factor': self.BIG_ATTR_FACTOR}],
             'unit':                    [('mdi.alpha-u-box',), {'color': SpyderPalette.ICON_5, 'scale_factor': self.BIG_ATTR_FACTOR}],
-            'text':                    [('mdi.alphabetical',), {'color': self.MAIN_FG_COLOR, 'scale_factor': self.BIG_ATTR_FACTOR}],
+            'text':                    [('mdi.alphabetical-variant',), {'color': self.MAIN_FG_COLOR, 'scale_factor': self.BIG_ATTR_FACTOR}],
             'file':                    [('mdi.file',), {'color': self.MAIN_FG_COLOR, 'scale_factor': self.SMALL_ATTR_FACTOR}],
             'snippet':                 [('mdi.alpha-s-box',), {'color': SpyderPalette.GROUP_11, 'scale_factor': self.BIG_ATTR_FACTOR}],
             'attribute':               [('mdi.alpha-a-box',), {'color': SpyderPalette.GROUP_12, 'scale_factor': self.BIG_ATTR_FACTOR}],


### PR DESCRIPTION
## Description of Changes

This changes the icon used for text completions so it's visually different from the ones corresponding to LSP symbols.

**Before**

![imagen](https://user-images.githubusercontent.com/365293/133844659-efec0238-70dd-428f-8c26-68ae5eb27e1e.png)

**After**

![image](https://user-images.githubusercontent.com/365293/142041478-32f04920-2517-4112-9248-bcadd6799b2a.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
