### PR TITLE
PR: Change cursor to pointing hand when single click option is on in Files and Projects

### DIFF
--- a/spyder/plugins/explorer/widgets/tests/test_explorer.py
+++ b/spyder/plugins/explorer/widgets/tests/test_explorer.py
@@ -204,11 +204,11 @@ def test_single_click_to_open(qtbot, file_explorer):
                         assert full_path != file_explorer.label1.text()
 
     # Test single click to open
-    treewidget.set_single_click_to_open(True)
+    treewidget.set_conf('single_click_to_open', True)
     run_test_helper(single_click=True, initial_index=initial_index)
 
     # Test double click to open
-    treewidget.set_single_click_to_open(False)
+    treewidget.set_conf('single_click_to_open', False)
     run_test_helper(single_click=False, initial_index=initial_index)
 
 


### PR DESCRIPTION
## Description of Changes

I think this makes more intuitive to use that option because, thanks to browsers, you know what to expect when clicking on something and the cursor has that shape.

![Single-click](https://user-images.githubusercontent.com/365293/134037820-5eac581d-ee9f-4551-9bb9-49d17e7fb0cc.gif)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
