### PR TITLE
PR: Clean up sys.path and entry-points in bootstrap

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -130,21 +130,8 @@ if args.debug:
     # if operation is successful
 
 
-# Add this path to the front of sys.path
-sys.path.insert(0, DEVPATH)
-print("*. Patched sys.path with %s" % DEVPATH)
-
-# Add external dependencies subrepo paths to be the next entries
-# (1, 2, etc) of sys.path
-DEPS_PATH = osp.join(DEVPATH, 'external-deps')
-i = 1
-for path in os.listdir(DEPS_PATH):
-    external_dep_path = osp.join(DEPS_PATH, path)
-    sys.path.insert(i, external_dep_path)
-    print("*. Patched sys.path with %s" % external_dep_path)
-    i += 1
-
 # Create an egg-info folder to declare the PyLS subrepo entry points.
+DEPS_PATH = osp.join(DEVPATH, 'external-deps')
 pyls_submodule = osp.join(DEPS_PATH, 'python-lsp-server')
 pyls_installation_dir = osp.join(pyls_submodule, '.installation-dir')
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -175,44 +175,9 @@ subprocess.check_output(
 
 atexit.register(remove_pyls_installation)
 
-print("*. Declaring completion providers")
-
-# Register completion providers
-fallback = pkg_resources.EntryPoint.parse(
-    'fallback = spyder.plugins.completion.providers.fallback.provider:'
-    'FallbackProvider')
-
-snippets = pkg_resources.EntryPoint.parse(
-    'snippets = spyder.plugins.completion.providers.snippets.provider:'
-    'SnippetsProvider'
-)
-
-lsp = pkg_resources.EntryPoint.parse(
-    'lsp = spyder.plugins.completion.providers.languageserver.provider:'
-    'LanguageServerProvider'
-)
-
-kite = pkg_resources.EntryPoint.parse(
-    'kite = spyder.plugins.completion.providers.kite.provider:'
-    'KiteProvider'
-)
-
-# Create a fake Spyder distribution
-d = pkg_resources.Distribution(__file__)
-
-# Add the providers to the fake EntryPoint
-d._ep_map = {
-    'spyder.completions': {
-        'fallback': fallback,
-        'snippets': snippets,
-        'lsp': lsp,
-        'kite': kite
-    }
-}
-
-# Add the fake distribution to the global working_set
-pkg_resources.working_set.add(d, 'spyder')
-
+# Add spyder egg-info
+subprocess.check_output([
+    sys.executable, '-W', 'ignore', 'setup.py', 'egg_info'])
 
 # Selecting the GUI toolkit: PyQt5 if installed
 if args.gui is None:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -24,7 +24,6 @@ import atexit
 import argparse
 import os
 import os.path as osp
-import pkg_resources
 import shutil
 import subprocess
 import sys

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -147,16 +147,13 @@ for path in os.listdir(DEPS_PATH):
 # Create an egg-info folder to declare the PyLS subrepo entry points.
 pyls_submodule = osp.join(DEPS_PATH, 'python-lsp-server')
 pyls_installation_dir = osp.join(pyls_submodule, '.installation-dir')
-pyls_installation_egg = osp.join(
-    pyls_submodule, 'python_lsp_server.egg-info')
 
 
 def remove_pyls_installation():
     shutil.rmtree(pyls_installation_dir, ignore_errors=True)
-    shutil.rmtree(pyls_installation_egg, ignore_errors=True)
 
 
-if osp.exists(pyls_installation_dir) or osp.exists(pyls_installation_egg):
+if osp.exists(pyls_installation_dir):
     # Remove any leftover installation from previous execution
     print("*. Removing previous PyLSP local installation.")
     remove_pyls_installation()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* Remove extraneous external-deps paths from sys.path
* Do not remove python-lsp-server egg-info at exit
* Create Spyder egg-info and use real plugin entry-points rather than patching provider entry-points to fake Spyder distribution.

### Comments
Adding the external-deps (python-lsp-server, qdarkstyle, and spyder-kernels) to the sys.path is not necessary. Whether they are installed in site-packages (as normal or on the CI) or whether they are installed in develop mode (under DEV) they will be included in Python's search path. Explicitly adding them to the sys.path here creates duplicate and redundant entries.

Removing the egg-info for python-lsp-server breaks its installation in other environments that have it installed in develop mode. There is no need to remove the egg-info anyway, regardless of the installation method.

Regarding the plugin entry-points, I've proposed this before and was unable to convince others to adopt it, but I will try again. Using Spyder's egg-info for plugin entry-point ensures that the actual entry-point mechanism is used (which is what should be tested) and `python setup.py egg_info` _only creates the egg-info and does not change existing environments_ .

If I'm mistaken on any of these points, please enlighten me :-)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary 
<!--- Thanks for your help making Spyder better for everyone! --->
