### PR TITLE
PR: Use conda-forge and mamba for testing

### DIFF
--- a/.github/workflows/test-files.yml
+++ b/.github/workflows/test-files.yml
@@ -69,7 +69,7 @@ jobs:
           sudo apt-get update --fix-missing
           sudo apt-get install libxcb-randr0-dev libxcb-xtest0-dev libxcb-xinerama0-dev libxcb-shape0-dev libxcb-xkb-dev libegl1-mesa libxkbcommon-x11-0 xterm --fix-missing
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         env:
           # Increase this value to reset cache if requirements/*.txt has not changed
           CACHE_NUMBER: 0
@@ -78,19 +78,22 @@ jobs:
           key: ${{ runner.os }}-cacheconda-installconda-${{ matrix.PYTHON_VERSION }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('requirements/*.txt') }}
       - name: Cache pip
         if: env.RUN_BUILD == 'true'
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-cachepip-installconda-${{ env.CACHE_NUMBER }}-${{ hashFiles('requirements/*.txt') }}
+          key: ${{ runner.os }}-cachepip-installconda-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
       - name: Install Conda
         if: env.RUN_BUILD == 'true'
         uses: conda-incubator/setup-miniconda@v2
         with:
            activate-environment: test
-           auto-update-conda: true
+           auto-update-conda: false
            auto-activate-base: false
            python-version: ${{ matrix.PYTHON_VERSION }}
            use-only-tar-bz2: true
+           channels: conda-forge,defaults
+           channel-priority: strict
+           miniforge-variant: Mambaforge
       - name: Create test environment
         if: env.RUN_BUILD == 'true'
         shell: bash -l {0}

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -73,7 +73,7 @@ jobs:
           sudo apt-get update --fix-missing
           sudo apt-get install libxcb-randr0-dev libxcb-xtest0-dev libxcb-xinerama0-dev libxcb-shape0-dev libxcb-xkb-dev libegl1-mesa libxkbcommon-x11-0 xterm --fix-missing
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         env:
           # Increase this value to reset cache if requirements/*.txt has not changed
           CACHE_NUMBER: 0
@@ -82,19 +82,22 @@ jobs:
           key: ${{ runner.os }}-cacheconda-install${{ matrix.INSTALL_TYPE }}-${{ matrix.PYTHON_VERSION }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('requirements/*.txt') }}
       - name: Cache pip
         if: env.RUN_BUILD == 'true'
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('requirements/*.txt') }}
+          key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
       - name: Install Conda
         if: env.RUN_BUILD == 'true'
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: test
-          auto-update-conda: true
+          auto-update-conda: false
           auto-activate-base: false
           python-version: ${{ matrix.PYTHON_VERSION }}
           use-only-tar-bz2: true
+          channels: conda-forge,defaults
+          channel-priority: strict
+          miniforge-variant: Mambaforge
       - name: Create test environment
         if: env.RUN_BUILD == 'true'
         shell: bash -l {0}

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -66,7 +66,7 @@ jobs:
         shell: bash -l {0}
         run: echo "RUN_BUILD=true" >> $GITHUB_ENV
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         env:
           # Increase this value to reset cache if requirements/*.txt has not changed
           CACHE_NUMBER: 0
@@ -75,19 +75,22 @@ jobs:
           key: ${{ runner.os }}-cacheconda-install${{ matrix.INSTALL_TYPE }}-${{ matrix.PYTHON_VERSION }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('requirements/*.txt') }}
       - name: Cache pip
         if: env.RUN_BUILD == 'true'
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/Library/Caches/pip
-          key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('requirements/*.txt') }}
+          key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
       - name: Install Conda
         if: env.RUN_BUILD == 'true'
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: test
-          auto-update-conda: true
+          auto-update-conda: false
           auto-activate-base: false
           python-version: ${{ matrix.PYTHON_VERSION }}
           use-only-tar-bz2: true
+          channels: conda-forge,defaults
+          channel-priority: strict
+          miniforge-variant: Mambaforge
       - name: Create test environment
         if: env.RUN_BUILD == 'true'
         shell: bash -l {0}

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -66,7 +66,7 @@ jobs:
         shell: bash -l {0}
         run: echo "RUN_BUILD=true" >> $GITHUB_ENV
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         env:
           # Increase this value to reset cache if requirements/*.txt has not changed
           CACHE_NUMBER: 0
@@ -75,19 +75,22 @@ jobs:
           key: ${{ runner.os }}-cacheconda-install${{ matrix.INSTALL_TYPE }}-${{ matrix.PYTHON_VERSION }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('requirements/*.txt') }}
       - name: Cache pip
         if: env.RUN_BUILD == 'true'
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('requirements/*.txt') }}
+          key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
       - name: Install Conda
         if: env.RUN_BUILD == 'true'
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: test
-          auto-update-conda: true
+          auto-update-conda: false
           auto-activate-base: false
           python-version: ${{ matrix.PYTHON_VERSION }}
           use-only-tar-bz2: true
+          channels: conda-forge,defaults
+          channel-priority: strict
+          miniforge-variant: Mambaforge
       - name: Create test environment
         if: env.RUN_BUILD == 'true'
         shell: bash -l {0}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ $ workon spyder-dev
 After you have created your development environment, you need to install Spyder's necessary dependencies. The easiest way to do so (with Anaconda) is
 
 ```bash
-$ conda install -c spyder-ide/label/dev --file requirements/conda.txt
+$ conda install -c conda-forge --file requirements/conda.txt
 ```
 
 This installs all Spyder's dependencies into the environment.
@@ -99,7 +99,7 @@ $ python bootstrap.py --debug
 To install our test dependencies under Anaconda:
 
 ```bash
-$ conda install -c spyder-ide --file requirements/tests.txt
+$ conda install -c conda-forge --file requirements/tests.txt
 ```
 
 If using `pip` (for experts only), run the following from the directory where your git clone is stored:

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -29,9 +29,7 @@ dependencies:
 - pyls-spyder >=0.4.0
 - pyqt <5.13
 - python-lsp-black >=1.0.0
-# NOTE: There's no need to set constraints for python-lsp-server
-# here because Spyder uses the subrepo for it when started in Binder.
-- python-lsp-server
+- python-lsp-server >=1.2.2,<1.3.0
 - pyxdg >=0.26
 - pyzmq >=17
 - qdarkstyle =3.0.2
@@ -42,9 +40,7 @@ dependencies:
 - rtree >=0.9.7
 - setuptools >=49.6.0
 - sphinx >=0.6.6
-# NOTE: There's no need to set constraints for spyder-kernels here
-# because Spyder uses the subrepo for it when started in Binder.
-- spyder-kernels
+- spyder-kernels >=2.1.1,<2.2.0
 - textdistance >=4.2.0
 - three-merge >=0.1.1
 - watchdog >=0.10.3

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -25,9 +25,7 @@ pylint >=2.5.0,<2.10.0
 pyls-spyder >=0.4.0
 pyqt <5.13
 python-lsp-black >=1.0.0
-# There's no need to set a version for python-lsp-server
-# because we install it from master for our tests.
-python-lsp-server
+python-lsp-server >=1.2.2,<1.3.0
 pyxdg >=0.26
 pyzmq >=17
 qdarkstyle =3.0.2
@@ -38,9 +36,7 @@ qtpy >=1.5.0
 rtree >=0.9.7
 setuptools >=49.6.0
 sphinx >=0.6.6
-# NOTE: There's no need to set a version for spyder-kernels
-# here because we're using a subrepo for it to run our tests.
-spyder-kernels
+spyder-kernels >=2.1.1,<2.2.0
 textdistance >=4.2.0
 three-merge >=0.1.1
 watchdog >=0.10.3

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -3187,6 +3187,7 @@ def test_runcell_cache(main_window, qtbot, debug):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
+@pytest.mark.skipif(os.name == 'nt', reason="Fails on Windows")
 def test_path_manager_updates_clients(qtbot, main_window, tmpdir):
     """Check that on path manager updates, consoles correctly update."""
     main_window.show_path_manager()

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -226,7 +226,8 @@ def test_move_multiple_lines_up(editor_bot):
     assert editor.toPlainText() == expected_new_text
 
 
-@pytest.mark.skipif(os.name == 'nt', reason="It fails on Windows")
+@pytest.mark.skipif(not sys.platform.startswith('linux'),
+                    reason="Works only on Linux")
 def test_copy_lines_down_up(editor_bot, mocker, qtbot):
     """
     Test that copy lines down and copy lines up are working as expected.

--- a/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
@@ -23,6 +23,7 @@ from qtpy.QtGui import QTextCursor
 import pytest
 
 # Local imports
+from spyder.config.base import running_in_ci
 from spyder.plugins.editor.widgets import editor
 from spyder.plugins.outlineexplorer.editor import OutlineExplorerProxyEditor
 from spyder.plugins.outlineexplorer.main_widget import OutlineExplorerWidget
@@ -229,8 +230,7 @@ def test_sync_file_order(editorstack, outlineexplorer, test_files):
 
 
 # ---- Test single file mode
-@pytest.mark.skipif(not sys.platform == 'darwin',
-                    reason="Fails on Linux and Windows")
+@pytest.mark.skipif(running_in_ci(), reason="Fails on CIs")
 def test_toggle_off_show_all_files(editorstack, outlineexplorer, test_files,
                                    qtbot):
     """

--- a/spyder/plugins/outlineexplorer/tests/test_widgets.py
+++ b/spyder/plugins/outlineexplorer/tests/test_widgets.py
@@ -10,10 +10,12 @@ Tests for editortool.py
 # Standard Libray Imports
 import json
 import os.path as osp
+import sys
 from textwrap import dedent
 from unittest.mock import MagicMock
 
 # Third party imports
+from flaky import flaky
 import pytest
 from qtpy.QtCore import Qt
 
@@ -201,6 +203,7 @@ def test_outline_explorer(case, create_outlineexplorer):
     assert root_tree == expected_tree
 
 
+@pytest.mark.skipif(sys.platform == 'darwin', reason="Fails on Mac")
 def test_go_to_cursor_position(create_outlineexplorer, qtbot):
     """
     Test that clicking on the 'Go to cursor position' button located in the
@@ -223,6 +226,7 @@ def test_go_to_cursor_position(create_outlineexplorer, qtbot):
     assert outlineexplorer.treewidget.currentItem().text(0) == 'inner'
 
 
+@flaky(max_runs=10)
 def test_follow_cursor(create_outlineexplorer, qtbot):
     """
     Test that the cursor is followed.
@@ -248,6 +252,7 @@ def test_follow_cursor(create_outlineexplorer, qtbot):
     assert outlineexplorer.treewidget.currentItem().text(0) == 'b'
 
 
+@flaky(max_runs=10)
 def test_go_to_cursor_position_with_new_file(create_outlineexplorer, qtbot):
     """
     Test that clicking on the 'Go to cursor position' button located in the
@@ -269,6 +274,7 @@ def test_go_to_cursor_position_with_new_file(create_outlineexplorer, qtbot):
     assert outlineexplorer.treewidget.currentItem().text(0) == filename
 
 
+@flaky(max_runs=10)
 def test_go_to_last_item(create_outlineexplorer, qtbot):
     """
     Test that clicking on the 'Go to cursor position' button located in the

--- a/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
@@ -73,6 +73,7 @@ def test_object_arrays_display(qtbot):
     assert u'[Numpy array]' == dlg.arraywidget.model.data(idx)
 
 
+@pytest.mark.skipif(os.name == 'nt', reason="Segfaults on Windows")
 def test_attribute_errors(qtbot):
     """
     Verify that we don't get a AttributeError for certain structured arrays.
@@ -84,6 +85,7 @@ def test_attribute_errors(qtbot):
     dlg = setup_arrayeditor(qtbot, data['S'])
     contents = dlg.arraywidget.model.get_value(dlg.arraywidget.model.index(0, 0))
     assert_array_equal(contents, data['S'][0][0][0])
+
 
 def test_type_errors(qtbot):
     """
@@ -98,6 +100,7 @@ def test_type_errors(qtbot):
     assert_array_equal(contents, np.ones(10))
 
 
+@pytest.mark.skipif(sys.platform == 'darwin', reason="Fails on Mac")
 def test_arrayeditor_format(qtbot):
     """Changes the format of the array and validates its selected content."""
     arr = np.array([1, 2, 3], dtype=np.float32)

--- a/spyder/tests/test_dependencies_in_sync.py
+++ b/spyder/tests/test_dependencies_in_sync.py
@@ -14,7 +14,6 @@ import yaml
 
 # Local imports
 from spyder.dependencies import DESCRIPTIONS, OPTIONAL
-from spyder.py3compat import PY2
 
 # Constants
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -205,11 +204,6 @@ def test_dependencies_for_binder_in_sync():
     if 'pytest-xvfb' in spyder_env:
         spyder_env.pop('pytest-xvfb')
 
-    # There's no need to test for this because we install it
-    # from master in some cases.
-    for req in [spyder_env, spyder_reqs]:
-        req.pop('python-lsp-server')
-
     # Check that the requirement files match the environment yaml file
     full_reqs = {}
     full_reqs.update(test_reqs)
@@ -225,21 +219,8 @@ def test_dependencies_for_spyder_dialog_in_sync():
     spyder_deps = parse_spyder_dependencies()
     spyder_reqs = parse_requirements(REQ_FPATH)
 
-    # No need to check for these deps because either we're using
-    # a subrepo for them or we're installing them from master.
-    for req in [spyder_deps, spyder_reqs]:
-        req.pop('spyder-kernels')
-        req.pop('python-lsp-server')
-
     if 'pyqt' in spyder_reqs:
         spyder_reqs.pop('pyqt')
-
-    if PY2:
-        if 'ipython' in spyder_reqs:
-            spyder_reqs.pop('ipython')
-
-        if 'ipython' in spyder_deps:
-            spyder_deps.pop('ipython')
 
     assert spyder_deps == spyder_reqs
 
@@ -250,12 +231,6 @@ def test_dependencies_for_spyder_setup_install_requires_in_sync():
     """
     spyder_setup = parse_setup_install_requires(SETUP_FPATH)
     spyder_reqs = parse_requirements(REQ_FPATH)
-
-    # No need to check for these deps because either we're using
-    # a subrepo for them or we're installing them from master.
-    for req in [spyder_reqs, spyder_setup]:
-        req.pop('spyder-kernels')
-        req.pop('python-lsp-server')
 
     if 'pyqtwebengine' in spyder_setup:
         spyder_setup.pop('pyqtwebengine')


### PR DESCRIPTION
## Description of Changes

- Installing from conda-forge is necessary to add new binary dependencies to Spyder which are not available in the `defaults` channels (e.g. `jellyfish`).
- This also helps to test that our core deps (`spyder-kernels` and `python-lsp-server`) are in sync with our other installation methods (i.e. `setup.py` and Binder).

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
