### PR TITLE
PR: Add a test to check that the breakpoint builtin is working

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 2.x
-	commit = c24e88f0f303bce22fb24b3c4fc3ce54b13cf63c
-	parent = f8dc5121c140e1002b6cdbe3a57965f379d59a50
+	branch = fix-breakpoint-builtin
+	commit = a1dd3d5ec75ec4e275ea9f17ed94e1443fc2dd5b
+	parent = ff22dcb601397829cee80c07d1d1b268469a99c7
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = fix-breakpoint-builtin
-	commit = a1dd3d5ec75ec4e275ea9f17ed94e1443fc2dd5b
-	parent = ff22dcb601397829cee80c07d1d1b268469a99c7
+	branch = 2.x
+	commit = d151e3b4f01a1284487b6183def17161307f8bb5
+	parent = eb1cd5b7fe9ddb77a1869512c129d89c93484a46
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/console/start.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/start.py
@@ -121,6 +121,15 @@ def kernel_config():
             "del builtins.spyder_runfile; del builtins"
         )
 
+    # Prevent other libraries to change the breakpoint builtin.
+    # This started to be a problem since IPykernel 6.3.0.
+    if sys.version_info[0:2] >= (3, 7):
+        spy_cfg.IPKernelApp.exec_lines.append(
+            "import sys; import pdb; "
+            "sys.breakpointhook = pdb.set_trace; "
+            "del sys; del pdb"
+        )
+
     # Run lines of code at startup
     run_lines_o = os.environ.get('SPY_RUN_LINES_O')
     if run_lines_o is not None:

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
@@ -487,7 +487,7 @@ def get_file_code(filename, save_all=True):
     try:
         file_code = frontend_request().get_file_code(
             filename, save_all=save_all)
-    except (CommError, TimeoutError):
+    except (CommError, TimeoutError, RuntimeError):
         file_code = None
     if file_code is None:
         with open(filename, 'r') as f:

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -213,8 +213,9 @@ class IPythonConsole(SpyderPluginWidget):
 
         self.tabwidget.set_close_function(self.close_client)
 
-        self.main.editor.sig_file_debug_message_requested.connect(
-            self.print_debug_file_msg)
+        if self.main.editor:
+            self.main.editor.sig_file_debug_message_requested.connect(
+                self.print_debug_file_msg)
 
         if sys.platform == 'darwin':
             tab_container = QWidget()


### PR DESCRIPTION
## Description of Changes

- This was broken because `debugpy` (a new dependency since IPykernel 6) registers its own breakpoint hook.
- Depends on https://github.com/spyder-ide/spyder-kernels/pull/322. This makes `sys.breakpointhook` to simply be `pdb.set_trace`.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16444.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
