### PR TITLE
Fix autoformat issue 16280 spyder

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 2.x
-	commit = d151e3b4f01a1284487b6183def17161307f8bb5
-	parent = eb1cd5b7fe9ddb77a1869512c129d89c93484a46
+	branch = fix_autoformat_issue_16280_kernel
+	commit = 15b66780db9f26d8db0df558d6c7fbbd7ba621fe
+	parent = fba6e064f630cb42db3b519509a984d87e3dbb6c
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/CHANGELOG.md
+++ b/external-deps/spyder-kernels/CHANGELOG.md
@@ -1,7 +1,19 @@
 # History of changes
 
-## Version 2.1.1 (2021-09-01)
+## Version 2.1.2 (2021-09-28)
 
+### Pull Requests Merged
+
+* [PR 323](https://github.com/spyder-ide/spyder-kernels/pull/323) - PR: Add `ipython_genutils` dependency for testing, by [@ccordoba12](https://github.com/ccordoba12)
+* [PR 322](https://github.com/spyder-ide/spyder-kernels/pull/322) - PR: Prevent other libraries to change the breakpoint builtin, by [@ccordoba12](https://github.com/ccordoba12)
+
+In this release 2 pull requests were closed.
+
+
+----
+
+
+## Version 2.1.1 (2021-09-01)
 
 ### Pull Requests Merged
 

--- a/external-deps/spyder-kernels/requirements/tests.txt
+++ b/external-deps/spyder-kernels/requirements/tests.txt
@@ -11,3 +11,5 @@ pytest-cov
 scipy
 xarray
 pillow
+# Remove when Anaconda updates to a newer ipykernel
+ipython_genutils

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
@@ -481,12 +481,11 @@ def exec_code(code, filename, ns_globals, ns_locals=None, post_mortem=False):
     __tracebackhide__ = "__pdb_exit__"
 
 
-def get_file_code(filename, save_all=True):
+def get_file_code(filename):
     """Retrive the content of a file."""
     # Get code from spyder
     try:
-        file_code = frontend_request().get_file_code(
-            filename, save_all=save_all)
+        file_code = frontend_request().get_file_code(filename)
     except (CommError, TimeoutError, RuntimeError):
         file_code = None
     if file_code is None:
@@ -665,7 +664,7 @@ def runcell(cellname, filename=None, post_mortem=False):
     # See Spyder PR #7310.
     ipython_shell.events.trigger('post_execute')
     try:
-        file_code = get_file_code(filename, save_all=False)
+        file_code = get_file_code(filename)
     except Exception:
         file_code = None
     with NamespaceManager(filename, current_namespace=True,

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -795,16 +795,13 @@ the sympy module (e.g. plot)
             return editor.get_current_editorstack()
         raise RuntimeError('No editorstack found.')
 
-    def handle_get_file_code(self, filename, save_all=True):
+    def handle_get_file_code(self, filename):
         """
         Return the bytes that compose the file.
 
         Bytes are returned instead of str to support non utf-8 files.
         """
         editorstack = self.get_editorstack()
-        if save_all and self.get_conf(
-                'save_all_before_run', default=True, section='editor'):
-            editorstack.save_all(save_new_files=False)
         editor = self.get_editor(filename)
 
         if editor is None:


### PR DESCRIPTION
## Description of Changes
Fix autoformat on save when running a script: Autoformat may replicate lines of code when autosave before running a script is triggered. See commit message for details.

### Issue(s) Resolved

Fixes #16280.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:
rear1019
