### PR TITLE
PR: Fix link to Spyder docs in connect to external kernel dialog

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
@@ -39,8 +39,8 @@ class KernelConnectionDialog(QDialog, SpyderConfigurationAccessor):
             "<tt>kernel-1234.json</tt>) of the existing kernel, and enter "
             "the SSH information if connecting to a remote machine. "
             "To learn more about starting external kernels and connecting "
-            "to them, see <a href=\"https://docs.spyder-ide.org/"
-            "ipythonconsole.html#connect-to-an-external-kernel\">"
+            "to them, see <a href=\"https://docs.spyder-ide.org/5/panes/"
+            "ipythonconsole.html#using-external-kernels\">"
             "our documentation</a>.</p>"))
         main_label.setWordWrap(True)
         main_label.setAlignment(Qt.AlignJustify)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

As helpfully spotted by @hyamanieu in spyder-ide/spyder-docs#297 , the URL to the external kernel docs in the Connect to kernel dialog is out of date and doesn't work. This PR fixes that. I also checked all the other URLs to the docs, and confirmed the rest are all up to date and working.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM-Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
