### PR TITLE
PR: Fix fallback to Spyder 2 icon theme to handle QtAwesome FontError

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1088,7 +1088,8 @@ class MainWindow(QMainWindow):
         # names given for plugins
         try:
             if attr in self._INTERNAL_PLUGINS_MAPPING.keys():
-                return self.get_plugin(self._INTERNAL_PLUGINS_MAPPING[attr])
+                return self.get_plugin(
+                    self._INTERNAL_PLUGINS_MAPPING[attr], error=False)
             return self.get_plugin(attr)
         except SpyderAPIError:
             pass


### PR DESCRIPTION


<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

The fallback didn't work since when handling the `FontError` another error raised (an `AttributeError` due to using 
 `get_plugin` with the default `error` kwarg set to `True` for internal plugins in the overwriter of the `_getattr_` method)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16537


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
