### PR TITLE
PR: Fix QImage.scaled() with PyQt5 >= 5.15 (Tours)

### DIFF
--- a/spyder/plugins/tours/widgets.py
+++ b/spyder/plugins/tours/widgets.py
@@ -1069,8 +1069,8 @@ class OpenTourDialog(QDialog):
         image_path = get_image_path(icon_filename)
         image = QPixmap(image_path)
         image_label = QLabel()
-        image_height = image.height() * DialogStyle.IconScaleFactor
-        image_width = image.width() * DialogStyle.IconScaleFactor
+        image_height = int(image.height() * DialogStyle.IconScaleFactor)
+        image_width = int(image.width() * DialogStyle.IconScaleFactor)
         image = image.scaled(image_width, image_height, Qt.KeepAspectRatio,
                              Qt.SmoothTransformation)
         image_label.setPixmap(image)


### PR DESCRIPTION
It looks like PyQt5 >= 5.15 doesn’t accept float arguments in
QImage.scaled(). PyQt5 5.14.1 issues the following warning:

```
<stdin>:1: DeprecationWarning: an integer is required (got type float).
Implicit conversion to integers using __int__ is deprecated, and may be
removed in a future version of Python.
```

### Issue(s) Resolved

Fixes #16571 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:

rear1019
