### PR TITLE
PR: Fix QProcess error messages in Completions plugin

### DIFF
--- a/spyder/plugins/completion/providers/languageserver/client.py
+++ b/spyder/plugins/completion/providers/languageserver/client.py
@@ -384,11 +384,18 @@ class LSPClient(QObject, LSPMethodProviderMixIn, SpyderConfigurationAccessor):
             self.notifier.activated.disconnect(self.on_msg_received)
             self.notifier.setEnabled(False)
             self.notifier = None
+
+        # waitForFinished(): Wait some time for process to exit. This fixes an
+        # error message by Qt (“QProcess: Destroyed while process (…) is still
+        # running.”). No further error handling because we are out of luck
+        # anyway if the process doesn’t finish.
         if self.transport is not None:
             self.transport.kill()
+            self.transport.waitForFinished(1000)
         self.context.destroy()
         if self.server is not None:
             self.server.kill()
+            self.server.waitForFinished(1000)
 
     def is_transport_alive(self):
         """Detect if transport layer is alive."""


### PR DESCRIPTION
## Description of Changes

This PR fixes two error message issued by Qt which are related QThread/QProcess. The error messages appears on the console when Spyder is closed.

The QProcess error has been observed both with PyQt (Qt 5.15.2/PyQt 5.15.4) and PySide (Qt 5.15.0/PySide 5.1.50) on the current `5.x` branch and with `v5.1.5`. The QThread error has been observed with PySide (PyQt not checked). 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

rear1019

<!--- Thanks for your help making Spyder better for everyone! --->
