### PR TITLE
PR: Update py2app to 0.27 (Mac app)

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -38,7 +38,7 @@ jobs:
           if [[ -z ${LITE_FLAG} ]]; then
               INSTALL_FLAGS+=('-r' 'req-scientific.txt')
           fi
-          ${pythonLocation}/bin/python -m pip install -U pip setuptools
+          ${pythonLocation}/bin/python -m pip install -U pip setuptools wheel
           ${pythonLocation}/bin/python -m pip install -r req-build.txt -r req-extras.txt -r req-plugins.txt "${INSTALL_FLAGS[@]}" -e ${GITHUB_WORKSPACE}
           ${pythonLocation}/bin/python -m pip uninstall -q -y spyder
       - name: Install Subrepos
@@ -48,9 +48,9 @@ jobs:
           do
               if [ "$dep" = "python-lsp-server" ]; then
                   SETUPTOOLS_SCM_PRETEND_VERSION=`${pythonLocation}/bin/python ${GITHUB_WORKSPACE}/pylsp_utils.py` \
-                  ${pythonLocation}/bin/python -m pip install -e ${GITHUB_WORKSPACE}/external-deps/$dep
+                  ${pythonLocation}/bin/python -m pip install ${GITHUB_WORKSPACE}/external-deps/$dep
               else
-                  ${pythonLocation}/bin/python -m pip install -e ${GITHUB_WORKSPACE}/external-deps/$dep
+                  ${pythonLocation}/bin/python -m pip install ${GITHUB_WORKSPACE}/external-deps/$dep
               fi
           done
       - name: Show Build Environment

--- a/installers/macOS/packages.py
+++ b/installers/macOS/packages.py
@@ -1,5 +1,9 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
 """
 NOTES
 -----

--- a/installers/macOS/packages.py
+++ b/installers/macOS/packages.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+NOTES
+-----
+py2app includes all packages in Spyder.app/Contents/Resources/lib/
+python<ver>.zip, but some packages have issues when placed there.
+The following packages are included in py2app's PACKAGES option so that
+they will be placed in Spyder.app/Contents/Resources/lib/python<ver>
+instead.
+
+alabaster :
+    Error message: [Errno 20] Not a directory: '<path>/Resources/lib/
+    python38.zip/alabaster'
+astroid :
+    ImportError: cannot import name 'context' from 'astroid'
+    (<path>/Resources/lib/python38.zip/astroid/__init__.pyc)
+blib2to3 :
+    File "<frozen zipimport>", line 177, in get_data
+    KeyError: 'blib2to3/Users/rclary/Library/Caches/black/20.8b1/
+    Grammar3.8.6.final.0.pickle'
+debugpy :
+    NotADirectoryError: [Errno 20] Not a directory:
+    '<path>/Resources/lib/python39.zip/debugpy/_vendored'
+docutils :
+    [Errno 20] Not a directory: '<path>/Resources/lib/python39.zip/
+    docutils/writers/latex2e/docutils.sty'
+humanfriendly :
+    spyder-terminal plugin
+    ModuleNotFoundError: No module named 'humanfriendly.tables'
+IPython :
+    [IPKernelApp] WARNING | Could not copy README_STARTUP to startup dir.
+    Source file
+    <path>/Resources/lib/python38.zip/IPython/core/profile/README_STARTUP
+    does not exist
+jedi :
+    jedi.api.environment.InvalidPythonEnvironment: Could not get version
+    information for '<path>/Contents/MacOS/python': InternalError("The
+    subprocess <path>/Contents/MacOS/python has crashed (EOFError('Ran out
+    of input'), stderr=).")
+jinja2 :
+    No module named 'jinja2.ext'
+keyring :
+    ModuleNotFoundError: No module named 'keyring.backends.<mod>'
+pandas :
+    From Variable explorer: KeyError('pandas._libs.interval')
+parso :
+    jedi.api.environment.InvalidPythonEnvironment: Could not get version
+    information for '/Users/rclary/opt/miniconda3/envs/c2w_37/bin/python':
+    InternalError("The subprocess /Users/rclary/opt/miniconda3/envs/c2w_37/
+    bin/python has crashed (EOFError('Ran out of input'), stderr=).")
+PIL :
+    Library not loaded: @loader_path/.dylibs/libjpeg.9.dylib
+    Note: only applicable to not-Lite build
+pkg_resources:
+    ImportError: The 'more_itertools' package is required; normally this is
+    bundled with this package so if you get this warning, consult the
+    packager of your distribution.
+pygments :
+    ModuleNotFoundError: No module named 'pygments.formatters.latex'
+pylint :
+    <path>/Contents/MacOS/python: No module named pylint.__main__
+pylsp :
+    <path>/Contents/MacOS/python: No module named pylsp
+    Note: still occurs in alias mode
+pylsp_black :
+    Mandatory: python-pyls-black >=1.0.0 : None (NOK)
+pyls_spyder :
+    Mandatory: pyls_spyder >=0.1.1 : None (NOK)
+qtawesome :
+    NotADirectoryError: [Errno 20] Not a directory: '<path>/Resourses/lib/
+    python38.zip/qtawesome/fonts/fontawesome4.7-webfont.ttf'
+setuptools :
+    Mandatory: setuptools >=49.6.0 : None (NOK)
+sphinx :
+    No module named 'sphinx.builders.changes'
+spyder :
+    NotADirectoryError: [Errno 20] Not a directory: '<path>/Resources/lib/
+    python38.zip/spyder/app/mac_stylesheet.qss'
+spyder_kernels :
+    No module named spyder_kernels.console.__main__
+spyder_terminal :
+    No module named spyder_terminal.server
+textdistance :
+    NotADirectoryError: [Errno 20] Not a directory: '<path>/Resources/lib/
+    python39.zip/textdistance/libraries.json'
+"""
+
+# Packages that cannot be in the zip folder
+PACKAGES = [
+    'alabaster',
+    'astroid',
+    'blib2to3',
+    'debugpy',
+    'docutils',
+    'humanfriendly',
+    'IPython',
+    'jedi',
+    'jinja2',
+    'keyring',
+    'pkg_resources',
+    'parso',
+    'pygments',
+    'pylint',
+    'pylsp',
+    'pylsp_black',
+    'pyls_spyder',
+    'qtawesome',
+    'setuptools',
+    'sphinx',
+    'spyder',
+    'spyder_kernels',
+    'spyder_terminal',
+    'textdistance',
+]
+
+# Packages to exclude
+EXCLUDES = []
+
+# modules that py2app misses
+INCLUDES = [
+    '_sitebuiltins',  # required for IPython help()
+    'jellyfish',
+    # required for sphinx
+    'sphinxcontrib.applehelp',
+    'sphinxcontrib.devhelp',
+    'sphinxcontrib.htmlhelp',
+    'sphinxcontrib.jsmath',
+    'sphinxcontrib.qthelp',
+    'sphinxcontrib.serializinghtml',
+    'platformdirs.macos',  # required for platformdirs
+]
+
+SCIENTIFIC = [
+    'cython',
+    'matplotlib',
+    'numpy',
+    'pandas',
+    'scipy',
+    'sympy',
+]

--- a/installers/macOS/packages.py
+++ b/installers/macOS/packages.py
@@ -9,39 +9,17 @@ The following packages are included in py2app's PACKAGES option so that
 they will be placed in Spyder.app/Contents/Resources/lib/python<ver>
 instead.
 
-alabaster :
-    Error message: [Errno 20] Not a directory: '<path>/Resources/lib/
-    python38.zip/alabaster'
-astroid :
-    ImportError: cannot import name 'context' from 'astroid'
-    (<path>/Resources/lib/python38.zip/astroid/__init__.pyc)
 blib2to3 :
     File "<frozen zipimport>", line 177, in get_data
     KeyError: 'blib2to3/Users/rclary/Library/Caches/black/20.8b1/
     Grammar3.8.6.final.0.pickle'
-debugpy :
-    NotADirectoryError: [Errno 20] Not a directory:
-    '<path>/Resources/lib/python39.zip/debugpy/_vendored'
-docutils :
-    [Errno 20] Not a directory: '<path>/Resources/lib/python39.zip/
-    docutils/writers/latex2e/docutils.sty'
 humanfriendly :
     spyder-terminal plugin
     ModuleNotFoundError: No module named 'humanfriendly.tables'
-jedi :
-    jedi.api.environment.InvalidPythonEnvironment: Could not get version
-    information for '<path>/Contents/MacOS/python': InternalError("The
-    subprocess <path>/Contents/MacOS/python has crashed (EOFError('Ran out
-    of input'), stderr=).")
 jinja2 :
     No module named 'jinja2.ext'
 keyring :
     ModuleNotFoundError: No module named 'keyring.backends.<mod>'
-parso :
-    jedi.api.environment.InvalidPythonEnvironment: Could not get version
-    information for '/Users/rclary/opt/miniconda3/envs/c2w_37/bin/python':
-    InternalError("The subprocess /Users/rclary/opt/miniconda3/envs/c2w_37/
-    bin/python has crashed (EOFError('Ran out of input'), stderr=).")
 PIL :
     Library not loaded: @loader_path/.dylibs/libjpeg.9.dylib
     Note: only applicable to not-Lite build
@@ -55,9 +33,6 @@ pylsp_black :
     Mandatory: python-pyls-black >=1.0.0 : None (NOK)
 pyls_spyder :
     Mandatory: pyls_spyder >=0.1.1 : None (NOK)
-qtawesome :
-    NotADirectoryError: [Errno 20] Not a directory: '<path>/Resourses/lib/
-    python38.zip/qtawesome/fonts/fontawesome4.7-webfont.ttf'
 setuptools :
     Mandatory: setuptools >=49.6.0 : None (NOK)
 spyder :
@@ -67,33 +42,22 @@ spyder_kernels :
     No module named spyder_kernels.console.__main__
 spyder_terminal :
     No module named spyder_terminal.server
-textdistance :
-    NotADirectoryError: [Errno 20] Not a directory: '<path>/Resources/lib/
-    python39.zip/textdistance/libraries.json'
 """
 
 # Packages that cannot be in the zip folder
 PACKAGES = [
-    'alabaster',
-    'astroid',
     'blib2to3',
-    'debugpy',
-    'docutils',
     'humanfriendly',
-    'jedi',
     'jinja2',
     'keyring',
     'pkg_resources',
-    'parso',
     'pylint',
     'pylsp_black',
     'pyls_spyder',
-    'qtawesome',
     'setuptools',
     'spyder',
     'spyder_kernels',
     'spyder_terminal',
-    'textdistance',
 ]
 
 # Packages to exclude

--- a/installers/macOS/packages.py
+++ b/installers/macOS/packages.py
@@ -28,11 +28,6 @@ docutils :
 humanfriendly :
     spyder-terminal plugin
     ModuleNotFoundError: No module named 'humanfriendly.tables'
-IPython :
-    [IPKernelApp] WARNING | Could not copy README_STARTUP to startup dir.
-    Source file
-    <path>/Resources/lib/python38.zip/IPython/core/profile/README_STARTUP
-    does not exist
 jedi :
     jedi.api.environment.InvalidPythonEnvironment: Could not get version
     information for '<path>/Contents/MacOS/python': InternalError("The
@@ -42,8 +37,6 @@ jinja2 :
     No module named 'jinja2.ext'
 keyring :
     ModuleNotFoundError: No module named 'keyring.backends.<mod>'
-pandas :
-    From Variable explorer: KeyError('pandas._libs.interval')
 parso :
     jedi.api.environment.InvalidPythonEnvironment: Could not get version
     information for '/Users/rclary/opt/miniconda3/envs/c2w_37/bin/python':
@@ -56,13 +49,8 @@ pkg_resources:
     ImportError: The 'more_itertools' package is required; normally this is
     bundled with this package so if you get this warning, consult the
     packager of your distribution.
-pygments :
-    ModuleNotFoundError: No module named 'pygments.formatters.latex'
 pylint :
     <path>/Contents/MacOS/python: No module named pylint.__main__
-pylsp :
-    <path>/Contents/MacOS/python: No module named pylsp
-    Note: still occurs in alias mode
 pylsp_black :
     Mandatory: python-pyls-black >=1.0.0 : None (NOK)
 pyls_spyder :
@@ -72,8 +60,6 @@ qtawesome :
     python38.zip/qtawesome/fonts/fontawesome4.7-webfont.ttf'
 setuptools :
     Mandatory: setuptools >=49.6.0 : None (NOK)
-sphinx :
-    No module named 'sphinx.builders.changes'
 spyder :
     NotADirectoryError: [Errno 20] Not a directory: '<path>/Resources/lib/
     python38.zip/spyder/app/mac_stylesheet.qss'
@@ -94,20 +80,16 @@ PACKAGES = [
     'debugpy',
     'docutils',
     'humanfriendly',
-    'IPython',
     'jedi',
     'jinja2',
     'keyring',
     'pkg_resources',
     'parso',
-    'pygments',
     'pylint',
-    'pylsp',
     'pylsp_black',
     'pyls_spyder',
     'qtawesome',
     'setuptools',
-    'sphinx',
     'spyder',
     'spyder_kernels',
     'spyder_terminal',
@@ -119,16 +101,8 @@ EXCLUDES = []
 
 # modules that py2app misses
 INCLUDES = [
-    '_sitebuiltins',  # required for IPython help()
     'jellyfish',
-    # required for sphinx
-    'sphinxcontrib.applehelp',
-    'sphinxcontrib.devhelp',
-    'sphinxcontrib.htmlhelp',
-    'sphinxcontrib.jsmath',
-    'sphinxcontrib.qthelp',
-    'sphinxcontrib.serializinghtml',
-    'platformdirs.macos',  # required for platformdirs
+    'pylsp',
 ]
 
 SCIENTIFIC = [

--- a/installers/macOS/packages.py
+++ b/installers/macOS/packages.py
@@ -60,3 +60,46 @@ SCIENTIFIC = [
     'scipy',
     'sympy',
 ]
+
+
+def patch_py2app():
+    """
+    Patch py2app PyQt recipe and site.py for version 0.27.
+    Remove after version 0.28 is available.
+    """
+    from importlib.util import find_spec
+    from importlib.metadata import version
+    from packaging.version import parse
+    from pathlib import Path
+
+    from setup import logger
+
+    logger.info('Patching py2app')
+
+    py2app_ver = version('py2app')
+    if parse(py2app_ver) > parse('0.27'):
+        raise DeprecationWarning(f'py2app version {py2app_ver} > 0.27; '
+                                 'stop using patch_py2app.')
+
+    root = Path(find_spec('py2app').origin).parent
+
+    # Patch site.py
+    site_file = root / 'apptemplate' / 'lib' / 'site.py'
+    append_text = ("builtins.quit = "
+                   "_sitebuiltins.Quitter('quit', 'Ctrl-D (i.e. EOF)')\n"
+                   "builtins.exit = "
+                   "_sitebuiltins.Quitter('exit', 'Ctrl-D (i.e. EOF)')\n")
+    text = site_file.read_text()
+    if append_text not in text:
+        site_file.write_text(text + append_text)
+
+    # Patch qt5.py
+    qt5_file = root / 'recipes' / 'qt5.py'
+    search_text = "if qtdir != os.path.dirname(PyQt5.__file__):"
+    replace_text = "if os.path.dirname(PyQt5.__file__) not in qtdir:"
+    text = qt5_file.read_text()
+    if replace_text not in text:
+        qt5_file.write_text(text.replace(search_text, replace_text))
+
+
+patch_py2app()

--- a/installers/macOS/packages.py
+++ b/installers/macOS/packages.py
@@ -9,26 +9,13 @@ The following packages are included in py2app's PACKAGES option so that
 they will be placed in Spyder.app/Contents/Resources/lib/python<ver>
 instead.
 
-blib2to3 :
-    File "<frozen zipimport>", line 177, in get_data
-    KeyError: 'blib2to3/Users/rclary/Library/Caches/black/20.8b1/
-    Grammar3.8.6.final.0.pickle'
 humanfriendly :
     spyder-terminal plugin
     ModuleNotFoundError: No module named 'humanfriendly.tables'
-jinja2 :
-    No module named 'jinja2.ext'
-keyring :
-    ModuleNotFoundError: No module named 'keyring.backends.<mod>'
-PIL :
-    Library not loaded: @loader_path/.dylibs/libjpeg.9.dylib
-    Note: only applicable to not-Lite build
 pkg_resources:
     ImportError: The 'more_itertools' package is required; normally this is
     bundled with this package so if you get this warning, consult the
     packager of your distribution.
-pylint :
-    <path>/Contents/MacOS/python: No module named pylint.__main__
 pylsp_black :
     Mandatory: python-pyls-black >=1.0.0 : None (NOK)
 pyls_spyder :
@@ -46,12 +33,8 @@ spyder_terminal :
 
 # Packages that cannot be in the zip folder
 PACKAGES = [
-    'blib2to3',
     'humanfriendly',
-    'jinja2',
-    'keyring',
     'pkg_resources',
-    'pylint',
     'pylsp_black',
     'pyls_spyder',
     'setuptools',

--- a/installers/macOS/req-build.txt
+++ b/installers/macOS/req-build.txt
@@ -1,4 +1,4 @@
 # For building standalone Mac app
-py2app==0.22
+py2app>=0.27
 dmgbuild>=1.4.2
 jupyter-core<4.9  # remove after py2app update

--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -66,11 +66,9 @@ def make_app_bundle(dist_dir, make_lite=False):
 
     if make_lite:
         EXCLUDES.extend(SCIENTIFIC)
-        EXCLUDES.append('PIL')
         EXCLUDE_EGG.extend(['pillow'])
     else:
         INCLUDES.extend(SCIENTIFIC)
-        PACKAGES.extend(['PIL'])
 
     EXCLUDE_EGG.extend(EXCLUDES)
     EDIT_EXT = [ext[1:] for ext in _get_extensions(EDIT_FILETYPES)]

--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -54,90 +54,6 @@ def make_app_bundle(dist_dir, make_lite=False):
     make_lite : bool, optional
         Whether to create the application bundle with minimal packages.
         The default is False.
-
-    NOTES
-    -----
-    py2app includes all packages in Spyder.app/Contents/Resources/lib/
-    python<ver>.zip, but some packages have issues when placed there.
-    The following packages are included in py2app's PACKAGES option so that
-    they will be placed in Spyder.app/Contents/Resources/lib/python<ver>
-    instead.
-
-    alabaster :
-        Error message: [Errno 20] Not a directory: '<path>/Resources/lib/
-        python38.zip/alabaster'
-    astroid :
-        ImportError: cannot import name 'context' from 'astroid'
-        (<path>/Resources/lib/python38.zip/astroid/__init__.pyc)
-    blib2to3 :
-        File "<frozen zipimport>", line 177, in get_data
-        KeyError: 'blib2to3/Users/rclary/Library/Caches/black/20.8b1/
-        Grammar3.8.6.final.0.pickle'
-    debugpy :
-        NotADirectoryError: [Errno 20] Not a directory:
-        '<path>/Resources/lib/python39.zip/debugpy/_vendored'
-    docutils :
-        [Errno 20] Not a directory: '<path>/Resources/lib/python39.zip/
-        docutils/writers/latex2e/docutils.sty'
-    humanfriendly :
-        spyder-terminal plugin
-        ModuleNotFoundError: No module named 'humanfriendly.tables'
-    IPython :
-        [IPKernelApp] WARNING | Could not copy README_STARTUP to startup dir.
-        Source file
-        <path>/Resources/lib/python38.zip/IPython/core/profile/README_STARTUP
-        does not exist
-    jedi :
-        jedi.api.environment.InvalidPythonEnvironment: Could not get version
-        information for '<path>/Contents/MacOS/python': InternalError("The
-        subprocess <path>/Contents/MacOS/python has crashed (EOFError('Ran out
-        of input'), stderr=).")
-    jinja2 :
-        No module named 'jinja2.ext'
-    keyring :
-        ModuleNotFoundError: No module named 'keyring.backends.<mod>'
-    pandas :
-        From Variable explorer: KeyError('pandas._libs.interval')
-    parso :
-        jedi.api.environment.InvalidPythonEnvironment: Could not get version
-        information for '/Users/rclary/opt/miniconda3/envs/c2w_37/bin/python':
-        InternalError("The subprocess /Users/rclary/opt/miniconda3/envs/c2w_37/
-        bin/python has crashed (EOFError('Ran out of input'), stderr=).")
-    PIL :
-        Library not loaded: @loader_path/.dylibs/libjpeg.9.dylib
-        Note: only applicable to not-Lite build
-    pkg_resources:
-        ImportError: The 'more_itertools' package is required; normally this is
-        bundled with this package so if you get this warning, consult the
-        packager of your distribution.
-    pygments :
-        ModuleNotFoundError: No module named 'pygments.formatters.latex'
-    pylint :
-        <path>/Contents/MacOS/python: No module named pylint.__main__
-    pylsp :
-        <path>/Contents/MacOS/python: No module named pylsp
-        Note: still occurs in alias mode
-    pylsp_black :
-        Mandatory: python-pyls-black >=1.0.0 : None (NOK)
-    pyls_spyder :
-        Mandatory: pyls_spyder >=0.1.1 : None (NOK)
-    qtawesome :
-        NotADirectoryError: [Errno 20] Not a directory: '<path>/Resourses/lib/
-        python38.zip/qtawesome/fonts/fontawesome4.7-webfont.ttf'
-    setuptools :
-        Mandatory: setuptools >=49.6.0 : None (NOK)
-    sphinx :
-        No module named 'sphinx.builders.changes'
-    spyder :
-        NotADirectoryError: [Errno 20] Not a directory: '<path>/Resources/lib/
-        python38.zip/spyder/app/mac_stylesheet.qss'
-    spyder_kernels :
-        No module named spyder_kernels.console.__main__
-    spyder_terminal :
-        No module named spyder_terminal.server
-    textdistance :
-        NotADirectoryError: [Errno 20] Not a directory: '<path>/Resources/lib/
-        python39.zip/textdistance/libraries.json'
     """
     from spyder.config.utils import EDIT_FILETYPES, _get_extensions
 
@@ -157,33 +73,16 @@ def make_app_bundle(dist_dir, make_lite=False):
     build_type = 'lite' if make_lite else 'full'
     logger.info('Creating %s app bundle...', build_type)
 
-    PACKAGES = ['alabaster', 'astroid', 'blib2to3', 'debugpy', 'docutils',
-                'humanfriendly', 'IPython', 'jedi', 'jinja2', 'keyring',
-                'pkg_resources', 'parso', 'pygments', 'pylint', 'pylsp',
-                'pylsp_black', 'pyls_spyder', 'qtawesome', 'setuptools',
-                'sphinx', 'spyder', 'spyder_kernels', 'spyder_terminal',
-                'textdistance'
-                ]
-    INCLUDES = ['_sitebuiltins',  # required for IPython help()
-                'jellyfish',
-                # required for sphinx
-                'sphinxcontrib.applehelp', 'sphinxcontrib.devhelp',
-                'sphinxcontrib.htmlhelp', 'sphinxcontrib.jsmath',
-                'sphinxcontrib.qthelp', 'sphinxcontrib.serializinghtml',
-                'platformdirs.macos',  # required for platformdirs
-                ]
-    EXCLUDES = []
+    from packages import PACKAGES, INCLUDES, EXCLUDES, SCIENTIFIC
+
     EXCLUDE_EGG = ['py2app']
 
     if make_lite:
-        EXCLUDES.extend([
-            'numpy', 'scipy', 'pandas', 'matplotlib', 'cython', 'sympy', 'PIL'
-        ])
+        EXCLUDES.extend(SCIENTIFIC)
+        EXCLUDES.append('PIL')
         EXCLUDE_EGG.extend(['pillow'])
     else:
-        INCLUDES.extend([
-            'numpy', 'scipy', 'pandas', 'matplotlib', 'cython', 'sympy'
-        ])
+        INCLUDES.extend(SCIENTIFIC)
         PACKAGES.extend(['pandas', 'PIL'])
 
     EXCLUDE_EGG.extend(EXCLUDES)

--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -57,19 +57,6 @@ def make_app_bundle(dist_dir, make_lite=False):
     """
     from spyder.config.utils import EDIT_FILETYPES, _get_extensions
 
-    # Patch py2app for IPython help()
-    py2app_file = pkg_resources.pkgutil.get_loader('py2app').get_filename()
-    site_file = os.path.join(os.path.dirname(py2app_file), 'apptemplate',
-                             'lib', 'site.py')
-    logger.info('Patching %s...', site_file)
-    with open(site_file, 'a+') as f:
-        f.seek(0)
-        content = f.read()
-        if 'builtins.help = _sitebuiltins._Helper()' not in content:
-            f.write('\nimport builtins'
-                    '\nimport _sitebuiltins'
-                    '\nbuiltins.help = _sitebuiltins._Helper()\n')
-
     build_type = 'lite' if make_lite else 'full'
     logger.info('Creating %s app bundle...', build_type)
 
@@ -83,15 +70,10 @@ def make_app_bundle(dist_dir, make_lite=False):
         EXCLUDE_EGG.extend(['pillow'])
     else:
         INCLUDES.extend(SCIENTIFIC)
-        PACKAGES.extend(['pandas', 'PIL'])
+        PACKAGES.extend(['PIL'])
 
     EXCLUDE_EGG.extend(EXCLUDES)
     EDIT_EXT = [ext[1:] for ext in _get_extensions(EDIT_FILETYPES)]
-
-    # Get rtree dylibs
-    rtree_loc = pkg_resources.get_distribution('rtree').module_path
-    rtree_dylibs = os.scandir(os.path.join(rtree_loc, 'rtree', 'lib'))
-    FRAMEWORKS = [lib.path for lib in rtree_dylibs]
 
     OPTIONS = {
         'optimize': 0,
@@ -100,7 +82,6 @@ def make_app_bundle(dist_dir, make_lite=False):
         'excludes': EXCLUDES,
         'iconfile': ICONFILE,
         'dist_dir': dist_dir,
-        'frameworks': FRAMEWORKS,
         'emulate_shell_environment': True,
         'plist': {
             'CFBundleDocumentTypes': [{'CFBundleTypeExtensions': EDIT_EXT,


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Updated macOS installer to use the latest `py2app=0.27` .
This version of py2app includes many improved recipes, greatly simplifying our lists of packages that have to be excluded from zip archive or included in the bundle.
`py2app` now also handles the `egg-info`/`dist` files.

A patch is still required and can be removed at a later `py2app` version.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary 

<!--- Thanks for your help making Spyder better for everyone! --->
