### PR TITLE
PR: Limit jupyter-core to be less than 4.9 for macOS Installer

### DIFF
--- a/installers/macOS/req-build.txt
+++ b/installers/macOS/req-build.txt
@@ -1,3 +1,4 @@
 # For building standalone Mac app
 py2app==0.22
 dmgbuild>=1.4.2
+jupyter-core<4.9  # remove after py2app update


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Limit jupyter-core to version <4.9.
This should be a temporary fix for failure to load nbconvert in macOS installers until this can be resolved with py2app.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16649


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary 

<!--- Thanks for your help making Spyder better for everyone! --->
