### PR TITLE
PR: Try to fix bug when setting cursor shape for single click to open (Files/Projects)

### DIFF
--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -1601,12 +1601,13 @@ class DirView(QTreeView, SpyderWidgetMixin):
     # ------------------------------------------------------------------------
     def set_single_click_to_open(self, value):
         """Set single click to open items."""
-        # Track mouse movements to change cursor shape.
+        # Track mouse movements to change cursor shape when the option is
+        # True. This activates the mouseMoveEvent declared above.
         if value:
             self.setMouseTracking(True)
         else:
-            self.unsetCursor()
             self.setMouseTracking(False)
+            self.unsetCursor()
 
     def set_file_associations(self, value):
         """Set file associations open items."""


### PR DESCRIPTION
## Description of Changes

- In some circumstances the pointing hand cursor is shown when single click to open is not active.
- This could help to solve that problem. However, I'm not really sure it does because this bug is really hard to reproduce.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
