### PR TITLE
PR: Catch error when trying to install event filter in WebView widget

### DIFF
--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -367,9 +367,15 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
         else:
             super(WebView, self).setHtml(html, baseUrl)
 
-        # The event filter needs to be installed every time html is set
-        # because the proxy changes with new content.
-        self.focusProxy().installEventFilter(self)
+        # This is required to catch an error with PyQt 5.9, for which
+        # it seems this functionality is not working.
+        # Fixes spyder-ide/spyder#16703
+        try:
+            # The event filter needs to be installed every time html is set
+            # because the proxy changes with new content.
+            self.focusProxy().installEventFilter(self)
+        except AttributeError:
+            pass
 
     def load(self, url):
         """


### PR DESCRIPTION
## Description of Changes

It seems this problem appears only in older PyQt versions (i.e. 5.9)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16703.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
