### PR TITLE
PR: UX improvements to panes that inherit from OneColumnTree widget

### DIFF
--- a/.github/scripts/modules_test.sh
+++ b/.github/scripts/modules_test.sh
@@ -88,6 +88,9 @@ for f in spyder/*/*/*.py; do
     if [[ $f == spyder/api/plugins/*.py ]]; then
         continue
     fi
+    if [[ $f == spyder/plugins/pylint/main_widget.py ]]; then
+        continue
+    fi
     python "$f"
     if [ $? -ne 0 ]; then
         exit 1

--- a/spyder/plugins/findinfiles/widgets/main_widget.py
+++ b/spyder/plugins/findinfiles/widgets/main_widget.py
@@ -583,7 +583,8 @@ class FindInFilesWidget(PluginMainWidget):
 
         # Setup result_browser
         self.result_browser.set_path(options[0])
-        self.result_browser.longest_item = ''
+        self.result_browser.longest_file_item = ''
+        self.result_browser.longest_line_item = ''
 
         # Start
         self.running = True

--- a/spyder/plugins/findinfiles/widgets/main_widget.py
+++ b/spyder/plugins/findinfiles/widgets/main_widget.py
@@ -446,6 +446,7 @@ class FindInFilesWidget(PluginMainWidget):
         Current search thread has finished.
         """
         self.result_browser.set_sorting(ON)
+        self.result_browser.set_width()
         self.result_browser.expandAll()
         if self.search_thread is None:
             return
@@ -580,8 +581,9 @@ class FindInFilesWidget(PluginMainWidget):
         # Update and set options
         self._update_options()
 
-        # Set path in result_browser
+        # Setup result_browser
         self.result_browser.set_path(options[0])
+        self.result_browser.longest_item = ''
 
         # Start
         self.running = True

--- a/spyder/plugins/findinfiles/widgets/results_browser.py
+++ b/spyder/plugins/findinfiles/widgets/results_browser.py
@@ -40,7 +40,8 @@ class LineMatchItem(QTreeWidgetItem):
     def __init__(self, parent, lineno, colno, match, font, text_color):
         self.lineno = lineno
         self.colno = colno
-        self.match = match
+        self.match = match['formatted_text']
+        self.plain_match = match['text']
         self.text_color = text_color
         self.font = font
         super().__init__(parent, [self.__repr__()], QTreeWidgetItem.Type)

--- a/spyder/plugins/findinfiles/widgets/results_browser.py
+++ b/spyder/plugins/findinfiles/widgets/results_browser.py
@@ -50,6 +50,7 @@ class LineMatchItem(QTreeWidgetItem):
         _str = (
             f"<!-- LineMatchItem -->"
             f"<p style=\"color:'{self.text_color}';\">"
+            f'&nbsp;&nbsp;'
             f"<b>{self.lineno}</b> ({self.colno}): "
             f"<span style='font-family:{self.font.family()};"
             f"font-size:{self.font.pointSize()}pt;'>{match}</span></p>"

--- a/spyder/plugins/findinfiles/widgets/results_browser.py
+++ b/spyder/plugins/findinfiles/widgets/results_browser.py
@@ -206,7 +206,13 @@ class ResultsBrowser(OneColumnTree):
 
     def clicked(self, item):
         """Click event."""
-        self.activated(item)
+        if isinstance(item, FileMatchItem):
+            if item.isExpanded():
+                self.collapseItem(item)
+            else:
+                self.expandItem(item)
+        else:
+            self.activated(item)
 
     def clear_title(self, search_text):
         self.font = get_font()

--- a/spyder/plugins/findinfiles/widgets/search_thread.py
+++ b/spyder/plugins/findinfiles/widgets/search_thread.py
@@ -372,8 +372,8 @@ class SearchThread(QThread):
 
         match_color = SpyderPalette.COLOR_OCCURRENCE_4
         trunc_line = dict(
-            text = ''.join([left, match, right]),
-            formatted_text = (
+            text=''.join([left, match, right]),
+            formatted_text=(
                 f'<span style="color:{self.text_color}">'
                 f'{html_escape(left)}'
                 f'<span style="background-color:{match_color}">'

--- a/spyder/plugins/findinfiles/widgets/search_thread.py
+++ b/spyder/plugins/findinfiles/widgets/search_thread.py
@@ -26,6 +26,15 @@ from spyder.utils.palette import SpyderPalette
 _ = get_translation('spyder')
 
 
+# ---- Constants
+# ----------------------------------------------------------------------------
+ELLIPSIS = '...'
+MAX_RESULT_LENGTH = 80
+MAX_NUM_CHAR_FRAGMENT = 40
+
+
+# ---- Thread
+# ----------------------------------------------------------------------------
 class SearchThread(QThread):
     """Find in files search thread."""
     PYTHON_EXTENSIONS = ['.py', '.pyw', '.pyx', '.ipy', '.pyi', '.pyt']
@@ -307,10 +316,6 @@ class SearchThread(QThread):
         """
         Shorten text on line to display the match within `max_line_length`.
         """
-        ellipsis = '...'
-        max_line_length = 80
-        max_num_char_fragment = 40
-
         html_escape_table = {
             "&": "&amp;",
             '"': "&quot;",
@@ -326,7 +331,7 @@ class SearchThread(QThread):
         line = str(line)
         left, match, right = line[:start], line[start:end], line[end:]
 
-        if len(line) > max_line_length:
+        if len(line) > MAX_RESULT_LENGTH:
             offset = (len(line) - len(match)) // 2
 
             left = left.split(' ')
@@ -334,8 +339,8 @@ class SearchThread(QThread):
 
             if num_left_words == 1:
                 left = left[0]
-                if len(left) > max_num_char_fragment:
-                    left = ellipsis + left[-offset:]
+                if len(left) > MAX_NUM_CHAR_FRAGMENT:
+                    left = ELLIPSIS + left[-offset:]
                 left = [left]
 
             right = right.split(' ')
@@ -343,39 +348,40 @@ class SearchThread(QThread):
 
             if num_right_words == 1:
                 right = right[0]
-                if len(right) > max_num_char_fragment:
-                    right = right[:offset] + ellipsis
+                if len(right) > MAX_NUM_CHAR_FRAGMENT:
+                    right = right[:offset] + ELLIPSIS
                 right = [right]
 
             left = left[-4:]
             right = right[:4]
 
             if len(left) < num_left_words:
-                left = [ellipsis] + left
+                left = [ELLIPSIS] + left
 
             if len(right) < num_right_words:
-                right = right + [ellipsis]
+                right = right + [ELLIPSIS]
 
             left = ' '.join(left)
             right = ' '.join(right)
 
-            if len(left) > max_num_char_fragment:
-                left = ellipsis + left[-30:]
+            if len(left) > MAX_NUM_CHAR_FRAGMENT:
+                left = ELLIPSIS + left[-30:]
 
-            if len(right) > max_num_char_fragment:
-                right = right[:30] + ellipsis
-
-        left = html_escape(left)
-        right = html_escape(right)
-        match = html_escape(match)
+            if len(right) > MAX_NUM_CHAR_FRAGMENT:
+                right = right[:30] + ELLIPSIS
 
         match_color = SpyderPalette.COLOR_OCCURRENCE_4
-        trunc_line = (
-            f'<span style="color:{self.text_color}">'
-            f'{left}'
-            f'<span style="background-color:{match_color}">{match}</span>'
-            f'{right}'
-            f'</span>'
+        trunc_line = dict(
+            text = ''.join([left, match, right]),
+            formatted_text = (
+                f'<span style="color:{self.text_color}">'
+                f'{html_escape(left)}'
+                f'<span style="background-color:{match_color}">'
+                f'{html_escape(match)}'
+                f'</span>'
+                f'{html_escape(right)}'
+                f'</span>'
+            )
         )
 
         return trunc_line

--- a/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
+++ b/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
@@ -257,7 +257,7 @@ def test_truncate_result_with_different_input(findinfiles, qtbot, line_input):
     truncated_line = thread.truncate_result(line_input, slice_start,
                                             slice_end)
     # then
-    assert truncated_line == expected_result
+    assert truncated_line['formatted_text'] == expected_result
 
 
 @pytest.mark.parametrize('findinfiles',

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -794,7 +794,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         root_item = editor_root.node
         text = ''
         if isinstance(item, FileRootItem):
-            line = 1
+            line = None
             if id(root_item) != id(item):
                 root_item = item
         else:

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -169,8 +169,14 @@ class ResultsTree(OneColumnTree):
             self.sig_edit_goto_requested.emit(fname, lineno, "")
 
     def clicked(self, item):
-        """Click event"""
-        self.activated(item)
+        """Click event."""
+        if isinstance(item, CategoryItem):
+            if item.isExpanded():
+                self.collapseItem(item)
+            else:
+                self.expandItem(item)
+        else:
+            self.activated(item)
 
     def clear_results(self):
         self.clear()

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -87,7 +87,54 @@ class PylintWidgetToolbarItems:
     Stretcher2 = 'stretcher_2'
 
 
-# --- Widgets
+# ---- Items
+class CategoryItem(QTreeWidgetItem):
+    """
+    Category item for results.
+
+    Notes
+    -----
+    Possible categories are Convention, Refactor, Warning and Error.
+    """
+
+    CATEGORIES = {
+        "Convention": {
+            'translation_string': _("Convention"),
+            'icon': ima.icon("convention")
+        },
+        "Refactor": {
+            'translation_string': _("Refactor"),
+            'icon': ima.icon("refactor")
+        },
+        "Warning": {
+            'translation_string': _("Warning"),
+            'icon': ima.icon("warning")
+        },
+        "Error": {
+            'translation_string': _("Error"),
+            'icon': ima.icon("error")
+        }
+    }
+
+    def __init__(self, parent, category, number_of_messages):
+        # Messages string to append to category.
+        if number_of_messages > 1 or number_of_messages == 0:
+            messages = _('messages')
+        else:
+            messages = _('message')
+
+        # Category title.
+        title = self.CATEGORIES[category]['translation_string']
+        title += f" ({number_of_messages} {messages})"
+
+        super().__init__(parent, [title], QTreeWidgetItem.Type)
+
+        # Set icon
+        icon = self.CATEGORIES[category]['icon']
+        self.setIcon(0, icon)
+
+
+# ---- Widgets
 # ----------------------------------------------------------------------------
 # TODO: display results on 3 columns instead of 1: msg_id, lineno, message
 class ResultsTree(OneColumnTree):
@@ -135,23 +182,21 @@ class ResultsTree(OneColumnTree):
         self.refresh()
 
     def refresh(self):
-        title = _("Results for ")+self.filename
+        title = _("Results for ") + self.filename
         self.set_title(title)
         self.clear()
         self.data = {}
 
         # Populating tree
         results = (
-            (_("Convention"), ima.icon("convention"), self.results["C:"]),
-            (_("Refactor"), ima.icon("refactor"), self.results["R:"]),
-            (_("Warning"), ima.icon("warning"), self.results["W:"]),
-            (_("Error"), ima.icon("error"), self.results["E:"]),
+            ("Convention", self.results["C:"]),
+            ("Refactor", self.results["R:"]),
+            ("Warning", self.results["W:"]),
+            ("Error", self.results["E:"]),
         )
-        for title, icon, messages in results:
-            title += " (%d message%s)" % (len(messages),
-                                          "s" if len(messages) > 1 else "")
-            title_item = QTreeWidgetItem(self, [title], QTreeWidgetItem.Type)
-            title_item.setIcon(0, icon)
+
+        for category, messages in results:
+            title_item = CategoryItem(self, category, len(messages))
             if not messages:
                 title_item.setDisabled(True)
 

--- a/spyder/widgets/onecolumntree.py
+++ b/spyder/widgets/onecolumntree.py
@@ -6,7 +6,7 @@
 
 # Third party imports
 from qtpy import PYQT5
-from qtpy.QtCore import Slot
+from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import QTreeWidget
 
 # Local imports
@@ -63,9 +63,10 @@ class OneColumnTree(QTreeWidget, SpyderWidgetMixin):
         self.itemSelectionChanged.connect(self.item_selection_changed)
 
         self.item_selection_changed()
+        self.setMouseTracking(True)
 
-    # --- SpyderWidgetMixin API
-    # ------------------------------------------------------------------------
+    # ---- SpyderWidgetMixin API
+    # -------------------------------------------------------------------------
     def setup(self):
         self.menu = self.create_menu("context_menu")
 
@@ -129,8 +130,8 @@ class OneColumnTree(QTreeWidget, SpyderWidgetMixin):
     def update_actions(self):
         pass
 
-    # --- Public API
-    # ------------------------------------------------------------------------
+    # ---- Public API
+    # -------------------------------------------------------------------------
     def activated(self, item):
         """Double-click event"""
         raise NotImplementedError
@@ -279,6 +280,21 @@ class OneColumnTree(QTreeWidget, SpyderWidgetMixin):
             self.insertTopLevelItem(index, item)
         self.restore_expanded_state()
 
+    # ---- Qt methods
+    # -------------------------------------------------------------------------
     def contextMenuEvent(self, event):
         """Override Qt method"""
         self.menu.popup(event.globalPos())
+
+    def mouseMoveEvent(self, event):
+        """Change cursor shape."""
+        index = self.indexAt(event.pos())
+        if index.isValid():
+            vrect = self.visualRect(index)
+            item_identation = vrect.x() - self.visualRect(self.rootIndex()).x()
+            if event.pos().x() > item_identation:
+                # When hovering over results
+                self.setCursor(Qt.PointingHandCursor)
+            else:
+                # On every other element
+                self.setCursor(Qt.ArrowCursor)

--- a/spyder/widgets/onecolumntree.py
+++ b/spyder/widgets/onecolumntree.py
@@ -7,7 +7,7 @@
 # Third party imports
 from qtpy import PYQT5
 from qtpy.QtCore import Qt, Slot
-from qtpy.QtWidgets import QTreeWidget
+from qtpy.QtWidgets import QAbstractItemView, QHeaderView, QTreeWidget
 
 # Local imports
 from spyder.api.widgets.mixins import SpyderWidgetMixin
@@ -62,8 +62,15 @@ class OneColumnTree(QTreeWidget, SpyderWidgetMixin):
         self.itemClicked.connect(self.clicked)
         self.itemSelectionChanged.connect(self.item_selection_changed)
 
-        self.item_selection_changed()
+        # To use mouseMoveEvent
         self.setMouseTracking(True)
+
+        # Use horizontal scrollbar when needed
+        self.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
+        self.header().setSectionResizeMode(0, QHeaderView.ResizeToContents)
+        self.header().setStretchLastSection(False)
+
+        self.item_selection_changed()
 
     # ---- SpyderWidgetMixin API
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## Description of Changes

* The panes that use that widget are Outline, Find and Code Analysis.
* Change mouse shape to pointing hand when hovering over tree elements

    ![pointing](https://user-images.githubusercontent.com/365293/139908483-a2761aa8-4d8e-4a14-8dea-0ab1724e09dc.gif)

* Collapse tree roots with a single click

    ![collapse](https://user-images.githubusercontent.com/365293/139909462-95e55e5e-8ad3-42de-acc1-2a46a3588f42.gif)

* Show horizontal scrollbar if content is too wide

    ![scrollbar](https://user-images.githubusercontent.com/365293/139909793-f935ba22-8be4-4f83-9c9e-da4d47f3b5b8.gif)

* Showing a background color when hovering entries in Find (before we were not showing any color).

    ![hover](https://user-images.githubusercontent.com/365293/143079114-40440089-96fc-430b-a914-dc4672d22fa5.gif)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
