### PR TITLE
PR: PySide - Do not pass `None` to QTreeView.setExpanded() (prevents a TypeError)

### DIFF
--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -90,11 +90,11 @@ class ProjectExplorerWidget(PluginMainWidget):
             self.treewidget.set_root_path(osp.dirname(directory))
             self.treewidget.set_folder_names([osp.basename(directory)])
         self.treewidget.setup_project_view()
-        try:
+
+        index = self.treewidget.get_index(directory)
+        if index is not None:
             self.treewidget.setExpanded(self.treewidget.get_index(directory),
                                         True)
-        except TypeError:
-            pass
 
     def clear(self):
         """Show an empty view"""


### PR DESCRIPTION
## Description of Changes

Minor patch to improve compatibility with PySide.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
rear1019

<!--- Thanks for your help making Spyder better for everyone! --->
