### PR TITLE
PR: Reimport ArrayEditor when displaying PIL images to avoid error (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -181,6 +181,10 @@ class CollectionsDelegate(QItemDelegate):
                 np.ndarray is not FakeObject and
                 PIL.Image is not FakeObject and
                 not object_explorer):
+            # Sometimes the ArrayEditor import above is not seen (don't know
+            # why), so we need to reimport it here.
+            # Fixes spyder-ide/spyder#16731
+            from .arrayeditor import ArrayEditor
             arr = np.array(value)
             editor = ArrayEditor(parent=parent)
             if not editor.setup_and_check(arr, title=key, readonly=readonly):

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -15,7 +15,7 @@ import operator
 
 # Third party imports
 from qtpy.compat import to_qvariant
-from qtpy.QtCore import QDateTime, Qt, Signal, Slot
+from qtpy.QtCore import QDateTime, Qt, Signal
 from qtpy.QtWidgets import (QAbstractItemDelegate, QDateEdit, QDateTimeEdit,
                             QItemDelegate, QLineEdit, QMessageBox, QTableView)
 from spyder_kernels.utils.lazymodules import (
@@ -32,8 +32,6 @@ from spyder.plugins.variableexplorer.widgets.arrayeditor import ArrayEditor
 from spyder.plugins.variableexplorer.widgets.dataframeeditor import (
     DataFrameEditor)
 from spyder.plugins.variableexplorer.widgets.texteditor import TextEditor
-from spyder.plugins.variableexplorer.widgets.objectexplorer.attribute_model \
-    import safe_tio_call
 
 
 LARGE_COLLECTION = 1e5


### PR DESCRIPTION
## Description of Changes

- I don't understand why but sometimes when we try to display an image through the Variable Explorer, Spyder throws an error saying that ArrayEditor is not defined.
- This avoids that error by reimporting ArrayEditor before using it.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16731

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
