### PR TITLE
PR: Fix crashes when certain plugins are not available

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1203,7 +1203,7 @@ class MainWindow(QMainWindow):
             console.toggle_view_action.setChecked(False)
             console.dockwidget.hide()
 
-        # Show Help and IPython consoles by default
+        # Show Help and IPython console by default
         plugins_to_show = []
         if help_plugin:
             plugins_to_show.append(help_plugin)

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -208,12 +208,13 @@ class Editor(SpyderPluginWidget):
         self.readwrite_status = ReadWriteStatus(self)
 
         # TODO: temporal fix while editor uses new API
-        statusbar = self.main.statusbar
-        statusbar.add_status_widget(self.readwrite_status)
-        statusbar.add_status_widget(self.eol_status)
-        statusbar.add_status_widget(self.encoding_status)
-        statusbar.add_status_widget(self.cursorpos_status)
-        statusbar.add_status_widget(self.vcs_status)
+        statusbar = self.main.get_plugin(Plugins.StatusBar, error=False)
+        if statusbar:
+            statusbar.add_status_widget(self.readwrite_status)
+            statusbar.add_status_widget(self.eol_status)
+            statusbar.add_status_widget(self.encoding_status)
+            statusbar.add_status_widget(self.cursorpos_status)
+            statusbar.add_status_widget(self.vcs_status)
 
         layout = QVBoxLayout()
         self.dock_toolbar = QToolBar(self)
@@ -1226,11 +1227,13 @@ class Editor(SpyderPluginWidget):
         completions = self.main.get_plugin(Plugins.Completions, error=False)
         outlineexplorer = self.main.get_plugin(
             Plugins.OutlineExplorer, error=False)
-        ipyconsole = self.main.get_plugin(Plugins.IPythonConsole)
+        ipyconsole = self.main.get_plugin(Plugins.IPythonConsole, error=False)
+
         self.main.restore_scrollbar_position.connect(
             self.restore_scrollbar_position)
         self.main.console.sig_edit_goto_requested.connect(self.load)
         self.redirect_stdio.connect(self.main.redirect_internalshell_stdio)
+
         if completions:
             self.main.completions.sig_language_completions_available.connect(
                 self.register_completion_capabilities)

--- a/spyder/plugins/history/plugin.py
+++ b/spyder/plugins/history/plugin.py
@@ -16,6 +16,7 @@ from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
 from spyder.api.translations import get_translation
+from spyder.config.base import get_conf_path
 from spyder.plugins.history.confpage import HistoryConfigPage
 from spyder.plugins.history.widgets import HistoryWidget
 
@@ -43,6 +44,11 @@ class HistoryLog(SpyderDockablePlugin):
     This signal is emitted when the focus of the code editor storing history
     changes.
     """
+
+    def __init__(self, parent=None, configuration=None):
+        """Initialization."""
+        super().__init__(parent, configuration)
+        self.add_history(get_conf_path('history.py'))
 
     # --- SpyderDockablePlugin API
     # ------------------------------------------------------------------------

--- a/spyder/plugins/history/tests/test_plugin.py
+++ b/spyder/plugins/history/tests/test_plugin.py
@@ -13,9 +13,9 @@ import pytest
 from qtpy.QtGui import QTextOption
 
 # Local imports
+from spyder.config.base import get_conf_path
 from spyder.config.manager import CONF
 from spyder.plugins.history import plugin as history
-from spyder.py3compat import to_text_string
 
 
 # =============================================================================
@@ -33,7 +33,7 @@ def create_file(name, content):
 # Qt Test Fixtures
 # =============================================================================
 @pytest.fixture
-def historylog(qtbot, monkeypatch):
+def historylog(qtbot):
     """
     Return a fixture for base history log, which is a plugin widget.
     """
@@ -57,8 +57,8 @@ def test_init(historylog):
     and widgets for a new HistoryLog instance.
     """
     hl = historylog
-    assert hl.get_widget().editors == []
-    assert hl.get_widget().filenames == []
+    assert len(hl.get_widget().editors) == 1
+    assert len(hl.get_widget().filenames) == 1
     assert len(hl.get_actions()) == 6
 
 
@@ -73,7 +73,7 @@ def test_add_history(historylog):
     hw = historylog.get_widget()
 
     # No editors yet.
-    assert len(hw.editors) == 0
+    assert len(hw.editors) == 1
 
     # Add one file.
     name1 = 'test_history.py'
@@ -85,18 +85,18 @@ def test_add_history(historylog):
     hl.add_history(path1)
 
     # Check tab and editor were created correctly.
-    assert len(hw.editors) == 1
-    assert hw.filenames == [path1]
-    assert hw.tabwidget.currentIndex() == 0
+    assert len(hw.editors) == 2
+    assert hw.filenames == [get_conf_path('history.py'), path1]
+    assert hw.tabwidget.currentIndex() == 1
     assert not hw.editors[0].linenumberarea.isVisible()
     assert hw.editors[0].wordWrapMode() == QTextOption.NoWrap
-    assert hw.tabwidget.tabText(0) == tab1
-    assert hw.tabwidget.tabToolTip(0) == path1
+    assert hw.tabwidget.tabText(1) == tab1
+    assert hw.tabwidget.tabToolTip(1) == path1
 
     # Try to add same file -- does not process filename again, so
     # linenumbers and wrap doesn't change.
     hw.add_history(path1)
-    assert hw.tabwidget.currentIndex() == 0
+    assert hw.tabwidget.currentIndex() == 1
     # assert not hw.editors[0].linenumberarea.isVisible()
 
     # Add another file.
@@ -109,26 +109,25 @@ def test_add_history(historylog):
     hw.add_history(path2)
 
     # Check second tab and editor were created correctly.
-    assert len(hw.editors) == 2
-    assert hw.filenames == [path1, path2]
-    assert hw.tabwidget.currentIndex() == 1
-    assert hw.editors[1].wordWrapMode() == (
+    assert len(hw.editors) == 3
+    assert hw.filenames == [get_conf_path('history.py'), path1, path2]
+    assert hw.tabwidget.currentIndex() == 2
+    assert hw.editors[2].wordWrapMode() == (
         QTextOption.WrapAtWordBoundaryOrAnywhere)
-    assert hw.editors[1].linenumberarea.isVisible()
-    assert hw.tabwidget.tabText(1) == tab2
-    assert hw.tabwidget.tabToolTip(1) == path2
-    assert hw.filenames == [path1, path2]
+    assert hw.editors[2].linenumberarea.isVisible()
+    assert hw.tabwidget.tabText(2) == tab2
+    assert hw.tabwidget.tabToolTip(2) == path2
 
     # Check differences between tabs based on setup.
-    assert hw.editors[0].supported_language
-    assert hw.editors[0].isReadOnly()
-    assert not hw.editors[0].isVisible()
-    assert hw.editors[0].toPlainText() == text1
-
-    assert not hw.editors[1].supported_language
+    assert hw.editors[1].supported_language
     assert hw.editors[1].isReadOnly()
-    assert hw.editors[1].isVisible()
-    assert hw.editors[1].toPlainText() == text2
+    assert not hw.editors[1].isVisible()
+    assert hw.editors[1].toPlainText() == text1
+
+    assert not hw.editors[2].supported_language
+    assert hw.editors[2].isReadOnly()
+    assert hw.editors[2].isVisible()
+    assert hw.editors[2].toPlainText() == text2
 
 
 def test_append_to_history(qtbot, historylog):
@@ -138,7 +137,6 @@ def test_append_to_history(qtbot, historylog):
     Test adding text to a history file.  Also test the go_to_eof config
     option for positioning the cursor.
     """
-    hl = historylog
     hw = historylog.get_widget()
 
     # Toggle to move to the end of the file after appending.
@@ -148,27 +146,27 @@ def test_append_to_history(qtbot, historylog):
     text1 = 'import re\n'
     path1 = create_file('test_history.py', text1)
     hw.add_history(path1)
-    hw.editors[0].set_cursor_position('sof')
+    hw.editors[1].set_cursor_position('sof')
     hw.append_to_history(path1, 'foo = "bar"\n')
-    assert hw.editors[0].toPlainText() == text1 + 'foo = "bar"\n'
-    assert hw.tabwidget.currentIndex() == 0
+    assert hw.editors[1].toPlainText() == text1 + 'foo = "bar"\n'
+    assert hw.tabwidget.currentIndex() == 1
 
     # Cursor moved to end.
-    assert hw.editors[0].is_cursor_at_end()
-    assert not hw.editors[0].linenumberarea.isVisible()
+    assert hw.editors[1].is_cursor_at_end()
+    assert not hw.editors[1].linenumberarea.isVisible()
 
     # Toggle to not move cursor after appending.
     hw.set_conf('go_to_eof', False)
 
     # Force cursor to the beginning of the file.
-    hw.editors[0].set_cursor_position('sof')
+    hw.editors[1].set_cursor_position('sof')
     hw.append_to_history(path1, 'a = r"[a-z]"\n')
-    assert hw.editors[0].toPlainText() == ('import re\n'
+    assert hw.editors[1].toPlainText() == ('import re\n'
                                            'foo = "bar"\n'
                                            'a = r"[a-z]"\n')
 
     # Cursor not at end.
-    assert not hw.editors[0].is_cursor_at_end()
+    assert not hw.editors[1].is_cursor_at_end()
 
 
 def test_toggle_wrap_mode(historylog):
@@ -183,18 +181,18 @@ def test_toggle_wrap_mode(historylog):
 
     # Starts with wrap mode off.
     hw.set_conf('wrap', False)
-    assert hw.editors[0].wordWrapMode() == QTextOption.NoWrap
+    assert hw.editors[1].wordWrapMode() == QTextOption.NoWrap
     assert not hw.get_conf('wrap')
 
     # Toggles wrap mode on.
     hw.set_conf('wrap', True)
-    assert hw.editors[0].wordWrapMode() == (
+    assert hw.editors[1].wordWrapMode() == (
         QTextOption.WrapAtWordBoundaryOrAnywhere)
     assert hw.get_conf('wrap')
 
     # Toggles wrap mode off.
     hw.set_conf('wrap', False)
-    assert hw.editors[0].wordWrapMode() == QTextOption.NoWrap
+    assert hw.editors[1].wordWrapMode() == QTextOption.NoWrap
     assert not hw.get_conf('wrap')
 
 
@@ -210,17 +208,17 @@ def test_toggle_line_numbers(historylog):
 
     # Starts without line numbers.
     hw.set_conf('line_numbers', False)
-    assert not hw.editors[0].linenumberarea.isVisible()
+    assert not hw.editors[1].linenumberarea.isVisible()
     assert not hw.get_conf('line_numbers')
 
     # Toggles line numbers on.
     hw.set_conf('line_numbers', True)
-    assert hw.editors[0].linenumberarea.isVisible()
+    assert hw.editors[1].linenumberarea.isVisible()
     assert hw.get_conf('line_numbers')
 
     # Toggles line numbers off.
     hw.set_conf('line_numbers', False)
-    assert not hw.editors[0].linenumberarea.isVisible()
+    assert not hw.editors[1].linenumberarea.isVisible()
     assert not hw.get_conf('line_numbers')
 
 

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -17,12 +17,12 @@ from qtpy.QtCore import Signal
 
 # Local imports
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
-from spyder.api.plugin_registration.decorators import on_plugin_available
+from spyder.api.plugin_registration.decorators import (
+    on_plugin_available, on_plugin_teardown)
 from spyder.api.translations import get_translation
-from spyder.config.base import get_conf_path
 from spyder.plugins.ipythonconsole.confpage import IPythonConsoleConfigPage
 from spyder.plugins.ipythonconsole.widgets.main_widget import (
-    IPythonConsoleWidget)
+    IPythonConsoleWidget, IPythonConsoleWidgetOptionsMenus)
 from spyder.plugins.mainmenu.api import (
     ApplicationMenus, ConsolesMenuSections, HelpMenuSections)
 from spyder.utils.programs import get_temp_dir
@@ -319,13 +319,6 @@ class IPythonConsole(SpyderDockablePlugin):
         # Connect Console focus request with Editor
         self.sig_editor_focus_requested.connect(self._switch_to_editor)
 
-    @on_plugin_available(plugin=Plugins.History)
-    def on_history_available(self):
-        # Show history file if no console is visible
-        if not self.get_widget().is_visible:
-            history = self.get_plugin(Plugins.History)
-            history.add_history(get_conf_path('history.py'))
-
     @on_plugin_available(plugin=Plugins.Projects)
     def on_projects_available(self):
         projects = self.get_plugin(Plugins.Projects)
@@ -333,6 +326,52 @@ class IPythonConsole(SpyderDockablePlugin):
         widget.projects_available = True
         projects.sig_project_loaded.connect(self._on_project_loaded)
         projects.sig_project_closed.connect(self._on_project_closed)
+
+    @on_plugin_teardown(plugin=Plugins.Preferences)
+    def on_preferences_teardown(self):
+        # Register conf page
+        preferences = self.get_plugin(Plugins.Preferences)
+        preferences.deregister_plugin_preferences(self)
+
+    @on_plugin_teardown(plugin=Plugins.MainMenu)
+    def on_main_menu_teardown(self):
+        mainmenu = self.get_plugin(Plugins.MainMenu)
+        mainmenu.remove_application_menu(ApplicationMenus.Consoles)
+
+        # IPython documentation menu
+        mainmenu.remove_item_from_application_menu(
+            IPythonConsoleWidgetOptionsMenus.Documentation,
+            menu_id=ApplicationMenus.Help
+         )
+
+    @on_plugin_teardown(plugin=Plugins.Editor)
+    def on_editor_teardown(self):
+        editor = self.get_plugin(Plugins.Editor)
+        self.sig_edit_goto_requested.disconnect(editor.load)
+        self.sig_edit_goto_requested[str, int, str, bool].disconnect(
+            self._load_file_in_editor)
+        editor.breakpoints_saved.disconnect(self.set_spyder_breakpoints)
+        editor.run_in_current_ipyclient.disconnect(self.run_script)
+        editor.run_cell_in_ipyclient.disconnect(self.run_cell)
+        editor.debug_cell_in_ipyclient.disconnect(self.debug_cell)
+
+        # Connect Editor debug action with Console
+        self.sig_pdb_state_changed.disconnect(editor.update_pdb_state)
+        editor.exec_in_extconsole.disconnect(
+            self.execute_code_and_focus_editor)
+        editor.sig_file_debug_message_requested.disconnect(
+            self.print_debug_file_msg)
+
+        # Connect Console focus request with Editor
+        self.sig_editor_focus_requested.disconnect(self._switch_to_editor)
+
+    @on_plugin_teardown(plugin=Plugins.Projects)
+    def on_projects_teardown(self):
+        projects = self.get_plugin(Plugins.Projects)
+        widget = self.get_widget()
+        widget.projects_available = False
+        projects.sig_project_loaded.disconnect(self._on_project_loaded)
+        projects.sig_project_closed.disconnect(self._on_project_closed)
 
     def update_font(self):
         """Update font from Preferences"""

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -201,7 +201,7 @@ class IPythonConsole(SpyderDockablePlugin):
         The new working directory path.
     """
 
-    # --- SpyderDockablePlugin API
+    # ---- SpyderDockablePlugin API
     # -------------------------------------------------------------------------
     @staticmethod
     def get_name():
@@ -387,7 +387,7 @@ class IPythonConsole(SpyderDockablePlugin):
     def on_mainwindow_visible(self):
         self.create_new_client(give_focus=False)
 
-    # --- Private methods
+    # ---- Private methods
     # -------------------------------------------------------------------------
     def _load_file_in_editor(self, fname, lineno, word, processevents):
         editor = self.get_plugin(Plugins.Editor)
@@ -421,11 +421,10 @@ class IPythonConsole(SpyderDockablePlugin):
                     except Exception:
                         pass
 
-    # --- Public API
+    # ---- Public API
     # -------------------------------------------------------------------------
 
-    # ---- Spyder Kernels handlers registry functionality ---------------------
-    # -------------------------------------------------------------------------
+    # ---- Spyder Kernels handlers registry functionality
     def register_spyder_kernel_call_handler(self, handler_id, handler):
         """
         Register a callback for it to be available for the kernels of new
@@ -814,7 +813,7 @@ class IPythonConsole(SpyderDockablePlugin):
         """
         self.get_widget().restart_kernel()
 
-    # ---- For documentation and help -----------------------------------------
+    # ---- For documentation and help
     def show_intro(self):
         """Show intro to IPython help."""
         self.get_widget().show_intro()


### PR DESCRIPTION
## Description of Changes

- Spyder was crashing after turning off several plugins (e.g. Help, Shortcuts or the Editor). This should fix most of those errors.
- Add teardown methods to the IPython console to be able to turn it off. They were missing after #16324.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
