### PR TITLE
PR: Constrain IPython to be less rhan 7.28.0 for macOS installer

### DIFF
--- a/installers/macOS/req-build.txt
+++ b/installers/macOS/req-build.txt
@@ -2,3 +2,4 @@
 py2app==0.22
 dmgbuild>=1.4.2
 jupyter-core<4.9  # remove after py2app update
+ipython<7.28.0  # remove after py2app update


### PR DESCRIPTION
## Description of Changes

Constrain IPython<7.28.0 for macOS installer only, until #16651 can be merged.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16828


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@mrclary 
<!--- Thanks for your help making Spyder better for everyone! --->
