### PR TITLE
PR: Improve the "Create new project" dialog (Projects)

### DIFF
--- a/spyder/plugins/projects/api.py
+++ b/spyder/plugins/projects/api.py
@@ -9,21 +9,17 @@ Projects Plugin API.
 """
 
 # Standard library imports
-import os
 import os.path as osp
 from collections import OrderedDict
 
 # Local imports
-from spyder.api.exceptions import SpyderAPIError
 from spyder.api.translations import get_translation
 from spyder.config.base import get_project_config_folder
 from spyder.plugins.projects.utils.config import (ProjectMultiConfig,
                                                   PROJECT_NAME_MAP,
                                                   PROJECT_DEFAULTS,
                                                   PROJECT_CONF_VERSION,
-                                                  WORKSPACE, CODESTYLE,
-                                                  ENCODING, VCS)
-
+                                                  WORKSPACE)
 
 # Localization
 _ = get_translation("spyder")
@@ -43,7 +39,7 @@ class BaseProjectType:
         self.root_path = root_path
         self.open_project_files = []
         self.open_non_project_files = []
-        path = os.path.join(root_path, get_project_config_folder(), 'config')
+        path = osp.join(root_path, get_project_config_folder(), 'config')
         self.config = ProjectMultiConfig(
             PROJECT_NAME_MAP,
             path=path,
@@ -72,9 +68,9 @@ class BaseProjectType:
         """Set a list of files opened by the project."""
         processed_recent_files = []
         for recent_file in recent_files:
-            if os.path.isfile(recent_file):
+            if osp.isfile(recent_file):
                 try:
-                    relative_recent_file = os.path.relpath(
+                    relative_recent_file = osp.relpath(
                         recent_file, self.root_path)
                     processed_recent_files.append(relative_recent_file)
                 except ValueError:
@@ -95,11 +91,11 @@ class BaseProjectType:
         else:
             recent_files = self.get_option("recent_files", default=[])
 
-        recent_files = [recent_file if os.path.isabs(recent_file)
-                        else os.path.join(self.root_path, recent_file)
+        recent_files = [recent_file if osp.isabs(recent_file)
+                        else osp.join(self.root_path, recent_file)
                         for recent_file in recent_files]
         for recent_file in recent_files[:]:
-            if not os.path.isfile(recent_file):
+            if not osp.isfile(recent_file):
                 recent_files.remove(recent_file)
 
         return list(OrderedDict.fromkeys(recent_files))

--- a/spyder/plugins/projects/widgets/projectdialog.py
+++ b/spyder/plugins/projects/widgets/projectdialog.py
@@ -11,7 +11,6 @@ from __future__ import print_function
 
 # Standard library imports
 import errno
-import os
 import os.path as osp
 import sys
 import tempfile
@@ -97,6 +96,7 @@ class ProjectDialog(QDialog):
         self.combo_python_version = QComboBox()
 
         self.label_information = QLabel("")
+        self.label_information.hide()
 
         self.button_select_location = create_toolbutton(
             self,
@@ -125,15 +125,15 @@ class ProjectDialog(QDialog):
         self.combo_python_version.setCurrentIndex(
             python_versions.index(current_python_version))
         self.setWindowTitle(_('Create new project'))
-        self.setFixedWidth(500)
         self.label_python_version.setVisible(False)
         self.combo_python_version.setVisible(False)
 
         # Layouts
         layout_top = QHBoxLayout()
         layout_top.addWidget(self.radio_new_dir)
+        layout_top.addSpacing(15)
         layout_top.addWidget(self.radio_from_dir)
-        layout_top.addStretch(1)
+        layout_top.addSpacing(200)
         self.groupbox.setLayout(layout_top)
 
         layout_grid = QGridLayout()
@@ -150,11 +150,11 @@ class ProjectDialog(QDialog):
 
         layout = QVBoxLayout()
         layout.addWidget(self.groupbox)
-        layout.addSpacing(10)
+        layout.addSpacing(8)
         layout.addLayout(layout_grid)
-        layout.addStretch()
-        layout.addSpacing(20)
+        layout.addSpacing(8)
         layout.addWidget(self.bbox)
+        layout.setSizeConstraint(layout.SetFixedSize)
 
         self.setLayout(layout)
 
@@ -190,6 +190,7 @@ class ProjectDialog(QDialog):
         # Setup
         self.text_project_name.setEnabled(self.radio_new_dir.isChecked())
         self.label_information.setText('')
+        self.label_information.hide()
 
         if name and self.radio_new_dir.isChecked():
             # Allow to create projects only on new directories.
@@ -221,6 +222,7 @@ class ProjectDialog(QDialog):
 
         # Set message
         if msg:
+            self.label_information.show()
             self.label_information.setText('\n' + msg)
 
         # Allow to create project if validation was successful
@@ -264,7 +266,6 @@ def test():
         @staticmethod
         def validate_name(path, name):
             return False, "BOOM!"
-
 
     app = qapplication()
     dlg = ProjectDialog(None, {"empty": MockProjectType})

--- a/spyder/plugins/projects/widgets/projectdialog.py
+++ b/spyder/plugins/projects/widgets/projectdialog.py
@@ -71,6 +71,15 @@ class ProjectDialog(QDialog):
         self.location = get_home_dir()
 
         # Widgets
+        projects_url = "http://docs.spyder-ide.org/current/panes/projects.html"
+        self.description_label = QLabel(
+            _(f"Select a new or existing directory to create a new Spyder "
+              f"project in it. To learn more about projects, take a look at "
+              f"our <a href=\"{projects_url}\">documentation</a>.")
+        )
+        self.description_label.setOpenExternalLinks(True)
+        self.description_label.setWordWrap(True)
+
         self.groupbox = QGroupBox()
         self.radio_new_dir = QRadioButton(_("New directory"))
         self.radio_from_dir = QRadioButton(_("Existing directory"))
@@ -131,6 +140,8 @@ class ProjectDialog(QDialog):
         layout_grid.addWidget(self.label_information, 3, 0, 1, 3)
 
         layout = QVBoxLayout()
+        layout.addWidget(self.description_label)
+        layout.addSpacing(3)
         layout.addWidget(self.groupbox)
         layout.addSpacing(8)
         layout.addLayout(layout_grid)

--- a/spyder/plugins/projects/widgets/projectdialog.py
+++ b/spyder/plugins/projects/widgets/projectdialog.py
@@ -26,7 +26,6 @@ from qtpy.QtWidgets import (QComboBox, QDialog, QDialogButtonBox, QGridLayout,
 from spyder.config.base import _, get_home_dir
 from spyder.utils.icon_manager import ima
 from spyder.utils.qthelpers import create_toolbutton
-from spyder.py3compat import to_text_string
 
 
 def is_writable(path):
@@ -68,15 +67,6 @@ class ProjectDialog(QDialog):
         self.setWindowFlags(
             self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
 
-        # Variables
-        current_python_version = '.'.join(
-            [to_text_string(sys.version_info[0]),
-             to_text_string(sys.version_info[1])])
-        python_versions = ['2.7', '3.4', '3.5']
-        if current_python_version not in python_versions:
-            python_versions.append(current_python_version)
-            python_versions = sorted(python_versions)
-
         self.project_name = None
         self.location = get_home_dir()
 
@@ -88,12 +78,10 @@ class ProjectDialog(QDialog):
         self.label_project_name = QLabel(_('Project name'))
         self.label_location = QLabel(_('Location'))
         self.label_project_type = QLabel(_('Project type'))
-        self.label_python_version = QLabel(_('Python version'))
 
         self.text_project_name = QLineEdit()
         self.text_location = QLineEdit(get_home_dir())
         self.combo_project_type = QComboBox()
-        self.combo_python_version = QComboBox()
 
         self.label_information = QLabel("")
         self.label_information.hide()
@@ -102,7 +90,8 @@ class ProjectDialog(QDialog):
             self,
             triggered=self.select_location,
             icon=ima.icon('DirOpenIcon'),
-            tip=_("Select directory"))
+            tip=_("Select directory")
+        )
         self.button_cancel = QPushButton(_('Cancel'))
         self.button_create = QPushButton(_('Create'))
 
@@ -111,7 +100,6 @@ class ProjectDialog(QDialog):
         self.bbox.addButton(self.button_create, QDialogButtonBox.ActionRole)
 
         # Widget setup
-        self.combo_python_version.addItems(python_versions)
         self.radio_new_dir.setChecked(True)
         self.text_location.setEnabled(True)
         self.text_location.setReadOnly(True)
@@ -122,11 +110,7 @@ class ProjectDialog(QDialog):
                             in project_types.items()]:
             self.combo_project_type.addItem(name, id_)
 
-        self.combo_python_version.setCurrentIndex(
-            python_versions.index(current_python_version))
         self.setWindowTitle(_('Create new project'))
-        self.label_python_version.setVisible(False)
-        self.combo_python_version.setVisible(False)
 
         # Layouts
         layout_top = QHBoxLayout()
@@ -144,9 +128,7 @@ class ProjectDialog(QDialog):
         layout_grid.addWidget(self.button_select_location, 1, 2)
         layout_grid.addWidget(self.label_project_type, 2, 0)
         layout_grid.addWidget(self.combo_project_type, 2, 1, 1, 2)
-        layout_grid.addWidget(self.label_python_version, 3, 0)
-        layout_grid.addWidget(self.combo_python_version, 3, 1, 1, 2)
-        layout_grid.addWidget(self.label_information, 4, 0, 1, 3)
+        layout_grid.addWidget(self.label_information, 3, 0, 1, 3)
 
         layout = QVBoxLayout()
         layout.addWidget(self.groupbox)

--- a/spyder/plugins/projects/widgets/projectdialog.py
+++ b/spyder/plugins/projects/widgets/projectdialog.py
@@ -7,8 +7,6 @@
 # -----------------------------------------------------------------------------
 """Project creation dialog."""
 
-from __future__ import print_function
-
 # Standard library imports
 import errno
 import os.path as osp
@@ -171,6 +169,7 @@ class ProjectDialog(QDialog):
         if location and location != '.':
             if is_writable(location):
                 self.location = location
+                self.text_project_name.setText(osp.basename(location))
                 self.update_location()
 
     def update_location(self, text=''):

--- a/spyder/plugins/projects/widgets/tests/test_projectdialog.py
+++ b/spyder/plugins/projects/widgets/tests/test_projectdialog.py
@@ -25,13 +25,8 @@ def projects_dialog(qtbot):
     """Set up ProjectDialog."""
     dlg = ProjectDialog(None, {'Empty project': EmptyProject})
     qtbot.addWidget(dlg)
+    dlg.show()
     return dlg
-
-
-def test_project_dialog(projects_dialog):
-    """Run project dialog."""
-    projects_dialog.show()
-    assert projects_dialog
 
 
 @pytest.mark.skipif(os.name != 'nt', reason="Specific to Windows platform")
@@ -69,6 +64,56 @@ def test_projectdialog_location(monkeypatch):
     mock_getexistingdirectory.return_value = r"c:\\a_a_1//Bbbb\2345//d-6D"
     dlg.select_location()
     assert dlg.location == r"c:\a_a_1\Bbbb\2345\d-6D"
+
+
+def test_directory_validations(projects_dialog, monkeypatch, tmpdir):
+    """
+    Test that we perform appropiate validations before allowing users to
+    create a project in a directory.
+    """
+    dlg = projects_dialog
+
+    # Assert button_create is disabled by default
+    assert not dlg.button_create.isEnabled()
+    assert not dlg.button_create.isDefault()
+
+    # Set location to tmpdir root
+    dlg.location = str(tmpdir)
+    dlg.text_location.setText(str(tmpdir))
+
+    # Check that we don't allow to create projects in existing directories when
+    # 'New directory' is selected.
+    dlg.radio_new_dir.click()
+    tmpdir.mkdir('foo')
+    dlg.text_project_name.setText('foo')
+    assert not dlg.button_create.isEnabled()
+    assert not dlg.button_create.isDefault()
+    assert dlg.label_information.text() == '\nThis directory already exists!'
+
+    # Selecting 'Existing directory' should allow to create a project there
+    dlg.radio_from_dir.click()
+    assert dlg.button_create.isEnabled()
+    assert dlg.button_create.isDefault()
+    assert dlg.label_information.text() == ''
+
+    # Create a Spyder project
+    folder = tmpdir.mkdir('bar')
+    folder.mkdir('.spyproject')
+
+    # Mock selecting a directory
+    mock_getexistingdirectory = Mock()
+    monkeypatch.setattr('spyder.plugins.projects.widgets.projectdialog' +
+                        '.getexistingdirectory', mock_getexistingdirectory)
+    mock_getexistingdirectory.return_value = str(folder)
+
+    # Check that we don't allow to create projects in existing directories when
+    # 'Existing directory' is selected and there's already a Spyder project
+    # there.
+    dlg.select_location()
+    assert not dlg.button_create.isEnabled()
+    assert not dlg.button_create.isDefault()
+    msg = '\nThis directory is already a Spyder project!'
+    assert dlg.label_information.text() == msg
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of Changes

- Add message to explain users how to use that dialog.
- Validate selected directories and show a message about why a project can't be created at a particular location.
- Disable `Create` button when validation doesn't pass.
- Make that pressing `Enter` selects `Create` when validation pass.
- Make dialog to auto-resize when content is hidden.
- Remove unnecessary empty space.

**Before**

![image](https://user-images.githubusercontent.com/365293/142282959-2a7c79ec-dedc-4793-8080-eb2e7d9a90d3.png)

**After**

![image](https://user-images.githubusercontent.com/365293/142283080-e7b5cac0-bccf-4d09-962f-9862f6031fcf.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16745.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
