### PR TITLE
PR: Don't use Matplotlib in a test to prevent hangs

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -694,16 +694,13 @@ def test_get_help_ipython_console(main_window, qtbot):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
-@pytest.mark.skipif(
-    not sys.platform.startswith('linux') or
-    (sys.platform.startswith('linux') and os.environ.get('USE_CONDA') == 'false'),
-    reason="Does not work on Mac and Windows!")
+@pytest.mark.skipif(not sys.platform.startswith('linux'),
+                    reason="Does not work on Mac and Windows!")
 @pytest.mark.use_introspection
 @pytest.mark.parametrize(
     "object_info",
     [("range", "range"),
-     ("import matplotlib.pyplot as plt",
-      "The object-oriented API is recommended for more complex plots.")])
+     ("import numpy as np", "An array object of arbitrary homogeneous items")])
 def test_get_help_editor(main_window, qtbot, object_info):
     """Test that Help works when called from the Editor."""
     help_plugin = main_window.help


### PR DESCRIPTION
## Description of Changes

- It seems that that test hangs with the latest Matplotlib (3.5.0)
- This is a much better solution than the one I came up with in #16845.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
