### PR TITLE
PR: Run asyncio and normal handlers in the kernel (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = 2.x
-	commit = bab5670eb2953d4a9e6d9d7ee5346f86caa227b2
-	parent = 0c64d3c619b18a7ef0b166dddd2737649639f3a3
+	commit = 842ec6ea5ceeda6acfe1557e5425111ad5141be3
+	parent = 04794d3c147a4570c194f7349950fe78f09f3921
 	method = merge
 	cmdver = 0.4.3


### PR DESCRIPTION
## Description of Changes

- We were not running both handlers correctly, which (for instance) was preventing `nest_asyncio` to do its job.
- Depends on spyder-ide/spyder-kernels#317

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16863.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
