### PR TITLE
PR: Save and restore geometry of undocked plugins

### DIFF
--- a/spyder/api/plugin_registration/registry.py
+++ b/spyder/api/plugin_registration/registry.py
@@ -426,6 +426,13 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
 
             # Remove the plugin from the main window (if graphical)
             if isinstance(plugin_instance, SpyderDockablePlugin):
+                # Save if plugin was undocked to restore it the next time.
+                if plugin_instance.get_widget().windowwidget:
+                    plugin_instance.set_conf('undocked_on_window_close', True)
+                else:
+                    plugin_instance.set_conf('undocked_on_window_close', False)
+
+                # Close undocked plugins.
                 plugin_instance.close_window()
 
             # Perform plugin closure tasks
@@ -434,6 +441,15 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
             # Disconnect depending plugins from the plugin to delete
             self._notify_plugin_teardown(plugin_name)
             if isinstance(plugin_instance, SpyderPluginWidget):
+                # Save if plugin was undocked to restore it the next time.
+                if plugin_instance._undocked_window:
+                    plugin_instance.set_option(
+                        'undocked_on_window_close', True)
+                else:
+                    plugin_instance.set_option(
+                        'undocked_on_window_close', False)
+
+                # Close undocked plugins.
                 plugin_instance._close_window()
 
         # Delete plugin from the registry and auxiliary structures

--- a/spyder/api/widgets/auxiliary_widgets.py
+++ b/spyder/api/widgets/auxiliary_widgets.py
@@ -18,15 +18,9 @@ from spyder.utils.stylesheet import APP_STYLESHEET
 
 
 class SpyderWindowWidget(QMainWindow):
-    """
-    MainWindow subclass that contains a Spyder Plugin.
-    """
-    sig_closed = Signal()
-    """
-    This signal is emitted when this widget is closed.
-    """
+    """MainWindow subclass that contains a Spyder Plugin."""
 
-    # --- Signals
+    # ---- Signals
     # ------------------------------------------------------------------------
     sig_closed = Signal()
     """This signal is emitted when the close event is fired."""
@@ -81,8 +75,6 @@ class MainCornerWidget(QToolBar):
         self._actions.append(self.addWidget(widget))
 
     def get_widget(self, widget_id):
-        """
-        Return a widget by unique id..
-        """
+        """Return a widget by unique id."""
         if widget_id in self._widgets:
             return self._widgets[widget_id]

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -721,7 +721,6 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
 
         self.set_ancestor(window)
         self._update_actions()
-        window.sig_closed.connect(self.close_window)
         window.show()
 
     @Slot()

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -13,6 +13,7 @@ subclass of PluginMainWidget.
 
 # Standard library imports
 from collections import OrderedDict
+import logging
 import sys
 from typing import Optional
 
@@ -44,6 +45,9 @@ from spyder.widgets.tabs import Tabs
 
 # Localization
 _ = get_translation('spyder')
+
+# Logging
+logger = logging.getLogger(__name__)
 
 
 class PluginMainWidgetWidgets:
@@ -703,6 +707,8 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
         """
         Create a QMainWindow instance containing this widget.
         """
+        logger.debug("Undocking plugin")
+
         # Widgets
         self.windowwidget = window = SpyderWindowWidget(self)
 
@@ -740,6 +746,8 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
         """
         Close QMainWindow instance that contains this widget.
         """
+        logger.debug("Docking plugin back to the main window")
+
         if self.windowwidget is not None:
             # Save window geometry to restore it when undocking the plugin
             # again.

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1246,9 +1246,26 @@ class MainWindow(QMainWindow):
             assert 'pandas' not in sys.modules
             assert 'matplotlib' not in sys.modules
 
+        # Restore undocked plugins
+        self.restore_undocked_plugins()
+
         # Notify that the setup of the mainwindow was finished
         self.is_setting_up = False
         self.sig_setup_finished.emit()
+
+    def restore_undocked_plugins(self):
+        """Restore plugins that were undocked in the previous session."""
+        logger.info("Restoring undocked plugins from the previous session")
+
+        for plugin_name in PLUGIN_REGISTRY:
+            plugin = PLUGIN_REGISTRY.get_plugin(plugin_name)
+            if isinstance(plugin, SpyderDockablePlugin):
+                if plugin.get_conf('undocked_on_window_close', default=False):
+                    plugin.get_widget().create_window()
+            elif isinstance(plugin, SpyderPluginWidget):
+                if plugin.get_option('undocked_on_window_close',
+                                     default=False):
+                    plugin._create_window()
 
     def set_window_title(self):
         """Set window title."""

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -18,7 +18,7 @@ import shutil
 import sys
 import tempfile
 from textwrap import dedent
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock
 import uuid
 
 # Third party imports
@@ -34,8 +34,8 @@ import pkg_resources
 from pkg_resources import parse_version
 import pylint
 import pytest
-from qtpy import PYQT5, PYQT_VERSION
-from qtpy.QtCore import Qt, QTimer, QUrl
+from qtpy import PYQT_VERSION
+from qtpy.QtCore import Qt, QTimer
 from qtpy.QtTest import QTest
 from qtpy.QtGui import QImage, QTextCursor
 from qtpy.QtWidgets import (QAction, QApplication, QFileDialog, QLineEdit,
@@ -43,17 +43,15 @@ from qtpy.QtWidgets import (QAction, QApplication, QFileDialog, QLineEdit,
 from qtpy.QtWebEngineWidgets import WEBENGINE
 
 # Local imports
-from spyder import __trouble_url__, __project_url__
+from spyder import __trouble_url__
 from spyder.api.utils import get_class_values
 from spyder.api.widgets.auxiliary_widgets import SpyderWindowWidget
 from spyder.api.plugins import Plugins
 from spyder.app import start
-from spyder.app.mainwindow import MainWindow
 from spyder.config.base import (
     get_home_dir, get_conf_path, get_module_path, running_in_ci)
 from spyder.config.manager import CONF
 from spyder.dependencies import DEPENDENCIES
-from spyder.plugins.base import PluginWindow
 from spyder.plugins.help.widgets import ObjectComboBox
 from spyder.plugins.help.tests.test_plugin import check_text
 from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -12,8 +12,6 @@ This file only deals with non-GUI configuration features
 sip API incompatibility issue in spyder's non-gui modules)
 """
 
-from __future__ import print_function
-
 import codecs
 import locale
 import os
@@ -397,9 +395,10 @@ def get_available_translations():
     # is added, to ensure LANGUAGE_CODES is updated.
     for lang in langs:
         if lang not in LANGUAGE_CODES:
-            error = ('Update LANGUAGE_CODES (inside config/base.py) if a new '
-                     'translation has been added to Spyder')
-            print(error)  # spyder: test-skip
+            if DEV:
+                error = ('Update LANGUAGE_CODES (inside config/base.py) if a '
+                         'new translation has been added to Spyder')
+                print(error)  # spyder: test-skip
             return ['en']
     return langs
 

--- a/spyder/plugins/help/plugin.py
+++ b/spyder/plugins/help/plugin.py
@@ -12,20 +12,18 @@ Help Plugin.
 import os
 
 # Third party imports
-from qtpy.QtCore import Qt, Signal
+from qtpy.QtCore import Signal
 
 # Local imports
-from spyder import __docs_url__, __forum_url__, __trouble_url__
+from spyder.api.exceptions import SpyderAPIError
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
 from spyder.api.translations import get_translation
 from spyder.config.base import get_conf_path
 from spyder.config.fonts import DEFAULT_SMALL_DELTA
-from spyder.plugins.console.api import ConsoleActions
 from spyder.plugins.help.confpage import HelpConfigPage
 from spyder.plugins.help.widgets import HelpWidget
-from spyder.utils.qthelpers import start_file
 
 # Localization
 _ = get_translation('spyder')
@@ -203,8 +201,11 @@ class Help(SpyderDockablePlugin):
             widget.set_plain_text_color_scheme(self.get_color_scheme())
 
         # To make auto-connection changes take place instantly
-        editor = self.get_plugin(Plugins.Editor)
-        editor.apply_plugin_settings({'connect_to_oi'})
+        try:
+            editor = self.get_plugin(Plugins.Editor)
+            editor.apply_plugin_settings({'connect_to_oi'})
+        except SpyderAPIError:
+            pass
 
     # --- Private API
     # ------------------------------------------------------------------------

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1379,6 +1379,7 @@ def test_remove_old_std_files(ipyconsole, qtbot):
 
 @flaky(max_runs=10)
 @pytest.mark.use_startup_wdir
+@pytest.mark.skipif(os.name == 'nt', reason="Too flaky on Windows")
 def test_console_working_directory(ipyconsole, qtbot):
     """Test for checking the working directory."""
     shell = ipyconsole.get_current_shellwidget()


### PR DESCRIPTION
## Description of Changes

* The position and size of undocked plugins is saved when they are docked back to the main window. This allows us to restore those attributes when they are undocked again.
* If a plugin is undocked when the main window was closed, we restore it as undocked in the next session.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16216 
Fixes #10649 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
