### PR TITLE
PR: Update RELEASE and MAINTENANCE files and fix some IPython Console issues

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,27 +1,27 @@
 These are some instructions meant for maintainers of this repo.
 
 * To avoid pushing to our main repo by accident, please use `https` for your `usptream` remote. That should make git to ask for your credentials (at least in Unix systems).
-* After merging a PR against the stable branch (e.g. `4.x`), you need to immediately merge it against `master` and push your changes to Github.
+* After merging a PR against the stable branch (e.g. `5.x`), you need to immediately merge it against `master` and push your changes to Github.
   For that you need to perform the following steps in your local clone:
 
-    - git checkout 4.x
+    - git checkout 5.x
     - git fetch upstream
-    - git merge upstream/4.x
+    - git merge upstream/5.x
     - git checkout master
-    - git merge 4.x
+    - git merge 5.x
     - Commit with the following message:
 
-          Merge from 4.x: PR #<pr-number>
+          Merge from 5.x: PR #<pr-number>
 
           Fixes #<fixed-issue-number>
 
       If the PR doesn't fix any issue, the second line is unnecessary.
     - git push upstream master
 
-* To merge against `master` a PR that involved updating our spyder-kernels subrepo in the stable branch (e.g. `4.x`), you need to perform the following actions:
+* To merge against `master` a PR that involved updating our spyder-kernels subrepo in the stable branch (e.g. `5.x`), you need to perform the following actions:
 
     - git checkout master
-    - git merge 4.x
+    - git merge 5.x
     - git reset -- external-deps/spyder-kernels
     - git checkout -- external-deps/spyder-kernels
     - git commit with the files left and the same message format as above.
@@ -33,6 +33,6 @@ These are some instructions meant for maintainers of this repo.
 
 * There's a bot that constantly monitors all issues in order to close duplicates or already solved issues and inform users what they can do about them (basically wait to be fixed or update).
 
-    The patterns detected by the bot and the messages shown to users can be configured in `.github/workflows/duplicates.yml` (only avaiable in our `master` branch because there's no need to have it in `4.x`).
+    The patterns detected by the bot and the messages shown to users can be configured in `.github/workflows/duplicates.yml` (only avaiable in our `master` branch because there's no need to have it in `5.x`).
 
     Please open a PR to add new messages or update previous ones, so other members of the team can decide if the messages are appropriate.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -107,7 +107,7 @@ To release a new version of Spyder you need to follow these steps:
   - `spyder/dependencies.py`
   - `requirements/conda.txt`
   - `binder/environment.yml`
-  - `spyder/plugins/ipythonconsole/plugin.py`
+  - `spyder/plugins/ipythonconsole/widgets/main_widget.py` (look up for the constants `SPYDER_KERNELS_MIN_VERSION` and `SPYDER_KERNELS_MAX_VERSION`)
 
 * Commit with
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -183,10 +183,10 @@ To release a new version of Spyder you need to follow these steps:
 ## After the release
 
 * Publish release in our Github Releases page:
-      * Copy the contents of the previous release description (updating the relevant information and links to point to the new Spyder version and changelog entry).
-      * Edit the previous release description to only have the changelog line.
+  - Copy the contents of the previous release description (updating the relevant information and links to point to the new Spyder version and changelog entry).
+  - Edit the previous release description to only have the changelog line.
 
-* Publish release announcements to our [list](https://groups.google.com/group/spyderlib) (following [Announcements.md](Announcements.md)) after the installers have been build.
+* Publish release announcement to our [list](https://groups.google.com/group/spyderlib) (following [Announcements.md](Announcements.md)) after the installers have been built.
 
 * Merge PR on Conda-forge for Spyder. For that you can go to
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -98,10 +98,6 @@ To release a new version of Spyder you need to follow these steps:
   **Notes**:
 
   - Review carefully the release notes of those packages to see if it's necessary to add new dependencies or update the constraints on the current ones (e.g. `jedi >=0.17.2`).
-  - After merging each of those PRs, give a ping to the Anaconda team telling them that these packages are required for the new Spyder version. You need to use the handle `@anaconda-pkg-build` for that. Here is an example of this kind of messages:
-
-    https://github.com/conda-forge/spyder-kernels-feedstock/pull/58#issuecomment-725664085
-
 
 * Create a new branch in your fork with the name `update-core-deps`
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -89,6 +89,20 @@ To release a new version of Spyder you need to follow these steps:
 
 * Release a new version of `python-lsp-server`, if required.
 
+* Merge PRs on Conda-forge that update the `spyder-kernels` and `python-lsp-server` feedstocks (usually an automatic PR will appear that can be either merged as it is or be use as boilerplate):
+
+  - `spyder-kernels`: https://github.com/conda-forge/spyder-kernels-feedstock
+
+  - `python-lsp-server`: https://github.com/conda-forge/python-lsp-server-feedstock
+
+  **Notes**:
+
+  - Review carefully the release notes of those packages to see if it's necessary to add new dependencies or update the constraints on the current ones (e.g. `jedi >=0.17.2`).
+  - After merging each of those PRs, give a ping to the Anaconda team telling them that these packages are required for the new Spyder version. You need to use the handle `@anaconda-pkg-build` for that. Here is an example of this kind of messages:
+
+    https://github.com/conda-forge/spyder-kernels-feedstock/pull/58#issuecomment-725664085
+
+
 * Create a new branch in your fork with the name `update-core-deps`
 
 * Update the version of any packages required before the release in the following files:
@@ -109,7 +123,7 @@ To release a new version of Spyder you need to follow these steps:
       git subrepo pull external-deps/spyder-kernels
       git subrepo pull external-deps/python-lsp-server
 
-* Merge this PR following the procedure mentioned on `MAINTENANCE.md`
+* Merge this PR following the procedure mentioned on [`MAINTENANCE.md`](MAINTENANCE.md)
 
 ## To do the release
 
@@ -119,7 +133,7 @@ To release a new version of Spyder you need to follow these steps:
 
 * Update CHANGELOG.md with `loghub spyder-ide/spyder -m vX.X.X`
 
-* Add sections for `New features` and `Important fixes` in CHANGELOG.md. For this take a look at closed issues and PRs for the current milestone.
+* Add sections for `New features`, `Important fixes` and `New API features` in CHANGELOG.md. For this take a look at closed issues and PRs for the current milestone.
 
 * `git add .` and `git commit -m "Update Changelog"`
 
@@ -139,7 +153,7 @@ To release a new version of Spyder you need to follow these steps:
 
 * pip install -U pip setuptools twine wheel
 
-* python3 setup.py bdist_wheel
+* python setup.py bdist_wheel
 
 * twine check dist/*
 
@@ -168,24 +182,17 @@ To release a new version of Spyder you need to follow these steps:
 
 ## After the release
 
-* Publish release in our Github Releases page.
+* Publish release in our Github Releases page:
+      * Copy the contents of the previous release description (updating the relevant information and links to point to the new Spyder version and changelog entry).
+      * Edit the previous release description to only have the changelog line.
 
-* Publish release announcements to our list.
+* Publish release announcements to our [list](https://groups.google.com/group/spyderlib) (following [Announcements.md](Announcements.md)) after the installers have been build.
 
-* Merge PRs on Conda-forge that update the `spyder-kernels` and `python-lsp-server` feedstocks.
-
-  **Notes**:
-
-  - Review carefully the release notes of those packages to see if it's necessary to add new dependencies or update the constraints on the current ones (e.g. `jedi >=0.17.2`).
-  - After merging each of those PRs, give a ping to the Anaconda team telling them that these packages are required for the new Spyder version. You need to use the handle `@anaconda-pkg-build` for that. Here is an example of this kinf of messages:
-
-    https://github.com/conda-forge/spyder-kernels-feedstock/pull/58#issuecomment-725664085
-
-* After those PRs are merged, go to
+* Merge PR on Conda-forge for Spyder. For that you can go to
 
   https://github.com/conda-forge/spyder-feedstock
 
-  and merge the corresponding PR for the new release.
+  and merge the corresponding PR for the new release (usually an automatic PR will appear that can be either merged as it is or be use as boilerplate).
 
   **Notes**:
 

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -581,7 +581,9 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
         """Shutdown connection and kernel if needed."""
         self.dialog_manager.close_all()
         self.remove_std_files(is_last_client)
-        shutdown_kernel = is_last_client and not self.is_external_kernel
+        shutdown_kernel = (
+            is_last_client and not self.is_external_kernel
+            and not self.is_error_shown)
         self.shellwidget.shutdown(shutdown_kernel)
 
     def interrupt_kernel(self):

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -57,9 +57,17 @@ _ = get_translation('spyder')
 # ---- Constants
 # =============================================================================
 MAIN_BG_COLOR = QStylePalette.COLOR_BACKGROUND_1
-SPYDER_KERNELS_VERSION = '>=2.2.0;<2.3.0'
-SPYDER_KERNELS_CONDA = 'conda install spyder-kernels=2.2'
-SPYDER_KERNELS_PIP = 'pip install spyder-kernels==2.2.*'
+SPYDER_KERNELS_MIN_VERSION = '2.2.0'
+SPYDER_KERNELS_MAX_VERSION = '2.3.0'
+SPYDER_KERNELS_VERSION = (
+    f'>={SPYDER_KERNELS_MIN_VERSION};<{SPYDER_KERNELS_MAX_VERSION}')
+SPYDER_KERNELS_VERSION_MSG = _(
+    '>= {0} and < {1}'.format(
+        SPYDER_KERNELS_MIN_VERSION, SPYDER_KERNELS_MAX_VERSION))
+SPYDER_KERNELS_CONDA = (
+    f'conda install spyder-kernels={SPYDER_KERNELS_MIN_VERSION[:-2]}')
+SPYDER_KERNELS_PIP = (
+    f'pip install spyder-kernels=={SPYDER_KERNELS_MIN_VERSION[:-1]}*')
 
 
 class IPythonConsoleWidgetActions:
@@ -1521,7 +1529,7 @@ class IPythonConsoleWidget(PluginMainWidget):
                       "<tt>{1}</tt>"
                       "<br><br>or<br><br>"
                       "<tt>{2}</tt>".format(
-                          SPYDER_KERNELS_VERSION,
+                          SPYDER_KERNELS_VERSION_MSG,
                           SPYDER_KERNELS_CONDA,
                           SPYDER_KERNELS_PIP
                       ))

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -57,6 +57,9 @@ _ = get_translation('spyder')
 # ---- Constants
 # =============================================================================
 MAIN_BG_COLOR = QStylePalette.COLOR_BACKGROUND_1
+SPYDER_KERNELS_VERSION = '>=2.2.0;<2.3.0'
+SPYDER_KERNELS_CONDA = 'conda install spyder-kernels=2.2'
+SPYDER_KERNELS_PIP = 'pip install spyder-kernels==2.2.*'
 
 
 class IPythonConsoleWidgetActions:
@@ -1505,19 +1508,23 @@ class IPythonConsoleWidget(PluginMainWidget):
             has_spyder_kernels = programs.is_module_installed(
                 'spyder_kernels',
                 interpreter=pyexec,
-                version='>=2.2.0;<2.3.0')
+                version=SPYDER_KERNELS_VERSION)
             if not has_spyder_kernels and not running_under_pytest():
                 client.show_kernel_error(
                     _("Your Python environment or installation doesn't have "
                       "the <tt>spyder-kernels</tt> module or the right "
-                      "version of it installed (>= 2.2.0 and < 2.3.0). "
+                      "version of it installed ({0}). "
                       "Without this module is not possible for Spyder to "
                       "create a console for you.<br><br>"
                       "You can install it by running in a system terminal:"
                       "<br><br>"
-                      "<tt>conda install spyder-kernels=2.1</tt>"
+                      "<tt>{1}</tt>"
                       "<br><br>or<br><br>"
-                      "<tt>pip install spyder-kernels==2.1.*</tt>")
+                      "<tt>{2}</tt>".format(
+                          SPYDER_KERNELS_VERSION,
+                          SPYDER_KERNELS_CONDA,
+                          SPYDER_KERNELS_PIP
+                      ))
                 )
                 return
 

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -251,6 +251,11 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
         Executes source or the input buffer, possibly prompting for more
         input.
         """
+        # Needed for cases where there is no kernel initialized but
+        # an execution is trigger like when setting initial configs.
+        # See spyder-ide/spyder#16896
+        if self.kernel_client is None:
+            return
         if self._executing:
             self._execute_queue.append((source, hidden, interactive))
             return

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -252,7 +252,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
         input.
         """
         # Needed for cases where there is no kernel initialized but
-        # an execution is trigger like when setting initial configs.
+        # an execution is triggered like when setting initial configs.
         # See spyder-ide/spyder#16896
         if self.kernel_client is None:
             return


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

* Add more info to the RELEASE file. Update MAINTENANCE file (was using `4.x` in the commands).
* Change spyder-kernels version message structure to be translated properly (and fix missing outdated installation commands). New message: 

![imagen](https://user-images.githubusercontent.com/16781833/143602729-bef66d2f-6d83-4b5f-a759-1e3956b5cc05.png)

Also while checking this seems like an error raises when closing a client if no kernel is started (due for example not having the correct version of  `spyder-kernels` installed):

```

Traceback (most recent call last):
  File "D:\Acer\Documentos\Spyder\spyder\spyder\plugins\ipythonconsole\widgets\main_widget.py", line 1753, in close_client
    client.shutdown(last_client)
  File "D:\Acer\Documentos\Spyder\spyder\spyder\plugins\ipythonconsole\widgets\client.py", line 585, in shutdown
    self.shellwidget.shutdown(shutdown_kernel)
  File "D:\Acer\Documentos\Spyder\spyder\spyder\plugins\ipythonconsole\widgets\shell.py", line 176, in shutdown
    self.kernel_manager.stop_restarter()
AttributeError: 'NoneType' object has no attribute 'stop_restarter'

```

And seems like if the interpreter doesn't have the correct version of spyder-kernels the next time you try to launch Spyder it crashes while trying to apply config values:

```

File "D:\Acer\Documentos\Spyder\spyder\spyder\plugins\ipythonconsole\widgets\main_widget.py", line 748, in change_clients_autocall
    self._change_client_conf(
  File "D:\Acer\Documentos\Spyder\spyder\spyder\plugins\ipythonconsole\widgets\main_widget.py", line 895, in _change_client_conf
    client_conf_func(value)
  File "D:\Acer\Documentos\Spyder\spyder\spyder\plugins\ipythonconsole\widgets\shell.py", line 407, in set_autocall
    self.execute(cmd.format(autocall), hidden=True)
  File "D:\Acer\Documentos\Spyder\spyder\spyder\plugins\ipythonconsole\widgets\shell.py", line 257, in execute
    super(ShellWidget, self).execute(source, hidden, interactive)
  File "D:\Acer\Documentos\Spyder\spyder\spyder\plugins\ipythonconsole\widgets\debugging.py", line 569, in execute
    return super(DebuggingWidget, self).execute(
  File "C:\Users\dalth\anaconda3\envs\spyder_dev\lib\site-packages\qtconsole\console_widget.py", line 647, in execute
    self._execute(source, hidden)
  File "C:\Users\dalth\anaconda3\envs\spyder_dev\lib\site-packages\qtconsole\frontend_widget.py", line 285, in _execute
    msg_id = self.kernel_client.execute(source, hidden)
AttributeError: 'NoneType' object has no attribute 'execute'

```

~Should I fix this two issues in a different PR or maybe in this one @ccordoba12 ?~

Fixes https://github.com/spyder-ide/spyder/issues/16896
Fixes https://github.com/spyder-ide/spyder/issues/16898

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
