### PR TITLE
PR: Fix applying configuration options to the editor

### DIFF
--- a/spyder/api/config/decorators.py
+++ b/spyder/api/config/decorators.py
@@ -10,8 +10,7 @@ Spyder API helper decorators.
 
 # Standard library imports
 import functools
-from typing import Callable, Type, Any, Optional, Union, List
-import inspect
+from typing import Callable, Optional, Union, List
 
 # Local imports
 from spyder.config.types import ConfigurationKey

--- a/spyder/api/preferences.py
+++ b/spyder/api/preferences.py
@@ -10,10 +10,7 @@ API to create an entry in Spyder Preferences associated to a given plugin.
 
 # Standard library imports
 import types
-from typing import Tuple, Union, Set
-
-# Third party imports
-from qtpy.QtWidgets import QWidget
+from typing import Set
 
 # Local imports
 from spyder.config.manager import CONF

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -386,8 +386,11 @@ class CompletionPlugin(SpyderPluginV2):
         provider tabs.
         """
         providers_to_update = set({})
-        options = [x[1] if isinstance(x, tuple) and
-                   len(x) == 2 and x[0] is None else x for x in options]
+        options = [
+            x[1] if isinstance(x, tuple) and
+            len(x) == 2 and x[0] is None or 'editor'
+            else x for x in options
+        ]
         for option in options:
             if option == 'completions_wait_for_ms':
                 self.wait_for_ms = self.get_conf(
@@ -405,49 +408,6 @@ class CompletionPlugin(SpyderPluginV2):
                         self.unregister_statusbar(provider_name)
                 elif option_name == 'provider_configuration':
                     providers_to_update |= {provider_name}
-
-        # FIXME: Remove this after migrating the ConfManager to an observer
-        # pattern.
-        editor_method_sec_opts = {
-            'set_code_snippets_enabled': (self.CONF_SECTION,
-                                          'enable_code_snippets'),
-            'set_hover_hints_enabled':  (self.CONF_SECTION,
-                                         'provider_configuration',
-                                         'lsp',
-                                         'values',
-                                         'enable_hover_hints'),
-            'set_format_on_save': (self.CONF_SECTION,
-                                   'provider_configuration',
-                                   'lsp',
-                                   'values',
-                                   'format_on_save'),
-            'set_automatic_completions_enabled': ('editor',
-                                                  'automatic_completions'),
-            'set_completions_hint_enabled': ('editor', 'completions_hint'),
-            'set_completions_hint_after_ms': ('editor',
-                                              'completions_hint_after_ms'),
-            'set_underline_errors_enabled': ('editor', 'underline_errors'),
-            'set_automatic_completions_after_chars': (
-                'editor', 'automatic_completions_after_chars'),
-            'set_automatic_completions_after_ms': (
-                'editor', 'automatic_completions_after_ms'),
-            'set_edgeline_columns': (self.CONF_SECTION,
-                                     'provider_configuration',
-                                     'lsp',
-                                     'values',
-                                     'pycodestyle/max_line_length'),
-            'set_edgeline_enabled': ('editor', 'edge_line'),
-        }
-
-        for method_name, (sec, *opt) in editor_method_sec_opts.items():
-            opt = tuple(opt)
-            if len(opt) == 1:
-                opt = opt[0]
-            if opt in options:
-                opt_value = self.get_conf(opt, section=sec)
-                self.sig_editor_rpc.emit('call_all_editorstacks',
-                                         (method_name, (opt_value,),),
-                                         {})
 
         # Update entries in the source menu
         # FIXME: Delete this after CONF is moved to an observer pattern.

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -12,17 +12,15 @@ introspection providers.
 """
 
 # Standard library imports
-from collections import defaultdict
 import functools
 import inspect
 import logging
 import os
 from pkg_resources import parse_version, iter_entry_points
-from typing import List, Any, Union, Optional, Tuple
+from typing import List, Union
 
 # Third-party imports
 from qtpy.QtCore import QMutex, QMutexLocker, QTimer, Slot, Signal
-from qtpy.QtWidgets import QMessageBox
 
 # Local imports
 from spyder.config.manager import CONF

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -3005,6 +3005,9 @@ class Editor(SpyderPluginWidget):
     def apply_plugin_settings(self, options):
         """Apply configuration file's plugin settings"""
         if self.editorstacks is not None:
+            # Get option names from the tuples sent by Preferences
+            options = list({option[1] for option in options})
+
             # --- syntax highlight and text rendering settings
             color_scheme_n = 'color_scheme_name'
             color_scheme_o = self.get_color_scheme()

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4472,7 +4472,10 @@ class CodeEditor(TextEditBaseWidget):
             return super(CodeEditor, self).event(event)
 
     def _start_completion_timer(self):
-        """Helper to start timer or complete."""
+        """Helper to start timer for automatic completions or handle them."""
+        if not self.automatic_completions:
+            return
+
         if self.automatic_completions_after_ms > 0:
             self._timer_autocomplete.start(
                 self.automatic_completions_after_ms)
@@ -4711,6 +4714,9 @@ class CodeEditor(TextEditBaseWidget):
 
     def _handle_completions(self):
         """Handle on the fly completions after delay."""
+        if not self.automatic_completions:
+            return
+
         cursor = self.textCursor()
         pos = cursor.position()
         cursor.select(QTextCursor.WordUnderCursor)
@@ -4758,7 +4764,7 @@ class CodeEditor(TextEditBaseWidget):
         if (len(text) >= self.automatic_completions_after_chars
                 and self._last_key_pressed_text or is_backspace):
             # Perform completion on the fly
-            if self.automatic_completions and not self.in_comment_or_string():
+            if not self.in_comment_or_string():
                 # Variables can include numbers and underscores
                 if (text.isalpha() or text.isalnum() or '_' in text
                         or '.' in text):

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4636,7 +4636,8 @@ class CodeEditor(TextEditBaseWidget):
             # redefine this basic action which should have been implemented
             # natively
             self.stdkey_end(shift, ctrl)
-        elif text in self.auto_completion_characters:
+        elif (text in self.auto_completion_characters and
+                self.automatic_completions):
             self.insert_text(text)
             if text == ".":
                 if not self.in_comment_or_string():

--- a/spyder/plugins/preferences/api.py
+++ b/spyder/plugins/preferences/api.py
@@ -10,25 +10,22 @@ Preferences plugin public facing API
 
 # Standard library imports
 import ast
-import functools
 import os.path as osp
 
 # Third party imports
 from qtpy import API
 from qtpy.compat import (getexistingdirectory, getopenfilename, from_qvariant,
                          to_qvariant)
-from qtpy.QtCore import QSize, Qt, Signal, Slot, QRegExp
+from qtpy.QtCore import Qt, Signal, Slot, QRegExp
 from qtpy.QtGui import QColor, QRegExpValidator, QTextOption
-from qtpy.QtWidgets import (QButtonGroup, QCheckBox, QComboBox, QDialog,
-                            QDialogButtonBox, QDoubleSpinBox, QFontComboBox,
-                            QGridLayout, QGroupBox, QHBoxLayout, QLabel,
-                            QLineEdit, QListView, QListWidget, QListWidgetItem,
-                            QMessageBox, QPushButton, QRadioButton,
-                            QScrollArea, QSpinBox, QSplitter, QStackedWidget,
-                            QVBoxLayout, QWidget, QPlainTextEdit, QTabWidget)
+from qtpy.QtWidgets import (QButtonGroup, QCheckBox, QComboBox, QDoubleSpinBox,
+                            QFontComboBox, QGridLayout, QGroupBox, QHBoxLayout,
+                            QLabel, QLineEdit, QMessageBox, QPushButton,
+                            QRadioButton, QSpinBox, QVBoxLayout, QWidget,
+                            QPlainTextEdit, QTabWidget)
 
 # Local imports
-from spyder.config.base import _, load_lang_conf
+from spyder.config.base import _
 from spyder.config.manager import CONF
 from spyder.config.user import NoDefault
 from spyder.py3compat import to_text_string


### PR DESCRIPTION
## Description of Changes

- Applying any option to the editor required a restart. This was probably caused by the changes in #16012.
- Applying options that are set through the Completion preferences page was also broken. I think this is another side effect of #16012.
- Improve performance when automatic completions are off.
- Remove unused imports in several places.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16439.
Fixes #14188.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
