### PR TITLE
PR: Move DPI change message dialog to the primaryScreen center

### DIFF
--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -17,6 +17,7 @@ import glob
 
 # Third party imports
 from qtpy.QtCore import Qt, QThread, QTimer, Signal, Slot
+from qtpy.QtGui import QGuiApplication
 from qtpy.QtWidgets import QAction, QMessageBox, QPushButton
 
 # Local imports
@@ -566,3 +567,12 @@ class ApplicationContainer(PluginMainContainer):
             self.dpi_messagebox.finished.connect(
                 lambda result: self.handle_dpi_change_response(result, dpi))
             self.dpi_messagebox.open()
+            # Show dialog always in the primary screen to prevent not being
+            # able to see it if a screen gets disconnected while
+            # in suspended state. See spyder-ide/spyder#16390
+            dpi_messagebox_width = self.dpi_messagebox.rect().width()
+            dpi_messagebox_height = self.dpi_messagebox.rect().height()
+            screen_geometry = QGuiApplication.primaryScreen().geometry()
+            x = (screen_geometry.width() - dpi_messagebox_width) / 2
+            y = (screen_geometry.height() - dpi_messagebox_height) / 2
+            self.dpi_messagebox.move(x, y)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Move always the dpi message dialog to the primary screen to prevent loosing track of it when disconnecting screens while the machine is suspended 


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16390 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
