### PR TITLE
PR: Fix detection of non-installed modules (Dependencies)

### DIFF
--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -404,19 +404,21 @@ def status(deps=DEPENDENCIES, linesep=os.linesep):
     maxwidth += 1
     text = ""
     prev_order = '-1'
-    for order, title, version in sorted(data,
-                                        key=lambda x: x[0] + x[1].lower()):
+    for order, title, version in sorted(
+            data, key=lambda x: x[0] + x[1].lower()):
         if order != prev_order:
-            text += '{sep}# {name}:{sep}'.format(
-                sep=linesep, name=order_dep[order].capitalize())
+            name = order_dep[order]
+            if name == MANDATORY:
+                text += f'# {name.capitalize()}:{linesep}'
+            else:
+                text += f'{linesep}# {name.capitalize()}:{linesep}'
             prev_order = order
 
-        text += '{title}:  {version}{linesep}'.format(
-            title=title.ljust(maxwidth), version=version, linesep=linesep)
+        text += f'{title.ljust(maxwidth)}:  {version}{linesep}'
 
-    # Remove spurious linesep's when reporting deps to Github
+    # Remove spurious linesep when reporting deps to Github
     if not linesep == '<br>':
-        text = text[1:-1]
+        text = text[:-1]
 
     return text
 

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -871,7 +871,8 @@ def get_package_version(package_name):
         return None
 
 
-def is_module_installed(module_name, version=None, interpreter=None):
+def is_module_installed(module_name, version=None, interpreter=None,
+                        distribution_name=None):
     """
     Return True if module ``module_name`` is installed
 
@@ -885,6 +886,9 @@ def is_module_installed(module_name, version=None, interpreter=None):
     If ``interpreter`` is not None, checks if a module is installed with a
     given ``version`` in the ``interpreter``'s environment. Otherwise checks
     in Spyder's environment.
+
+    ``distribution_name`` is the distribution name of a package. For instance,
+    for pylsp_black that name is python_lsp_black.
     """
     if interpreter is not None:
         if is_python_interpreter(interpreter):
@@ -929,6 +933,12 @@ def is_module_installed(module_name, version=None, interpreter=None):
                 return False
         except Exception:
             pass
+
+        # Try to get the module version from its distribution name. For
+        # instance, pylsp_black doesn't have a version but that can be
+        # obtained from its distribution, called python_lsp_black.
+        if not module_version and distribution_name:
+            module_version = get_package_version(distribution_name)
 
     if version is None:
         return True

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -852,12 +852,8 @@ def check_version(actver, version, cmp_op):
 
 def get_module_version(module_name):
     """Return module version or None if version can't be retrieved."""
-    ver = None
-    try:
-        mod = __import__(module_name)
-        ver = getattr(mod, '__version__', getattr(mod, 'VERSION', None))
-    except ModuleNotFoundError:
-        pass
+    mod = __import__(module_name)
+    ver = getattr(mod, '__version__', getattr(mod, 'VERSION', None))
     if not ver:
         ver = get_package_version(module_name)
     return ver

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -288,6 +288,7 @@ Icon=/blah/blah.xpm
 def test_get_package_version():
     # Primarily a test of pkg_resources/setuptools being installed properly
     assert get_package_version('IPython')
+    assert get_package_version('python_lsp_black')
 
 
 def test_get_module_version():

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -188,6 +188,8 @@ def test_is_module_installed():
     assert is_module_installed('qtconsole', '>=4.5')
     assert not is_module_installed('IPython', '>=1.0;<3.0')
     assert is_module_installed('jedi', '>=0.7.0')
+    assert not is_module_installed('foo')
+    assert not is_module_installed('foo1', '>=1.2.0')
 
 
 def test_is_module_installed_with_custom_interpreter():

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -289,9 +289,9 @@ def test_get_package_version():
 
 
 def test_get_module_version():
-    # pyls_black should not have a __version__ attribute, so tests that the
+    # intervaltree should not have a __version__ attribute, so test that the
     # fallback mechanism to get_package_version is working
-    assert get_module_version('python_lsp_black')
+    assert get_module_version('intervaltree')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description of Changes

- `programs.is_module_installed` was returning `True` for non-installed modules. That regression was introduced in Spyder 5.1.0, specifically in commit d535da2, part of #15657.
- That commit tried to handle the case of `python-lsp-black`, whose module name (`pylsp_black`) if different from its Setuptools distribution one (`python_lsp_black`).
- This PR improves the situation by handling that case better and adding tests for non-installed modules.
- It also removes a blank line before the `Mandatory` section of our dependencies, which was shown when reporting the status of missing dependencies after Spyder starts.

    **Before**

    ![imagen](https://user-images.githubusercontent.com/365293/144491347-1d3f20e9-d834-45af-9bc4-278d28d13dab.png)

    **After**

    ![imagen](https://user-images.githubusercontent.com/365293/144490968-3f7c098f-0c17-476c-bbea-c3ddbf8bf6f3.png)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16935.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
