### PR TITLE
PR: Fix errors when other plugins are not available (Editor)

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -385,7 +385,9 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         # This is required to start workspace before completion
         # services when Spyder starts with an open project.
         # TODO: Find a better solution for it in the future!!
-        self.main.projects.start_workspace_services()
+        projects = self.main.get_plugin(Plugins.Projects, error=False)
+        if projects:
+            projects.start_workspace_services()
 
         self.completion_capabilities[language] = dict(capabilities)
         for editorstack in self.editorstacks:
@@ -1884,7 +1886,6 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         if self.main.get_plugin(Plugins.Completions, error=False):
             self.main.completions.update_client_status(languages)
 
-
     # ------ Bookmarks
     def save_bookmarks(self, filename, bookmarks):
         """Receive bookmark changes and save them."""
@@ -2017,8 +2018,9 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                     break
             basedir = getcwd_or_home()
 
-            if self.main.projects.get_active_project() is not None:
-                basedir = self.main.projects.get_active_project_path()
+            projects = self.main.get_plugin(Plugins.Projects, error=False)
+            if projects and projects.get_active_project() is not None:
+                basedir = projects.get_active_project_path()
             else:
                 c_fname = self.get_current_filename()
                 if c_fname is not None and c_fname != self.TEMPFILE_PATH:
@@ -2249,12 +2251,16 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             else:
                 # processevents is false only when calling from debugging
                 current_editor.sig_debug_stop.emit(goto[index])
-                current_sw = self.main.ipyconsole.get_current_shellwidget()
-                current_sw.sig_prompt_ready.connect(
-                    current_editor.sig_debug_stop[()].emit)
-                current_pdb_state = self.main.ipyconsole.get_pdb_state()
-                pdb_last_step = self.main.ipyconsole.get_pdb_last_step()
-                self.update_pdb_state(current_pdb_state, pdb_last_step)
+
+                ipyconsole = self.main.get_plugin(
+                    Plugins.IPythonConsole, error=False)
+                if ipyconsole:
+                    current_sw = ipyconsole.get_current_shellwidget()
+                    current_sw.sig_prompt_ready.connect(
+                        current_editor.sig_debug_stop[()].emit)
+                    current_pdb_state = ipyconsole.get_pdb_state()
+                    pdb_last_step = ipyconsole.get_pdb_last_step()
+                    self.update_pdb_state(current_pdb_state, pdb_last_step)
 
     @Slot()
     def print_file(self):
@@ -2296,8 +2302,14 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         """
         if not CONF.get('ipython_console', 'pdb_prevent_closing'):
             return True
-        debugging = self.main.ipyconsole.get_pdb_state()
-        last_pdb_step = self.main.ipyconsole.get_pdb_last_step()
+        ipyconsole = self.main.get_plugin(Plugins.IPythonConsole, error=False)
+
+        debugging = False
+        last_pdb_step = {}
+        if ipyconsole:
+            debugging = ipyconsole.get_pdb_state()
+            last_pdb_step = ipyconsole.get_pdb_last_step()
+
         can_close = True
         if debugging and 'fname' in last_pdb_step and filename:
             if osp.normcase(last_pdb_step['fname']) == osp.normcase(filename):
@@ -2581,7 +2593,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             current_stack.hide_tooltip()
 
         # Update debugging state
-        ipyconsole = getattr(self.main, 'ipyconsole', None)
+        ipyconsole = self.main.get_plugin(Plugins.IPythonConsole, error=False)
         if ipyconsole is not None:
             pdb_state = ipyconsole.get_pdb_state()
             pdb_last_step = ipyconsole.get_pdb_last_step()
@@ -2712,13 +2724,17 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
 
     def stop_debugging(self):
         """Stop debugging"""
-        self.main.ipyconsole.stop_debugging()
+        ipyconsole = self.main.get_plugin(Plugins.IPythonConsole, error=False)
+        if ipyconsole:
+            ipyconsole.stop_debugging()
 
     def debug_command(self, command):
         """Debug actions"""
         self.switch_to_plugin()
-        self.main.ipyconsole.pdb_execute_command(command)
-        self.main.ipyconsole.switch_to_plugin()
+        ipyconsole = self.main.get_plugin(Plugins.IPythonConsole, error=False)
+        if ipyconsole:
+            ipyconsole.pdb_execute_command(command)
+            ipyconsole.switch_to_plugin()
 
     # ----- Handlers for the IPython Console kernels
     def _get_editorstack(self):

--- a/spyder/plugins/editor/tests/conftest.py
+++ b/spyder/plugins/editor/tests/conftest.py
@@ -11,9 +11,11 @@
 import os.path as osp
 from unittest.mock import MagicMock, Mock
 
+from spyder.api.plugins import Plugins
+from spyder.utils.qthelpers import qapplication
+
 # This is needed to avoid an error because QtAwesome
 # needs a QApplication to work correctly.
-from spyder.utils.qthelpers import qapplication
 app = qapplication()
 
 from qtpy.QtWidgets import QMainWindow
@@ -41,19 +43,17 @@ def editor_plugin(qtbot, monkeypatch):
         def __getattr__(self, attr):
             if attr.endswith('actions'):
                 return []
-            elif attr == 'projects':
-                projects = Mock()
-                projects.get_active_project.return_value = None
-                return projects
-            elif attr == 'ipyconsole':
-                ipyconsole = Mock()
-                ipyconsole.get_pdb_state.return_value = False
-                return ipyconsole
             else:
                 return Mock()
 
         def get_spyder_pythonpath(*args):
             return []
+
+        def get_plugin(self, plugin_name, error=True):
+            if plugin_name in [Plugins.IPythonConsole, Plugins.Projects]:
+                return None
+            else:
+                return Mock()
 
     window = MainMock()
     editor = Editor(window)


### PR DESCRIPTION
## Description of Changes

- Spyder was crashing at start-up if Projects is not available, so we need to check for its presence first before trying to use it.
- I also took the opportunity to do the same for some actions that depend on the IPython console.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16931.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
