### PR TITLE
PR: Override RichJupyterWidget._get_color() because we use a custom style (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -23,6 +23,7 @@ from qtpy import QtCore, QtWidgets, QtGui
 # Local imports
 from spyder.config.base import (
     _, is_pynsist, running_in_mac_app, running_under_pytest)
+from spyder.config.gui import get_color_scheme
 from spyder.py3compat import to_text_string
 from spyder.utils.palette import SpyderPalette
 from spyder.utils import encoding
@@ -944,6 +945,17 @@ the sympy module (e.g. plot)
             self._highlighter._clear_caches()
         else:
             self._highlighter.set_style_sheet(self.style_sheet)
+
+    def _get_colors(self, color):
+        """
+        Get a color as qtconsole.styles.get_colors() would return from
+        a builtin Pygments style
+        """
+        color_scheme = get_color_scheme(self.syntax_style)
+        return dict(
+            bgcolor = color_scheme['background'],
+            select = color_scheme['background'],
+            fgcolor = color_scheme['normal'][0])[color]
 
     def _prompt_started_hook(self):
         """Emit a signal when the prompt is ready."""

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -953,9 +953,9 @@ the sympy module (e.g. plot)
         """
         color_scheme = get_color_scheme(self.syntax_style)
         return dict(
-            bgcolor = color_scheme['background'],
-            select = color_scheme['background'],
-            fgcolor = color_scheme['normal'][0])[color]
+            bgcolor=color_scheme['background'],
+            select=color_scheme['background'],
+            fgcolor=color_scheme['normal'][0])[color]
 
     def _prompt_started_hook(self):
         """Emit a signal when the prompt is ready."""

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -949,7 +949,7 @@ the sympy module (e.g. plot)
     def _get_colors(self, color):
         """
         Get a color as qtconsole.styles.get_colors() would return from
-        a builtin Pygments style
+        a builtin Pygments style.
         """
         color_scheme = get_color_scheme(self.syntax_style)
         return dict(

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -946,9 +946,9 @@ the sympy module (e.g. plot)
         else:
             self._highlighter.set_style_sheet(self.style_sheet)
 
-    def _get_colors(self, color):
+    def _get_color(self, color):
         """
-        Get a color as qtconsole.styles.get_colors() would return from
+        Get a color as qtconsole.styles._get_color() would return from
         a builtin Pygments style.
         """
         color_scheme = get_color_scheme(self.syntax_style)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


This is a follow-up on https://github.com/jupyter/qtconsole/pull/512

| before | This PR + https://github.com/jupyter/qtconsole/pull/512 + ipython/ipython#13372 |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4623504/144723007-a31a0bc3-c461-4e63-8813-6df89399eeab.png) | ![image](https://user-images.githubusercontent.com/4623504/144722989-bb56e8a4-2e53-431d-a219-66e692bc57ce.png) |



### Issue(s) Resolved

Fixes #14895
Fixes last comments (non-sympy) in #3798


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: bnavigator

<!--- Thanks for your help making Spyder better for everyone! --->
