### PR TITLE
PR: Fix get_text_with_eol for files with CRLF line endings

### DIFF
--- a/spyder/plugins/editor/widgets/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/tests/conftest.py
@@ -212,3 +212,19 @@ def search_codeeditor(completions_codeeditor, qtbot_module, request):
     request.addfinalizer(teardown)
 
     return code_editor, find_replace
+
+
+@pytest.fixture
+def editorbot(qtbot):
+    widget = CodeEditor(None)
+    widget.setup_editor(linenumbers=True,
+                        markers=True,
+                        tab_mode=False,
+                        font=QFont("Courier New", 10),
+                        show_blanks=True, color_scheme='spyder/dark',
+                        scroll_past_end=True)
+    widget.setup_editor(language='Python')
+    widget.resize(640, 480)
+    qtbot.addWidget(widget)
+    widget.show()
+    return widget

--- a/spyder/plugins/editor/widgets/tests/test_codeeditor.py
+++ b/spyder/plugins/editor/widgets/tests/test_codeeditor.py
@@ -18,7 +18,6 @@ import pytest
 # Local imports
 from spyder.utils.qthelpers import qapplication
 from spyder.plugins.editor.widgets.editor import codeeditor
-from spyder.py3compat import PY2, PY3
 
 HERE = osp.dirname(osp.abspath(__file__))
 ASSETS = osp.join(HERE, 'assets')
@@ -67,34 +66,6 @@ def test_editor_lower_to_upper(editorbot):
     assert text != new_text
 
 
-@pytest.mark.skipif(PY3, reason='Test only makes sense on Python 2.')
-def test_editor_log_lsp_handle_errors(editorbot, capsys):
-    """Test the lsp error handling / dialog report Python 2."""
-    widget = editorbot
-    params = {
-        'params': {
-            'activeParameter': 'boo',
-            'signatures': {
-                'documentation': b'\x81',
-                'label': 'foo',
-                'parameters': {
-                    'boo': {
-                        'documentation': b'\x81',
-                        'label': 'foo',
-                    },
-                }
-            }
-        }
-    }
-
-    widget.process_signatures(params)
-    captured = capsys.readouterr()
-    test_1 = "Error when processing signature" in captured.err
-    test_2 = "codec can't decode byte 0x81" in captured.err
-    assert test_1 or test_2
-
-
-@pytest.mark.skipif(PY2, reason="Python 2 strings don't have attached encoding.")
 @pytest.mark.parametrize(
     "input_text, expected_text, keys, strip_all",
     [
@@ -240,7 +211,6 @@ def test_in_string(editorbot, input_text, expected_state):
         assert widget.in_string(cursor) == expected_state[1]
 
 
-@pytest.mark.skipif(PY2, reason="Doesn't work with python 2 on travis.")
 def test_comment(editorbot):
     """
     Test that in_string works correctly.

--- a/spyder/plugins/editor/widgets/tests/test_codeeditor.py
+++ b/spyder/plugins/editor/widgets/tests/test_codeeditor.py
@@ -14,29 +14,11 @@ from qtpy.QtGui import QFont, QTextCursor, QMouseEvent
 from qtpy.QtWidgets import QTextEdit
 import pytest
 
-# Local imports
-from spyder.utils.qthelpers import qapplication
-from spyder.plugins.editor.widgets.editor import codeeditor
 
 HERE = osp.dirname(osp.abspath(__file__))
 ASSETS = osp.join(HERE, 'assets')
 
-# --- Fixtures
-# -----------------------------------------------------------------------------
-@pytest.fixture
-def editorbot(qtbot):
-    widget = codeeditor.CodeEditor(None)
-    widget.setup_editor(linenumbers=True, markers=True, tab_mode=False,
-                        font=QFont("Courier New", 10),
-                        show_blanks=True, color_scheme='spyder/dark',
-                        scroll_past_end=True)
-    widget.setup_editor(language='Python')
-    qtbot.addWidget(widget)
-    widget.show()
-    return widget
 
-# --- Tests
-# -----------------------------------------------------------------------------
 def test_editor_upper_to_lower(editorbot):
     widget = editorbot
     text = 'UPPERCASE'

--- a/spyder/plugins/editor/widgets/tests/test_codeeditor.py
+++ b/spyder/plugins/editor/widgets/tests/test_codeeditor.py
@@ -35,14 +35,14 @@ def editorbot(qtbot):
     widget.setup_editor(language='Python')
     qtbot.addWidget(widget)
     widget.show()
-    return qtbot, widget
+    return widget
 
 # --- Tests
 # -----------------------------------------------------------------------------
 # testing lowercase transformation functionality
 
 def test_editor_upper_to_lower(editorbot):
-    qtbot, widget = editorbot
+    widget = editorbot
     text = 'UPPERCASE'
     widget.set_text(text)
     cursor = widget.textCursor()
@@ -55,7 +55,7 @@ def test_editor_upper_to_lower(editorbot):
 
 
 def test_editor_lower_to_upper(editorbot):
-    qtbot, widget = editorbot
+    widget = editorbot
     text = 'uppercase'
     widget.set_text(text)
     cursor = widget.textCursor()
@@ -70,7 +70,7 @@ def test_editor_lower_to_upper(editorbot):
 @pytest.mark.skipif(PY3, reason='Test only makes sense on Python 2.')
 def test_editor_log_lsp_handle_errors(editorbot, capsys):
     """Test the lsp error handling / dialog report Python 2."""
-    qtbot, widget = editorbot
+    widget = editorbot
     params = {
         'params': {
             'activeParameter': 'boo',
@@ -167,12 +167,12 @@ def test_editor_log_lsp_handle_errors(editorbot, capsys):
          [Qt.Key_Enter, Qt.Key_Enter, Qt.Key_Backspace],
          True),
     ])
-def test_editor_rstrip_keypress(editorbot, input_text, expected_text, keys,
-                                strip_all):
+def test_editor_rstrip_keypress(editorbot, qtbot, input_text, expected_text,
+                                keys, strip_all):
     """
     Test that whitespace is removed when leaving a line.
     """
-    qtbot, widget = editorbot
+    widget = editorbot
     widget.strip_trailing_spaces_on_modify = strip_all
     widget.set_text(input_text)
     cursor = widget.textCursor()
@@ -225,7 +225,7 @@ def test_in_string(editorbot, input_text, expected_state):
     """
     Test that in_string works correctly.
     """
-    qtbot, widget = editorbot
+    widget = editorbot
     widget.set_text(input_text + '\n  ')
     cursor = widget.textCursor()
 
@@ -245,7 +245,7 @@ def test_comment(editorbot):
     """
     Test that in_string works correctly.
     """
-    qtbot, widget = editorbot
+    widget = editorbot
     widget.set_text("import numpy")
     cursor = widget.textCursor()
     cursor.setPosition(8)
@@ -257,9 +257,9 @@ def test_comment(editorbot):
     assert widget.toPlainText() == "import numpy"
 
 
-def test_undo_return(editorbot):
+def test_undo_return(editorbot, qtbot):
     """Test that we can undo a return."""
-    qtbot, editor = editorbot
+    editor = editorbot
     text = "if True:\n    0"
     returned_text = "if True:\n    0\n    "
     editor.set_text(text)
@@ -293,7 +293,7 @@ def test_brace_match(editorbot):
      * CodeEditor.in_string
     """
     # Create editor with contents loaded from assets/brackets.py
-    qtbot, editor = editorbot
+    editor = editorbot
     with open(osp.join(ASSETS, 'braces.py'), 'r') as file:
         editor.set_text(file.read())
 
@@ -367,9 +367,9 @@ def test_brace_match(editorbot):
         assert editor.bracepos == expected
 
 
-def test_editor_backspace_char(editorbot):
+def test_editor_backspace_char(editorbot, qtbot):
     """Regression test for issue spyder-ide/spyder#12663."""
-    qtbot, editor = editorbot
+    editor = editorbot
     text = "0123456789\nabcdefghij\n9876543210\njihgfedcba\n"
     editor.set_text(text)
     expected_column = 7
@@ -391,9 +391,9 @@ def test_editor_backspace_char(editorbot):
         assert editor.textCursor().columnNumber() == expected_column
 
 
-def test_editor_backspace_selection(editorbot):
+def test_editor_backspace_selection(editorbot, qtbot):
     """Regression test for issue spyder-ide/spyder#12663."""
-    qtbot, editor = editorbot
+    editor = editorbot
     text = "0123456789\nabcdefghij\n9876543210\njihgfedcba\n"
     editor.set_text(text)
     expected_column = 5
@@ -419,9 +419,9 @@ def test_editor_backspace_selection(editorbot):
     assert editor.textCursor().columnNumber() == expected_column
 
 
-def test_editor_delete_char(editorbot):
+def test_editor_delete_char(editorbot, qtbot):
     """Regression test for issue spyder-ide/spyder#12663."""
-    qtbot, editor = editorbot
+    editor = editorbot
     text = "0123456789\nabcdefghij\n9876543210\njihgfedcba\n"
     editor.set_text(text)
     expected_column = 2
@@ -443,9 +443,9 @@ def test_editor_delete_char(editorbot):
 
 # Fails in CI Linux tests, but not necessarily on all Linux installations
 @pytest.mark.skipif(sys.platform.startswith('linux'), reason='Fail on Linux')
-def test_editor_delete_selection(editorbot):
+def test_editor_delete_selection(editorbot, qtbot):
     """Regression test for issue spyder-ide/spyder#12663."""
-    qtbot, editor = editorbot
+    editor = editorbot
     text = "0123456789\nabcdefghij\n9876543210\njihgfedcba\n"
     editor.set_text(text)
     expected_column = 5

--- a/spyder/plugins/editor/widgets/tests/test_codeeditor.py
+++ b/spyder/plugins/editor/widgets/tests/test_codeeditor.py
@@ -12,7 +12,6 @@ import sys
 from qtpy.QtCore import Qt, QEvent
 from qtpy.QtGui import QFont, QTextCursor, QMouseEvent
 from qtpy.QtWidgets import QTextEdit
-from pytestqt import qtbot
 import pytest
 
 # Local imports
@@ -29,7 +28,7 @@ def editorbot(qtbot):
     widget = codeeditor.CodeEditor(None)
     widget.setup_editor(linenumbers=True, markers=True, tab_mode=False,
                         font=QFont("Courier New", 10),
-                        show_blanks=True, color_scheme='Zenburn',
+                        show_blanks=True, color_scheme='spyder/dark',
                         scroll_past_end=True)
     widget.setup_editor(language='Python')
     qtbot.addWidget(widget)
@@ -38,8 +37,6 @@ def editorbot(qtbot):
 
 # --- Tests
 # -----------------------------------------------------------------------------
-# testing lowercase transformation functionality
-
 def test_editor_upper_to_lower(editorbot):
     widget = editorbot
     text = 'UPPERCASE'
@@ -476,6 +473,24 @@ def test_qtbug35861(qtbot):
         assert widget.textCursor().columnNumber() == (expected_column - 1)
         qtbot.keyClick(widget, Qt.Key_Up)
         assert widget.textCursor().columnNumber() == expected_column
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "def foo(x):\n    return x\n",      # LF
+        "def foo(x):\r\n    return x\r\n",  # CRLF
+        "def foo(x):\r    return x\r"       # CR
+    ]
+)
+def test_get_text_with_eol(editorbot, text):
+    """
+    Test that get_text_with_eol returns the right text with the most
+    common line endings.
+    """
+    editor = editorbot
+    editor.set_text(text)
+    assert editor.get_text_with_eol() == text
 
 
 if __name__ == '__main__':

--- a/spyder/plugins/editor/widgets/tests/test_goto.py
+++ b/spyder/plugins/editor/widgets/tests/test_goto.py
@@ -17,7 +17,6 @@ import pytest
 
 # Local imports
 from spyder.config.base import running_in_ci
-from spyder.plugins.editor.widgets.tests.test_codeeditor import editorbot
 from spyder.utils.vcs import get_git_remotes
 
 # Constants
@@ -83,7 +82,7 @@ TEST_FILE_REL = 'conftest.py'
     )
 def test_goto_uri(qtbot, editorbot, mocker, params):
     """Test that the uri search is working correctly."""
-    _, code_editor = editorbot
+    code_editor = editorbot
     code_editor.show()
     mocker.patch.object(QDesktopServices, 'openUrl')
 
@@ -123,7 +122,7 @@ def test_goto_uri(qtbot, editorbot, mocker, params):
 
 def test_goto_uri_project_root_path(qtbot, editorbot, mocker, tmpdir):
     """Test that the uri search is working correctly."""
-    _, code_editor = editorbot
+    code_editor = editorbot
     code_editor.show()
     mock_project_dir = str(tmpdir)
     expected_output_path = os.path.join(mock_project_dir, "some-file.txt")
@@ -174,7 +173,7 @@ def test_goto_uri_message_box(qtbot, editorbot, mocker):
     Test that a message box is displayed when the shorthand issue notation is
     used (gh-123) indicating the user that the file is not under a repository
     """
-    _, code_editor = editorbot
+    code_editor = editorbot
     code_editor.filename = TEMPFILE_PATH
     code_editor._last_hover_pattern_key = 'issue'
 
@@ -198,7 +197,7 @@ def test_goto_uri_message_box(qtbot, editorbot, mocker):
 
 def test_pattern_highlight_regression(qtbot, editorbot):
     """Fix regression on spyder-ide/spyder#11376."""
-    _, code_editor = editorbot
+    code_editor = editorbot
     code_editor.show()
 
     # This was generating an infinite loop

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -41,9 +41,9 @@ from spyder.widgets.arraybuilder import ArrayBuilderDialog
 # List of possible EOL symbols
 EOL_SYMBOLS = [
     # Put first as it correspond to a single line return
-    "\r\n"  # Carriage Return + Line Feed
-    "\n",  # Line Feed
+    "\r\n",  # Carriage Return + Line Feed
     "\r",  # Carriage Return
+    "\n",  # Line Feed
     "\v",  # Line Tabulation
     "\x0b",  # Line Tabulation
     "\f",  # Form Feed


### PR DESCRIPTION
## Description of Changes

- This was broken after #16864.
- Add a regression test for that method so it doesn't break in the future.
- Do some cleanup for the CodeEditor tests.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
