### PR TITLE
PR: Cast floats to ints in tab switcher (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -130,9 +130,9 @@ class TabSwitcherWidget(QListWidget):
 
     def set_dialog_position(self):
         """Positions the tab switcher in the top-center of the editor."""
-        left = self.editor.geometry().width()/2 - self.width()/2
-        top = (self.editor.tabs.tabBar().geometry().height() +
-               self.editor.fname_label.geometry().height())
+        left = int(self.editor.geometry().width()/2 - self.width()/2)
+        top = int(self.editor.tabs.tabBar().geometry().height() +
+                  self.editor.fname_label.geometry().height())
 
         self.move(self.editor.mapToGlobal(QPoint(left, top)))
 


### PR DESCRIPTION
## Description of Changes

Floats are not automatically cast to ints in Python 3.10, so we need to do it manually.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16960.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
