### PR TITLE
PR: Limit the number of flags in the editor

### DIFF
--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -23,6 +23,7 @@ from spyder.plugins.completion.api import DiagnosticSeverity
 
 
 REFRESH_RATE = 1000
+
 # Maximum number of flags to print in a file
 MAX_FLAGS = 1000
 
@@ -220,10 +221,11 @@ class ScrollFlagArea(Panel):
                         continue
                     geometry = editor.blockBoundingGeometry(block)
                     rect_y = ceil(
-                        geometry.y()
-                        + geometry.height() / 2 + rect_h / 2)
+                        geometry.y() +
+                        geometry.height() / 2 +
+                        rect_h / 2
+                    )
                     painter.drawRect(rect_x, rect_y, rect_w, rect_h)
-
             elif last_line == 0:
                 # Only one line
                 for block in dict_flag_lists[flag_type]:

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -23,6 +23,8 @@ from spyder.plugins.completion.api import DiagnosticSeverity
 
 
 REFRESH_RATE = 1000
+# Maximum number of flags to print in a file
+MAX_FLAGS = 1000
 
 
 class ScrollFlagArea(Panel):
@@ -146,7 +148,7 @@ class ScrollFlagArea(Panel):
                     flag_type = None
 
                 if flag_type is not None:
-                    self._dict_flag_list[flag_type].append(block.blockNumber())
+                    self._dict_flag_list[flag_type].append(block)
 
             block = block.next()
 
@@ -194,17 +196,9 @@ class ScrollFlagArea(Panel):
         last_y_pos = self.value_to_position(
             last_line + 0.5, scale_factor, offset) - self.FLAGS_DY / 2
 
-        def compute_flag_ypos(block):
-            line_number = block.firstLineNumber()
-            if editor.verticalScrollBar().maximum() == 0:
-                geometry = editor.blockBoundingGeometry(block)
-                pos = geometry.y() + geometry.height() / 2 + self.FLAGS_DY / 2
-            elif last_line != 0:
-                frac = line_number / last_line
-                pos = first_y_pos + frac * (last_y_pos - first_y_pos)
-            else:
-                pos = first_y_pos
-            return ceil(pos)
+        # Compute the height of a line and of a flag in lines.
+        line_height = last_y_pos - first_y_pos
+        flag_height_lines = rect_h * last_line / line_height
 
         # All the lists of block numbers for flags
         dict_flag_lists = {
@@ -216,14 +210,39 @@ class ScrollFlagArea(Panel):
         for flag_type in dict_flag_lists:
             painter.setBrush(self._facecolors[flag_type])
             painter.setPen(self._edgecolors[flag_type])
-            for block_number in dict_flag_lists[flag_type]:
-                # Find the block
-                block = editor.document().findBlockByNumber(block_number)
-                if not block.isValid():
-                    continue
-                # paint if everything else is fine
-                rect_y = compute_flag_ypos(block)
-                painter.drawRect(rect_x, rect_y, rect_w, rect_h)
+            if editor.verticalScrollBar().maximum() == 0:
+                # No scroll
+                for block in dict_flag_lists[flag_type]:
+                    if not block.isValid():
+                        continue
+                    geometry = editor.blockBoundingGeometry(block)
+                    rect_y = ceil(
+                        geometry.y()
+                        + geometry.height() / 2 + rect_h / 2)
+                    painter.drawRect(rect_x, rect_y, rect_w, rect_h)
+
+            elif last_line == 0:
+                # Only one line
+                for block in dict_flag_lists[flag_type]:
+                    if not block.isValid():
+                        continue
+                    rect_y = ceil(first_y_pos)
+                    painter.drawRect(rect_x, rect_y, rect_w, rect_h)
+            else:
+                # Many lines
+                if len(dict_flag_lists[flag_type]) < MAX_FLAGS:
+                    # If the file is too long, do not freeze the editor
+                    next_line = 0
+                    for block in dict_flag_lists[flag_type]:
+                        block_line = block.firstLineNumber()
+                        # block_line = -1 if invalid
+                        if block_line < next_line:
+                            # Don't print flags on top of flags
+                            continue
+                        next_line = block_line + flag_height_lines / 2
+                        frac = block_line / last_line
+                        rect_y = ceil(first_y_pos + frac * line_height)
+                        painter.drawRect(rect_x, rect_y, rect_w, rect_h)
 
         # Paint the slider range
         if not self._unit_testing:

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -237,6 +237,8 @@ class ScrollFlagArea(Panel):
                     # If the file is too long, do not freeze the editor
                     next_line = 0
                     for block in dict_flag_lists[flag_type]:
+                        if not block.isValid():
+                            continue
                         block_line = block.firstLineNumber()
                         # block_line = -1 if invalid
                         if block_line < next_line:

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -198,7 +198,10 @@ class ScrollFlagArea(Panel):
 
         # Compute the height of a line and of a flag in lines.
         line_height = last_y_pos - first_y_pos
-        flag_height_lines = rect_h * last_line / line_height
+        if line_height > 0:
+            flag_height_lines = rect_h * last_line / line_height
+        else:
+            flag_height_lines = 0
 
         # All the lists of block numbers for flags
         dict_flag_lists = {

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2506,7 +2506,7 @@ class CodeEditor(TextEditBaseWidget):
         extra_selections = self.get_extra_selections('occurrences')
         first_occurrence = None
         while cursor:
-            self.occurrences.append(cursor.blockNumber())
+            self.occurrences.append(cursor.block())
             selection = self.get_selection(cursor)
             if len(selection.cursor.selectedText()) > 0:
                 extra_selections.append(selection)
@@ -2550,7 +2550,7 @@ class CodeEditor(TextEditBaseWidget):
             selection = TextDecoration(self.textCursor())
             selection.format.setBackground(self.found_results_color)
             selection.cursor.setPosition(pos1)
-            self.found_results.append(selection.cursor.blockNumber())
+            self.found_results.append(selection.cursor.block())
             selection.cursor.setPosition(pos2, QTextCursor.KeepAnchor)
             extra_selections.append(selection)
         self.set_extra_selections('find', extra_selections)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
If there are too many flags in the document, the flags will slow down the printing. This disables the flags of a type if there are more than 10000.

To reproduce, create a file with:
```
with open("test.py", "w") as f:
    for i in range(10000):
        f.write("aaaaaa\n")
```
This will create 10000 error flags, which will slow down spyder significantly


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
