### PR TITLE
PR: Fix option to maintain focus on editor after running cells or selections

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -85,8 +85,8 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
     # Signals
     run_in_current_ipyclient = Signal(str, str, str,
                                       bool, bool, bool, bool, bool)
-    run_cell_in_ipyclient = Signal(str, object, str, bool)
-    debug_cell_in_ipyclient = Signal(str, object, str, bool)
+    run_cell_in_ipyclient = Signal(str, object, str, bool, bool)
+    debug_cell_in_ipyclient = Signal(str, object, str, bool, bool)
     exec_in_extconsole = Signal(str, bool)
     redirect_stdio = Signal(bool)
 
@@ -1535,14 +1535,9 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         editorstack.exec_in_extconsole.connect(
                                     lambda text, option:
                                     self.exec_in_extconsole.emit(text, option))
-        editorstack.run_cell_in_ipyclient.connect(
-            lambda code, cell_name, filename, run_cell_copy:
-            self.run_cell_in_ipyclient.emit(code, cell_name, filename,
-                                            run_cell_copy))
+        editorstack.run_cell_in_ipyclient.connect(self.run_cell_in_ipyclient)
         editorstack.debug_cell_in_ipyclient.connect(
-            lambda code, cell_name, filename, run_cell_copy:
-            self.debug_cell_in_ipyclient.emit(code, cell_name, filename,
-                                              run_cell_copy))
+            self.debug_cell_in_ipyclient)
         editorstack.update_plugin_title.connect(
                                    lambda: self.sig_update_plugin_title.emit())
         editorstack.editor_focus_changed.connect(self.save_focused_editorstack)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -180,8 +180,8 @@ class EditorStack(QWidget):
     ending_long_process = Signal(str)
     redirect_stdio = Signal(bool)
     exec_in_extconsole = Signal(str, bool)
-    run_cell_in_ipyclient = Signal(str, object, str, bool)
-    debug_cell_in_ipyclient = Signal(str, object, str, bool)
+    run_cell_in_ipyclient = Signal(str, object, str, bool, bool)
+    debug_cell_in_ipyclient = Signal(str, object, str, bool, bool)
     update_plugin_title = Signal()
     editor_focus_changed = Signal()
     zoom_in = Signal()
@@ -2752,15 +2752,7 @@ class EditorStack(QWidget):
         else:
             move_func = self.get_current_editor().go_to_previous_cell
 
-        if self.focus_to_editor:
-            move_func()
-        else:
-            term = QApplication.focusWidget()
-            move_func()
-            term.setFocus()
-            term = QApplication.focusWidget()
-            move_func()
-            term.setFocus()
+        move_func()
 
     def re_run_last_cell(self):
         """Run the previous cell again."""
@@ -2795,13 +2787,12 @@ class EditorStack(QWidget):
         """
         (filename, cell_name) = cell_id
         if editor.is_python_or_ipython():
-            args = (text, cell_name, filename, self.run_cell_copy)
+            args = (text, cell_name, filename, self.run_cell_copy,
+                    self.focus_to_editor)
             if debug:
                 self.debug_cell_in_ipyclient.emit(*args)
             else:
                 self.run_cell_in_ipyclient.emit(*args)
-        if self.focus_to_editor and not editor.hasFocus():
-            editor.setFocus()
 
     #  ------ Drag and drop
     def dragEnterEvent(self, event):

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -602,7 +602,7 @@ class IPythonConsole(SpyderDockablePlugin):
             console_namespace)
 
     def run_cell(self, code, cell_name, filename, run_cell_copy,
-                 function='runcell'):
+                 focus_to_editor, function='runcell'):
         """
         Run cell in current or dedicated client.
 
@@ -618,6 +618,9 @@ class IPythonConsole(SpyderDockablePlugin):
         run_cell_copy : bool
             True if the cell should be executed line by line,
             False if the provided `function` should be used.
+        focus_to_editor: bool
+            Whether to give focus to the editor after running the cell. If
+            False, focus is given to the console.
         function : str, optional
             Name handler of the kernel function to be used to execute the cell
             in case `run_cell_copy` is False.
@@ -629,9 +632,11 @@ class IPythonConsole(SpyderDockablePlugin):
 
         """
         self.get_widget().run_cell(
-            code, cell_name, filename, run_cell_copy, function=function)
+            code, cell_name, filename, run_cell_copy, focus_to_editor,
+            function=function)
 
-    def debug_cell(self, code, cell_name, filename, run_cell_copy):
+    def debug_cell(self, code, cell_name, filename, run_cell_copy,
+                   focus_to_editor):
         """
         Debug current cell.
 
@@ -647,13 +652,17 @@ class IPythonConsole(SpyderDockablePlugin):
         run_cell_copy : bool
             True if the cell should be executed line by line,
             False if the `debugcell` kernel function should be used.
+        focus_to_editor: bool
+            Whether to give focus to the editor after debugging the cell. If
+            False, focus is given to the console.
 
         Returns
         -------
         None.
 
         """
-        self.get_widget().debug_cell(code, cell_name, filename, run_cell_copy)
+        self.get_widget().debug_cell(code, cell_name, filename, run_cell_copy,
+                                     focus_to_editor)
 
     def execute_code(self, lines, current_client=True, clear_variables=False):
         """

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -2085,7 +2085,7 @@ class IPythonConsoleWidget(PluginMainWidget):
 
     # ---- For cells
     def run_cell(self, code, cell_name, filename, run_cell_copy,
-                 function='runcell'):
+                 focus_to_editor, function='runcell'):
         """Run cell in current or dedicated client."""
 
         def norm(text):
@@ -2112,7 +2112,7 @@ class IPythonConsoleWidget(PluginMainWidget):
                 line = code.strip()
 
             try:
-                self.execute_code(line, set_focus=False)
+                self.execute_code(line, set_focus=not focus_to_editor)
             except AttributeError:
                 pass
             self.sig_switch_to_plugin_requested.emit()
@@ -2127,9 +2127,11 @@ class IPythonConsoleWidget(PluginMainWidget):
                 QMessageBox.Ok
             )
 
-    def debug_cell(self, code, cell_name, filename, run_cell_copy):
+    def debug_cell(self, code, cell_name, filename, run_cell_copy,
+                   focus_to_editor):
         """Debug current cell."""
-        self.run_cell(code, cell_name, filename, run_cell_copy, 'debugcell')
+        self.run_cell(code, cell_name, filename, run_cell_copy,
+                      focus_to_editor, 'debugcell')
 
     # ---- For scripts
     def run_script(self, filename, wdir, args, debug, post_mortem,


### PR DESCRIPTION
## Description of Changes

- This is the option

    ![imagen](https://user-images.githubusercontent.com/365293/145124957-fc34d3f5-0e70-49ad-9cf4-89856d938b0d.png)

- It probably broke in #16324.
- I added a test for it so we can be sure it doesn't break in the future.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
