### PR TITLE
PR: Fix changing color scheme and UI theme (Appearance)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,7 +16,6 @@ import os.path as osp
 import shutil
 import subprocess
 import sys
-import warnings
 
 
 # ---- To activate/deactivate certain things for pytest's only

--- a/spyder/api/plugin_registration/registry.py
+++ b/spyder/api/plugin_registration/registry.py
@@ -19,7 +19,6 @@ from spyder.config.base import _, running_under_pytest
 from spyder.config.manager import CONF
 from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.api.plugin_registration._confpage import PluginsConfigPage
-from spyder.api.plugins.enum import Plugins
 from spyder.api.exceptions import SpyderAPIError
 from spyder.api.plugins import (
     Plugins, SpyderPluginV2, SpyderDockablePlugin, SpyderPluginWidget,

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -4332,7 +4332,7 @@ foo(1)
 
     # Change focus_to_editor option
     main_window.editor.set_option('focus_to_editor', focus_to_editor)
-    main_window.editor.apply_plugin_settings({(None, 'focus_to_editor')})
+    main_window.editor.apply_plugin_settings({'focus_to_editor'})
     code_editor = main_window.editor.get_current_editor()
 
     # Wait for the console to be up

--- a/spyder/plugins/appearance/confpage.py
+++ b/spyder/plugins/appearance/confpage.py
@@ -8,16 +8,13 @@
 
 from qtconsole.styles import dark_color
 from qtpy.QtCore import Slot
-from qtpy.QtWidgets import (QApplication, QDialog, QFontComboBox,
-                            QGridLayout, QGroupBox, QMessageBox,
-                            QPushButton, QStackedWidget, QStyleFactory,
-                            QVBoxLayout)
+from qtpy.QtWidgets import (QFontComboBox, QGridLayout, QGroupBox, QMessageBox,
+                            QPushButton, QStackedWidget, QVBoxLayout)
 
 from spyder.api.preferences import PluginConfigPage
 from spyder.api.translations import get_translation
 from spyder.config.gui import get_font, is_dark_font_color, set_font
 from spyder.config.manager import CONF
-from spyder.config.utils import is_gtk_desktop
 from spyder.plugins.appearance.widgets import SchemeEditor
 from spyder.utils import syntaxhighlighters
 from spyder.utils.palette import QStylePalette

--- a/spyder/plugins/appearance/confpage.py
+++ b/spyder/plugins/appearance/confpage.py
@@ -45,6 +45,7 @@ class AppearanceConfigPage(PluginConfigPage):
                                               ui_theme_choices,
                                               'ui_theme',
                                               restart=True)
+        self.ui_combobox = ui_theme_combo.combobox
 
         themes = ['Spyder 2', 'Spyder 3']
         icon_choices = list(zip(themes, [theme.lower() for theme in themes]))

--- a/spyder/plugins/appearance/confpage.py
+++ b/spyder/plugins/appearance/confpage.py
@@ -169,55 +169,31 @@ class AppearanceConfigPage(PluginConfigPage):
             plugin.update_font()
 
     def apply_settings(self):
-        self.set_option('selected', self.current_scheme)
-        color_scheme = self.get_option('selected')
-
-        # A dark color scheme is characterized by a light font and viceversa
-        is_dark_color_scheme = not is_dark_font_color(color_scheme)
         ui_theme = self.get_option('ui_theme')
+        mismatch = self.color_scheme_and_ui_theme_mismatch(
+            self.current_scheme, ui_theme)
 
         if ui_theme == 'automatic':
-            if ((self.is_dark_interface() and not is_dark_color_scheme) or
-                    (not self.is_dark_interface() and is_dark_color_scheme)):
+            if mismatch:
+                # Ask for a restart
                 self.changed_options.add('ui_theme')
-            elif 'ui_theme' in self.changed_options:
-                self.changed_options.remove('ui_theme')
-
-            if 'ui_theme' not in self.changed_options:
-                self.main.editor.apply_plugin_settings(['color_scheme_name'])
-
-                for plugin in self.main.thirdparty_plugins:
-                    try:
-                        # New API
-                        plugin.apply_conf(['color_scheme_name'])
-                    except AttributeError:
-                        # Old API
-                        plugin.apply_plugin_settings(['color_scheme_name'])
-
-                self.update_combobox()
-                self.update_preview()
+            else:
+                # Don't ask for a restart
+                if 'ui_theme' in self.changed_options:
+                    self.changed_options.remove('ui_theme')
         else:
             if 'ui_theme' in self.changed_options:
-                if ((self.is_dark_interface() and ui_theme == 'dark') or
-                    (not self.is_dark_interface() and ui_theme == 'light')):
+                if not mismatch:
+                    # Don't ask for a restart
                     self.changed_options.remove('ui_theme')
+            else:
+                if mismatch:
+                    # Ask for a restart
+                    self.changed_options.add('ui_theme')
 
-            if 'ui_theme' not in self.changed_options:
-                self.main.editor.apply_plugin_settings(['color_scheme_name'])
+        self.update_combobox()
+        self.update_preview()
 
-                for plugin in self.main.thirdparty_plugins:
-                    try:
-                        # New API
-                        plugin.apply_conf(['color_scheme_name'])
-                    except AttributeError:
-                        # Old API
-                        plugin.apply_plugin_settings(['color_scheme_name'])
-
-                self.update_combobox()
-                self.update_preview()
-
-        if self.main.historylog is not None:
-            self.main.historylog.apply_conf(['color_scheme_name'])
         return set(self.changed_options)
 
     # Helpers
@@ -431,3 +407,32 @@ class AppearanceConfigPage(PluginConfigPage):
         detect correctly the current theme.
         """
         return dark_color(QStylePalette.COLOR_BACKGROUND_1)
+
+    def color_scheme_and_ui_theme_mismatch(self, color_scheme, ui_theme):
+        """
+        Detect if there is a mismatch between the current color scheme and
+        UI theme.
+
+        Parameters
+        ----------
+        color_scheme: str
+            Name of one of Spyder's color schemes. For instance: 'Zenburn' or
+            'Monokai'.
+        ui_theme: str
+            Name of the one of Spyder's interface themes. This can 'automatic',
+            'dark' or 'light'.
+        """
+        # A dark color scheme is characterized by a light font and viceversa
+        is_dark_color_scheme = not is_dark_font_color(color_scheme)
+        if ui_theme == 'automatic':
+            mismatch = (
+                (self.is_dark_interface() and not is_dark_color_scheme) or
+                (not self.is_dark_interface() and is_dark_color_scheme)
+            )
+        else:
+            mismatch = (
+                (self.is_dark_interface() and ui_theme == 'light') or
+                (not self.is_dark_interface() and ui_theme == 'dark')
+            )
+
+        return mismatch

--- a/spyder/plugins/appearance/plugin.py
+++ b/spyder/plugins/appearance/plugin.py
@@ -37,8 +37,8 @@ class Appearance(SpyderPluginV2):
     CONF_FILE = False
     CAN_BE_DISABLED = False
 
-    # --- SpyderPluginV2 API
-    # ------------------------------------------------------------------------
+    # ---- SpyderPluginV2 API
+    # -------------------------------------------------------------------------
     @staticmethod
     def get_name():
         return _("Appearance")

--- a/spyder/plugins/appearance/tests/__init__.py
+++ b/spyder/plugins/appearance/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+
+"""Appearance tests."""

--- a/spyder/plugins/appearance/tests/test_confpage.py
+++ b/spyder/plugins/appearance/tests/test_confpage.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+
+# Third-party imports
+import pytest
+
+# Local imports
+from spyder.plugins.appearance.plugin import Appearance
+from spyder.plugins.preferences.api import SpyderConfigPage
+from spyder.plugins.preferences.tests.conftest import (
+    config_dialog, MainWindowMock)
+
+
+@pytest.mark.parametrize(
+    'config_dialog',
+    [[MainWindowMock, [], [Appearance]]],
+    indirect=True)
+def test_change_ui_theme_and_color_scheme(config_dialog, mocker, qtbot):
+    """Test that changing color scheme or UI theme works as expected."""
+    # Patch methods whose calls we want to check
+    mocker.patch.object(SpyderConfigPage, "prompt_restart_required")
+
+    # Get reference to Preferences dialog and widget page to interact with
+    dlg = config_dialog
+    widget = config_dialog.get_page()
+
+    # List of color schemes
+    names = widget.get_option('names')
+
+    # Assert no restarts have been requested so far.
+    assert SpyderConfigPage.prompt_restart_required.call_count == 0
+
+    # Assert default UI theme is 'automatic' and interface is dark. The other
+    # tests below depend on this.
+    assert widget.get_option('ui_theme') == 'automatic'
+    assert widget.is_dark_interface()
+
+    # Change to another dark color scheme
+    widget.schemes_combobox.setCurrentIndex(names.index('monokai'))
+    dlg.apply_btn.click()
+    assert SpyderConfigPage.prompt_restart_required.call_count == 0
+
+    # Change to a light color scheme
+    widget.schemes_combobox.setCurrentIndex(names.index('pydev'))
+    dlg.apply_btn.clicked.emit()
+    assert SpyderConfigPage.prompt_restart_required.call_count == 1
+
+    # Change to the 'dark' ui theme
+    widget.ui_combobox.setCurrentIndex(2)
+    dlg.apply_btn.clicked.emit()
+    assert SpyderConfigPage.prompt_restart_required.call_count == 1
+
+    # Change to the 'automatic' ui theme
+    widget.ui_combobox.setCurrentIndex(0)
+    dlg.apply_btn.clicked.emit()
+    assert SpyderConfigPage.prompt_restart_required.call_count == 2
+
+    # Change to the 'light' ui theme
+    widget.ui_combobox.setCurrentIndex(1)
+    dlg.apply_btn.clicked.emit()
+    assert SpyderConfigPage.prompt_restart_required.call_count == 3
+
+    # Change to another dark color scheme
+    widget.schemes_combobox.setCurrentIndex(names.index('solarized/dark'))
+    dlg.apply_btn.clicked.emit()
+    assert SpyderConfigPage.prompt_restart_required.call_count == 4
+
+    # Change to the 'automatic' ui theme again
+    widget.ui_combobox.setCurrentIndex(0)
+    dlg.apply_btn.clicked.emit()
+    assert SpyderConfigPage.prompt_restart_required.call_count == 4

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -386,11 +386,6 @@ class CompletionPlugin(SpyderPluginV2):
         provider tabs.
         """
         providers_to_update = set({})
-        options = [
-            x[1] if isinstance(x, tuple) and
-            len(x) == 2 and x[0] is None or 'editor'
-            else x for x in options
-        ]
         for option in options:
             if option == 'completions_wait_for_ms':
                 self.wait_for_ms = self.get_conf(

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -3020,8 +3020,6 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         """Apply configuration file's plugin settings"""
         if self.editorstacks is not None:
             # --- syntax highlight and text rendering settings
-            color_scheme_n = 'color_scheme_name'
-            color_scheme_o = self.get_color_scheme()
             currentline_n = 'highlight_current_line'
             currentline_o = self.get_option(currentline_n)
             currentcell_n = 'highlight_current_cell'
@@ -3034,8 +3032,6 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             focus_to_editor_o = self.get_option(focus_to_editor_n)
 
             for editorstack in self.editorstacks:
-                if color_scheme_n in options:
-                    editorstack.set_color_scheme(color_scheme_o)
                 if currentline_n in options:
                     editorstack.set_highlight_current_line_enabled(
                                                                 currentline_o)
@@ -3269,6 +3265,13 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             logger.debug(f"Set underline errors to {value}")
             for editorstack in self.editorstacks:
                 editorstack.set_underline_errors_enabled(value)
+
+    @on_conf_change(option='selected', section='appearance')
+    def set_color_scheme(self, value):
+        if self.editorstacks is not None:
+            logger.debug(f"Set color scheme to {value}")
+            for editorstack in self.editorstacks:
+                editorstack.set_color_scheme(value)
 
     # --- Open files
     def get_open_filenames(self):

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -3019,9 +3019,6 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
     def apply_plugin_settings(self, options):
         """Apply configuration file's plugin settings"""
         if self.editorstacks is not None:
-            # Get option names from the tuples sent by Preferences
-            options = list({option[1] for option in options})
-
             # --- syntax highlight and text rendering settings
             color_scheme_n = 'color_scheme_name'
             color_scheme_o = self.get_color_scheme()

--- a/spyder/plugins/help/plugin.py
+++ b/spyder/plugins/help/plugin.py
@@ -195,10 +195,6 @@ class Help(SpyderDockablePlugin):
 
     def apply_conf(self, options_set, notify=False):
         super().apply_conf(options_set)
-        widget = self.get_widget()
-
-        if 'color_scheme_name' in options_set:
-            widget.set_plain_text_color_scheme(self.get_color_scheme())
 
         # To make auto-connection changes take place instantly
         try:

--- a/spyder/plugins/help/widgets.py
+++ b/spyder/plugins/help/widgets.py
@@ -547,6 +547,10 @@ class HelpWidget(PluginMainWidget):
         else:
             self.force_refresh()
 
+    @on_conf_change(section='appearance', option='selected')
+    def change_color_scheme(self, value):
+        self.set_plain_text_color_scheme(value)
+
     def update_actions(self):
         for __, action in self.get_actions().items():
             # IMPORTANT: Since we are defining the main actions in here

--- a/spyder/plugins/history/widgets.py
+++ b/spyder/plugins/history/widgets.py
@@ -156,7 +156,7 @@ class HistoryWidget(PluginMainWidget):
     @on_conf_change(option='selected', section='appearance')
     def on_color_scheme_change(self, value):
         for editor in self.editors:
-            editor.set_font(self.font)
+            editor.set_color_scheme(value)
 
     # --- Public API
     # ------------------------------------------------------------------------

--- a/spyder/plugins/maininterpreter/tests/test_confpage.py
+++ b/spyder/plugins/maininterpreter/tests/test_confpage.py
@@ -12,8 +12,6 @@ import time
 # Local imports
 from spyder.api.plugins import Plugins
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
-from spyder.config.manager import CONF
-from spyder.plugins.preferences.api import PreferencePages
 from spyder.plugins.maininterpreter.plugin import MainInterpreter
 from spyder.plugins.preferences.tests.conftest import MainWindowMock
 from spyder.utils.conda import get_list_conda_envs
@@ -22,7 +20,7 @@ from spyder.utils.pyenv import get_list_pyenv_envs
 
 # Get envs to show them in the Main interpreter page. This is actually
 # done in a thread in the InterpreterStatus widget.
-# We also recording the time needed to get them to compare it with the
+# We're also recording the time needed to get them to compare it with the
 # loading time of that config page.
 t0 = time.time()
 get_list_conda_envs()
@@ -31,14 +29,11 @@ GET_ENVS_TIME = time.time() - t0
 
 
 def test_load_time(qtbot):
-    from spyder.plugins.maininterpreter.confpage import (
-        MainInterpreterConfigPage)
-
     # Create Preferences dialog
     main = MainWindowMock()
     preferences = main.get_plugin(Plugins.Preferences)
 
-    main_interpreter = PLUGIN_REGISTRY.register_plugin(main, MainInterpreter)
+    PLUGIN_REGISTRY.register_plugin(main, MainInterpreter)
 
     # Create page and measure time to do it
     t0 = time.time()

--- a/spyder/plugins/preferences/api.py
+++ b/spyder/plugins/preferences/api.py
@@ -212,7 +212,10 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
             checkbox.clicked[bool].connect(lambda _, opt=option, sect=sec:
                                            self.has_been_modified(sect, opt))
             if checkbox.restart_required:
-                self.restart_options[(sec, option)] = checkbox.text()
+                if sec is None:
+                    self.restart_options[option] = checkbox.text()
+                else:
+                    self.restart_options[(sec, option)] = checkbox.text()
         for radiobutton, (sec, option, default) in list(
                 self.radiobuttons.items()):
             radiobutton.setChecked(self.get_option(option, default,
@@ -220,7 +223,10 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
             radiobutton.toggled.connect(lambda _foo, opt=option, sect=sec:
                                         self.has_been_modified(sect, opt))
             if radiobutton.restart_required:
-                self.restart_options[(sec, option)] = radiobutton.label_text
+                if sec is None:
+                    self.restart_options[option] = radiobutton.label_text
+                else:
+                    self.restart_options[(sec, option)] = radiobutton.label_text
         for lineedit, (sec, option, default) in list(self.lineedits.items()):
             data = self.get_option(option, default, section=sec)
             if getattr(lineedit, 'content_type', None) == list:
@@ -229,7 +235,10 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
             lineedit.textChanged.connect(lambda _, opt=option, sect=sec:
                                          self.has_been_modified(sect, opt))
             if lineedit.restart_required:
-                self.restart_options[(sec, option)] = lineedit.label_text
+                if sec is None:
+                    self.restart_options[option] = lineedit.label_text
+                else:
+                    self.restart_options[(sec, option)] = lineedit.label_text
         for textedit, (sec, option, default) in list(self.textedits.items()):
             data = self.get_option(option, default, section=sec)
             if getattr(textedit, 'content_type', None) == list:
@@ -240,7 +249,10 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
             textedit.textChanged.connect(lambda opt=option, sect=sec:
                                          self.has_been_modified(sect, opt))
             if textedit.restart_required:
-                self.restart_options[(sec, option)] = textedit.label_text
+                if sec is None:
+                    self.restart_options[option] = textedit.label_text
+                else:
+                    self.restart_options[(sec, option)] = textedit.label_text
         for spinbox, (sec, option, default) in list(self.spinboxes.items()):
             spinbox.setValue(self.get_option(option, default, section=sec))
             spinbox.valueChanged.connect(lambda _foo, opt=option, sect=sec:
@@ -263,7 +275,10 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
                                                  self.has_been_modified(
                                                      sect, opt))
             if combobox.restart_required:
-                self.restart_options[(sec, option)] = combobox.label_text
+                if sec is None:
+                    self.restart_options[option] = combobox.label_text
+                else:
+                    self.restart_options[(sec, option)] = combobox.label_text
 
         for (fontbox, sizebox), option in list(self.fontboxes.items()):
             rich_font = True if "rich" in option.lower() else False
@@ -318,17 +333,20 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
         """Save settings to configuration file"""
         for checkbox, (sec, option, _default) in list(
                 self.checkboxes.items()):
-            if (sec, option) in self.changed_options:
+            if (option in self.changed_options or
+                    (sec, option) in self.changed_options):
                 value = checkbox.isChecked()
                 self.set_option(option, value, section=sec,
                                 recursive_notification=False)
         for radiobutton, (sec, option, _default) in list(
                 self.radiobuttons.items()):
-            if (sec, option) in self.changed_options:
+            if (option in self.changed_options or
+                    (sec, option) in self.changed_options):
                 self.set_option(option, radiobutton.isChecked(), section=sec,
                                 recursive_notification=False)
         for lineedit, (sec, option, _default) in list(self.lineedits.items()):
-            if (sec, option) in self.changed_options:
+            if (option in self.changed_options or
+                    (sec, option) in self.changed_options):
                 data = lineedit.text()
                 content_type = getattr(lineedit, 'content_type', None)
                 if content_type == list:
@@ -338,7 +356,8 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
                 self.set_option(option, data, section=sec,
                                 recursive_notification=False)
         for textedit, (sec, option, _default) in list(self.textedits.items()):
-            if (sec, option) in self.changed_options:
+            if (option in self.changed_options or
+                    (sec, option) in self.changed_options):
                 data = textedit.toPlainText()
                 content_type = getattr(textedit, 'content_type', None)
                 if content_type == dict:
@@ -353,11 +372,13 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
                 self.set_option(option, data, section=sec,
                                 recursive_notification=False)
         for spinbox, (sec, option, _default) in list(self.spinboxes.items()):
-            if (sec, option) in self.changed_options:
+            if (option in self.changed_options or
+                    (sec, option) in self.changed_options):
                 self.set_option(option, spinbox.value(), section=sec,
                                 recursive_notification=False)
         for combobox, (sec, option, _default) in list(self.comboboxes.items()):
-            if (sec, option) in self.changed_options:
+            if (option in self.changed_options or
+                    (sec, option) in self.changed_options):
                 data = combobox.itemData(combobox.currentIndex())
                 self.set_option(option, from_qvariant(data, to_text_string),
                                 section=sec, recursive_notification=False)
@@ -367,13 +388,15 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
                 font.setPointSize(sizebox.value())
                 self.set_font(font, option)
         for clayout, (sec, option, _default) in list(self.coloredits.items()):
-            if (sec, option) in self.changed_options:
+            if (option in self.changed_options or
+                    (sec, option) in self.changed_options):
                 self.set_option(option,
                                 to_text_string(clayout.lineedit.text()),
                                 section=sec, recursive_notification=False)
         for (clayout, cb_bold, cb_italic), (sec, option, _default) in list(
                 self.scedits.items()):
-            if (sec, option) in self.changed_options:
+            if (option in self.changed_options or
+                    (sec, option) in self.changed_options):
                 color = to_text_string(clayout.lineedit.text())
                 bold = cb_bold.isChecked()
                 italic = cb_italic.isChecked()
@@ -383,7 +406,10 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
     @Slot(str)
     def has_been_modified(self, section, option):
         self.set_modified(True)
-        self.changed_options.add((section, option))
+        if section is None:
+            self.changed_options.add(option)
+        else:
+            self.changed_options.add((section, option))
 
     def create_checkbox(self, text, option, default=NoDefault,
                         tip=None, msg_warning=None, msg_info=None,

--- a/spyder/plugins/preferences/plugin.py
+++ b/spyder/plugins/preferences/plugin.py
@@ -310,7 +310,6 @@ class Preferences(SpyderPluginV2):
 
     @on_plugin_teardown(plugin=Plugins.MainMenu)
     def on_main_menu_teardown(self):
-        container = self.get_container()
         main_menu = self.get_plugin(Plugins.MainMenu)
 
         main_menu.remove_item_from_application_menu(
@@ -325,7 +324,6 @@ class Preferences(SpyderPluginV2):
 
     @on_plugin_teardown(plugin=Plugins.Toolbar)
     def on_toolbar_teardown(self):
-        container = self.get_container()
         toolbar = self.get_plugin(Plugins.Toolbar)
         toolbar.remove_item_from_application_toolbar(
             PreferencesActions.Show,

--- a/spyder/plugins/preferences/tests/conftest.py
+++ b/spyder/plugins/preferences/tests/conftest.py
@@ -102,6 +102,7 @@ class ConfigDialogTester:
         setattr(self._main, 'set_prefs_size',
                 types.MethodType(set_prefs_size, self._main))
 
+        PLUGIN_REGISTRY.reset()
         PLUGIN_REGISTRY.sig_plugin_ready.connect(self._main.register_plugin)
         PLUGIN_REGISTRY.register_plugin(self._main, Preferences)
 

--- a/spyder/plugins/preferences/tests/conftest.py
+++ b/spyder/plugins/preferences/tests/conftest.py
@@ -10,7 +10,6 @@ Testing utilities to be used with pytest.
 """
 
 import types
-
 from unittest.mock import Mock, MagicMock
 
 # Third party imports

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -24,7 +24,6 @@ import textwrap
 from qtpy.QtCore import QPoint, QRegularExpression, Qt
 from qtpy.QtGui import QCursor, QTextCursor, QTextDocument
 from qtpy.QtWidgets import QApplication
-from qtpy import QT_VERSION
 from spyder_kernels.utils.dochelpers import (getargspecfromtext, getobj,
                                              getsignaturefromtext)
 


### PR DESCRIPTION
## Description of Changes

- Show a restart message whenever there is a mismatch between the selected UI theme and color scheme in preferences. That functionality broke in #16012.
- Fix observers that need to react to changes in color scheme. This was not working as expected for all plugins that need it (i.e. editor, help, history and IPython console).
- Add tests for the Appearance config page so its UX to change color schemes and UI themes doesn't break yet again (that UX is tricky to get right).
- In Preferences, don't add `section` to changed and restart options when it is `None`. This allow us to send the set of changed options to plugins in the same way as before #16012 was merged (not only Appearance but several other things were broken due to that).
- Cleanup unused imports.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
