### PR TITLE
Fix typo in NOTICE.txt

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -489,7 +489,7 @@ spyder/utils/external/github.py
 
 
 
-Sphinixfy (from the Sage Project)
+Sphinxify (from the Sage Project)
 ---------------------------------
 
 
@@ -502,7 +502,7 @@ Site: https://www.sagemath.org/
 Source: https://github.com/sagemath/sagenb
 License: BSD (3-clause) License | https://opensource.org/licenses/BSD-3-Clause
 
-Modifications made to each file adapt Sphinixfy to Spyder and fix bugs.
+Modifications made to each file adapt Sphinxify to Spyder and fix bugs.
 
 
 Distributed under the terms of the BSD License.


### PR DESCRIPTION
## Description of Changes

"Sphinixfy" should be "Sphinxify" twice in `NOTICE.txt`.  This patch corrects this typo.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org), clauses (a) and (d),
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:
Julian Gilbey