### PR TITLE
PR: Don't show Kite dialog the third time Spyder starts

### DIFF
--- a/spyder/plugins/completion/providers/kite/provider.py
+++ b/spyder/plugins/completion/providers/kite/provider.py
@@ -140,8 +140,6 @@ class KiteProvider(SpyderCompletionProvider):
             self.kite_process.kill()
 
     def on_mainwindow_visible(self):
-        self.sig_call_statusbar.emit(
-            KiteStatusWidget.ID, 'mainwindow_setup_finished', tuple(), {})
         self.client.sig_response_ready.connect(self._kite_onboarding)
         self.client.sig_status_response_ready.connect(self._kite_onboarding)
         self.client.sig_onboarding_response_ready.connect(


### PR DESCRIPTION
## Description of Changes

- Since Kite is not unsupported anymore, there's no need to keep showing that dialog.
- Besides, that dialog wrongly leads users to think that Spyder still works with Kite.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16744

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
