### PR TITLE
PR: Update CI workflows to use macOS 10.15

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -9,7 +9,7 @@ name: Create macOS App Bundle and DMG
 jobs:
   build:
     name: macOS App Bundle
-    runs-on: macos-latest
+    runs-on: macos-10.15
     strategy:
       matrix:
         build_type: ['Full', 'Lite']

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   build:
     name: Py${{ matrix.PYTHON_VERSION }}, ${{ matrix.INSTALL_TYPE }}, ${{ matrix.TEST_TYPE }}
-    runs-on: macos-latest
+    runs-on: macos-10.15
     env:
       CI: 'true'
       CODECOV_TOKEN: "56731c25-9b1f-4340-8b58-35739bfbc52d"


### PR DESCRIPTION
## Description of Changes


<!--- Explain what you've done and why --->

Seems like by default now `macos-latest` is MacOS 11



### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
