### PR TITLE
PR: Improve message about missing spyder-kernels (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1521,20 +1521,22 @@ class IPythonConsoleWidget(PluginMainWidget):
                 client.show_kernel_error(
                     _("The Python environment or installation whose "
                       "interpreter is located at"
-                      "<br><br>"
-                      "{0}<tt>{1}</tt>"
-                      "<br><br>"
+                      "<pre>"
+                      "    <tt>{0}</tt>"
+                      "</pre>"
                       "doesn't have the <tt>spyder-kernels</tt> module or the "
-                      "right version of it installed ({2}). "
+                      "right version of it installed ({1}). "
                       "Without this module is not possible for Spyder to "
                       "create a console for you.<br><br>"
                       "You can install it by activating your environment (if "
                       "necessary) and then running in a system terminal:"
-                      "<br><br>"
-                      "{0}<tt>{3}</tt>"
-                      "<br><br>or<br><br>"
-                      "{0}<tt>{4}</tt>").format(
-                          '&nbsp;' * 8,
+                      "<pre>"
+                      "    <tt>{2}</tt>"
+                      "</pre>"
+                      "or"
+                      "<pre>"
+                      "    <tt>{3}</tt>"
+                      "</pre>").format(
                           pyexec,
                           SPYDER_KERNELS_VERSION_MSG,
                           SPYDER_KERNELS_CONDA,

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1519,16 +1519,23 @@ class IPythonConsoleWidget(PluginMainWidget):
                 version=SPYDER_KERNELS_VERSION)
             if not has_spyder_kernels and not running_under_pytest():
                 client.show_kernel_error(
-                    _("Your Python environment or installation doesn't have "
-                      "the <tt>spyder-kernels</tt> module or the right "
-                      "version of it installed ({0}). "
+                    _("The Python environment or installation whose "
+                      "interpreter is located at"
+                      "<br><br>"
+                      "{0}<tt>{1}</tt>"
+                      "<br><br>"
+                      "doesn't have the <tt>spyder-kernels</tt> module or the "
+                      "right version of it installed ({2}). "
                       "Without this module is not possible for Spyder to "
                       "create a console for you.<br><br>"
-                      "You can install it by running in a system terminal:"
+                      "You can install it by activating your environment (if "
+                      "necessary) and then running in a system terminal:"
                       "<br><br>"
-                      "<tt>{1}</tt>"
+                      "{0}<tt>{3}</tt>"
                       "<br><br>or<br><br>"
-                      "<tt>{2}</tt>").format(
+                      "{0}<tt>{4}</tt>").format(
+                          '&nbsp;' * 8,
+                          pyexec,
                           SPYDER_KERNELS_VERSION_MSG,
                           SPYDER_KERNELS_CONDA,
                           SPYDER_KERNELS_PIP


### PR DESCRIPTION
## Description of Changes

- Now we show the path of the interpreter that doesn't have the right version of spyder-kernels in the message.
- This way users will know where they have to update/install spyder-kernels for the IPyhotn console to work again.

**Before**

![imagen](https://user-images.githubusercontent.com/365293/146292910-e934c203-b372-4a0c-988f-bf9142bc927e.png)

**After**

![imagen](https://user-images.githubusercontent.com/365293/146292811-cd6aab0a-3b12-4235-bee4-704bcd7fada4.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17027 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
