### PR TITLE
PR: Fix setting EOL characters when the user decides their preferred ones in Preferences

### DIFF
--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -6,7 +6,6 @@
 
 """Editor config page."""
 
-from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (QGridLayout, QGroupBox, QHBoxLayout, QLabel,
                             QTabWidget, QVBoxLayout, QWidget)
 
@@ -280,18 +279,21 @@ class EditorConfigPage(PluginConfigPage):
         check_eol_box = newcb(_("Fix automatically and show warning "
                                 "message box"),
                               'check_eol_chars', default=True)
-        convert_eol_on_save_box = newcb(_("On Save: convert EOL characters"
-                                          " to"),
-                                        'convert_eol_on_save', default=False)
-        eol_combo_choices = ((_("LF (UNIX)"), 'LF'),
-                             (_("CRLF (Windows)"), 'CRLF'),
-                             (_("CR (Mac)"), 'CR'),
-                             )
-        convert_eol_on_save_combo = self.create_combobox("",
-                                                         eol_combo_choices,
-                                                         ('convert_eol_on_'
-                                                          'save_to'),
-                                                         )
+        convert_eol_on_save_box = newcb(
+            _("Convert end-of-line characters to the following on save:"),
+            'convert_eol_on_save',
+            default=False
+        )
+        eol_combo_choices = (
+            (_("LF (Unix)"), 'LF'),
+            (_("CRLF (Windows)"), 'CRLF'),
+            (_("CR (macOS)"), 'CR'),
+        )
+        convert_eol_on_save_combo = self.create_combobox(
+            "",
+            eol_combo_choices,
+            'convert_eol_on_save_to',
+        )
         convert_eol_on_save_box.toggled.connect(
                 convert_eol_on_save_combo.setEnabled)
         convert_eol_on_save_combo.setEnabled(

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -862,20 +862,27 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                                name="transform to lowercase")
         # ----------------------------------------------------------------------
 
-        self.win_eol_action = create_action(self,
-                           _("Carriage return and line feed (Windows)"),
-                           toggled=lambda checked: self.toggle_eol_chars('nt', checked))
-        self.linux_eol_action = create_action(self,
-                           _("Line feed (UNIX)"),
-                           toggled=lambda checked: self.toggle_eol_chars('posix', checked))
-        self.mac_eol_action = create_action(self,
-                           _("Carriage return (Mac)"),
-                           toggled=lambda checked: self.toggle_eol_chars('mac', checked))
+        self.win_eol_action = create_action(
+            self,
+            _("Carriage return and line feed (Windows)"),
+            toggled=lambda checked: self.toggle_eol_chars('nt', checked)
+        )
+        self.linux_eol_action = create_action(
+            self,
+            _("Line feed (UNIX)"),
+            toggled=lambda checked: self.toggle_eol_chars('posix', checked)
+        )
+        self.mac_eol_action = create_action(
+            self,
+            _("Carriage return (Mac)"),
+            toggled=lambda checked: self.toggle_eol_chars('mac', checked)
+        )
         eol_action_group = QActionGroup(self)
         eol_actions = (self.win_eol_action, self.linux_eol_action,
                        self.mac_eol_action)
         add_actions(eol_action_group, eol_actions)
         eol_menu = QMenu(_("Convert end-of-line characters"), self)
+        eol_menu.setObjectName('checkbox-padding')
         add_actions(eol_menu, eol_actions)
 
         trailingspaces_action = create_action(

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2520,7 +2520,9 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             editor = self.get_current_editor()
             if self.__set_eol_chars:
                 self.switch_to_plugin()
-                editor.set_eol_chars(sourcecode.get_eol_chars_from_os_name(os_name))
+                editor.set_eol_chars(
+                    eol_chars=sourcecode.get_eol_chars_from_os_name(os_name)
+                )
 
     @Slot()
     def remove_trailing_spaces(self):

--- a/spyder/plugins/editor/tests/conftest.py
+++ b/spyder/plugins/editor/tests/conftest.py
@@ -78,9 +78,9 @@ def python_files(tmpdir_factory):
                  ('file1.py', 'file2.py', 'file3.py', 'file4.py',
                   'untitled4.py')]
     for filename in filenames:
-        with open(filename, 'w') as f:
+        with open(filename, 'w', newline='') as f:
             f.write("# -*- coding: utf-8 -*-\n"
-                    "print(Hello World!)\n")
+                    "print('Hello World!')\n")
 
     return filenames, tmpdir
 

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2789,7 +2789,7 @@ class CodeEditor(TextEditBaseWidget):
     def set_text(self, text):
         """Set the text of the editor"""
         self.setPlainText(text)
-        self.set_eol_chars(text)
+        self.set_eol_chars(text=text)
         self.document_did_change(text)
 
         if (isinstance(self.highlighter, sh.PygmentsSH)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2642,22 +2642,29 @@ class EditorStack(QWidget):
         return finfo
 
     def set_os_eol_chars(self, index=None, osname=None):
-        """Sets the EOL character(s) based on the operating system.
+        """
+        Sets the EOL character(s) based on the operating system.
 
         If `osname` is None, then the default line endings for the current
-        operating system (`os.name` value) will be used.
+        operating system will be used.
 
-        `osname` can be one of:
-            ('posix', 'nt', 'java')
+        `osname` can be one of: 'posix', 'nt', 'mac'.
         """
         if osname is None:
-            osname = os.name
+            if os.name == 'nt':
+                osname = 'nt'
+            elif sys.platform == 'darwin':
+                osname = 'mac'
+            else:
+                osname = 'posix'
+
         if index is None:
             index = self.get_stack_index()
+
         finfo = self.data[index]
         eol_chars = sourcecode.get_eol_chars_from_os_name(osname)
         logger.debug(f"Set OS eol chars {eol_chars} for file {finfo.filename}")
-        finfo.editor.set_eol_chars(eol_chars)
+        finfo.editor.set_eol_chars(eol_chars=eol_chars)
         finfo.editor.document().setModified(True)
 
     def remove_trailing_spaces(self, index=None):

--- a/spyder/plugins/editor/widgets/tests/test_bookmarks.py
+++ b/spyder/plugins/editor/widgets/tests/test_bookmarks.py
@@ -209,7 +209,7 @@ def test_load_bookmark(editor_plugin_open_files):
     edtr.stdkey_backspace()
     editor.load_bookmark(2)
 
-    assert edtr.get_cursor_line_column() == (1, 18)
+    assert edtr.get_cursor_line_column() == (1, 20)
 
     # Check if loading bookmark switches file correctly
     editor.save_bookmark(2)

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -682,13 +682,31 @@ class BaseEditMixin(object):
         pass
 
     #------EOL characters
-    def set_eol_chars(self, text):
-        """Set widget end-of-line (EOL) characters from text (analyzes text)"""
-        if not is_text_string(text): # testing for QString (PyQt API#1)
-            text = to_text_string(text)
-        eol_chars = sourcecode.get_eol_chars(text)
-        is_document_modified = eol_chars is not None and self.eol_chars is not None
-        self.eol_chars = eol_chars
+    def set_eol_chars(self, text=None, eol_chars=None):
+        """
+        Set widget end-of-line (EOL) characters.
+
+        Parameters
+        ----------
+        text: str
+            Text to detect EOL characters from.
+        eol_chars: str
+            EOL characters to set.
+
+        Notes
+        -----
+        If `text` is passed, then `eol_chars` has no effect.
+        """
+        if text is not None:
+            detected_eol_chars = sourcecode.get_eol_chars(text)
+            is_document_modified = (
+                detected_eol_chars is not None and self.eol_chars is not None
+            )
+            self.eol_chars = detected_eol_chars
+        elif eol_chars is not None:
+            is_document_modified = eol_chars != self.eol_chars
+            self.eol_chars = eol_chars
+
         if is_document_modified:
             self.document().setModified(True)
             if self.sig_eol_chars_changed is not None:

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -29,7 +29,7 @@ from spyder_kernels.utils.dochelpers import (getargspecfromtext, getobj,
 
 # Local imports
 from spyder.config.manager import CONF
-from spyder.py3compat import is_text_string, to_text_string
+from spyder.py3compat import to_text_string
 from spyder.utils import encoding, sourcecode
 from spyder.utils import syntaxhighlighters as sh
 from spyder.utils.misc import get_error_match


### PR DESCRIPTION
## Description of Changes

- This functionality, along with changing EOLs from the `Source > Convert end-of-line characters` menu was broken.
- Add regression tests so it doesn't break in the future.
- Improve text and combobox options related to that.

    **Before**

    ![imagen](https://user-images.githubusercontent.com/365293/146649028-06004ece-e675-480e-8c32-1bf4676f1adc.png)

    **After**    

    ![imagen](https://user-images.githubusercontent.com/365293/146648990-3555cc5f-27b5-414b-b30d-230348243692.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17045.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
