### PR TITLE
PR: Avoid showing bening kernel errors in console banner (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -393,6 +393,8 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
         stderr = self.stderr_obj.poll_file_change()
         starting = self.shellwidget._starting
         if stderr:
+            if self.is_bening_error(stderr):
+                return
             if self.shellwidget.isHidden():
                 # Avoid printing the same thing again
                 if self.error_text != '<tt>%s</tt>' % stderr:
@@ -494,12 +496,7 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
         """Show kernel initialization errors in infowidget."""
         self.error_text = error
 
-        # Filter out benign errors
-        if "http://bugs.python.org/issue1666807" in error:
-            # See spyder-ide/spyder#16828
-            return
-        if "https://bugs.python.org/issue1180193" in error:
-            # See spyder-ide/spyder#16927
+        if self.is_bening_error(error):
             return
 
         InstallerIPythonKernelError(error)
@@ -528,6 +525,18 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
 
         # Tell the client we're in error mode
         self.is_error_shown = True
+
+    def is_bening_error(self, error):
+        """Decide if an error is benign in order to filter it."""
+        if "http://bugs.python.org/issue1666807" in error:
+            # See spyder-ide/spyder#16828
+            return True
+
+        if "https://bugs.python.org/issue1180193" in error:
+            # See spyder-ide/spyder#16927
+            return True
+
+        return False
 
     def get_name(self):
         """Return client name"""


### PR DESCRIPTION
## Description of Changes

There's no need to display those errors (as the one shown below) because it gives the impression that something is wrong in the console, when that's not really the case.

![imagen](https://user-images.githubusercontent.com/365293/146652790-e30a9d50-d8fd-420d-a2b8-750110b3a36c.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17026.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
