### PR TITLE
PR: Don't print DeprecationWarning's that come from comm handlers (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 2.x
-	commit = 55596355e903306c3ab3279393db7cffcf181676
-	parent = 07ea6e9ee60ab77e0b89fb0a0a6998d868a29f9e
+	branch = supress-deprecation-warnings
+	commit = 5d49e76509b0ad874ea1022bea4fe9d511633556
+	parent = 95f159d224cc07d9c293fd190262d747611c3256
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = supress-deprecation-warnings
-	commit = 5d49e76509b0ad874ea1022bea4fe9d511633556
-	parent = 95f159d224cc07d9c293fd190262d747611c3256
+	branch = 2.x
+	commit = 9414b463f43e8e1ba41d8db3d43a9fe961574faa
+	parent = 75cdb83ae7ec9557300be3056a146f29620818ec
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/README.md
+++ b/external-deps/spyder-kernels/README.md
@@ -64,7 +64,7 @@ PEP257 style guidelines.
 
 Spyder and its subprojects are funded thanks to the generous support of
 
-[![Quansight](https://static.wixstatic.com/media/095d2c_2508c560e87d436ea00357abc404cf1d~mv2.png/v1/crop/x_0,y_9,w_915,h_329/fill/w_380,h_128,al_c,usm_0.66_1.00_0.01/095d2c_2508c560e87d436ea00357abc404cf1d~mv2.png)](https://www.quansight.com/)[![Numfocus](https://i2.wp.com/numfocus.org/wp-content/uploads/2017/07/NumFocus_LRG.png?fit=320%2C148&ssl=1)](https://numfocus.org/)
+[![Quansight](https://user-images.githubusercontent.com/16781833/142477716-53152d43-99a0-470c-a70b-c04bbfa97dd4.png)](https://www.quansight.com/)[![Numfocus](https://i2.wp.com/numfocus.org/wp-content/uploads/2017/07/NumFocus_LRG.png?fit=320%2C148&ssl=1)](https://numfocus.org/)
 
 and the donations we have received from our users around the world through [Open Collective](https://opencollective.com/spyder/):
 

--- a/external-deps/spyder-kernels/spyder_kernels/comms/frontendcomm.py
+++ b/external-deps/spyder-kernels/spyder_kernels/comms/frontendcomm.py
@@ -281,9 +281,14 @@ class WriteWrapper():
 
     def __call__(self, string):
         """Print warning once."""
-        if not self._warning_shown:
-            self._warning_shown = True
-            self._write(
-                "\nOutput from spyder call "
-                + repr(self._name) + ":\n")
-        return self._write(string)
+        # Don't print DeprecationWarning's because they unnecessarily pollute
+        # the console.
+        # Fixes spyder-ide/spyder#14928
+        # Fixes spyder-ide/spyder-kernels#343
+        if 'DeprecationWarning' not in string:
+            if not self._warning_shown:
+                self._warning_shown = True
+                self._write(
+                    "\nOutput from spyder call "
+                    + repr(self._name) + ":\n")
+            return self._write(string)


### PR DESCRIPTION
## Description of Changes

- Those warnings don't provide valuable information and only pollute the console.
- Depends on spyder-ide/spyder-kernels#350

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14928.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
