### PR TITLE
PR: Reconfigure client before a kernel restart (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -43,6 +43,7 @@ from spyder.plugins.help.tests.test_plugin import check_text
 from spyder.plugins.help.utils.sphinxify import CSS_PATH
 from spyder.plugins.ipythonconsole.plugin import IPythonConsole
 from spyder.plugins.ipythonconsole.utils.style import create_style_class
+from spyder.plugins.ipythonconsole.widgets import ClientWidget
 from spyder.utils.programs import get_temp_dir
 from spyder.utils.conda import is_conda_env
 
@@ -1126,10 +1127,13 @@ def test_clear_and_reset_magics_dbg(ipyconsole, qtbot):
 
 
 @flaky(max_runs=3)
-def test_restart_kernel(ipyconsole, qtbot):
+def test_restart_kernel(ipyconsole, mocker, qtbot):
     """
     Test that kernel is restarted correctly
     """
+    # Mock method we want to check
+    mocker.patch.object(ClientWidget, "_show_mpl_backend_errors")
+
     shell = ipyconsole.get_current_shellwidget()
     qtbot.waitUntil(lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
 
@@ -1144,6 +1148,10 @@ def test_restart_kernel(ipyconsole, qtbot):
 
     assert 'Restarting kernel...' in shell._control.toPlainText()
     assert not shell.is_defined('a')
+
+    # Check that we try to show Matplotlib backend errors at the beginning and
+    # after the restart.
+    assert ClientWidget._show_mpl_backend_errors.call_count == 2
 
 
 @flaky(max_runs=3)

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -204,9 +204,10 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
             self.restart_thread.wait()
 
     # ----- Private methods ---------------------------------------------------
-    def _before_prompt_is_ready(self):
-        """Configure shellwidget before kernel is connected."""
-        self._show_loading_page()
+    def _before_prompt_is_ready(self, show_loading_page=True):
+        """Configuration before kernel is connected."""
+        if show_loading_page:
+            self._show_loading_page()
         self.shellwidget.sig_prompt_ready.connect(
             self._when_prompt_is_ready)
         # If remote execution, the loading page should be hidden as well
@@ -635,6 +636,9 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
                 # Stop autorestart mechanism
                 sw.kernel_manager.stop_restarter()
                 sw.kernel_manager.autorestart = False
+
+                # Reconfigure client before the new kernel is connected again.
+                self._before_prompt_is_ready(show_loading_page=False)
 
                 # Create and run restarting thread
                 if (self.restart_thread is not None

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -25,7 +25,6 @@ from spyder.config.base import (
     _, is_pynsist, running_in_mac_app, running_under_pytest)
 from spyder.py3compat import to_text_string
 from spyder.utils.palette import SpyderPalette
-from spyder.utils import encoding
 from spyder.utils.clipboard_helper import CLIPBOARD_HELPER
 from spyder.utils import syntaxhighlighters as sh
 from spyder.plugins.ipythonconsole.utils.style import (


### PR DESCRIPTION
## Description of Changes

- This is necessary to show errors when setting the Matplotlib backend after the kernel restarts, among other things.
- Part of spyder-ide/spyder-kernels#347.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
