### PR TITLE
PR: Add validation for registration/unregistration of completion provider status bar widgets

### DIFF
--- a/spyder/plugins/completion/container.py
+++ b/spyder/plugins/completion/container.py
@@ -55,7 +55,7 @@ class CompletionContainer(PluginMainContainer):
 
     def get_provider_statusbar_keys(self, provider_name):
         """Get the list of statusbar keys for the given provider."""
-        return self.provider_statusbars[provider_name]
+        return self.provider_statusbars.get(provider_name, [])
 
     def statusbar_rpc(self, status_key: str, method: str, args: tuple,
                       kwargs: dict):

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -451,8 +451,11 @@ class CompletionPlugin(SpyderPluginV2):
             provider.STATUS_BAR_CLASSES, provider_name)
         if plugin_loaded:
             for id_ in widgets_ids:
-                currrent_widget = container.statusbar_widgets[id_]
-                self.statusbar.add_status_widget(currrent_widget)
+                # Validation to check for status bar registration before
+                # addition. See spyder-ide/spyder#16977
+                if id_ not in container.statusbar_widgets:
+                    current_widget = container.statusbar_widgets[id_]
+                    self.statusbar.add_status_widget(current_widget)
 
     def unregister_statusbar(self, provider_name):
         """
@@ -463,11 +466,15 @@ class CompletionPlugin(SpyderPluginV2):
         provider_name: str
             Name of the provider that is going to delete statusbar widgets.
         """
+        container = self.get_container()
         provider_keys = self.get_container().get_provider_statusbar_keys(
             provider_name)
         for id_ in provider_keys:
-            self.get_container().remove_statusbar_widget(id_)
-            self.statusbar.remove_status_widget(id_)
+            # Validation to check for status bar registration before trying
+            # to removal. See spyder-ide/spyder#16977
+            if id_ in container.statusbar_widgets[id_]:
+                self.get_container().remove_statusbar_widget(id_)
+                self.statusbar.remove_status_widget(id_)
 
     # -------- Completion provider initialization redefinition wrappers -------
     def gather_providers_and_configtabs(self):

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -452,7 +452,8 @@ class CompletionPlugin(SpyderPluginV2):
         if plugin_loaded:
             for id_ in widgets_ids:
                 # Validation to check for status bar registration before
-                # addition. See spyder-ide/spyder#16977
+                # adding a widget.
+                # See spyder-ide/spyder#16977
                 if id_ not in container.statusbar_widgets:
                     current_widget = container.statusbar_widgets[id_]
                     self.statusbar.add_status_widget(current_widget)
@@ -471,7 +472,8 @@ class CompletionPlugin(SpyderPluginV2):
             provider_name)
         for id_ in provider_keys:
             # Validation to check for status bar registration before trying
-            # to removal. See spyder-ide/spyder#16977
+            # to remove a widget.
+            # See spyder-ide/spyder#16977
             if id_ in container.statusbar_widgets[id_]:
                 self.get_container().remove_statusbar_widget(id_)
                 self.statusbar.remove_status_widget(id_)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Interacting with completion checkbox preferences related with enabling completion providers (checking/uncheking them leaving them in the same initial state) can lead to trying to register/unregister already register/unregister completion status bar widgets.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16997


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
