### PR TITLE
PR: Make Pylint plugin tests run independently from the rest in our test suite

### DIFF
--- a/spyder/plugins/pylint/tests/test_pylint.py
+++ b/spyder/plugins/pylint/tests/test_pylint.py
@@ -15,7 +15,15 @@ from unittest.mock import Mock, MagicMock
 # Third party imports
 import pytest
 from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QMainWindow
+from qtpy.QtWidgets import QApplication, QMainWindow
+
+# This is necessary to run these tests independently from the rest in our
+# test suite.
+# NOTE: Don't move it to another place; it needs to be before importing the
+# Pylint plugin below.
+# Fixes spyder-ide/spyder#17071
+if QApplication.instance() is None:
+    app = QApplication([])
 
 # Local imports
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY

--- a/spyder/plugins/pylint/tests/test_pylint.py
+++ b/spyder/plugins/pylint/tests/test_pylint.py
@@ -60,12 +60,11 @@ bad-names={bad_names}
 good-names=e
 """
 
-
 class MainWindowMock(QMainWindow):
     sig_editor_focus_changed = Signal(str)
 
     def __init__(self):
-        super(MainWindowMock, self).__init__(None)
+        super().__init__(None)
         self.editor = Mock()
         self.editor.sig_editor_focus_changed = self.sig_editor_focus_changed
         self.projects = MagicMock()
@@ -82,15 +81,22 @@ class MainWindowMock(QMainWindow):
 @pytest.fixture
 def pylint_plugin(mocker, qtbot):
     main_window = MainWindowMock()
+    main_window.resize(640, 480)
     main_window.projects.get_active_project_path = mocker.MagicMock(
         return_value=None)
+    main_window.show()
+
     plugin = Pylint(parent=main_window, configuration=CONF)
     plugin._register()
     plugin.set_conf("history_filenames", [])
+
     widget = plugin.get_widget()
+    widget.resize(640, 480)
     widget.filecombo.clear()
-    qtbot.addWidget(widget)
-    yield plugin
+    widget.show()
+
+    qtbot.addWidget(main_window)
+    return plugin
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description of Changes

- Running

      pytest spyder/plugins/pylint/tests/test_pylint.py

    was failing because it required a `QApplication` to be present before importing the Pylint plugin.

- I also improved those tests a bit by making them clearly visible while running.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17071.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
