### PR TITLE
PR: Fix traitlets deprecation warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -241,6 +241,7 @@ install_requires = [
     'spyder-kernels>=2.2.0,<2.3.0',
     'textdistance>=4.2.0',
     'three-merge>=0.1.1',
+    'traitlets>=4.1',
     'watchdog>=0.10.3'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -241,7 +241,6 @@ install_requires = [
     'spyder-kernels>=2.2.0,<2.3.0',
     'textdistance>=4.2.0',
     'three-merge>=0.1.1',
-    'traitlets>=4.1',
     'watchdog>=0.10.3'
 ]
 

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -19,6 +19,7 @@ from threading import Lock
 from qtpy.QtCore import Signal, QThread
 from qtpy.QtWidgets import QMessageBox
 from qtpy import QtCore, QtWidgets, QtGui
+from traitlets import observe
 
 # Local imports
 from spyder.config.base import (
@@ -933,7 +934,8 @@ the sympy module (e.g. plot)
         super(ShellWidget, self)._handle_kernel_restarted(*args, **kwargs)
         self.sig_kernel_restarted.emit()
 
-    def _syntax_style_changed(self):
+    @observe('syntax_style')
+    def _syntax_style_changed(self, changed=None):
         """Refresh the highlighting with the current syntax style by class."""
         if self._highlighter is None:
             # ignore premature calls


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->

Fixed the traitlets DeprecationWarning raised by `spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py::test_banners`.  The unit test should no longer raise a warning after this change.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14534 with thanks to @dalthviz 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org),
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @juliangilbey 

<!--- Thanks for your help making Spyder better for everyone! --->
