### PR TITLE
PR: Make Pylint config page test run independently from the rest in our test suite

### DIFF
--- a/spyder/plugins/pylint/tests/test_pylint_config_dialog.py
+++ b/spyder/plugins/pylint/tests/test_pylint_config_dialog.py
@@ -10,8 +10,16 @@ from unittest.mock import MagicMock
 
 # Third party imports
 from qtpy.QtCore import Signal, QObject
-from qtpy.QtWidgets import QMainWindow
+from qtpy.QtWidgets import QApplication, QMainWindow
 import pytest
+
+# This is necessary to run these tests independently from the rest in our
+# test suite.
+# NOTE: Don't move it to another place; it needs to be before importing the
+# Pylint plugin below.
+# Fixes spyder-ide/spyder#17071
+if QApplication.instance() is None:
+    app = QApplication([])
 
 # Local imports
 from spyder.plugins.pylint.plugin import Pylint


### PR DESCRIPTION
…py as well

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

The issue #17071 turns out to also affect `test_pylint_config_dialog.py`, leading to intermittent segfaults and other tests possibly failing.  This PR applies the same patch as #17074 (which was against `test_pylint.py`) to this other Pylint test.

### Issue(s) Resolved

Fixes #17071 (or its doppelganger!)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @juliangilbey 

<!--- Thanks for your help making Spyder better for everyone! --->
