### PR TITLE
PR: Fix a couple of focus issues with the IPython console

### DIFF
--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -772,11 +772,7 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
                 self._update_actions()
 
     def change_visibility(self, enable, force_focus=None):
-        """
-        Dock widget visibility has changed.
-        """
-        is_visible = not self.is_visible
-
+        """Dock widget visibility has changed."""
         if self.dockwidget is None:
             return
 
@@ -789,7 +785,7 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
         raise_and_focus = getattr(self, 'RAISE_AND_FOCUS', None)
 
         if force_focus is None:
-            if raise_and_focus or not is_visible:
+            if raise_and_focus and enable:
                 focus_widget = self.get_focus_widget()
                 if focus_widget:
                     focus_widget.setFocus()

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -4398,5 +4398,35 @@ foo(1)
         assert focus_widget is control
 
 
+@pytest.mark.slow
+@flaky(max_runs=3)
+def test_focus_to_consoles(main_window, qtbot):
+    """
+    Check that we give focus to the text widget of our consoles after focus
+    is given to their dockwidgets.
+    """
+    # Wait for the console to be up
+    shell = main_window.ipyconsole.get_current_shellwidget()
+    qtbot.waitUntil(lambda: shell._prompt_html is not None,
+                    timeout=SHELL_TIMEOUT)
+    control = main_window.ipyconsole.get_widget().get_focus_widget()
+
+    # Show internal console
+    console = main_window.get_plugin(Plugins.Console)
+    console.toggle_view_action.setChecked(True)
+
+    # Change to the IPython console and assert focus is given to its focus
+    # widget
+    main_window.ipyconsole.dockwidget.raise_()
+    focus_widget = QApplication.focusWidget()
+    assert focus_widget is control
+
+    # Change to the Internal console and assert focus is given to its focus
+    # widget
+    console.dockwidget.raise_()
+    focus_widget = QApplication.focusWidget()
+    assert focus_widget is console.get_widget().get_focus_widget()
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -4344,12 +4344,21 @@ foo(1)
     # Be sure the focus is on the editor before proceeding
     code_editor.setFocus()
 
-    # Click the run cell button
+    # Select the run cell button to click it
     run_cell_action = main_window.run_toolbar_actions[1]
     run_cell_button = main_window.run_toolbar.widgetForAction(run_cell_action)
-    qtbot.mouseClick(run_cell_button, Qt.LeftButton)
-    qtbot.wait(1000)
 
+    # Make sure we don't switch to the console after pressing the button
+    if focus_to_editor:
+        with qtbot.assertNotEmitted(
+            main_window.ipyconsole.sig_switch_to_plugin_requested, wait=1000
+        ):
+            qtbot.mouseClick(run_cell_button, Qt.LeftButton)
+    else:
+        qtbot.mouseClick(run_cell_button, Qt.LeftButton)
+        qtbot.wait(1000)
+
+    # Check the right widget has focus
     focus_widget = QApplication.focusWidget()
     if focus_to_editor:
         assert focus_widget is code_editor
@@ -4366,13 +4375,22 @@ foo(1)
     cursor.movePosition(QTextCursor.PreviousBlock, QTextCursor.KeepAnchor)
     code_editor.setTextCursor(cursor)
 
-    # Click the run selection button
+    # Select the run selection button to click it
     run_selection_action = main_window.run_toolbar_actions[3]
     run_selection_button = main_window.run_toolbar.widgetForAction(
         run_selection_action)
-    qtbot.mouseClick(run_selection_button, Qt.LeftButton)
-    qtbot.wait(1000)
 
+    # Make sure we don't switch to the console after pressing the button
+    if focus_to_editor:
+        with qtbot.assertNotEmitted(
+            main_window.ipyconsole.sig_switch_to_plugin_requested, wait=1000
+        ):
+            qtbot.mouseClick(run_selection_button, Qt.LeftButton)
+    else:
+        qtbot.mouseClick(run_selection_button, Qt.LeftButton)
+        qtbot.wait(1000)
+
+    # Check the right widget has focus
     focus_widget = QApplication.focusWidget()
     if focus_to_editor:
         assert focus_widget is code_editor

--- a/spyder/plugins/console/plugin.py
+++ b/spyder/plugins/console/plugin.py
@@ -42,6 +42,7 @@ class Console(SpyderDockablePlugin):
     CONF_FILE = False
     TABIFY = [Plugins.IPythonConsole, Plugins.History]
     CAN_BE_DISABLED = False
+    RAISE_AND_FOCUS = True
 
     # --- Signals
     # ------------------------------------------------------------------------

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -48,6 +48,7 @@ class IPythonConsole(SpyderDockablePlugin):
     CONF_WIDGET_CLASS = IPythonConsoleConfigPage
     CONF_FILE = False
     DISABLE_ACTIONS_WHEN_HIDDEN = False
+    RAISE_AND_FOCUS = True
 
     # Signals
     sig_append_to_history_requested = Signal(str, str)

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -79,11 +79,6 @@ class IPythonConsole(SpyderDockablePlugin):
     This signal is emitted when the plugin focus changes.
     """
 
-    sig_editor_focus_requested = Signal()
-    """
-    This signal will request to change the focus to the editor if available.
-    """
-
     sig_edit_goto_requested = Signal((str, int, str), (str, int, str, bool))
     """
     This signal will request to open a file in a given row and column
@@ -219,8 +214,6 @@ class IPythonConsole(SpyderDockablePlugin):
             self.sig_append_to_history_requested)
         widget.sig_focus_changed.connect(self.sig_focus_changed)
         widget.sig_switch_to_plugin_requested.connect(self.switch_to_plugin)
-        widget.sig_editor_focus_requested.connect(
-            self.sig_editor_focus_requested)
         widget.sig_history_requested.connect(self.sig_history_requested)
         widget.sig_edit_goto_requested.connect(self.sig_edit_goto_requested)
         widget.sig_edit_goto_requested[str, int, str, bool].connect(
@@ -316,9 +309,6 @@ class IPythonConsole(SpyderDockablePlugin):
         editor.sig_file_debug_message_requested.connect(
             self.print_debug_file_msg)
 
-        # Connect Console focus request with Editor
-        self.sig_editor_focus_requested.connect(self._switch_to_editor)
-
     @on_plugin_available(plugin=Plugins.Projects)
     def on_projects_available(self):
         projects = self.get_plugin(Plugins.Projects)
@@ -361,9 +351,6 @@ class IPythonConsole(SpyderDockablePlugin):
             self.execute_code_and_focus_editor)
         editor.sig_file_debug_message_requested.disconnect(
             self.print_debug_file_msg)
-
-        # Connect Console focus request with Editor
-        self.sig_editor_focus_requested.disconnect(self._switch_to_editor)
 
     @on_plugin_teardown(plugin=Plugins.Projects)
     def on_projects_teardown(self):

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -683,11 +683,11 @@ class IPythonConsole(SpyderDockablePlugin):
         Execute lines in IPython console and eventually set focus
         to the Editor.
         """
-        console = self
-        console.switch_to_plugin()
-        console.execute_code(lines)
+        self.execute_code(lines)
         if focus_to_editor and self.get_plugin(Plugins.Editor):
             self._switch_to_editor()
+        else:
+            self.switch_to_plugin()
 
     def stop_debugging(self):
         """Stop debugging in the current console."""

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -2121,7 +2121,13 @@ class IPythonConsoleWidget(PluginMainWidget):
                 self.execute_code(line, set_focus=not focus_to_editor)
             except AttributeError:
                 pass
-            self.sig_switch_to_plugin_requested.emit()
+
+            # This is necessary to prevent raising the console if the editor
+            # and console are tabified next to each other and the 'Maintain
+            # focus in the editor' option is activated.
+            # Fixes spyder-ide/spyder#17028
+            if not focus_to_editor:
+                self.sig_switch_to_plugin_requested.emit()
         else:
             # XXX: not sure it can really happen
             QMessageBox.warning(

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -162,11 +162,6 @@ class IPythonConsoleWidget(PluginMainWidget):
     This signal will request to change the focus to the plugin.
     """
 
-    sig_editor_focus_requested = Signal()
-    """
-    This signal will request to change the focus to the editor if available.
-    """
-
     sig_edit_goto_requested = Signal((str, int, str), (str, int, str, bool))
     """
     This signal will request to open a file in a given row and column


### PR DESCRIPTION
## Description of Changes

- Give focus to its focus widget after it's made visible (and do the same for the Internal console).
- Don't switch to it after running cells if the `focus_to_editor` option is `True`.
- Remove `sig_editor_focus_requested` because it was not used.
- Add regression tests for these changes.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17028.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
