### PR TITLE
PR: Fix autopep8 formatting and more failing tests

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1850,7 +1850,7 @@ def test_change_cwd_dbg(main_window, qtbot):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
-@pytest.mark.skipif(os.name == 'nt' or PY2, reason="It times out sometimes")
+@pytest.mark.skipif(os.name == 'nt', reason="Times out sometimes")
 def test_varexp_magic_dbg(main_window, qtbot):
     """Test that %varexp is working while debugging."""
     nsb = main_window.variableexplorer.current_widget()
@@ -1874,7 +1874,7 @@ def test_varexp_magic_dbg(main_window, qtbot):
         qtbot.mouseClick(debug_button, Qt.LeftButton)
 
     # Get to an object that can be plotted
-    for _ in range(2):
+    for _ in range(3):
         with qtbot.waitSignal(shell.executed):
             qtbot.keyClicks(control, '!n')
             qtbot.keyClick(control, Qt.Key_Enter)

--- a/spyder/config/lsp.py
+++ b/spyder/config/lsp.py
@@ -47,7 +47,7 @@ PYTHON_CONFIG = {
                 'autopep8': {
                     'enabled': True
                 },
-                'black': {
+                'pylsp_black': {
                     'enabled': False
                 },
                 'yapf': {

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -367,9 +367,14 @@ def add(modname, package_name, features, required_version,
     """Add Spyder dependency"""
     global DEPENDENCIES
     for dependency in DEPENDENCIES:
+        # Avoid showing an unnecessary error when running our tests.
+        if running_in_ci() and 'spyder_boilerplate' in modname:
+            continue
+
         if dependency.modname == modname:
             raise ValueError(
                 f"Dependency has already been registered: {modname}")
+
     DEPENDENCIES += [Dependency(modname, package_name, features,
                                 required_version,
                                 installed_version, kind)]

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -756,8 +756,8 @@ class LanguageServerProvider(SpyderCompletionProvider):
 
         # Autoformatting configuration
         formatter = self.get_conf('formatting')
-        formatter = 'pyls_black' if formatter == 'black' else formatter
-        formatters = ['autopep8', 'yapf', 'pyls_black']
+        formatter = 'pylsp_black' if formatter == 'black' else formatter
+        formatters = ['autopep8', 'yapf', 'pylsp_black']
         formatter_options = {
             fmt: {
                 'enabled': fmt == formatter
@@ -765,8 +765,8 @@ class LanguageServerProvider(SpyderCompletionProvider):
             for fmt in formatters
         }
 
-        if formatter == 'pyls_black':
-            formatter_options['pyls_black']['line_length'] = cs_max_line_length
+        if formatter == 'pylsp_black':
+            formatter_options['pylsp_black']['line_length'] = cs_max_line_length
 
         # PyLS-Spyder configuration
         group_cells = self.get_conf(

--- a/spyder/plugins/editor/widgets/tests/assets/yapf_range.py
+++ b/spyder/plugins/editor/widgets/tests/assets/yapf_range.py
@@ -10,6 +10,7 @@ import os;import sys
 
 # %% functions
 def d():
+
     def inner():
         return 2
 

--- a/spyder/plugins/editor/widgets/tests/assets/yapf_result.py
+++ b/spyder/plugins/editor/widgets/tests/assets/yapf_result.py
@@ -11,6 +11,7 @@ import sys
 
 # %% functions
 def d():
+
     def inner():
         return 2
 
@@ -43,6 +44,7 @@ def c():
 
 # %% classes
 class Class1:
+
     def __init__(self):
         super(Class1, self).__init__()
         self.x = 2

--- a/spyder/plugins/editor/widgets/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/tests/test_formatting.py
@@ -12,6 +12,7 @@ import os.path as osp
 
 # Third party imports
 import pytest
+import yapf
 
 # Qt imports
 from qtpy.QtGui import QTextCursor
@@ -28,6 +29,14 @@ autopep8 = pytest.param(
     marks=pytest.mark.skipif(
         os.name == 'nt',
         reason='autopep8 produces a different output on Windows'
+    )
+)
+
+yapf = pytest.param(
+    'yapf',
+    marks=pytest.mark.skipif(
+        yapf.__version__ < '0.32.0',
+        reason='Older versions produce different outputs'
     )
 )
 
@@ -48,7 +57,7 @@ def get_formatter_values(formatter, range_fmt=False):
 
 @pytest.mark.slow
 @pytest.mark.order(1)
-@pytest.mark.parametrize('formatter', [autopep8, 'yapf', 'black'])
+@pytest.mark.parametrize('formatter', [autopep8, yapf, 'black'])
 def test_document_formatting(formatter, completions_codeeditor, qtbot):
     """Validate text autoformatting via autopep8, yapf or black."""
     code_editor, completion_plugin = completions_codeeditor
@@ -82,7 +91,7 @@ def test_document_formatting(formatter, completions_codeeditor, qtbot):
 @pytest.mark.slow
 @pytest.mark.order(1)
 @pytest.mark.parametrize(
-    'formatter', [autopep8, 'yapf', 'black'])
+    'formatter', [autopep8, yapf, 'black'])
 def test_document_range_formatting(formatter, completions_codeeditor, qtbot):
     """Validate text range autoformatting."""
     code_editor, completion_plugin = completions_codeeditor

--- a/spyder/plugins/editor/widgets/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/tests/test_warnings.py
@@ -269,7 +269,10 @@ def test_update_warnings_after_closequotes(qtbot, completions_codeeditor_linting
     editor, _ = completions_codeeditor_linting
     editor.textCursor().insertText("print('test)\n")
 
-    expected = [['EOL while scanning string literal', 1]]
+    if sys.version_info >= (3, 10):
+        expected = [['unterminated string literal (detected at line 1)', 1]]
+    else:
+        expected = [['EOL while scanning string literal', 1]]
 
     # Notify changes.
     with qtbot.waitSignal(editor.completions_response_signal, timeout=30000):
@@ -306,8 +309,16 @@ def test_update_warnings_after_closebrackets(qtbot, completions_codeeditor_linti
     editor, _ = completions_codeeditor_linting
     editor.textCursor().insertText("print('test'\n")
 
-    expected = [['unexpected EOF while parsing', 1],
-                ['E901 TokenError: EOF in multi-line statement', 2]]
+    if sys.version_info >= (3, 10):
+        expected = [
+            ["'(' was never closed", 1],
+            ['E901 TokenError: EOF in multi-line statement', 2]
+        ]
+    else:
+        expected = [
+            ['unexpected EOF while parsing', 1],
+            ['E901 TokenError: EOF in multi-line statement', 2]
+        ]
 
     # Notify changes.
     with qtbot.waitSignal(editor.completions_response_signal, timeout=30000):


### PR DESCRIPTION
## Description of Changes

- We were not using `autopep8` for formatting when selected but `black`. That happened because we were not disabling the `black` PyLSP plugin correctly, so this one was taking precedence.
- This also fixes more failing tests for Python 3.10 and the latest version of Yapf in our test suite.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17102
Fixes #17101 
Fixes #17100

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
