### PR TITLE
Zen Knit Syntex highlighter for python markdown

### DIFF
--- a/spyder/plugins/editor/utils/languages.py
+++ b/spyder/plugins/editor/utils/languages.py
@@ -23,7 +23,7 @@ ALL_LANGUAGES = {
     'Cpp': ('c', 'cc', 'cpp', 'cxx', 'h', 'hh', 'hpp', 'hxx'),
     'OpenCL': ('cl',),
     'Yaml': ('yaml', 'yml'),
-    'Markdown': ('md', 'mdw'),
+    'Markdown': ('md', 'mdw', 'pyz'),
     # Every other language
     'None': ('', ),
 }


### PR DESCRIPTION
## Description of Changes


* [X] Wrote at least one-line docstrings (for any new functions)
Adding .pyz file as markdown to add support to syntex highligher for .pyz (Zen Knit)




### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.
