### PR TITLE
PR: Fix renaming files in the editor after the folder that contains them was renamed in Files

### DIFF
--- a/spyder/plugins/explorer/plugin.py
+++ b/spyder/plugins/explorer/plugin.py
@@ -110,14 +110,16 @@ class Explorer(SpyderDockablePlugin):
         Folder to remove.
     """
 
-    sig_folder_renamed = Signal(str)
+    sig_folder_renamed = Signal(str, str)
     """
     This signal is emitted when a folder is renamed.
 
     Parameters
     ----------
-    path: str
-        Folder to remove.
+    old_path: str
+        Old path for renamed folder.
+    new_path: str
+        New path for renamed folder.
     """
 
     sig_interpreter_opened = Signal(str)

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -228,8 +228,10 @@ class DirView(QTreeView, SpyderWidgetMixin):
 
     Parameters
     ----------
-    path: str
-        Folder to remove.
+    old_path: str
+        Old path for renamed folder.
+    new_path: str
+        New path for renamed folder.
     """
 
     sig_open_file_requested = Signal(str)

--- a/spyder/plugins/explorer/widgets/main_widget.py
+++ b/spyder/plugins/explorer/widgets/main_widget.py
@@ -115,14 +115,16 @@ class ExplorerWidget(PluginMainWidget):
         Folder to remove.
     """
 
-    sig_tree_renamed = Signal(str)
+    sig_tree_renamed = Signal(str, str)
     """
     This signal is emitted when a folder is renamed.
 
     Parameters
     ----------
-    path: str
-        Folder to remove.
+    old_path: str
+        Old path for renamed folder.
+    new_path: str
+        New path for renamed folder.
     """
 
     sig_run_requested = Signal(str)


### PR DESCRIPTION
## Description of Changes

- This was broken due to a couple of wrong signal signatures. 
- Add a test to avoid regressions in the future.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17129.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
