### PR TITLE
PR: Catch error when computing the max of a dataframe column (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -241,19 +241,25 @@ class DataFrameModel(QAbstractTableModel):
         if self.df.shape[0] == 0: # If no rows to compute max/min then return
             return
         self.max_min_col = []
-        for dummy, col in self.df.iteritems():
-            if col.dtype in REAL_NUMBER_TYPES + COMPLEX_NUMBER_TYPES:
-                if col.dtype in REAL_NUMBER_TYPES:
-                    vmax = col.max(skipna=True)
-                    vmin = col.min(skipna=True)
+        for __, col in self.df.iteritems():
+            # This is necessary to catch an error in Pandas when computing
+            # the maximum of a column.
+            # Fixes spyder-ide/spyder#17145
+            try:
+                if col.dtype in REAL_NUMBER_TYPES + COMPLEX_NUMBER_TYPES:
+                    if col.dtype in REAL_NUMBER_TYPES:
+                        vmax = col.max(skipna=True)
+                        vmin = col.min(skipna=True)
+                    else:
+                        vmax = col.abs().max(skipna=True)
+                        vmin = col.abs().min(skipna=True)
+                    if vmax != vmin:
+                        max_min = [vmax, vmin]
+                    else:
+                        max_min = [vmax, vmin - 1]
                 else:
-                    vmax = col.abs().max(skipna=True)
-                    vmin = col.abs().min(skipna=True)
-                if vmax != vmin:
-                    max_min = [vmax, vmin]
-                else:
-                    max_min = [vmax, vmin - 1]
-            else:
+                    max_min = None
+            except TypeError:
                 max_min = None
             self.max_min_col.append(max_min)
 


### PR DESCRIPTION
## Description of Changes

It seems this is caused because a column's dtype is reported as numeric and yet ends up with string and float data on it.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17145.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
