### PR TITLE
PR: Fix hang when setting the Tk backend on Windows (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.github/workflows/linux-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/linux-tests.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false 
       matrix:
         PYTHON_VERSION: ['2.7', '3.7', '3.8', '3.9']
+    timeout-minutes: 10
     steps:
       - name: Checkout branch
         uses: actions/checkout@v1
@@ -35,17 +36,16 @@ jobs:
            activate-environment: test
            auto-update-conda: true
            auto-activate-base: false
+           channels: conda-forge
+           miniforge-variant: Mambaforge
            python-version: ${{ matrix.PYTHON_VERSION }} 
       - name: Install package dependencies
         shell: bash -l {0}
         run: |
-          conda install --file requirements/posix.txt -y -q
-          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install --file requirements/python-27.txt -y -q; fi
+          if [ "$PYTHON_VERSION" != "2.7" ]; then mamba install --file requirements/posix.txt -y -q; else mamba install --file requirements/python-27.txt -y -q; fi
       - name: Install test dependencies
         shell: bash -l {0}
-        run: |
-          conda install nomkl -y -q
-          conda install --file requirements/tests.txt -y -q
+        run: mamba install --file requirements/tests.txt -y -q
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/external-deps/spyder-kernels/.github/workflows/macos-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/macos-tests.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false 
       matrix:
         PYTHON_VERSION: ['2.7', '3.7', '3.8', '3.9']
+    timeout-minutes: 10
     steps:
       - name: Checkout branch
         uses: actions/checkout@v1
@@ -31,17 +32,16 @@ jobs:
            activate-environment: test
            auto-update-conda: true
            auto-activate-base: false
+           channels: conda-forge
+           miniforge-variant: Mambaforge
            python-version: ${{ matrix.PYTHON_VERSION }} 
       - name: Install package dependencies
         shell: bash -l {0}
         run: |
-          conda install --file requirements/posix.txt -y -q
-          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install --file requirements/python-27.txt -y -q; fi
+          if [ "$PYTHON_VERSION" != "2.7" ]; then mamba install --file requirements/posix.txt -y -q; else mamba install --file requirements/python-27.txt -y -q; fi
       - name: Install test dependencies
         shell: bash -l {0}
-        run: |
-          conda install nomkl -y -q
-          conda install --file requirements/tests.txt -y -q
+        run: mamba install --file requirements/tests.txt -y -q
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/external-deps/spyder-kernels/.github/workflows/windows-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/windows-tests.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false 
       matrix:
         PYTHON_VERSION: ['3.7', '3.8', '3.9']
+    timeout-minutes: 10
     steps:
       - name: Checkout branch
         uses: actions/checkout@v1
@@ -31,14 +32,16 @@ jobs:
            activate-environment: test
            auto-update-conda: true
            auto-activate-base: false
+           channels: conda-forge
+           miniforge-variant: Mambaforge
            python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Install package dependencies
         shell: bash -l {0}
-        run: conda install --file requirements/windows.txt -y -q
+        run: mamba install --file requirements/windows.txt -y -q
       - name: Install test dependencies
         shell: bash -l {0}
         run: |
-          conda install --file requirements/tests.txt -y -q
+          mamba install --file requirements/tests.txt -y -q
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = 2.x
-	commit = ce13d9616f9d5e71828b84f403912ea4efe36573
-	parent = 8454770df17a32a4b89b6237cf97b2f1a4f96f42
+	commit = 6687b49eb9c97934872382937c8cfd0769bf1967
+	parent = e29db93e2a67ca98cd9e7da4b356bb685bf53a29
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/requirements/posix.txt
+++ b/external-deps/spyder-kernels/requirements/posix.txt
@@ -1,4 +1,6 @@
 cloudpickle
-ipykernel
+ipykernel>=6.6.1
+ipython>=7.6.0,<8
+jupyter_client>=7.1.0
+pyzmq>=22.1.0
 wurlitzer>=1.0.3
-ipython<8

--- a/external-deps/spyder-kernels/requirements/python-27.txt
+++ b/external-deps/spyder-kernels/requirements/python-27.txt
@@ -1,2 +1,9 @@
-click =7
+decorator<5
 backports.functools_lru_cache
+cloudpickle
+ipykernel<5
+jupyter_client>=5.3.4,<6
+pyzmq>=17
+wurlitzer>=1.0.3
+# To avoid an error with conda
+click =7

--- a/external-deps/spyder-kernels/requirements/windows.txt
+++ b/external-deps/spyder-kernels/requirements/windows.txt
@@ -1,5 +1,7 @@
 cloudpickle
-ipykernel
+ipykernel>=6.6.1
+ipython>=7.6.0,<8
+jupyter_client>=7.1.0
+pyzmq>=22.1.0
 # Pin pip version since we are getting 9.x and it causes IPython 6.1.0 to be installed
 pip>=19.3.1
-ipython<8

--- a/external-deps/spyder-kernels/setup.py
+++ b/external-deps/spyder-kernels/setup.py
@@ -40,12 +40,13 @@ REQUIREMENTS = [
     'backports.functools-lru-cache; python_version<"3"',
     'cloudpickle',
     'ipykernel<5; python_version<"3"',
-    'ipykernel>=5.3.0; python_version>="3"',
+    'ipykernel>=6.6.1; python_version>="3"',
     'ipython<6; python_version<"3"',
     'ipython>=7.6.0,<8; python_version>="3"',
     'jupyter-client>=5.3.4,<6; python_version<"3"',
     'jupyter-client>=7.1.0; python_version>="3"',
-    'pyzmq>=17',
+    'pyzmq>=17,<20; python_version<"3"',
+    'pyzmq>=22.1.0; python_version>="3"',
     'wurlitzer>=1.0.3;platform_system!="Windows"',
 ]
 

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -330,7 +330,6 @@ def test_auto_backend(ipyconsole, qtbot):
 
 @flaky(max_runs=3)
 @pytest.mark.tk_backend
-@pytest.mark.skipif(os.name == 'nt', reason="Fails on Windows")
 def test_tk_backend(ipyconsole, qtbot):
     """Test that the Tkinter backend was set correctly."""
     # Wait until the window is fully up


### PR DESCRIPTION
## Description of Changes

- This was fixed in ipython/ipykernel#830, part of IPykernel 6.6.1
- We now run `test_tk_backend` on Windows because it works.
- Depends on spyder-ide/spyder-kernels#360.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17024


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
