### PR TITLE
PR: Convert to int variable used to paint indent guides (Editor)

### DIFF
--- a/spyder/plugins/editor/panels/indentationguides.py
+++ b/spyder/plugins/editor/panels/indentationguides.py
@@ -91,8 +91,8 @@ class IndentationGuide(Panel):
 
                 if end_whitespace and end_whitespace != total_whitespace:
                     font_metrics = self.editor.fontMetrics()
-                    x = (font_metrics.width(total_whitespace * '9') +
-                         self.bar_offset + offset)
+                    x = int(font_metrics.width(total_whitespace * '9') +
+                            self.bar_offset + offset)
                     painter.drawLine(x, top, x, bottom)
 
     # --- Other methods


### PR DESCRIPTION
## Description of Changes

This error only appears on Python 3.10 because we were trying to automatically cast a float to an int.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17159.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
