### PR TITLE
PR: Show tooltip with full path name in Files and Projects

### DIFF
--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -283,6 +283,10 @@ class DirView(QTreeView, SpyderWidgetMixin):
         self.setSelectionMode(self.ExtendedSelection)
         header.setContextMenuPolicy(Qt.CustomContextMenu)
 
+        # Track mouse movements. This activates the mouseMoveEvent declared
+        # below.
+        self.setMouseTracking(True)
+
     # ---- SpyderWidgetMixin API
     # ------------------------------------------------------------------------
     def setup(self):
@@ -787,17 +791,21 @@ class DirView(QTreeView, SpyderWidgetMixin):
             self.clicked(index=self.indexAt(event.pos()))
 
     def mouseMoveEvent(self, event):
-        """Change cursor shape when using single_click_to_open option."""
+        """Actions to take with mouse movements."""
         index = self.indexAt(event.pos())
         if index.isValid():
-            vrect = self.visualRect(index)
-            item_identation = vrect.x() - self.visualRect(self.rootIndex()).x()
-            if event.pos().x() > item_identation:
-                # When hovering over directories or files
-                self.setCursor(Qt.PointingHandCursor)
-            else:
-                # On every other element
-                self.setCursor(Qt.ArrowCursor)
+            if self.get_conf('single_click_to_open'):
+                vrect = self.visualRect(index)
+                item_identation = (
+                    vrect.x() - self.visualRect(self.rootIndex()).x()
+                )
+
+                if event.pos().x() > item_identation:
+                    # When hovering over directories or files
+                    self.setCursor(Qt.PointingHandCursor)
+                else:
+                    # On every other element
+                    self.setCursor(Qt.ArrowCursor)
 
         super().mouseMoveEvent(event)
 
@@ -1603,12 +1611,8 @@ class DirView(QTreeView, SpyderWidgetMixin):
     # ------------------------------------------------------------------------
     def set_single_click_to_open(self, value):
         """Set single click to open items."""
-        # Track mouse movements to change cursor shape when the option is
-        # True. This activates the mouseMoveEvent declared above.
-        if value:
-            self.setMouseTracking(True)
-        else:
-            self.setMouseTracking(False)
+        # Reset cursor shape
+        if not value:
             self.unsetCursor()
 
     def set_file_associations(self, value):


### PR DESCRIPTION
## Description of Changes

This is a small improvement to allow users quickly see the full path name in those panes, in case it's not clearly visible in the pane itself.

![imagen](https://user-images.githubusercontent.com/365293/149010393-908f7613-13fa-42bf-8cf7-3e1427b8b9fe.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
