### PR TITLE
PR: Add missing parent param to QObjects/QWidgets on the status bar base classes

### DIFF
--- a/spyder/api/widgets/status.py
+++ b/spyder/api/widgets/status.py
@@ -102,12 +102,12 @@ class StatusBarWidget(QWidget, SpyderWidgetMixin):
             self._icon = self.get_icon()
             self._pixmap = None
             self._icon_size = QSize(16, 16)  # Should this be adjustable?
-            self.label_icon = QLabel()
+            self.label_icon = QLabel(self)
             self.set_icon()
 
         # Label
         if self.show_label:
-            self.label_value = QLabel()
+            self.label_value = QLabel(self)
             self.set_value('')
 
             # See spyder-ide/spyder#9044.
@@ -214,7 +214,7 @@ class BaseTimerStatus(StatusBarWidget):
         self.label_value.setMinimumWidth(fm.width('000%'))
 
         # Setup
-        self.timer = QTimer()
+        self.timer = QTimer(self)
         self.timer.timeout.connect(self.update_status)
         self.timer.start(self._interval)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Missing parent for some widgets inside the base `StatusBarWidget` and `BaseTimerStatus` classes where causing some extra windows to pop-up


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16676 

Supersedes #17171 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
