### PR TITLE
PR: Raise Help and IPython console to be visible only the first time Spyder starts

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1153,8 +1153,6 @@ class MainWindow(QMainWindow):
         is triggered.
         """
         # Required plugins
-        help_plugin = self.get_plugin(Plugins.Help, error=False)
-        ipyconsole = self.get_plugin(Plugins.IPythonConsole, error=False)
         projects = self.get_plugin(Plugins.Projects, error=False)
         editor = self.get_plugin(Plugins.Editor, error=False)
 
@@ -1194,16 +1192,6 @@ class MainWindow(QMainWindow):
             # Connect the window to the signal emitted by the previous server
             # when it gets a client connected to it
             self.sig_open_external_file.connect(self.open_external_file)
-
-        # Show Help and IPython console by default
-        plugins_to_show = []
-        if help_plugin:
-            plugins_to_show.append(help_plugin)
-        if ipyconsole:
-            plugins_to_show.append(ipyconsole)
-        for plugin in plugins_to_show:
-            if plugin.dockwidget.isVisible():
-                plugin.dockwidget.raise_()
 
         # Update plugins toggle actions to show the "Switch to" plugin shortcut
         self._update_shortcuts_in_panes_menu()

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1157,7 +1157,6 @@ class MainWindow(QMainWindow):
         ipyconsole = self.get_plugin(Plugins.IPythonConsole, error=False)
         projects = self.get_plugin(Plugins.Projects, error=False)
         editor = self.get_plugin(Plugins.Editor, error=False)
-        console = self.get_plugin(Plugins.Console, error=False)
 
         # Process pending events and hide splash before loading the
         # previous session.
@@ -1195,12 +1194,6 @@ class MainWindow(QMainWindow):
             # Connect the window to the signal emitted by the previous server
             # when it gets a client connected to it
             self.sig_open_external_file.connect(self.open_external_file)
-
-        # Hide Internal Console so that people don't use it instead of
-        # the External or IPython ones
-        if console and console.dockwidget.isVisible() and DEV is None:
-            console.toggle_view_action.setChecked(False)
-            console.dockwidget.hide()
 
         # Show Help and IPython console by default
         plugins_to_show = []

--- a/spyder/plugins/console/plugin.py
+++ b/spyder/plugins/console/plugin.py
@@ -20,6 +20,7 @@ from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
 from spyder.api.translations import get_translation
+from spyder.config.base import DEV
 from spyder.plugins.console.widgets.main_widget import (
     ConsoleWidget, ConsoleWidgetActions)
 from spyder.plugins.mainmenu.api import ApplicationMenus, FileMenuSections
@@ -129,7 +130,6 @@ class Console(SpyderDockablePlugin):
 
     @on_plugin_teardown(plugin=Plugins.MainMenu)
     def on_main_menu_teardown(self):
-        widget = self.get_widget()
         mainmenu = self.get_plugin(Plugins.MainMenu)
         mainmenu.remove_item_from_application_menu(
             ConsoleWidgetActions.Quit,
@@ -145,6 +145,12 @@ class Console(SpyderDockablePlugin):
 
     def on_mainwindow_visible(self):
         self.set_exit_function(self.main.closing)
+
+        # Hide this plugin when not in development so that people don't
+        # use it instead of the IPython console
+        if DEV is None:
+            self.toggle_view_action.setChecked(False)
+            self.dockwidget.hide()
 
     # --- API
     # ------------------------------------------------------------------------

--- a/spyder/plugins/help/plugin.py
+++ b/spyder/plugins/help/plugin.py
@@ -125,8 +125,7 @@ class Help(SpyderDockablePlugin):
         shortcuts = self.get_plugin(Plugins.Shortcuts)
 
         # See: spyder-ide/spyder#6992
-        self._show_intro_message = lambda: self.show_intro_message()
-        shortcuts.sig_shortcuts_updated.connect(self._show_intro_message)
+        shortcuts.sig_shortcuts_updated.connect(self.show_intro_message)
 
         if self.is_plugin_available(Plugins.MainMenu):
             self._setup_menus()
@@ -173,7 +172,7 @@ class Help(SpyderDockablePlugin):
     @on_plugin_teardown(plugin=Plugins.Shortcuts)
     def on_shortcuts_teardown(self):
         shortcuts = self.get_plugin(Plugins.Shortcuts)
-        shortcuts.sig_shortcuts_updated.disconnect(self._show_intro_message)
+        shortcuts.sig_shortcuts_updated.disconnect(self.show_intro_message)
 
     @on_plugin_teardown(plugin=Plugins.MainMenu)
     def on_main_menu_teardown(self):

--- a/spyder/plugins/help/plugin.py
+++ b/spyder/plugins/help/plugin.py
@@ -203,6 +203,12 @@ class Help(SpyderDockablePlugin):
         except SpyderAPIError:
             pass
 
+    def on_mainwindow_visible(self):
+        # Raise plugin the first time Spyder starts
+        if self.get_conf('show_first_time', default=True):
+            self.dockwidget.raise_()
+            self.set_conf('show_first_time', False)
+
     # --- Private API
     # ------------------------------------------------------------------------
     def _setup_menus(self):
@@ -279,7 +285,6 @@ class Help(SpyderDockablePlugin):
 
     def show_intro_message(self):
         """Show the IPython introduction message."""
-        self.switch_to_plugin()
         self.get_widget().show_intro_message()
 
     def show_rich_text(self, text, collapse=False, img_path=''):

--- a/spyder/plugins/help/widgets.py
+++ b/spyder/plugins/help/widgets.py
@@ -783,10 +783,10 @@ class HelpWidget(PluginMainWidget):
             "activate this behavior in %s.")
         prefs = _("Preferences > Help")
 
-        shortcut_editor = self.get_conf('editor/inspect current object',
-                                        section='shortcuts')
-        shortcut_console = self.get_conf('console/inspect current object',
-                                         section='shortcuts')
+        shortcut_editor = self.get_conf(
+            'editor/inspect current object', section='shortcuts')
+        shortcut_console = self.get_conf(
+            'ipython_console/inspect current object', section='shortcuts')
 
         if sys.platform == 'darwin':
             shortcut_editor = shortcut_editor.replace('Ctrl', 'Cmd')

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -375,6 +375,11 @@ class IPythonConsole(SpyderDockablePlugin):
     def on_mainwindow_visible(self):
         self.create_new_client(give_focus=False)
 
+        # Raise plugin the first time Spyder starts
+        if self.get_conf('show_first_time', default=True):
+            self.dockwidget.raise_()
+            self.set_conf('show_first_time', False)
+
     # ---- Private methods
     # -------------------------------------------------------------------------
     def _load_file_in_editor(self, fname, lineno, word, processevents):

--- a/spyder/plugins/shortcuts/plugin.py
+++ b/spyder/plugins/shortcuts/plugin.py
@@ -199,10 +199,8 @@ class Shortcuts(SpyderPluginV2):
 
                     if add_shortcut_to_tip:
                         add_shortcut_to_tooltip(qobject, context, name)
-
                 elif isinstance(qobject, QShortcut):
                     qobject.setKey(keyseq)
-
             except RuntimeError:
                 # Object has been deleted
                 toberemoved.append(index)


### PR DESCRIPTION
## Description of Changes

- This preserves the window layout left by users in previous sessions, instead of imposing our own.
- Move hiding the Internal console when not in development to its `on_mainwindow_visible` method.
- Remove an unnecessary slot in the Help pane.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15331.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
