### PR TITLE
PR: Increase required versions for Python and PyQt/Pyside

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,14 +189,14 @@ to install them separately in those cases.
 ### Build dependencies
 
 When installing Spyder from its source package, the only requirement is to have
-a Python version equal or greater than 3.6.
+a Python version equal or greater than 3.7.
 
 ### Runtime dependencies
 
 The basic dependencies to run Spyder are:
 
-* **Python** 3.6+: The core language Spyder is written in and for.
-* **PyQt5** 5.6+: Python bindings for Qt, used for Spyder's GUI.
+* **Python** 3.7+: The core language Spyder is written in and for.
+* **PyQt5** 5.9+: Python bindings for Qt, used for Spyder's GUI.
 
 The rest our dependencies (both required and optional) are declared in
 [this file](https://github.com/spyder-ide/spyder/blob/master/spyder/dependencies.py).

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ from setuptools.command.install import install
 # Taken from the notebook setup.py -- Modified BSD License
 # =============================================================================
 v = sys.version_info
-if v[0] >= 3 and v[:2] < (3, 6):
-    error = "ERROR: Spyder requires Python version 3.6 and above."
+if v[0] >= 3 and v[:2] < (3, 7):
+    error = "ERROR: Spyder requires Python version 3.7 and above."
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -178,14 +178,13 @@ setup_args = dict(
     package_data={LIBNAME: get_package_data(LIBNAME, EXTLIST)},
     scripts=[osp.join('scripts', fname) for fname in SCRIPTS],
     data_files=get_data_files(),
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Operating System :: MacOS',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/spyder/app/tests/spyder-boilerplate/setup.py
+++ b/spyder/app/tests/spyder-boilerplate/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email="spyder.python@gmail.com",
     description="Plugin that registers a programmatic custom layout",
     license="MIT license",
-    python_requires='>= 3.6',
+    python_requires='>= 3.7',
     install_requires=[
         "qtpy",
         "qtawesome",

--- a/spyder/requirements.py
+++ b/spyder/requirements.py
@@ -39,7 +39,7 @@ def check_path():
 
 def check_qt():
     """Check Qt binding requirements"""
-    qt_infos = dict(pyqt5=("PyQt5", "5.6"), pyside2=("PySide2", "5.6"))
+    qt_infos = dict(pyqt5=("PyQt5", "5.9"), pyside2=("PySide2", "5.12"))
     try:
         import qtpy
         package_name, required_ver = qt_infos[qtpy.API]


### PR DESCRIPTION
## Description of Changes

- The minimal Python version we require now is 3.7 (3.6 reached end-of-life last December).
- For PyQt we now require 5.9 and for PySide 5.12

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16971.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
