### PR TITLE
PR: Skip Spyder-kernels check for now (Dependencies)

### DIFF
--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -334,6 +334,9 @@ class Dependency(object):
 
     def check(self):
         """Check if dependency is installed"""
+        if self.modname == 'spyder_kernels':
+            # TODO: Remove when spyder-kernels 3 is released!
+            return True
         if self.required_version:
             installed = programs.is_module_installed(
                 self.modname,


### PR DESCRIPTION
## Description of Changes

This avoids an error in the Mac app tests until we release a new, stable version of Spyder-kernels 3.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
