### PR TITLE
PR: Stop copying black dist-info when building Windows installers and update constraints for numpy and black

### DIFF
--- a/.github/workflows/installer-win.yml
+++ b/.github/workflows/installer-win.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         build_type: ['Lite', 'Full']
     env:
-      ASSETS_URL: 'https://github.com/spyder-ide/windows-installer-assets/releases/download/0.0.5/assets.zip'
+      ASSETS_URL: 'https://github.com/spyder-ide/windows-installer-assets/releases/download/0.0.6/assets.zip'
       UNWANTED_PACKAGES: ${{github.event_name == 'pull_request' && 'pip spyder-kernels python-slugify Rtree QDarkStyle PyNaCl' || 'pip python-slugify Rtree PyNaCl' }}
       SKIP_PACKAGES: 'bcrypt slugify'
       ADD_PACKAGES: ${{github.event_name == 'pull_request' && 'spyder_kernels blib2to3 _black_version blackd rtree qdarkstyle nacl' || 'blib2to3 _black_version blackd rtree nacl' }}

--- a/installers/Windows/installer.py
+++ b/installers/Windows/installer.py
@@ -99,7 +99,6 @@ packages=
     ntsecuritycon
     {packages}
 files={package_dist_info} > $INSTDIR/pkgs
-    black-20.8b1.dist-info > $INSTDIR/pkgs
     __main__.py > $INSTDIR/pkgs/jedi/inference/compiled/subprocess
     __init__.py > $INSTDIR/pkgs/pylint
     lib
@@ -339,13 +338,6 @@ def run(python_version, bitness, repo_root, entrypoint, package, icon_path,
         with tempfile.TemporaryDirectory(
                 prefix="installer-pynsist-") as work_dir:
             print("Temporary working directory at", work_dir)
-
-            # NOTE: SHOULD BE TEMPORAL (until black has wheels available).
-            # See the 'files' section on the pynsist template config too.
-            print("Copying dist.info for black-20.8b1")
-            shutil.copytree(
-                "installers/Windows/assets/black/black-20.8b1.dist-info",
-                os.path.join(work_dir, "black-20.8b1.dist-info"))
 
             # NOTE: SHOULD BE TEMPORAL (until jedi has the fix available).
             # See the 'files' section on the pynsist template config too.

--- a/installers/Windows/req-extras-pull-request.txt
+++ b/installers/Windows/req-extras-pull-request.txt
@@ -10,8 +10,7 @@ rope
 yapf
 
 # Scientific packages (for Same as Spyder)
-# Ping NumPy version to 1.19.3 do message error on Windows
-numpy==1.19.3
+numpy
 scipy
 pandas
 matplotlib
@@ -24,7 +23,3 @@ sympy
 
 # There are no wheels for version 3.3
 cryptography==3.2.1
-
-# Workaround for black 22 until we release a new version of
-# pylsp-black
-black==21.12b0

--- a/installers/Windows/req-extras-release.txt
+++ b/installers/Windows/req-extras-release.txt
@@ -10,8 +10,7 @@ rope
 yapf
 
 # Scientific packages (for Same as Spyder)
-# Ping NumPy version to 1.19.3 do message error on Windows
-numpy==1.19.3
+numpy
 scipy
 pandas
 matplotlib


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

* See https://github.com/spyder-ide/windows-installer-assets/pull/7 (depends on that and a new tag -> 0.0.6)
* Remove constraints for numpy and black

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
