### PR TITLE
PR: Fix bug when viewing Dataframes in Python 3.10 (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -757,7 +757,7 @@ class DataFrameHeaderModel(QAbstractTableModel):
             if orientation == Qt.Horizontal:
                 return Qt.AlignCenter
             else:
-                return Qt.AlignRight | Qt.AlignVCenter
+                return int(Qt.AlignRight | Qt.AlignVCenter)
         if role != Qt.DisplayRole and role != Qt.ToolTipRole:
             return None
         if self.axis == 1 and self._shape[1] <= 1:
@@ -849,7 +849,7 @@ class DataFrameLevelModel(QAbstractTableModel):
             if orientation == Qt.Horizontal:
                 return Qt.AlignCenter
             else:
-                return Qt.AlignRight | Qt.AlignVCenter
+                return int(Qt.AlignRight | Qt.AlignVCenter)
         if role != Qt.DisplayRole and role != Qt.ToolTipRole:
             return None
         if self.model.header_shape[0] <= 1 and orientation == Qt.Horizontal:


### PR DESCRIPTION
## Description of Changes

It seems this was caused by an implicit conversion of float to int.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17361.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
