### PR TITLE
PR: Load previous session if Projects is disabled

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1208,13 +1208,18 @@ class MainWindow(QMainWindow):
         else:
             # Load last project if a project was active when Spyder
             # was closed
+            reopen_last_session = False
             if projects:
                 projects.reopen_last_project()
+                if projects.get_active_project() is None:
+                    reopen_last_session = True
+            else:
+                reopen_last_session = True
 
-            # If no project is active, load last session
-            if projects and projects.get_active_project() is None:
-                if editor:
-                    editor.setup_open_files(close_previous_files=False)
+            # If no project is active or Projects is disabled, load last
+            # session
+            if editor and reopen_last_session:
+                editor.setup_open_files(close_previous_files=False)
 
         # Raise the menuBar to the top of the main window widget's stack
         # Fixes spyder-ide/spyder#3887.

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -140,7 +140,7 @@ class Projects(SpyderDockablePlugin):
     # ------------------------------------------------------------------------
     @staticmethod
     def get_name():
-        return _("Project")
+        return _("Projects")
 
     def get_description(self):
         return _("Create Spyder projects and manage their files.")


### PR DESCRIPTION
## Description of Changes

- An error in the logic to decide how to load the previous session prevented that, if Projects was disabled, we didn't load any session at all.
- Fix the title of the Projects plugin. It was named as `Project` but I think it should be `Projects`.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17360 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
