### PR TITLE
PR: Fix for arguments to be converted to string format

### DIFF
--- a/spyder/plugins/ipythonconsole/comms/kernelcomm.py
+++ b/spyder/plugins/ipythonconsole/comms/kernelcomm.py
@@ -191,7 +191,10 @@ class KernelComm(CommBase, QObject):
                 raise RuntimeError("Kernel is dead")
             else:
                 # The user has other problems
-                logger.info("Dropping message because kernel is dead: %s", str(call_dict))
+                logger.info(
+                    "Dropping message because kernel is dead: %s",
+                    str(call_dict)
+                )
                 return
 
         settings = call_dict['settings']

--- a/spyder/plugins/ipythonconsole/comms/kernelcomm.py
+++ b/spyder/plugins/ipythonconsole/comms/kernelcomm.py
@@ -191,10 +191,7 @@ class KernelComm(CommBase, QObject):
                 raise RuntimeError("Kernel is dead")
             else:
                 # The user has other problems
-                logger.info(
-                    "Dropping message because kernel is dead: ",
-                    str(call_dict)
-                )
+                logger.info("Dropping message because kernel is dead: %s", str(call_dict))
                 return
 
         settings = call_dict['settings']


### PR DESCRIPTION
## Description of Changes

Added %s in logger.info("Dropping message because kernel is dead: ", str(call_dict)) .

Now "logger.info("Dropping message because kernel is dead: %s", str(call_dict))" .

<!--- Explain what you've done and why --->
```
BUG: Some log arguments are not converted to string format

Error in sys.excepthook:
Traceback (most recent call last):
  File "C:\Users\dan-s\miniconda3\envs\ciermag-develop\lib\site-packages\spyder\plugins\ipythonconsole\widgets\client.py", line 767, in kernel_restarted_message
    self.poll_std_file_change()
  File "C:\Users\dan-s\miniconda3\envs\ciermag-develop\lib\site-packages\spyder\plugins\ipythonconsole\widgets\client.py", line 392, in poll_std_file_change
    self.shellwidget.call_kernel().flush_std()
  File "C:\Users\dan-s\miniconda3\envs\ciermag-develop\lib\site-packages\spyder_kernels\comms\commbase.py", line 554, in __call__
    return self._comms_wrapper._get_call_return_value(
  File "C:\Users\dan-s\miniconda3\envs\ciermag-develop\lib\site-packages\spyder\plugins\ipythonconsole\comms\kernelcomm.py", line 194, in _get_call_return_value
    logger.info(
  File "C:\Users\dan-s\miniconda3\envs\ciermag-develop\lib\logging\__init__.py", line 1446, in info
    self._log(INFO, msg, args, **kwargs)
  File "C:\Users\dan-s\miniconda3\envs\ciermag-develop\lib\logging\__init__.py", line 1589, in _log
    self.handle(record)
  File "C:\Users\dan-s\miniconda3\envs\ciermag-develop\lib\logging\__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "C:\Users\dan-s\miniconda3\envs\ciermag-develop\lib\logging\__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "C:\Users\dan-s\miniconda3\envs\ciermag-develop\lib\logging\__init__.py", line 954, in handle
    self.emit(record)
  File "c:\users\dan-s\ciermag-system-develop\packages\pymr\pymr\core\log.py", line 101, in emit
    record_formatted = self.format(record)
  File "C:\Users\dan-s\miniconda3\envs\ciermag-develop\lib\logging\__init__.py", line 929, in format
    return fmt.format(record)
  File "C:\Users\dan-s\miniconda3\envs\ciermag-develop\lib\logging\__init__.py", line 668, in format
    record.message = record.getMessage()
  File "C:\Users\dan-s\miniconda3\envs\ciermag-develop\lib\logging\__init__.py", line 373, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting

```