### PR TITLE
PR: Remove support for outdated and unused Matplotlib backends (IPython Console)

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = remove-old-backends
-	commit = e82b146c27c7d2af5320e65458b11154852bae6f
-	parent = 939f92ebe7163e68f24dd77bc862b742b5a964b3
+	branch = 2.x
+	commit = cd95368e5c2cd26753429dd2b56c318b0bfeaf5b
+	parent = e22cd92dce47175f03a0ce5aa16d66c70fee6949
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 2.x
-	commit = fac77a39f72bb2c62dc8f6704ab7c2adca7e85a6
-	parent = c77960d49c1368bb70c133d28d827fa550f2e0ff
+	branch = remove-old-backends
+	commit = e82b146c27c7d2af5320e65458b11154852bae6f
+	parent = 939f92ebe7163e68f24dd77bc862b742b5a964b3
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/utils/mpl.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/mpl.py
@@ -29,12 +29,8 @@ else:
 MPL_BACKENDS_TO_SPYDER = {
     inline_backend: 0,
     'Qt5Agg': 2,
-    'Qt4Agg': 3,
+    'TkAgg': 3,
     'MacOSX': 4,
-    'GTK3Agg': 5,
-    'GTKAgg': 6,
-    'WX': 7,
-    'TkAgg': 8
 }
 
 
@@ -42,8 +38,6 @@ def automatic_backend():
     """Get Matplolib automatic backend option."""
     if is_module_installed('PyQt5'):
         auto_backend = 'qt5'
-    elif is_module_installed('PyQt4'):
-        auto_backend = 'qt4'
     elif is_module_installed('_tkinter'):
         auto_backend = 'tk'
     else:
@@ -56,10 +50,6 @@ MPL_BACKENDS_FROM_SPYDER = {
     '0': 'inline',
     '1': automatic_backend(),
     '2': 'qt5',
-    '3': 'qt4',
-    '4': 'osx',
-    '5': 'gtk3',
-    '6': 'gtk',
-    '7': 'wx',
-    '8': 'tk'
+    '3': 'tk',
+    '4': 'osx'
 }

--- a/spyder/plugins/ipythonconsole/confpage.py
+++ b/spyder/plugins/ipythonconsole/confpage.py
@@ -110,16 +110,10 @@ class IPythonConsoleConfigPage(PluginConfigPage):
                               "separate window.") % (inline, automatic))
         bend_label.setWordWrap(True)
 
-        backends = [(inline, 0), (automatic, 1), ("Qt5", 2), ("Qt4", 3)]
+        backends = [(inline, 0), (automatic, 1), ("Qt5", 2), ("Tkinter", 3)]
 
         if sys.platform == 'darwin':
-            backends.append(("OS X", 4))
-        if sys.platform.startswith('linux'):
-            backends.append(("Gtk3", 5))
-            backends.append(("Gtk", 6))
-        if PY2:
-            backends.append(("Wx", 7))
-        backends.append(("Tkinter", 8))
+            backends.append(("macOS", 4))
         backends = tuple(backends)
 
         backend_box = self.create_combobox(

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -151,7 +151,7 @@ def ipyconsole(qtbot, request, tmpdir):
     # Use the Tkinter backend if requested
     tk_backend = request.node.get_closest_marker('tk_backend')
     if tk_backend:
-        configuration.set('ipython_console', 'pylab/backend', 8)
+        configuration.set('ipython_console', 'pylab/backend', 3)
 
     # Start a Pylab client if requested
     pylab_client = request.node.get_closest_marker('pylab_client')


### PR DESCRIPTION
## Description of Changes

- The Qt4 backend is no longer supported by Matplotlib.
- We have not received bug reports about the Gtk backends (even if they are broken with the latest Matplotlib), so we assume no one is using them.
- Depends on spyder-ide/spyder-kernels#375

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17172.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
