### PR TITLE
PR: Completely disable Kite provider (Completions)

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -173,11 +173,6 @@ lsp = pkg_resources.EntryPoint.parse(
     'LanguageServerProvider'
 )
 
-kite = pkg_resources.EntryPoint.parse(
-    'kite = spyder.plugins.completion.providers.kite.provider:'
-    'KiteProvider'
-)
-
 # Create a fake Spyder distribution
 d = pkg_resources.Distribution(__file__)
 
@@ -187,7 +182,6 @@ d._ep_map = {
         'fallback': fallback,
         'snippets': snippets,
         'lsp': lsp,
-        'kite': kite
     }
 }
 

--- a/setup.py
+++ b/setup.py
@@ -310,8 +310,6 @@ spyder_completions_entry_points = [
      'FallbackProvider'),
     ('snippets = spyder.plugins.completion.providers.snippets.provider:'
      'SnippetsProvider'),
-    ('kite = spyder.plugins.completion.providers.kite.provider:'
-     'KiteProvider'),
     ('lsp = spyder.plugins.completion.providers.languageserver.provider:'
      'LanguageServerProvider'),
 ]

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -330,7 +330,7 @@ DEFAULTS = [
             ('completions',
              {
                'enable': True,
-               'kite_call_to_action': True,
+               'kite_call_to_action': False,
                'enable_code_snippets': True,
                'completions_wait_for_ms': 200,
                'enabled_providers': {},
@@ -637,4 +637,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '70.2.0'
+CONF_VERSION = '70.3.0'

--- a/spyder/plugins/completion/confpage.py
+++ b/spyder/plugins/completion/confpage.py
@@ -53,10 +53,6 @@ class CompletionConfigPage(PluginConfigPage):
             tip=_("Default is 3"), section='editor')
         code_snippets_box = newcb(
             _("Enable code snippets"), 'enable_code_snippets')
-        kite_cta_box = newcb(
-            _("Notify me when Kite can provide missing completions "
-              "(but is unavailable)"),
-            'kite_call_to_action')
         completions_after_idle = self.create_spinbox(
             _("Show automatic completions after keyboard idle (ms):"), None,
             'automatic_completions_after_ms', min_=0, max_=10000, step=10,
@@ -72,15 +68,14 @@ class CompletionConfigPage(PluginConfigPage):
         completions_layout.addWidget(completion_hint_box, 0, 0)
         completions_layout.addWidget(code_snippets_box, 1, 0)
         completions_layout.addWidget(automatic_completion_box, 2, 0)
-        completions_layout.addWidget(kite_cta_box, 3, 0)
-        completions_layout.addWidget(completions_after_characters.plabel, 4, 0)
-        completions_layout.addWidget(completions_after_characters.spinbox, 4, 1)
-        completions_layout.addWidget(completions_after_idle.plabel, 5, 0)
-        completions_layout.addWidget(completions_after_idle.spinbox, 5, 1)
-        completions_layout.addWidget(completions_hint_after_idle.plabel, 6, 0)
-        completions_layout.addWidget(completions_hint_after_idle.spinbox, 6, 1)
-        completions_layout.addWidget(completions_wait_for_ms.plabel, 7, 0)
-        completions_layout.addWidget(completions_wait_for_ms.spinbox, 7, 1)
+        completions_layout.addWidget(completions_after_characters.plabel, 3, 0)
+        completions_layout.addWidget(completions_after_characters.spinbox, 3, 1)
+        completions_layout.addWidget(completions_after_idle.plabel, 4, 0)
+        completions_layout.addWidget(completions_after_idle.spinbox, 4, 1)
+        completions_layout.addWidget(completions_hint_after_idle.plabel, 5, 0)
+        completions_layout.addWidget(completions_hint_after_idle.spinbox, 5, 1)
+        completions_layout.addWidget(completions_wait_for_ms.plabel, 6, 0)
+        completions_layout.addWidget(completions_wait_for_ms.spinbox, 6, 1)
         completions_layout.setColumnStretch(2, 6)
         self.completions_group.setLayout(completions_layout)
 

--- a/spyder/plugins/completion/confpage.py
+++ b/spyder/plugins/completion/confpage.py
@@ -69,7 +69,8 @@ class CompletionConfigPage(PluginConfigPage):
         completions_layout.addWidget(code_snippets_box, 1, 0)
         completions_layout.addWidget(automatic_completion_box, 2, 0)
         completions_layout.addWidget(completions_after_characters.plabel, 3, 0)
-        completions_layout.addWidget(completions_after_characters.spinbox, 3, 1)
+        completions_layout.addWidget(
+            completions_after_characters.spinbox, 3, 1)
         completions_layout.addWidget(completions_after_idle.plabel, 4, 0)
         completions_layout.addWidget(completions_after_idle.spinbox, 4, 1)
         completions_layout.addWidget(completions_hint_after_idle.plabel, 5, 0)

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -268,7 +268,7 @@ class CompletionPlugin(SpyderPluginV2):
                  'linting requests sent to multiple providers.')
 
     def get_icon(self):
-        return self.create_icon('lspserver')
+        return self.create_icon('completions')
 
     def on_initialize(self):
         self.sig_interpreter_changed.connect(self.update_completion_status)

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -234,6 +234,12 @@ class CompletionPlugin(SpyderPluginV2):
         # entrypoints
         for entry_point in iter_entry_points(COMPLETION_ENTRYPOINT):
             try:
+                # This absolutely ensures that the Kite provider won't be
+                # loaded. For instance, it can happen when you have an older
+                # Spyder version installed, but you're running it with
+                # bootstrap.
+                if 'kite' in entry_point.name:
+                    continue
                 logger.debug(f'Loading entry point: {entry_point}')
                 Provider = entry_point.resolve()
                 self._instantiate_and_register_provider(Provider)


### PR DESCRIPTION
## Description of Changes

- Kite reached end-of-life last year, so we don't need to support it anymore.
- This does the minimal changes to disable Kite for now. After 5.3.0 is released, we can see how to remove it from our codebase.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17108.
Fixes #16595.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
