### PR TITLE
PR: Use only paths last element for filtering in the project explorer

### DIFF
--- a/spyder/plugins/projects/widgets/projectexplorer.py
+++ b/spyder/plugins/projects/widgets/projectexplorer.py
@@ -91,8 +91,10 @@ class ProxyModel(QSortFilterProxyModel):
         else:
             for p in [osp.normcase(p) for p in self.path_list]:
                 if path == p or path.startswith(p + os.sep):
-                    if not any([d in path for d in self.PATHS_TO_SHOW]):
-                        if any([d in path for d in self.PATHS_TO_HIDE]):
+                    if not any([path.endswith(os.sep + d)
+                                for d in self.PATHS_TO_SHOW]):
+                        if any([path.endswith(os.sep + d)
+                                for d in self.PATHS_TO_HIDE]):
                             return False
                         else:
                             return True


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Filter shown project explorer paths using only the last element in the path


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17217


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
