### PR TITLE
PR: Update macOS app to import user environment variables

### DIFF
--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -202,6 +202,7 @@ def make_app_bundle(dist_dir, make_lite=False):
         'iconfile': ICONFILE,
         'dist_dir': dist_dir,
         'frameworks': FRAMEWORKS,
+        'emulate_shell_environment': True,
         'plist': {
             'CFBundleDocumentTypes': [{'CFBundleTypeExtensions': EDIT_EXT,
                                        'CFBundleTypeName': 'Text File',


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

For the Windows installer and launching Spyder from the command line, user environment variables are inherited. This was not the case for the macOS application. This PR changes the macOS installer to inherit the user's environment variables, similar to the case for launching from the command line.

### Issue(s) Resolved

Fixes #14843 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary 

<!--- Thanks for your help making Spyder better for everyone! --->
