### PR TITLE
PR: Make context run cell icons match run menu icons

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4385,11 +4385,11 @@ class CodeEditor(TextEditBaseWidget):
             shortcut=CONF.get_shortcut('editor', 'run cell'),
             triggered=self.sig_run_cell.emit)
         self.run_cell_and_advance_action = create_action(
-            self, _("Run cell and advance"), icon=ima.icon('run_cell'),
+            self, _("Run cell and advance"), icon=ima.icon('run_cell_advance'),
             shortcut=CONF.get_shortcut('editor', 'run cell and advance'),
             triggered=self.sig_run_cell_and_advance.emit)
         self.re_run_last_cell_action = create_action(
-            self, _("Re-run last cell"), icon=ima.icon('run_cell'),
+            self, _("Re-run last cell"),
             shortcut=CONF.get_shortcut('editor', 're-run last cell'),
             triggered=self.sig_re_run_last_cell.emit)
         self.run_selection_action = create_action(


### PR DESCRIPTION

## Description of Changes
Minor change to the icons of the context menu to make them consistent and match that of the Run menu.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

The run menu icons for running cell code looks like this, with different icon for `Run cell` and `Run cell and advance` and no icon for `Re-run last cell`. 
![run_menu](https://user-images.githubusercontent.com/2330659/159034245-dc9c254b-5dff-407e-aeaf-64557c233f15.png)

The context menu on 5.3.0.dev0 looks like this, with the `Run cell` icon repeated for `Run cell and advance` and `Re-run last cell`. 
![run_context_pre](https://user-images.githubusercontent.com/2330659/159034274-f418d560-9144-4f1b-8614-a08f8680275d.png)

This PR sets the proper icon for  `Run cell and advance` and removes `Re-run last cell` on the context menu, so that it is consistent with the Run menu.
![run_context_post](https://user-images.githubusercontent.com/2330659/159034284-c2ec10e2-8905-4262-8b9c-14d226265f3d.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

No issue opened


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @rhkarls 

<!--- Thanks for your help making Spyder better for everyone! --->
