### PR TITLE
PR: Consistently handle PYTHONPATH and add Import feature to PYTHONPATH Manager

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = 2.x
-	commit = 55502d546049e406ef08f7b23389bd3a01200eb2
-	parent = 3f2ac31bd24fce382656b892ef1efb7f112fee09
+	commit = 4302062d84d25f5402264bcc64ef93d752a51779
+	parent = af394b507a7aa0a7bb2e2314ebc31dbcb9a3de90
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/console/tests/test_console_kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/tests/test_console_kernel.py
@@ -1116,6 +1116,8 @@ def test_get_interactive_backend(backend):
         if backend is not None:
             client.execute("%matplotlib {}".format(backend))
             client.get_shell_msg(timeout=TIMEOUT)
+            client.execute("import time; time.sleep(.1)")
+            client.get_shell_msg(timeout=TIMEOUT)
 
         # Get backend
         code = "backend = get_ipython().kernel.get_mpl_interactive_backend()"

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
@@ -814,12 +814,15 @@ builtins.cell_count = cell_count
 
 
 # =============================================================================
-# Extend sys.path with paths that come from Spyder
+# PYTHONPATH and sys.path Adjustments
 # =============================================================================
+# PYTHONPATH is not passed to kernel directly, see spyder-ide/spyder#13519
+# This allows the kernel to start without crashing if modules in PYTHONPATH
+# shadow standard library modules.
 def set_spyder_pythonpath():
     pypath = os.environ.get('SPY_PYTHONPATH')
     if pypath:
-        pathlist = pypath.split(os.pathsep)
-        sys.path.extend(pathlist)
+        sys.path.extend(pypath.split(os.pathsep))
+        os.environ.update({'PYTHONPATH': pypath})
 
 set_spyder_pythonpath()

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spyderpdb.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spyderpdb.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2009- Spyder Kernels Contributors
 #
@@ -91,6 +92,9 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         super(SpyderPdb, self).__init__()
         self._pdb_breaking = False
         self._frontend_notified = False
+
+        # content of tuple: (filename, line number)
+        self._previous_step = None
 
         # Don't report hidden frames for IPython 7.24+. This attribute
         # has no effect in previous versions.
@@ -542,6 +546,12 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         return result
 
     # --- Methods overriden by us for Spyder integration
+    def postloop(self):
+        # postloop() is called when the debugger’s input prompt exists. Reset
+        # _previous_step so that publish_pdb_state() actually notifies Spyder
+        # about a changed frame the next the input prompt is entered again.
+        self._previous_step = None
+
     def preloop(self):
         """Ask Spyder for breakpoints before the first prompt is created."""
         try:
@@ -554,7 +564,7 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
             if self.starting:
                 self.set_spyder_breakpoints(pdb_settings['breakpoints'])
             if self.send_initial_notification:
-                self.notify_spyder()
+                self.publish_pdb_state()
         except (CommError, TimeoutError):
             logger.debug("Could not get breakpoints from the frontend.")
         super(SpyderPdb, self).preloop()
@@ -644,9 +654,11 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
 
     def postcmd(self, stop, line):
         """
-        Notify spyder on any pdb command.
+        Notify spyder about (possibly) changed frame
+
+        Note: The PDB commands “up”, “down” and “jump” change the current frame.
         """
-        self.notify_spyder()
+        self.publish_pdb_state()
         return super(SpyderPdb, self).postcmd(stop, line)
 
     if PY2:
@@ -743,11 +755,16 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
                     logger.debug(
                         "Could not send a Pdb continue call to the frontend.")
 
-    def notify_spyder(self):
-        """Send kernel state to the frontend."""
+    def publish_pdb_state(self):
+        """
+        Send debugger state (frame position) to the frontend.
+
+        The state is only sent if it has changed since the last update.
+        """
 
         frame = self.curframe
         if frame is None:
+            self._previous_step = None
             return
 
         # Get filename and line number of the current frame
@@ -759,12 +776,20 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
                 pass
         lineno = frame.f_lineno
 
+        if self._previous_step == (fname, lineno):
+            return
+
         # Set step of the current frame (if any)
         step = {}
+        self._previous_step = None
         if isinstance(fname, basestring) and isinstance(lineno, int):
             step = dict(fname=fname, lineno=lineno)
+            self._previous_step = (fname, lineno)
 
-        get_ipython().kernel.publish_pdb_state(step)
+        try:
+            frontend_request(blocking=False).pdb_state(dict(step=step))
+        except (CommError, TimeoutError):
+            logger.debug("Could not send Pdb state to the frontend.")
 
     def run(self, cmd, globals=None, locals=None):
         """Debug a statement executed via the exec() function.
@@ -820,6 +845,12 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         sys.settrace(self.trace_dispatch)
         self.lastcmd = debugger.lastcmd
         get_ipython().pdb_session = self
+
+        # Reset _previous_step so that publish_pdb_state() called from within
+        # postcmd() notifies Spyder about a changed debugger position. The reset
+        # is required because the recursive debugger might change the position,
+        # but the parent debugger (self) is not aware of this.
+        self._previous_step = None
 
 
 def get_new_debugger(filename, continue_if_has_breakpoints):

--- a/external-deps/spyder-kernels/spyder_kernels/utils/dochelpers.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/dochelpers.py
@@ -238,7 +238,8 @@ def getargs(obj):
         func_obj = getattr(obj, '__init__')
     else:
         return []
-    if not hasattr(func_obj, 'func_code'):
+
+    if not hasattr(func_obj, '__code__'):
         # Builtin: try to extract info from doc
         args = getargsfromdoc(func_obj)
         if args is not None:
@@ -246,24 +247,29 @@ def getargs(obj):
         else:
             # Example: PyQt5
             return getargsfromdoc(obj)
-    args, _, _ = inspect.getargs(func_obj.func_code)
+
+    args, _, _ = inspect.getargs(func_obj.__code__)
     if not args:
         return getargsfromdoc(obj)
-    
+
     # Supporting tuple arguments in def statement:
     for i_arg, arg in enumerate(args):
         if isinstance(arg, list):
             args[i_arg] = "(%s)" % ", ".join(arg)
-            
+
     defaults = get_func_defaults(func_obj)
     if defaults is not None:
         for index, default in enumerate(defaults):
-            args[index+len(args)-len(defaults)] += '='+repr(default)
+            args[index + len(args) - len(defaults)] += '=' + repr(default)
+
     if inspect.isclass(obj) or inspect.ismethod(obj):
         if len(args) == 1:
             return None
-        if 'self' in args:
-            args.remove('self')
+
+    # Remove 'self' from args
+    if 'self' in args:
+        args.remove('self')
+
     return args
 
 

--- a/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_dochelpers.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_dochelpers.py
@@ -9,9 +9,9 @@
 """
 Tests for dochelpers.py
 """
+
 # Standard library imports
 import os
-import sys
 
 # Test library imports
 import pytest
@@ -27,57 +27,29 @@ class Test(object):
         pass
 
 
-@pytest.mark.skipif(not PY2, reason="It fails in Python 3")
+@pytest.mark.skipif(PY2 or os.name == 'nt',
+                    reason="Only works on Linux and Mac")
 def test_dochelpers():
     """Test dochelpers."""
+    assert getargtxt(Test.method) == ['x, ', 'y=2']
     assert not getargtxt(Test.__init__)
-    if PY2:                    
-        assert getargtxt(Test.method) == ['x, ', 'y=2']
-        assert getdoc(sorted) == {'note': 'Function of __builtin__ module',
-                                  'argspec': u'(iterable, cmp=None, key=None, '
-                                              'reverse=False)',
-                                  'docstring': u'sorted(iterable, cmp=None, '
-                                                'key=None, reverse=False) --> '
-                                                'new sorted list',
-                                  'name': 'sorted'}
-        assert getargtxt(sorted) == ['iterable, ', ' cmp=None, ',
-                                     ' key=None, ', ' reverse=False']
-    else:
-        assert not getargtxt(Test.method)
-        if os.name == 'nt':
-            assert getdoc(sorted) == {'note': 'Function of builtins module',
-                                      'argspec': '(...)',
-                                      'docstring': 'Return a new list '
-                                                   'containing '
-                                                   'all items from the '
-                                                   'iterable in ascending '
-                                                   'order.\n\nA custom '
-                                                   'key function can be '
-                                                   'supplied to customise the '
-                                                   'sort order, and '
-                                                   'the\nreverse flag can be '
-                                                   'set to request the result '
-                                                   'in descending order.',
-                                      'name': 'sorted'}
-        else:
-            assert getdoc(sorted) == {'note': 'Function of builtins module',
-                                      'argspec': '(...)',
-                                      'docstring': 'Return a new list '
-                                                   'containing '
-                                                   'all items from the '
-                                                   'iterable in ascending '
-                                                   'order.\n\nA custom '
-                                                   'key function can be '
-                                                   'supplied to customize the '
-                                                   'sort order, and '
-                                                   'the\nreverse flag can be '
-                                                   'set to request the result '
-                                                   'in descending order.',
-                                      'name': 'sorted'}
-        assert not getargtxt(sorted)
+
+    assert getdoc(sorted) == {
+        'note': 'Function of builtins module',
+        'argspec': '(...)',
+        'docstring': 'Return a new list containing all items from the '
+                     'iterable in ascending order.\n\nA custom key function '
+                     'can be supplied to customize the sort order, and the\n'
+                     'reverse flag can be set to request the result in '
+                     'descending order.',
+        'name': 'sorted'
+    }
+    assert not getargtxt(sorted)
+
     assert isdefined('numpy.take', force_import=True)
     assert isdefined('__import__')
-    assert not isdefined('.keys', force_import=True)
+    assert not isdefined('zzz', force_import=True)
+
     assert getobj('globals') == 'globals'
     assert not getobj('globals().keys')
     assert getobj('+scipy.signal.') == 'scipy.signal'

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1720,15 +1720,6 @@ class MainWindow(QMainWindow):
         # Load new path
         new_path_dict_p = self.get_spyder_pythonpath_dict()  # Includes project
 
-        # Update Spyder interpreter
-        for path in path_dict:
-            while path in sys.path:
-                sys.path.remove(path)
-
-        for path, active in reversed(new_path_dict_p.items()):
-            if active:
-                sys.path.insert(1, path)
-
         # Any plugin that needs to do some work based on this signal should
         # connect to it on plugin registration
         self.sig_pythonpath_changed.emit(path_dict, new_path_dict_p)

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1580,9 +1580,10 @@ class MainWindow(QMainWindow):
                     executable = get_python_executable()
                 else:
                     executable = CONF.get('main_interpreter', 'executable')
+                pypath = CONF.get('main', 'spyder_pythonpath', None)
                 programs.run_python_script_in_terminal(
                         fname, wdir, args, interact, debug, python_args,
-                        executable)
+                        executable, pypath)
             except NotImplementedError:
                 QMessageBox.critical(self, _("Run"),
                                      _("Running an external system terminal "

--- a/spyder/app/start.py
+++ b/spyder/app/start.py
@@ -6,15 +6,23 @@
 # (see spyder/__init__.py for details)
 # -----------------------------------------------------------------------------
 
+# Remove PYTHONPATH paths from sys.path before other imports to protect against
+# shadowed standard libraries.
+import os
+import sys
+if os.environ.get('PYTHONPATH'):
+    for path in os.environ['PYTHONPATH'].split(os.pathsep):
+        try:
+            sys.path.remove(path.rstrip(os.sep))
+        except ValueError:
+            pass
 
 # Standard library imports
 import ctypes
 import logging
-import os
 import os.path as osp
 import random
 import socket
-import sys
 import time
 
 # Prevent showing internal logging errors

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -801,6 +801,7 @@ class LanguageServerProvider(SpyderCompletionProvider):
 
         # Jedi configuration
         env_vars = os.environ.copy()  # Ensure env is indepependent of PyLSP's
+        env_vars.pop('PYTHONPATH', None)
         if self.get_conf('default', section='main_interpreter'):
             # If not explicitly set, jedi uses PyLSP's sys.path instead of
             # sys.executable's sys.path. This may be a bug in jedi.

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -14,6 +14,7 @@ import functools
 import logging
 import os
 import os.path as osp
+import sys
 
 # Third-party imports
 from qtpy.QtCore import Signal, Slot, QTimer
@@ -799,15 +800,15 @@ class LanguageServerProvider(SpyderCompletionProvider):
         }
 
         # Jedi configuration
+        env_vars = os.environ.copy()  # Ensure env is indepependent of PyLSP's
         if self.get_conf('default', section='main_interpreter'):
-            environment = None
-            env_vars = None
+            # If not explicitly set, jedi uses PyLSP's sys.path instead of
+            # sys.executable's sys.path. This may be a bug in jedi.
+            environment = sys.executable
         else:
             environment = self.get_conf('executable',
                                         section='main_interpreter')
-            env_vars = os.environ.copy()
-            # external interpreter should not use internal PYTHONPATH
-            env_vars.pop('PYTHONPATH', None)
+            # External interpreter cannot have PYTHONHOME
             if running_in_mac_app():
                 env_vars.pop('PYTHONHOME', None)
 

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -132,6 +132,9 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
         # to the kernel sys.path
         env_vars.pop('VIRTUAL_ENV', None)
 
+        # Do not pass PYTHONPATH to kernels directly, spyder-ide/spyder#13519
+        env_vars.pop('PYTHONPATH', None)
+
         # List of paths declared by the user, plus project's path, to
         # add to PYTHONPATH
         pathlist = self.get_conf(
@@ -192,7 +195,6 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
                 env_vars['PYDEVD_DISABLE_FILE_VALIDATION'] = 1
             else:
                 env_vars.pop('PYTHONHOME', None)
-                env_vars.pop('PYTHONPATH', None)
 
         # Remove this variable because it prevents starting kernels for
         # external interpreters when present.

--- a/spyder/plugins/ipythonconsole/utils/tests/test_spyder_kernel.py
+++ b/spyder/plugins/ipythonconsole/utils/tests/test_spyder_kernel.py
@@ -11,7 +11,6 @@ Tests for the Spyder kernel
 import os
 import pytest
 
-from spyder.config.base import running_in_ci
 from spyder.config.manager import CONF
 from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec
 from spyder.py3compat import PY2, is_binary_string, to_text_string
@@ -19,27 +18,32 @@ from spyder.utils.encoding import to_fs_from_unicode
 
 
 @pytest.mark.parametrize('default_interpreter', [True, False])
-@pytest.mark.skipif(not running_in_ci(), reason="Only works in CI")
-def test_preserve_pypath(tmpdir, default_interpreter):
+def test_kernel_pypath(tmpdir, default_interpreter):
     """
-    Test that PYTHONPATH is preserved in the env vars passed to the kernel
+    Test that PYTHONPATH and spyder_pythonpath option are properly handled
     when an external interpreter is used or not.
 
     Regression test for spyder-ide/spyder#8681.
+    Regression test for spyder-ide/spyder#17511.
     """
     # Set default interpreter value
     CONF.set('main_interpreter', 'default', default_interpreter)
 
-    # Add a path to PYTHONPATH env var
+    # Add a path to PYTHONPATH and spyder_pythonpath config option
     pypath = to_text_string(tmpdir.mkdir('test-pypath'))
     os.environ['PYTHONPATH'] = pypath
+    CONF.set('main', 'spyder_pythonpath', [pypath])
 
-    # Check that PYTHONPATH is in our kernelspec
     kernel_spec = SpyderKernelSpec()
-    assert pypath in kernel_spec.env['PYTHONPATH']
 
-    # Restore default value
+    # Check that PYTHONPATH is not in our kernelspec
+    # and pypath is in SPY_PYTHONPATH
+    assert 'PYTHONPATH' not in kernel_spec.env
+    assert pypath in kernel_spec.env['SPY_PYTHONPATH']
+
+    # Restore default values
     CONF.set('main_interpreter', 'default', True)
+    CONF.set('main', 'spyder_pythonpath', [])
 
 
 def test_python_interpreter(tmpdir):

--- a/spyder/plugins/profiler/widgets/main_widget.py
+++ b/spyder/plugins/profiler/widgets/main_widget.py
@@ -870,7 +870,8 @@ class ProfilerDataTree(QTreeWidget, SpyderWidgetMixin):
         return (map(self.color_string, islice(zip(*data), 1, 4)))
 
     def populate_tree(self, parentItem, children_list):
-        """Recursive method to create each item (and associated data)
+        """
+        Recursive method to create each item (and associated data)
         in the tree.
         """
         for child_key in children_list:

--- a/spyder/plugins/profiler/widgets/main_widget.py
+++ b/spyder/plugins/profiler/widgets/main_widget.py
@@ -54,6 +54,7 @@ logger = logging.getLogger(__name__)
 # ----------------------------------------------------------------------------
 MAIN_TEXT_COLOR = QStylePalette.COLOR_TEXT_1
 
+
 class ProfilerWidgetActions:
     # Triggers
     Browse = 'browse_action'
@@ -86,6 +87,7 @@ class ProfilerWidgetInformationToolbarItems:
     Stretcher1 = 'stretcher_1'
     Stretcher2 = 'stretcher_2'
     DateLabel = 'date_label'
+
 
 # --- Utils
 # ----------------------------------------------------------------------------
@@ -617,7 +619,7 @@ class ProfilerWidget(PluginMainWidget):
         self.datelabel.setText(date_text)
 
 
-class TreeWidgetItem( QTreeWidgetItem ):
+class TreeWidgetItem(QTreeWidgetItem):
     def __init__(self, parent=None):
         QTreeWidgetItem.__init__(self, parent)
 
@@ -630,7 +632,7 @@ class TreeWidgetItem( QTreeWidgetItem ):
                 if t0 is not None and t1 is not None:
                     return t0 > t1
 
-            return float( self.text(column) ) > float( otherItem.text(column) )
+            return float(self.text(column)) > float(otherItem.text(column))
         except ValueError:
             return self.text(column) > otherItem.text(column)
 
@@ -732,12 +734,12 @@ class ProfilerDataTree(QTreeWidget, SpyderWidgetMixin):
         self.stats1 = stats_indi
         self.stats = stats_indi[0].stats
 
-    def compare(self,filename):
+    def compare(self, filename):
         self.hide_diff_cols(False)
         self.compare_file = filename
 
     def hide_diff_cols(self, hide):
-        for i in (2,4,6):
+        for i in (2, 4, 6):
             self.setColumnHidden(i, hide)
 
     def save_data(self, filename):
@@ -766,7 +768,7 @@ class ProfilerDataTree(QTreeWidget, SpyderWidgetMixin):
 
     def show_tree(self):
         """Populate the tree with profiler data and display it."""
-        self.initialize_view() # Clear before re-populating
+        self.initialize_view()  # Clear before re-populating
         self.setItemsExpandable(True)
         self.setSortingEnabled(False)
         rootkey = self.find_root()  # This root contains profiler overhead
@@ -774,7 +776,7 @@ class ProfilerDataTree(QTreeWidget, SpyderWidgetMixin):
             self.populate_tree(self, self.find_callees(rootkey))
             self.resizeColumnToContents(0)
             self.setSortingEnabled(True)
-            self.sortItems(1, Qt.AscendingOrder) # FIXME: hardcoded index
+            self.sortItems(1, Qt.AscendingOrder)  # FIXME: hardcoded index
             self.change_view(1)
 
     def function_info(self, functionKey):
@@ -868,14 +870,16 @@ class ProfilerDataTree(QTreeWidget, SpyderWidgetMixin):
         return (map(self.color_string, islice(zip(*data), 1, 4)))
 
     def populate_tree(self, parentItem, children_list):
-        """Recursive method to create each item (and associated data) in the tree."""
+        """Recursive method to create each item (and associated data)
+        in the tree.
+        """
         for child_key in children_list:
             self.item_depth += 1
             (filename, line_number, function_name, file_and_line, node_type
              ) = self.function_info(child_key)
 
-            ((total_calls, total_calls_dif), (loc_time, loc_time_dif), (cum_time,
-             cum_time_dif)) = self.format_output(child_key)
+            ((total_calls, total_calls_dif), (loc_time, loc_time_dif),
+             (cum_time, cum_time_dif)) = self.format_output(child_key)
 
             child_item = TreeWidgetItem(parentItem)
             self.item_list.append(child_item)
@@ -886,7 +890,7 @@ class ProfilerDataTree(QTreeWidget, SpyderWidgetMixin):
             child_item.setData(0, Qt.DisplayRole, function_name)
             child_item.setIcon(0, self.icon_list[node_type])
 
-            child_item.setToolTip(1, _('Time in function '\
+            child_item.setToolTip(1, _('Time in function '
                                        '(including sub-functions)'))
             child_item.setData(1, Qt.DisplayRole, cum_time)
             child_item.setTextAlignment(1, Qt.AlignRight)
@@ -895,8 +899,8 @@ class ProfilerDataTree(QTreeWidget, SpyderWidgetMixin):
             child_item.setForeground(2, QColor(cum_time_dif[1]))
             child_item.setTextAlignment(2, Qt.AlignLeft)
 
-            child_item.setToolTip(3, _('Local time in function '\
-                                      '(not in sub-functions)'))
+            child_item.setToolTip(3, _('Local time in function '
+                                       '(not in sub-functions)'))
 
             child_item.setData(3, Qt.DisplayRole, loc_time)
             child_item.setTextAlignment(3, Qt.AlignRight)
@@ -905,7 +909,7 @@ class ProfilerDataTree(QTreeWidget, SpyderWidgetMixin):
             child_item.setForeground(4, QColor(loc_time_dif[1]))
             child_item.setTextAlignment(4, Qt.AlignLeft)
 
-            child_item.setToolTip(5, _('Total number of calls '\
+            child_item.setToolTip(5, _('Total number of calls '
                                        '(including recursion)'))
 
             child_item.setData(5, Qt.DisplayRole, total_calls)
@@ -915,7 +919,7 @@ class ProfilerDataTree(QTreeWidget, SpyderWidgetMixin):
             child_item.setForeground(6, QColor(total_calls_dif[1]))
             child_item.setTextAlignment(6, Qt.AlignLeft)
 
-            child_item.setToolTip(7, _('File:line '\
+            child_item.setToolTip(7, _('File:line '
                                        'where function is defined'))
             child_item.setData(7, Qt.DisplayRole, file_and_line)
             #child_item.setExpanded(True)
@@ -956,11 +960,13 @@ class ProfilerDataTree(QTreeWidget, SpyderWidgetMixin):
 
     def get_top_level_items(self):
         """Iterate over top level items"""
-        return [self.topLevelItem(_i) for _i in range(self.topLevelItemCount())]
+        return [self.topLevelItem(_i)
+                for _i in range(self.topLevelItemCount())]
 
     def get_items(self, maxlevel):
         """Return all items with a level <= `maxlevel`"""
         itemlist = []
+
         def add_to_itemlist(item, maxlevel, level=1):
             level += 1
             for index in range(item.childCount()):
@@ -968,6 +974,7 @@ class ProfilerDataTree(QTreeWidget, SpyderWidgetMixin):
                 itemlist.append(citem)
                 if level <= maxlevel:
                     add_to_itemlist(citem, maxlevel, level)
+
         for tlitem in self.get_top_level_items():
             itemlist.append(tlitem)
             if maxlevel > 0:
@@ -975,13 +982,13 @@ class ProfilerDataTree(QTreeWidget, SpyderWidgetMixin):
         return itemlist
 
     def change_view(self, change_in_depth):
-        """Change the view depth by expand or collapsing all same-level nodes"""
+        """Change view depth by expanding or collapsing all same-level nodes"""
         self.current_view_depth += change_in_depth
         if self.current_view_depth < 0:
             self.current_view_depth = 0
         self.collapseAll()
         if self.current_view_depth > 0:
-            for item in self.get_items(maxlevel=self.current_view_depth-1):
+            for item in self.get_items(maxlevel=self.current_view_depth - 1):
                 item.setExpanded(True)
 
 
@@ -993,25 +1000,25 @@ def primes(n):
     Simple test function
     Taken from http://www.huyng.com/posts/python-performance-analysis/
     """
-    if n==2:
+    if n == 2:
         return [2]
-    elif n<2:
+    elif n < 2:
         return []
-    s=list(range(3,n+1,2))
+    s = list(range(3, n + 1, 2))
     mroot = n ** 0.5
-    half=(n+1)//2-1
-    i=0
-    m=3
+    half = (n + 1) // 2 - 1
+    i = 0
+    m = 3
     while m <= mroot:
         if s[i]:
-            j=(m*m-3)//2
-            s[j]=0
-            while j<half:
-                s[j]=0
-                j+=m
-        i=i+1
-        m=2*i+3
-    return [2]+[x for x in s if x]
+            j = (m * m - 3) // 2
+            s[j] = 0
+            while j < half:
+                s[j] = 0
+                j += m
+        i = i + 1
+        m = 2 * i + 3
+    return [2] + [x for x in s if x]
 
 
 def test():

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -213,6 +213,7 @@ class IconManager():
             'vcs_commit':              [('mdi.source-commit',), {'color': SpyderPalette.ICON_3}],
             'vcs_browse':              [('mdi.source-repository',), {'color': SpyderPalette.ICON_3}],
             'fileimport':              [('mdi.download',), {'color': self.MAIN_FG_COLOR}],
+            'fileexport':              [('mdi.upload',), {'color': self.MAIN_FG_COLOR}],
             'options_less':            [('mdi.minus-box',), {'color': self.MAIN_FG_COLOR}],
             'options_more':            [('mdi.plus-box',), {'color': self.MAIN_FG_COLOR}],
             'ArrowDown':               [('mdi.arrow-down-bold-circle',), {'color': self.MAIN_FG_COLOR}],

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -223,40 +223,6 @@ def get_common_path(pathlist):
                 return osp.abspath(common)
 
 
-def add_pathlist_to_PYTHONPATH(env, pathlist, drop_env=True):
-    """
-    Add a PYTHONPATH entry to a list of environment variables.
-
-    This allows to extend the environment of an external process
-    created with QProcess with our additions to PYTHONPATH.
-
-    Parameters
-    ----------
-    env: list
-        List of environment variables in the format of
-        QProcessEnvironment.
-    pathlist: list
-        List of paths to add to PYTHONPATH
-    drop_env: bool
-        Whether to drop PYTHONPATH previously found in the environment.
-    """
-    # PyQt API 1/2 compatibility-related tests:
-    assert isinstance(env, list)
-    assert all([is_text_string(path) for path in env])
-
-    pypath = "PYTHONPATH"
-    pathstr = os.pathsep.join(pathlist)
-    if not drop_env:
-        for index, var in enumerate(env[:]):
-            if var.startswith(pypath + '='):
-                env[index] = var.replace(
-                    pypath + '=',
-                    pypath + '=' + pathstr + os.pathsep
-                )
-    else:
-        env.append(pypath + '=' + pathstr)
-
-
 def memoize(obj):
     """
     Memoize objects to trade memory for execution speed

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -15,7 +15,7 @@ import sys
 import stat
 import socket
 
-from spyder.py3compat import is_text_string, getcwd
+from spyder.py3compat import getcwd
 from spyder.config.base import get_home_dir
 
 
@@ -26,8 +26,8 @@ def __remove_pyc_pyo(fname):
     """Eventually remove .pyc and .pyo files associated to a Python script"""
     if osp.splitext(fname)[1] == '.py':
         for ending in ('c', 'o'):
-            if osp.exists(fname+ending):
-                os.remove(fname+ending)
+            if osp.exists(fname + ending):
+                os.remove(fname + ending)
 
 
 def rename_file(source, dest):
@@ -83,7 +83,7 @@ def select_port(default_port=20128):
                                  socket.SOCK_STREAM,
                                  socket.IPPROTO_TCP)
 #            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind( ("127.0.0.1", default_port) )
+            sock.bind(("127.0.0.1", default_port))
         except socket.error as _msg:  # analysis:ignore
             default_port += 1
         else:
@@ -105,6 +105,7 @@ def count_lines(path, extensions=None, excluded_dirnames=None):
                       '.f03', '.f08']
     if excluded_dirnames is None:
         excluded_dirnames = ['build', 'dist', '.hg', '.svn']
+
     def get_filelines(path):
         dfiles, dlines = 0, 0
         if osp.splitext(path)[1] in extensions:
@@ -216,7 +217,7 @@ def get_common_path(pathlist):
             return abspardir(common)
         else:
             for path in pathlist:
-                if not osp.isdir(osp.join(common, path[len(common)+1:])):
+                if not osp.isdir(osp.join(common, path[len(common) + 1:])):
                     # `common` is not the real common prefix
                     return abspardir(common)
             else:

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -720,8 +720,8 @@ def get_python_args(fname, python_args, interact, debug, end_args):
     return p_args
 
 
-def run_python_script_in_terminal(fname, wdir, args, interact,
-                                  debug, python_args, executable=None):
+def run_python_script_in_terminal(fname, wdir, args, interact, debug,
+                                  python_args, executable=None, pypath=None):
     """
     Run Python script in an external system terminal.
 
@@ -729,6 +729,12 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
     """
     if executable is None:
         executable = get_python_executable()
+
+    env = {**os.environ}
+    env.pop('PYTHONPATH', None)
+    if pypath is not None:
+        pypath = os.pathsep.join(pypath)
+        env['PYTHONPATH'] = pypath
 
     # Quote fname in case it has spaces (all platforms)
     fname = f'"{fname}"'
@@ -746,7 +752,7 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
         cmd = f'start cmd.exe /K ""{executable}" '
         cmd += ' '.join(p_args) + '"' + ' ^&^& exit'
         try:
-            run_shell_command(cmd, cwd=wdir)
+            run_shell_command(cmd, cwd=wdir, env=env)
         except WindowsError:
             from qtpy.QtWidgets import QMessageBox
             from spyder.config.base import _
@@ -763,7 +769,7 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
             if is_program_installed(program['cmd']):
                 cmd = [program['cmd'], program['execute-option'], executable]
                 cmd.extend(p_args)
-                run_shell_command(' '.join(cmd), cwd=wdir)
+                run_shell_command(' '.join(cmd), cwd=wdir, env=env)
                 return
     elif sys.platform == 'darwin':
         f = tempfile.NamedTemporaryFile('wt', prefix='run_spyder_',
@@ -773,6 +779,8 @@ def run_python_script_in_terminal(fname, wdir, args, interact,
             f.write('cd "{}"\n'.format(wdir))
         if running_in_mac_app(executable):
             f.write(f'export PYTHONHOME={os.environ["PYTHONHOME"]}\n')
+        if pypath is not None:
+            f.write(f'export PYTHONPATH={pypath}\n')
         f.write(' '.join([executable] + p_args))
         f.close()
         os.chmod(f.name, 0o777)

--- a/spyder/utils/tests/test_misc.py
+++ b/spyder/utils/tests/test_misc.py
@@ -15,9 +15,7 @@ import os
 import pytest
 
 # Local imports
-from spyder.utils.misc import (
-    get_common_path, add_pathlist_to_PYTHONPATH
-)
+from spyder.utils.misc import get_common_path
 
 
 def test_get_common_path():
@@ -36,29 +34,6 @@ def test_get_common_path():
                                 '/Python/spyder/spyder.widgets',
                                 '/Python/spyder-v21/spyder.utils',
                                 ]) == '/Python'
-
-
-@pytest.mark.parametrize("drop_env", [True, False])
-def test_add_pathlist_to_PYTHONPATH(drop_env):
-    """Test for add_pathlist_to_PYTHONPATH."""
-    pathlist = ['test123', 'test456']
-
-    if drop_env:
-        env = []
-        expected = ['PYTHONPATH=' + pathlist[0] + os.pathsep + pathlist[1]]
-    else:
-        env = ['PYTHONPATH=test0']
-        expected = [
-            'PYTHONPATH=' +
-            pathlist[0] +
-            os.pathsep +
-            pathlist[1] +
-            os.pathsep +
-            'test0'
-        ]
-
-    add_pathlist_to_PYTHONPATH(env, pathlist, drop_env=drop_env)
-    assert env == expected
 
 
 if __name__ == "__main__":

--- a/spyder/utils/tests/test_misc.py
+++ b/spyder/utils/tests/test_misc.py
@@ -21,15 +21,13 @@ from spyder.utils.misc import get_common_path
 def test_get_common_path():
     """Test getting the common path."""
     if os.name == 'nt':
-        assert get_common_path([
-                                'D:\\Python\\spyder-v21\\spyder\\widgets',
+        assert get_common_path(['D:\\Python\\spyder-v21\\spyder\\widgets',
                                 'D:\\Python\\spyder\\spyder\\utils',
                                 'D:\\Python\\spyder\\spyder\\widgets',
                                 'D:\\Python\\spyder-v21\\spyder\\utils',
                                 ]) == 'D:\\Python'
     else:
-        assert get_common_path([
-                                '/Python/spyder-v21/spyder.widgets',
+        assert get_common_path(['/Python/spyder-v21/spyder.widgets',
                                 '/Python/spyder/spyder.utils',
                                 '/Python/spyder/spyder.widgets',
                                 '/Python/spyder-v21/spyder.utils',

--- a/spyder/widgets/pathmanager.py
+++ b/spyder/widgets/pathmanager.py
@@ -70,7 +70,7 @@ class PathManager(QDialog):
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.setWindowTitle(_("PYTHONPATH manager"))
         self.setWindowIcon(ima.icon('pythonpath'))
-        self.resize(500, 300)
+        self.resize(500, 400)
         self.import_button.setVisible(sync)
         self.export_button.setVisible(os.name == 'nt' and sync)
 
@@ -221,17 +221,29 @@ class PathManager(QDialog):
 
         if env_pypath:
             env_pypath = env_pypath.split(os.pathsep)
-            env_pypath_msg = '<br>'.join(env_pypath)
-	        answer = QMessageBox.question(
-                self,
-                _("Import"),
-                _("Do you want to import the contents of your "
-                  "<tt>PYTHONPATH</tt> environment variable into Spyder? "
-                  "The following paths will be imported:"
-                  "<br><br>" + env_pypath_msg),
-                QMessageBox.No | QMessageBox.Yes, QMessageBox.Yes)
 
-            if answer == QMessageBox.Yes:
+            dlg = QDialog(self)
+            dlg.setWindowTitle(_("PYTHONPATH"))
+            dlg.setWindowIcon(ima.icon('pythonpath'))
+            dlg.setAttribute(Qt.WA_DeleteOnClose)
+            dlg.setMinimumWidth(400)
+
+            label = QLabel("The following paths will be imported.")
+            listw = QListWidget(dlg)
+            listw.addItems(env_pypath)
+
+            bbox = QDialogButtonBox(
+                QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+            bbox.accepted.connect(dlg.accept)
+            bbox.rejected.connect(dlg.reject)
+
+            layout = QVBoxLayout()
+            layout.addWidget(label)
+            layout.addWidget(listw)
+            layout.addWidget(bbox)
+            dlg.setLayout(layout)
+
+            if dlg.exec():
                 spy_pypath = self.get_path_dict()
                 n = len(spy_pypath)
 
@@ -476,7 +488,7 @@ def test():
     _ = qapplication()
     dlg = PathManager(
         None,
-        path=tuple(sys.path[:-2]),
+        path=tuple(sys.path[4:-2]),
         read_only_path=tuple(sys.path[-2:]),
     )
 

--- a/spyder/widgets/pathmanager.py
+++ b/spyder/widgets/pathmanager.py
@@ -226,8 +226,9 @@ class PathManager(QDialog):
         answer = QMessageBox.question(
             self,
             _("Import"),
-            _("Do you want to import the following paths into "
-              "PYTHONPATH Manager?"
+            _("Do you want to import the contents of your <tt>PYTHONPATH</tt> "
+              "environment variable into Spyder? The following paths will be "
+              "imported:"
               "<br><br>"
               + env_pypath_msg),
             QMessageBox.No | QMessageBox.Yes, QMessageBox.Yes)

--- a/spyder/widgets/pathmanager.py
+++ b/spyder/widgets/pathmanager.py
@@ -37,7 +37,7 @@ class PathManager(QDialog):
                  not_active_path=None, sync=True):
         """Path manager dialog."""
         super(PathManager, self).__init__(parent)
-        assert isinstance(path, (tuple, None))
+        assert isinstance(path, (tuple, type(None)))
 
         self.path = path or ()
         self.read_only_path = read_only_path or ()
@@ -220,19 +220,31 @@ class PathManager(QDialog):
         env_pypath = os.environ.get('PYTHONPATH', '')
         if not env_pypath:
             return
+
         env_pypath = env_pypath.split(os.pathsep)
-        env_pypath.reverse()
+        env_pypath_msg = '<br>'.join(env_pypath)
+        answer = QMessageBox.question(
+            self,
+            _("Import"),
+            _("Do you want to import the following paths into "
+              "PYTHONPATH Manager?"
+              "<br><br>"
+              + env_pypath_msg),
+            QMessageBox.No | QMessageBox.Yes, QMessageBox.Yes)
 
-        spy_pypath = self.get_path_dict()
-        n = len(spy_pypath)
+        if answer == QMessageBox.Yes:
+            spy_pypath = self.get_path_dict()
+            n = len(spy_pypath)
 
-        for path in env_pypath:
-            if (path in spy_pypath) or not self.check_path(path):
-                continue
-            item = self._create_item(path)
-            self.listwidget.insertItem(n, item)
+            for path in reversed(env_pypath):
+                if (path in spy_pypath) or not self.check_path(path):
+                    continue
+                item = self._create_item(path)
+                self.listwidget.insertItem(n, item)
 
-        self.refresh()
+            self.refresh()
+        else:
+            return
 
     @Slot()
     def export_pythonpath(self):

--- a/spyder/widgets/pathmanager.py
+++ b/spyder/widgets/pathmanager.py
@@ -19,7 +19,7 @@ from qtpy.compat import getexistingdirectory
 from qtpy.QtCore import Qt, Signal, Slot
 from qtpy.QtWidgets import (QDialog, QDialogButtonBox, QHBoxLayout,
                             QListWidget, QListWidgetItem, QMessageBox,
-                            QVBoxLayout)
+                            QVBoxLayout, QLabel)
 
 # Local imports
 from spyder.config.base import _
@@ -75,6 +75,13 @@ class PathManager(QDialog):
         self.export_button.setVisible(os.name == 'nt' and sync)
 
         # Layouts
+        description = QLabel(
+            _("Only paths listed here will be passed to IPython consoles and "
+              "the language server<br>as additional Python search paths."
+              "<br>"
+              "Paths in your system <b>PYTHONPATH</b> environment variable "
+              "can be imported to this list.")
+        )
         top_layout = QHBoxLayout()
         self._add_widgets_to_layout(self.top_toolbar_widgets, top_layout)
 
@@ -84,6 +91,7 @@ class PathManager(QDialog):
         bottom_layout.addWidget(self.bbox)
 
         layout = QVBoxLayout()
+        layout.addWidget(description)
         layout.addLayout(top_layout)
         layout.addWidget(self.listwidget)
         layout.addLayout(bottom_layout)

--- a/spyder/widgets/pathmanager.py
+++ b/spyder/widgets/pathmanager.py
@@ -72,16 +72,17 @@ class PathManager(QDialog):
         self.setWindowIcon(ima.icon('pythonpath'))
         self.resize(500, 300)
         self.import_button.setVisible(sync)
-        self.export_button.setVisible(os.name == 'nt' and sync)
+        # self.export_button.setVisible(os.name == 'nt' and sync)
 
         # Layouts
         description = QLabel(
-            _("Only paths listed here will be passed to IPython consoles and "
-              "the language server<br>as additional Python search paths."
-              "<br>"
-              "Paths in your system <b>PYTHONPATH</b> environment variable "
-              "can be imported to this list.")
+            _("The paths listed below will be passed to IPython consoles and "
+              "the language server as additional locations to search for "
+              "Python modules. Any paths in your system <b>PYTHONPATH</b> "
+              "environment variable can be imported here if you'd like to use "
+              "them.")
         )
+        description.setWordWrap(True)
         top_layout = QHBoxLayout()
         self._add_widgets_to_layout(self.top_toolbar_widgets, top_layout)
 
@@ -242,12 +243,12 @@ class PathManager(QDialog):
         answer = QMessageBox.question(
             self,
             _("Export"),
-            _("This will export Spyder's path list to "
+            _("This will export Spyder's path list to the "
               "<b>PYTHONPATH</b> environment variable for the current user, "
               "allowing you to run your Python modules outside Spyder "
               "without having to configure sys.path. "
-              "<br>"
-              "Do you want to clear contents of PYTHONPATH before "
+              "<br><br>"
+              "Do you want to clear the contents of PYTHONPATH before "
               "adding Spyder's path list?"),
             QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel)
 
@@ -467,7 +468,7 @@ def test():
         sys.stdout.write(str(path_dict))
 
     dlg.sig_path_changed.connect(callback)
-    dlg.exec_()
+    sys.exit(dlg.exec_())
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/pathmanager.py
+++ b/spyder/widgets/pathmanager.py
@@ -246,7 +246,8 @@ class PathManager(QDialog):
             QMessageBox.information(
                 self,
                 _("PYTHONPATH"),
-                _("<tt>PYTHONPATH</tt> is empty; nothing to import."),
+                _("Your <tt>PYTHONPATH</tt> environment variable is empty, so "
+                  "there is nothing to import."),
                 QMessageBox.Ok)
 
     @Slot()

--- a/spyder/widgets/pathmanager.py
+++ b/spyder/widgets/pathmanager.py
@@ -228,7 +228,8 @@ class PathManager(QDialog):
             dlg.setAttribute(Qt.WA_DeleteOnClose)
             dlg.setMinimumWidth(400)
 
-            label = QLabel("The following paths will be imported.")
+            label = QLabel("The following paths from your PYTHONPATH "
+                           "environment variable will be imported.")
             listw = QListWidget(dlg)
             listw.addItems(env_pypath)
 
@@ -260,7 +261,8 @@ class PathManager(QDialog):
                 _("PYTHONPATH"),
                 _("Your <tt>PYTHONPATH</tt> environment variable is empty, so "
                   "there is nothing to import."),
-                QMessageBox.Ok)
+                QMessageBox.Ok
+            )
 
     @Slot()
     def export_pythonpath(self):
@@ -278,7 +280,8 @@ class PathManager(QDialog):
               "<br><br>"
               "Do you want to clear the contents of PYTHONPATH before "
               "adding Spyder's path list?"),
-            QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel)
+            QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel
+        )
 
         if answer == QMessageBox.Cancel:
             return

--- a/spyder/widgets/pathmanager.py
+++ b/spyder/widgets/pathmanager.py
@@ -72,15 +72,15 @@ class PathManager(QDialog):
         self.setWindowIcon(ima.icon('pythonpath'))
         self.resize(500, 300)
         self.import_button.setVisible(sync)
-        # self.export_button.setVisible(os.name == 'nt' and sync)
+        self.export_button.setVisible(os.name == 'nt' and sync)
 
         # Layouts
         description = QLabel(
             _("The paths listed below will be passed to IPython consoles and "
               "the language server as additional locations to search for "
-              "Python modules. Any paths in your system <b>PYTHONPATH</b> "
-              "environment variable can be imported here if you'd like to use "
-              "them.")
+              "Python modules.<br><br>"
+              "Any paths in your system <tt>PYTHONPATH</tt> environment "
+              "variable can be imported here if you'd like to use them.")
         )
         description.setWordWrap(True)
         top_layout = QHBoxLayout()

--- a/spyder/widgets/pathmanager.py
+++ b/spyder/widgets/pathmanager.py
@@ -218,34 +218,36 @@ class PathManager(QDialog):
     def import_pythonpath(self):
         """Import from PYTHONPATH environment variable"""
         env_pypath = os.environ.get('PYTHONPATH', '')
-        if not env_pypath:
-            return
 
-        env_pypath = env_pypath.split(os.pathsep)
-        env_pypath_msg = '<br>'.join(env_pypath)
-        answer = QMessageBox.question(
-            self,
-            _("Import"),
-            _("Do you want to import the contents of your <tt>PYTHONPATH</tt> "
-              "environment variable into Spyder? The following paths will be "
-              "imported:"
-              "<br><br>"
-              + env_pypath_msg),
-            QMessageBox.No | QMessageBox.Yes, QMessageBox.Yes)
+        if env_pypath:
+            env_pypath = env_pypath.split(os.pathsep)
+            env_pypath_msg = '<br>'.join(env_pypath)
+	        answer = QMessageBox.question(
+                self,
+                _("Import"),
+                _("Do you want to import the contents of your "
+                  "<tt>PYTHONPATH</tt> environment variable into Spyder? "
+                  "The following paths will be imported:"
+                  "<br><br>" + env_pypath_msg),
+                QMessageBox.No | QMessageBox.Yes, QMessageBox.Yes)
 
-        if answer == QMessageBox.Yes:
-            spy_pypath = self.get_path_dict()
-            n = len(spy_pypath)
+            if answer == QMessageBox.Yes:
+                spy_pypath = self.get_path_dict()
+                n = len(spy_pypath)
 
-            for path in reversed(env_pypath):
-                if (path in spy_pypath) or not self.check_path(path):
-                    continue
-                item = self._create_item(path)
-                self.listwidget.insertItem(n, item)
+                for path in reversed(env_pypath):
+                    if (path in spy_pypath) or not self.check_path(path):
+                        continue
+                    item = self._create_item(path)
+                    self.listwidget.insertItem(n, item)
 
-            self.refresh()
+                self.refresh()
         else:
-            return
+            QMessageBox.information(
+                self,
+                _("PYTHONPATH"),
+                _("<tt>PYTHONPATH</tt> is empty; nothing to import."),
+                QMessageBox.Ok)
 
     @Slot()
     def export_pythonpath(self):

--- a/spyder/widgets/tests/test_pathmanager.py
+++ b/spyder/widgets/tests/test_pathmanager.py
@@ -63,7 +63,7 @@ def test_check_uncheck_path(pathmanager):
 @pytest.mark.parametrize('pathmanager',
                          [(['p1', 'p2', 'p3'], ['p4', 'p5', 'p6'], [])],
                          indirect=True)
-def test_synchronize_with_PYTHONPATH(pathmanager, mocker):
+def test_export_to_PYTHONPATH(pathmanager, mocker):
     # Import here to prevent an ImportError when testing on unix systems
     from spyder.utils.environ import (get_user_env, set_user_env,
                                       listdict2envdict)
@@ -78,7 +78,7 @@ def test_synchronize_with_PYTHONPATH(pathmanager, mocker):
                         return_value=pathmanager_mod.QMessageBox.Yes)
 
     # Assert that PYTHONPATH is synchronized correctly with Spyder's path list
-    pathmanager.synchronize()
+    pathmanager.export_pythonpath()
     expected_pathlist = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6']
     env = get_user_env()
     assert env['PYTHONPATH'] == expected_pathlist
@@ -86,7 +86,7 @@ def test_synchronize_with_PYTHONPATH(pathmanager, mocker):
     # Uncheck 'path2' and assert that it is removed from PYTHONPATH when it
     # is synchronized with Spyder's path list
     pathmanager.listwidget.item(1).setCheckState(Qt.Unchecked)
-    pathmanager.synchronize()
+    pathmanager.export_pythonpath()
     expected_pathlist = ['p1', 'p3', 'p4', 'p5', 'p6']
     env = get_user_env()
     assert env['PYTHONPATH'] == expected_pathlist
@@ -99,7 +99,7 @@ def test_synchronize_with_PYTHONPATH(pathmanager, mocker):
     # Uncheck 'path3' and assert that it is kept in PYTHONPATH when it
     # is synchronized with Spyder's path list
     pathmanager.listwidget.item(2).setCheckState(Qt.Unchecked)
-    pathmanager.synchronize()
+    pathmanager.export_pythonpath()
     expected_pathlist = ['p3', 'p1', 'p4', 'p5', 'p6']
     env = get_user_env()
     assert env['PYTHONPATH'] == expected_pathlist


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


Explicitly excluded system `PYTHONPATH` paths from Editor completion paths, IPython Console `sys.path`, and IPython Console `os.environ['PYTHONPATH']`.
Added feature to import system `PYTHONPATH` paths into PYTHONPATH Manager.

The "Syncronize..." feature (Windows only) is changed to "Export" to better complement "Import" and comport with what it actually does. This remains a Windows only feature for the time being.

Resolved an issue where a path was added after canceling "Select directory" dialog.

![ppm](https://user-images.githubusercontent.com/9618975/165896851-1bb4987a-08b3-4308-b3cd-e64cb7ab1bf9.gif)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17511 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
