### PR TITLE
PR: Fix issue where pythonw could not be used in macOS application

### DIFF
--- a/spyder/utils/conda.py
+++ b/spyder/utils/conda.py
@@ -10,13 +10,9 @@
 import json
 import os
 import os.path as osp
-import subprocess
 import sys
 
-from spyder.config.base import running_in_mac_app, get_home_dir
-from spyder.utils.programs import (find_program, run_program,
-                                   run_shell_command)
-
+from spyder.utils.programs import find_program, run_program, run_shell_command
 
 WINDOWS = os.name == 'nt'
 CONDA_ENV_LIST_CACHE = {}


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Replaced `is_anaconda()` with `is_conda_env(pyexec=real_filename)` in `is_python_interpreter`.
The former was checking Spyder's runtime environment executable instead of the executable in to be tested.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14575


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary

<!--- Thanks for your help making Spyder better for everyone! --->
