### PR TITLE
Editor: Avoid error when getting urls content from clipboard's mime data

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2870,6 +2870,7 @@ class CodeEditor(TextEditBaseWidget):
         """
         clipboard = QApplication.clipboard()
         text = to_text_string(clipboard.text())
+
         if clipboard.mimeData().hasUrls():
             # Have copied file and folder urls pasted as text paths.
             # See spyder-ide/spyder#8644 for details.
@@ -2881,7 +2882,12 @@ class CodeEditor(TextEditBaseWidget):
                                           replace(osp.os.sep, '/')
                                           + '"' for url in urls)
                 else:
-                    text = urls[0].toLocalFile().replace(osp.os.sep, '/')
+                    # The `urls` list can be empty, so we need to check that
+                    # before proceeding.
+                    # Fixes spyder-ide/spyder#17521
+                    if urls:
+                        text = urls[0].toLocalFile().replace(osp.os.sep, '/')
+
         eol_chars = self.get_line_separator()
         if len(text.splitlines()) > 1:
             text = eol_chars.join((text + eol_chars).splitlines())


### PR DESCRIPTION
## Description of Changes

The `urls` of `clipboard.mimeData()` can be empty and we were not accounting for that case.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17521

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
