### PR TITLE
PR: Make entries of `Convert end-of-line characters` menu match the ones in Preferences

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -876,17 +876,17 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
 
         self.win_eol_action = create_action(
             self,
-            _("Carriage return and line feed (Windows)"),
+            _("CRLF (Windows)"),
             toggled=lambda checked: self.toggle_eol_chars('nt', checked)
         )
         self.linux_eol_action = create_action(
             self,
-            _("Line feed (UNIX)"),
+            _("LF (Unix)"),
             toggled=lambda checked: self.toggle_eol_chars('posix', checked)
         )
         self.mac_eol_action = create_action(
             self,
-            _("Carriage return (Mac)"),
+            _("CR (macOS)"),
             toggled=lambda checked: self.toggle_eol_chars('mac', checked)
         )
         eol_action_group = QActionGroup(self)

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -3471,6 +3471,12 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                         self.editorwindows_to_be_created.append(
                             layout_settings)
                 self.set_last_focused_editorstack(self, self.editorstacks[0])
+
+            # This is necessary to update the statusbar widgets after files
+            # have been loaded.
+            editorstack = self.get_current_editorstack()
+            if editorstack:
+                self.get_current_editorstack().refresh()
         else:
             self.__load_temp_file()
         self.set_create_new_file_if_empty(True)


### PR DESCRIPTION
## Description of Changes

In 5.2.2 I updated the entries that appear in this dropdown in Preferences:

![imagen](https://user-images.githubusercontent.com/365293/159602474-873500a4-886e-4069-88c2-2dff428d91dd.png)

However, I missed that we have the menu `Source > Convert end-of-line characters` to switch EOLs on demand, and the entries there should match the ones in Preferences:

![imagen](https://user-images.githubusercontent.com/365293/159602793-6f426591-96c4-4046-8cfb-eaa7c6409db6.png)

This PR does precisely that

![imagen](https://user-images.githubusercontent.com/365293/159602869-12e19107-35e1-4dbc-8291-7942cce304e7.png)

I also fixed a minor issue: we were not showing the right EOLs in the statusbar and that menu for the file that has focus after Spyder starts or when switching projects.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
