### PR TITLE
PR: Pass new environment variable to the kernel and remove some benign errors thanks to debugpy 1.6.0 (IPython console)

### DIFF
--- a/installers/macOS/req-build.txt
+++ b/installers/macOS/req-build.txt
@@ -2,4 +2,3 @@
 py2app>=0.27
 dmgbuild>=1.4.2
 setuptools<61.0.0  # remove when there is a better fix #17547
-debugpy<1.6.0  # remove when fix available for #17552

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -198,9 +198,15 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
             env_vars['SPY_RUN_CYTHON'] = True
 
         # App considerations
-        if (running_in_mac_app() or is_pynsist()) and not default_interpreter:
-            env_vars.pop('PYTHONHOME', None)
-            env_vars.pop('PYTHONPATH', None)
+        if (running_in_mac_app() or is_pynsist()):
+            if default_interpreter:
+                # See spyder-ide/spyder#16927
+                # See spyder-ide/spyder#16828
+                # See spyder-ide/spyder#17552
+                env_vars['PYDEVD_DISABLE_FILE_VALIDATION'] = 1
+            else:
+                env_vars.pop('PYTHONHOME', None)
+                env_vars.pop('PYTHONPATH', None)
 
         # Remove this variable because it prevents starting kernels for
         # external interpreters when present.

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -521,14 +521,6 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
     def is_benign_error(self, error):
         """Decide if an error is benign in order to filter it."""
         benign_errors = [
-            # See spyder-ide/spyder#16828
-            "This version of python seems to be incorrectly compiled",
-            "internal generated filenames are not absolute",
-            "This may make the debugger miss breakpoints",
-            "http://bugs.python.org/issue1666807",
-            # See spyder-ide/spyder#16927
-            "It seems the debugger cannot resolve",
-            "https://bugs.python.org/issue1180193",
             # Old error
             "No such comm"
         ]


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

- Removed relevant errors from the benign error filter in `ipythonconsole` plugin
- Added the environment variable `PYDEVD_DISABLE_FILE_VALIDATION` to IPython Console 

The advent of `debugpy=1.6.0` provided an environment variable to bypass the errors encountered in #16927, #16828, and #17552.

Currently, only 1.5.2 is available on conda-forge; when 1.6.0 is available, I'll mark as ready for review.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17552


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary

<!--- Thanks for your help making Spyder better for everyone! --->
