### PR TITLE
PR: Disable option that excludes uppercase variables (Variable Explorer)

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -174,7 +174,7 @@ DEFAULTS = [
                                           # with ConfigParser's interpolation
               'excluded_names': EXCLUDED_NAMES,
               'exclude_private': True,
-              'exclude_uppercase': True,
+              'exclude_uppercase': False,
               'exclude_capitalized': False,
               'exclude_unsupported': False,
               'exclude_callables_and_modules': True,
@@ -639,4 +639,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '70.3.0'
+CONF_VERSION = '70.4.0'


### PR DESCRIPTION
## Description of Changes

Users (especially newbies) are really confused by not seeing uppercase variables in the Variable Explorer. So it's better to disable that option by default, instead of having it enabled.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16402

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
