### PR TITLE
PR: Fix setting max line length for Black (Completions)

### DIFF
--- a/spyder/config/lsp.py
+++ b/spyder/config/lsp.py
@@ -50,6 +50,11 @@ PYTHON_CONFIG = {
                 'pylsp_black': {
                     'enabled': False
                 },
+                'black': {
+                    'line_length': 79,
+                    'preview': False,
+                    'cache_config': False,
+                },
                 'yapf': {
                     'enabled': False
                 },

--- a/spyder/plugins/editor/widgets/tests/assets/autopep8_max_line.py
+++ b/spyder/plugins/editor/widgets/tests/assets/autopep8_max_line.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+Spyder Editor
+
+This is a temporary script file.
+"""
+
+import os
+import sys
+
+
+# %% functions
+def d():
+    def inner(): return 2
+    return inner
+# ---- func 1 and 2
+
+
+def func1():
+    for i in range(3):
+        print(i)
+
+
+def func2():
+    if True:
+        pass
+# ---- other functions
+
+
+def a():
+    pass
+
+
+def b():
+    pass
+
+
+def c():
+    pass
+
+
+# %% classes
+class Class1:
+    def __init__(self):
+        super(
+            Class1, self).__init__()
+        self.x = 2
+
+    def method3(self):
+        pass
+
+    def method2(self):
+        pass
+
+    def method1(self):
+        pass

--- a/spyder/plugins/editor/widgets/tests/assets/black_max_line.py
+++ b/spyder/plugins/editor/widgets/tests/assets/black_max_line.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""
+Spyder Editor
+
+This is a temporary script file.
+"""
+
+import os
+import sys
+
+
+# %% functions
+def d():
+    def inner():
+        return 2
+
+    return inner
+
+
+# ---- func 1 and 2
+def func1():
+    for i in range(
+        3
+    ):
+        print(i)
+
+
+def func2():
+    if True:
+        pass
+
+
+# ---- other functions
+def a():
+    pass
+
+
+def b():
+    pass
+
+
+def c():
+    pass
+
+
+# %% classes
+class Class1:
+    def __init__(
+        self,
+    ):
+        super(
+            Class1,
+            self,
+        ).__init__()
+        self.x = 2
+
+    def method3(
+        self,
+    ):
+        pass
+
+    def method2(
+        self,
+    ):
+        pass
+
+    def method1(
+        self,
+    ):
+        pass

--- a/spyder/plugins/editor/widgets/tests/assets/yapf_max_line.py
+++ b/spyder/plugins/editor/widgets/tests/assets/yapf_max_line.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+Spyder Editor
+
+This is a temporary script file.
+"""
+
+import os
+import sys
+
+
+# %% functions
+def d():
+
+    def inner():
+        return 2
+
+    return inner
+
+
+# ---- func 1 and 2
+def func1():
+    for i in range(
+            3):
+        print(i)
+
+
+def func2():
+    if True:
+        pass
+
+
+# ---- other functions
+def a():
+    pass
+
+
+def b():
+    pass
+
+
+def c():
+    pass
+
+
+# %% classes
+class Class1:
+
+    def __init__(
+            self):
+        super(
+            Class1,
+            self
+        ).__init__(
+        )
+        self.x = 2
+
+    def method3(
+            self):
+        pass
+
+    def method2(
+            self):
+        pass
+
+    def method1(
+            self):
+        pass

--- a/spyder/plugins/editor/widgets/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/tests/test_formatting.py
@@ -12,18 +12,18 @@ import os.path as osp
 
 # Third party imports
 import pytest
-import yapf
-
-# Qt imports
 from qtpy.QtGui import QTextCursor
+import yapf
 
 # Local imports
 from spyder.config.manager import CONF
 from spyder.utils.programs import is_module_installed
 
 
+# ---- Auxiliary constants and functions
 HERE = osp.dirname(osp.abspath(__file__))
 ASSETS = osp.join(HERE, 'assets')
+
 
 autopep8 = pytest.param(
     'autopep8',
@@ -50,8 +50,14 @@ black = pytest.param(
 )
 
 
-def get_formatter_values(formatter, newline, range_fmt=False):
-    suffix = 'range' if range_fmt else 'result'
+def get_formatter_values(formatter, newline, range_fmt=False, max_line=False):
+    if range_fmt:
+        suffix = 'range'
+    elif max_line:
+        suffix = 'max_line'
+    else:
+        suffix = 'result'
+
     original_file = osp.join(ASSETS, 'original_file.py')
     formatted_file = osp.join(ASSETS, '{0}_{1}.py'.format(formatter, suffix))
 
@@ -66,6 +72,7 @@ def get_formatter_values(formatter, newline, range_fmt=False):
     return text, result
 
 
+# ---- Tests
 @pytest.mark.slow
 @pytest.mark.order(1)
 @pytest.mark.parametrize('formatter', [autopep8, yapf, black])
@@ -76,10 +83,13 @@ def test_document_formatting(formatter, newline, completions_codeeditor,
     code_editor, completion_plugin = completions_codeeditor
     text, expected = get_formatter_values(formatter, newline)
 
-    # After this call the manager needs to be reinitialized
-    CONF.set('completions',
-             ('provider_configuration', 'lsp', 'values','formatting'),
-             formatter)
+    # Set formatter
+    CONF.set(
+        'completions',
+        ('provider_configuration', 'lsp', 'values', 'formatting'),
+        formatter
+    )
+    completion_plugin.after_configuration_update([])
     qtbot.wait(2000)
 
     # Set text in editor
@@ -114,10 +124,12 @@ def test_document_range_formatting(formatter, newline, completions_codeeditor,
     code_editor, completion_plugin = completions_codeeditor
     text, expected = get_formatter_values(formatter, newline, range_fmt=True)
 
-    # After this call the manager needs to be reinitialized
-    CONF.set('completions',
-             ('provider_configuration', 'lsp', 'values','formatting'),
-             formatter)
+    # Set formatter
+    CONF.set(
+        'completions',
+        ('provider_configuration', 'lsp', 'values', 'formatting'),
+        formatter
+    )
     completion_plugin.after_configuration_update([])
     qtbot.wait(2000)
 
@@ -150,4 +162,48 @@ def test_document_range_formatting(formatter, newline, completions_codeeditor,
 
     # Wait to text to be formatted
     qtbot.wait(2000)
+    assert code_editor.get_text_with_eol() == expected
+
+
+@pytest.mark.slow
+@pytest.mark.order(1)
+@pytest.mark.parametrize('formatter', [autopep8, black])
+def test_max_line_length(formatter, completions_codeeditor, qtbot):
+    """Validate autoformatting with a different value of max_line_length."""
+    code_editor, completion_plugin = completions_codeeditor
+    text, expected = get_formatter_values(
+        formatter, newline='\n', max_line=True)
+    max_line_length = 20
+
+    # Set formatter and max line length options
+    CONF.set(
+        'completions',
+        ('provider_configuration', 'lsp', 'values', 'formatting'),
+        formatter
+    )
+    CONF.set(
+        'completions',
+        ('provider_configuration', 'lsp', 'values',
+         'pycodestyle/max_line_length'),
+        max_line_length
+    )
+    completion_plugin.after_configuration_update([])
+    qtbot.wait(2000)
+
+    # Set text in editor
+    code_editor.set_text(text)
+
+    # Notify changes
+    with qtbot.waitSignal(
+            code_editor.completions_response_signal, timeout=30000):
+        code_editor.document_did_change()
+
+    # Perform formatting
+    with qtbot.waitSignal(
+            code_editor.completions_response_signal, timeout=30000):
+        code_editor.format_document()
+
+    # Wait for text to be formatted
+    qtbot.wait(2000)
+
     assert code_editor.get_text_with_eol() == expected

--- a/spyder/plugins/editor/widgets/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/tests/test_formatting.py
@@ -44,7 +44,7 @@ yapf = pytest.param(
 black = pytest.param(
     'black',
     marks=pytest.mark.skipif(
-        is_module_installed('pylsp_black', '<1.2.0'),
+        is_module_installed('python-lsp-black', '<1.2.0'),
         reason="Versions older than 1.2 don't handle eol's correctly"
     )
 )


### PR DESCRIPTION
## Description of Changes

- This was not working due to the lack of client-side options to configure `python-lsp-black`, which were added in its 1.2.0 version.
- Also set other configuration options added in that version.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14558

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
