### PR TITLE
PR: Fix usage of `os._exit` to save Editor and Projects plugins state

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1529,9 +1529,26 @@ class MainWindow(QMainWindow):
                 return False
 
         # TODO: This should be managed in a different way
-        # Prevents segfaults on close in the MacOS app and showing a warning
-        # message if spyder-terminal is installed
-        if not running_under_pytest():
+        # Prevents segfaults on close in the MacOS app
+        if running_in_mac_app():
+            # Close Editor and projects to run logic to save state:
+            # Open files/project, check unsaved files, etc.
+            if self.editor is not None:
+                try:
+                    self.editor.close()
+                    self.editor.deleteLater()
+                    self.plugin_registry.delete_plugin(
+                        Plugins.Editor, teardown=False)
+                except RuntimeError:
+                    pass
+            if self.projects is not None:
+                try:
+                    self.projects.get_widget().close()
+                    self.projects.get_widget().deleteLater()
+                    self.plugin_registry.delete_plugin(
+                        Plugins.Projects, teardown=False)
+                except RuntimeError:
+                    pass
             # Save window settings *after* closing all plugin windows, in order
             # to show them in their previous locations in the next session.
             # Fixes spyder-ide/spyder#12139

--- a/spyder/utils/workers.py
+++ b/spyder/utils/workers.py
@@ -77,7 +77,10 @@ class PythonWorker(QObject):
             error = err
 
         if not self._is_finished:
-            self.sig_finished.emit(self, output, error)
+            try:
+                self.sig_finished.emit(self, output, error)
+            except RuntimeError:
+                pass
         self._is_finished = True
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

When shutting down the application using `os._exit` we where not running the closing logic for the plugins. Although the majority of plugins only do cleaning tasks (stopping things running with threads or closing child widgets), some plugins also do tasks to preserver/check their state like for example the Editor (check for unsaved files, save recent files, save openend files, etc) and Projects (save if some project is active, recent projects, etc). 

Also since https://github.com/spyder-ide/spyder-terminal/pull/315 was merged and a [new release for spyder-terminal](https://github.com/spyder-ide/spyder-terminal/releases/tag/v1.2.2) done we can again just call `os._exit` when running in the macOS installer (since there an `abort 6` message appears when closing with the usual logic).


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
