### PR TITLE
PR: Fix layout issue when closing with unsaved files

### DIFF
--- a/spyder/api/plugin_registration/registry.py
+++ b/spyder/api/plugin_registration/registry.py
@@ -530,6 +530,23 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
         if not can_close:
             return False
 
+        # Delete Spyder 4 internal plugins
+        for plugin_name in set(self.internal_plugins):
+            if plugin_name not in excluding:
+                plugin_instance = self.plugin_registry[plugin_name]
+                if isinstance(plugin_instance, SpyderPlugin):
+                    try:
+                        plugin_instance.deleteLater()
+                    except RuntimeError:
+                        pass
+                    can_close &= self.delete_plugin(
+                        plugin_name, teardown=False)
+                    if not can_close and not close_immediately:
+                        break
+
+        if not can_close:
+            return False
+
         # Delete Spyder 5+ external plugins
         for plugin_name in set(self.external_plugins):
             if plugin_name not in excluding:
@@ -565,24 +582,7 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
         if not can_close and not close_immediately:
             return False
 
-        # Delete Spyder 4 internal plugins
-        for plugin_name in set(self.internal_plugins):
-            if plugin_name not in excluding:
-                plugin_instance = self.plugin_registry[plugin_name]
-                if isinstance(plugin_instance, SpyderPlugin):
-                    try:
-                        plugin_instance.close()
-                        plugin_instance.deleteLater()
-                    except RuntimeError:
-                        pass
-                    can_close &= self.delete_plugin(
-                        plugin_name, teardown=False)
-                    if not can_close and not close_immediately:
-                        break
-
-        if not can_close:
-            return False
-
+        # Delete Spyder 5 internal plugins
         for plugin_name in set(self.internal_plugins):
             if plugin_name not in excluding:
                 plugin_instance = self.plugin_registry[plugin_name]

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1535,7 +1535,6 @@ class MainWindow(QMainWindow):
             # Open files/project, check unsaved files, etc.
             if self.editor is not None:
                 try:
-                    self.editor.close()
                     self.editor.deleteLater()
                     self.plugin_registry.delete_plugin(
                         Plugins.Editor, teardown=False)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Close Editor first and not call `close()` in the plugin instance to prevent Editor layout issue when closing with unsaved files

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
