### PR TITLE
PR: Ensure `QFont.setPointSize` receives an int argument (Shortcuts)

### DIFF
--- a/spyder/plugins/shortcuts/widgets/summary.py
+++ b/spyder/plugins/shortcuts/widgets/summary.py
@@ -45,7 +45,7 @@ class ShortcutsSummaryDialog(QDialog):
         # Calculate font and amount of elements in each column
         # according screen size
         width, height = self.get_screen_resolution()
-        font_size = height / 80
+        font_size = height // 80
         font_size = max(min(font_size, MAX_FONT_SIZE), MIN_FONT_SIZE)
         shortcuts_column = (height - 8 * font_size) / (font_size +16)
 

--- a/spyder/plugins/shortcuts/widgets/summary.py
+++ b/spyder/plugins/shortcuts/widgets/summary.py
@@ -45,7 +45,7 @@ class ShortcutsSummaryDialog(QDialog):
         # Calculate font and amount of elements in each column
         # according screen size
         width, height = self.get_screen_resolution()
-        font_size = height // 80
+        font_size = int(round(height / 80))
         font_size = max(min(font_size, MAX_FONT_SIZE), MIN_FONT_SIZE)
         shortcuts_column = (height - 8 * font_size) / (font_size +16)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Thanks for your work on this version!  I'm close to getting it working for Debian....

The test `spyder/plugins/shortcuts/widgets/tests/test_summary.py::test_shortcutssummary` fails with Python 3.10 because `QFont().setPointSize()` requires an integer argument, and Python no longer performs implicit float -> integer conversions.  This patch fixes the cause.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: juliangilbey

<!--- Thanks for your help making Spyder better for everyone! --->
