### PR TITLE
PR: Ignore `REVIEW.md` from `check-manifest` and fix `setup.py` patch for Windows installers on PRs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ ignore =
     CODE_OF_CONDUCT.md
     CONTRIBUTING.md
     RELEASE.md
+    REVIEW.md
     TROUBLESHOOTING.md
     MAINTENANCE.md
     binder/**

--- a/setup.py
+++ b/setup.py
@@ -249,7 +249,7 @@ install_requires = [
 # building Windows installers on PRs
 if 'dev' in __version__ and WINDOWS_INSTALLER_NAME:
     install_requires.remove('spyder-kernels>=2.3.0,<2.4.0')
-    install_requires.append('spyder-kernels>=2.3.0,<=2.4.0.dev0')
+    install_requires.append('spyder-kernels>=2.3.0,<=3.0.0.dev0')
 
 extras_require = {
     'test:platform_system == "Windows"': ['pywin32'],


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->

`check-manifest` validation failing due to new `REVIEW.md` file. Building Windows installers failing on master due to wrong `spyder-kernels` version requirement patch.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
