### PR TITLE
PR: Improve the way command line options are handled by plugins

### DIFF
--- a/spyder/api/_version.py
+++ b/spyder/api/_version.py
@@ -6,5 +6,5 @@
 
 """Spyder API Version."""
 
-VERSION_INFO = (0, 6, 0)
+VERSION_INFO = (0, 7, 0)
 __version__ = '.'.join(map(str, VERSION_INFO))

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -664,6 +664,13 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
 
         return get_font(option=option, font_size_delta=font_size_delta)
 
+    def get_command_line_options(self):
+        """
+        Get command line options passed by the user when they started
+        Spyder in a system terminal.
+        """
+        return self._main._cli_options
+
     # --- API: Mandatory methods to define -----------------------------------
     # ------------------------------------------------------------------------
     @staticmethod

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -668,6 +668,8 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
         """
         Get command line options passed by the user when they started
         Spyder in a system terminal.
+
+        See app/cli_options.py for the option names.
         """
         return self._main._cli_options
 

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -16,6 +16,7 @@ import inspect
 import logging
 import os
 import os.path as osp
+import sys
 from typing import List, Union
 import warnings
 
@@ -33,6 +34,7 @@ from spyder.api.widgets.main_container import PluginMainContainer
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.api.widgets.mixins import SpyderActionMixin
 from spyder.api.widgets.mixins import SpyderWidgetMixin
+from spyder.app.cli_options import get_options
 from spyder.config.gui import get_color_scheme, get_font
 from spyder.config.manager import CONF
 from spyder.config.user import NoDefault
@@ -671,7 +673,12 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
 
         See app/cli_options.py for the option names.
         """
-        return self._main._cli_options
+        if self._main is not None:
+            return self._main._cli_options
+        else:
+            # This is necessary when the plugin has no parent.
+            sys_argv = [sys.argv[0]]  # Avoid options passed to pytest
+            return get_options(sys_argv)[0]
 
     # --- API: Mandatory methods to define -----------------------------------
     # ------------------------------------------------------------------------

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -544,6 +544,9 @@ class MainWindow(QMainWindow):
             self.open_project = None
         self.window_title = options.window_title
 
+        # Save command line options for plugins to access them
+        self._cli_options = options
+
         logger.info("Start of MainWindow constructor")
 
         def signal_handler(signum, frame=None):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -669,7 +669,6 @@ class MainWindow(QMainWindow):
         self.is_starting_up = True
         self.is_setting_up = True
 
-        self.floating_dockwidgets = []
         self.window_size = None
         self.window_position = None
 
@@ -1141,13 +1140,6 @@ class MainWindow(QMainWindow):
                 pass
 
         self.restore_scrollbar_position.emit()
-
-        # Workaround for spyder-ide/spyder#880.
-        # QDockWidget objects are not painted if restored as floating
-        # windows, so we must dock them before showing the mainwindow,
-        # then set them again as floating windows here.
-        for widget in self.floating_dockwidgets:
-            widget.setFloating(True)
 
         # Server to maintain just one Spyder instance and open files in it if
         # the user tries to start other instances with

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -819,19 +819,6 @@ class MainWindow(QMainWindow):
         logger.info("Loading switcher...")
         self.create_switcher()
 
-        message = _(
-            "Spyder Internal Console\n\n"
-            "This console is used to report application\n"
-            "internal errors and to inspect Spyder\n"
-            "internals with the following commands:\n"
-            "  spy.app, spy.window, dir(spy)\n\n"
-            "Please don't use it to run your code\n\n"
-        )
-        CONF.set('internal_console', 'message', message)
-        CONF.set('internal_console', 'commands', [])
-        CONF.set('internal_console', 'namespace', {})
-        CONF.set('internal_console', 'show_internal_errors', True)
-
         # Load and register internal and external plugins
         external_plugins = find_external_plugins()
         internal_plugins = find_internal_plugins()

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -532,8 +532,6 @@ class MainWindow(QMainWindow):
         if os.name == "nt":
             qapp.setWindowIcon(ima.get_icon("windows_app_icon"))
 
-        self.init_workdir = options.working_directory
-
         # Set default style
         self.default_style = str(qapp.style().objectName())
 
@@ -833,9 +831,6 @@ class MainWindow(QMainWindow):
         CONF.set('internal_console', 'commands', [])
         CONF.set('internal_console', 'namespace', {})
         CONF.set('internal_console', 'show_internal_errors', True)
-
-        # Working directory initialization
-        CONF.set('workingdir', 'init_workdir', self.init_workdir)
 
         # Load and register internal and external plugins
         external_plugins = find_external_plugins()

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -114,10 +114,6 @@ if os.name == 'nt':
 # Module logger
 logger = logging.getLogger(__name__)
 
-# Get the cwd before initializing WorkingDirectory, which sets it to the one
-# used in the last session
-CWD = getcwd_or_home()
-
 #==============================================================================
 # Install Qt messaage handler
 #==============================================================================
@@ -135,6 +131,7 @@ class MainWindow(QMainWindow):
     SPYDER_PATH = get_conf_path('path')
     SPYDER_NOT_ACTIVE_PATH = get_conf_path('not_active_path')
     DEFAULT_LAYOUTS = 4
+    INITIAL_CWD = getcwd_or_home()
 
     # Signals
     restore_scrollbar_position = Signal()
@@ -1648,7 +1645,7 @@ class MainWindow(QMainWindow):
 
     def get_initial_working_directory(self):
         """Return the initial working directory."""
-        return CWD
+        return self.INITIAL_CWD
 
     def open_external_file(self, fname):
         """

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -930,7 +930,7 @@ def test_window_title(main_window, tmpdir):
     projects.open_project(path=path)
 
     # Set non-ascii window title
-    main_window.window_title = u'اختبار'
+    main_window._cli_options.window_title = u'اختبار'
 
     # Assert window title is computed without errors
     # and has the expected strings

--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -300,8 +300,7 @@ def create_window(WindowClass, app, splash, options, args):
     main.post_visible_setup()
 
     if main.console:
-        namespace = CONF.get('internal_console', 'namespace', {})
-        main.console.start_interpreter(namespace)
+        main.console.start_interpreter(namespace={})
         main.console.set_namespace_item('spy', Spy(app=app, window=main))
 
     # Propagate current configurations to all configuration observers

--- a/spyder/plugins/console/plugin.py
+++ b/spyder/plugins/console/plugin.py
@@ -260,7 +260,6 @@ class Console(SpyderDockablePlugin):
         Stdin and stdout are now redirected through the internal console.
         """
         widget = self.get_widget()
-        widget.set_conf('namespace', namespace)
         widget.start_interpreter(namespace)
 
     def set_namespace_item(self, name, value):

--- a/spyder/plugins/console/tests/test_plugin.py
+++ b/spyder/plugins/console/tests/test_plugin.py
@@ -11,19 +11,20 @@ Tests for the console plugin.
 """
 
 # Standard library imports
-from unittest.mock import call, Mock
+from unittest.mock import call
+import sys
 
 # Third party imports
+from flaky import flaky
+import pytest
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QMainWindow
-import pytest
-from flaky import flaky
 
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
 from spyder.api.plugins import SpyderPluginV2
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
-from spyder.config.manager import CONF
+from spyder.app.cli_options import get_options
 from spyder.plugins.console.plugin import Console
 from spyder.widgets.reporterror import SpyderErrorDialog
 
@@ -45,6 +46,9 @@ def console_plugin(qtbot):
 
     class MainWindowMock(QMainWindow):
         def __init__(self):
+            # This avoids using the cli options passed to pytest
+            sys_argv = [sys.argv[0]]
+            self._cli_options = get_options(sys_argv)[0]
             super().__init__()
 
     window = MainWindowMock()

--- a/spyder/plugins/console/widgets/internalshell.py
+++ b/spyder/plugins/console/widgets/internalshell.py
@@ -147,7 +147,7 @@ class InternalShell(PythonShellWidget):
     # TODO: I think this is not being used now?
     sig_focus_changed = Signal()
 
-    def __init__(self, parent=None, namespace=None, commands=[], message=None,
+    def __init__(self, parent=None, commands=[], message=None,
                  max_line_count=300, exitfunc=None, profile=False,
                  multithreaded=True):
         super().__init__(parent, get_conf_path('history_internal.py'),

--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -117,6 +117,11 @@ class ConsoleWidget(PluginMainWidget):
         self.error_traceback = ''
         self.dismiss_error = False
 
+        # Options that come from the command line
+        cli_options = plugin.get_command_line_options()
+        profile = cli_options.profile
+        multithreaded = cli_options.multithreaded
+
         # Widgets
         self.dialog_manager = DialogManager()
         self.error_dlg = None
@@ -126,8 +131,8 @@ class ConsoleWidget(PluginMainWidget):
             commands=self.get_conf('commands', []),
             message=self.get_conf('message', ''),
             max_line_count=self.get_conf('max_line_count'),
-            profile=self.get_conf('profile', False),
-            multithreaded=self.get_conf('multithreaded', False),
+            profile=profile,
+            multithreaded=multithreaded,
         )
         self.find_widget = FindReplace(self)
 

--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -117,6 +117,16 @@ class ConsoleWidget(PluginMainWidget):
         self.error_traceback = ''
         self.dismiss_error = False
 
+        # Header message
+        message = _(
+            "Spyder Internal Console\n\n"
+            "This console is used to report application\n"
+            "internal errors and to inspect Spyder\n"
+            "internals with the following commands:\n"
+            "  spy.app, spy.window, dir(spy)\n\n"
+            "Please don't use it to run your code\n\n"
+        )
+
         # Options that come from the command line
         cli_options = plugin.get_command_line_options()
         profile = cli_options.profile
@@ -126,10 +136,8 @@ class ConsoleWidget(PluginMainWidget):
         self.dialog_manager = DialogManager()
         self.error_dlg = None
         self.shell = InternalShell(  # TODO: Move to use SpyderWidgetMixin?
-            parent=parent,
-            namespace=self.get_conf('namespace', {}),
-            commands=self.get_conf('commands', []),
-            message=self.get_conf('message', ''),
+            commands=[],
+            message=message,
             max_line_count=self.get_conf('max_line_count'),
             profile=profile,
             multithreaded=multithreaded,

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -501,14 +501,6 @@ class Layout(SpyderPluginV2):
                 self.setup_layout(default=True)
                 return
 
-            # Workaround for spyder-ide/spyder#880.
-            # QDockWidget objects are not painted if restored as floating
-            # windows, so we must dock them before showing the mainwindow.
-            for widget in self.children():
-                if isinstance(widget, QDockWidget) and widget.isFloating():
-                    self.floating_dockwidgets.append(widget)
-                    widget.setFloating(False)
-
         # Is fullscreen?
         if is_fullscreen:
             self.main.setWindowState(Qt.WindowFullScreen)

--- a/spyder/plugins/preferences/tests/conftest.py
+++ b/spyder/plugins/preferences/tests/conftest.py
@@ -9,6 +9,8 @@
 Testing utilities to be used with pytest.
 """
 
+# Standard library imports
+import sys
 import types
 from unittest.mock import Mock, MagicMock
 
@@ -20,6 +22,7 @@ import pytest
 # Local imports
 from spyder.api.plugins import Plugins
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
+from spyder.app.cli_options import get_options
 from spyder.config.manager import CONF
 from spyder.plugins.preferences.plugin import Preferences
 from spyder.utils.icon_manager import ima
@@ -38,6 +41,10 @@ class MainWindowMock(QMainWindow):
         self._APPLICATION_TOOLBARS = MagicMock()
 
         self.console = Mock()
+
+        # To provide command line options for plugins that need them
+        sys_argv = [sys.argv[0]]  # Avoid options passed to pytest
+        self._cli_options = get_options(sys_argv)[0]
 
         PLUGIN_REGISTRY.reset()
         PLUGIN_REGISTRY.sig_plugin_ready.connect(self.register_plugin)

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -13,10 +13,10 @@ updating the file tree explorer associated with a project
 
 # Standard library imports
 import configparser
+import logging
 import os
 import os.path as osp
 import shutil
-import functools
 from collections import OrderedDict
 
 # Third party imports
@@ -31,7 +31,7 @@ from spyder.api.plugin_registration.decorators import (
 from spyder.api.translations import get_translation
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.config.base import (get_home_dir, get_project_config_folder,
-                                running_under_pytest)
+                                running_in_mac_app, running_under_pytest)
 from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils import encoding
 from spyder.utils.icon_manager import ima
@@ -47,8 +47,9 @@ from spyder.plugins.completion.api import (
 from spyder.plugins.completion.decorators import (
     request, handles, class_register)
 
-# Localization
+# Localization and logging
 _ = get_translation("spyder")
+logger = logging.getLogger(__name__)
 
 
 class ProjectsMenuSubmenus:
@@ -402,6 +403,26 @@ class Projects(SpyderDockablePlugin):
             self.open_project(path=project)
         return opener
 
+    def on_mainwindow_visible(self):
+        # Open project passed on the command line or reopen last one.
+        cli_options = self.get_command_line_options()
+        initial_cwd = self._main.get_initial_working_directory()
+
+        if cli_options.project is not None:
+            # This doesn't work for our Mac app
+            if not running_in_mac_app():
+                logger.debug('Opening project from the command line')
+                project = osp.normpath(
+                    osp.join(initial_cwd, cli_options.project)
+                )
+                self.open_project(
+                    project,
+                    workdir=cli_options.working_directory
+                )
+        else:
+            logger.debug('Reopening project from last session')
+            self.reopen_last_project()
+
     # ------ Public API -------------------------------------------------------
     @Slot()
     def create_new_project(self):
@@ -468,6 +489,9 @@ class Projects(SpyderDockablePlugin):
                 return
         else:
             path = encoding.to_unicode_from_fs(path)
+
+        logger.debug(f'Opening project located at {path}')
+
         if project is None:
             project_type_class = self._load_project_type_class(path)
             project = project_type_class(

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -636,11 +636,17 @@ class Projects(SpyderDockablePlugin):
                                              default=None)
 
         # Needs a safer test of project existence!
-        if (current_project_path and
-                self.is_valid_project(current_project_path)):
-            self.open_project(path=current_project_path,
-                              restart_consoles=True,
-                              save_previous_files=False)
+        if (
+            current_project_path and
+            self.is_valid_project(current_project_path)
+        ):
+            cli_options = self.get_command_line_options()
+            self.open_project(
+                path=current_project_path,
+                restart_consoles=True,
+                save_previous_files=False,
+                workdir=cli_options.working_directory
+            )
             self.load_config()
 
     def get_project_filenames(self):

--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -67,8 +67,10 @@ def projects(qtbot, mocker, request, tmpdir):
     # Main window mock
     main_window = MainWindowProjectsMock(None)
     if use_cli_project:
-        cli_project = tmpdir.mkdir('cli_project_dir')
-        main_window._cli_options.project = str(cli_project)
+        tmpdir.mkdir('cli_project_dir')
+
+        # This allows us to test relative paths passed on the command line
+        main_window._cli_options.project = 'cli_project_dir'
 
     # Create plugin
     projects = Projects(configuration=CONF)

--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -22,6 +22,8 @@ import pytest
 from flaky import flaky
 
 # Local imports
+from spyder.app.cli_options import get_options
+from spyder.config.base import running_in_ci
 from spyder.config.manager import CONF
 import spyder.plugins.base
 from spyder.plugins.projects.plugin import Projects, QMessageBox
@@ -34,8 +36,9 @@ from spyder.py3compat import to_text_string
 # ---- Fixtures
 # =============================================================================
 @pytest.fixture
-def projects(qtbot, mocker):
+def projects(qtbot, mocker, request, tmpdir):
     """Projects plugin fixture."""
+    use_cli_project = request.node.get_closest_marker('use_cli_project')
 
     class EditorMock(MagicMock):
         def get_open_filenames(self):
@@ -44,6 +47,12 @@ def projects(qtbot, mocker):
             return []
 
     class MainWindowProjectsMock(MainWindowMock):
+        def __init__(self, parent):
+            # This avoids using the cli options passed to pytest
+            sys_argv = [sys.argv[0]]
+            self._cli_options = get_options(sys_argv)[0]
+            super().__init__(parent)
+
         def __getattr__(self, attr):
             if attr == 'ipyconsole':
                 return None
@@ -52,8 +61,14 @@ def projects(qtbot, mocker):
             except AttributeError:
                 return MagicMock()
 
+        def get_initial_working_directory(self):
+            return str(tmpdir)
+
     # Main window mock
     main_window = MainWindowProjectsMock(None)
+    if use_cli_project:
+        cli_project = tmpdir.mkdir('cli_project_dir')
+        main_window._cli_options.project = str(cli_project)
 
     # Create plugin
     projects = Projects(configuration=CONF)
@@ -347,6 +362,7 @@ def test_project_explorer_tree_root(projects, tmpdir, qtbot):
 
 @flaky(max_runs=5)
 @pytest.mark.skipif(sys.platform == 'darwin', reason="Fails on Mac")
+@pytest.mark.skipif(not running_in_ci(), reason="Hangs locally sometimes")
 def test_filesystem_notifications(qtbot, projects, tmpdir):
     """
     Test that filesystem notifications are emitted when creating,
@@ -463,6 +479,38 @@ def test_loaded_and_closed_signals(create_projects, tmpdir, mocker, qtbot):
     with qtbot.waitSignals(
             [projects.sig_project_loaded, projects.sig_project_closed]):
         projects.open_project(path=path2)
+
+
+@pytest.mark.use_cli_project
+def test_project_cli(projects):
+    """Test that we can open a project from the command line."""
+    # Simulate opening a project when the main window is visible
+    projects.on_mainwindow_visible()
+
+    # Verify that we created the expected project
+    active_project = projects.get_active_project_path()
+    assert osp.split(active_project)[-1] == 'cli_project_dir'
+
+    # Close project
+    projects.close_project()
+
+
+def test_reopen_project(projects, tmpdir):
+    """Test that we can reopen a project from the last session."""
+    # Create project
+    last_project = tmpdir.mkdir('last_project_dir')
+    last_project.mkdir('.spyproject')
+    projects.set_conf('current_project_path', str(last_project))
+
+    # Simulate opening a project when the main window is visible
+    projects.on_mainwindow_visible()
+
+    # Verify that we created the expected project
+    active_project = projects.get_active_project_path()
+    assert osp.split(active_project)[-1] == 'last_project_dir'
+
+    # Close project
+    projects.close_project()
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/workingdirectory/container.py
+++ b/spyder/plugins/workingdirectory/container.py
@@ -273,7 +273,6 @@ class WorkingDirectoryContainer(PluginMainContainer):
 
             if emit:
                 self.sig_current_directory_changed.emit(directory)
-
         except OSError:
             self.history.pop(self.histindex)
 

--- a/spyder/plugins/workingdirectory/plugin.py
+++ b/spyder/plugins/workingdirectory/plugin.py
@@ -78,7 +78,11 @@ class WorkingDirectory(SpyderPluginV2):
         self.sig_current_directory_changed.connect(
             lambda path, plugin=None: self.chdir(path, plugin))
 
-        container.set_history(self.load_history())
+        cli_options = self.get_command_line_options()
+        container.set_history(
+            self.load_history(),
+            cli_options.working_directory
+        )
 
     @on_plugin_available(plugin=Plugins.Toolbar)
     def on_toolbar_available(self):

--- a/spyder/plugins/workingdirectory/tests/test_workingdirectory.py
+++ b/spyder/plugins/workingdirectory/tests/test_workingdirectory.py
@@ -5,36 +5,62 @@
 #
 """Tests for workingdirectory plugin."""
 
-# Test library imports
-import pytest
-import os
+# Standard library imports
 import os.path as osp
+import sys
+from unittest.mock import Mock
+
+# Third-party imports
+import pytest
+from qtpy.QtWidgets import QMainWindow
 
 # Local imports
-from spyder.plugins.workingdirectory.plugin import WorkingDirectory
+from spyder.app.cli_options import get_options
 from spyder.config.base import get_home_dir
 from spyder.config.manager import CONF
+from spyder.plugins.workingdirectory.plugin import WorkingDirectory
+
 
 NEW_DIR = 'new_workingdir'
 
 
+class MainWindow(QMainWindow):
+
+    def __init__(self):
+        # This avoids using the cli options passed to pytest
+        sys_argv = [sys.argv[0]]
+        self._cli_options = get_options(sys_argv)[0]
+        super().__init__()
+
+    def get_plugin(self, plugin):
+        return Mock()
+
+
 @pytest.fixture
-def setup_workingdirectory(qtbot, request):
+def setup_workingdirectory(qtbot, request, tmpdir):
     """Setup working directory plugin."""
     CONF.reset_to_defaults()
     use_startup_wdir = request.node.get_closest_marker('use_startup_wdir')
-    if use_startup_wdir:
-        new_wdir = osp.join(os.getcwd(), NEW_DIR)
-        if not osp.exists(new_wdir):
-            os.mkdir(new_wdir)
-        CONF.set('workingdir', 'startup/use_fixed_directory', True)
-        CONF.set('workingdir', 'startup/fixed_directory', new_wdir)
-    else:
-        CONF.set('workingdir', 'startup/use_fixed_directory', False)
-        CONF.set('workingdir', 'console/use_fixed_directory', False)
-        CONF.set('workingdir', 'startup/fixed_directory', get_home_dir())
+    use_cli_wdir = request.node.get_closest_marker('use_cli_wdir')
 
-    workingdirectory = WorkingDirectory(None, configuration=CONF)
+    # Setting default options
+    CONF.set('workingdir', 'startup/use_fixed_directory', False)
+    CONF.set('workingdir', 'console/use_fixed_directory', False)
+    CONF.set('workingdir', 'startup/fixed_directory', get_home_dir())
+
+    # Create main window and new directory
+    main_window = MainWindow()
+
+    if use_startup_wdir:
+        new_wdir = tmpdir.mkdir(NEW_DIR + '_startup')
+        CONF.set('workingdir', 'startup/use_fixed_directory', True)
+        CONF.set('workingdir', 'startup/fixed_directory', str(new_wdir))
+    elif use_cli_wdir:
+        new_wdir = tmpdir.mkdir(NEW_DIR + '_cli')
+        main_window._cli_options.working_directory = str(new_wdir)
+
+    workingdirectory = WorkingDirectory(main_window, configuration=CONF)
+    workingdirectory.on_initialize()
     workingdirectory.close = lambda: True
 
     return workingdirectory
@@ -58,12 +84,35 @@ def test_get_workingdir(setup_workingdirectory):
 
 @pytest.mark.use_startup_wdir
 def test_get_workingdir_startup(setup_workingdirectory):
-    """Test the method that defines the working directory at home."""
+    """
+    Test the method that sets the working directory according to the one
+    selected in preferences.
+    """
     workingdirectory = setup_workingdirectory
-    # Start the working directory on the home directory
-    act_wdir = workingdirectory.get_workdir()
-    folders = osp.split(act_wdir)
-    assert folders[-1] == NEW_DIR
+
+    # Get the current working directory
+    cwd = workingdirectory.get_workdir()
+    folders = osp.split(cwd)
+
+    # Asert working directory is the expected one
+    assert folders[-1] == NEW_DIR + '_startup'
+    CONF.reset_to_defaults()
+
+
+@pytest.mark.use_cli_wdir
+def test_get_workingdir_cli(setup_workingdirectory):
+    """
+    Test that the plugin sets the working directory passed by users on the
+    command line with the --workdir option.
+    """
+    workingdirectory = setup_workingdirectory
+
+    # Get the current working directory
+    cwd = workingdirectory.get_container().history[-1]
+    folders = osp.split(cwd)
+
+    # Asert working directory is the expected one
+    assert folders[-1] == NEW_DIR + '_cli'
     CONF.reset_to_defaults()
 
 


### PR DESCRIPTION
## Description of Changes

- Add a new API method for plugins to access command line options.
- Use it to simplify how different plugins handle those options (i.e. Projects, Internal console and Working directory).
- Fix the `--workdir`/`-w` cli option
- Remove some dead code in `MainWindow`.
- Add tests wherever possible.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17589

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
