### PR TITLE
PR: Convert coordinates to position DPI message to int (Application)

### DIFF
--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -577,6 +577,7 @@ class ApplicationContainer(PluginMainContainer):
             self.dpi_messagebox.finished.connect(
                 lambda result: self.handle_dpi_change_response(result, dpi))
             self.dpi_messagebox.open()
+
             # Show dialog always in the primary screen to prevent not being
             # able to see it if a screen gets disconnected while
             # in suspended state. See spyder-ide/spyder#16390
@@ -585,4 +586,7 @@ class ApplicationContainer(PluginMainContainer):
             screen_geometry = QGuiApplication.primaryScreen().geometry()
             x = (screen_geometry.width() - dpi_messagebox_width) / 2
             y = (screen_geometry.height() - dpi_messagebox_height) / 2
-            self.dpi_messagebox.move(x, y)
+
+            # Convert coordinates to int to avoid a TypeError in Python 3.10
+            # Fixes spyder-ide/spyder#17677
+            self.dpi_messagebox.move(int(x), int(y))


### PR DESCRIPTION
## Description of Changes

Not doing that generates an error in Python 3.10 because it doesn't automatically cast floats to ints.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17677.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
