### PR TITLE
PR: Fix clear for `Open with` menu in the Files pane

### DIFF
--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -661,7 +661,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             if len(assoc) >= 1:
                 actions = self._create_file_associations_actions()
                 self.open_with_submenu.menuAction().setVisible(True)
-                self.open_with_submenu.clear()
+                self.open_with_submenu.clear_actions()
                 for action in actions:
                     self.add_item_to_menu(
                         action,


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Actions duplication in menu (SpyderMenu) since for that kind of menu the custom method `clear_actions` needs to be call to actually clear all actions references.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15460


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
