### PR TITLE
PR: Pass `APPDATA` env var to the process that starts the PyLSP server (Completions)

### DIFF
--- a/spyder/plugins/completion/providers/languageserver/client.py
+++ b/spyder/plugins/completion/providers/languageserver/client.py
@@ -28,7 +28,9 @@ import psutil
 # Local imports
 from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.config.base import (
-    DEV, get_conf_path, get_debug_level, running_in_ci, running_under_pytest)
+    DEV, get_conf_path, get_debug_level, is_pynsist, running_in_ci,
+    running_under_pytest)
+from spyder.config.utils import is_anaconda
 from spyder.plugins.completion.api import (
     CLIENT_CAPABILITES, SERVER_CAPABILITES,
     TEXT_DOCUMENT_SYNC_OPTIONS, CompletionRequestTypes,
@@ -291,12 +293,23 @@ class LSPClient(QObject, LSPMethodProviderMixIn, SpyderConfigurationAccessor):
             if not osp.exists(cwd):
                 os.makedirs(cwd)
 
-            # On Windows, some modules (notably Matplotlib)
-            # cause exceptions if they cannot get the user home.
-            # So, we need to pass the USERPROFILE env variable to
-            # the PyLS.
-            if os.name == "nt" and "USERPROFILE" in os.environ:
-                env.insert("USERPROFILE", os.environ["USERPROFILE"])
+            if os.name == "nt":
+                # On Windows, some modules (notably Matplotlib)
+                # cause exceptions if they cannot get the user home.
+                # So, we need to pass the USERPROFILE env variable to
+                # the PyLSP.
+                if "USERPROFILE" in os.environ:
+                    env.insert("USERPROFILE", os.environ["USERPROFILE"])
+
+                # The PyLSP can't start on pip installations if APPDATA
+                # is missing and the user has installed their packages on
+                # that directory.
+                # Fixes spyder-ide/spyder#17661
+                if (
+                    not (is_anaconda() or is_pynsist())
+                    and "APPDATA" in os.environ
+                ):
+                    env.insert("APPDATA", os.environ["APPDATA"])
         else:
             # There's no need to define a cwd for other servers.
             cwd = None


### PR DESCRIPTION
## Description of Changes

Without this variable, the server won't start for Pip installations where the server and its dependencies are installed in the `APPDATA` directory.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17661.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
