### PR TITLE
PR: Remove macOS app flow fork in closing Spyder

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -60,7 +60,7 @@ jobs:
         run: ${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dist-dir ${DISTDIR}
       - name: Test Application Bundle
         if: ${{github.event_name == 'pull_request'}}
-        run: ./test_app.sh -t 60 ${DISTDIR}
+        run: ./test_app.sh -t 60 -d 10 ${DISTDIR}
       - name: Build Disk Image
         run: ${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dist-dir ${DISTDIR} --dmg --no-app
       - name: Upload Artifact

--- a/installers/macOS/req-extras.txt
+++ b/installers/macOS/req-extras.txt
@@ -8,3 +8,5 @@ pyflakes
 pyxdg
 rope
 yapf
+# Temporarily limit jupyter-client spyder-ide/spyder#17615
+jupyter-client<7.2.1

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1163,7 +1163,7 @@ class MainWindow(QMainWindow):
             # when it gets a client connected to it
             self.sig_open_external_file.connect(self.open_external_file)
 
-        
+
         # Update plugins toggle actions to show the "Switch to" plugin shortcut
         self._update_shortcuts_in_panes_menu()
 
@@ -1499,68 +1499,36 @@ class MainWindow(QMainWindow):
             if reply == QMessageBox.No:
                 return False
 
-        # TODO: This should be managed in a different way
-        # Prevents segfaults on close in the MacOS app
-        if running_in_mac_app():
-            # Close Editor and projects to run logic to save state:
-            # Open files/project, check unsaved files, etc.
-            if self.editor is not None:
-                try:
-                    self.editor.deleteLater()
-                    self.plugin_registry.delete_plugin(
-                        Plugins.Editor, teardown=False)
-                except RuntimeError:
-                    pass
-            if self.projects is not None:
-                try:
-                    self.projects.get_widget().close()
-                    self.projects.get_widget().deleteLater()
-                    self.plugin_registry.delete_plugin(
-                        Plugins.Projects, teardown=False)
-                except RuntimeError:
-                    pass
-            # Save window settings *after* closing all plugin windows, in order
-            # to show them in their previous locations in the next session.
-            # Fixes spyder-ide/spyder#12139
-            prefix = 'window' + '/'
-            if self.layouts is not None:
-                self.layouts.save_current_window_settings(prefix)
+        can_close = self.plugin_registry.delete_all_plugins(
+            excluding={Plugins.Layout},
+            close_immediately=close_immediately)
 
-            # Close application
-            os._exit(0)
-            app = qapplication()  # analysis:ignore
-            del app
-        else:
-            can_close = self.plugin_registry.delete_all_plugins(
-                excluding={Plugins.Layout},
-                close_immediately=close_immediately)
+        if not can_close and not close_immediately:
+            return False
 
-            if not can_close and not close_immediately:
-                return False
+        # Save window settings *after* closing all plugin windows, in order
+        # to show them in their previous locations in the next session.
+        # Fixes spyder-ide/spyder#12139
+        prefix = 'window' + '/'
+        if self.layouts is not None:
+            self.layouts.save_current_window_settings(prefix)
+            try:
+                layouts_container = self.layouts.get_container()
+                if layouts_container:
+                    layouts_container.close()
+                    layouts_container.deleteLater()
+                self.layouts.deleteLater()
+                self.plugin_registry.delete_plugin(
+                    Plugins.Layout, teardown=False)
+            except RuntimeError:
+                pass
 
-            # Save window settings *after* closing all plugin windows, in order
-            # to show them in their previous locations in the next session.
-            # Fixes spyder-ide/spyder#12139
-            prefix = 'window' + '/'
-            if self.layouts is not None:
-                self.layouts.save_current_window_settings(prefix)
-                try:
-                    layouts_container = self.layouts.get_container()
-                    if layouts_container:
-                        layouts_container.close()
-                        layouts_container.deleteLater()
-                    self.layouts.deleteLater()
-                    self.plugin_registry.delete_plugin(
-                        Plugins.Layout, teardown=False)
-                except RuntimeError:
-                    pass
+        self.already_closed = True
 
-            self.already_closed = True
+        if CONF.get('main', 'single_instance') and self.open_files_server:
+            self.open_files_server.close()
 
-            if CONF.get('main', 'single_instance') and self.open_files_server:
-                self.open_files_server.close()
-
-            QApplication.processEvents()
+        QApplication.processEvents()
 
         return True
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->

Closing the Spyder application in `mainwindow.py` has a flow control fork for the macOS standalone application. This is removed.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17729 
Partial fix for #17731


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary 

<!--- Thanks for your help making Spyder better for everyone! --->
