### PR TITLE
PR: Remove possibility of passing separate configuration object for testing

### DIFF
--- a/spyder/api/config/mixins.py
+++ b/spyder/api/config/mixins.py
@@ -37,7 +37,6 @@ class SpyderConfigurationAccessor:
     # used to record the object's permanent data in Spyder
     # config system.
     CONF_SECTION = None
-    CONFIGURATION = CONF
 
     def get_conf(self,
                  option: ConfigurationKey,
@@ -74,7 +73,7 @@ class SpyderConfigurationAccessor:
                 'class attribute!'
             )
 
-        return self.CONFIGURATION.get(section, option, default)
+        return CONF.get(section, option, default)
 
     def get_conf_options(self, section: Optional[str] = None):
         """
@@ -102,7 +101,7 @@ class SpyderConfigurationAccessor:
                 'A SpyderConfigurationAccessor must define a `CONF_SECTION` '
                 'class attribute!'
             )
-        return self.CONFIGURATION.options(section)
+        return CONF.options(section)
 
     def set_conf(self,
                  option: ConfigurationKey,
@@ -135,7 +134,7 @@ class SpyderConfigurationAccessor:
                 'A SpyderConfigurationAccessor must define a `CONF_SECTION` '
                 'class attribute!'
             )
-        self.CONFIGURATION.set(
+        CONF.set(
             section,
             option,
             value,
@@ -162,7 +161,7 @@ class SpyderConfigurationAccessor:
                 'A SpyderConfigurationAccessor must define a `CONF_SECTION` '
                 'class attribute!'
             )
-        self.CONFIGURATION.remove_option(section, option)
+        CONF.remove_option(section, option)
 
     def get_conf_default(self,
                          option: ConfigurationKey,
@@ -184,7 +183,7 @@ class SpyderConfigurationAccessor:
                 'A SpyderConfigurationAccessor must define a `CONF_SECTION` '
                 'class attribute!'
             )
-        return self.CONFIGURATION.get_default(section, option)
+        return CONF.get_default(section, option)
 
     def get_shortcut(self, name: str, context: Optional[str] = None) -> str:
         """
@@ -208,7 +207,7 @@ class SpyderConfigurationAccessor:
             If the section does not exist in the configuration.
         """
         context = self.CONF_SECTION if context is None else context
-        return self.CONFIGURATION.get_shortcut(context, name)
+        return CONF.get_shortcut(context, name)
 
     def config_shortcut(
             self, action: QAction, name: str, parent: QWidget,
@@ -237,7 +236,7 @@ class SpyderConfigurationAccessor:
             shortcuts preferences page.
         """
         shortcut_context = self.CONF_SECTION if context is None else context
-        return self.CONFIGURATION.config_shortcut(
+        return CONF.config_shortcut(
             action,
             shortcut_context,
             name,
@@ -247,7 +246,7 @@ class SpyderConfigurationAccessor:
     @property
     def old_conf_version(self):
         """Get old Spyder configuration version."""
-        return self.CONFIGURATION.old_spyder_version
+        return CONF.old_spyder_version
 
 
 class SpyderConfigurationObserver(SpyderConfigurationAccessor):
@@ -264,10 +263,8 @@ class SpyderConfigurationObserver(SpyderConfigurationAccessor):
     the corresponding registered method is called with the new value.
     """
 
-    def __init__(self, configuration=None):
+    def __init__(self):
         super().__init__()
-        if configuration is not None:
-            self.CONFIGURATION = configuration
         if self.CONF_SECTION is None:
             warnings.warn(
                 'A SpyderConfigurationObserver must define a `CONF_SECTION` '
@@ -287,11 +284,11 @@ class SpyderConfigurationObserver(SpyderConfigurationAccessor):
             for option in observed_options:
                 logger.debug(f'{self} is observing {option} '
                              f'in section {section}')
-                self.CONFIGURATION.observe_configuration(self, section, option)
+                CONF.observe_configuration(self, section, option)
 
     def __del__(self):
         # Remove object from the configuration observer
-        self.CONFIGURATION.unobserve_configuration(self)
+        CONF.unobserve_configuration(self)
 
     def _gather_observers(self):
         """Gather all the methods decorated with `on_conf_change`."""

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -36,7 +36,6 @@ from spyder.api.widgets.mixins import SpyderActionMixin
 from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.app.cli_options import get_options
 from spyder.config.gui import get_color_scheme, get_font
-from spyder.config.manager import CONF
 from spyder.config.user import NoDefault
 from spyder.utils.icon_manager import ima
 from spyder.utils.image_path_manager import IMAGE_PATH_MANAGER
@@ -283,8 +282,7 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
         # SpyderPluginObserver and SpyderConfigurationObserver when using
         # super(), see https://fuhm.net/super-harmful/
         SpyderPluginObserver.__init__(self)
-        SpyderConfigurationObserver.__init__(
-            self, configuration=configuration)
+        SpyderConfigurationObserver.__init__(self)
 
         self._main = parent
         self._widget = None
@@ -302,21 +300,11 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
         self.PLUGIN_NAME = self.NAME
 
         if self.CONTAINER_CLASS is not None:
-            if (issubclass(self.CONTAINER_CLASS, PluginMainWidget)
-                    and configuration is not CONF
-                    and configuration is not None):
-                self._container = container = self.CONTAINER_CLASS(
-                    name=self.NAME,
-                    plugin=self,
-                    parent=parent,
-                    configuration=configuration
-                )
-            else:
-                self._container = container = self.CONTAINER_CLASS(
-                    name=self.NAME,
-                    plugin=self,
-                    parent=parent
-                )
+            self._container = container = self.CONTAINER_CLASS(
+                name=self.NAME,
+                plugin=self,
+                parent=parent
+            )
 
             if isinstance(container, SpyderWidgetMixin):
                 container.setup()

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -33,7 +33,6 @@ from spyder.api.widgets.menus import (MainWidgetMenu, OptionsMenuSections,
                                       PluginMainWidgetMenus)
 from spyder.api.widgets.mixins import SpyderToolbarMixin, SpyderWidgetMixin
 from spyder.api.widgets.toolbars import MainWidgetToolbar
-from spyder.config.manager import CONF
 from spyder.py3compat import qbytearray_to_str
 from spyder.utils.qthelpers import create_waitspinner, set_menu_icons
 from spyder.utils.registries import (
@@ -192,14 +191,12 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
     needs its ancestor to be updated.
     """
 
-    def __init__(self, name, plugin, parent=None, configuration=CONF):
+    def __init__(self, name, plugin, parent=None):
         if PYQT5:
-            super().__init__(parent=parent, class_parent=plugin,
-                             configuration=configuration)
+            super().__init__(parent=parent, class_parent=plugin)
         else:
             QWidget.__init__(self, parent)
-            SpyderWidgetMixin.__init__(self, class_parent=plugin,
-                                       configuration=configuration)
+            SpyderWidgetMixin.__init__(self, class_parent=plugin)
 
         # Attributes
         # --------------------------------------------------------------------

--- a/spyder/api/widgets/mixins.py
+++ b/spyder/api/widgets/mixins.py
@@ -576,16 +576,14 @@ class SpyderWidgetMixin(SpyderActionMixin, SpyderMenuMixin,
     # Context name used to store actions, toolbars, toolbuttons and menus
     CONTEXT_NAME = None
 
-    def __init__(self, class_parent=None, configuration=CONF):
+    def __init__(self, class_parent=None):
         for attr in ['CONF_SECTION', 'PLUGIN_NAME']:
             if getattr(self, attr, None) is None:
                 if hasattr(class_parent, attr):
                     # Inherit class_parent CONF_SECTION/PLUGIN_NAME value
                     setattr(self, attr, getattr(class_parent, attr))
-        if configuration is None:
-            configuration = CONF
 
-        super().__init__(configuration=configuration)
+        super().__init__()
 
     @staticmethod
     def create_icon(name):

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1095,6 +1095,7 @@ def test_runconfig_workdir(main_window, qtbot, tmpdir):
 @pytest.mark.order(1)
 @pytest.mark.no_new_console
 @flaky(max_runs=3)
+@pytest.mark.skipif(sys.platform == 'darwin', reason='Hangs sometimes on Mac')
 def test_dedicated_consoles(main_window, qtbot):
     """Test running code in dedicated consoles."""
     from spyder.plugins.run.widgets import RunConfiguration

--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -108,8 +108,8 @@ class ConsoleWidget(PluginMainWidget):
         Example `{'name': str, 'ignore_unknown': bool}`.
     """
 
-    def __init__(self, name, plugin, parent=None, configuration=None):
-        super().__init__(name, plugin, parent, configuration=configuration)
+    def __init__(self, name, plugin, parent=None):
+        super().__init__(name, plugin, parent)
 
         logger.info("Initializing...")
 

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -43,7 +43,7 @@ from spyder.app.cli_options import get_options
 from spyder.config.base import (
     get_home_dir, running_in_ci, running_in_ci_with_conda)
 from spyder.config.gui import get_color_scheme
-from spyder.config.manager import ConfigurationManager
+from spyder.config.manager import CONF
 from spyder.py3compat import PY2, to_text_string
 from spyder.plugins.help.tests.test_plugin import check_text
 from spyder.plugins.help.utils.sphinxify import CSS_PATH
@@ -99,9 +99,9 @@ def get_conda_test_env(test_env_name=u'spytest-ž'):
 # Qt Test Fixtures
 # =============================================================================
 @pytest.fixture
-def ipyconsole(qtbot, request, tmpdir):
+def ipyconsole(qtbot, request):
     """IPython console fixture."""
-    configuration = ConfigurationManager(conf_path=str(tmpdir))
+    configuration = CONF
     no_web_widgets = request.node.get_closest_marker('no_web_widgets')
 
     class MainWindowMock(QMainWindow):

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1865,6 +1865,7 @@ def test_startup_code_pdb(ipyconsole, qtbot):
     "backend",
     ['inline', 'qt5', 'tk', 'osx']
 )
+@pytest.mark.skipif(sys.platform == 'darwin', reason="Hangs frequently on Mac")
 def test_pdb_eventloop(ipyconsole, qtbot, backend):
     """Check if setting an event loop while debugging works."""
     # Skip failing tests

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -70,11 +70,6 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
 
     def __init__(self, is_cython=False, is_pylab=False,
                  is_sympy=False, **kwargs):
-        # Needed to handle other configuration objects than the default CONF.
-        # Useful for changing preferences when testing while using the
-        # `ipyconsole` fixture.
-        configuration = kwargs.pop('configuration', self.CONFIGURATION)
-        self.CONFIGURATION = configuration
         super(SpyderKernelSpec, self).__init__(**kwargs)
         self.is_cython = is_cython
         self.is_pylab = is_pylab

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -105,7 +105,6 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
                  ask_before_restart=True,
                  ask_before_closing=False,
                  css_path=None,
-                 configuration=None,
                  handlers={},
                  stderr_obj=None,
                  stdout_obj=None,
@@ -151,8 +150,8 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
             is_external_kernel=is_external_kernel,
             is_spyder_kernel=is_spyder_kernel,
             handlers=handlers,
-            local_kernel=True,
-            configuration=configuration)
+            local_kernel=True
+        )
         self.infowidget = self.container.infowidget
         self.blank_page = self._create_blank_page()
         self.loading_page = self._create_loading_page()

--- a/spyder/plugins/ipythonconsole/widgets/debugging.py
+++ b/spyder/plugins/ipythonconsole/widgets/debugging.py
@@ -187,11 +187,6 @@ class DebuggingWidget(DebuggingHistoryWidget, SpyderConfigurationAccessor):
         # Temporary flags
         self._tmp_reading = False
         # super init
-        # Needed to handle other configuration objects than the default CONF.
-        # Useful for changing preferences when testing while using the
-        # `ipyconsole` fixture.
-        configuration = kwargs.pop('configuration', self.CONFIGURATION)
-        self.CONFIGURATION = configuration
         super(DebuggingWidget, self).__init__(*args, **kwargs)
 
         # Adapted from qtconsole/frontend_widget.py

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -292,9 +292,8 @@ class IPythonConsoleWidget(PluginMainWidget):
                              "required to create IPython consoles. Please "
                              "make it writable.")
 
-    def __init__(self, name=None, plugin=None, parent=None,
-                 configuration=None):
-        super().__init__(name, plugin, parent, configuration=configuration)
+    def __init__(self, name=None, plugin=None, parent=None):
+        super().__init__(name, plugin, parent)
 
         self.menu_actions = None
         self.master_clients = 0
@@ -1155,7 +1154,6 @@ class IPythonConsoleWidget(PluginMainWidget):
                               reset_warning=reset_warning,
                               ask_before_restart=ask_before_restart,
                               css_path=self.css_path,
-                              configuration=self.CONFIGURATION,
                               handlers=self.registered_spyder_kernel_handlers,
                               stderr_obj=stderr_obj,
                               stdout_obj=stdout_obj,
@@ -1575,7 +1573,6 @@ class IPythonConsoleWidget(PluginMainWidget):
                               ask_before_restart=ask_before_restart,
                               ask_before_closing=ask_before_closing,
                               css_path=self.css_path,
-                              configuration=self.CONFIGURATION,
                               handlers=self.registered_spyder_kernel_handlers,
                               stderr_obj=stderr_obj,
                               stdout_obj=stdout_obj,
@@ -2097,8 +2094,7 @@ class IPythonConsoleWidget(PluginMainWidget):
         """Create a kernel spec for our own kernels"""
         return SpyderKernelSpec(is_cython=is_cython,
                                 is_pylab=is_pylab,
-                                is_sympy=is_sympy,
-                                configuration=self.CONFIGURATION)
+                                is_sympy=is_sympy)
 
     def create_kernel_manager_and_kernel_client(self, connection_file,
                                                 stderr_handle,


### PR DESCRIPTION
## Description of Changes

- This leads to use different configuration objects for setting and getting options, which can introduce inconsistencies in future tests. Actually, I found this problem while trying to create a test for issue #17737.
- It doesn't seem necessary anymore, i.e. tests pass without it.
- Skip some tests that hang sometimes on Mac.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
