### PR TITLE
PR: Implement mouse XButton navigation in the editor

### DIFF
--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -44,6 +44,8 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
     focus_changed = Signal()
     sig_insert_completion = Signal(str)
     sig_eol_chars_changed = Signal(str)
+    sig_prev_cursor = Signal()
+    sig_next_cursor = Signal()
 
     def __init__(self, parent=None):
         QPlainTextEdit.__init__(self, parent)
@@ -1058,6 +1060,13 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
     # ----Qt Events
     def mousePressEvent(self, event):
         """Reimplement Qt method"""
+
+        # mouse buttons for forward and backward navigation
+        if event.button() == Qt.XButton1:
+            self.sig_prev_cursor.emit()
+        elif event.button() == Qt.XButton2:
+            self.sig_next_cursor.emit()
+
         if sys.platform.startswith('linux') and event.button() == Qt.MidButton:
             self.calltip_widget.hide()
             self.setFocus()

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2556,6 +2556,8 @@ class EditorStack(QWidget):
         editor.zoom_reset.connect(lambda: self.zoom_reset.emit())
         editor.sig_eol_chars_changed.connect(
             lambda eol_chars: self.refresh_eol_chars(eol_chars))
+        editor.sig_next_cursor.connect(self.sig_next_cursor.emit)
+        editor.sig_prev_cursor.connect(self.sig_prev_cursor.emit)
 
         self.find_widget.set_editor(editor)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

I added navigation with XButtons (the typical extra two buttons on a mouse used for browsing backward and forward) in the code editor.
This improves code browsing if the mouse has this ability.

I don't know if this is testable and how, as it only adds a new trigger which is forwarded to the one in the EditorStack.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15948


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Florian Maurer

<!--- Thanks for your help making Spyder better for everyone! --->
