### PR TITLE
PR: Set correct executable of profiler, when using non-default interpreter

### DIFF
--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -803,7 +803,7 @@ class LanguageServerProvider(SpyderCompletionProvider):
             environment = None
             env_vars = None
         else:
-            environment = self.get_conf('custom_interpreter',
+            environment = self.get_conf('executable',
                                         section='main_interpreter')
             env_vars = os.environ.copy()
             # external interpreter should not use internal PYTHONPATH

--- a/spyder/plugins/maininterpreter/confpage.py
+++ b/spyder/plugins/maininterpreter/confpage.py
@@ -48,30 +48,17 @@ class MainInterpreterConfigPage(PluginConfigPage):
                 valid_custom_list.append(path)
         self.set_option('custom_interpreters_list', valid_custom_list)
 
-        # Python executable selection (initializing default values as well)
+        # add custom_interpreter to executable selection
         executable = self.get_option('executable', get_python_executable())
-        if self.get_option('default'):
+
+        # the following checks are probably handled elsewhere, but they don't hurt either
+        if self.get_option('default') or not osp.isfile(executable):
             executable = get_python_executable()
+        elif not self.get_option('custom_interpreter'):
+            self.set_option('custom_interpreter', ' ')
 
-        if not osp.isfile(executable):
-            # This is absolutely necessary, in case the Python interpreter
-            # executable has been moved since last Spyder execution (following
-            # a Python distribution upgrade for example)
-            self.set_option('executable', get_python_executable())
-        elif executable.endswith('pythonw.exe'):
-            # That should not be necessary because this case is already taken
-            # care of by the `get_python_executable` function but, this was
-            # implemented too late, so we have to fix it here too, in case
-            # the Python executable has already been set with pythonw.exe:
-            self.set_option('executable',
-                            executable.replace("pythonw.exe", "python.exe"))
-
-        if not self.get_option('default'):
-            if not self.get_option('custom_interpreter'):
-                self.set_option('custom_interpreter', ' ')
-
-            plugin._add_to_custom_interpreters(executable)
-            self.validate_custom_interpreters_list()
+        plugin._add_to_custom_interpreters(executable)
+        self.validate_custom_interpreters_list()
 
     def initialize(self):
         super().initialize()

--- a/spyder/plugins/maininterpreter/container.py
+++ b/spyder/plugins/maininterpreter/container.py
@@ -53,31 +53,30 @@ class MainInterpreterContainer(PluginMainContainer):
 
     @on_conf_change(option=['default', 'custom_interpreter', 'custom'])
     def section_conf_update(self, option, value):
-        if option in ['default', 'custom_interpreter', 'custom'] and value:
-            self._update_status()
-            self.sig_interpreter_changed.emit()
-
-            # Set new interpreter
-            executable = osp.normpath(self.get_conf('custom_interpreter'))
-            if (option in ['custom', 'custom_interpreter'] and
-                    osp.isfile(executable)):
+        if (option == 'default' and value) or (option == 'custom' and not value):
+            executable = get_python_executable()
+        else:
+            executable = self.get_conf('custom_interpreter')
+            if osp.isfile(executable):
                 self.sig_add_to_custom_interpreters_requested.emit(executable)
+            else:
+                executable = get_python_executable()
+                self.set_option('custom_interpreter', ' ')
+        if executable != self.get_conf('executable'):
+            self.set_conf('executable', executable)
+
+    @on_conf_change(option=['executable'])
+    def section_executable_update(self, value):
+        # announce update
+        self._update_status()
+        self.sig_interpreter_changed.emit()
 
     def on_close(self):
         self.interpreter_status.close()
 
     # ---- Public API
     def get_main_interpreter(self):
-        if self.get_conf('default'):
-            return get_python_executable()
-        else:
-            executable = osp.normpath(self.get_conf('custom_interpreter'))
-
-            # Check if custom interpreter is still present
-            if osp.isfile(executable):
-                return executable
-            else:
-                return get_python_executable()
+        return self.get_conf('executable', get_python_executable())
 
     # ---- Private API
     def _update_status(self):

--- a/spyder/plugins/maininterpreter/plugin.py
+++ b/spyder/plugins/maininterpreter/plugin.py
@@ -99,12 +99,6 @@ class MainInterpreter(SpyderPluginV2):
         statusbar = self.get_plugin(Plugins.StatusBar)
         statusbar.remove_status_widget(self.interpreter_status.ID)
 
-    # ---- Public API
-    def get_interpreter(self):
-        """Get current interpreter."""
-        container = self.get_container()
-        return container.get_main_interpreter()
-
     @property
     def interpreter_status(self):
         return self.get_container().interpreter_status
@@ -126,4 +120,3 @@ class MainInterpreter(SpyderPluginV2):
         if interpreter not in custom_list:
             custom_list.append(interpreter)
             self.set_conf('custom_interpreters_list', custom_list)
-        self.set_conf('executable', interpreter)

--- a/spyder/plugins/maininterpreter/widgets/status.py
+++ b/spyder/plugins/maininterpreter/widgets/status.py
@@ -19,6 +19,7 @@ from qtpy.QtCore import QTimer, Signal
 from spyder.api.translations import get_translation
 from spyder.api.widgets.status import BaseTimerStatus
 from spyder.utils.conda import get_list_conda_envs
+from spyder.utils.misc import get_python_executable
 from spyder.utils.programs import get_interpreter_info
 from spyder.utils.pyenv import get_list_pyenv_envs
 from spyder.utils.workers import WorkerManager
@@ -73,7 +74,7 @@ class InterpreterStatus(BaseTimerStatus):
             # Env was removed on Mac or Linux
             self.set_conf('custom', False)
             self.set_conf('default', True)
-            self.update_interpreter(sys.executable)
+            self.update_interpreter(get_python_executable())
         elif not osp.isfile(self._interpreter):
             # This can happen on Windows because the interpreter was
             # renamed to .conda_trash
@@ -81,7 +82,7 @@ class InterpreterStatus(BaseTimerStatus):
                 # If conda-meta is missing, it means the env was removed
                 self.set_conf('custom', False)
                 self.set_conf('default', True)
-                self.update_interpreter(sys.executable)
+                self.update_interpreter(get_python_executable())
             else:
                 # If not, it means the interpreter is being updated so
                 # we need to update its version

--- a/spyder/plugins/profiler/widgets/main_widget.py
+++ b/spyder/plugins/profiler/widgets/main_widget.py
@@ -561,9 +561,6 @@ class ProfilerWidget(PluginMainWidget):
             p_args.extend(shell_split(args))
 
         executable = self.get_conf('executable', section='main_interpreter')
-        if executable.endswith("spyder.exe"):
-            # py2exe distribution
-            executable = "python.exe"
 
         self.process.start(executable, p_args)
         running = self.process.waitForStarted()

--- a/spyder/plugins/profiler/widgets/main_widget.py
+++ b/spyder/plugins/profiler/widgets/main_widget.py
@@ -560,7 +560,7 @@ class ProfilerWidget(PluginMainWidget):
         if args:
             p_args.extend(shell_split(args))
 
-        executable = sys.executable
+        executable = self.get_conf('executable', section='main_interpreter')
         if executable.endswith("spyder.exe"):
             # py2exe distribution
             executable = "python.exe"

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -159,7 +159,7 @@ def get_error_match(text):
 
 
 def get_python_executable():
-    """Return path to Python executable"""
+    """Return path to Spyder Python executable"""
     executable = sys.executable.replace("pythonw.exe", "python.exe")
     if executable.endswith("spyder.exe"):
         # py2exe distribution


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

I looked into this old community-issue and found that it is still reproducible.
The profiler always uses the sys.executable and not the configured one.
This is fixed by accessing the current executable from the config.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1884


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Florian Maurer

<!--- Thanks for your help making Spyder better for everyone! --->
