### PR TITLE
PR: Fix saving variables as .spydata if no file extension is given

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -220,7 +220,8 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
             else:
                 QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
                 QApplication.processEvents()
-                error_message = self.shellwidget.load_data(self.filename, extension)
+                error_message = self.shellwidget.load_data(self.filename,
+                                                           extension)
                 QApplication.restoreOverrideCursor()
                 QApplication.processEvents()
     

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -240,19 +240,21 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
         self.shellwidget.reset_namespace(warning=warning, message=True)
         self.editor.automatic_column_width = True
 
-    def save_data(self, filename=None):
+    def save_data(self):
         """Save data"""
+        filename = self.filename
         if filename is None:
-            filename = self.filename
-            if filename is None:
-                filename = getcwd_or_home()
-            filename, _selfilter = getsavefilename(self, _("Save data"),
-                                                   filename,
-                                                   iofunctions.save_filters)
-            if filename:
-                self.filename = filename
-            else:
-                return False
+            filename = getcwd_or_home()
+        ext = osp.splitext(filename)[1].lower()
+        if not ext:
+            filename = filename + '.spydata'
+        filename, _selfilter = getsavefilename(self, _("Save data"),
+                                               filename,
+                                               iofunctions.save_filters)
+        if filename:
+            self.filename = filename
+        else:
+            return False
 
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
         QApplication.processEvents()

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -181,15 +181,15 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
             self.filename = str(filename)
             if os.name == "nt":
                 self.filename = remove_backslashes(self.filename)
-            ext = osp.splitext(self.filename)[1].lower()
+            extension = osp.splitext(self.filename)[1].lower()
 
-            if ext not in iofunctions.load_funcs:
+            if extension not in iofunctions.load_funcs:
                 buttons = QMessageBox.Yes | QMessageBox.Cancel
                 answer = QMessageBox.question(self, title,
                             _("<b>Unsupported file extension '%s'</b><br><br>"
                               "Would you like to import it anyway "
                               "(by selecting a known file format)?"
-                              ) % ext, buttons)
+                              ) % extension, buttons)
                 if answer == QMessageBox.Cancel:
                     return
                 formats = list(iofunctions.load_extensions.keys())
@@ -197,11 +197,11 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
                                                 _('Open file as:'),
                                                 formats, 0, False)
                 if ok:
-                    ext = iofunctions.load_extensions[str(item)]
+                    extension = iofunctions.load_extensions[str(item)]
                 else:
                     return
 
-            load_func = iofunctions.load_funcs[ext]
+            load_func = iofunctions.load_funcs[extension]
                 
             # 'import_wizard' (self.setup_io)
             if isinstance(load_func, str):
@@ -220,7 +220,7 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
             else:
                 QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
                 QApplication.processEvents()
-                error_message = self.shellwidget.load_data(self.filename, ext)
+                error_message = self.shellwidget.load_data(self.filename, extension)
                 QApplication.restoreOverrideCursor()
                 QApplication.processEvents()
     
@@ -245,8 +245,10 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
         filename = self.filename
         if filename is None:
             filename = getcwd_or_home()
-        ext = osp.splitext(filename)[1].lower()
-        if not ext:
+        extension = osp.splitext(filename)[1].lower()
+        if not extension:
+            # Needed to prevent trying to save a data file without extension
+            # See spyder-ide/spyder#7196
             filename = filename + '.spydata'
         filename, _selfilter = getsavefilename(self, _("Save data"),
                                                filename,


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

While this does not fix the major file save dialog problems mentioned in #7196 it allows to save the workspace in a pickle file without finding out which extension is needed.
Currently, `.mat` and `.spydata` is supported to write data, and it makes sense to prefer `.spydata` here.

I also removed the filename option from the save method, as it is never used.
If the method would be called with `filename='text.spydata'` it would anyway save as `self.filename` which would be wrong.
So I hope it is fine to remove the optional parameter.

Thank you!

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #7196


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Florian Maurer

<!--- Thanks for your help making Spyder better for everyone! --->
