### PR TITLE
PR: Improve style and UX of new toolbar in collections viewer (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -72,8 +72,6 @@ class VariableExplorerContextMenuActions:
     ImshowAction = 'imshow_action'
     SaveArrayAction = 'save_array_action'
     InsertAction = 'insert_action'
-    InsertActionAbove = 'insert_action_above'
-    InsertActionBelow = 'insert_action_below'
     RemoveAction = 'remove_action'
     RenameAction = 'rename_action'
     DuplicateAction = 'duplicate_action'
@@ -219,12 +217,14 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         resize_rows_action = self.create_action(
             VariableExplorerContextMenuActions.ResizeRowsAction,
             text=_("Resize rows to contents"),
+            icon=self.create_icon('collapse_row'),
             triggered=self.resize_rows
         )
 
         resize_columns_action = self.create_action(
             VariableExplorerContextMenuActions.ResizeColumnsAction,
             _("Resize columns to contents"),
+            icon=self.create_icon('collapse_column'),
             triggered=self.resize_columns
         )
 

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -80,7 +80,8 @@ class VariableExplorerContextMenuActions:
 
 class VariableExplorerContextMenuSections:
     Edit = 'edit_section'
-    Rename = 'rename_section'
+    Insert = 'insert_section'
+    View = 'view_section'
     Resize = 'resize_section'
 
 
@@ -342,25 +343,31 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         # ---- Context menu to show when there are variables present
         self.context_menu = self.create_menu(
             VariableExplorerWidgetMenus.PopulatedContextMenu)
-        for item in [self.edit_action, self.plot_action, self.hist_action,
-                     self.imshow_action, self.save_array_action,
-                     self.insert_action, self.remove_action, self.copy_action,
-                     self.paste_action, self.view_action]:
+        for item in [self.edit_action, self.copy_action, self.paste_action,
+                     self.rename_action, self.remove_action,
+                     self.save_array_action]:
             self.add_item_to_menu(
                 item,
                 menu=self.context_menu,
                 section=VariableExplorerContextMenuSections.Edit,
             )
 
-        for item in [self.rename_action, self.duplicate_action]:
+        for item in [self.insert_action, self.duplicate_action]:
             self.add_item_to_menu(
                 item,
                 menu=self.context_menu,
-                section=VariableExplorerContextMenuSections.Rename,
+                section=VariableExplorerContextMenuSections.Insert,
             )
 
-        for item in [resize_rows_action, resize_columns_action,
-                     self.show_minmax_action]:
+        for item in [self.view_action, self.plot_action, self.hist_action,
+                     self.imshow_action, self.show_minmax_action]:
+            self.add_item_to_menu(
+                item,
+                menu=self.context_menu,
+                section=VariableExplorerContextMenuSections.View,
+            )
+
+        for item in [resize_rows_action, resize_columns_action]:
             self.add_item_to_menu(
                 item,
                 menu=self.context_menu,

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -195,6 +195,8 @@ class IconManager():
             'hist':                    [('mdi.chart-histogram',), {'color': self.MAIN_FG_COLOR}],
             'imshow':                  [('mdi.image',), {'color': self.MAIN_FG_COLOR}],
             'insert':                  [('mdi.login',), {'color': self.MAIN_FG_COLOR}],
+            'insert_above':            [('mdi.table-arrow-up',), {'color': self.MAIN_FG_COLOR}],
+            'insert_below':            [('mdi.table-arrow-down',), {'color': self.MAIN_FG_COLOR}],
             'rename':                  [('mdi.rename-box',), {'color': self.MAIN_FG_COLOR}],
             'move':                    [('mdi.file-move',), {'color': self.MAIN_FG_COLOR}],
             'edit_add':                [('mdi.plus',), {'color': self.MAIN_FG_COLOR}],

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -46,6 +46,7 @@ from spyder_kernels.utils.nsview import (
 
 # Local imports
 from spyder.api.config.mixins import SpyderConfigurationAccessor
+from spyder.api.widgets.toolbars import SpyderToolbar
 from spyder.config.base import _
 from spyder.config.fonts import DEFAULT_SMALL_DELTA
 from spyder.config.gui import get_font
@@ -61,7 +62,7 @@ from spyder.plugins.variableexplorer.widgets.importwizard import ImportWizard
 from spyder.widgets.helperwidgets import CustomSortFilterProxy
 from spyder.plugins.variableexplorer.widgets.basedialog import BaseDialog
 from spyder.utils.palette import SpyderPalette
-from spyder.api.widgets.toolbars import SpyderToolbar
+from spyder.utils.stylesheet import PANES_TOOLBAR_STYLESHEET
 
 
 # Maximum length of a serialized variable to be set in the kernel
@@ -1317,7 +1318,9 @@ class CollectionsEditorWidget(QWidget):
         else:
             self.editor = CollectionsEditorTableView(self, data, readonly,
                                                      title)
+
         toolbar = SpyderToolbar(parent=None, title='Editor toolbar')
+        toolbar.setStyleSheet(str(PANES_TOOLBAR_STYLESHEET))
 
         for item in self.editor.menu_actions:
             if item is not None:

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -666,12 +666,12 @@ class BaseTableView(QTableView, SpyderConfigurationAccessor):
         )
         self.insert_action_above = create_action(
             self, _("Insert above"),
-            icon=ima.icon('insert'),
+            icon=ima.icon('insert_above'),
             triggered=lambda: self.insert_item(below=False)
         )
         self.insert_action_below = create_action(
             self, _("Insert below"),
-            icon=ima.icon('insert'),
+            icon=ima.icon('insert_below'),
             triggered=lambda: self.insert_item(below=True)
         )
         self.remove_action = create_action(self, _("Remove"),

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -27,8 +27,8 @@ import warnings
 
 # Third party imports
 from qtpy.compat import getsavefilename, to_qvariant
-from qtpy.QtCore import (QAbstractTableModel, QModelIndex, Qt,
-                         Signal, Slot)
+from qtpy.QtCore import (
+    QAbstractTableModel, QItemSelectionModel, QModelIndex, Qt, Signal, Slot)
 from qtpy.QtGui import QColor, QKeySequence
 from qtpy.QtWidgets import (
     QApplication, QHBoxLayout, QHeaderView, QInputDialog, QLineEdit, QMenu,
@@ -1058,7 +1058,7 @@ class BaseTableView(QTableView, SpyderConfigurationAccessor):
             key = row
             data.insert(row, '')
         elif isinstance(data, dict):
-            key, valid = QInputDialog.getText(self, _( 'Insert'), _( 'Key:'),
+            key, valid = QInputDialog.getText(self, _('Insert'), _('Key:'),
                                               QLineEdit.Normal)
             if valid and to_text_string(key):
                 key = try_to_eval(to_text_string(key))
@@ -1072,6 +1072,15 @@ class BaseTableView(QTableView, SpyderConfigurationAccessor):
 
         if valid and to_text_string(value):
             self.new_value(key, try_to_eval(to_text_string(value)))
+
+        # Deselect selection after introducing an item.
+        # * This avoids showing the wrong buttons in our toolbar when the
+        # operation is completed.
+        # * Also, if we leave something selected here, then the next insertion
+        # operation won't introduce the item in the expected row. That's why
+        # we need to force users to select a row again after this.
+        self.selectionModel().select(index, QItemSelectionModel.Select)
+        self.selectionModel().select(index, QItemSelectionModel.Deselect)
 
     @Slot()
     def view_item(self):

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -30,11 +30,9 @@ from qtpy.compat import getsavefilename, to_qvariant
 from qtpy.QtCore import (QAbstractTableModel, QModelIndex, Qt,
                          Signal, Slot)
 from qtpy.QtGui import QColor, QKeySequence
-from qtpy.QtWidgets import (QAbstractItemView, QApplication, QDialog,
-                            QHBoxLayout, QHeaderView, QInputDialog,
-                            QLineEdit, QMenu, QMessageBox,
-                            QPushButton, QTableView, QVBoxLayout,
-                            QWidget)
+from qtpy.QtWidgets import (
+    QApplication, QHBoxLayout, QHeaderView, QInputDialog, QLineEdit, QMenu,
+    QMessageBox, QPushButton, QTableView, QVBoxLayout, QWidget)
 from spyder_kernels.utils.lazymodules import (
     FakeObject, numpy as np, pandas as pd, PIL)
 from spyder_kernels.utils.misc import fix_reference_name
@@ -54,7 +52,8 @@ from spyder.py3compat import (io, is_binary_string, PY3, to_text_string,
                               is_type_text_string, NUMERIC_TYPES)
 from spyder.utils.icon_manager import ima
 from spyder.utils.misc import getcwd_or_home
-from spyder.utils.qthelpers import add_actions, create_action, mimedata2url
+from spyder.utils.qthelpers import (
+    add_actions, create_action, MENU_SEPARATOR, mimedata2url)
 from spyder.utils.stringmatching import get_search_scores, get_search_regex
 from spyder.plugins.variableexplorer.widgets.collectionsdelegate import (
     CollectionsDelegate)
@@ -688,22 +687,37 @@ class BaseTableView(QTableView, SpyderConfigurationAccessor):
             _("View with the Object Explorer"),
             icon=ima.icon('outline_explorer'),
             triggered=self.view_item)
+
         menu = QMenu(self)
-        self.menu_actions = [self.edit_action, self.plot_action,
-                             self.hist_action, self.imshow_action,
-                             self.save_array_action, self.insert_action,
-                             self.insert_action_above,
-                             self.insert_action_below,
-                             self.remove_action, self.copy_action,
-                             self.paste_action, self.view_action,
-                             None, self.rename_action, self.duplicate_action,
-                             None, resize_action, resize_columns_action]
+        self.menu_actions = [
+            self.edit_action,
+            self.copy_action,
+            self.paste_action,
+            self.rename_action,
+            self.remove_action,
+            self.save_array_action,
+            MENU_SEPARATOR,
+            self.insert_action,
+            self.insert_action_above,
+            self.insert_action_below,
+            self.duplicate_action,
+            MENU_SEPARATOR,
+            self.view_action,
+            self.plot_action,
+            self.hist_action,
+            self.imshow_action,
+            MENU_SEPARATOR,
+            resize_action,
+            resize_columns_action
+        ]
         add_actions(menu, self.menu_actions)
+
         self.empty_ws_menu = QMenu(self)
         add_actions(
             self.empty_ws_menu,
             [self.insert_action, self.paste_action]
         )
+
         return menu
 
 

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -993,22 +993,35 @@ class BaseTableView(QTableView, SpyderConfigurationAccessor):
     def copy_item(self, erase_original=False, new_name=None):
         """Copy item"""
         indexes = self.selectedIndexes()
+
         if not indexes:
             return
+
         if self.proxy_model:
             idx_rows = unsorted_unique(
                 [self.proxy_model.mapToSource(idx).row() for idx in indexes])
         else:
             idx_rows = unsorted_unique([idx.row() for idx in indexes])
+
         if len(idx_rows) > 1 or not indexes[0].isValid():
             return
+
         orig_key = self.source_model.keys[idx_rows[0]]
         if erase_original:
+            if not isinstance(orig_key, str):
+                QMessageBox.warning(
+                    self,
+                    _("Warning"),
+                    _("You can only rename keys that are strings")
+                )
+                return
+
             title = _('Rename')
             field_text = _('New variable name:')
         else:
             title = _('Duplicate')
             field_text = _('Variable name:')
+
         data = self.source_model.get_data()
         if isinstance(data, (list, set)):
             new_key, valid = len(data), True

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -45,7 +45,7 @@ from spyder_kernels.utils.nsview import (
 # Local imports
 from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.api.widgets.toolbars import SpyderToolbar
-from spyder.config.base import _
+from spyder.config.base import _, running_under_pytest
 from spyder.config.fonts import DEFAULT_SMALL_DELTA
 from spyder.config.gui import get_font
 from spyder.py3compat import (io, is_binary_string, PY3, to_text_string,
@@ -1011,7 +1011,10 @@ class BaseTableView(QTableView, SpyderConfigurationAccessor):
             keys = [self.source_model.keys[idx_row] for idx_row in idx_rows]
             self.remove_values(keys)
 
-        self._deselect_index(current_index)
+        # This avoids a segfault in our tests that doesn't happen when
+        # removing items manually.
+        if not running_under_pytest():
+            self._deselect_index(current_index)
 
     def copy_item(self, erase_original=False, new_name=None):
         """Copy item"""

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -153,23 +153,29 @@ def test_remove_remote_variable(qtbot, monkeypatch):
     """Test the removing of the correct remote variable."""
     variables = {'a': {'type': 'int',
                        'size': 1,
-                       'color': '#0000ff',
-                       'view': '1'},
+                       'view': '1',
+                       'python_type': 'int',
+                       'numpy_type': 'Unknown'},
                  'b': {'type': 'int',
                        'size': 1,
-                       'color': '#0000ff',
-                       'view': '2'},
+                       'view': '2',
+                       'python_type': 'int',
+                       'numpy_type': 'Unknown'},
                  'c': {'type': 'int',
                        'size': 1,
-                       'color': '#0000ff',
-                       'view': '3'},
+                       'view': '3',
+                       'python_type': 'int',
+                       'numpy_type': 'Unknown'},
                  'd': {'type': 'str',
-                       'size': 1, 'color': '#800000',
-                       'view': '4'},
+                       'size': 1,
+                       'view': '4',
+                       'python_type': 'int',
+                       'numpy_type': 'Unknown'},
                  'e': {'type': 'int',
                        'size': 1,
-                       'color': '#0000ff',
-                       'view': '5'}}
+                       'view': '5',
+                       'python_type': 'int',
+                       'numpy_type': 'Unknown'}}
     editor = RemoteCollectionsEditorTableView(None, variables.copy())
     qtbot.addWidget(editor)
     editor.setCurrentIndex(editor.model.index(1, 0))
@@ -179,19 +185,24 @@ def test_remove_remote_variable(qtbot, monkeypatch):
         assert names == ['b']
         data = {'a': {'type': 'int',
                       'size': 1,
-                      'color': '#0000ff',
-                      'view': '1'},
+                      'view': '1',
+                      'python_type': 'int',
+                      'numpy_type': 'Unknown'},
                 'c': {'type': 'int',
                       'size': 1,
-                      'color': '#0000ff',
-                      'view': '3'},
+                      'view': '3',
+                      'python_type': 'int',
+                      'numpy_type': 'Unknown'},
                 'd': {'type': 'str',
-                      'size': 1, 'color': '#800000',
-                      'view': '4'},
+                      'size': 1,
+                      'view': '4',
+                      'python_type': 'int',
+                      'numpy_type': 'Unknown'},
                 'e': {'type': 'int',
                       'size': 1,
-                      'color': '#0000ff',
-                      'view': '5'}}
+                      'view': '5',
+                      'python_type': 'int',
+                      'numpy_type': 'Unknown'}}
         editor.set_data(data)
     monkeypatch.setattr(
         'spyder.widgets'
@@ -221,11 +232,17 @@ def test_filter_rows(qtbot):
     """Test rows filtering."""
     data = (
         {'dfa':
-            {'type': 'DataFrame', 'size': (2, 1), 'color': '#00ff00',
-             'view': 'Column names: 0'},
+            {'type': 'DataFrame',
+             'size': (2, 1),
+             'view': 'Column names: 0',
+             'python_type': 'DataFrame',
+             'numpy_type': 'Unknown'},
          'dfb':
-            {'type': 'DataFrame', 'size': (2, 1), 'color': '#00ff00',
-             'view': 'Column names: 0'}}
+            {'type': 'DataFrame',
+             'size': (2, 1),
+             'view': 'Column names: 0',
+             'python_type': 'DataFrame',
+             'numpy_type': 'Unknown'}}
     )
     editor = RemoteCollectionsEditorTableView(None, data)
     editor.finder = NamespacesBrowserFinder(


### PR DESCRIPTION
## Description of Changes

- This is a follow up of PR #17473 to improve the style of the new toolbar by using the same stylesheet of pane toolbars and reorganize its icons a bit.
- Add new icons for `Insert above`/`Insert below` actions (they were using the same as the `Insert` action).
- Set disabled state color for SVG icons. Before buttons associated to those icons appeared active even if they were disabled.
- Enable/disable buttons in the toolbar according to certain conditions (e.g. is there something selected and in the same row? Is it read only?)
- Improve the context menu of collections and the Variable Explorer.

----

**Before**

![image](https://user-images.githubusercontent.com/365293/166482556-f76b5c21-18bd-4435-88fa-1081976a0f7e.png)

![image](https://user-images.githubusercontent.com/365293/166482793-938b0f52-4524-47b2-8fdd-02303e6b0491.png)

![imagen](https://user-images.githubusercontent.com/365293/168480981-1e9e7ead-7211-4072-8322-bab39f5620f5.png)

----

**After**

![image](https://user-images.githubusercontent.com/365293/166481705-3b91b03f-690b-42f5-a6b5-c536e114dfc7.png)

![image](https://user-images.githubusercontent.com/365293/166482095-8490a05f-8302-4ed8-b519-a62d551f711e.png)

![imagen](https://user-images.githubusercontent.com/365293/168480935-2688e242-6798-47d2-94da-34ae3e255877.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
