### PR TITLE
PR: Fix saving of external plugin config in on_close()

### DIFF
--- a/spyder/api/plugin_registration/registry.py
+++ b/spyder/api/plugin_registration/registry.py
@@ -410,10 +410,6 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
         logger.debug(f'Deleting plugin {plugin_name}')
         plugin_instance = self.plugin_registry[plugin_name]
 
-        # Remove config
-        if plugin_instance.CONF_FILE:
-            CONF.unregister_plugin(plugin_instance)
-
         # Determine if plugin can be closed
         can_delete = True
         if isinstance(plugin_instance, SpyderPluginV2):
@@ -493,6 +489,10 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
         # Delete plugin from the registry and auxiliary structures
         self.plugin_dependents.pop(plugin_name, None)
         self.plugin_dependencies.pop(plugin_name, None)
+        if plugin_instance.CONF_FILE:
+            # This must be done after on_close() so that plugins can modify
+            # their (external) config therein.
+            CONF.unregister_plugin(plugin_instance)
 
         for plugin in self.plugin_dependents:
             all_plugin_dependents = self.plugin_dependents[plugin]


### PR DESCRIPTION
## Description of Changes

See commit message for details. EDIT: This error has been detected while porting the Watchlist Plugin (see https://github.com/spyder-ide/spyder/issues/16438) to Spyder v5.3.0.

* [ ] Added unit test(s) covering the changes (if testable) (This really needs a test, but I am not sure where to put it)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:

rear1019