### PR TITLE
PR: Close Preferences when closing Spyder

### DIFF
--- a/spyder/plugins/preferences/plugin.py
+++ b/spyder/plugins/preferences/plugin.py
@@ -346,6 +346,8 @@ class Preferences(SpyderPluginV2):
             application = self.get_plugin(Plugins.Application)
             application.sig_restart_requested.emit()
 
-    def can_close(self) -> bool:
+    def on_close(self, cancelable=False):
         container = self.get_container()
-        return not container.is_dialog_open()
+        if container.is_preferences_open():
+            container.close_preferences()
+        return True

--- a/spyder/plugins/preferences/widgets/container.py
+++ b/spyder/plugins/preferences/widgets/container.py
@@ -91,8 +91,13 @@ class PreferencesContainer(PluginMainContainer):
         """Preference page index has changed."""
         self.dialog_index = index
 
-    def is_dialog_open(self):
+    def is_preferences_open(self):
+        """Check if preferences is open."""
         return self.dialog is not None and self.dialog.isVisible()
+
+    def close_preferences(self):
+        """Close preferences"""
+        self.dialog.close()
 
     def show_preferences(self):
         """Show preferences."""


### PR DESCRIPTION
## Description of Changes

It was not possible to close Spyder when the Preferences dialog is open because we were preventing that. However, now that's not a good idea because plugins are closed sequentially, so stopping the close process at Preferences caused our layout to be messed up the next time Spyder is started.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17784.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
