### PR TITLE
PR: Fix collision between `format_on_save` and other Editor formatting options

### DIFF
--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -148,6 +148,21 @@ class EditorConfigPage(PluginConfigPage):
             'tab_stop_width_spaces',
             default=4, min_=1, max_=8, step=1)
 
+        format_on_save = CONF.get(
+            'completions',
+            ('provider_configuration', 'lsp', 'values', 'format_on_save'),
+            False
+        )
+        if format_on_save:
+            disabled_options = [
+                removetrail_box, add_newline_box, remove_trail_newline_box]
+            for disabled_option in disabled_options:
+                disabled_option.setToolTip(
+                    _("This option is disabled since the "
+                      "<i>Autoformat files on save</i> option is active.")
+                )
+                disabled_option.setDisabled(format_on_save)
+
         def enable_tabwidth_spin(index):
             if index == 7:  # Tabulations
                 tabwidth_spin.plabel.setEnabled(True)

--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -9,6 +9,8 @@
 from qtpy.QtWidgets import (QGridLayout, QGroupBox, QHBoxLayout, QLabel,
                             QTabWidget, QVBoxLayout, QWidget)
 
+from spyder.api.config.decorators import on_conf_change
+from spyder.api.config.mixins import SpyderConfigurationObserver
 from spyder.api.preferences import PluginConfigPage
 from spyder.config.base import _
 from spyder.config.manager import CONF
@@ -20,7 +22,14 @@ GOOGLEDOC = "https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_goo
 DOCSTRING_SHORTCUT = CONF.get('shortcuts', 'editor/docstring')
 
 
-class EditorConfigPage(PluginConfigPage):
+class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
+    def __init__(self, plugin, parent):
+        PluginConfigPage.__init__(self, plugin, parent)
+        SpyderConfigurationObserver.__init__(self)
+        self.removetrail_box = None
+        self.add_newline_box = None
+        self.remove_trail_newline_box = None
+
     def get_name(self):
         return _("Editor")
 
@@ -117,16 +126,16 @@ class EditorConfigPage(PluginConfigPage):
             _("Intelligent backspace"),
             'intelligent_backspace',
             default=True)
-        removetrail_box = newcb(
+        self.removetrail_box = newcb(
             _("Automatically remove trailing spaces when saving files"),
             'always_remove_trailing_spaces',
             default=False)
-        add_newline_box = newcb(
+        self.add_newline_box = newcb(
             _("Insert a newline at the end if one does not exist when saving "
               "a file"),
             'add_newline',
             default=False)
-        remove_trail_newline_box = newcb(
+        self.remove_trail_newline_box = newcb(
             _("Trim all newlines after the final one when saving a file"),
             'always_remove_trailing_newlines',
             default=False)
@@ -153,15 +162,7 @@ class EditorConfigPage(PluginConfigPage):
             ('provider_configuration', 'lsp', 'values', 'format_on_save'),
             False
         )
-        if format_on_save:
-            disabled_options = [
-                removetrail_box, add_newline_box, remove_trail_newline_box]
-            for disabled_option in disabled_options:
-                disabled_option.setToolTip(
-                    _("This option is disabled since the "
-                      "<i>Autoformat files on save</i> option is active.")
-                )
-                disabled_option.setDisabled(format_on_save)
+        self.on_format_save_state(format_on_save)
 
         def enable_tabwidth_spin(index):
             if index == 7:  # Tabulations
@@ -192,9 +193,9 @@ class EditorConfigPage(PluginConfigPage):
         sourcecode_layout.addWidget(close_quotes_box)
         sourcecode_layout.addWidget(tab_mode_box)
         sourcecode_layout.addWidget(ibackspace_box)
-        sourcecode_layout.addWidget(removetrail_box)
-        sourcecode_layout.addWidget(add_newline_box)
-        sourcecode_layout.addWidget(remove_trail_newline_box)
+        sourcecode_layout.addWidget(self.removetrail_box)
+        sourcecode_layout.addWidget(self.add_newline_box)
+        sourcecode_layout.addWidget(self.remove_trail_newline_box)
         sourcecode_layout.addWidget(strip_mode_box)
         sourcecode_layout.addLayout(indent_tab_layout)
 
@@ -337,3 +338,36 @@ class EditorConfigPage(PluginConfigPage):
         vlayout = QVBoxLayout()
         vlayout.addWidget(self.tabs)
         self.setLayout(vlayout)
+
+    @on_conf_change(
+        option=('provider_configuration', 'lsp', 'values', 'format_on_save'),
+        section='completions'
+    )
+    def on_format_save_state(self, value):
+        """
+        Change options following the `format_on_save` completion option.
+
+        Parameters
+        ----------
+        value : bool
+            If the completion `format_on_save` option is enabled or disabled.
+
+        Returns
+        -------
+        None.
+
+        """
+        options = [
+            self.removetrail_box,
+            self.add_newline_box,
+            self.remove_trail_newline_box]
+        for option in options:
+            if option:
+                if value:
+                    option.setToolTip(
+                        _("This option is disabled since the "
+                          "<i>Autoformat files on save</i> option is active.")
+                    )
+                else:
+                    option.setToolTip("")
+                option.setDisabled(value)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1880,11 +1880,15 @@ class EditorStack(QWidget):
                 return self.save_as(index=index)
             # The file doesn't need to be saved
             return True
-        if self.always_remove_trailing_spaces:
+        # The following options (`always_remove_trailing_spaces`,
+        # `remove_trailing_newlines` and `add_newline`) also depend on the
+        # `format_on_save` value.
+        # See spyder-ide/spyder#17716
+        if self.always_remove_trailing_spaces and not self.format_on_save:
             self.remove_trailing_spaces(index)
-        if self.remove_trailing_newlines:
+        if self.remove_trailing_newlines and not self.format_on_save:
             self.trim_trailing_newlines(index)
-        if self.add_newline:
+        if self.add_newline and not self.format_on_save:
             self.add_newline_to_file(index)
         if self.convert_eol_on_save:
             # hack to account for the fact that the config file saves

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1880,6 +1880,7 @@ class EditorStack(QWidget):
                 return self.save_as(index=index)
             # The file doesn't need to be saved
             return True
+
         # The following options (`always_remove_trailing_spaces`,
         # `remove_trailing_newlines` and `add_newline`) also depend on the
         # `format_on_save` value.
@@ -1890,6 +1891,7 @@ class EditorStack(QWidget):
             self.trim_trailing_newlines(index)
         if self.add_newline and not self.format_on_save:
             self.add_newline_to_file(index)
+
         if self.convert_eol_on_save:
             # hack to account for the fact that the config file saves
             # CR/LF/CRLF while set_os_eol_chars wants the os.name value.


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

There was a collision between the autoformat on save option other Editor formatting options available. Due to that those options need to be disregard if autoformat on save is on.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17716 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
