### PR TITLE
PR: Check that signature response is not empty before processing it (Completions)

### DIFF
--- a/spyder/plugins/completion/providers/languageserver/providers/document.py
+++ b/spyder/plugins/completion/providers/languageserver/providers/document.py
@@ -152,7 +152,7 @@ class DocumentProvider:
 
     @handles(CompletionRequestTypes.DOCUMENT_SIGNATURE)
     def process_signature_completion(self, response, req_id):
-        if len(response['signatures']) > 0:
+        if response and len(response['signatures']) > 0:
             response['signatures'] = response['signatures'][
                 response['activeSignature']]
             response['provider'] = LSP_COMPLETION


### PR DESCRIPTION
## Description of Changes

This was caused because the PyLSP can send an empty list as response for signatures if Jedi fails to get them, and we were not accounting for that possibility.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17778.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
