### PR TITLE
PR: Wait for autoformat before returning on 'save' method (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -33,8 +33,8 @@ from diff_match_patch import diff_match_patch
 from IPython.core.inputtransformer2 import TransformerManager
 from qtpy import QT_VERSION
 from qtpy.compat import to_qvariant
-from qtpy.QtCore import (QEvent, QRegExp, Qt, QTimer, QThread, QUrl, Signal,
-                         Slot)
+from qtpy.QtCore import (QEvent, QEventLoop, QRegExp, Qt, QTimer, QThread,
+                         QUrl, Signal, Slot)
 from qtpy.QtGui import (QColor, QCursor, QFont, QKeySequence, QPaintEvent,
                         QPainter, QMouseEvent, QTextCursor, QDesktopServices,
                         QKeyEvent, QTextDocument, QTextFormat, QTextOption,
@@ -520,6 +520,8 @@ class CodeEditor(TextEditBaseWidget):
 
         # Autoformat on save
         self.format_on_save = False
+        self.format_eventloop = QEventLoop(None)
+        self.format_timer = QTimer(self)
 
         # Mouse tracking
         self.setMouseTracking(True)
@@ -2989,7 +2991,6 @@ class CodeEditor(TextEditBaseWidget):
             if indentations:
                 max_dedent = min(indentations)
                 lines_adjustment = max(lines_adjustment, -max_dedent)
-    
             # Get new text
             remaining_lines = [
                 self.adjust_indentation(line, lines_adjustment)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -16,14 +16,13 @@ import logging
 import os
 import os.path as osp
 import sys
-import functools
 import unicodedata
 
 # Third party imports
 import qstylizer.style
 from qtpy.compat import getsavefilename
-from qtpy.QtCore import (QByteArray, QEventLoop, QFileInfo, QPoint, QSize, Qt,
-                         QTimer, Signal, Slot)
+from qtpy.QtCore import (QByteArray, QFileInfo, QPoint, QSize, Qt, QTimer,
+                         Signal, Slot)
 from qtpy.QtGui import QFont, QTextCursor
 from qtpy.QtWidgets import (QAction, QApplication, QFileDialog, QHBoxLayout,
                             QLabel, QMainWindow, QMessageBox, QMenu,
@@ -1902,23 +1901,23 @@ class EditorStack(QWidget):
         try:
             if self.format_on_save and finfo.editor.formatting_enabled:
                 # Wait for document autoformat and then save
-
+                print('FORMAT')
                 # Waiting for the autoformat to complete is needed
                 # when the file is going to be closed after saving.
                 # See spyder-ide/spyder#17836
-                format_eventloop = QEventLoop(None)
-                format_timeout = QTimer(self)
-                format_timeout.setSingleShot(True)
-                format_timeout.timeout.connect(format_eventloop.quit)
+                format_eventloop = finfo.editor.format_eventloop
+                format_timer = finfo.editor.format_timer
+                format_timer.setSingleShot(True)
+                format_timer.timeout.connect(format_eventloop.quit)
 
                 finfo.editor.sig_stop_operation_in_progress.connect(
                     lambda: self._save_file(finfo))
                 finfo.editor.sig_stop_operation_in_progress.connect(
-                    format_timeout.stop)
+                    format_timer.stop)
                 finfo.editor.sig_stop_operation_in_progress.connect(
                     format_eventloop.quit)
 
-                format_timeout.start(10000)
+                format_timer.start(10000)
                 finfo.editor.format_document()
                 format_eventloop.exec_()
             else:

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1901,7 +1901,7 @@ class EditorStack(QWidget):
         try:
             if self.format_on_save and finfo.editor.formatting_enabled:
                 # Wait for document autoformat and then save
-                print('FORMAT')
+
                 # Waiting for the autoformat to complete is needed
                 # when the file is going to be closed after saving.
                 # See spyder-ide/spyder#17836

--- a/spyder/plugins/editor/widgets/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/tests/conftest.py
@@ -50,6 +50,21 @@ def codeeditor_factory():
     return editor
 
 
+def editor_factory(new_file=True, text=None):
+    editorstack = EditorStack(None, [])
+    editorstack.set_find_widget(FindReplace(editorstack))
+    editorstack.set_io_actions(Mock(), Mock(), Mock(), Mock())
+    if new_file:
+        if not text:
+            text = ('a = 1\n'
+                    'print(a)\n'
+                    '\n'
+                    'x = 2')  # a newline is added at end
+        finfo = editorstack.new('foo.py', 'utf-8', text)
+        return editorstack, finfo.editor
+    return editorstack, None
+
+
 @pytest.fixture
 def setup_editor(qtbot):
     """
@@ -57,16 +72,60 @@ def setup_editor(qtbot):
     The cursor is at the empty line below the code.
     Returns tuple with EditorStack and CodeEditor.
     """
-    text = ('a = 1\n'
-            'print(a)\n'
-            '\n'
-            'x = 2')  # a newline is added at end
-    editorStack = EditorStack(None, [])
-    editorStack.set_find_widget(FindReplace(editorStack))
-    editorStack.set_io_actions(Mock(), Mock(), Mock(), Mock())
-    finfo = editorStack.new('foo.py', 'utf-8', text)
-    qtbot.addWidget(editorStack)
-    return editorStack, finfo.editor
+    editorstack, code_editor = editor_factory()
+    qtbot.addWidget(editorstack)
+    return editorstack, code_editor
+
+
+@pytest.fixture
+def completions_editor(
+        completion_plugin_all_started, qtbot_module, request, capsys,
+        tmp_path):
+    """Editorstack instance with LSP services activated."""
+    # Create a CodeEditor instance
+    editorstack, editor = editor_factory(new_file=False)
+    editorstack.set_format_on_save(True)
+    qtbot_module.addWidget(editorstack)
+
+    completion_plugin, capabilities = completion_plugin_all_started
+    completion_plugin.wait_for_ms = 2000
+
+    CONF.set('completions', 'enable_code_snippets', False)
+    completion_plugin.after_configuration_update([])
+    CONF.notify_section_all_observers('completions')
+
+    file_path = tmp_path / 'test.py'
+    editor = editorstack.new(str(file_path), 'utf-8', '').editor
+    # Redirect editor LSP requests to lsp_manager
+    editor.sig_perform_completion_request.connect(
+        completion_plugin.send_request)
+
+    completion_plugin.register_file('python', str(file_path), editor)
+    editor.start_completion_services()
+    editor.register_completion_capabilities(capabilities)
+
+    with qtbot_module.waitSignal(
+            editor.completions_response_signal, timeout=30000):
+        editor.document_did_open()
+
+    def teardown():
+        editor.completion_widget.hide()
+        editor.tooltip_widget.hide()
+        editor.hide()
+
+        # Capture stderr and assert there are no errors
+        sys_stream = capsys.readouterr()
+        sys_err = sys_stream.err
+
+        if PY2:
+            sys_err = to_text_string(sys_err).encode('utf-8')
+        assert sys_err == ''
+
+    request.addfinalizer(teardown)
+
+    editorstack.show()
+
+    return file_path, editorstack, editor, completion_plugin
 
 
 @pytest.fixture

--- a/spyder/plugins/editor/widgets/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/tests/conftest.py
@@ -84,7 +84,6 @@ def completions_editor(
     """Editorstack instance with LSP services activated."""
     # Create a CodeEditor instance
     editorstack, editor = editor_factory(new_file=False)
-    editorstack.set_format_on_save(True)
     qtbot_module.addWidget(editorstack)
 
     completion_plugin, capabilities = completion_plugin_all_started

--- a/spyder/plugins/editor/widgets/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/tests/conftest.py
@@ -116,9 +116,6 @@ def completions_editor(
         # Capture stderr and assert there are no errors
         sys_stream = capsys.readouterr()
         sys_err = sys_stream.err
-
-        if PY2:
-            sys_err = to_text_string(sys_err).encode('utf-8')
         assert sys_err == ''
 
     request.addfinalizer(teardown)

--- a/spyder/plugins/editor/widgets/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/tests/test_formatting.py
@@ -215,7 +215,7 @@ def test_max_line_length(formatter, completions_codeeditor, qtbot):
 @pytest.mark.parametrize('formatter', [autopep8, black])
 def test_closing_document_formatting(
         formatter, completions_editor, qtbot, monkeypatch):
-    """Validate text autoformatting via autopep8, yapf or black."""
+    """Check that auto-formatting works when closing an usaved file."""
     file_path, editorstack, code_editor, completion_plugin = completions_editor
     text, expected = get_formatter_values(formatter, newline='\n')
 

--- a/spyder/plugins/editor/widgets/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/tests/test_formatting.py
@@ -220,6 +220,7 @@ def test_closing_document_formatting(
     text, expected = get_formatter_values(formatter, newline='\n')
 
     # Set formatter
+    editorstack.set_format_on_save(True)
     CONF.set(
         'completions',
         ('provider_configuration', 'lsp', 'values', 'formatting'),


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Since the autoformat option can take time we need to wait before returning on the editor `save` method to prevent lossing changes when closing an unsaved file.

Depends on https://github.com/spyder-ide/spyder/pull/17860


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17836 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
