### PR TITLE
PR: Add micromamba executable to the Windows installer

### DIFF
--- a/.github/workflows/installer-win.yml
+++ b/.github/workflows/installer-win.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         build_type: ['Lite', 'Full']
     env:
-      ASSETS_URL: 'https://github.com/spyder-ide/windows-installer-assets/releases/download/0.0.6/assets.zip'
+      ASSETS_URL: 'https://github.com/spyder-ide/windows-installer-assets/releases/download/0.0.7/assets.zip'
       UNWANTED_PACKAGES: ${{github.event_name == 'pull_request' && 'pip spyder-kernels python-slugify Rtree QDarkStyle PyNaCl' || 'pip python-slugify Rtree PyNaCl' }}
       SKIP_PACKAGES: 'bcrypt slugify'
       ADD_PACKAGES: ${{github.event_name == 'pull_request' && 'spyder_kernels blib2to3 _black_version blackd rtree qdarkstyle nacl' || 'blib2to3 _black_version blackd rtree nacl' }}

--- a/installers/Windows/installer.py
+++ b/installers/Windows/installer.py
@@ -104,6 +104,7 @@ files={package_dist_info} > $INSTDIR/pkgs
     lib
     tcl86t.dll > $INSTDIR/pkgs
     tk86t.dll > $INSTDIR/pkgs
+    micromamba.exe > $INSTDIR/bin
 [Build]
 installer_name={installer_name}
 nsi_template={template}
@@ -361,6 +362,11 @@ def run(python_version, bitness, repo_root, entrypoint, package, icon_path,
             shutil.copy(
                 "installers/Windows/assets/tcl/tk86t.dll",
                 os.path.join(work_dir, "tk86t.dll"))
+
+            print("Copying micromamba assets")
+            shutil.copy(
+                "installers/Windows/assets/micromamba/micromamba.exe",
+                os.path.join(work_dir, "micromamba.exe"))
 
             print("Copying NSIS plugins into discoverable path")
             shutil.copy(

--- a/installers/Windows/installer.py
+++ b/installers/Windows/installer.py
@@ -104,7 +104,7 @@ files={package_dist_info} > $INSTDIR/pkgs
     lib
     tcl86t.dll > $INSTDIR/pkgs
     tk86t.dll > $INSTDIR/pkgs
-    micromamba.exe > $INSTDIR/bin
+    micromamba.exe > $INSTDIR/pkgs/spyder/bin
 [Build]
 installer_name={installer_name}
 nsi_template={template}

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -594,7 +594,10 @@ def get_spyder_umamba_path():
         path = osp.join(osp.dirname(osp.dirname(__file__)),
                         'bin', 'micromamba')
     elif is_pynsist():
-        path = None  # TODO: when micromamba is added to Windows installer
+        base_path = osp.abspath(osp.dirname(__file__))
+        bin_path = osp.abspath(
+            osp.join(base_path, '..', '..', '..', 'bin'))
+        path = osp.join(bin_path, 'micromamba.exe')
     else:
         path = None
 

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -594,10 +594,8 @@ def get_spyder_umamba_path():
         path = osp.join(osp.dirname(osp.dirname(__file__)),
                         'bin', 'micromamba')
     elif is_pynsist():
-        base_path = osp.abspath(osp.dirname(__file__))
-        bin_path = osp.abspath(
-            osp.join(base_path, '..', '..', '..', 'bin'))
-        path = osp.join(bin_path, 'micromamba.exe')
+        path = osp.abspath(osp.join(osp.dirname(osp.dirname(__file__)),
+                                    'bin', 'micromamba.exe'))
     else:
         path = None
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Depends on https://github.com/spyder-ide/windows-installer-assets/pull/8 and a new assets release
Part of https://github.com/spyder-ide/spyder/pull/17692

Updates the assets URL to get the micromamba executable when building the Windows installers

Checked installing locally the PR Windos full installer and the path from micromamba seems correct :+1:

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
