### PR TITLE
PR: Add missing PyQtWebEngine dependency for conda-forge

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -29,6 +29,7 @@ dependencies:
 - pylint >=2.5.0
 - pyls-spyder >=0.4.0
 - pyqt <5.16
+- pyqtwebengine <5.16
 - python-lsp-black >=1.2.0
 - python-lsp-server >=1.4.1,<1.5.0
 - pyxdg >=0.26

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -25,6 +25,7 @@ pygments >=2.0
 pylint >=2.5.0
 pyls-spyder >=0.4.0
 pyqt <5.16
+pyqtwebengine <5.16
 python-lsp-black >=1.2.0
 python-lsp-server >=1.4.1,<1.5.0
 pyxdg >=0.26


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

With[ PyQt 5.15.4 available on conda-forge](https://anaconda.org/conda-forge/pyqt), we also need to require [PyQtWebEngine 5.15.4](https://anaconda.org/conda-forge/pyqtwebengine) (for our tests when installing on conda-forge)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
