### PR TITLE
PR: Remove dependence on fixed macOS application bundle name

### DIFF
--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -118,7 +118,6 @@ def make_disk_image(dist_dir, make_lite=False):
     dmg_name += '.dmg'
     dmgfile = (dist_dir / dmg_name).as_posix()
 
-
     settings_file = (THISDIR / 'dmg_settings.py').as_posix()
     settings = {
         'files': [(dist_dir / MAC_APP_NAME).as_posix()],

--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from setuptools import setup
 
 from spyder import __version__ as SPYVER
-from spyder.config.base import MAC_APP_NAME
 
 # Setup logger
 fmt = Formatter('%(asctime)s [%(levelname)s] [%(name)s] -> %(message)s')
@@ -34,6 +33,7 @@ SPYREPO = (THISDIR / '..' / '..').resolve()
 ICONFILE = SPYREPO / 'img_src' / 'spyder.icns'
 APPSCRIPT = SPYREPO / 'scripts' / 'spyder'
 
+MAC_APP_NAME = 'Spyder.app'
 APP_BASE_NAME = MAC_APP_NAME[:-4]
 
 # Python version

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -549,9 +549,6 @@ EXCLUDED_NAMES = ['nan', 'inf', 'infty', 'little_endian', 'colorbar_doc',
 #==============================================================================
 # Mac application utilities
 #==============================================================================
-MAC_APP_NAME = 'Spyder.app'
-
-
 def running_in_mac_app(pyexec=None):
     """
     Check if Python executable is located inside a standalone Mac app.

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -286,7 +286,7 @@ def get_conf_paths():
         search_paths = []
         tmpfolder = str(tempfile.gettempdir())
         for i in range(3):
-            path = os.path.join(tmpfolder, 'site-config-'+str(i))
+            path = os.path.join(tmpfolder, 'site-config-' + str(i))
             if not os.path.isdir(path):
                 os.makedirs(path)
             search_paths.append(path)
@@ -356,6 +356,7 @@ def is_pynsist():
         return pkgs_path in os.environ.get('PYTHONPATH')
     return False
 
+
 #==============================================================================
 # Translations
 #==============================================================================
@@ -380,6 +381,7 @@ LANGUAGE_CODES = {
 # Disabled languages because their translations are outdated or incomplete
 DISABLED_LANGUAGES = ['hu', 'pl']
 
+
 def get_available_translations():
     """
     List available translations for spyder based on the folders found in the
@@ -394,7 +396,7 @@ def get_available_translations():
     langs = [DEFAULT_LANGUAGE] + langs
 
     # Remove disabled languages
-    langs = list( set(langs) - set(DISABLED_LANGUAGES) )
+    langs = list(set(langs) - set(DISABLED_LANGUAGES))
 
     # Check that there is a language code available in case a new translation
     # is added, to ensure LANGUAGE_CODES is updated.
@@ -513,6 +515,7 @@ def get_translation(modname, dirname=None):
     try:
         _trans = gettext.translation(modname, locale_path, codeset="utf-8")
         lgettext = _trans.lgettext
+
         def translate_gettext(x):
             if not PY3 and is_unicode(x):
                 x = x.encode("utf-8")
@@ -525,6 +528,7 @@ def get_translation(modname, dirname=None):
     except Exception:
         return translate_dumb
 
+
 # Translation callback
 _ = get_translation("spyder")
 
@@ -534,12 +538,12 @@ _ = get_translation("spyder")
 #==============================================================================
 # Variable explorer display / check all elements data types for sequences:
 # (when saving the variable explorer contents, check_all is True,
-CHECK_ALL = False #XXX: If True, this should take too much to compute...
+CHECK_ALL = False  # XXX: If True, this should take too much to compute...
 
 EXCLUDED_NAMES = ['nan', 'inf', 'infty', 'little_endian', 'colorbar_doc',
                   'typecodes', '__builtins__', '__main__', '__doc__', 'NaN',
                   'Inf', 'Infinity', 'sctypes', 'rcParams', 'rcParamsDefault',
-                  'sctypeNA', 'typeNA', 'False_', 'True_',]
+                  'sctypeNA', 'typeNA', 'False_', 'True_']
 
 
 #==============================================================================
@@ -561,9 +565,12 @@ def running_in_mac_app(pyexec=None):
     if pyexec is None:
         pyexec = sys.executable
 
-    if sys.platform == "darwin":
-        if MAC_APP_NAME not in pyexec:
-            return False
+    # EXECUTABLEPATH only exists if Spyder is a macOS app bundle
+    # EXECUTABLEPATH = .../<app name>.app/Conents/MacOS/Spyder
+    app_exe_path = os.environ.get('EXECUTABLEPATH', None)
+
+    if (sys.platform == "darwin" and app_exe_path
+            and pyexec == osp.join(osp.dirname(app_exe_path), 'python')):
         return True
     else:
         return False

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -565,15 +565,27 @@ def running_in_mac_app(pyexec=None):
     if pyexec is None:
         pyexec = sys.executable
 
-    # EXECUTABLEPATH only exists if Spyder is a macOS app bundle
-    # EXECUTABLEPATH = .../<app name>.app/Conents/MacOS/Spyder
-    app_exe_path = os.environ.get('EXECUTABLEPATH', None)
+    bpath = get_mac_app_bundle_path()
 
-    if (sys.platform == "darwin" and app_exe_path
-            and pyexec == osp.join(osp.dirname(app_exe_path), 'python')):
+    if bpath and pyexec == osp.join(bpath, 'Contents/MacOS/python'):
         return True
     else:
         return False
+
+
+def get_mac_app_bundle_path():
+    """
+    Return the full path to the macOS app bundle. Otherwise return None.
+
+    EXECUTABLEPATH environment variable only exists if Spyder is a macOS app
+    bundle. In which case it will always end with
+    "/<app name>.app/Conents/MacOS/Spyder".
+    """
+    app_exe_path = os.environ.get('EXECUTABLEPATH', None)
+    if sys.platform == "darwin" and app_exe_path:
+        return osp.dirname(osp.dirname(osp.dirname(osp.abspath(app_exe_path))))
+    else:
+        return None
 
 
 # =============================================================================

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -545,10 +545,7 @@ EXCLUDED_NAMES = ['nan', 'inf', 'infty', 'little_endian', 'colorbar_doc',
 #==============================================================================
 # Mac application utilities
 #==============================================================================
-if PY3:
-    MAC_APP_NAME = 'Spyder.app'
-else:
-    MAC_APP_NAME = 'Spyder-Py2.app'
+MAC_APP_NAME = 'Spyder.app'
 
 
 def running_in_mac_app(pyexec=None):

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -20,11 +20,10 @@ import types
 from qtpy.compat import from_qvariant, to_qvariant
 from qtpy.QtCore import (QEvent, QLibraryInfo, QLocale, QObject, Qt, QTimer,
                          QTranslator, QUrl, Signal, Slot)
-from qtpy.QtGui import (
-    QDesktopServices, QIcon, QKeyEvent, QKeySequence, QPixmap)
+from qtpy.QtGui import QDesktopServices, QKeyEvent, QKeySequence, QPixmap
 from qtpy.QtWidgets import (QAction, QApplication, QDialog, QHBoxLayout,
                             QLabel, QLineEdit, QMenu, QPlainTextEdit,
-                            QProxyStyle, QPushButton, QStyle, QToolBar,
+                            QProxyStyle, QPushButton, QStyle,
                             QToolButton, QVBoxLayout, QWidget)
 
 # Local imports
@@ -37,7 +36,6 @@ from spyder.utils.image_path_manager import get_image_path
 from spyder.utils.palette import QStylePalette
 from spyder.utils.registries import ACTION_REGISTRY, TOOLBUTTON_REGISTRY
 from spyder.widgets.waitingspinner import QWaitingSpinner
-from spyder.config.manager import CONF
 
 # Third party imports
 if sys.platform == "darwin":
@@ -129,7 +127,7 @@ def qapplication(translate=True, test_time=3):
     if test_ci is not None:
         timer_shutdown = QTimer(app)
         timer_shutdown.timeout.connect(app.quit)
-        timer_shutdown.start(test_time*1000)
+        timer_shutdown.start(test_time * 1000)
     return app
 
 
@@ -147,14 +145,17 @@ def file_uri(fname):
 
 
 QT_TRANSLATOR = None
+
+
 def install_translator(qapp):
     """Install Qt translator to the QApplication instance"""
     global QT_TRANSLATOR
     if QT_TRANSLATOR is None:
         qt_translator = QTranslator()
-        if qt_translator.load("qt_"+QLocale.system().name(),
-                      QLibraryInfo.location(QLibraryInfo.TranslationsPath)):
-            QT_TRANSLATOR = qt_translator # Keep reference alive
+        if qt_translator.load(
+                "qt_" + QLocale.system().name(),
+                QLibraryInfo.location(QLibraryInfo.TranslationsPath)):
+            QT_TRANSLATOR = qt_translator  # Keep reference alive
     if QT_TRANSLATOR is not None:
         qapp.installTranslator(QT_TRANSLATOR)
 
@@ -382,6 +383,7 @@ def wrap_toggled(toggled, section, option):
 
 def add_configuration_update(action):
     """Add on_configuration_change to a SpyderAction that depends on CONF."""
+
     def on_configuration_change(self, _option, _section, value):
         self.blockSignals(True)
         self.setChecked(value)
@@ -512,6 +514,7 @@ class DialogManager(QObject):
     Object that keep references to non-modal dialog boxes for another QObject,
     typically a QMainWindow or any kind of QWidget
     """
+
     def __init__(self):
         QObject.__init__(self)
         self.dialogs = {}
@@ -529,9 +532,9 @@ class DialogManager(QObject):
             dialog.show()
             self.dialogs[id(dialog)] = dialog
             dialog.accepted.connect(
-                              lambda eid=id(dialog): self.dialog_finished(eid))
+                lambda eid=id(dialog): self.dialog_finished(eid))
             dialog.rejected.connect(
-                              lambda eid=id(dialog): self.dialog_finished(eid))
+                lambda eid=id(dialog): self.dialog_finished(eid))
 
     def dialog_finished(self, dialog_id):
         """Manage non-modal dialog boxes"""
@@ -548,7 +551,7 @@ def get_filetype_icon(fname):
     ext = osp.splitext(fname)[1]
     if ext.startswith('.'):
         ext = ext[1:]
-    return ima.get_icon( "%s.png" % ext, ima.icon('FileIcon') )
+    return ima.get_icon("%s.png" % ext, ima.icon('FileIcon'))
 
 
 class SpyderAction(QAction):
@@ -572,6 +575,7 @@ class ShowStdIcons(QWidget):
     """
     Dialog showing standard icons
     """
+
     def __init__(self, parent):
         QWidget.__init__(self, parent)
         layout = QHBoxLayout()
@@ -585,10 +589,10 @@ class ShowStdIcons(QWidget):
                 icon = ima.get_std_icon(child)
                 label = QLabel()
                 label.setPixmap(icon.pixmap(32, 32))
-                icon_layout.addWidget( label )
-                icon_layout.addWidget( QLineEdit(child.replace('SP_', '')) )
+                icon_layout.addWidget(label)
+                icon_layout.addWidget(QLineEdit(child.replace('SP_', '')))
                 col_layout.addLayout(icon_layout)
-                cindex = (cindex+1) % row_nb
+                cindex = (cindex + 1) % row_nb
                 if cindex == 0:
                     layout.addLayout(col_layout)
         self.setLayout(layout)

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -28,7 +28,7 @@ from qtpy.QtWidgets import (QAction, QApplication, QDialog, QHBoxLayout,
                             QToolButton, QVBoxLayout, QWidget)
 
 # Local imports
-from spyder.config.base import MAC_APP_NAME
+from spyder.config.base import get_mac_app_bundle_path
 from spyder.config.manager import CONF
 from spyder.py3compat import configparser, is_text_string, to_text_string, PY2
 from spyder.utils.icon_manager import ima
@@ -751,7 +751,7 @@ class MacApplication(QApplication):
                 pass
             elif self._has_started:
                 self.sig_open_external_file.emit(fname)
-            elif MAC_APP_NAME not in fname:
+            else:
                 self._pending_file_open.append(fname)
         return QApplication.event(self, event)
 
@@ -771,16 +771,14 @@ def register_app_launchservices(
     Register app to the Apple launch services so it can open Python files
     """
     app = QApplication.instance()
-    # If top frame is MAC_APP_NAME, set ourselves to open files at startup
-    origin_filename = get_origin_filename()
-    if MAC_APP_NAME in origin_filename:
-        bundle_idx = origin_filename.find(MAC_APP_NAME)
-        old_handler = als.get_bundle_identifier_for_path(
-            origin_filename[:bundle_idx] + MAC_APP_NAME)
+
+    # If macOS app, set ourselves to open files at startup
+    bundle = get_mac_app_bundle_path()
+    if bundle:
+        old_handler = als.get_bundle_identifier_for_path(bundle)
     else:
         # Else, just restore the previous handler
-        old_handler = als.get_UTI_handler(
-            uniform_type_identifier, role)
+        old_handler = als.get_UTI_handler(uniform_type_identifier, role)
 
     app._original_handlers[(uniform_type_identifier, role)] = old_handler
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Removed dependence on the fixed constant `MAC_APP_NAME`.

This was used both for setting the name of the macOS application bundle as well as for determining if Spyder was launched as a macOS application.  It is really unnecessary to set the application bundle name anywhere in the source code except for the installer script.
Furthermore, the application bundle name `Spyder.app` is an unreliable test for whether Spyder launched as a macOS application bundle.

This test was made more robust by looking at the `EXECUTABLEPATH` environment variable which is only set on macOS platforms when Spyder is launched as an application bundle.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17861


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
