### PR TITLE
PR: Do not resolve symlink on Python interpreter file selection

### DIFF
--- a/spyder/plugins/preferences/api.py
+++ b/spyder/plugins/preferences/api.py
@@ -19,10 +19,10 @@ from qtpy.compat import (getexistingdirectory, getopenfilename, from_qvariant,
 from qtpy.QtCore import Qt, Signal, Slot, QRegExp
 from qtpy.QtGui import QColor, QRegExpValidator, QTextOption
 from qtpy.QtWidgets import (QButtonGroup, QCheckBox, QComboBox, QDoubleSpinBox,
-                            QFontComboBox, QGridLayout, QGroupBox, QHBoxLayout,
-                            QLabel, QLineEdit, QMessageBox, QPushButton,
-                            QRadioButton, QSpinBox, QVBoxLayout, QWidget,
-                            QPlainTextEdit, QTabWidget)
+                            QFileDialog, QFontComboBox, QGridLayout, QGroupBox,
+                            QHBoxLayout, QLabel, QLineEdit, QMessageBox,
+                            QPlainTextEdit, QPushButton, QRadioButton,
+                            QSpinBox, QTabWidget, QVBoxLayout, QWidget)
 
 # Local imports
 from spyder.config.base import _
@@ -566,7 +566,7 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
         browsedir.setLayout(layout)
         return browsedir
 
-    def select_file(self, edit, filters=None):
+    def select_file(self, edit, filters=None, **kwargs):
         """Select File"""
         basedir = osp.dirname(to_text_string(edit.text()))
         if not osp.isdir(basedir):
@@ -574,7 +574,8 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
         if filters is None:
             filters = _("All files (*)")
         title = _("Select file")
-        filename, _selfilter = getopenfilename(self, title, basedir, filters)
+        filename, _selfilter = getopenfilename(self, title, basedir, filters,
+                                               **kwargs)
         if filename:
             edit.setText(filename)
 
@@ -733,7 +734,9 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
             msg)
         browse_btn = QPushButton(ima.icon('FileIcon'), '', self)
         browse_btn.setToolTip(_("Select file"))
-        browse_btn.clicked.connect(lambda: self.select_file(edit, filters))
+        options = QFileDialog.DontResolveSymlinks
+        browse_btn.clicked.connect(
+            lambda: self.select_file(edit, filters, options=options))
 
         layout = QGridLayout()
         layout.addWidget(combobox, 0, 0, 0, 9)

--- a/spyder/plugins/preferences/api.py
+++ b/spyder/plugins/preferences/api.py
@@ -189,8 +189,8 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
                 text = to_text_string(lineedit.text())
                 if not validator(text):
                     QMessageBox.critical(self, self.get_name(),
-                                     "%s:<br><b>%s</b>" % (invalid_msg, text),
-                                     QMessageBox.Ok)
+                                         f"{invalid_msg}:<br><b>{text}</b>",
+                                         QMessageBox.Ok)
                     return False
 
         if self.tabs is not None and status:
@@ -271,9 +271,9 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
                     index = None
             if index:
                 combobox.setCurrentIndex(index)
-            combobox.currentIndexChanged.connect(lambda _foo, opt=option, sect=sec:
-                                                 self.has_been_modified(
-                                                     sect, opt))
+            combobox.currentIndexChanged.connect(
+                lambda _foo, opt=option, sect=sec:
+                    self.has_been_modified(sect, opt))
             if combobox.restart_required:
                 if sec is None:
                     self.restart_options[option] = combobox.label_text
@@ -762,7 +762,7 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
         if fontfilters is not None:
             fontbox.setFontFilters(fontfilters)
 
-        sizelabel = QLabel("  "+_("Size"))
+        sizelabel = QLabel("  " + _("Size"))
         sizebox = QSpinBox()
         sizebox.setRange(7, 100)
         self.fontboxes[(fontbox, sizebox)] = option


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Send `QFileDialog.DontResolveSymlinks` option to `select_file` in `create_file_combobox` for Python interpreter preferences.
This ensures that symlinks are not resolved.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17872 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary

<!--- Thanks for your help making Spyder better for everyone! --->
