### PR TITLE
PR: Don't use create_application when showing message about not being able to load CONF

### DIFF
--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -641,9 +641,16 @@ class ConfigurationManager(object):
 try:
     CONF = ConfigurationManager()
 except Exception:
-    from qtpy.QtWidgets import QMessageBox
-    from spyder.app.utils import create_application
-    app = create_application()
+    from qtpy.QtWidgets import QApplication, QMessageBox
+
+    # Create QApplication in order to display the message below.
+    # NOTE: We don't use the functions we have to create a QApplication here
+    # because they could import CONF at some point, which would make this
+    # this fallback fail.
+    # See issue spyder-ide/spyder#17889
+    app = QApplication(['Spyder'])
+    app.setApplicationName('Spyder')
+
     reset_reply = QMessageBox.critical(
         None, 'Spyder',
         _("There was an error while loading Spyder configuration options. "

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -643,13 +643,17 @@ try:
 except Exception:
     from qtpy.QtWidgets import QApplication, QMessageBox
 
-    # Create QApplication in order to display the message below.
-    # NOTE: We don't use the functions we have to create a QApplication here
+    # Check if there's an app already running
+    app = QApplication.instance()
+
+    # Create app, if there's none, in order to display the message below.
+    # NOTE: Don't use the functions we have to create a QApplication here
     # because they could import CONF at some point, which would make this
-    # this fallback fail.
+    # fallback fail.
     # See issue spyder-ide/spyder#17889
-    app = QApplication(['Spyder'])
-    app.setApplicationName('Spyder')
+    if app is None:
+        app = QApplication(['Spyder'])
+        app.setApplicationName('Spyder')
 
     reset_reply = QMessageBox.critical(
         None, 'Spyder',


### PR DESCRIPTION
## Description of Changes

- This is a small enhancement over PR #17526 to not use our own functions to create a QApplication to avoid importing CONF when importing them, which makes our fallback fail.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17889

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
