### PR TITLE
PR: Improve updating Main Interpreter status bar widget when the current one is removed

### DIFF
--- a/spyder/plugins/maininterpreter/container.py
+++ b/spyder/plugins/maininterpreter/container.py
@@ -52,7 +52,7 @@ class MainInterpreterContainer(PluginMainContainer):
         pass
 
     @on_conf_change(option=['default', 'custom_interpreter', 'custom'])
-    def section_conf_update(self, option, value):
+    def on_interpreter_changed(self, option, value):
         if ((option == 'default' and value) or
                 (option == 'custom' and not value)):
             executable = get_python_executable()


### PR DESCRIPTION
## Description of Changes

- This takes advantage of the improvements done in PR #17788.
- Now we only need to change the `custom` or `default` interpreter options and an update to the status bar will be triggered automatically. So, we don't to do it manually anymore.
- I also eliminated the externally removed interpreter from the list of ones available to be set by the user.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
