### PR TITLE
PR: Don't use cached kernel for a full console restart

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -33,3 +33,4 @@ markers =
     known_leak: Known thread or open file leaks
     no_new_console: Prevent creating a new IPython console when reusing a mainwindow instance
     close_main_window: Close main window instance after test
+    no_web_widgets

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1542,14 +1542,15 @@ class IPythonConsoleWidget(PluginMainWidget):
     @Slot(bool, bool)
     @Slot(bool, str, bool)
     def create_new_client(self, give_focus=True, filename='', is_cython=False,
-                          is_pylab=False, is_sympy=False, given_name=None):
+                          is_pylab=False, is_sympy=False, given_name=None,
+                          no_cache=False):
         """Create a new client"""
         self.master_clients += 1
         client_id = dict(int_id=str(self.master_clients),
                          str_id='A')
         std_dir = self._test_dir if self._test_dir else None
         cf, km, kc, stderr_obj, stdout_obj = self.get_new_kernel(
-            is_cython, is_pylab, is_sympy, std_dir=std_dir)
+            is_cython, is_pylab, is_sympy, std_dir=std_dir, no_cache=no_cache)
 
         if cf is not None:
             fault_obj = StdFile(cf, '.fault', std_dir)
@@ -1656,7 +1657,7 @@ class IPythonConsoleWidget(PluginMainWidget):
                                            password)
 
     def get_new_kernel(self, is_cython=False, is_pylab=False,
-                       is_sympy=False, std_dir=None):
+                       is_sympy=False, std_dir=None, no_cache=False):
         """Get a new kernel, and cache one for next time."""
         # Cache another kernel for next time.
         kernel_spec = self.create_kernel_spec(
@@ -1666,8 +1667,9 @@ class IPythonConsoleWidget(PluginMainWidget):
         )
 
         new_kernel = self.create_new_kernel(kernel_spec, std_dir)
-        if new_kernel[2] is None:
-            # error
+
+        if new_kernel[2] is None or no_cache:
+            # error or remove cache if requested
             self.close_cached_kernel()
             return new_kernel
 
@@ -1991,7 +1993,7 @@ class IPythonConsoleWidget(PluginMainWidget):
         for i in range(len(self.clients)):
             client = self.clients[-1]
             self.close_client(client=client, ask_recursive=False)
-        self.create_new_client(give_focus=False)
+        self.create_new_client(give_focus=False, no_cache=True)
         self.create_new_client_if_empty = True
 
     def current_client_inspect_object(self):

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1543,14 +1543,14 @@ class IPythonConsoleWidget(PluginMainWidget):
     @Slot(bool, str, bool)
     def create_new_client(self, give_focus=True, filename='', is_cython=False,
                           is_pylab=False, is_sympy=False, given_name=None,
-                          no_cache=False):
+                          cache=True):
         """Create a new client"""
         self.master_clients += 1
         client_id = dict(int_id=str(self.master_clients),
                          str_id='A')
         std_dir = self._test_dir if self._test_dir else None
         cf, km, kc, stderr_obj, stdout_obj = self.get_new_kernel(
-            is_cython, is_pylab, is_sympy, std_dir=std_dir, no_cache=no_cache)
+            is_cython, is_pylab, is_sympy, std_dir=std_dir, cache=cache)
 
         if cf is not None:
             fault_obj = StdFile(cf, '.fault', std_dir)
@@ -1657,7 +1657,7 @@ class IPythonConsoleWidget(PluginMainWidget):
                                            password)
 
     def get_new_kernel(self, is_cython=False, is_pylab=False,
-                       is_sympy=False, std_dir=None, no_cache=False):
+                       is_sympy=False, std_dir=None, cache=True):
         """Get a new kernel, and cache one for next time."""
         # Cache another kernel for next time.
         kernel_spec = self.create_kernel_spec(
@@ -1668,8 +1668,8 @@ class IPythonConsoleWidget(PluginMainWidget):
 
         new_kernel = self.create_new_kernel(kernel_spec, std_dir)
 
-        if new_kernel[2] is None or no_cache:
-            # error or remove cache if requested
+        if new_kernel[2] is None or not cache:
+            # error or remove/don't use cache if requested
             self.close_cached_kernel()
             return new_kernel
 
@@ -1993,7 +1993,7 @@ class IPythonConsoleWidget(PluginMainWidget):
         for i in range(len(self.clients)):
             client = self.clients[-1]
             self.close_client(client=client, ask_recursive=False)
-        self.create_new_client(give_focus=False, no_cache=True)
+        self.create_new_client(give_focus=False, cache=False)
         self.create_new_client_if_empty = True
 
     def current_client_inspect_object(self):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

When restarting the console when for example opening a project, the cached kernel was being used which caused an inconsistency regardsing the PYTHONPATH modified when you have a project open, or you open/close a project

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17915


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
