### PR TITLE
PR: Remove PYTHONHOME from QProcess.processEnvironment in profiler

### DIFF
--- a/spyder/plugins/profiler/widgets/main_widget.py
+++ b/spyder/plugins/profiler/widgets/main_widget.py
@@ -34,7 +34,7 @@ from qtpy.QtWidgets import (QApplication, QLabel, QMessageBox, QTreeWidget,
 from spyder.api.translations import get_translation
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.api.widgets.mixins import SpyderWidgetMixin
-from spyder.config.base import get_conf_path
+from spyder.config.base import get_conf_path, running_in_mac_app
 from spyder.plugins.variableexplorer.widgets.texteditor import TextEditor
 from spyder.py3compat import to_text_string
 from spyder.utils.misc import get_python_executable, getcwd_or_home
@@ -543,6 +543,13 @@ class ProfilerWidget(PluginMainWidget):
             proc_env.insert('PYTHONPATH', os.pathsep.join(pythonpath))
         self.process.setProcessEnvironment(proc_env)
 
+        executable = self.get_conf('executable', section='main_interpreter')
+
+        if not running_in_mac_app(executable):
+            env = self.process.processEnvironment()
+            env.remove('PYTHONHOME')
+            self.process.setProcessEnvironment(env)
+
         self.output = ''
         self.error_output = ''
         self.running = True
@@ -559,8 +566,6 @@ class ProfilerWidget(PluginMainWidget):
 
         if args:
             p_args.extend(shell_split(args))
-
-        executable = self.get_conf('executable', section='main_interpreter')
 
         self.process.start(executable, p_args)
         running = self.process.waitForStarted()


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

The profiler widget's start method uses a QProcess that does not remove PYTHONHOME from the process environment when running external environments. This PR resolves that issue.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #18010


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary 

<!--- Thanks for your help making Spyder better for everyone! --->
