### PR TITLE
PR: Only build Full macOS app on pull requests

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -7,12 +7,26 @@ on:
 name: Create macOS App Bundle and DMG
 
 jobs:
+  matrix_prep:
+    name: Matrix Prep
+    runs-on: macos-10.15
+    outputs:
+      build_type: ${{ steps.set-matrix.outputs.build_type }}
+    steps:
+    - id: set-matrix
+      run: |
+        if [[ ${GITHUB_EVENT_NAME} == 'release' ]]; then
+            build_type=$(echo [\"Full\", \"Lite\"])
+        else
+            build_type=$(echo [\"Lite\"])
+        fi
+        echo ::set-output name=build_type::{\"build_type\":$(echo $build_type)}
   build:
     name: macOS App Bundle
     runs-on: macos-10.15
+    needs: matrix_prep
     strategy:
-      matrix:
-        build_type: ['Full', 'Lite']
+      matrix: ${{fromJson(needs.matrix_prep.outputs.build_type)}}
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -16,11 +16,11 @@ jobs:
     - id: set-matrix
       run: |
         if [[ ${GITHUB_EVENT_NAME} == 'release' ]]; then
-            build_type=$(echo [\"Full\", \"Lite\"])
+            build_type=$(echo '["Full", "Lite"]')
         else
-            build_type=$(echo [\"Full\"])
+            build_type=$(echo '["Full"]')
         fi
-        echo ::set-output name=build_type::{\"build_type\":$(echo $build_type)}
+        echo ::set-output name=build_type::'{"build_type":$(echo $build_type)}'
   build:
     name: macOS App Bundle
     runs-on: macos-10.15

--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -18,7 +18,7 @@ jobs:
         if [[ ${GITHUB_EVENT_NAME} == 'release' ]]; then
             build_type=$(echo [\"Full\", \"Lite\"])
         else
-            build_type=$(echo [\"Lite\"])
+            build_type=$(echo [\"Full\"])
         fi
         echo ::set-output name=build_type::{\"build_type\":$(echo $build_type)}
   build:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Since artifacts for PRs are primarily used by developers for verification, only the Lite version of the macOS app is built on pull requests. On releases, both Lite and Full versions are built. This may free up some CI resources.

Additionally, `pandas` (and `numpy`) are added to the Lite build in order for `pandas` objects to be inspected in the Variable Explorer in the Lite app version.

@spyder-ide/core-developers, let me know what you think of these ideas.

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary 

<!--- Thanks for your help making Spyder better for everyone! --->
