### PR TITLE
PR: Fix issue where nbconvert was not importable in macOS application

### DIFF
--- a/installers/macOS/packages.py
+++ b/installers/macOS/packages.py
@@ -58,7 +58,6 @@ INCLUDES = [
 
 SCIENTIFIC = [
     'cython',
-    'defusedxml',
     'matplotlib',
     'numpy',
     'openpyxl',

--- a/installers/macOS/req-scientific.txt
+++ b/installers/macOS/req-scientific.txt
@@ -1,6 +1,5 @@
 # Scientific packages (for Same as Spyder)
 cython
-defusedxml
 matplotlib
 numpy
 openpyxl


### PR DESCRIPTION
`defusedxml` was already a dependency of `nbconvert`, so it was redundent to include in the scientific packages list for the full version, but this also caused it to be explicitly excluded for the lite version, hence the issue for `nbconvert`.

Related to #18106