### PR TITLE
PR: Fix syntax issues in macOS installer workflow file

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -8,7 +8,7 @@ name: Create macOS App Bundle and DMG
 
 jobs:
   matrix_prep:
-    name: Matrix Prep
+    name: Determine Build Matrix
     runs-on: macos-10.15
     outputs:
       build_type: ${{ steps.set-matrix.outputs.build_type }}
@@ -16,11 +16,11 @@ jobs:
     - id: set-matrix
       run: |
         if [[ ${GITHUB_EVENT_NAME} == 'release' ]]; then
-            build_type=$(echo '["Full", "Lite"]')
+            build_type=$(echo "['Full', 'Lite']")
         else
-            build_type=$(echo '["Full"]')
+            build_type=$(echo "['Full']")
         fi
-        echo ::set-output name=build_type::'{"build_type":$(echo $build_type)}'
+        echo "::set-output name=build_type::{'build_type':$(echo $build_type)}"
   build:
     name: macOS App Bundle
     runs-on: macos-10.15

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -14,6 +14,8 @@ on:
       - '**.bat'
       - '**.py'
       - '**.sh'
+      - '!installers/**'
+      - '!.github/workflows/installer*.yml'
 
   pull_request:
     branches:
@@ -28,6 +30,8 @@ on:
       - '**.bat'
       - '**.py'
       - '**.sh'
+      - '!installers/**'
+      - '!.github/workflows/installer*.yml'
 
 jobs:
   build:

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -14,6 +14,8 @@ on:
       - '**.bat'
       - '**.py'
       - '**.sh'
+      - '!installers/**'
+      - '!.github/workflows/installer*.yml'
 
   pull_request:
     branches:
@@ -28,6 +30,8 @@ on:
       - '**.bat'
       - '**.py'
       - '**.sh'
+      - '!installers/**'
+      - '!.github/workflows/installer*.yml'
 
 jobs:
   build:

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -14,6 +14,8 @@ on:
       - '**.bat'
       - '**.py'
       - '**.sh'
+      - '!installers/**'
+      - '!.github/workflows/installer*.yml'
 
   pull_request:
     branches:
@@ -28,6 +30,8 @@ on:
       - '**.bat'
       - '**.py'
       - '**.sh'
+      - '!installers/**'
+      - '!.github/workflows/installer*.yml'
 
 jobs:
   build:


### PR DESCRIPTION
#18120 had syntax issues in the workflow file that resulted in the build job failing to start without indicating failure.
This PR remedies that.

Additionally, pytests are not run if only installer files are changed.