### PR TITLE
PR: Prevent showing monitor scale change message if auto high DPI is selected and some other fixes

### DIFF
--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -549,7 +549,12 @@ class ApplicationContainer(PluginMainContainer):
                     sys.platform == 'darwin'):
                 return
 
+            if self.get_conf('high_dpi_scaling'):
+                return
+
             if self.dpi_messagebox is not None:
+                self.dpi_messagebox.activateWindow()
+                self.dpi_messagebox.raise_()
                 return
 
             self.dpi_messagebox = MessageCheckBox(icon=QMessageBox.Warning,
@@ -590,3 +595,4 @@ class ApplicationContainer(PluginMainContainer):
             # Convert coordinates to int to avoid a TypeError in Python 3.10
             # Fixes spyder-ide/spyder#17677
             self.dpi_messagebox.move(int(x), int(y))
+            self.dpi_messagebox.adjustSize()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

* Try to ensure the window scale change dialog is always in top to prevent blocking the main window
* Fix checkbox position overlaping other content or not being placed correctly
* Don't show editor scale change if auto high DPI is selected


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14883 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
