### PR TITLE
PR: Don't connect Qt signals to the `emit` method of others to avoid segfaults

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2287,7 +2287,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                 if ipyconsole:
                     current_sw = ipyconsole.get_current_shellwidget()
                     current_sw.sig_prompt_ready.connect(
-                        current_editor.sig_debug_stop[()].emit)
+                        current_editor.sig_debug_stop[()])
                     current_pdb_state = ipyconsole.get_pdb_state()
                     pdb_last_step = ipyconsole.get_pdb_last_step()
                     self.update_pdb_state(current_pdb_state, pdb_last_step)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4423,45 +4423,45 @@ class CodeEditor(TextEditBaseWidget):
         self.run_cell_action = create_action(
             self, _("Run cell"), icon=ima.icon('run_cell'),
             shortcut=CONF.get_shortcut('editor', 'run cell'),
-            triggered=self.sig_run_cell.emit)
+            triggered=self.sig_run_cell)
         self.run_cell_and_advance_action = create_action(
             self, _("Run cell and advance"), icon=ima.icon('run_cell_advance'),
             shortcut=CONF.get_shortcut('editor', 'run cell and advance'),
-            triggered=self.sig_run_cell_and_advance.emit)
+            triggered=self.sig_run_cell_and_advance)
         self.re_run_last_cell_action = create_action(
             self, _("Re-run last cell"),
             shortcut=CONF.get_shortcut('editor', 're-run last cell'),
-            triggered=self.sig_re_run_last_cell.emit)
+            triggered=self.sig_re_run_last_cell)
         self.run_selection_action = create_action(
             self, _("Run &selection or current line"),
             icon=ima.icon('run_selection'),
             shortcut=CONF.get_shortcut('editor', 'run selection'),
-            triggered=self.sig_run_selection.emit)
+            triggered=self.sig_run_selection)
         self.run_to_line_action = create_action(
             self, _("Run to current line"),
             shortcut=CONF.get_shortcut('editor', 'run to line'),
-            triggered=self.sig_run_to_line.emit)
+            triggered=self.sig_run_to_line)
         self.run_from_line_action = create_action(
             self, _("Run from current line"),
             shortcut=CONF.get_shortcut('editor', 'run from line'),
-            triggered=self.sig_run_from_line.emit)
+            triggered=self.sig_run_from_line)
         self.debug_cell_action = create_action(
             self, _("Debug cell"), icon=ima.icon('debug_cell'),
             shortcut=CONF.get_shortcut('editor', 'debug cell'),
-            triggered=self.sig_debug_cell.emit)
+            triggered=self.sig_debug_cell)
 
         # Zoom actions
         zoom_in_action = create_action(
             self, _("Zoom in"), icon=ima.icon('zoom_in'),
             shortcut=QKeySequence(QKeySequence.ZoomIn),
-            triggered=self.zoom_in.emit)
+            triggered=self.zoom_in)
         zoom_out_action = create_action(
             self, _("Zoom out"), icon=ima.icon('zoom_out'),
             shortcut=QKeySequence(QKeySequence.ZoomOut),
-            triggered=self.zoom_out.emit)
+            triggered=self.zoom_out)
         zoom_reset_action = create_action(
             self, _("Zoom reset"), shortcut=QKeySequence("Ctrl+0"),
-            triggered=self.zoom_reset.emit)
+            triggered=self.zoom_reset)
 
         # Docstring
         writer = self.writer_docstring

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2498,7 +2498,7 @@ class EditorStack(QWidget):
         editor.sig_debug_cell.connect(self.debug_cell)
         editor.sig_run_cell_and_advance.connect(self.run_cell_and_advance)
         editor.sig_re_run_last_cell.connect(self.re_run_last_cell)
-        editor.sig_new_file.connect(self.sig_new_file.emit)
+        editor.sig_new_file.connect(self.sig_new_file)
         editor.sig_breakpoints_saved.connect(self.sig_breakpoints_saved)
         editor.sig_process_code_analysis.connect(
             lambda: self.update_code_analysis_actions.emit())
@@ -2577,8 +2577,8 @@ class EditorStack(QWidget):
         editor.zoom_reset.connect(lambda: self.zoom_reset.emit())
         editor.sig_eol_chars_changed.connect(
             lambda eol_chars: self.refresh_eol_chars(eol_chars))
-        editor.sig_next_cursor.connect(self.sig_next_cursor.emit)
-        editor.sig_prev_cursor.connect(self.sig_prev_cursor.emit)
+        editor.sig_next_cursor.connect(self.sig_next_cursor)
+        editor.sig_prev_cursor.connect(self.sig_prev_cursor)
 
         self.find_widget.set_editor(editor)
 

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -550,9 +550,9 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         """
         self.sig_free_memory_requested.emit()
         QTimer.singleShot(self.INITIAL_FREE_MEMORY_TIME_TRIGGER,
-                          self.sig_free_memory_requested.emit)
+                          self.sig_free_memory_requested)
         QTimer.singleShot(self.SECONDARY_FREE_MEMORY_TIME_TRIGGER,
-                          self.sig_free_memory_requested.emit)
+                          self.sig_free_memory_requested)
 
     def resize_rows(self):
         self._current_editor.resizeRowsToContents()

--- a/spyder/widgets/dock.py
+++ b/spyder/widgets/dock.py
@@ -170,7 +170,7 @@ class DockTitleBar(QWidget):
             f"background-color: {QStylePalette.COLOR_BACKGROUND_3}")
 
         close_button = CloseButton(self, button_size)
-        close_button.clicked.connect(parent.sig_plugin_closed.emit)
+        close_button.clicked.connect(parent.sig_plugin_closed)
 
         hlayout = QHBoxLayout(self)
         hlayout.setSpacing(0)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
connecting a Signal to another signal's emit method might lead to a segfault. The signals must be connected directly.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
