### PR TITLE
PR: Fix issue where micromamba activation script was not properly executed.

### DIFF
--- a/spyder/plugins/ipythonconsole/scripts/conda-activate.bat
+++ b/spyder/plugins/ipythonconsole/scripts/conda-activate.bat
@@ -13,10 +13,15 @@ chcp 65001>nul
 :: Activate kernel environment
 echo %CONDA_ACTIVATE_SCRIPT%| findstr /e "micromamba.exe">Nul && (
     for /f %%i in ('%CONDA_ACTIVATE_SCRIPT% shell activate %CONDA_ENV_PATH%') do set SCRIPT=%%i
-    call %SCRIPT%
-) || (
-    call %CONDA_ACTIVATE_SCRIPT% %CONDA_ENV_PATH%
+    goto micromamba
 )
 
-:: Start kernel
+:: Activate using conda
+call %CONDA_ACTIVATE_SCRIPT% %CONDA_ENV_PATH%
+goto start
+
+:micromamba Activate using micromamba
+call %SCRIPT%
+
+:start Start kernel
 %CONDA_ENV_PYTHON% -m spyder_kernels.console -f %SPYDER_KERNEL_SPEC%

--- a/spyder/plugins/ipythonconsole/scripts/conda-activate.bat
+++ b/spyder/plugins/ipythonconsole/scripts/conda-activate.bat
@@ -11,17 +11,16 @@ set SPYDER_KERNEL_SPEC=%4
 chcp 65001>nul
 
 :: Activate kernel environment
-echo %CONDA_ACTIVATE_SCRIPT%| findstr /e "micromamba.exe">Nul && (
-    for /f %%i in ('%CONDA_ACTIVATE_SCRIPT% shell activate %CONDA_ENV_PATH%') do set SCRIPT=%%i
-    goto micromamba
-)
-
-:: Activate using conda
-call %CONDA_ACTIVATE_SCRIPT% %CONDA_ENV_PATH%
-goto start
+echo %CONDA_ACTIVATE_SCRIPT%| findstr /e "micromamba.exe">Nul && goto micromamba || goto conda
 
 :micromamba Activate using micromamba
+for /f %%i in ('%CONDA_ACTIVATE_SCRIPT% shell activate %CONDA_ENV_PATH%') do set SCRIPT=%%i
 call %SCRIPT%
+goto start
+
+:conda Activate using conda
+call %CONDA_ACTIVATE_SCRIPT% %CONDA_ENV_PATH%
+goto start
 
 :start Start kernel
 %CONDA_ENV_PYTHON% -m spyder_kernels.console -f %SPYDER_KERNEL_SPEC%


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Windows batch scripts do not expand variables inside logic statements if the variable is assigned inside the logic statement. Thus the micromamba activation script was not executed and the environment was not activated. The call to the activation script is moved outside the logic statement, so now it is executed and the environment is properly activated.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #18003


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary

<!--- Thanks for your help making Spyder better for everyone! --->
