### PR TITLE
PR: Show environment variables for all operating systems and modernize `spyder.utils.environ` module

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -466,13 +466,8 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
             try:
                 context = '_'
                 name = 'switch to {}'.format(plugin.CONF_SECTION)
-                shortcut = self.get_shortcut(
-                    name,
-                    context,
-                    plugin_name=plugin.CONF_SECTION
-                )
             except (cp.NoSectionError, cp.NoOptionError):
-                shortcut = None
+                pass
 
             sc = QShortcut(QKeySequence(), self,
                            lambda: self.switch_to_plugin(plugin))
@@ -844,28 +839,30 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
 
         # Switcher shortcuts
         self.file_switcher_action = create_action(
-                                    self,
-                                    _('File switcher...'),
-                                    icon=ima.icon('filelist'),
-                                    tip=_('Fast switch between files'),
-                                    triggered=self.open_switcher,
-                                    context=Qt.ApplicationShortcut,
-                                    id_='file_switcher')
+            self,
+            _('File switcher...'),
+            icon=ima.icon('filelist'),
+            tip=_('Fast switch between files'),
+            triggered=self.open_switcher,
+            context=Qt.ApplicationShortcut,
+            id_='file_switcher'
+        )
         self.register_shortcut(self.file_switcher_action, context="_",
                                name="File switcher")
         self.symbol_finder_action = create_action(
-                                    self, _('Symbol finder...'),
-                                    icon=ima.icon('symbol_find'),
-                                    tip=_('Fast symbol search in file'),
-                                    triggered=self.open_symbolfinder,
-                                    context=Qt.ApplicationShortcut,
-                                    id_='symbol_finder')
+            self, _('Symbol finder...'),
+            icon=ima.icon('symbol_find'),
+            tip=_('Fast symbol search in file'),
+            triggered=self.open_symbolfinder,
+            context=Qt.ApplicationShortcut,
+            id_='symbol_finder'
+        )
         self.register_shortcut(self.symbol_finder_action, context="_",
                                name="symbol finder", add_shortcut_to_tip=True)
 
         def create_edit_action(text, tr_text, icon):
             textseq = text.split(' ')
-            method_name = textseq[0].lower()+"".join(textseq[1:])
+            method_name = textseq[0].lower() + "".join(textseq[1:])
             action = create_action(self, tr_text,
                                    icon=icon,
                                    triggered=self.global_callback,
@@ -901,10 +898,11 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         ]
         for switcher_action in switcher_actions:
             mainmenu.add_item_to_application_menu(
-                    switcher_action,
-                    menu_id=ApplicationMenus.File,
-                    section=FileMenuSections.Switcher,
-                    before_section=FileMenuSections.Restart)
+                switcher_action,
+                menu_id=ApplicationMenus.File,
+                section=FileMenuSections.Switcher,
+                before_section=FileMenuSections.Restart
+            )
         self.set_splash("")
 
         # Toolbars
@@ -1324,7 +1322,7 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
     def update_edit_menu(self):
         """Update edit menu"""
         widget, textedit_properties = self.get_focus_widget_properties()
-        if textedit_properties is None: # widget is not an editor/console
+        if textedit_properties is None:  # widget is not an editor/console
             return
         # !!! Below this line, widget is expected to be a QPlainTextEdit
         #     instance
@@ -1343,10 +1341,10 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         self.selectall_action.setEnabled(True)
 
         # Undo, redo
-        self.undo_action.setEnabled( readwrite_editor \
-                                     and widget.document().isUndoAvailable() )
-        self.redo_action.setEnabled( readwrite_editor \
-                                     and widget.document().isRedoAvailable() )
+        self.undo_action.setEnabled(readwrite_editor
+                                    and widget.document().isUndoAvailable())
+        self.redo_action.setEnabled(readwrite_editor
+                                    and widget.document().isRedoAvailable())
 
         # Copy, cut, paste, delete
         has_selection = widget.has_selected_text()
@@ -1369,7 +1367,7 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
             child.setEnabled(False)
 
         widget, textedit_properties = self.get_focus_widget_properties()
-        if textedit_properties is None: # widget is not an editor/console
+        if textedit_properties is None:  # widget is not an editor/console
             return
 
         # !!! Below this line, widget is expected to be a QPlainTextEdit
@@ -1513,8 +1511,9 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
                     )
                 pypath = self.get_conf('spyder_pythonpath', default=None)
                 programs.run_python_script_in_terminal(
-                        fname, wdir, args, interact, debug, python_args,
-                        executable, pypath)
+                    fname, wdir, args, interact, debug, python_args,
+                    executable, pypath
+                )
             except NotImplementedError:
                 QMessageBox.critical(self, _("Run"),
                                      _("Running an external system terminal "
@@ -1956,11 +1955,13 @@ def main(options, args):
         else:
             mainwindow = create_window(MainWindow, app, splash, options, args)
     except FontError:
-        QMessageBox.information(None, "Spyder",
-                "Spyder was unable to load the <i>Spyder 3</i> "
-                "icon theme. That's why it's going to fallback to the "
-                "theme used in Spyder 2.<br><br>"
-                "For that, please close this window and start Spyder again.")
+        QMessageBox.information(
+            None, "Spyder",
+            "Spyder was unable to load the <i>Spyder 3</i> "
+            "icon theme. That's why it's going to fallback to the "
+            "theme used in Spyder 2.<br><br>"
+            "For that, please close this window and start Spyder again."
+        )
         CONF.set('appearance', 'icon_theme', 'spyder 2')
     if mainwindow is None:
         # An exception occurred

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -926,11 +926,8 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
             triggered=self.show_path_manager,
             tip=_("PYTHONPATH manager"),
             id_='spyder_path_action')
-        from spyder.plugins.application.container import (
-            ApplicationActions, WinUserEnvDialog)
-        winenv_action = None
-        if WinUserEnvDialog:
-            winenv_action = ApplicationActions.SpyderWindowsEnvVariables
+        from spyder.plugins.application.container import ApplicationActions
+        winenv_action = ApplicationActions.SpyderWindowsEnvVariables
         mainmenu.add_item_to_application_menu(
             spyder_path_action,
             menu_id=ApplicationMenus.Tools,

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -927,7 +927,7 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
             tip=_("PYTHONPATH manager"),
             id_='spyder_path_action')
         from spyder.plugins.application.container import ApplicationActions
-        user_env_action = ApplicationActions.SpyderWindowsEnvVariables
+        user_env_action = ApplicationActions.SpyderUserEnvVariables
         mainmenu.add_item_to_application_menu(
             spyder_path_action,
             menu_id=ApplicationMenus.Tools,

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -927,12 +927,12 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
             tip=_("PYTHONPATH manager"),
             id_='spyder_path_action')
         from spyder.plugins.application.container import ApplicationActions
-        winenv_action = ApplicationActions.SpyderWindowsEnvVariables
+        user_env_action = ApplicationActions.SpyderWindowsEnvVariables
         mainmenu.add_item_to_application_menu(
             spyder_path_action,
             menu_id=ApplicationMenus.Tools,
             section=ToolsMenuSections.Tools,
-            before=winenv_action,
+            before=user_env_action,
             before_section=ToolsMenuSections.External
         )
 

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -172,7 +172,7 @@ class ApplicationContainer(PluginMainContainer):
         else:
             tip = ("Show current user environment "
                    "variables (i.e. for all sessions)")
-        self.winenv_action = self.create_action(
+        self.user_env_action = self.create_action(
             ApplicationActions.SpyderWindowsEnvVariables,
             _("Current user environment variables..."),
             icon=self.create_icon('win_env'),

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -66,7 +66,7 @@ class ApplicationActions:
     SpyderAbout = "spyder_about_action"
 
     # Tools
-    SpyderWindowsEnvVariables = "spyder_windows_env_variables_action"
+    SpyderUserEnvVariables = "spyder_user_env_variables_action"
 
     # File
     # The name of the action needs to match the name of the shortcut
@@ -173,7 +173,7 @@ class ApplicationContainer(PluginMainContainer):
             tip = ("Show current user environment "
                    "variables (i.e. for all sessions)")
         self.user_env_action = self.create_action(
-            ApplicationActions.SpyderWindowsEnvVariables,
+            ApplicationActions.SpyderUserEnvVariables,
             _("Current user environment variables..."),
             icon=self.create_icon('win_env'),
             tip=_(tip),

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -177,7 +177,7 @@ class ApplicationContainer(PluginMainContainer):
             _("Current user environment variables..."),
             icon=self.create_icon('environment'),
             tip=_(tip),
-            triggered=self.show_windows_env_variables)
+            triggered=self.show_user_env_variables)
 
         # Application base actions
         self.restart_action = self.create_action(
@@ -235,7 +235,7 @@ class ApplicationContainer(PluginMainContainer):
         abt.show()
 
     @Slot()
-    def show_windows_env_variables(self):
+    def show_user_env_variables(self):
         """Show Windows current user environment variables."""
         self.dialog_manager.show(UserEnvDialog(self))
 

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -175,7 +175,7 @@ class ApplicationContainer(PluginMainContainer):
         self.user_env_action = self.create_action(
             ApplicationActions.SpyderUserEnvVariables,
             _("Current user environment variables..."),
-            icon=self.create_icon('win_env'),
+            icon=self.create_icon('environment'),
             tip=_(tip),
             triggered=self.show_windows_env_variables)
 

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -31,16 +31,12 @@ from spyder.config.base import (get_conf_path, get_debug_level, is_pynsist,
                                 running_in_mac_app)
 from spyder.plugins.application.widgets.status import ApplicationUpdateStatus
 from spyder.plugins.console.api import ConsoleActions
+from spyder.utils.environ import UserEnvDialog
 from spyder.utils.qthelpers import start_file, DialogManager
 from spyder.widgets.about import AboutDialog
 from spyder.widgets.dependencies import DependenciesDialog
 from spyder.widgets.helperwidgets import MessageCheckBox
 from spyder.workers.updates import WorkerUpdates
-
-
-WinUserEnvDialog = None
-if os.name == 'nt':
-    from spyder.utils.environ import WinUserEnvDialog
 
 # Localization
 _ = get_translation('spyder')
@@ -170,17 +166,18 @@ class ApplicationContainer(PluginMainContainer):
             menurole=QAction.AboutRole)
 
         # Tools actions
-        if WinUserEnvDialog is not None:
-            self.winenv_action = self.create_action(
-                ApplicationActions.SpyderWindowsEnvVariables,
-                _("Current user environment variables..."),
-                icon=self.create_icon('win_env'),
-                tip=_("Show and edit current user environment "
-                      "variables in Windows registry "
-                      "(i.e. for all sessions)"),
-                triggered=self.show_windows_env_variables)
+        if os.name == 'nt':
+            tip = ("Show and edit current user environment variables in "
+                   "Windows registry (i.e. for all sessions)")
         else:
-            self.winenv_action = None
+            tip = ("Show current user environment "
+                   "variables (i.e. for all sessions)")
+        self.winenv_action = self.create_action(
+            ApplicationActions.SpyderWindowsEnvVariables,
+            _("Current user environment variables..."),
+            icon=self.create_icon('win_env'),
+            tip=_(tip),
+            triggered=self.show_windows_env_variables)
 
         # Application base actions
         self.restart_action = self.create_action(
@@ -240,7 +237,7 @@ class ApplicationContainer(PluginMainContainer):
     @Slot()
     def show_windows_env_variables(self):
         """Show Windows current user environment variables."""
-        self.dialog_manager.show(WinUserEnvDialog(self))
+        self.dialog_manager.show(UserEnvDialog(self))
 
     # ---- Updates
     # -------------------------------------------------------------------------

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -167,11 +167,11 @@ class ApplicationContainer(PluginMainContainer):
 
         # Tools actions
         if os.name == 'nt':
-            tip = ("Show and edit current user environment variables in "
-                   "Windows registry (i.e. for all sessions)")
+            tip = _("Show and edit current user environment variables in "
+                    "Windows registry (i.e. for all sessions)")
         else:
-            tip = ("Show current user environment variables (i.e. for all "
-                   "sessions)")
+            tip = _("Show current user environment variables (i.e. for all "
+                    "sessions)")
         self.user_env_action = self.create_action(
             ApplicationActions.SpyderUserEnvVariables,
             _("Current user environment variables..."),

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -170,8 +170,8 @@ class ApplicationContainer(PluginMainContainer):
             tip = ("Show and edit current user environment variables in "
                    "Windows registry (i.e. for all sessions)")
         else:
-            tip = ("Show current user environment "
-                   "variables (i.e. for all sessions)")
+            tip = ("Show current user environment variables (i.e. for all "
+                   "sessions)")
         self.user_env_action = self.create_action(
             ApplicationActions.SpyderUserEnvVariables,
             _("Current user environment variables..."),

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -285,7 +285,7 @@ class Application(SpyderPluginV2):
         """Add base actions and menus to the Tools menu."""
         mainmenu = self.get_plugin(Plugins.MainMenu)
         mainmenu.remove_item_from_application_menu(
-            ApplicationActions.SpyderWindowsEnvVariables,
+            ApplicationActions.SpyderUserEnvVariables,
             menu_id=ApplicationMenus.Tools)
 
         if get_debug_level() >= 2:

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -28,8 +28,7 @@ from spyder.config.base import (DEV, get_module_path, get_debug_level,
                                 running_under_pytest)
 from spyder.plugins.application.confpage import ApplicationConfigPage
 from spyder.plugins.application.container import (
-    ApplicationActions, ApplicationContainer, ApplicationPluginMenus,
-    WinUserEnvDialog)
+    ApplicationActions, ApplicationContainer, ApplicationPluginMenus)
 from spyder.plugins.console.api import ConsoleActions
 from spyder.plugins.mainmenu.api import (
     ApplicationMenus, FileMenuSections, HelpMenuSections, ToolsMenuSections)
@@ -181,11 +180,10 @@ class Application(SpyderPluginV2):
     def _populate_tools_menu(self):
         """Add base actions and menus to the Tools menu."""
         mainmenu = self.get_plugin(Plugins.MainMenu)
-        if WinUserEnvDialog is not None:
-            mainmenu.add_item_to_application_menu(
-                self.winenv_action,
-                menu_id=ApplicationMenus.Tools,
-                section=ToolsMenuSections.Tools)
+        mainmenu.add_item_to_application_menu(
+            self.winenv_action,
+            menu_id=ApplicationMenus.Tools,
+            section=ToolsMenuSections.Tools)
 
         if get_debug_level() >= 2:
             mainmenu.add_item_to_application_menu(
@@ -286,10 +284,9 @@ class Application(SpyderPluginV2):
     def _depopulate_tools_menu(self):
         """Add base actions and menus to the Tools menu."""
         mainmenu = self.get_plugin(Plugins.MainMenu)
-        if WinUserEnvDialog is not None:
-            mainmenu.remove_item_from_application_menu(
-                ApplicationActions.SpyderWindowsEnvVariables,
-                menu_id=ApplicationMenus.Tools)
+        mainmenu.remove_item_from_application_menu(
+            ApplicationActions.SpyderWindowsEnvVariables,
+            menu_id=ApplicationMenus.Tools)
 
         if get_debug_level() >= 2:
             mainmenu.remove_item_from_application_menu(

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -181,7 +181,7 @@ class Application(SpyderPluginV2):
         """Add base actions and menus to the Tools menu."""
         mainmenu = self.get_plugin(Plugins.MainMenu)
         mainmenu.add_item_to_application_menu(
-            self.winenv_action,
+            self.user_env_action,
             menu_id=ApplicationMenus.Tools,
             section=ToolsMenuSections.Tools)
 
@@ -430,9 +430,9 @@ class Application(SpyderPluginV2):
         return self.get_container().about_action
 
     @property
-    def winenv_action(self):
+    def user_env_action(self):
         """Show Spyder's Windows user env variables dialog box."""
-        return self.get_container().winenv_action
+        return self.get_container().user_env_action
 
     @property
     def restart_action(self):

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -99,7 +99,7 @@ class RemoteEnvDialog(CollectionsEditor):
 
     def __init__(self, environ, parent=None,
                  title=_("Environment variables"), readonly=True):
-        super(RemoteEnvDialog, self).__init__(parent)
+        super().__init__(parent)
         try:
             self.setup(
                 envdict2listdict(environ),
@@ -135,8 +135,7 @@ class UserEnvDialog(RemoteEnvDialog):
             title = _(r"HKEY_CURRENT_USER\Environment")
             readonly = False
 
-        super(UserEnvDialog, self).__init__(get_user_env(), parent,
-                                            title, readonly)
+        super().__init__(get_user_env(), parent, title, readonly)
 
         if os.name == 'nt':
             if parent is None:

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -98,12 +98,12 @@ class RemoteEnvDialog(CollectionsEditor):
     """Remote process environment variables dialog."""
 
     def __init__(self, environ, parent=None,
-                 title="Environment variables", readonly=True):
+                 title=_("Environment variables"), readonly=True):
         super(RemoteEnvDialog, self).__init__(parent)
         try:
             self.setup(
                 envdict2listdict(environ),
-                title=_(title),
+                title=title,
                 readonly=readonly,
                 icon=ima.icon('environ')
             )
@@ -129,10 +129,10 @@ class UserEnvDialog(RemoteEnvDialog):
     """User Environment Variables Viewer/Editor"""
 
     def __init__(self, parent=None):
-        title = "User Environment variables"
+        title = _("User Environment variables")
         readonly = True
         if os.name == 'nt':
-            title = r"HKEY_CURRENT_USER\Environment"
+            title = _(r"HKEY_CURRENT_USER\Environment")
             readonly = False
 
         super(UserEnvDialog, self).__init__(get_user_env(), parent,

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -8,6 +8,9 @@
 Environment variable utilities.
 """
 
+# TODO: Remove Python 2.x support
+# TODO: Make functions platform agnostic
+
 # Standard library imports
 import os
 

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -22,7 +22,7 @@ except Exception:
 from spyder.config.base import _
 from spyder.widgets.collectionseditor import CollectionsEditor
 from spyder.utils.icon_manager import ima
-from spyder.utils.programs import get_user_environment_variables
+from spyder.utils.programs import run_shell_command
 
 
 def envdict2listdict(envdict):
@@ -40,6 +40,30 @@ def listdict2envdict(listdict):
         if isinstance(val, list):
             listdict[key] = os.path.pathsep.join(val)
     return listdict
+
+
+def get_user_environment_variables():
+    """
+    Get user environment variables from a subprocess.
+
+    Returns
+    -------
+    env_var : dict
+        Key-value pairs of environment variables.
+    """
+    if os.name == 'nt':
+        cmd = "set"
+    else:
+        cmd = "printenv"
+    proc = run_shell_command(cmd)
+    stdout, stderr = proc.communicate()
+    res = stdout.decode().strip().split(os.linesep)
+    env_var = {}
+    for kv in res:
+        k, v = kv.split('=', 1)
+        env_var[k] = v
+
+    return env_var
 
 
 def get_user_env():

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -15,7 +15,7 @@ import os
 from qtpy.QtWidgets import QMessageBox
 try:
     import winreg
-except ImportError:
+except Exception:
     pass
 
 # Local imports
@@ -159,7 +159,7 @@ class UserEnvDialog(RemoteEnvDialog):
         """Reimplement Qt method"""
         if os.name == 'nt':
             set_user_env(listdict2envdict(self.get_value()), parent=self)
-        super(UserEnvDialog, self).accept()
+        super().accept()
 
 
 def test():

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -82,6 +82,7 @@ class RemoteEnvDialog(CollectionsEditor):
 
 class EnvDialog(RemoteEnvDialog):
     """Environment variables Dialog"""
+
     def __init__(self, parent=None):
         RemoteEnvDialog.__init__(self, dict(os.environ), parent=parent)
 
@@ -121,30 +122,35 @@ try:
             SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0,
                                "Environment", SMTO_ABORTIFHUNG, 5000)
         except Exception:
-            QMessageBox.warning(parent, _("Warning"),
-                        _("Module <b>pywin32 was not found</b>.<br>"
-                          "Please restart this Windows <i>session</i> "
-                          "(not the computer) for changes to take effect."))
+            QMessageBox.warning(
+                parent, _("Warning"),
+                _("Module <b>pywin32 was not found</b>.<br>"
+                  "Please restart this Windows <i>session</i> "
+                  "(not the computer) for changes to take effect.")
+            )
 
     class WinUserEnvDialog(CollectionsEditor):
         """Windows User Environment Variables Editor"""
+
         def __init__(self, parent=None):
             super(WinUserEnvDialog, self).__init__(parent)
             self.setup(get_user_env(),
                        title=r"HKEY_CURRENT_USER\Environment")
             if parent is None:
                 parent = self
-            QMessageBox.warning(parent, _("Warning"),
-                        _("If you accept changes, "
-                          "this will modify the current user environment "
-                          "variables directly <b>in Windows registry</b>. "
-                          "Use it with precautions, at your own risks.<br>"
-                          "<br>Note that for changes to take effect, you will "
-                          "need to restart the parent process of this applica"
-                          "tion (simply restart Spyder if you have executed it "
-                          "from a Windows shortcut, otherwise restart any "
-                          "application from which you may have executed it, "
-                          "like <i>Python(x,y) Home</i> for example)"))
+            QMessageBox.warning(
+                parent, _("Warning"),
+                _("If you accept changes, "
+                  "this will modify the current user environment "
+                  "variables directly <b>in Windows registry</b>. "
+                  "Use it with precautions, at your own risks.<br>"
+                  "<br>Note that for changes to take effect, you will "
+                  "need to restart the parent process of this applica"
+                  "tion (simply restart Spyder if you have executed it "
+                  "from a Windows shortcut, otherwise restart any "
+                  "application from which you may have executed it, "
+                  "like <i>Python(x,y) Home</i> for example)")
+            )
 
         def accept(self):
             """Reimplement Qt method"""
@@ -153,6 +159,7 @@ try:
 
 except Exception:
     pass
+
 
 def main():
     """Run Windows environment variable editor"""
@@ -164,6 +171,7 @@ def main():
         dialog = EnvDialog()
     dialog.show()
     app.exec_()
+
 
 if __name__ == "__main__":
     main()

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -10,13 +10,13 @@ Environment variable utilities.
 
 # Standard library imports
 import os
-
-# Third party imports
-from qtpy.QtWidgets import QMessageBox
 try:
     import winreg
 except Exception:
     pass
+
+# Third party imports
+from qtpy.QtWidgets import QMessageBox
 
 # Local imports
 from spyder.config.base import _
@@ -153,10 +153,10 @@ class UserEnvDialog(RemoteEnvDialog):
     """User Environment Variables Viewer/Editor"""
 
     def __init__(self, parent=None):
-        title = _("User Environment variables")
+        title = _("User environment variables")
         readonly = True
         if os.name == 'nt':
-            title = _(r"HKEY_CURRENT_USER\Environment")
+            title = _(r"User environment variables in Windows registry")
             readonly = False
 
         super().__init__(get_user_env(), parent, title, readonly)

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -32,7 +32,6 @@ import psutil
 # Local imports
 from spyder.config.base import (running_under_pytest, get_home_dir,
                                 running_in_mac_app)
-from spyder.py3compat import is_text_string, to_text_string
 from spyder.utils import encoding
 from spyder.utils.misc import get_python_executable
 
@@ -714,7 +713,7 @@ def shell_split(text):
     function (see standard library `shlex`) except that it is supporting
     unicode strings (shlex does not support unicode until Python 2.7.3).
     """
-    assert is_text_string(text)  # in case a QString is passed...
+    assert isinstance(text, str)  # in case a QString is passed...
     pattern = r'(\s+|(?<!\\)".*?(?<!\\)"|(?<!\\)\'.*?(?<!\\)\')'
     out = []
     for token in re.split(pattern, text):
@@ -1031,7 +1030,7 @@ def check_python_help(filename):
     try:
         proc = run_program(filename, ['-c', 'import this'], env={})
         stdout, _ = proc.communicate()
-        stdout = to_text_string(stdout)
+        stdout = str(stdout)
         valid_lines = [
             'Beautiful is better than ugly.',
             'Explicit is better than implicit.',

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -347,6 +347,37 @@ def get_username():
     return username
 
 
+def get_user_environment_variable(key, default=None):
+    """
+    Get user environment variable(s) from a subprocess.
+
+    Parameters
+    ----------
+    key : str
+        Name of environment variable.
+    default : str | None
+        Default value returned if `key` does not exist or is unset.
+
+    Returns
+    -------
+    val : str | None
+        Value of the environment variable. If the environment variable does
+        not exist or is unset, the value of `default` is returned.
+
+    """
+    if os.name == 'nt':
+        cmd = f"echo %{key}%"
+    else:
+        cmd = f"echo ${key}"
+    proc = run_shell_command(cmd)
+    stdout, stderr = proc.communicate()
+    val = stdout.decode().strip()
+    if val:
+        return val
+    else:
+        return default
+
+
 def _get_win_reg_info(key_path, hive, flag, subkeys):
     """
     See: https://stackoverflow.com/q/53132434

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -344,30 +344,6 @@ def get_username():
     return username
 
 
-def get_user_environment_variables():
-    """
-    Get user environment variables from a subprocess.
-
-    Returns
-    -------
-    env_var : dict
-        Key-value pairs of environment variables.
-    """
-    if os.name == 'nt':
-        cmd = "set"
-    else:
-        cmd = "printenv"
-    proc = run_shell_command(cmd)
-    stdout, stderr = proc.communicate()
-    res = stdout.decode().strip().split(os.linesep)
-    env_var = {}
-    for kv in res:
-        k, v = kv.split('=', 1)
-        env_var[k] = v
-
-    return env_var
-
-
 def _get_win_reg_info(key_path, hive, flag, subkeys):
     """
     See: https://stackoverflow.com/q/53132434

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -347,35 +347,29 @@ def get_username():
     return username
 
 
-def get_user_environment_variable(key, default=None):
+def get_user_environment_variables():
     """
-    Get user environment variable(s) from a subprocess.
-
-    Parameters
-    ----------
-    key : str
-        Name of environment variable.
-    default : str | None
-        Default value returned if `key` does not exist or is unset.
+    Get user environment variables from a subprocess.
 
     Returns
     -------
-    val : str | None
-        Value of the environment variable. If the environment variable does
-        not exist or is unset, the value of `default` is returned.
+    env_var : dict
+        Key-value pairs of environment variables
 
     """
     if os.name == 'nt':
-        cmd = f"echo %{key}%"
+        cmd = "set"
     else:
-        cmd = f"echo ${key}"
+        cmd = "printenv"
     proc = run_shell_command(cmd)
     stdout, stderr = proc.communicate()
-    val = stdout.decode().strip()
-    if val:
-        return val
-    else:
-        return default
+    res = stdout.decode().strip().split(os.linesep)
+    env_var = {}
+    for kv in res:
+        k, v = kv.split('=', 1)
+        env_var[k] = v
+
+    return env_var
 
 
 def _get_win_reg_info(key_path, hive, flag, subkeys):

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -351,8 +351,7 @@ def get_user_environment_variables():
     Returns
     -------
     env_var : dict
-        Key-value pairs of environment variables
-
+        Key-value pairs of environment variables.
     """
     if os.name == 'nt':
         cmd = "set"

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -696,8 +696,7 @@ def run_python_script(package=None, module=None, args=[], p_args=[]):
     package=None -> module is in sys.path (standard library modules)
     """
     assert module is not None
-    assert (isinstance(args, (tuple, list))
-            and isinstance(p_args, (tuple, list)))
+    assert isinstance(args, (tuple, list)) and isinstance(p_args, (tuple, list))
     path = python_script_exists(package, module)
     run_program(sys.executable, p_args + [path] + args)
 

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -139,7 +139,7 @@ def find_program(basename):
         # Windows platforms
         extensions = ('.exe', '.bat', '.cmd')
         if not basename.endswith(extensions):
-            names = [basename+ext for ext in extensions]+[basename]
+            names = [basename + ext for ext in extensions] + [basename]
     for name in names:
         path = is_program_installed(name)
         if path:
@@ -222,9 +222,8 @@ def run_shell_command(cmdstr, **subprocess_kwargs):
     :subprocess_kwargs: These will be passed to subprocess.Popen.
     """
     if 'shell' in subprocess_kwargs and not subprocess_kwargs['shell']:
-        raise ProgramError(
-                'The "shell" kwarg may be omitted, but if '
-                'provided it must be True.')
+        raise ProgramError('The "shell" kwarg may be omitted, but if '
+                           'provided it must be True.')
     else:
         subprocess_kwargs['shell'] = True
 
@@ -238,7 +237,7 @@ def run_shell_command(cmdstr, **subprocess_kwargs):
     for stream in ['stdin', 'stdout', 'stderr']:
         subprocess_kwargs.setdefault(stream, subprocess.PIPE)
     subprocess_kwargs = alter_subprocess_kwargs_by_platform(
-            **subprocess_kwargs)
+        **subprocess_kwargs)
     return subprocess.Popen(cmdstr, **subprocess_kwargs)
 
 
@@ -265,9 +264,8 @@ def run_program(program, args=None, **subprocess_kwargs):
     :subprocess_kwargs: These will be passed to subprocess.Popen.
     """
     if 'shell' in subprocess_kwargs and subprocess_kwargs['shell']:
-        raise ProgramError(
-                "This function is only for non-shell programs, "
-                "use run_shell_command() instead.")
+        raise ProgramError("This function is only for non-shell programs, "
+                           "use run_shell_command() instead.")
     fullcmd = find_program(program)
     if not fullcmd:
         raise ProgramError("Program %s was not found" % program)
@@ -276,7 +274,7 @@ def run_program(program, args=None, **subprocess_kwargs):
     for stream in ['stdin', 'stdout', 'stderr']:
         subprocess_kwargs.setdefault(stream, subprocess.PIPE)
     subprocess_kwargs = alter_subprocess_kwargs_by_platform(
-            **subprocess_kwargs)
+        **subprocess_kwargs)
     return subprocess.Popen(fullcmd, **subprocess_kwargs)
 
 
@@ -683,7 +681,7 @@ def python_script_exists(package=None, module=None):
     else:
         spec = importlib.util.find_spec(package)
         if spec:
-            path = osp.join(spec.origin, module)+'.py'
+            path = osp.join(spec.origin, module) + '.py'
         else:
             path = None
     if path:
@@ -699,7 +697,8 @@ def run_python_script(package=None, module=None, args=[], p_args=[]):
     package=None -> module is in sys.path (standard library modules)
     """
     assert module is not None
-    assert isinstance(args, (tuple, list)) and isinstance(p_args, (tuple, list))
+    assert (isinstance(args, (tuple, list))
+            and isinstance(p_args, (tuple, list)))
     path = python_script_exists(package, module)
     run_program(sys.executable, p_args + [path] + args)
 
@@ -984,7 +983,7 @@ def is_python_interpreter(filename):
     real_filename = os.path.realpath(filename)  # To follow symlink if existent
 
     if (not osp.isfile(real_filename) or
-        not is_python_interpreter_valid_name(real_filename)):
+            not is_python_interpreter_valid_name(real_filename)):
         return False
 
     # File exists and has valid name

--- a/spyder/utils/tests/test_environ.py
+++ b/spyder/utils/tests/test_environ.py
@@ -26,14 +26,10 @@ from spyder.utils.environ import clean_env
 
 @pytest.fixture
 def environ_dialog(qtbot):
-    "Setup the Environment variables Dialog taking into account the os."
+    "Setup the Environment variables Dialog."
     QTimer.singleShot(1000, lambda: close_message_box(qtbot))
-    if os.name == 'nt':
-        from spyder.utils.environ import WinUserEnvDialog
-        dialog = WinUserEnvDialog()
-    else:
-        from spyder.utils.environ import EnvDialog
-        dialog = EnvDialog()
+    from spyder.utils.environ import UserEnvDialog
+    dialog = UserEnvDialog()
     qtbot.addWidget(dialog)
 
     return dialog

--- a/spyder/utils/tests/test_environ.py
+++ b/spyder/utils/tests/test_environ.py
@@ -15,6 +15,7 @@ import pytest
 from qtpy.QtCore import QTimer
 
 # Local imports
+from spyder.utils.environ import get_user_environment_variables, UserEnvDialog
 from spyder.utils.test import close_message_box
 
 
@@ -22,11 +23,19 @@ from spyder.utils.test import close_message_box
 def environ_dialog(qtbot):
     "Setup the Environment variables Dialog."
     QTimer.singleShot(1000, lambda: close_message_box(qtbot))
-    from spyder.utils.environ import UserEnvDialog
     dialog = UserEnvDialog()
     qtbot.addWidget(dialog)
 
     return dialog
+
+
+def test_get_user_environment_variables():
+    """Test get_user_environment_variables function"""
+
+    # All platforms should have a path environment variable, but
+    # Windows may have mixed case.
+    keys = {k.lower() for k in get_user_environment_variables()}
+    assert "path" in keys
 
 
 def test_environ(environ_dialog, qtbot):

--- a/spyder/utils/tests/test_environ.py
+++ b/spyder/utils/tests/test_environ.py
@@ -10,7 +10,6 @@ Tests for environ.py
 
 # Standard library imports
 import os
-import subprocess
 
 # Test library imports
 import pytest

--- a/spyder/utils/tests/test_environ.py
+++ b/spyder/utils/tests/test_environ.py
@@ -8,9 +8,6 @@
 Tests for environ.py
 """
 
-# Standard library imports
-import os
-
 # Test library imports
 import pytest
 
@@ -18,9 +15,7 @@ import pytest
 from qtpy.QtCore import QTimer
 
 # Local imports
-from spyder.py3compat import PY3
 from spyder.utils.test import close_message_box
-from spyder.utils.environ import clean_env
 
 
 @pytest.fixture
@@ -38,21 +33,6 @@ def test_environ(environ_dialog, qtbot):
     """Test the environment variables dialog."""
     environ_dialog.show()
     assert environ_dialog
-
-
-@pytest.mark.skipif(
-    PY3 or os.name == 'nt',
-    reason=("This tests only applies to Python 2."),
-)
-def test_clean_env():
-    env = {
-        'foo': '/foo/bar/測試',
-        'bar': '/spam',
-        'PYTHONPATH': u'\u6e2c\u8a66',
-    }
-    new_env = clean_env(env)
-    assert new_env['foo'] == '/foo/bar/\xe6\xb8\xac\xe8\xa9\xa6'
-    assert new_env['PYTHONPATH'] == '\xe6\xb8\xac\xe8\xa9\xa6'
 
 
 if __name__ == "__main__":

--- a/spyder/utils/tests/test_environ.py
+++ b/spyder/utils/tests/test_environ.py
@@ -34,6 +34,11 @@ def test_environ(environ_dialog, qtbot):
     environ_dialog.show()
     assert environ_dialog
 
+    # All platforms should have a path environment variable, but
+    # Windows may have mixed case.
+    keys = {k.lower() for k in environ_dialog.get_value()}
+    assert "path" in keys
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -1516,7 +1516,12 @@ class CollectionsEditor(BaseDialog):
         if icon is None:
             self.setWindowIcon(ima.icon('dictedit'))
 
-        self.setWindowFlags(Qt.Window)
+        if sys.platform == 'darwin':
+            # See spyder-ide/spyder#9051
+            self.setWindowFlags(Qt.Tool)
+        else:
+            # Make the dialog act as a window
+            self.setWindowFlags(Qt.Window)
 
     @Slot()
     def save_and_close_enable(self):

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -144,7 +144,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
         self.total_rows = None
         self.showndata = None
         self.keys = None
-        self.title = to_text_string(title) # in case title is not a string
+        self.title = to_text_string(title)  # in case title is not a string
         if self.title:
             self.title = self.title + ' - '
         self.sizes = []
@@ -345,13 +345,13 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
     def get_value(self, index):
         """Return current value"""
         if index.column() == 0:
-            return self.keys[ index.row() ]
+            return self.keys[index.row()]
         elif index.column() == 1:
-            return self.types[ index.row() ]
+            return self.types[index.row()]
         elif index.column() == 2:
-            return self.sizes[ index.row() ]
+            return self.sizes[index.row()]
         else:
-            return self._data[ self.keys[index.row()] ]
+            return self._data[self.keys[index.row()]]
 
     def get_bgcolor(self, index):
         """Background color depending on value"""
@@ -426,13 +426,13 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
         elif role == Qt.TextAlignmentRole:
             if index.column() == 3:
                 if len(display.splitlines()) < 3:
-                    return to_qvariant(int(Qt.AlignLeft|Qt.AlignVCenter))
+                    return to_qvariant(int(Qt.AlignLeft | Qt.AlignVCenter))
                 else:
-                    return to_qvariant(int(Qt.AlignLeft|Qt.AlignTop))
+                    return to_qvariant(int(Qt.AlignLeft | Qt.AlignTop))
             else:
-                return to_qvariant(int(Qt.AlignLeft|Qt.AlignVCenter))
+                return to_qvariant(int(Qt.AlignLeft | Qt.AlignVCenter))
         elif role == Qt.BackgroundColorRole:
-            return to_qvariant( self.get_bgcolor(index) )
+            return to_qvariant(self.get_bgcolor(index))
         elif role == Qt.FontRole:
             return to_qvariant(get_font(font_size_delta=DEFAULT_SMALL_DELTA))
         return to_qvariant()
@@ -445,7 +445,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel):
         if orientation == Qt.Horizontal:
             headers = (self.header0, _("Type"), _("Size"), _("Value"),
                        _("Score"))
-            return to_qvariant( headers[i_column] )
+            return to_qvariant(headers[i_column])
         else:
             return to_qvariant()
 
@@ -468,8 +468,8 @@ class CollectionsModel(ReadOnlyCollectionsModel):
 
     def set_value(self, index, value):
         """Set value"""
-        self._data[ self.keys[index.row()] ] = value
-        self.showndata[ self.keys[index.row()] ] = value
+        self._data[self.keys[index.row()]] = value
+        self.showndata[self.keys[index.row()]] = value
         self.sizes[index.row()] = get_size(value)
         self.types[index.row()] = get_human_readable_type(value)
         self.sig_setting_data.emit()
@@ -642,13 +642,17 @@ class BaseTableView(QTableView, SpyderConfigurationAccessor):
         self.edit_action = create_action(self, _("Edit"),
                                          icon=ima.icon('edit'),
                                          triggered=self.edit_item)
-        self.plot_action = create_action(self, _("Plot"),
-                                    icon=ima.icon('plot'),
-                                    triggered=lambda: self.plot_item('plot'))
+        self.plot_action = create_action(
+            self, _("Plot"),
+            icon=ima.icon('plot'),
+            triggered=lambda: self.plot_item('plot')
+        )
         self.plot_action.setVisible(False)
-        self.hist_action = create_action(self, _("Histogram"),
-                                    icon=ima.icon('hist'),
-                                    triggered=lambda: self.plot_item('hist'))
+        self.hist_action = create_action(
+            self, _("Histogram"),
+            icon=ima.icon('hist'),
+            triggered=lambda: self.plot_item('hist')
+        )
         self.hist_action.setVisible(False)
         self.imshow_action = create_action(self, _("Show image"),
                                            icon=ima.icon('imshow'),
@@ -719,7 +723,6 @@ class BaseTableView(QTableView, SpyderConfigurationAccessor):
         )
 
         return menu
-
 
     # ------ Remote/local API -------------------------------------------------
     def remove_values(self, keys):
@@ -1133,7 +1136,7 @@ class BaseTableView(QTableView, SpyderConfigurationAccessor):
         except:
             try:
                 if 'matplotlib' not in sys.modules:
-                    import matplotlib
+                    import matplotlib  # noqa
                 return True
             except Exception:
                 QMessageBox.warning(self, _("Import error"),
@@ -1187,11 +1190,11 @@ class BaseTableView(QTableView, SpyderConfigurationAccessor):
         self.redirect_stdio.emit(False)
         filename, _selfilter = getsavefilename(self, title,
                                                self.array_filename,
-                                               _("NumPy arrays")+" (*.npy)")
+                                               _("NumPy arrays") + " (*.npy)")
         self.redirect_stdio.emit(True)
         if filename:
             self.array_filename = filename
-            data = self.delegate.get_value( self.currentIndex() )
+            data = self.delegate.get_value(self.currentIndex())
             try:
                 import numpy as np
                 np.save(self.array_filename, data)
@@ -1278,6 +1281,7 @@ class BaseTableView(QTableView, SpyderConfigurationAccessor):
 
 class CollectionsEditorTableView(BaseTableView):
     """CollectionsEditor table view"""
+
     def __init__(self, parent, data, readonly=False, title="",
                  names=False):
         BaseTableView.__init__(self, parent)
@@ -1373,7 +1377,7 @@ class CollectionsEditorTableView(BaseTableView):
         """Edit item"""
         data = self.source_model.get_data()
         from spyder.plugins.variableexplorer.widgets.objecteditor import (
-                oedit)
+            oedit)
         oedit(data[key])
 
     def plot(self, key, funcname):
@@ -1405,10 +1409,12 @@ class CollectionsEditorTableView(BaseTableView):
 
 class CollectionsEditorWidget(QWidget):
     """Dictionary Editor Widget"""
+
     def __init__(self, parent, data, readonly=False, title="", remote=False):
         QWidget.__init__(self, parent)
         if remote:
-            self.editor = RemoteCollectionsEditorTableView(self, data, readonly)
+            self.editor = RemoteCollectionsEditorTableView(self, data,
+                                                           readonly)
         else:
             self.editor = CollectionsEditorTableView(self, data, readonly,
                                                      title)
@@ -1438,6 +1444,7 @@ class CollectionsEditorWidget(QWidget):
 
 class CollectionsEditor(BaseDialog):
     """Collections Editor Dialog"""
+
     def __init__(self, parent=None):
         super().__init__(parent)
 
@@ -1458,11 +1465,9 @@ class CollectionsEditor(BaseDialog):
         if isinstance(data, (dict, set)):
             # dictionary, set
             self.data_copy = data.copy()
-            datalen = len(data)
         elif isinstance(data, (tuple, list)):
             # list, tuple
             self.data_copy = data[:]
-            datalen = len(data)
         else:
             # unknown object
             import copy
@@ -1473,7 +1478,6 @@ class CollectionsEditor(BaseDialog):
             except (TypeError, AttributeError):
                 readonly = True
                 self.data_copy = data
-            datalen = len(get_object_attrs(data))
 
         # If the copy has a different type, then do not allow editing, because
         # this would change the type after saving; cf. spyder-ide/spyder#6936.
@@ -1534,6 +1538,7 @@ class CollectionsEditor(BaseDialog):
 #==============================================================================
 class RemoteCollectionsDelegate(CollectionsDelegate):
     """CollectionsEditor Item Delegate"""
+
     def __init__(self, parent=None):
         CollectionsDelegate.__init__(self, parent)
 
@@ -1552,6 +1557,7 @@ class RemoteCollectionsDelegate(CollectionsDelegate):
 
 class RemoteCollectionsEditorTableView(BaseTableView):
     """DictEditor table view"""
+
     def __init__(self, parent, data, shellwidget=None, remote_editing=False,
                  create_menu=False):
         BaseTableView.__init__(self, parent)
@@ -1849,8 +1855,8 @@ def get_test_data():
             'date': testdate,
             'datetime': datetime.datetime(1945, 5, 8, 23, 1, 0, int(1.5e5)),
             'timedelta': test_timedelta,
-            'complex': 2+1j,
-            'complex64': np.complex64(2+1j),
+            'complex': 2 + 1j,
+            'complex64': np.complex64(2 + 1j),
             'complex128': np.complex128(9j),
             'int8_scalar': np.int8(8),
             'int16_scalar': np.int16(16),

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -1512,12 +1512,7 @@ class CollectionsEditor(BaseDialog):
         if icon is None:
             self.setWindowIcon(ima.icon('dictedit'))
 
-        if sys.platform == 'darwin':
-            # See spyder-ide/spyder#9051
-            self.setWindowFlags(Qt.Tool)
-        else:
-            # Make the dialog act as a window
-            self.setWindowFlags(Qt.Window)
+        self.setWindowFlags(Qt.Window)
 
     @Slot()
     def save_and_close_enable(self):

--- a/spyder/widgets/pathmanager.py
+++ b/spyder/widgets/pathmanager.py
@@ -217,6 +217,7 @@ class PathManager(QDialog):
     @Slot()
     def import_pythonpath(self):
         """Import from PYTHONPATH environment variable"""
+        # TODO: Update method for retrieving PYTHONPATH
         env_pypath = os.environ.get('PYTHONPATH', '')
 
         if env_pypath:

--- a/spyder/widgets/pathmanager.py
+++ b/spyder/widgets/pathmanager.py
@@ -23,6 +23,7 @@ from qtpy.QtWidgets import (QDialog, QDialogButtonBox, QHBoxLayout,
 
 # Local imports
 from spyder.config.base import _
+from spyder.utils.environ import get_user_env, set_user_env
 from spyder.utils.icon_manager import ima
 from spyder.utils.misc import getcwd_or_home
 from spyder.utils.qthelpers import create_toolbutton
@@ -286,31 +287,26 @@ class PathManager(QDialog):
 
         if answer == QMessageBox.Cancel:
             return
-        elif answer == QMessageBox.Yes:
-            remove = True
-        else:
-            remove = False
 
-        from spyder.utils.environ import (get_user_env, listdict2envdict,
-                                          set_user_env)
         env = get_user_env()
 
         # Includes read only paths
-        active_path = tuple(k for k, v in self.get_path_dict(True).items()
-                            if v)
+        active_path = [k for k, v in self.get_path_dict(True).items() if v]
 
-        if remove:
+        if answer == QMessageBox.Yes:
             ppath = active_path
         else:
             ppath = env.get('PYTHONPATH', [])
             if not isinstance(ppath, list):
                 ppath = [ppath]
 
-            ppath = tuple(p for p in ppath if p not in active_path)
+            ppath = [p for p in ppath if p not in active_path]
             ppath = ppath + active_path
 
+        os.environ['PYTHONPATH'] = os.pathsep.join(ppath)
+
         env['PYTHONPATH'] = list(ppath)
-        set_user_env(listdict2envdict(env), parent=self)
+        set_user_env(env, parent=self)
 
     def get_path_dict(self, read_only=False):
         """


### PR DESCRIPTION
## What this PR does

- Provides a general tool for retrieving user environment variables: `spyder.utils.programs.get_user_environment_variables`. This returns a dictionary of string values.
- Updates `spyder.util.environ` classes and functions to be platform agnostic. Most notably, `WinUserEnvDialog` is renamed `UserEnvDialog`. The associated menubar item is now available on all platforms, though these are read-only, while Windows retains the ability to modify and export to the system environment.
- Removes Python 2.x dependence in `spyder.util.environ`.

## Motivation
#17512 Introduced a feature to import the user's `PYTHONPATH` environment variable into the PYTHONPATH Manager. This relies on Spyder inheriting this variable at runtime into `os.environ`. However, it may be more desirable to retrieve this environment variable on-demand rather than rely on its state at the time of Spyder launch.
See discussion comments: 
- https://github.com/spyder-ide/spyder/pull/17512#pullrequestreview-1015511299
- https://github.com/spyder-ide/spyder/pull/17408#issuecomment-1158428364
