### PR TITLE
PR: Hide completion widget when keypress has modifiers (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4624,6 +4624,12 @@ class CodeEditor(TextEditBaseWidget):
             # Fixes spyder-ide/spyder#11021
             self._start_completion_timer()
 
+        if event.modifiers() and self.is_completion_widget_visible():
+            # Hide completion widget before passing event modifiers
+            # since the keypress could be then a shortcut
+            # See spyder-ide/spyder#14806
+            self.completion_widget.hide()
+
         if key in {Qt.Key_Up, Qt.Key_Left, Qt.Key_Right, Qt.Key_Down}:
             self.hide_tooltip()
 

--- a/spyder/plugins/editor/widgets/tests/test_completions_hide.py
+++ b/spyder/plugins/editor/widgets/tests/test_completions_hide.py
@@ -6,11 +6,17 @@
 
 """Tests some cases were completions need to be hidden."""
 
+# Standard lirary imports
+import sys
+
 # Third party imports
 from flaky import flaky
 import pytest
 
 from qtpy.QtCore import Qt
+
+# Local imports
+from spyder.config.base import running_in_ci
 
 
 @pytest.mark.slow
@@ -105,16 +111,53 @@ def test_automatic_completions_widget_visible(completions_codeeditor, qtbot):
     qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)  # newline
 
     with qtbot.waitSignal(completion.sig_show_completions,
+                          timeout=10000):
+        qtbot.keyClicks(code_editor, 'math.acosh', delay=300)
+
+    assert completion.isVisible()
+
+    qtbot.keyPress(code_editor, Qt.Key_Backspace, delay=300)
+    qtbot.wait(500)
+    assert completion.isVisible()
+
+    qtbot.keyPress(code_editor, Qt.Key_Backspace, delay=300)
+    qtbot.wait(500)
+    assert completion.isVisible()
+
+    code_editor.toggle_code_snippets(True)
+
+
+@pytest.mark.slow
+@pytest.mark.order(1)
+@flaky(max_runs=5)
+@pytest.mark.skipif(running_in_ci() and sys.platform.startswith('linux'),
+                    reason="Stalls test suite with Linux on CI")
+def test_automatic_completions_hide_on_save(completions_codeeditor, qtbot):
+    """Test on-the-fly completion closing when using save shortcut (Ctrl + S).
+
+    Regression test for issue #14806.
+    """
+    code_editor, _ = completions_codeeditor
+    completion = code_editor.completion_widget
+    code_editor.toggle_code_snippets(False)
+
+    code_editor.set_text('some = 0\nsomething = 1\n')
+    cursor = code_editor.textCursor()
+    code_editor.moveCursor(cursor.End)
+
+    # Complete some -> [some, something]
+    with qtbot.waitSignal(completion.sig_show_completions,
                           timeout=10000) as sig:
-        qtbot.keyClicks(code_editor, 'math.aco')
+        qtbot.keyClicks(code_editor, 'some')
+    assert "some" in [x['label'] for x in sig.args[0]]
+    assert "something" in [x['label'] for x in sig.args[0]]
 
-    assert completion.isVisible()
+    # Hide completion widget when saving
+    qtbot.keyPress(
+        code_editor, Qt.Key_S, modifier=Qt.ControlModifier, delay=300)
+    qtbot.waitUntil(lambda: completion.isHidden())
 
-    qtbot.keyPress(code_editor, Qt.Key_Backspace, delay=300)
-    assert completion.isVisible()
-
-    qtbot.keyPress(code_editor, Qt.Key_Backspace, delay=300)
-    assert completion.isVisible()
+    code_editor.toggle_code_snippets(True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14806


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
