### PR TITLE
PR: Catch error when it's not possible to bind a port to `open_files_server` (Main Window)

### DIFF
--- a/spyder/app/start.py
+++ b/spyder/app/start.py
@@ -81,10 +81,11 @@ def send_args_to_spyder(args):
     """
     from spyder.config.manager import CONF
     port = CONF.get('main', 'open_files_port')
+    print_warning = True
 
     # Wait ~50 secs for the server to be up
     # Taken from https://stackoverflow.com/a/4766598/438386
-    for _x in range(200):
+    for __ in range(200):
         try:
             for arg in args:
                 client = socket.socket(socket.AF_INET, socket.SOCK_STREAM,
@@ -95,6 +96,13 @@ def send_args_to_spyder(args):
                 client.send(osp.abspath(arg))
                 client.close()
         except socket.error:
+            # Print informative warning to let users know what Spyder is doing
+            if print_warning:
+                print("Waiting for the server to open files and directories "
+                      "to be up (perhaps it failed to be started).")
+                print_warning = False
+
+            # Wait 250 ms before trying again
             time.sleep(0.25)
             continue
         break
@@ -249,7 +257,7 @@ def main():
                 send_args_to_spyder(args)
             else:
                 print("Spyder is already running. If you want to open a new \n"
-                      "instance, please pass to it the --new-instance option")
+                      "instance, please use the --new-instance option")
     else:
         from spyder.app import mainwindow
         if running_under_pytest():


### PR DESCRIPTION
## Description of Changes

Also print an informative message to tell users what Spyder is doing when a second instance is trying to send files to the main instance to be opened because it could appear as hanging when the server didn't start.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #18262.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
