### PR TITLE
PR: Do not reset the frames explorer while debugging

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -5169,6 +5169,21 @@ def test_frames_explorer(main_window, qtbot):
     assert frames_browser.frames is None
     assert not postmortem_debug_action.isEnabled()
 
+    # Test that quitting resets the explorer
+    with qtbot.waitSignal(shell.executed):
+        shell.execute('%debug print()')
+
+    assert len(frames_browser.frames) == 1
+    assert list(frames_browser.frames.keys())[0] == "pdb"
+    assert not postmortem_debug_action.isEnabled()
+
+    # Restart Kernel
+    with qtbot.waitSignal(shell.sig_prompt_ready, timeout=10000):
+        shell.ipyclient.restart_kernel()
+
+    assert frames_browser.frames is None
+    assert not postmortem_debug_action.isEnabled()
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -5184,6 +5184,25 @@ def test_frames_explorer(main_window, qtbot):
     assert frames_browser.frames is None
     assert not postmortem_debug_action.isEnabled()
 
+    if os.name == 'nt':
+        # Do not test kernel crashes on window
+        return
+
+    # Test that quitting resets the explorer
+    with qtbot.waitSignal(shell.executed):
+        shell.execute('%debug print()')
+
+    assert len(frames_browser.frames) == 1
+    assert list(frames_browser.frames.keys())[0] == "pdb"
+    assert not postmortem_debug_action.isEnabled()
+
+    # Crash Kernel
+    with qtbot.waitSignal(shell.sig_prompt_ready, timeout=10000):
+        shell.execute("import ctypes; ctypes.string_at(0)")
+
+    assert frames_browser.frames is None
+    assert not postmortem_debug_action.isEnabled()
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -5139,7 +5139,6 @@ def test_frames_explorer(main_window, qtbot):
     assert list(frames_browser.frames.keys())[0] == "ZeroDivisionError"
     assert postmortem_debug_action.isEnabled()
 
-
     # Test post mortem
     with qtbot.waitSignal(shell.executed):
         frames_explorer.postmortem()

--- a/spyder/plugins/framesexplorer/widgets/framesbrowser.py
+++ b/spyder/plugins/framesexplorer/widgets/framesbrowser.py
@@ -108,6 +108,7 @@ class FramesBrowser(QWidget, SpyderWidgetMixin):
         self.execution_frames = False
         self.post_mortem = False
         self.pdb_curindex = None
+
         if self.results_browser is not None:
             self.results_browser.set_frames(frames)
             self.results_browser.set_title(title)
@@ -132,7 +133,7 @@ class FramesBrowser(QWidget, SpyderWidgetMixin):
         self.shellwidget.pdb_execute_command(command)
 
     def set_from_pdb(self, pdb_stack, curindex):
-        """Set from pdb stack"""
+        """Set frames from pdb stack"""
         self._set_frames({'pdb': pdb_stack}, _("Pdb stack"))
         self.execution_frames = True
         self.pdb_curindex = curindex
@@ -142,7 +143,7 @@ class FramesBrowser(QWidget, SpyderWidgetMixin):
         self.sig_update_actions_requested.emit()
 
     def set_from_exception(self, etype, error, tb):
-        """Set from exception"""
+        """Set frames from exception"""
         self._set_frames({etype.__name__: tb}, _("Exception occured"))
         self.post_mortem = True
         self.execution_frames = True

--- a/spyder/plugins/framesexplorer/widgets/framesbrowser.py
+++ b/spyder/plugins/framesexplorer/widgets/framesbrowser.py
@@ -76,11 +76,6 @@ class FramesBrowser(QWidget, SpyderWidgetMixin):
             return False
         return self.finder.isVisible()
 
-    def set_post_mortem_enabled(self, enabled):
-        """Enable post-mortem button."""
-        self.post_mortem = enabled
-        self.sig_update_actions_requested.emit()
-
     def setup(self):
         """
         Setup the frames browser with provided settings.
@@ -108,10 +103,14 @@ class FramesBrowser(QWidget, SpyderWidgetMixin):
 
     def _set_frames(self, frames, title):
         """Set current frames"""
+        # Reset defaults
+        self.should_clear = False
+        self.execution_frames = False
+        self.post_mortem = False
+        self.pdb_curindex = None
         if self.results_browser is not None:
             self.results_browser.set_frames(frames)
             self.results_browser.set_title(title)
-
             try:
                 self.results_browser.sig_activated.disconnect(
                     self.set_pdb_index)
@@ -134,36 +133,34 @@ class FramesBrowser(QWidget, SpyderWidgetMixin):
 
     def set_from_pdb(self, pdb_stack, curindex):
         """Set from pdb stack"""
-        self.pdb_curindex = curindex
         self._set_frames({'pdb': pdb_stack}, _("Pdb stack"))
+        self.execution_frames = True
+        self.pdb_curindex = curindex
         self.set_current_item(0, curindex)
         self.results_browser.sig_activated.connect(
             self.set_pdb_index)
-        self.execution_frames = True
-        self.should_clear = False
-        self.set_post_mortem_enabled(False)
+        self.sig_update_actions_requested.emit()
 
     def set_from_exception(self, etype, error, tb):
         """Set from exception"""
         self._set_frames({etype.__name__: tb}, _("Exception occured"))
+        self.post_mortem = True
         self.execution_frames = True
-        self.should_clear = False
-        self.set_post_mortem_enabled(True)
+        self.sig_update_actions_requested.emit()
 
     def set_from_capture_frames(self, frames):
-        """Set from pdb call"""
+        """Set from captured frames"""
         self._set_frames(frames, _("Snapshot of frames"))
-        self.execution_frames = False
-        self.should_clear = False
-        self.set_post_mortem_enabled(False)
+        self.sig_update_actions_requested.emit()
 
     def clear_if_needed(self):
         """Execution finished. Clear if it is relevant."""
         if self.should_clear:
-            self.pdb_curindex = None
+            # Do not clear if still debugging
+            if self.shellwidget.is_debugging():
+                return
             self._set_frames(None, "")
-            self.should_clear = False
-            self.set_post_mortem_enabled(False)
+            self.sig_update_actions_requested.emit()
         elif self.execution_frames:
             self.should_clear = True
         self.execution_frames = False

--- a/spyder/plugins/framesexplorer/widgets/main_widget.py
+++ b/spyder/plugins/framesexplorer/widgets/main_widget.py
@@ -257,7 +257,11 @@ class FramesExplorerWidget(ShellConnectMainWidget):
         shellwidget = widget.shellwidget
 
         widget.sig_show_namespace.disconnect(shellwidget.set_namespace_view)
-        shellwidget.sig_prompt_ready.disconnect(widget.clear_if_needed)
+        try:
+            shellwidget.sig_prompt_ready.disconnect(widget.clear_if_needed)
+        except TypeError:
+            # disconnect was called elsewhere without argument
+            pass
         shellwidget.sig_pdb_prompt_ready.disconnect(widget.clear_if_needed)
 
         shellwidget.spyder_kernel_comm.register_call_handler(

--- a/spyder/plugins/framesexplorer/widgets/main_widget.py
+++ b/spyder/plugins/framesexplorer/widgets/main_widget.py
@@ -196,6 +196,7 @@ class FramesExplorerWidget(ShellConnectMainWidget):
             FramesExplorerWidgetActions.PostMortemDebug)
         refresh_action = self.get_action(
             FramesExplorerWidgetActions.Refresh)
+
         if widget is None:
             search = False
             post_mortem = False
@@ -204,6 +205,7 @@ class FramesExplorerWidget(ShellConnectMainWidget):
             search = widget.finder_is_visible()
             post_mortem = widget.post_mortem
             is_debugging = widget.pdb_curindex is not None
+
         search_action.setChecked(search)
         postmortem_debug_action.setEnabled(post_mortem)
         refresh_action.setEnabled(not is_debugging)
@@ -257,11 +259,13 @@ class FramesExplorerWidget(ShellConnectMainWidget):
         shellwidget = widget.shellwidget
 
         widget.sig_show_namespace.disconnect(shellwidget.set_namespace_view)
+
         try:
             shellwidget.sig_prompt_ready.disconnect(widget.clear_if_needed)
         except TypeError:
             # disconnect was called elsewhere without argument
             pass
+
         shellwidget.sig_pdb_prompt_ready.disconnect(widget.clear_if_needed)
 
         shellwidget.spyder_kernel_comm.register_call_handler(

--- a/spyder/plugins/framesexplorer/widgets/main_widget.py
+++ b/spyder/plugins/framesexplorer/widgets/main_widget.py
@@ -227,7 +227,8 @@ class FramesExplorerWidget(ShellConnectMainWidget):
         widget.sig_update_actions_requested.connect(self.update_actions)
 
         widget.sig_show_namespace.connect(shellwidget.set_namespace_view)
-        shellwidget.executed.connect(widget.clear_if_needed)
+        shellwidget.sig_prompt_ready.connect(widget.clear_if_needed)
+        shellwidget.sig_pdb_prompt_ready.connect(widget.clear_if_needed)
 
         shellwidget.spyder_kernel_comm.register_call_handler(
             "show_traceback", widget.set_from_exception)
@@ -256,7 +257,8 @@ class FramesExplorerWidget(ShellConnectMainWidget):
         shellwidget = widget.shellwidget
 
         widget.sig_show_namespace.disconnect(shellwidget.set_namespace_view)
-        shellwidget.executed.disconnect(widget.clear_if_needed)
+        shellwidget.sig_prompt_ready.disconnect(widget.clear_if_needed)
+        shellwidget.sig_pdb_prompt_ready.disconnect(widget.clear_if_needed)
 
         shellwidget.spyder_kernel_comm.register_call_handler(
             "show_traceback", None)

--- a/spyder/plugins/framesexplorer/widgets/main_widget.py
+++ b/spyder/plugins/framesexplorer/widgets/main_widget.py
@@ -122,7 +122,7 @@ class FramesExplorerWidget(ShellConnectMainWidget):
             register_shortcut=True
         )
 
-        self.capture_frames_action = self.create_action(
+        capture_frames_action = self.create_action(
             FramesExplorerWidgetActions.Refresh,
             text=_("Capture frames now"),
             icon=self.create_icon('refresh'),
@@ -130,7 +130,7 @@ class FramesExplorerWidget(ShellConnectMainWidget):
             register_shortcut=True,
         )
 
-        self.postmortem_debug_action = self.create_action(
+        postmortem_debug_action = self.create_action(
             FramesExplorerWidgetActions.PostMortemDebug,
             text=_("Post-mortem debug"),
             icon=self.create_icon('debug'),
@@ -160,8 +160,8 @@ class FramesExplorerWidget(ShellConnectMainWidget):
 
         # Main toolbar
         main_toolbar = self.get_main_toolbar()
-        for item in [search_action, self.capture_frames_action,
-                     self.postmortem_debug_action]:
+        for item in [search_action, capture_frames_action,
+                     postmortem_debug_action]:
             self.add_item_to_toolbar(
                 item,
                 toolbar=main_toolbar,
@@ -171,7 +171,7 @@ class FramesExplorerWidget(ShellConnectMainWidget):
         # ---- Context menu to show when there are frames present
         self.context_menu = self.create_menu(
             FramesExplorerWidgetMenus.PopulatedContextMenu)
-        for item in [self.view_locals_action, self.capture_frames_action]:
+        for item in [self.view_locals_action, capture_frames_action]:
             self.add_item_to_menu(
                 item,
                 menu=self.context_menu,
@@ -181,7 +181,7 @@ class FramesExplorerWidget(ShellConnectMainWidget):
         # ---- Context menu when the frames explorer is empty
         self.empty_context_menu = self.create_menu(
             FramesExplorerWidgetMenus.EmptyContextMenu)
-        for item in [self.capture_frames_action]:
+        for item in [capture_frames_action]:
             self.add_item_to_menu(
                 item,
                 menu=self.empty_context_menu,
@@ -194,14 +194,21 @@ class FramesExplorerWidget(ShellConnectMainWidget):
         search_action = self.get_action(FramesExplorerWidgetActions.Search)
         postmortem_debug_action = self.get_action(
             FramesExplorerWidgetActions.PostMortemDebug)
+        refresh_action = self.get_action(
+            FramesExplorerWidgetActions.Refresh)
         if widget is None:
             search = False
             post_mortem = False
+            is_debugging = False
         else:
             search = widget.finder_is_visible()
             post_mortem = widget.post_mortem
+            is_debugging = widget.pdb_curindex is not None
         search_action.setChecked(search)
         postmortem_debug_action.setEnabled(post_mortem)
+        refresh_action.setEnabled(not is_debugging)
+        self.context_menu.setEnabled(not is_debugging)
+
 
     # ---- ShellConnectMainWidget API
     # ------------------------------------------------------------------------
@@ -286,6 +293,9 @@ class FramesExplorerWidget(ShellConnectMainWidget):
         """Refresh frames table"""
         widget = self.current_widget()
         if widget is None:
+            return
+        if widget.pdb_curindex is not None:
+            # Disabled while debugging as the pdb stack is already shown
             return
         widget.shellwidget.call_kernel(
             interrupt=True, callback=widget.set_from_capture_frames


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
After https://github.com/spyder-ide/spyder-kernels/pull/381 the full stack is not sent to the frontend after every pdb command, so executing a command causes the frames explorer to reset. This PR solves that issue and adds a regression test.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
