### PR TITLE
PR: Prevent ZeroDivisionError when calculating plots scales and sizes (Plots)

### DIFF
--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -499,7 +499,12 @@ class FigureViewer(QScrollArea, SpyderWidgetMixin):
 
     def get_scaling(self):
         """Get the current scaling of the figure in percent."""
-        return round(self.figcanvas.width() / self.figcanvas.fwidth * 100)
+        width = self.figcanvas.width()
+        fwidth = self.figcanvas.fwidth
+        if fwidth != 0:
+            return round(width / fwidth * 100)
+        else:
+            return 100
 
     def reset_original_image(self):
         """Reset the image to its original size."""
@@ -1007,13 +1012,14 @@ class FigureThumbnail(QWidget):
         """
         fwidth = self.canvas.fwidth
         fheight = self.canvas.fheight
-        if fwidth / fheight > 1:
-            canvas_width = max_canvas_size
-            canvas_height = canvas_width / fwidth * fheight
-        else:
-            canvas_height = max_canvas_size
-            canvas_width = canvas_height / fheight * fwidth
-        self.canvas.setFixedSize(int(canvas_width), int(canvas_height))
+        if fheight != 0:
+            if fwidth / fheight > 1:
+                canvas_width = max_canvas_size
+                canvas_height = canvas_width / fwidth * fheight
+            else:
+                canvas_height = max_canvas_size
+                canvas_width = canvas_height / fheight * fwidth
+            self.canvas.setFixedSize(int(canvas_width), int(canvas_height))
         self.layout().setColumnMinimumWidth(0, max_canvas_size)
 
     def eventFilter(self, widget, event):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Add validations to prevent raising a `ZeroDivisionError` when checking figures/plots scaling/size


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15223 
Fixes #17753 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
