### PR TITLE
PR: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -8,6 +8,8 @@ name: Create macOS App Bundle and DMG
 
 jobs:
   matrix_prep:
+    permissions:
+      contents: none
     name: Determine Build Matrix
     runs-on: macos-10.15
     outputs:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
