### PR TITLE
PR: Fix filenames used for remote kernels while debugging

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = fix_debug_path
-	commit = 7120d564c880b0e3c60b106c8c1bfdf387fe5e23
-	parent = 55e72633ee6de0bd9dc37a3bb7cdac9b1d816153
+	branch = 2.x
+	commit = f35d7bce33288696c97434784627fbafb0e7389d
+	parent = 36c057e3c640e741c7d4fa8bf90aefb3caecdc97
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = fix_debug_path
-	commit = f213a6ba86f65a0e82dcfdae1adb6ce1177cd27f
-	parent = 3c84dc3331c9db6445166759ecb185a86ebfbd61
+	commit = 7120d564c880b0e3c60b106c8c1bfdf387fe5e23
+	parent = 55e72633ee6de0bd9dc37a3bb7cdac9b1d816153
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 2.x
-	commit = 4302062d84d25f5402264bcc64ef93d752a51779
-	parent = af394b507a7aa0a7bb2e2314ebc31dbcb9a3de90
+	branch = fix_debug_path
+	commit = f213a6ba86f65a0e82dcfdae1adb6ce1177cd27f
+	parent = 3c84dc3331c9db6445166759ecb185a86ebfbd61
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -619,11 +619,12 @@ class SpyderKernel(IPythonKernel):
                 sys.path.remove(path)
 
         # Add new paths
-        # We do this in reverse order as we use `sys.path.insert(1, path)`.
-        # This ensures the end result has the correct path order.
-        for path, active in reversed(new_path_dict.items()):
-            if active:
-                sys.path.insert(1, path)
+        pypath = [path for path, active in new_path_dict.items() if active]
+        if pypath:
+            sys.path.extend(pypath)
+            os.environ.update({'PYTHONPATH': os.pathsep.join(pypath)})
+        else:
+            os.environ.pop('PYTHONPATH', None)
 
     # -- Private API ---------------------------------------------------
     # --- For the Variable Explorer

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -619,12 +619,11 @@ class SpyderKernel(IPythonKernel):
                 sys.path.remove(path)
 
         # Add new paths
-        pypath = [path for path, active in new_path_dict.items() if active]
-        if pypath:
-            sys.path.extend(pypath)
-            os.environ.update({'PYTHONPATH': os.pathsep.join(pypath)})
-        else:
-            os.environ.pop('PYTHONPATH', None)
+        # We do this in reverse order as we use `sys.path.insert(1, path)`.
+        # This ensures the end result has the correct path order.
+        for path, active in reversed(new_path_dict.items()):
+            if active:
+                sys.path.insert(1, path)
 
     # -- Private API ---------------------------------------------------
     # --- For the Variable Explorer

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
@@ -811,12 +811,15 @@ builtins.cell_count = cell_count
 
 
 # =============================================================================
-# Extend sys.path with paths that come from Spyder
+# PYTHONPATH and sys.path Adjustments
 # =============================================================================
+# PYTHONPATH is not passed to kernel directly, see spyder-ide/spyder#13519
+# This allows the kernel to start without crashing if modules in PYTHONPATH
+# shadow standard library modules.
 def set_spyder_pythonpath():
     pypath = os.environ.get('SPY_PYTHONPATH')
     if pypath:
-        pathlist = pypath.split(os.pathsep)
-        sys.path.extend(pathlist)
+        sys.path.extend(pypath.split(os.pathsep))
+        os.environ.update({'PYTHONPATH': pypath})
 
 set_spyder_pythonpath()

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spydercustomize.py
@@ -23,17 +23,15 @@ import sys
 import time
 import warnings
 
-from IPython import __version__ as ipy_version
 from IPython.core.getipython import get_ipython
 
-from spyder_kernels.comms.frontendcomm import CommError, frontend_request
+from spyder_kernels.comms.frontendcomm import frontend_request
 from spyder_kernels.customize.namespace_manager import NamespaceManager
 from spyder_kernels.customize.spyderpdb import SpyderPdb, get_new_debugger
 from spyder_kernels.customize.umr import UserModuleReloader
 from spyder_kernels.py3compat import (
-    TimeoutError, PY2, _print, encode, compat_exec, FileNotFoundError)
-from spyder_kernels.customize.utils import (
-    capture_last_Expr, normalise_filename)
+    PY2, _print, encode, compat_exec, FileNotFoundError)
+from spyder_kernels.customize.utils import capture_last_Expr, canonic
 
 if not PY2:
     from IPython.core.inputtransformer2 import (
@@ -505,18 +503,23 @@ def exec_code(code, filename, ns_globals, ns_locals=None, post_mortem=False,
         __tracebackhide__ = "__pdb_exit__"
 
 
-def get_file_code(filename, save_all=True):
-    """Retrive the content of a file."""
+def get_file_code(filename, save_all=True, raise_exception=False):
+    """Retrieve the content of a file."""
     # Get code from spyder
     try:
-        file_code = frontend_request(blocking=True).get_file_code(
+        return frontend_request(blocking=True).get_file_code(
             filename, save_all=save_all)
-    except (CommError, TimeoutError, RuntimeError, FileNotFoundError):
-        file_code = None
-    if file_code is None:
-        with open(filename, 'r') as f:
-            return f.read()
-    return file_code
+    except Exception:
+        # Maybe this is a local file
+        try:
+            with open(filename, 'r') as f:
+                return f.read()
+        except FileNotFoundError:
+            pass
+        if raise_exception:
+            raise
+        # Else return None
+        return None
 
 
 def runfile(filename=None, args=None, wdir=None, namespace=None,
@@ -536,7 +539,7 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
 
 def _exec_file(filename=None, args=None, wdir=None, namespace=None,
                post_mortem=False, current_namespace=False, stack_depth=0,
-               exec_fun=None):
+               exec_fun=None, canonic_filename=None):
     # Tell IPython to hide this frame (>7.16)
     __tracebackhide__ = True
     ipython_shell = get_ipython()
@@ -544,11 +547,6 @@ def _exec_file(filename=None, args=None, wdir=None, namespace=None,
         filename = get_current_file_name()
         if filename is None:
             return
-    else:
-        # get_debugger replaces \\ by / so we must undo that here
-        # Otherwise code caching doesn't work
-        if os.name == 'nt':
-            filename = filename.replace('/', '\\')
 
     try:
         filename = filename.decode('utf-8')
@@ -562,22 +560,23 @@ def _exec_file(filename=None, args=None, wdir=None, namespace=None,
         __umr__.run()
     if args is not None and not isinstance(args, basestring):
         raise TypeError("expected a character buffer object")
+
     try:
-        file_code = get_file_code(filename)
+        file_code = get_file_code(filename, raise_exception=True)
     except Exception:
+        # Show an error and return None
         _print(
             "This command failed to be executed because an error occurred"
             " while trying to get the file code from Spyder's"
             " editor. The error was:\n\n")
         get_ipython().showtraceback(exception_only=True)
         return
-    if file_code is None:
-        _print("Could not get code from editor.\n")
-        return
 
-    # Normalise the filename
-    filename = os.path.abspath(filename)
-    filename = os.path.normcase(filename)
+    # Here the remote filename has been used. It must now be valid locally.
+    if canonic_filename is not None:
+        filename = canonic_filename
+    else:
+        filename = canonic(filename)
 
     with NamespaceManager(filename, namespace, current_namespace,
                           file_code=file_code, stack_depth=stack_depth + 1
@@ -655,7 +654,7 @@ def debugfile(filename=None, args=None, wdir=None, post_mortem=False,
     if shell.is_debugging():
         # Recursive
         code = (
-            "runfile({}".format(repr(normalise_filename(filename))) +
+            "runfile({}".format(repr(filename)) +
             ", args=%r, wdir=%r, current_namespace=%r)" % (
                 args, wdir, current_namespace)
         )
@@ -666,11 +665,13 @@ def debugfile(filename=None, args=None, wdir=None, post_mortem=False,
     else:
         debugger = get_new_debugger(filename, True)
         _exec_file(
-            filename=debugger.canonic(filename),
-            args=args, wdir=wdir,
+            filename=filename,
+            canonic_filename=debugger.canonic(filename),
+            args=args,
+            wdir=wdir,
             current_namespace=current_namespace,
             exec_fun=debugger.run,
-            stack_depth=1
+            stack_depth=1,
         )
 
 
@@ -696,7 +697,7 @@ def runcell(cellname, filename=None, post_mortem=False):
 
 
 def _exec_cell(cellname, filename=None, post_mortem=False, stack_depth=0,
-               exec_fun=None):
+               exec_fun=None, canonic_filename=None):
     """
     Execute a code cell with a given exec function.
     """
@@ -706,11 +707,6 @@ def _exec_cell(cellname, filename=None, post_mortem=False, stack_depth=0,
         filename = get_current_file_name()
         if filename is None:
             return
-    else:
-        # get_debugger replaces \\ by / so we must undo that here
-        # Otherwise code caching doesn't work
-        if os.name == 'nt':
-            filename = filename.replace('/', '\\')
     try:
         filename = filename.decode('utf-8')
     except (UnicodeError, TypeError, AttributeError):
@@ -736,14 +732,14 @@ def _exec_cell(cellname, filename=None, post_mortem=False, stack_depth=0,
     # Trigger `post_execute` to exit the additional pre-execution.
     # See Spyder PR #7310.
     ipython_shell.events.trigger('post_execute')
-    try:
-        file_code = get_file_code(filename, save_all=False)
-    except Exception:
-        file_code = None
+    file_code = get_file_code(filename, save_all=False)
 
-    # Normalise the filename
-    filename = os.path.abspath(filename)
-    filename = os.path.normcase(filename)
+    # Here the remote filename has been used. It must now be valid locally.
+    if canonic_filename is not None:
+        filename = canonic_filename
+    else:
+        # Normalise the filename
+        filename = canonic(filename)
 
     with NamespaceManager(filename, current_namespace=True,
                           file_code=file_code, stack_depth=stack_depth + 1
@@ -770,7 +766,7 @@ def debugcell(cellname, filename=None, post_mortem=False):
         # Recursive
         code = (
             "runcell({}, ".format(repr(cellname)) +
-            "{})".format(repr(normalise_filename(filename)))
+            "{})".format(repr(filename))
         )
         shell.pdb_session.enter_recursive_debugger(
             code, filename, False,
@@ -779,7 +775,8 @@ def debugcell(cellname, filename=None, post_mortem=False):
         debugger = get_new_debugger(filename, False)
         _exec_cell(
             cellname=cellname,
-            filename=debugger.canonic(filename),
+            filename=filename,
+            canonic_filename=debugger.canonic(filename),
             exec_fun=debugger.run,
             stack_depth=1
         )
@@ -814,15 +811,12 @@ builtins.cell_count = cell_count
 
 
 # =============================================================================
-# PYTHONPATH and sys.path Adjustments
+# Extend sys.path with paths that come from Spyder
 # =============================================================================
-# PYTHONPATH is not passed to kernel directly, see spyder-ide/spyder#13519
-# This allows the kernel to start without crashing if modules in PYTHONPATH
-# shadow standard library modules.
 def set_spyder_pythonpath():
     pypath = os.environ.get('SPY_PYTHONPATH')
     if pypath:
-        sys.path.extend(pypath.split(os.pathsep))
-        os.environ.update({'PYTHONPATH': pypath})
+        pathlist = pypath.split(os.pathsep)
+        sys.path.extend(pathlist)
 
 set_spyder_pythonpath()

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spyderpdb.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spyderpdb.py
@@ -839,7 +839,6 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
 
         debugger.set_remote_filename(filename)
         debugger.continue_if_has_breakpoints = continue_if_has_breakpoints
-        debugger._user_requested_quit = False
 
         # Enter recursive debugger
         sys.call_tracing(debugger.run, (code, globals, locals))
@@ -866,5 +865,4 @@ def get_new_debugger(filename, continue_if_has_breakpoints):
     debugger = SpyderPdb()
     debugger.set_remote_filename(filename)
     debugger.continue_if_has_breakpoints = continue_if_has_breakpoints
-    debugger._user_requested_quit = False
     return debugger

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spyderpdb.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spyderpdb.py
@@ -10,7 +10,6 @@
 import ast
 import bdb
 import logging
-import os
 import sys
 import traceback
 from collections import namedtuple
@@ -99,6 +98,9 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         # Don't report hidden frames for IPython 7.24+. This attribute
         # has no effect in previous versions.
         self.report_skipped = False
+
+        # Keep track of remote filename
+        self.remote_filename = None
 
     # --- Methods overriden for code execution
     def print_exclamation_warning(self):
@@ -774,6 +776,8 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
                 fname = unicode(fname, "utf-8")
             except TypeError:
                 pass
+        if fname == self.mainpyfile and self.remote_filename is not None:
+            fname = self.remote_filename
         lineno = frame.f_lineno
 
         if self._previous_step == (fname, lineno):
@@ -833,9 +837,7 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         debugger.use_rawinput = self.use_rawinput
         debugger.prompt = "(%s) " % self.prompt.strip()
 
-        filename = debugger.canonic(filename)
-        debugger._wait_for_mainpyfile = True
-        debugger.mainpyfile = filename
+        debugger.set_remote_filename(filename)
         debugger.continue_if_has_breakpoints = continue_if_has_breakpoints
         debugger._user_requested_quit = False
 
@@ -852,14 +854,17 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         # but the parent debugger (self) is not aware of this.
         self._previous_step = None
 
+    def set_remote_filename(self, filename):
+        """Set remote filename to signal Spyder on mainpyfile."""
+        self.remote_filename = filename
+        self.mainpyfile = self.canonic(filename)
+        self._wait_for_mainpyfile = True
+
 
 def get_new_debugger(filename, continue_if_has_breakpoints):
     """Get a new debugger."""
     debugger = SpyderPdb()
-
-    filename = debugger.canonic(filename)
-    debugger._wait_for_mainpyfile = True
-    debugger.mainpyfile = filename
+    debugger.set_remote_filename(filename)
     debugger.continue_if_has_breakpoints = continue_if_has_breakpoints
     debugger._user_requested_quit = False
     return debugger

--- a/external-deps/spyder-kernels/spyder_kernels/customize/utils.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/utils.py
@@ -117,9 +117,15 @@ def capture_last_Expr(code_ast, out_varname):
     return code_ast, capture_last_expression
 
 
-def normalise_filename(filename):
-    """Normalise path for window."""
-    # Recursive
-    if os.name == 'nt':
-        return filename.replace('\\', '/')
-    return filename
+def canonic(filename):
+    """
+    Return canonical form of filename.
+
+    This is a copy of bdb.canonic, so that the debugger will process 
+    filenames in the same way
+    """
+    if filename == "<" + filename[1:-1] + ">":
+        return filename
+    canonic = os.path.abspath(filename)
+    canonic = os.path.normcase(canonic)
+    return canonic


### PR DESCRIPTION
## Description of Changes

* Debugging with remote kernels is broken due to this.
* Depends on spyder-ide/spyder-kernels#389

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #18330 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
