### PR TITLE
PR: Add new API methods to the IPython console

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1137,8 +1137,7 @@ def test_connection_to_external_kernel(main_window, qtbot):
     # Test with a generic kernel
     km, kc = start_new_kernel()
 
-    main_window.ipyconsole.get_widget()._create_client_for_kernel(
-        kc.connection_file, None, None, None)
+    main_window.ipyconsole.create_client_for_kernel(kc.connection_file)
     shell = main_window.ipyconsole.get_current_shellwidget()
     qtbot.waitUntil(
         lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
@@ -1155,8 +1154,7 @@ def test_connection_to_external_kernel(main_window, qtbot):
 
     # Test with a kernel from Spyder
     spykm, spykc = start_new_kernel(spykernel=True)
-    main_window.ipyconsole.get_widget()._create_client_for_kernel(
-        spykc.connection_file, None, None, None)
+    main_window.ipyconsole.create_client_for_kernel(spykc.connection_file)
     shell = main_window.ipyconsole.get_current_shellwidget()
     qtbot.waitUntil(
         lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -333,7 +333,7 @@ class IPythonConsole(SpyderDockablePlugin):
     def on_working_directory_available(self):
         working_directory = self.get_plugin(Plugins.WorkingDirectory)
         working_directory.sig_current_directory_changed.connect(
-            self._save_working_directory)
+            self._set_working_directory)
 
     @on_plugin_teardown(plugin=Plugins.Preferences)
     def on_preferences_teardown(self):
@@ -381,7 +381,7 @@ class IPythonConsole(SpyderDockablePlugin):
     def on_working_directory_teardown(self):
         working_directory = self.get_plugin(Plugins.WorkingDirectory)
         working_directory.sig_current_directory_changed.disconnect(
-            self._save_working_directory)
+            self._set_working_directory)
 
     def update_font(self):
         """Update font from Preferences"""
@@ -438,9 +438,9 @@ class IPythonConsole(SpyderDockablePlugin):
                         pass
 
     @Slot(str)
-    def _save_working_directory(self, new_dir):
-        """Save current working directory on the main widget."""
-        self.get_widget().current_working_directory = new_dir
+    def _set_working_directory(self, new_dir):
+        """Set current working directory on the main widget."""
+        self.get_widget().set_working_directory(new_dir)
 
     # ---- Public API
     # -------------------------------------------------------------------------

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -489,6 +489,23 @@ class IPythonConsole(SpyderDockablePlugin):
         """Return the shellwidget of the current client"""
         return self.get_widget().get_current_shellwidget()
 
+    def rename_client_tab(self, client, given_name):
+        """
+        Rename a client's tab.
+
+        Parameters
+        ----------
+        client: spyder.plugins.ipythonconsole.widgets.client.ClientWidget
+            Client to rename.
+        given_name: str
+            New name to be given to the client's tab.
+
+        Returns
+        -------
+        None.
+        """
+        self.get_widget().rename_client_tab(client, given_name)
+
     def create_new_client(self, give_focus=True, filename='', is_cython=False,
                           is_pylab=False, is_sympy=False, given_name=None):
         """

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -452,7 +452,6 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().register_spyder_kernel_call_handler(
             handler_id, handler)
@@ -470,7 +469,6 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().unregister_spyder_kernel_call_handler(handler_id)
 
@@ -519,7 +517,6 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().create_new_client(
             give_focus=give_focus,
@@ -543,9 +540,35 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().create_client_for_file(filename, is_cython=is_cython)
+
+    def create_client_for_kernel(self, connection_file, hostname=None,
+                                 sshkey=None, password=None):
+        """
+        Create a client connected to an existing kernel.
+
+        Parameters
+        ----------
+        connection_file: str
+            Json file that has the kernel's connection info.
+        hostname: str, optional
+            Name or IP address of the remote machine where the kernel was
+            started. When this is provided, it's also necessary to pass either
+            the ``sshkey`` or ``password`` arguments.
+        sshkey: str, optional
+            SSH key file to connect to the remote machine where the kernel is
+            running.
+        password: str, optional
+            Password to authenticate to the remote machine where the kernel is
+            running.
+
+        Returns
+        -------
+        None.
+        """
+        self.get_widget().create_client_for_kernel(
+            connection_file, hostname, sshkey, password)
 
     def get_client_for_file(self, filename):
         """Get client associated with a given file name."""
@@ -599,7 +622,6 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().run_script(
             filename,
@@ -639,7 +661,6 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().run_cell(
             code, cell_name, filename, run_cell_copy, focus_to_editor,
@@ -669,7 +690,6 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().debug_cell(code, cell_name, filename, run_cell_copy,
                                      focus_to_editor)
@@ -692,7 +712,6 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().execute_code(
             lines,
@@ -734,7 +753,6 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().pdb_execute_command(command)
 
@@ -745,7 +763,6 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().print_debug_file_msg()
 
@@ -762,7 +779,6 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().set_current_client_working_directory(directory)
 
@@ -779,7 +795,6 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().set_working_directory(dirname)
 
@@ -804,7 +819,6 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().update_path(path_dict, new_path_dict)
 
@@ -828,7 +842,6 @@ class IPythonConsole(SpyderDockablePlugin):
         Returns
         -------
         None.
-
         """
         self.get_widget().restart_kernel()
 

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -2281,7 +2281,7 @@ def test_cwd_console_options(ipyconsole, qtbot, tmpdir):
 
     # Simulate a specific directory
     cwd_dir = str(tmpdir.mkdir('ipyconsole_cwd_test'))
-    ipyconsole.get_widget().current_working_directory = cwd_dir
+    ipyconsole.get_widget().set_working_directory(cwd_dir)
 
     # Get cwd of new client and assert is the expected one
     assert get_cwd_of_new_client() == cwd_dir

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -41,7 +41,7 @@ import sympy
 # Local imports
 from spyder.app.cli_options import get_options
 from spyder.config.base import (
-    get_home_dir, running_in_ci, running_in_ci_with_conda)
+    running_in_ci, running_in_ci_with_conda)
 from spyder.config.gui import get_color_scheme
 from spyder.config.manager import CONF
 from spyder.py3compat import PY2, to_text_string
@@ -218,9 +218,6 @@ def ipyconsole(qtbot, request, tmpdir):
                               is_sympy=is_sympy,
                               is_cython=is_cython)
     window.setCentralWidget(console.get_widget())
-
-    # Return working directory from the plugin
-    console._get_working_directory = lambda: get_home_dir()
 
     # Set exclamation mark to True
     configuration.set('ipython_console', 'pdb_use_exclamation_mark', True)
@@ -2287,7 +2284,7 @@ def test_cwd_console_options(ipyconsole, qtbot, tmpdir):
 
     # Simulate a specific directory
     cwd_dir = str(tmpdir.mkdir('ipyconsole_cwd_test'))
-    ipyconsole._get_working_directory = lambda: cwd_dir
+    ipyconsole.get_widget().current_working_directory = cwd_dir
 
     # Get cwd of new client and assert is the expected one
     assert get_cwd_of_new_client() == cwd_dir

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -551,7 +551,7 @@ def test_cython_client(ipyconsole, qtbot):
 def test_tab_rename_for_slaves(ipyconsole, qtbot):
     """Test slave clients are renamed correctly."""
     cf = ipyconsole.get_current_client().connection_file
-    ipyconsole.get_widget()._create_client_for_kernel(cf, None, None, None)
+    ipyconsole.create_client_for_kernel(cf)
     qtbot.waitUntil(lambda: len(ipyconsole.get_clients()) == 2)
 
     # Rename slave
@@ -1214,7 +1214,7 @@ def test_load_kernel_file_from_id(ipyconsole, qtbot):
     connection_file = osp.basename(client.connection_file)
     id_ = connection_file.split('kernel-')[-1].split('.json')[0]
 
-    ipyconsole.get_widget()._create_client_for_kernel(id_, None, None, None)
+    ipyconsole.create_client_for_kernel(id_)
     qtbot.waitUntil(lambda: len(ipyconsole.get_clients()) == 2)
 
     new_client = ipyconsole.get_clients()[1]
@@ -1233,7 +1233,7 @@ def test_load_kernel_file_from_location(ipyconsole, qtbot, tmpdir):
     connection_file = to_text_string(tmpdir.join(fname))
     shutil.copy2(client.connection_file, connection_file)
 
-    ipyconsole.get_widget()._create_client_for_kernel(connection_file, None, None, None)
+    ipyconsole.create_client_for_kernel(connection_file)
     qtbot.waitUntil(lambda: len(ipyconsole.get_clients()) == 2)
 
     assert len(ipyconsole.get_clients()) == 2
@@ -1248,8 +1248,7 @@ def test_load_kernel_file(ipyconsole, qtbot, tmpdir):
     shell = ipyconsole.get_current_shellwidget()
     client = ipyconsole.get_current_client()
 
-    ipyconsole.get_widget()._create_client_for_kernel(
-        client.connection_file, None, None, None)
+    ipyconsole.create_client_for_kernel(client.connection_file)
     qtbot.waitUntil(lambda: len(ipyconsole.get_clients()) == 2)
 
     new_client = ipyconsole.get_clients()[1]
@@ -1331,8 +1330,7 @@ def test_stderr_file_is_removed_two_kernels(ipyconsole, qtbot, monkeypatch):
     client = ipyconsole.get_current_client()
 
     # New client with the same kernel
-    ipyconsole.get_widget()._create_client_for_kernel(
-        client.connection_file, None, None, None)
+    ipyconsole.create_client_for_kernel(client.connection_file)
     assert len(ipyconsole.get_widget().get_related_clients(client)) == 1
     other_client = ipyconsole.get_widget().get_related_clients(client)[0]
     assert client.stderr_obj.filename == other_client.stderr_obj.filename
@@ -1353,8 +1351,7 @@ def test_stderr_file_remains_two_kernels(ipyconsole, qtbot, monkeypatch):
     client = ipyconsole.get_current_client()
 
     # New client with the same kernel
-    ipyconsole.get_widget()._create_client_for_kernel(
-        client.connection_file, None, None, None)
+    ipyconsole.create_client_for_kernel(client.connection_file)
 
     assert len(ipyconsole.get_widget().get_related_clients(client)) == 1
     other_client = ipyconsole.get_widget().get_related_clients(client)[0]

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -386,7 +386,7 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
                 if project_path is not None:
                     cwd_path = project_path
             elif self.get_conf('console/use_cwd', section='workingdir'):
-                cwd_path = self.container.current_working_directory
+                cwd_path = self.container.get_working_directory()
             elif self.get_conf(
                 'console/use_fixed_directory',
                 section='workingdir'

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -386,7 +386,7 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
                 if project_path is not None:
                     cwd_path = project_path
             elif self.get_conf('console/use_cwd', section='workingdir'):
-                cwd_path = self.container.get_working_directory()
+                cwd_path = self.container.current_working_directory
             elif self.get_conf(
                 'console/use_fixed_directory',
                 section='workingdir'

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1207,7 +1207,7 @@ class IPythonConsoleWidget(PluginMainWidget):
             pass
 
     def rename_client_tab(self, client, given_name):
-        """Rename client's tab."""
+        """Rename a client's tab."""
         index = self.get_client_index_from_id(id(client))
 
         if given_name is not None:

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1860,7 +1860,7 @@ class IPythonConsoleWidget(PluginMainWidget):
 
         # Connect to working directory
         shellwidget.sig_working_directory_changed.connect(
-            self.set_working_directory)
+            self.working_directory_changed)
 
         # Connect client execution state to be reflected in the interface
         client.sig_execution_state_changed.connect(self.update_actions)
@@ -2372,17 +2372,16 @@ class IPythonConsoleWidget(PluginMainWidget):
             )
 
     # ---- For working directory and path management
-    @property
-    def current_working_directory(self):
+    def set_working_directory(self, new_dir):
         """
-        Current working directory, as reported by the Working Directory plugin.
+        Set current working directory when changed by the Working Directory
+        plugin.
         """
-        return self._current_working_directory
+        self._current_working_directory = new_dir
 
-    @current_working_directory.setter
-    def current_working_directory(self, new_value):
-        """Set current working directory"""
-        self._current_working_directory = new_value
+    def get_working_directory(self):
+        """Get current working directory."""
+        return self._current_working_directory
 
     def set_current_client_working_directory(self, directory):
         """Set current client working directory."""
@@ -2390,10 +2389,10 @@ class IPythonConsoleWidget(PluginMainWidget):
         if shellwidget is not None:
             shellwidget.set_cwd(directory)
 
-    def set_working_directory(self, dirname):
+    def working_directory_changed(self, dirname):
         """
-        Set current working directory in the workingdirectory and explorer
-        plugins.
+        Notify that the working directory was changed in the current console
+        to other plugins.
         """
         if osp.isdir(dirname):
             self.sig_current_directory_changed.emit(dirname)


### PR DESCRIPTION
## Description of Changes

- These methods (i.e. `create_client_for_kernel` and `rename_client_tab`) are necessary to finish the migration of Spyder-notebook to the new API (see spyder-ide/spyder-notebook#369)
- This PR also corrects the way we handle the current working directory to use it to start new consoles. That was implemented as part of PR #17760 but it didn't follow the patterns of our new API.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
