### PR TITLE
PR: Fix error when closing error dialog (Console)

### DIFF
--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -429,7 +429,6 @@ class ConsoleWidget(PluginMainWidget):
                 self.error_dlg = SpyderErrorDialog(self)
                 self.error_dlg.set_color_scheme(
                     self.get_conf('selected', section='appearance'))
-                self.error_dlg.close_btn.clicked.connect(self.close_error_dlg)
                 self.error_dlg.rejected.connect(self.remove_error_dlg)
                 self.error_dlg.details.sig_go_to_error_requested.connect(
                     self.go_to_error)
@@ -458,15 +457,16 @@ class ConsoleWidget(PluginMainWidget):
         """
         Close error dialog.
         """
-        if self.error_dlg.dismiss_box.isChecked():
-            self.dismiss_error = True
-
-        self.error_dlg.reject()
+        if self.error_dlg:
+            self.error_dlg.reject()
 
     def remove_error_dlg(self):
         """
         Remove error dialog.
         """
+        if self.error_dlg.dismiss_box.isChecked():
+            self.dismiss_error = True
+
         self.error_dlg.disconnect()
         self.error_dlg = None
 


### PR DESCRIPTION
## Description of Changes

- This error only appears when using PyQt 5.15.
- It should appear with PyQt 5.12 too, but oddly it doesn't.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #18599.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
