### PR TITLE
PR: Don't double validate if plugins can be deleted/closed (Registry)

### DIFF
--- a/spyder/api/plugin_registration/registry.py
+++ b/spyder/api/plugin_registration/registry.py
@@ -446,7 +446,8 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
             # Close undocked plugins.
             plugin_instance._close_window()
 
-    def delete_plugin(self, plugin_name: str, teardown: bool = True) -> bool:
+    def delete_plugin(self, plugin_name: str, teardown: bool = True,
+                      check_can_delete: bool = True) -> bool:
         """
         Remove and delete a plugin from the registry by its name.
 
@@ -457,6 +458,9 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
         teardown: bool
             True if the teardown notification to other plugins should be sent
             when deleting the plugin, False otherwise.
+        check_can_delete: bool
+            True if the plugin should validate if can be closed in the moment,
+            False otherwise.
 
         Returns
         -------
@@ -468,9 +472,10 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
         plugin_instance = self.plugin_registry[plugin_name]
 
         # Determine if plugin can be closed
-        can_delete = self.can_delete_plugin(plugin_name)
-        if not can_delete:
-            return False
+        if check_can_delete:
+            can_delete = self.can_delete_plugin(plugin_name)
+            if not can_delete:
+                return False
 
         if isinstance(plugin_instance, SpyderPluginV2):
             # Cleanly delete plugin widgets. This avoids segfautls with
@@ -637,7 +642,7 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
                 plugin_instance = self.plugin_registry[plugin_name]
                 if isinstance(plugin_instance, SpyderPlugin):
                     can_close &= self.delete_plugin(
-                        plugin_name, teardown=False)
+                        plugin_name, teardown=False, check_can_delete=False)
                     if not can_close and not close_immediately:
                         break
 
@@ -650,7 +655,7 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
                 plugin_instance = self.plugin_registry[plugin_name]
                 if isinstance(plugin_instance, SpyderPlugin):
                     can_close &= self.delete_plugin(
-                        plugin_name, teardown=False)
+                        plugin_name, teardown=False, check_can_delete=False)
                     if not can_close and not close_immediately:
                         break
 
@@ -663,7 +668,7 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
                 plugin_instance = self.plugin_registry[plugin_name]
                 if isinstance(plugin_instance, SpyderPluginV2):
                     can_close &= self.delete_plugin(
-                        plugin_name, teardown=False)
+                        plugin_name, teardown=False, check_can_delete=False)
                     if not can_close and not close_immediately:
                         break
 
@@ -676,7 +681,7 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
                 plugin_instance = self.plugin_registry[plugin_name]
                 if isinstance(plugin_instance, SpyderPluginV2):
                     can_close &= self.delete_plugin(
-                        plugin_name, teardown=False)
+                        plugin_name, teardown=False, check_can_delete=False)
                     if not can_close and not close_immediately:
                         break
 

--- a/spyder/api/plugin_registration/registry.py
+++ b/spyder/api/plugin_registration/registry.py
@@ -459,8 +459,8 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
             True if the teardown notification to other plugins should be sent
             when deleting the plugin, False otherwise.
         check_can_delete: bool
-            True if the plugin should validate if can be closed in the moment,
-            False otherwise.
+            True if the plugin should validate if it can be closed when this
+            method is called, False otherwise.
 
         Returns
         -------


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

The validation for all the plugins was being done twice. Because of that the Editor was asking two times if a file need to be saved before exiting. This ensures is only done once for all the plugins before proceding to deleted them all


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #18624


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
