### PR TITLE
PR: Catch all passed tests, including parametrized tests with spaces in parameters

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -46,7 +46,7 @@ def get_passed_tests():
         # informative messages.
         test_re = re.compile(r'(spyder.*) (SKIPPED|PASSED|XFAIL) ')
         tests = []
-	for line in logfile:
+        for line in logfile:
             match = test_re.match(line)
             if match:
                 tests.append(match.group(1))

--- a/conftest.py
+++ b/conftest.py
@@ -42,8 +42,7 @@ def get_passed_tests():
         with open('pytest_log.txt') as f:
             logfile = f.readlines()
 
-        # All lines that start with 'spyder' are tests. The rest are
-        # informative messages.
+        # Detect all tests that passed before.
         test_re = re.compile(r'(spyder.*) (SKIPPED|PASSED|XFAIL) ')
         tests = []
         for line in logfile:

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ NOTE: DO NOT add fixtures here. It could generate problems with
 
 import os
 import os.path as osp
+import re
 
 # ---- To activate/deactivate certain things for pytest's only
 # NOTE: Please leave this before any other import here!!
@@ -43,13 +44,14 @@ def get_passed_tests():
 
         # All lines that start with 'spyder' are tests. The rest are
         # informative messages.
+        test_re = re.compile(r'(spyder.*) (SKIPPED|PASSED|XFAIL) ')
         tests = []
-        for line in logfile:
-            if line.startswith('spyder'):
-                tests.append(line.split()[0])
+	for line in logfile:
+            match = test_re.match(line)
+            if match:
+                tests.append(match.group(1))
 
-        # Don't include the last test to repeat it again.
-        return tests[:-1]
+        return tests
     else:
         return []
 


### PR DESCRIPTION
## Description of Changes

Some parametrized tests have spaces in their parameters, so they are not skipped on subsequent functions (the current `conftest.py` sees
```
spyder/utils/tests/test_syntaxhighlighters.py::test_python_outline_explorer_comment[# --- First variant] SKIPPED (Test passed in previous runs) [ 92%]
```
for example, and reads a node id of `spyder/utils/tests/test_syntaxhighlighters.py::test_python_outline_explorer_comment[#`, which does not match any test item.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->

This patch parses the log file a little more carefully to get any lines beginning `spyder` and to extract everything up to the test result for passing tests ("SKIPPED", in the above example).  As a further consequence, we now return all of the results, including the final one (as a failing test will not be captured by this modified code).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

(I haven't actually reported it as an issue.)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@juliangilbey
<!--- Thanks for your help making Spyder better for everyone! --->
