### PR TITLE
PR: Prefer a run-slow skip reason over an already passed one (Testing)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -66,14 +66,15 @@ def pytest_collection_modifyitems(config, items):
     skip_passed = pytest.mark.skip(reason="Test passed in previous runs")
 
     for item in items:
-        if item.nodeid in passed_tests:
-            item.add_marker(skip_passed)
-        elif slow_option:
+        if slow_option:
             if "slow" not in item.keywords:
                 item.add_marker(skip_fast)
         else:
             if "slow" in item.keywords:
                 item.add_marker(skip_slow)
+
+        if item.nodeid in passed_tests:
+            item.add_marker(skip_passed)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Currently, on a subsequent test run, `conftest.py` will report the reason for skipping a "run-slow" test if `--run-slow` is not specified as "Test passed in previous runs", which is not true.  This patch changes the order of the conditionals so that the "Need/Don't need --run-slow option to run" reason will be given precedence.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@juliangilbey 
<!--- Thanks for your help making Spyder better for everyone! --->
