### PR TITLE
PR: Run all tests, not stopping on first failure (Testing)

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -7,7 +7,7 @@ fi
 
 # Run tests
 if [ "$OS" = "linux" ]; then
-    xvfb-run --auto-servernum python runtests.py --color=yes | tee log.txt
+    xvfb-run --auto-servernum python runtests.py --color=yes | tee -a pytest_log.txt
 else
     python runtests.py --color=yes | tee -a pytest_log.txt
 fi

--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -5,13 +5,9 @@ if [ "$OS" = "macos" ]; then
     PATH=/Users/runner/miniconda3/envs/test/bin:/Users/runner/miniconda3/condabin:$PATH
 fi
 
-# Rename log file before running the test suite. Its contents will be read
-# before the next run (see conftest.py in the root of the repo).
-mv log.txt pytest_log.txt
-
 # Run tests
 if [ "$OS" = "linux" ]; then
     xvfb-run --auto-servernum python runtests.py --color=yes | tee log.txt
 else
-    python runtests.py --color=yes | tee log.txt
+    python runtests.py --color=yes | tee -a pytest_log.txt
 fi

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -129,7 +129,7 @@ jobs:
         if: env.RUN_BUILD == 'true'
         shell: bash -l {0}
         run: |
-          touch log.txt  # This is necessary to run the script below
+          rm -f pytest_log.txt  # Must remove any log file from a previous run
           bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh || \

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -133,10 +133,6 @@ jobs:
           bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh || \
-          bash -l .github/scripts/run_tests.sh || \
-          bash -l .github/scripts/run_tests.sh || \
-          bash -l .github/scripts/run_tests.sh || \
-          bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh
       - name: Coverage
         if: env.RUN_BUILD == 'true'

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -114,7 +114,7 @@ jobs:
         if: env.RUN_BUILD == 'true'
         shell: bash -l {0}
         run: |
-          touch log.txt  # This is necessary to run the script below
+          rm -f pytest_log.txt  # Must remove any log file from a previous run
           bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh || \

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -118,10 +118,6 @@ jobs:
           bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh || \
-          bash -l .github/scripts/run_tests.sh || \
-          bash -l .github/scripts/run_tests.sh || \
-          bash -l .github/scripts/run_tests.sh || \
-          bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh
       # Enable this if SSH debugging is required
       # - name: Setup tmate session

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -114,7 +114,7 @@ jobs:
         if: env.RUN_BUILD == 'true'
         shell: bash -l {0}
         run: |
-          touch log.txt  # This is necessary to run the script below
+          rm -f pytest_log.txt  # Must remove any log file from a previous run
           bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh || \

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -118,10 +118,6 @@ jobs:
           bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh || \
-          bash -l .github/scripts/run_tests.sh || \
-          bash -l .github/scripts/run_tests.sh || \
-          bash -l .github/scripts/run_tests.sh || \
-          bash -l .github/scripts/run_tests.sh || \
           bash -l .github/scripts/run_tests.sh
       - name: Coverage
         if: env.RUN_BUILD == 'true'

--- a/conftest.py
+++ b/conftest.py
@@ -44,11 +44,11 @@ def get_passed_tests():
 
         # Detect all tests that passed before.
         test_re = re.compile(r'(spyder.*) (SKIPPED|PASSED|XFAIL) ')
-        tests = []
+        tests = set()
         for line in logfile:
             match = test_re.match(line)
             if match:
-                tests.append(match.group(1))
+                tests.add(match.group(1))
 
         return tests
     else:

--- a/conftest.py
+++ b/conftest.py
@@ -43,7 +43,7 @@ def get_passed_tests():
             logfile = f.readlines()
 
         # Detect all tests that passed before.
-        test_re = re.compile(r'(spyder.*) (SKIPPED|PASSED|XFAIL) ')
+        test_re = re.compile(r'(spyder.*) [^ ]*(SKIPPED|PASSED|XFAIL)')
         tests = set()
         for line in logfile:
             match = test_re.match(line)

--- a/runtests.py
+++ b/runtests.py
@@ -36,8 +36,8 @@ def run_pytest(run_slow=False, extra_args=None):
                    '-W ignore::UserWarning', '--timeout=120']
 
     if CI:
-        # Exit on first failure and show coverage
-        pytest_args += ['-x', '--cov=spyder', '--no-cov-on-fail']
+        # Show coverage
+        pytest_args += ['--cov=spyder', '--no-cov-on-fail']
 
         # To display nice tests resume in Azure's web page
         if os.environ.get('AZURE', None) is not None:


### PR DESCRIPTION
## Description of Changes

You might be interested in this patch (or not); it more closely resembles what I have done on Debian.  Building on your improvements to `conftest.py`, this change is to attempt all the tests in the test suite on the first run (by removing the pytest `-x` option).  The reason for this is that most failures I have observed are transient, so typically all pass on the second pytest run.

The other small change this patch makes because of the above change is to append the log files together rather than starting afresh each run; in this way, if a pytest run crashes in the middle (which I have often seen on non-amd64 architectures), passes from previous runs are not lost.

The one thing I have not done in this patch, but I think would be reasonable, is to reduce the number of pytest runs (`run_tests.sh`) in the `.github/workflows/test-*.yml` files from 8 down to, say, 4: if the tests have not all passed after 4 runs under this new scheme, then it is unlikely that they would in 4 further runs.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@juliangilbey 
<!--- Thanks for your help making Spyder better for everyone! --->
