### PR TITLE
PR: Make style of "Print preview" dialog follow the rest of Spyder

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -23,8 +23,7 @@ import time
 from qtpy.compat import from_qvariant, getopenfilenames, to_qvariant
 from qtpy.QtCore import QByteArray, Qt, Signal, Slot, QDir
 from qtpy.QtGui import QTextCursor
-from qtpy.QtPrintSupport import (QAbstractPrintDialog, QPrintDialog, QPrinter,
-                                 QPrintPreviewDialog)
+from qtpy.QtPrintSupport import QAbstractPrintDialog, QPrintDialog, QPrinter
 from qtpy.QtWidgets import (QAction, QActionGroup, QApplication, QDialog,
                             QFileDialog, QInputDialog, QMenu, QSplitter,
                             QToolBar, QVBoxLayout, QWidget)
@@ -47,11 +46,12 @@ from spyder.widgets.findreplace import FindReplace
 from spyder.plugins.editor.confpage import EditorConfigPage
 from spyder.plugins.editor.utils.autosave import AutosaveForPlugin
 from spyder.plugins.editor.utils.switcher import EditorSwitcherManager
-from spyder.plugins.editor.widgets.codeeditor_widgets import Printer
+from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 from spyder.plugins.editor.widgets.editor import (EditorMainWindow,
                                                   EditorSplitter,
                                                   EditorStack,)
-from spyder.plugins.editor.widgets.codeeditor import CodeEditor
+from spyder.plugins.editor.widgets.printer import (
+    SpyderPrinter, SpyderPrintPreviewDialog)
 from spyder.plugins.editor.utils.bookmarks import (load_bookmarks,
                                                    save_bookmarks)
 from spyder.plugins.editor.utils.debugger import (clear_all_breakpoints,
@@ -2324,8 +2324,8 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         self._print_editor.set_font(self.get_font())
 
         # Create printer
-        printer = Printer(mode=QPrinter.HighResolution,
-                          header_font=self.get_font())
+        printer = SpyderPrinter(mode=QPrinter.HighResolution,
+                                header_font=self.get_font())
         print_dialog = QPrintDialog(printer, self._print_editor)
 
         # Adjust print options when user has selected text
@@ -2366,11 +2366,11 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         self._print_editor.set_font(self.get_font())
 
         # Create printer
-        printer = Printer(mode=QPrinter.HighResolution,
-                          header_font=self.get_font())
+        printer = SpyderPrinter(mode=QPrinter.HighResolution,
+                                header_font=self.get_font())
 
         # Create preview
-        preview = QPrintPreviewDialog(printer, self)
+        preview = SpyderPrintPreviewDialog(printer, self)
         preview.setWindowFlags(Qt.Window)
         preview.paintRequested.connect(
             lambda printer: self._print_editor.print_(printer)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -74,7 +74,7 @@ from spyder.plugins.editor.panels.utils import (
     merge_folding, collect_folding_regions)
 from spyder.plugins.completion.decorators import (
     request, handles, class_register)
-from spyder.plugins.editor.widgets.codeeditor_widgets import GoToLineDialog
+from spyder.plugins.editor.widgets.gotoline import GoToLineDialog
 from spyder.plugins.editor.widgets.base import TextEditBaseWidget
 from spyder.plugins.outlineexplorer.api import (OutlineExplorerData as OED,
                                                 is_cell_header)

--- a/spyder/plugins/editor/widgets/codeeditor_widgets.py
+++ b/spyder/plugins/editor/widgets/codeeditor_widgets.py
@@ -4,41 +4,12 @@
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
 
-import time
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QColor, QIntValidator
-from qtpy.QtPrintSupport import QPrinter
+from qtpy.QtGui import QIntValidator
 from qtpy.QtWidgets import (QDialog, QLabel, QLineEdit, QGridLayout,
                             QDialogButtonBox, QVBoxLayout, QHBoxLayout)
 
 from spyder.config.base import _
-
-
-# =============================================================================
-# CodeEditor's Printer
-# =============================================================================
-# TODO: Implement the header and footer support
-class Printer(QPrinter):
-    def __init__(self, mode=QPrinter.ScreenResolution, header_font=None):
-        QPrinter.__init__(self, mode)
-        self.setColorMode(QPrinter.Color)
-        self.setPageOrder(QPrinter.FirstPageFirst)
-        self.date = time.ctime()
-        if header_font is not None:
-            self.header_font = header_font
-
-    # <!> The following method is simply ignored by QPlainTextEdit
-    #     (this is a copy from QsciEditor's Printer)
-    def formatPage(self, painter, drawing, area, pagenr):
-        header = '%s - %s - Page %s' % (self.docName(), self.date, pagenr)
-        painter.save()
-        painter.setFont(self.header_font)
-        painter.setPen(QColor(Qt.black))
-        if drawing:
-            painter.drawText(area.right()-painter.fontMetrics().width(header),
-                             area.top()+painter.fontMetrics().ascent(), header)
-        area.setTop(area.top()+painter.fontMetrics().height()+5)
-        painter.restore()
 
 
 # =============================================================================

--- a/spyder/plugins/editor/widgets/gotoline.py
+++ b/spyder/plugins/editor/widgets/gotoline.py
@@ -9,12 +9,13 @@ from qtpy.QtGui import QIntValidator
 from qtpy.QtWidgets import (QDialog, QLabel, QLineEdit, QGridLayout,
                             QDialogButtonBox, QVBoxLayout, QHBoxLayout)
 
-from spyder.config.base import _
+from spyder.api.translations import get_translation
 
 
-# =============================================================================
-# Go to line dialog box
-# =============================================================================
+# Translations
+_ = get_translation('spyder')
+
+
 class GoToLineDialog(QDialog):
     def __init__(self, editor):
         QDialog.__init__(self, editor, Qt.WindowTitleHint

--- a/spyder/plugins/editor/widgets/printer.py
+++ b/spyder/plugins/editor/widgets/printer.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+import time
+
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QToolBar
+from qtpy.QtPrintSupport import QPrinter, QPrintPreviewDialog
+
+from spyder.utils.icon_manager import ima
+from spyder.utils.stylesheet import PANES_TOOLBAR_STYLESHEET
+
+
+# TODO: Implement header and footer support
+class SpyderPrinter(QPrinter):
+    def __init__(self, mode=QPrinter.ScreenResolution, header_font=None):
+        QPrinter.__init__(self, mode)
+        self.setColorMode(QPrinter.Color)
+        self.setPageOrder(QPrinter.FirstPageFirst)
+        self.date = time.ctime()
+        if header_font is not None:
+            self.header_font = header_font
+
+    # <!> The following method is simply ignored by QPlainTextEdit
+    #     (this is a copy from QsciEditor's Printer)
+    def formatPage(self, painter, drawing, area, pagenr):
+        header = '%s - %s - Page %s' % (self.docName(), self.date, pagenr)
+        painter.save()
+        painter.setFont(self.header_font)
+        painter.setPen(QColor(Qt.black))
+        if drawing:
+            painter.drawText(area.right()-painter.fontMetrics().width(header),
+                             area.top()+painter.fontMetrics().ascent(), header)
+        area.setTop(area.top()+painter.fontMetrics().height()+5)
+        painter.restore()
+
+
+class SpyderPrintPreviewDialog(QPrintPreviewDialog):
+    """
+    Subclass to make the default Qt dialog conform to the style and icons used
+    in Spyder.
+    """
+
+    def __init__(self, printer, parent=None):
+        super().__init__(printer, parent)
+        self.toolbar = self.findChildren(QToolBar)[0]
+        self.adjust_toolbar_style()
+
+    def adjust_toolbar_style(self):
+        """Make toolbar to follow Spyder style."""
+        self.toolbar.setStyleSheet(str(PANES_TOOLBAR_STYLESHEET))
+        self.toolbar.setMovable(False)
+
+        actions = self.toolbar.actions()
+
+        actions[0].setIcon(ima.icon('print.fit_width'))
+        actions[1].setIcon(ima.icon('print.fit_page'))
+        actions[2].setVisible(False)  # Separator
+
+        actions[4].setIcon(ima.icon('zoom_out'))
+        actions[5].setIcon(ima.icon('zoom_in'))
+        actions[6].setVisible(False)  # Separator
+
+        actions[7].setIcon(ima.icon('portrait'))
+        actions[8].setIcon(ima.icon('landscape'))
+        actions[9].setVisible(False)  # Separator
+
+        actions[10].setIcon(ima.icon('first_page'))
+        actions[11].setIcon(ima.icon('previous_page'))
+        actions[13].setIcon(ima.icon('next_page'))
+        actions[14].setIcon(ima.icon('last_page'))
+        actions[15].setVisible(False)  # Separator
+
+        actions[16].setIcon(ima.icon('print.single_page'))
+        actions[17].setVisible(False)  # No icon in Material design for this
+        actions[18].setIcon(ima.icon('print.multiple_pages'))
+        actions[19].setVisible(False)  # Separator
+
+        actions[20].setIcon(ima.icon('print.page_setup'))
+        actions[21].setIcon(ima.icon('print'))
+
+    def showEvent(self, event):
+        """
+        Give focus to the toolbar to avoid giving focus to the combobox that
+        shows the page percentage size, which is odd.
+        """
+        super().showEvent(event)
+        self.toolbar.setFocus()

--- a/spyder/plugins/editor/widgets/printer.py
+++ b/spyder/plugins/editor/widgets/printer.py
@@ -11,8 +11,13 @@ from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QToolBar
 from qtpy.QtPrintSupport import QPrinter, QPrintPreviewDialog
 
+from spyder.api.translations import get_translation
 from spyder.utils.icon_manager import ima
 from spyder.utils.stylesheet import PANES_TOOLBAR_STYLESHEET
+
+
+# Translations
+_ = get_translation('spyder')
 
 
 # TODO: Implement header and footer support
@@ -48,7 +53,9 @@ class SpyderPrintPreviewDialog(QPrintPreviewDialog):
     def __init__(self, printer, parent=None):
         super().__init__(printer, parent)
         self.toolbar = self.findChildren(QToolBar)[0]
+
         self.adjust_toolbar_style()
+        self.make_tooltips_translatable()
 
     def adjust_toolbar_style(self):
         """Make toolbar to follow Spyder style."""
@@ -77,11 +84,37 @@ class SpyderPrintPreviewDialog(QPrintPreviewDialog):
 
         actions[16].setIcon(ima.icon('print.single_page'))
         actions[17].setVisible(False)  # No icon in Material design for this
-        actions[18].setIcon(ima.icon('print.multiple_pages'))
+        actions[18].setIcon(ima.icon('print.all_pages'))
         actions[19].setVisible(False)  # Separator
 
         actions[20].setIcon(ima.icon('print.page_setup'))
         actions[21].setIcon(ima.icon('print'))
+
+    def make_tooltips_translatable(self):
+        """Make toolbar button tooltips translatable."""
+        # These are the tooltips shown by default by Qt. The number on the left
+        # is the corresponding action index in the toolbar.
+        translatable_tooltips = [
+            (0, _('Fit width')),
+            (1, _('Fit page')),
+            (4, _('Zoom out')),
+            (5, _('Zoom in')),
+            (7, _('Portrait')),
+            (8, _('Landscape')),
+            (10, _('First page')),
+            (11, _('Previous page')),
+            (13, _('Next page')),
+            (14, _('Last page')),
+            (16, _('Show single page')),
+            (18, _('Show overview of all pages')),
+            (20, _('Page setup')),
+            (21, _('Print')),
+        ]
+
+        actions = self.toolbar.actions()
+        for idx, tooltip in translatable_tooltips:
+            actions[idx].setText(tooltip)
+            actions[idx].setToolTip(tooltip)
 
     def showEvent(self, event):
         """

--- a/spyder/plugins/editor/widgets/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/tests/test_shortcuts.py
@@ -20,7 +20,7 @@ from qtpy.QtWidgets import QApplication
 
 # Local imports
 from spyder.config.base import running_in_ci
-from spyder.plugins.editor.widgets.codeeditor_widgets import GoToLineDialog
+from spyder.plugins.editor.widgets.gotoline import GoToLineDialog
 from spyder.plugins.editor.widgets.editor import EditorStack
 from spyder.config.manager import CONF
 

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -353,7 +353,7 @@ class IconManager():
             'first_page':              [('mdi.page-first',), {'color': self.MAIN_FG_COLOR}],
             'last_page':               [('mdi.page-last',), {'color': self.MAIN_FG_COLOR}],
             'print.single_page':       [('mdi.file-document-outline',), {'color': self.MAIN_FG_COLOR}],
-            'print.multiple_pages':    [('mdi.file-document-multiple-outline',), {'color': self.MAIN_FG_COLOR}],
+            'print.all_pages':         [('mdi.file-document-multiple-outline',), {'color': self.MAIN_FG_COLOR}],
             'print.page_setup':        [('mdi.ruler-square',), {'color': self.MAIN_FG_COLOR}],
         }
 

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -343,6 +343,18 @@ class IconManager():
             'statusbar':               [('mdi.dock-bottom',), {'color': self.MAIN_FG_COLOR}],
             # --- Plugin registry ---------------------------------------------------
             'plugins':                 [('mdi.puzzle',), {'color': self.MAIN_FG_COLOR}],
+            # --- Print preview dialog ----------------------------------------------
+            'print.fit_width':         [('mdi.arrow-expand-horizontal',), {'color': self.MAIN_FG_COLOR}],
+            'print.fit_page':          [('mdi.stretch-to-page-outline',), {'color': self.MAIN_FG_COLOR}],
+            'portrait':                [('mdi.crop-portrait',), {'color': self.MAIN_FG_COLOR}],
+            'landscape':               [('mdi.crop-landscape',), {'color': self.MAIN_FG_COLOR}],
+            'previous_page':           [('mdi.chevron-left',), {'color': self.MAIN_FG_COLOR}],
+            'next_page':               [('mdi.chevron-right',), {'color': self.MAIN_FG_COLOR}],
+            'first_page':              [('mdi.page-first',), {'color': self.MAIN_FG_COLOR}],
+            'last_page':               [('mdi.page-last',), {'color': self.MAIN_FG_COLOR}],
+            'print.single_page':       [('mdi.file-document-outline',), {'color': self.MAIN_FG_COLOR}],
+            'print.multiple_pages':    [('mdi.file-document-multiple-outline',), {'color': self.MAIN_FG_COLOR}],
+            'print.page_setup':        [('mdi.ruler-square',), {'color': self.MAIN_FG_COLOR}],
         }
 
     def get_std_icon(self, name, size=None):


### PR DESCRIPTION
## Description of Changes

- This is follow-up of PR #18808.
- I changed the dialog's icons to use Material design ones, made the toolbar follow the style of the other pane toolbars and also made the tooltip strings translatable.

**Before**

![imagen](https://user-images.githubusercontent.com/365293/181863505-4a35dbd7-d024-44a5-b1c1-ce42b21ebe6d.png)

**After**

![imagen](https://user-images.githubusercontent.com/365293/181863454-89829fca-6595-4ba6-9f9a-fe8255b0ef28.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
