### PR TITLE
PR: Add debug cell icon to the debug toolbar

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1156,6 +1156,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             debug_menu_actions + self.main.debug_menu_actions)
         debug_toolbar_actions = [
             self.debug_action,
+            self.debug_cell_action,
             self.debug_next_action,
             self.debug_step_action,
             self.debug_return_action,


### PR DESCRIPTION
I recreated this after the CRLF PR

## Description of Changes
I added the "Debug Cell" icon to the toolbar. 

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

Before
![debug](https://user-images.githubusercontent.com/70416691/181142650-1e779404-fd11-4b73-af93-763759252dd4.png)

After
![debug2](https://user-images.githubusercontent.com/70416691/181142874-aa53008c-83d4-4348-836f-868498c78316.png)


<!--- Explain what you've done and why --->

I find it extremely annoying that all of the major Debug tools are in the toolbar _except_ for the Debug Cell tool. And sometimes, when trying to click on it from the Debug menu, I accidentally hit the "Run File" toolbar icon instead. This PR adds the icon, keeping the same ordering that is used in the Debug menu.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: stevetracvc

<!--- Thanks for your help making Spyder better for everyone! --->
