### PR TITLE
PR: Fix call to show compatibility message for plugins (Mainwindow)

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -210,7 +210,7 @@ class MainWindow(QMainWindow):
         plugin.get_description()
 
         if not is_compatible:
-            self.show_compatibility_message(message)
+            self.show_plugin_compatibility_message(message)
             return
 
         # Connect Plugin Signals to main window methods


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->

If a plugin implements a compatibility check and it fails we were calling `show_compatibility_message` instead of `show_plugin_compatibility_message` causing an `AttributeError`





### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #18901


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
