### PR TITLE
PR: Improve `Maintain focus in the editor` option and unmaximize plugins when running/debugging code

### DIFF
--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -1043,7 +1043,8 @@ class SpyderDockablePlugin(SpyderPluginV2):
         """
         Switch to plugin and define if focus should be given or not.
         """
-        self.sig_switch_to_plugin_requested.emit(self, force_focus)
+        if self.get_widget().windowwidget is None:
+            self.sig_switch_to_plugin_requested.emit(self, force_focus)
 
     def set_ancestor(self, ancestor_widget):
         """

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -1069,6 +1069,9 @@ class SpyderDockablePlugin(SpyderPluginV2):
     def create_dockwidget(self, mainwindow):
         return self.get_widget().create_dockwidget(mainwindow)
 
+    def create_window(self):
+        self.get_widget().create_window()
+
     def close_window(self, save_undocked=False):
         self.get_widget().close_window(save_undocked=save_undocked)
 

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -269,6 +269,17 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
     To be used by plugins tracking main window position changes.
     """
 
+    sig_unmaximize_plugin_requested = Signal((), (object,))
+    """
+    This signal is emitted to inform the main window that it needs to
+    unmaximize the currently maximized plugin, if any.
+
+    Parameters
+    ----------
+    plugin_instance: SpyderDockablePlugin
+        Unmaximize plugin only if it is not `plugin_instance`.
+    """
+
     # --- Private attributes -------------------------------------------------
     # ------------------------------------------------------------------------
     # Define configuration name map for plugin to split configuration

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -83,8 +83,8 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
     stacked vertically and cannot be placed horizontally next to each other.
     """
 
-    # --- Attributes
-    # ------------------------------------------------------------------------
+    # ---- Attributes
+    # -------------------------------------------------------------------------
     ENABLE_SPINNER = False
     """
     This attribute enables/disables showing a spinner on the top right to the
@@ -114,8 +114,8 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
     the plugin, then this attribute should have a `None` value.
     """
 
-    # --- Signals
-    # ------------------------------------------------------------------------
+    # ---- Signals
+    # -------------------------------------------------------------------------
     sig_free_memory_requested = Signal()
     """
     This signal can be emitted to request the main application to garbage
@@ -206,12 +206,12 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
         self._plugin = plugin
         self._parent = parent
         self._default_margins = None
-        self.is_maximized = None
         self.is_visible = None
         self.dock_action = None
         self.undock_action = None
         self.close_action = None
         self._toolbars_already_rendered = False
+        self._is_maximized = False
 
         # Attribute used to access the action, toolbar, toolbutton and menu
         # registries
@@ -291,8 +291,8 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
         self._toolbars_layout.addLayout(self._main_toolbar_layout)
         self._main_layout.addLayout(self._toolbars_layout, stretch=1)
 
-    # --- Private Methods
-    # ------------------------------------------------------------------------
+    # ---- Private Methods
+    # -------------------------------------------------------------------------
     def _setup(self):
         """
         Setup default actions, create options menu, and connect signals.
@@ -452,8 +452,8 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
                 method = getattr(self.lock_unlock_action, method_name)
                 method(_("Unlock to move pane to another position"))
 
-    # --- Public Qt overriden methods
-    # ------------------------------------------------------------------------
+    # ---- Public Qt overriden methods
+    # -------------------------------------------------------------------------
     def setLayout(self, layout):
         """
         Set layout of the main widget of this plugin.
@@ -467,8 +467,8 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
         self.on_close()
         super().closeEvent(event)
 
-    # --- Public methods to use
-    # ------------------------------------------------------------------------
+    # ---- Public methods to use
+    # -------------------------------------------------------------------------
     def get_plugin(self):
         """
         Return the parent plugin.
@@ -735,8 +735,8 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
 
             # self._toolbars_already_rendered = True
 
-    # --- SpyderDockwidget handling ------------------------------------------
-    # ------------------------------------------------------------------------
+    # ---- SpyderDockwidget handling ------------------------------------------
+    # -------------------------------------------------------------------------
     @Slot()
     def create_window(self):
         """
@@ -925,6 +925,24 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
         else:
             self.dockwidget.set_title_bar()
 
+    def get_maximized_state(self):
+        """Get dockwidget's maximized state."""
+        return self._is_maximized
+
+    def set_maximized_state(self, state):
+        """
+        Set internal attribute that holds dockwidget's maximized state.
+
+        Parameters
+        ----------
+        state: bool
+            True if the plugin is maximized, False otherwise.
+        """
+        self._is_maximized = state
+
+        # This is necessary for old API plugins interacting with new ones.
+        self._plugin._ismaximized = state
+
     # --- API: methods to define or override
     # ------------------------------------------------------------------------
     def get_title(self):
@@ -963,6 +981,7 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
         This method **must** only operate on local attributes.
         """
         pass
+
 
 def run_test():
     # Third party imports

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -814,6 +814,7 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
 
             if self.dockwidget is not None:
                 self.sig_update_ancestor_requested.emit()
+                self.get_plugin().switch_to_plugin()
                 self.dockwidget.setWidget(self)
                 self.dockwidget.setVisible(True)
                 self.dockwidget.raise_()

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -385,15 +385,28 @@ class MainWindow(QMainWindow):
         last_plugin = self.last_plugin
         try:
             # New API
-            if (last_plugin is not None
-                    and last_plugin.get_widget().is_maximized
-                    and last_plugin is not plugin):
-                self.layouts.maximize_dockwidget()
+            if (
+                last_plugin is not None
+                and last_plugin.get_widget().is_maximized
+                and last_plugin is not plugin
+            ):
+                maximize_action = self.layouts.maximize_action
+                if maximize_action.isChecked():
+                    maximize_action.setChecked(False)
+                else:
+                    maximize_action.setChecked(True)
         except AttributeError:
             # Old API
-            if (last_plugin is not None and self.last_plugin._ismaximized
-                    and last_plugin is not plugin):
-                self.layouts.maximize_dockwidget()
+            if (
+                last_plugin is not None
+                and self.last_plugin._ismaximized
+                and last_plugin is not plugin
+            ):
+                maximize_action = self.layouts.maximize_action
+                if maximize_action.isChecked():
+                    maximize_action.setChecked(False)
+                else:
+                    maximize_action.setChecked(True)
 
         try:
             # New API

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -213,13 +213,16 @@ class MainWindow(QMainWindow):
             self.show_plugin_compatibility_message(message)
             return
 
-        # Connect Plugin Signals to main window methods
+        # Connect plugin signals to main window methods
         plugin.sig_exception_occurred.connect(self.handle_exception)
         plugin.sig_free_memory_requested.connect(self.free_memory)
         plugin.sig_quit_requested.connect(self.close)
         plugin.sig_redirect_stdio_requested.connect(
             self.redirect_internalshell_stdio)
         plugin.sig_status_message_requested.connect(self.show_status_message)
+        plugin.sig_unmaximize_plugin_requested.connect(self.unmaximize_plugin)
+        plugin.sig_unmaximize_plugin_requested[object].connect(
+            self.unmaximize_plugin)
 
         if isinstance(plugin, SpyderDockablePlugin):
             plugin.sig_focus_changed.connect(self.plugin_focus_changed)
@@ -356,6 +359,21 @@ class MainWindow(QMainWindow):
         possible).
         """
         self.layouts.switch_to_plugin(plugin, force_focus=force_focus)
+
+    def unmaximize_plugin(self, not_this_plugin=None):
+        """
+        Unmaximize currently maximized plugin, if any.
+
+        Parameters
+        ----------
+        not_this_plugin: SpyderDockablePlugin, optional
+            Unmaximize plugin if the maximized one is `not_this_plugin`.
+        """
+        if not_this_plugin is None:
+            self.layouts.unmaximize_dockwidget()
+        else:
+            self.layouts.unmaximize_other_dockwidget(
+                plugin_instance=not_this_plugin)
 
     def remove_dockwidget(self, plugin):
         """

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -387,7 +387,7 @@ class MainWindow(QMainWindow):
             # New API
             if (
                 last_plugin is not None
-                and last_plugin.get_widget().is_maximized
+                and last_plugin.get_widget().get_maximized_state()
                 and last_plugin is not plugin
             ):
                 maximize_action = self.layouts.maximize_action

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -357,21 +357,6 @@ class MainWindow(QMainWindow):
         # spyder/plugins/base::_switch_to_plugin
         return self.layouts.get_last_plugin()
 
-    def maximize_dockwidget(self, restore=False):
-        """
-        This is needed to prevent errors with the old API at
-        spyder/plugins/base::_switch_to_plugin.
-
-        See spyder-ide/spyder#15164
-
-        Parameters
-        ----------
-        restore : bool, optional
-            If the current dockwidget needs to be restored to its unmaximized
-            state. The default is False.
-        """
-        self.layouts.maximize_dockwidget(restore=restore)
-
     def switch_to_plugin(self, plugin, force_focus=None):
         """
         Switch to this plugin.

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1217,7 +1217,7 @@ class MainWindow(QMainWindow):
             plugin = PLUGIN_REGISTRY.get_plugin(plugin_name)
             if isinstance(plugin, SpyderDockablePlugin):
                 if plugin.get_conf('undocked_on_window_close', default=False):
-                    plugin.get_widget().create_window()
+                    plugin.create_window()
             elif isinstance(plugin, SpyderPluginWidget):
                 if plugin.get_option('undocked_on_window_close',
                                      default=False):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -345,21 +345,9 @@ class MainWindow(QMainWindow):
             conf_widget.initialize()
             return conf_widget
 
-    @property
-    def last_plugin(self):
-        """
-        Get last plugin with focus if it is a dockable widget.
-
-        If a non-dockable plugin has the focus this will return by default
-        the Editor plugin.
-        """
-        # Needed to prevent errors with the old API at
-        # spyder/plugins/base::_switch_to_plugin
-        return self.layouts.get_last_plugin()
-
     def switch_to_plugin(self, plugin, force_focus=None):
         """
-        Switch to this plugin.
+        Switch to `plugin`.
 
         Notes
         -----
@@ -367,44 +355,7 @@ class MainWindow(QMainWindow):
         this plugin to view (if it's hidden) and gives it focus (if
         possible).
         """
-        last_plugin = self.last_plugin
-        try:
-            # New API
-            if (
-                last_plugin is not None
-                and last_plugin.get_widget().get_maximized_state()
-                and last_plugin is not plugin
-            ):
-                maximize_action = self.layouts.maximize_action
-                if maximize_action.isChecked():
-                    maximize_action.setChecked(False)
-                else:
-                    maximize_action.setChecked(True)
-        except AttributeError:
-            # Old API
-            if (
-                last_plugin is not None
-                and self.last_plugin._ismaximized
-                and last_plugin is not plugin
-            ):
-                maximize_action = self.layouts.maximize_action
-                if maximize_action.isChecked():
-                    maximize_action.setChecked(False)
-                else:
-                    maximize_action.setChecked(True)
-
-        try:
-            # New API
-            if not plugin.toggle_view_action.isChecked():
-                plugin.toggle_view_action.setChecked(True)
-                plugin.get_widget().is_visible = False
-        except AttributeError:
-            # Old API
-            if not plugin._toggle_view_action.isChecked():
-                plugin._toggle_view_action.setChecked(True)
-                plugin._widget._is_visible = False
-
-        plugin.change_visibility(True, force_focus=force_focus)
+        self.layouts.switch_to_plugin(plugin, force_focus=force_focus)
 
     def remove_dockwidget(self, plugin):
         """

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -4167,7 +4167,7 @@ def test_running_namespace_refresh(main_window, qtbot, tmpdir):
     qtbot.wait(500)
     nsb.refresh_table()
     qtbot.waitUntil(lambda: len(nsb.editor.source_model._data) == 1)
-    assert 0 < int(nsb.editor.source_model._data['j']['view']) < 9
+    assert 0 < int(nsb.editor.source_model._data['j']['view']) <= 9
 
     qtbot.waitSignal(shell.executed)
 
@@ -4188,7 +4188,7 @@ def test_running_namespace_refresh(main_window, qtbot, tmpdir):
     qtbot.wait(500)
     nsb.refresh_table()
     qtbot.waitUntil(lambda: len(nsb.editor.source_model._data) == 1)
-    assert 0 < int(nsb.editor.source_model._data['i']['view']) < 9
+    assert 0 < int(nsb.editor.source_model._data['i']['view']) <= 9
 
 
 @pytest.mark.slow

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1911,15 +1911,12 @@ def test_maximize_minimize_plugins(main_window, qtbot):
 
     def get_random_plugin():
         """Get a random dockable plugin and give it focus"""
-        plugins = get_class_values(Plugins)
-        plugins.remove(Plugins.Editor)
-        plugins.remove(Plugins.IPythonConsole)
-        plugins.remove(Plugins.All)
+        plugins = main_window.get_dockable_plugins()
+        for plugin_name, plugin in plugins:
+            if plugin_name in [Plugins.Editor, Plugins.IPythonConsole]:
+                plugins.remove((plugin_name, plugin))
 
-        plugin = main_window.get_plugin(Plugins.Layout)
-        while not hasattr(plugin, 'WIDGET_CLASS'):
-            plugin_name = random.choice(plugins)
-            plugin = main_window.get_plugin(plugin_name)
+        plugin = random.choice(plugins)[1]
 
         if not plugin.get_widget().toggle_view_action.isChecked():
             plugin.toggle_view(True)

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1903,12 +1903,11 @@ def test_close_when_file_is_changed(main_window, qtbot):
 @pytest.mark.slow
 @flaky(max_runs=3)
 def test_maximize_minimize_plugins(main_window, qtbot):
-    """Test that the maximize button is working correctly."""
+    """Test that the maximize button is working as expected."""
     # Wait until the window is fully up
     shell = main_window.ipyconsole.get_current_shellwidget()
     qtbot.waitUntil(
         lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
-
 
     def get_random_plugin():
         """Get a random dockable plugin and give it focus"""
@@ -1931,7 +1930,8 @@ def test_maximize_minimize_plugins(main_window, qtbot):
 
     # Wait until the window is fully up
     shell = main_window.ipyconsole.get_current_shellwidget()
-    qtbot.waitUntil(lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
+    qtbot.waitUntil(lambda: shell._prompt_html is not None,
+                    timeout=SHELL_TIMEOUT)
 
     # Grab maximize button
     max_action = main_window.layouts.maximize_action
@@ -2005,13 +2005,14 @@ def test_maximize_minimize_plugins(main_window, qtbot):
     if hasattr(plugin_2, '_hide_after_test'):
         plugin_2.toggle_view(False)
 
+    # Stop debugger
     stop_debug_action = main_window.debug_toolbar_actions[5]
     stop_debug_button = main_window.debug_toolbar.widgetForAction(
         stop_debug_action)
     with qtbot.waitSignal(shell.executed):
         qtbot.mouseClick(stop_debug_button, Qt.LeftButton)
 
-    # Maximize a plugin and check that it's unmaximized after running code
+    # Maximize a plugin and check that it's unmaximized after running a file
     plugin_3 = get_random_plugin()
     qtbot.mouseClick(max_button, Qt.LeftButton)
     qtbot.mouseClick(run_button, Qt.LeftButton)
@@ -2019,6 +2020,30 @@ def test_maximize_minimize_plugins(main_window, qtbot):
     assert not max_action.isChecked()
     if hasattr(plugin_3, '_hide_after_test'):
         plugin_3.toggle_view(False)
+
+    # Maximize a plugin and check that it's unmaximized after running a cell
+    plugin_4 = get_random_plugin()
+    run_cell_action = main_window.run_toolbar_actions[1]
+    run_cell_button = main_window.run_toolbar.widgetForAction(run_cell_action)
+    qtbot.mouseClick(max_button, Qt.LeftButton)
+    qtbot.mouseClick(run_cell_button, Qt.LeftButton)
+    assert not plugin_4.get_widget().get_maximized_state()
+    assert not max_action.isChecked()
+    if hasattr(plugin_4, '_hide_after_test'):
+        plugin_4.toggle_view(False)
+
+    # Maximize a plugin and check that it's unmaximized after running a
+    # selection
+    plugin_5 = get_random_plugin()
+    run_selection_action = main_window.run_toolbar_actions[3]
+    run_selection_button = main_window.run_toolbar.widgetForAction(
+        run_selection_action)
+    qtbot.mouseClick(max_button, Qt.LeftButton)
+    qtbot.mouseClick(run_selection_button, Qt.LeftButton)
+    assert not plugin_5.get_widget().get_maximized_state()
+    assert not max_action.isChecked()
+    if hasattr(plugin_5, '_hide_after_test'):
+        plugin_5.toggle_view(False)
 
 
 @pytest.mark.slow
@@ -5082,13 +5107,13 @@ crash_func()
 def test_focus_to_editor(main_window, qtbot, tmpdir, focus_to_editor):
     """Test that the focus_to_editor option works as expected."""
 
-    def check_focus(button, debug=False):
+    def check_focus(button):
         # Give focus back to the editor before running the next test
         if not focus_to_editor:
             code_editor.setFocus()
 
         # Make sure we don't switch to the console after pressing the button
-        if focus_to_editor and not debug:
+        if focus_to_editor:
             with qtbot.assertNotEmitted(
                 main_window.ipyconsole.sig_switch_to_plugin_requested,
                 wait=1000
@@ -5138,7 +5163,7 @@ foo(1)
     # Run a file
     run_action = main_window.run_toolbar_actions[0]
     run_button = main_window.run_toolbar.widgetForAction(run_action)
-    check_focus(run_button, debug=True)
+    check_focus(run_button)
 
     # Run a cell
     run_cell_action = main_window.run_toolbar_actions[1]
@@ -5160,13 +5185,13 @@ foo(1)
     # Debug a file
     debug_action = main_window.debug_toolbar_actions[0]
     debug_button = main_window.debug_toolbar.widgetForAction(debug_action)
-    check_focus(debug_button, debug=True)
+    check_focus(debug_button)
 
     # Go to the next line while debugging
     debug_next_action = main_window.debug_toolbar_actions[1]
     debug_next_button = main_window.debug_toolbar.widgetForAction(
         debug_next_action)
-    check_focus(debug_next_button, debug=True)
+    check_focus(debug_next_button)
 
 
 @pytest.mark.slow

--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -295,12 +295,14 @@ class BasePluginWidgetMixin(object):
 
     def _switch_to_plugin(self):
         """Switch to plugin."""
+        last_plugin = self.main.layouts.get_last_plugin()
+        maximize_action = self.main.layouts.maximize_action
+
         if (
-            self.main.last_plugin is not None
-            and self.main.last_plugin._ismaximized
-            and self.main.last_plugin is not self
+            last_plugin is not None
+            and last_plugin._ismaximized
+            and last_plugin is not self
         ):
-            maximize_action = self.main.layouts.maximize_action
             if maximize_action.isChecked():
                 maximize_action.setChecked(False)
             else:

--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -295,13 +295,16 @@ class BasePluginWidgetMixin(object):
 
     def _switch_to_plugin(self):
         """Switch to plugin."""
-        if (self.main.last_plugin is not None and
-                self.main.last_plugin._ismaximized and
-                self.main.last_plugin is not self):
-            self.main.maximize_dockwidget()
-        if not self._toggle_view_action.isChecked():
-            self._toggle_view_action.setChecked(True)
-        self._visibility_changed(True)
+        if (
+            self.main.last_plugin is not None
+            and self.main.last_plugin._ismaximized
+            and self.main.last_plugin is not self
+        ):
+            maximize_action = self.main.layouts.maximize_action
+            if maximize_action.isChecked():
+                maximize_action.setChecked(False)
+            else:
+                maximize_action.setChecked(True)
 
     @Slot()
     def _plugin_closed(self):

--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -205,8 +205,10 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         # --- Run code tab ---
         saveall_box = newcb(_("Save all files before running script"),
                             'save_all_before_run')
-        focus_box = newcb(_("Maintain focus in the Editor after running cells "
-                            "or selections"), 'focus_to_editor')
+        focus_box = newcb(
+            _("Maintain focus in the editor after running or debugging code"),
+            'focus_to_editor'
+        )
         run_cell_box = newcb(_("Copy full cell contents to the console when "
                                "running code cells"), 'run_cell_copy')
 

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2866,7 +2866,6 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
 
     def debug_command(self, command):
         """Debug actions"""
-        self.switch_to_plugin()
         ipyconsole = self.main.get_plugin(Plugins.IPythonConsole, error=False)
         if ipyconsole:
             ipyconsole.pdb_execute_command(
@@ -3037,7 +3036,6 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
     @Slot()
     def debug_file(self):
         """Debug current script"""
-        self.switch_to_plugin()
         current_editor = self.get_current_editor()
         if current_editor is not None:
             current_editor.sig_debug_start.emit()

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -86,8 +86,8 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
     OPTIONAL = [Plugins.Completions, Plugins.OutlineExplorer]
 
     # Signals
-    run_in_current_ipyclient = Signal(str, str, str,
-                                      bool, bool, bool, bool, bool)
+    run_in_current_ipyclient = Signal(
+        str, str, str, bool, bool, bool, bool, bool, bool)
     run_cell_in_ipyclient = Signal(str, object, str, bool, bool)
     debug_cell_in_ipyclient = Signal(str, object, str, bool, bool)
     exec_in_extconsole = Signal(str, bool)
@@ -2968,9 +2968,6 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
     @Slot()
     def run_file(self, debug=False):
         """Run script inside current interpreter or in a new one"""
-        editorstack = self.get_current_editorstack()
-
-        editor = self.get_current_editor()
         fname = osp.abspath(self.get_current_filename())
 
         # Get fname's dirname before we escape the single and double
@@ -3033,12 +3030,6 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                                post_mortem, clear_namespace,
                                console_namespace)
         self.re_run_file(save_new_files=False)
-        if not interact and not debug:
-            # If external console dockwidget is hidden, it will be
-            # raised in top-level and so focus will be given to the
-            # current external shell automatically
-            # (see SpyderPluginWidget.visibility_changed method)
-            editor.setFocus()
 
     def set_dialog_size(self, size):
         self.dialog_size = size
@@ -3061,19 +3052,23 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                 return
         if self.__last_ec_exec is None:
             return
+
         (fname, wdir, args, interact, debug,
          python, python_args, current, systerm,
          post_mortem, clear_namespace,
          console_namespace) = self.__last_ec_exec
+        focus_to_editor = self.get_option('focus_to_editor')
+
         if not systerm:
-            self.run_in_current_ipyclient.emit(fname, wdir, args,
-                                               debug, post_mortem,
-                                               current, clear_namespace,
-                                               console_namespace)
+            self.run_in_current_ipyclient.emit(
+                fname, wdir, args, debug, post_mortem, current,
+                clear_namespace, console_namespace, focus_to_editor
+            )
         else:
-            self.main.open_external_console(fname, wdir, args, interact,
-                                            debug, python, python_args,
-                                            systerm, post_mortem)
+            self.main.open_external_console(
+                fname, wdir, args, interact, debug, python, python_args,
+                systerm, post_mortem
+            )
 
     @Slot()
     def run_selection(self):

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2869,8 +2869,8 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         self.switch_to_plugin()
         ipyconsole = self.main.get_plugin(Plugins.IPythonConsole, error=False)
         if ipyconsole:
-            ipyconsole.pdb_execute_command(command)
-            ipyconsole.switch_to_plugin()
+            ipyconsole.pdb_execute_command(
+                command, focus_to_editor=self.get_option('focus_to_editor'))
 
     # ----- Handlers for the IPython Console kernels
     def _get_editorstack(self):

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2833,7 +2833,8 @@ class EditorStack(QWidget):
             self.exec_in_extconsole.emit(text, self.focus_to_editor)
         if editor.is_cursor_on_last_line() and text:
             editor.append(editor.get_line_separator())
-        editor.move_cursor_to_next('line', 'down')
+        if self.focus_to_editor:
+            editor.move_cursor_to_next('line', 'down')
 
     def run_cell(self, debug=False):
         """Run current cell."""

--- a/spyder/plugins/explorer/plugin.py
+++ b/spyder/plugins/explorer/plugin.py
@@ -211,8 +211,13 @@ class Explorer(SpyderDockablePlugin):
             ipyconsole.create_client_from_path)
         self.sig_run_requested.connect(
             lambda fname:
-            ipyconsole.run_script(fname, osp.dirname(fname), '', False,
-                                  False, False, True, False))
+            ipyconsole.run_script(
+                filename=fname,
+                wdir=osp.dirname(fname),
+                current_client=False,
+                clear_variables=True,
+            )
+        )
 
     @on_plugin_teardown(plugin=Plugins.Editor)
     def on_editor_teardown(self):

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -627,9 +627,10 @@ class IPythonConsole(SpyderDockablePlugin):
                                        ask_recursive=ask_recursive)
 
     # ---- For execution and debugging
-    def run_script(self, filename, wdir, args, debug, post_mortem,
-                   current_client, clear_variables, console_namespace,
-                   focus_to_editor):
+    def run_script(self, filename, wdir, args='', debug=False,
+                   post_mortem=False, current_client=True,
+                   clear_variables=False, console_namespace=False,
+                   focus_to_editor=True):
         """
         Run script in current or dedicated client.
 
@@ -639,24 +640,24 @@ class IPythonConsole(SpyderDockablePlugin):
             Path to file that will be run.
         wdir : str
             Working directory from where the file should be run.
-        args : str
+        args : str, optional
             Arguments defined to run the file.
-        debug : bool
+        debug : bool, optional
             True if the run if for debugging the file,
             False for just running it.
-        post_mortem : bool
+        post_mortem : bool, optional
             True if in case of error the execution should enter in
             post-mortem mode, False otherwise.
-        current_client : bool
+        current_client : bool, optional
             True if the execution should be done in the current client,
             False if the execution needs to be done in a dedicated client.
-        clear_variables : bool
+        clear_variables : bool, optional
             True if all the variables should be removed before execution,
             False otherwise.
-        console_namespace : bool
+        console_namespace : bool, optional
             True if the console namespace should be used, False otherwise.
-        focus_to_editor: bool
-            Leave focus in editor after execution.
+        focus_to_editor: bool, optional
+            Leave focus in the editor after execution.
 
         Returns
         -------

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -40,7 +40,7 @@ class IPythonConsole(SpyderDockablePlugin):
 
     # This is required for the new API
     NAME = 'ipython_console'
-    REQUIRES = [Plugins.Console, Plugins.Preferences]
+    REQUIRES = [Plugins.Console, Plugins.Preferences, Plugins.Layout]
     OPTIONAL = [Plugins.Editor, Plugins.History, Plugins.MainMenu,
                 Plugins.Projects, Plugins.WorkingDirectory]
     TABIFY = [Plugins.History]
@@ -437,6 +437,19 @@ class IPythonConsole(SpyderDockablePlugin):
         """Set current working directory on the main widget."""
         self.get_widget().set_working_directory(new_dir)
 
+    def _unmaximize_plugin(self):
+        """
+        Unmaximize the currently maximized plugin, if any.
+
+        Notes
+        -----
+        We assume that users want to check output in the IPython console after
+        after running or debugging code. And for that we need to unmaximize any
+        plugin that is currently maximized.
+        """
+        layouts = self.get_plugin(Plugins.Layout)
+        layouts.unmaximize_dockwidget()
+
     # ---- Public API
     # -------------------------------------------------------------------------
 
@@ -649,6 +662,7 @@ class IPythonConsole(SpyderDockablePlugin):
         -------
         None.
         """
+        self._unmaximize_plugin()
         self.get_widget().run_script(
             filename,
             wdir,
@@ -689,6 +703,7 @@ class IPythonConsole(SpyderDockablePlugin):
         -------
         None.
         """
+        self._unmaximize_plugin()
         self.get_widget().run_cell(
             code, cell_name, filename, run_cell_copy, focus_to_editor,
             function=function)
@@ -718,6 +733,7 @@ class IPythonConsole(SpyderDockablePlugin):
         -------
         None.
         """
+        self._unmaximize_plugin()
         self.get_widget().debug_cell(code, cell_name, filename, run_cell_copy,
                                      focus_to_editor)
 
@@ -747,10 +763,12 @@ class IPythonConsole(SpyderDockablePlugin):
 
     def run_selection(self, lines, focus_to_editor=True):
         """Execute selected lines in the current console."""
+        self._unmaximize_plugin()
         self.get_widget().execute_code(lines, set_focus=not focus_to_editor)
 
     def stop_debugging(self):
         """Stop debugging in the current console."""
+        self._unmaximize_plugin()
         self.get_widget().stop_debugging()
 
     def get_pdb_state(self):
@@ -776,6 +794,7 @@ class IPythonConsole(SpyderDockablePlugin):
         -------
         None.
         """
+        self._unmaximize_plugin()
         self.get_widget().pdb_execute_command(command, focus_to_editor)
 
     def print_debug_file_msg(self):

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -620,7 +620,8 @@ class IPythonConsole(SpyderDockablePlugin):
 
     # ---- For execution and debugging
     def run_script(self, filename, wdir, args, debug, post_mortem,
-                   current_client, clear_variables, console_namespace):
+                   current_client, clear_variables, console_namespace,
+                   focus_to_editor):
         """
         Run script in current or dedicated client.
 
@@ -646,6 +647,8 @@ class IPythonConsole(SpyderDockablePlugin):
             False otherwise.
         console_namespace : bool
             True if the console namespace should be used, False otherwise.
+        focus_to_editor: bool
+            Leave focus in editor after execution.
 
         Returns
         -------
@@ -659,7 +662,8 @@ class IPythonConsole(SpyderDockablePlugin):
             post_mortem,
             current_client,
             clear_variables,
-            console_namespace)
+            console_namespace,
+            focus_to_editor)
 
     def run_cell(self, code, cell_name, filename, run_cell_copy,
                  focus_to_editor, function='runcell'):

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -443,7 +443,7 @@ class IPythonConsole(SpyderDockablePlugin):
 
         Notes
         -----
-        We assume that users want to check output in the IPython console after
+        We assume that users want to check output in the IPython console
         after running or debugging code. And for that we need to unmaximize any
         plugin that is currently maximized.
         """

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -40,7 +40,7 @@ class IPythonConsole(SpyderDockablePlugin):
 
     # This is required for the new API
     NAME = 'ipython_console'
-    REQUIRES = [Plugins.Console, Plugins.Preferences, Plugins.Layout]
+    REQUIRES = [Plugins.Console, Plugins.Preferences]
     OPTIONAL = [Plugins.Editor, Plugins.History, Plugins.MainMenu,
                 Plugins.Projects, Plugins.WorkingDirectory]
     TABIFY = [Plugins.History]
@@ -437,19 +437,6 @@ class IPythonConsole(SpyderDockablePlugin):
         """Set current working directory on the main widget."""
         self.get_widget().set_working_directory(new_dir)
 
-    def _unmaximize_plugin(self):
-        """
-        Unmaximize the currently maximized plugin, if any.
-
-        Notes
-        -----
-        We assume that users want to check output in the IPython console
-        after running or debugging code. And for that we need to unmaximize any
-        plugin that is currently maximized.
-        """
-        layouts = self.get_plugin(Plugins.Layout)
-        layouts.unmaximize_dockwidget()
-
     # ---- Public API
     # -------------------------------------------------------------------------
 
@@ -663,7 +650,7 @@ class IPythonConsole(SpyderDockablePlugin):
         -------
         None.
         """
-        self._unmaximize_plugin()
+        self.sig_unmaximize_plugin_requested.emit()
         self.get_widget().run_script(
             filename,
             wdir,
@@ -704,7 +691,7 @@ class IPythonConsole(SpyderDockablePlugin):
         -------
         None.
         """
-        self._unmaximize_plugin()
+        self.sig_unmaximize_plugin_requested.emit()
         self.get_widget().run_cell(
             code, cell_name, filename, run_cell_copy, focus_to_editor,
             function=function)
@@ -734,7 +721,7 @@ class IPythonConsole(SpyderDockablePlugin):
         -------
         None.
         """
-        self._unmaximize_plugin()
+        self.sig_unmaximize_plugin_requested.emit()
         self.get_widget().debug_cell(code, cell_name, filename, run_cell_copy,
                                      focus_to_editor)
 
@@ -764,12 +751,12 @@ class IPythonConsole(SpyderDockablePlugin):
 
     def run_selection(self, lines, focus_to_editor=True):
         """Execute selected lines in the current console."""
-        self._unmaximize_plugin()
+        self.sig_unmaximize_plugin_requested.emit()
         self.get_widget().execute_code(lines, set_focus=not focus_to_editor)
 
     def stop_debugging(self):
         """Stop debugging in the current console."""
-        self._unmaximize_plugin()
+        self.sig_unmaximize_plugin_requested.emit()
         self.get_widget().stop_debugging()
 
     def get_pdb_state(self):
@@ -795,7 +782,7 @@ class IPythonConsole(SpyderDockablePlugin):
         -------
         None.
         """
-        self._unmaximize_plugin()
+        self.sig_unmaximize_plugin_requested.emit()
         self.get_widget().pdb_execute_command(command, focus_to_editor)
 
     def print_debug_file_msg(self):

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -319,7 +319,7 @@ class IPythonConsole(SpyderDockablePlugin):
 
         # Connect Editor debug action with Console
         self.sig_pdb_state_changed.connect(editor.update_pdb_state)
-        editor.exec_in_extconsole.connect(self.execute_code_and_focus_editor)
+        editor.exec_in_extconsole.connect(self.run_selection)
         editor.sig_file_debug_message_requested.connect(
             self.print_debug_file_msg)
 
@@ -366,8 +366,7 @@ class IPythonConsole(SpyderDockablePlugin):
 
         # Connect Editor debug action with Console
         self.sig_pdb_state_changed.disconnect(editor.update_pdb_state)
-        editor.exec_in_extconsole.disconnect(
-            self.execute_code_and_focus_editor)
+        editor.exec_in_extconsole.disconnect(self.run_selection)
         editor.sig_file_debug_message_requested.disconnect(
             self.print_debug_file_msg)
 
@@ -407,10 +406,6 @@ class IPythonConsole(SpyderDockablePlugin):
     def _load_file_in_editor(self, fname, lineno, word, processevents):
         editor = self.get_plugin(Plugins.Editor)
         editor.load(fname, lineno, word, processevents=processevents)
-
-    def _switch_to_editor(self):
-        editor = self.get_plugin(Plugins.Editor)
-        editor.switch_to_plugin()
 
     def _on_project_loaded(self):
         projects = self.get_plugin(Plugins.Projects)
@@ -750,16 +745,9 @@ class IPythonConsole(SpyderDockablePlugin):
             current_client=current_client,
             clear_variables=clear_variables)
 
-    def execute_code_and_focus_editor(self, lines, focus_to_editor=True):
-        """
-        Execute lines in IPython console and eventually set focus
-        to the Editor.
-        """
-        self.execute_code(lines)
-        if focus_to_editor and self.get_plugin(Plugins.Editor):
-            self._switch_to_editor()
-        else:
-            self.switch_to_plugin()
+    def run_selection(self, lines, focus_to_editor=True):
+        """Execute selected lines in the current console."""
+        self.get_widget().execute_code(lines, set_focus=not focus_to_editor)
 
     def stop_debugging(self):
         """Stop debugging in the current console."""

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -773,7 +773,7 @@ class IPythonConsole(SpyderDockablePlugin):
         """Get last pdb step of the current console."""
         return self.get_widget().get_pdb_last_step()
 
-    def pdb_execute_command(self, command):
+    def pdb_execute_command(self, command, focus_to_editor):
         """
         Send command to the pdb kernel if possible.
 
@@ -781,12 +781,14 @@ class IPythonConsole(SpyderDockablePlugin):
         ----------
         command : str
             Command to execute by the pdb kernel.
+        focus_to_editor: bool
+            Leave focus in editor after the command is executed.
 
         Returns
         -------
         None.
         """
-        self.get_widget().pdb_execute_command(command)
+        self.get_widget().pdb_execute_command(command, focus_to_editor)
 
     def print_debug_file_msg(self):
         """

--- a/spyder/plugins/ipythonconsole/widgets/debugging.py
+++ b/spyder/plugins/ipythonconsole/widgets/debugging.py
@@ -198,6 +198,8 @@ class DebuggingWidget(DebuggingHistoryWidget, SpyderConfigurationAccessor):
         self._pdb_prompt = (None, None)  # prompt, password
         self._pdb_last_cmd = ''  # last command sent to pdb
         self._pdb_frame_loc = (None, None)  # fname, lineno
+        self._pdb_focus_to_editor = True  # Focus to editor after command
+                                          # execution
         # Command queue
         self._pdb_input_queue = []  # List of (code, hidden, echo_stack_entry)
         # Temporary flags
@@ -266,10 +268,11 @@ class DebuggingWidget(DebuggingHistoryWidget, SpyderConfigurationAccessor):
             prefix = '!'
         return prefix
 
-    def pdb_execute_command(self, command):
+    def pdb_execute_command(self, command, focus_to_editor=False):
         """
         Execute a pdb command
         """
+        self._pdb_focus_to_editor = focus_to_editor
         self.pdb_execute(
             self._pdb_cmd_prefix() + command, hidden=False,
             echo_stack_entry=False, add_history=False)

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -2357,8 +2357,9 @@ class IPythonConsoleWidget(PluginMainWidget):
             except AttributeError:
                 pass
 
-            # Show plugin after execution
-            self.sig_switch_to_plugin_requested.emit()
+            # Show plugin after execution if focus is going to be given to it.
+            if not focus_to_editor:
+                self.sig_switch_to_plugin_requested.emit()
         else:
             # XXX: not sure it can really happen
             QMessageBox.warning(

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -2262,7 +2262,7 @@ class IPythonConsoleWidget(PluginMainWidget):
 
             # This is necessary to prevent raising the console if the editor
             # and console are tabified next to each other and the 'Maintain
-            # focus in the editor' option is activated.
+            # focus in the editor' option is enabled.
             # Fixes spyder-ide/spyder#17028
             if not focus_to_editor:
                 self.sig_switch_to_plugin_requested.emit()
@@ -2435,15 +2435,26 @@ class IPythonConsoleWidget(PluginMainWidget):
                 sw.reset_namespace(warning=False)
             elif current_client and clear_variables:
                 sw.reset_namespace(warning=False)
+
             # Needed to handle an error when kernel_client is none.
             # See spyder-ide/spyder#6308.
             try:
                 sw.execute(str(lines))
             except AttributeError:
                 pass
-            self.activateWindow()
+
             if set_focus:
-                self.get_current_client().get_control().setFocus()
+                # The `activateWindow` call below needs to be inside this `if`
+                # to avoid giving focus to the console when it's undocked,
+                # users are running code from the editor and the 'Maintain
+                # focus in the editor' option is enabled.
+                # Fixes spyder-ide/spyder#3221
+                self.activateWindow()
+
+                # Gives focus to the current client
+                focus_widget = self.get_focus_widget()
+                if focus_widget:
+                    focus_widget.setFocus()
 
     # ---- For error handling
     def go_to_error(self, text):

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -2285,7 +2285,8 @@ class IPythonConsoleWidget(PluginMainWidget):
 
     # ---- For scripts
     def run_script(self, filename, wdir, args, debug, post_mortem,
-                   current_client, clear_variables, console_namespace):
+                   current_client, clear_variables, console_namespace,
+                   focus_to_editor):
         """Run script in current or dedicated client"""
         norm = lambda text: remove_backslashes(str(text))
 
@@ -2335,18 +2336,22 @@ class IPythonConsoleWidget(PluginMainWidget):
                     pass
                 elif current_client:
                     self.execute_code(line, current_client, clear_variables,
-                                      set_focus=False)
+                                      set_focus=not focus_to_editor)
                 else:
                     if is_new_client:
                         client.shellwidget.silent_execute('%clear')
                     else:
                         client.shellwidget.execute('%clear')
                     client.shellwidget.sig_prompt_ready.connect(
-                            lambda: self.execute_code(
-                                line, current_client, clear_variables,
-                                set_focus=False))
+                        lambda: self.execute_code(
+                            line, current_client, clear_variables,
+                            set_focus=not focus_to_editor
+                        )
+                    )
             except AttributeError:
                 pass
+
+            # Show plugin after execution
             self.sig_switch_to_plugin_requested.emit()
         else:
             # XXX: not sure it can really happen

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -696,6 +696,11 @@ class Layout(SpyderPluginV2):
                 # Old API
                 self._last_plugin.get_focus_widget().setFocus()
 
+    def unmaximize_dockwidget(self):
+        """Unmaximize any dockable plugin."""
+        if self.maximize_action.isChecked():
+            self.maximize_action.setChecked(False)
+
     def _update_fullscreen_action(self):
         if self._fullscreen_flag:
             icon = self.create_icon('window_nofullscreen')

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -725,6 +725,54 @@ class Layout(SpyderPluginV2):
         ):
             self.unmaximize_dockwidget()
 
+    def switch_to_plugin(self, plugin, force_focus=None):
+        """
+        Switch to `plugin`.
+
+        Notes
+        -----
+        This operation unmaximizes the current plugin (if any), raises
+        this plugin to view (if it's hidden) and gives it focus (if
+        possible).
+        """
+        last_plugin = self.get_last_plugin()
+
+        try:
+            # New API
+            if (
+                last_plugin is not None
+                and last_plugin.get_widget().get_maximized_state()
+                and last_plugin is not plugin
+            ):
+                if self.maximize_action.isChecked():
+                    self.maximize_action.setChecked(False)
+                else:
+                    self.maximize_action.setChecked(True)
+        except AttributeError:
+            # Old API
+            if (
+                last_plugin is not None
+                and last_plugin._ismaximized
+                and last_plugin is not plugin
+            ):
+                if self.maximize_action.isChecked():
+                    self.maximize_action.setChecked(False)
+                else:
+                    self.maximize_action.setChecked(True)
+
+        try:
+            # New API
+            if not plugin.toggle_view_action.isChecked():
+                plugin.toggle_view_action.setChecked(True)
+                plugin.get_widget().is_visible = False
+        except AttributeError:
+            # Old API
+            if not plugin._toggle_view_action.isChecked():
+                plugin._toggle_view_action.setChecked(True)
+                plugin._widget._is_visible = False
+
+        plugin.change_visibility(True, force_focus=force_focus)
+
     def _update_fullscreen_action(self):
         if self._fullscreen_flag:
             icon = self.create_icon('window_nofullscreen')

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -701,6 +701,30 @@ class Layout(SpyderPluginV2):
         if self.maximize_action.isChecked():
             self.maximize_action.setChecked(False)
 
+    def unmaximize_other_dockwidget(self, plugin_instance):
+        """
+        Unmaximize the currently maximized plugin, if not `plugin_instance`.
+        """
+        last_plugin = self.get_last_plugin()
+        is_maximized = False
+
+        if last_plugin is not None:
+            try:
+                # New API
+                is_maximized = (
+                    last_plugin.get_widget().get_maximized_state()
+                )
+            except AttributeError:
+                # Old API
+                is_maximized = last_plugin._ismaximized
+
+        if (
+            last_plugin is not None
+            and is_maximized
+            and last_plugin is not plugin_instance
+        ):
+            self.unmaximize_dockwidget()
+
     def _update_fullscreen_action(self):
         if self._fullscreen_flag:
             icon = self.create_icon('window_nofullscreen')

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -13,7 +13,7 @@ import os
 
 # Third party imports
 from qtpy.QtCore import Qt, QByteArray, QSize, QPoint, Slot
-from qtpy.QtWidgets import QApplication, QDesktopWidget, QDockWidget
+from qtpy.QtWidgets import QApplication, QDesktopWidget
 
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
@@ -641,10 +641,11 @@ class Layout(SpyderPluginV2):
             try:
                 # New API
                 self.main.setCentralWidget(self._last_plugin.get_widget())
+                self._last_plugin.get_widget().set_maximized_state(True)
             except AttributeError:
                 # Old API
                 self.main.setCentralWidget(self._last_plugin)
-            self._last_plugin._ismaximized = True
+                self._last_plugin._ismaximized = True
 
             # Workaround to solve an issue with editor's outline explorer:
             # (otherwise the whole plugin is hidden and so is the outline
@@ -679,7 +680,7 @@ class Layout(SpyderPluginV2):
 
             try:
                 # New API
-                self._last_plugin.get_widget().is_maximized = False
+                self._last_plugin.get_widget().set_maximized_state(False)
             except AttributeError:
                 # Old API
                 self._last_plugin._ismaximized = False

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -76,7 +76,7 @@ class Projects(SpyderDockablePlugin):
     NAME = 'project_explorer'
     CONF_SECTION = NAME
     CONF_FILE = False
-    REQUIRES = [Plugins.Layout]
+    REQUIRES = []
     OPTIONAL = [Plugins.Completions, Plugins.IPythonConsole, Plugins.Editor,
                 Plugins.MainMenu]
     WIDGET_CLASS = ProjectExplorerWidget
@@ -392,8 +392,7 @@ class Projects(SpyderDockablePlugin):
     def unmaximize(self):
         """Unmaximize the currently maximized plugin, if not self."""
         if self.main:
-            layouts = self.get_plugin(Plugins.Layout)
-            layouts.unmaximize_other_dockwidget(plugin_instance=self)
+            self.sig_unmaximize_plugin_requested[object].emit(self)
 
     def build_opener(self, project):
         """Build function opening passed project"""

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -393,25 +393,7 @@ class Projects(SpyderDockablePlugin):
         """Unmaximize the currently maximized plugin, if not self."""
         if self.main:
             layouts = self.get_plugin(Plugins.Layout)
-            last_plugin = layouts.get_last_plugin()
-            is_maximized = False
-
-            if last_plugin is not None:
-                try:
-                    # New API
-                    is_maximized = (
-                        last_plugin.get_widget().get_maximized_state()
-                    )
-                except AttributeError:
-                    # Old API
-                    is_maximized = last_plugin._ismaximized
-
-            if (
-                last_plugin is not None
-                and is_maximized
-                and last_plugin is not self
-            ):
-                layouts.unmaximize_dockwidget()
+            layouts.unmaximize_other_dockwidget(plugin_instance=self)
 
     def build_opener(self, project):
         """Build function opening passed project"""

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -76,7 +76,7 @@ class Projects(SpyderDockablePlugin):
     NAME = 'project_explorer'
     CONF_SECTION = NAME
     CONF_FILE = False
-    REQUIRES = []
+    REQUIRES = [Plugins.Layout]
     OPTIONAL = [Plugins.Completions, Plugins.IPythonConsole, Plugins.Editor,
                 Plugins.MainMenu]
     WIDGET_CLASS = ProjectExplorerWidget
@@ -392,10 +392,26 @@ class Projects(SpyderDockablePlugin):
     def unmaximize(self):
         """Unmaximize the currently maximized plugin, if not self."""
         if self.main:
-            if (self.main.last_plugin is not None and
-                    self.main.last_plugin._ismaximized and
-                    self.main.last_plugin is not self):
-                self.main.maximize_dockwidget()
+            layouts = self.get_plugin(Plugins.Layout)
+            last_plugin = layouts.get_last_plugin()
+            is_maximized = False
+
+            if last_plugin is not None:
+                try:
+                    # New API
+                    is_maximized = (
+                        last_plugin.get_widget().get_maximized_state()
+                    )
+                except AttributeError:
+                    # Old API
+                    is_maximized = last_plugin._ismaximized
+
+            if (
+                last_plugin is not None
+                and is_maximized
+                and last_plugin is not self
+            ):
+                layouts.unmaximize_dockwidget()
 
     def build_opener(self, project):
         """Build function opening passed project"""

--- a/spyder/plugins/tours/container.py
+++ b/spyder/plugins/tours/container.py
@@ -51,7 +51,7 @@ class ToursContainer(PluginMainContainer):
             TourActions.ShowTour,
             text=_("Show tour"),
             icon=self.create_icon('tour'),
-            triggered=lambda: self.show_tour(DEFAULT_TOUR)
+            triggered=lambda: plugin.show_tour(DEFAULT_TOUR)
         )
 
     # --- PluginMainContainer API

--- a/spyder/plugins/tours/plugin.py
+++ b/spyder/plugins/tours/plugin.py
@@ -33,6 +33,7 @@ class Tours(SpyderPluginV2):
     """
     NAME = 'tours'
     CONF_SECTION = NAME
+    REQUIRES = [Plugins.Layout]
     OPTIONAL = [Plugins.MainMenu]
     CONF_FILE = False
     CONTAINER_CLASS = ToursContainer
@@ -102,7 +103,8 @@ class Tours(SpyderPluginV2):
         index: int
             The tour index to display.
         """
-        self.main.maximize_dockwidget(restore=True)
+        layouts = self.get_plugin(Plugins.Layout)
+        layouts.unmaximize_dockwidget()
         self.get_container().show_tour(index)
 
     def show_tour_message(self, force=False):

--- a/spyder/plugins/tours/plugin.py
+++ b/spyder/plugins/tours/plugin.py
@@ -33,7 +33,6 @@ class Tours(SpyderPluginV2):
     """
     NAME = 'tours'
     CONF_SECTION = NAME
-    REQUIRES = [Plugins.Layout]
     OPTIONAL = [Plugins.MainMenu]
     CONF_FILE = False
     CONTAINER_CLASS = ToursContainer
@@ -103,8 +102,7 @@ class Tours(SpyderPluginV2):
         index: int
             The tour index to display.
         """
-        layouts = self.get_plugin(Plugins.Layout)
-        layouts.unmaximize_dockwidget()
+        self.sig_unmaximize_plugin_requested.emit()
         self.get_container().show_tour(index)
 
     def show_tour_message(self, force=False):


### PR DESCRIPTION
## Description of Changes

- Avoid giving focus to the IPython console when it's undocked, the user runs/debugs code and `Maintain focus to editor` is enabled.
- Keep focus in the editor in any run or debug operation and that option is enabled.
- Unmaximize any plugin before running or debugging code.
- Correctly set the state of the `Maximize` button when unmaximizing a plugin programmatically from other plugins (this was totally broken).
- Add `sig_unmaximize_plugin_requested` to `SpyderPluginV2` so that plugins can request to unmaximize the currently maximized plugin from others programmatically.
- Add `unmaximize_dockwidget` and `unmaximize_other_dockwidget` methods to the Layout plugin. Also move `switch_to_plugin` to it.
- Expand tests to catch possible regressions in the future.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #3221

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
