### PR TITLE
PR: [Do not merge] test kernel shutdown

### DIFF
--- a/external-deps/spyder-kernels/spyder_kernels/comms/commbase.py
+++ b/external-deps/spyder-kernels/spyder_kernels/comms/commbase.py
@@ -357,7 +357,7 @@ class CommBase:
 
         display_error = ('display_error' in settings and
                          settings['display_error'])
-        if is_error and display_error:
+        if is_error:
             data.print_error()
 
         send_reply = 'send_reply' in settings and settings['send_reply']

--- a/external-deps/spyder-kernels/spyder_kernels/console/shell.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/shell.py
@@ -60,17 +60,6 @@ class SpyderShell(ZMQInteractiveShell):
             stb = ['']
         super(SpyderShell, self)._showtraceback(etype, evalue, stb)
 
-    def enable_matplotlib(self, gui=None):
-        """Enable matplotlib."""
-        if gui is None or gui.lower() == "auto":
-            gui = automatic_backend()
-        gui, backend = super(SpyderShell, self).enable_matplotlib(gui)
-        try:
-            self.kernel.frontend_call(blocking=False).update_matplotlib_gui(gui)
-        except Exception:
-            pass
-        return gui, backend
-
     # --- For Pdb namespace integration
     def get_local_scope(self, stack_depth):
         """Get local scope at given frame depth."""

--- a/external-deps/spyder-kernels/spyder_kernels/console/shell.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/shell.py
@@ -41,6 +41,13 @@ class SpyderShell(ZMQInteractiveShell):
         super(SpyderShell, self).__init__(*args, **kwargs)
         self.register_debugger_sigint()
 
+    def ask_exit(self):
+        """Engage the exit actions."""
+        if self.active_eventloop != "inline":
+            # Some eventloops prevent the kernel from shutting down
+            self.enable_gui('inline')
+        return super(SpyderShell, self).ask_exit()
+
     def _showtraceback(self, etype, evalue, stb):
         """
         Don't show a traceback when exiting our debugger after entering

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1265,6 +1265,8 @@ def test_connection_to_external_kernel(main_window, qtbot):
     with qtbot.waitSignal(shell.executed):
         shell.execute('%matplotlib qt5')
     with qtbot.waitSignal(shell.executed):
+        shell.execute('1 + 1')
+    with qtbot.waitSignal(shell.executed):
         shell.execute('%debug print()')
     with qtbot.waitSignal(shell.executed):
         shell.execute('1 + 1')

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1261,9 +1261,18 @@ def test_connection_to_external_kernel(main_window, qtbot):
     assert "runfile" in shell._control.toPlainText()
     assert "3" in shell._control.toPlainText()
 
-    # Try quitting the kernels
+    # Try enabling a qt backend and debugging
     with qtbot.waitSignal(shell.executed):
-        shell.execute('quit()')
+        shell.execute('%matplotlib qt5')
+    with qtbot.waitSignal(shell.executed):
+        shell.execute('%debug print()')
+    with qtbot.waitSignal(shell.executed):
+        shell.execute('1 + 1')
+    with qtbot.waitSignal(shell.executed):
+        shell.execute('q')
+
+    # Try quitting the kernels
+    shell.execute('quit()')
     python_shell.execute('quit()')
 
     # Make sure everything quit properly

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -459,9 +459,6 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
         """Configure shellwidget after kernel is connected."""
         self.give_focus = give_focus
 
-        # Make sure the kernel sends the comm config over
-        self.shellwidget.call_kernel()._send_comm_config()
-
         # Set exit callback
         self.shellwidget.set_exit_callback()
 


### PR DESCRIPTION
I am trying to fix kernel shutdown in https://github.com/spyder-ide/spyder/pull/18837 and the tests fail on windows for some reason. Could somebody with window check whether debugging works with windows:

```
In [1]: %matplotlib qt5

In [2]: %debug print()
NOTE: Enter 'c' at the ipdb>  prompt to continue execution.
> <string>(1)<module>()


IPdb [1]: q

In [3]: 
```

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
