### PR TITLE
PR: Unmaximize debugger plugin when running debug commands

### DIFF
--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -417,6 +417,7 @@ class DebuggerWidget(ShellConnectMainWidget):
 
     def stop_debugging(self):
         """Stop debugging"""
+        self.sig_unmaximize_plugin_requested.emit()
         widget = self.current_widget()
         if widget is None:
             return
@@ -424,6 +425,7 @@ class DebuggerWidget(ShellConnectMainWidget):
 
     def debug_command(self, command):
         """Debug actions"""
+        self.sig_unmaximize_plugin_requested.emit()
         widget = self.current_widget()
         if widget is None:
             return


### PR DESCRIPTION
## Description of Changes

Also fix `test_maximize_minimize_plugins`. This test was expanded in PR #18928, but it needs some changes to work in master. That's because it relies on a couple of debugger actions, which are now present in the Debugger plugin.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
