### PR TITLE
PR: Add the ability to request unmaximizing plugins from widgets

### DIFF
--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -321,21 +321,18 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
                 container.setup()
                 container.update_actions()
 
-            if isinstance(container, PluginMainContainer):
-                # TODO: This signals should also affect the main_widgets?
-                # Currently this is not working for
-                # instances of PluginMainWidget subclasses
-                # Default signals to connect in main container or main widget.
-                container.sig_exception_occurred.connect(
-                    self.sig_exception_occurred)
-                container.sig_free_memory_requested.connect(
-                    self.sig_free_memory_requested)
-                container.sig_quit_requested.connect(
-                    self.sig_quit_requested)
-                container.sig_redirect_stdio_requested.connect(
-                    self.sig_redirect_stdio_requested)
-                container.sig_restart_requested.connect(
-                    self.sig_restart_requested)
+            # Default signals to connect in main container or main widget.
+            container.sig_free_memory_requested.connect(
+                self.sig_free_memory_requested)
+            container.sig_quit_requested.connect(self.sig_quit_requested)
+            container.sig_redirect_stdio_requested.connect(
+                self.sig_redirect_stdio_requested)
+            container.sig_exception_occurred.connect(
+                self.sig_exception_occurred)
+
+            # FIXME: This is semi-broken
+            # container.sig_restart_requested.connect(
+            #     self.sig_restart_requested)
 
             self.after_container_creation()
 

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -329,6 +329,8 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
                 self.sig_redirect_stdio_requested)
             container.sig_exception_occurred.connect(
                 self.sig_exception_occurred)
+            container.sig_unmaximize_plugin_requested.connect(
+                self.sig_unmaximize_plugin_requested)
 
             # FIXME: This is semi-broken
             # container.sig_restart_requested.connect(

--- a/spyder/api/widgets/main_container.py
+++ b/spyder/api/widgets/main_container.py
@@ -101,6 +101,17 @@ class PluginMainContainer(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
     error dialog.
     """
 
+    sig_unmaximize_plugin_requested = Signal((), (object,))
+    """
+    This signal is emitted to inform the main window that it needs to
+    unmaximize the currently maximized plugin, if any.
+
+    Parameters
+    ----------
+    plugin_instance: SpyderDockablePlugin
+        Unmaximize plugin only if it is not `plugin_instance`.
+    """
+
     def __init__(self, name, plugin, parent=None):
         if PYQT5:
             super().__init__(parent=parent, class_parent=plugin)

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -174,7 +174,7 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
 
     sig_toggle_view_changed = Signal(bool)
     """
-    This action is emitted to inform the visibility of a dockable plugin
+    This signal is emitted to inform the visibility of a dockable plugin
     has changed.
 
     This is triggered by checking/unchecking the entry for a pane in the
@@ -190,6 +190,17 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
     """
     This signal is emitted to inform the main window that a child widget
     needs its ancestor to be updated.
+    """
+
+    sig_unmaximize_plugin_requested = Signal((), (object,))
+    """
+    This signal is emitted to inform the main window that it needs to
+    unmaximize the currently maximized plugin, if any.
+
+    Parameters
+    ----------
+    plugin_instance: SpyderDockablePlugin
+        Unmaximize plugin only if it is not `plugin_instance`.
     """
 
     def __init__(self, name, plugin, parent=None):

--- a/spyder/plugins/console/plugin.py
+++ b/spyder/plugins/console/plugin.py
@@ -95,7 +95,6 @@ class Console(SpyderDockablePlugin):
         # Signals
         widget.sig_edit_goto_requested.connect(self.sig_edit_goto_requested)
         widget.sig_focus_changed.connect(self.sig_focus_changed)
-        widget.sig_quit_requested.connect(self.sig_quit_requested)
         widget.sig_refreshed.connect(self.sig_refreshed)
         widget.sig_help_requested.connect(self.sig_help_requested)
 

--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -95,9 +95,6 @@ class ConsoleWidget(PluginMainWidget):
     # Request to show a status message on the main window
     sig_show_status_requested = Signal(str)
 
-    # Request the main application to quit.
-    sig_quit_requested = Signal()
-
     sig_help_requested = Signal(dict)
     """
     This signal is emitted to request help on a given object `name`.

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -244,7 +244,6 @@ class IPythonConsole(SpyderDockablePlugin):
         widget.sig_help_requested.connect(self.sig_help_requested)
         widget.sig_current_directory_changed.connect(
             self.sig_current_directory_changed)
-        widget.sig_exception_occurred.connect(self.sig_exception_occurred)
 
         # Update kernels if python path is changed
         self.main.sig_pythonpath_changed.connect(self.update_path)

--- a/spyder/plugins/plots/widgets/main_widget.py
+++ b/spyder/plugins/plots/widgets/main_widget.py
@@ -64,17 +64,6 @@ class PlotsWidget(ShellConnectMainWidget):
     sig_figure_loaded = Signal()
     """This signal is emitted when a figure is loaded succesfully"""
 
-    sig_redirect_stdio_requested = Signal(bool)
-    """
-    This signal is emitted to request the main application to redirect
-    standard output/error when using Open/Save/Browse dialogs within widgets.
-
-    Parameters
-    ----------
-    redirect: bool
-        Start redirect (True) or stop redirect (False).
-    """
-
     def __init__(self, name=None, plugin=None, parent=None):
         super().__init__(name, plugin, parent)
 

--- a/spyder/plugins/profiler/widgets/main_widget.py
+++ b/spyder/plugins/profiler/widgets/main_widget.py
@@ -150,17 +150,6 @@ class ProfilerWidget(PluginMainWidget):
         Word to select on given row.
     """
 
-    sig_redirect_stdio_requested = Signal(bool)
-    """
-    This signal is emitted to request the main application to redirect
-    standard output/error when using Open/Save/Browse dialogs within widgets.
-
-    Parameters
-    ----------
-    redirect: bool
-        Start redirect (True) or stop redirect (False).
-    """
-
     sig_started = Signal()
     """This signal is emitted to inform the profiling process has started."""
 

--- a/spyder/plugins/pylint/plugin.py
+++ b/spyder/plugins/pylint/plugin.py
@@ -77,8 +77,6 @@ class Pylint(SpyderDockablePlugin):
 
         # Expose widget signals at the plugin level
         widget.sig_edit_goto_requested.connect(self.sig_edit_goto_requested)
-        widget.sig_redirect_stdio_requested.connect(
-            self.sig_redirect_stdio_requested)
         widget.sig_start_analysis_requested.connect(
             lambda: self.start_code_analysis())
 

--- a/spyder/plugins/tours/container.py
+++ b/spyder/plugins/tours/container.py
@@ -45,13 +45,15 @@ class ToursContainer(PluginMainContainer):
         self._tours = OrderedDict()
         self._tour_titles = OrderedDict()
         self._tour_widget = AnimatedTour(self._main)
+
         self._tour_dialog = OpenTourDialog(
             self, lambda: self.show_tour(DEFAULT_TOUR))
+
         self.tour_action = self.create_action(
             TourActions.ShowTour,
             text=_("Show tour"),
             icon=self.create_icon('tour'),
-            triggered=lambda: plugin.show_tour(DEFAULT_TOUR)
+            triggered=lambda: self.show_tour(DEFAULT_TOUR)
         )
 
     # --- PluginMainContainer API
@@ -101,6 +103,7 @@ class ToursContainer(PluginMainContainer):
         tour_id: str
             Unique tour string identifier.
         """
+        self.sig_unmaximize_plugin_requested.emit()
         tour_data = self._tours[tour_id]
         dic = {'last': 0, 'tour': tour_data}
         self._tour_widget.set_tour(tour_id, dic, self._main)

--- a/spyder/plugins/tours/plugin.py
+++ b/spyder/plugins/tours/plugin.py
@@ -102,7 +102,6 @@ class Tours(SpyderPluginV2):
         index: int
             The tour index to display.
         """
-        self.sig_unmaximize_plugin_requested.emit()
         self.get_container().show_tour(index)
 
     def show_tour_message(self, force=False):

--- a/spyder/plugins/variableexplorer/plugin.py
+++ b/spyder/plugins/variableexplorer/plugin.py
@@ -51,8 +51,7 @@ class VariableExplorer(SpyderDockablePlugin, ShellConnectMixin):
         return self.create_icon('dictedit')
 
     def on_initialize(self):
-        self.get_widget().sig_free_memory_requested.connect(
-            self.sig_free_memory_requested)
+        pass
 
     @on_plugin_available(plugin=Plugins.Preferences)
     def on_preferences_available(self):

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -9,9 +9,8 @@ Variable Explorer Main Plugin Widget.
 """
 
 # Third party imports
-from qtpy.QtCore import QTimer, Signal, Slot
-from qtpy.QtWidgets import (
-    QAction, QHBoxLayout, QWidget)
+from qtpy.QtCore import QTimer, Slot
+from qtpy.QtWidgets import QAction, QHBoxLayout, QWidget
 
 # Local imports
 from spyder.api.config.decorators import on_conf_change
@@ -97,9 +96,6 @@ class VariableExplorerWidget(ShellConnectMainWidget):
     # Other class constants
     INITIAL_FREE_MEMORY_TIME_TRIGGER = 60 * 1000  # ms
     SECONDARY_FREE_MEMORY_TIME_TRIGGER = 180 * 1000  # ms
-
-    # Signals
-    sig_free_memory_requested = Signal()
 
     def __init__(self, name=None, plugin=None, parent=None):
         super().__init__(name, plugin, parent)


### PR DESCRIPTION
## Description of Changes

- This was an oversight in PR #18928.
- I need it to fix our tests in master.
- Use this addition in the Tours plugin because it's more natural.
- Connect `PluginMainWidget` default signals to its plugin (we were only doing that for `PluginMainContainer`). Some things were broken due to that and others are now redundant.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
