### PR TITLE
PR: Allow plugins/widgets to ask for app restarts by emitting a signal

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -94,12 +94,13 @@ if installed_dev_repo:
 logger.info("Executing Spyder from source checkout")
 
 # Prepare arguments for Spyder's main script
+original_sys_argv = sys.argv.copy()
 sys.argv = [sys.argv[0]] + args.spyder_options
 
 # ---- Update os.environ
 
-# Store variable to be used in self.restart (restart spyder instance)
-os.environ['SPYDER_BOOTSTRAP_ARGS'] = str(sys.argv[1:])
+# Store variable to be used in self.restart (restart Spyder instance)
+os.environ['SPYDER_BOOTSTRAP_ARGS'] = str(original_sys_argv[1:])
 
 # Start Spyder with a clean configuration directory for testing purposes
 if args.safe_mode:

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -30,7 +30,6 @@ from spyder.api.config.mixins import SpyderConfigurationObserver
 from spyder.api.exceptions import SpyderAPIError
 from spyder.api.plugin_registration.mixins import SpyderPluginObserver
 from spyder.api.translations import get_translation
-from spyder.api.widgets.main_container import PluginMainContainer
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.api.widgets.mixins import SpyderActionMixin
 from spyder.api.widgets.mixins import SpyderWidgetMixin
@@ -325,16 +324,13 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
             container.sig_free_memory_requested.connect(
                 self.sig_free_memory_requested)
             container.sig_quit_requested.connect(self.sig_quit_requested)
+            container.sig_restart_requested.connect(self.sig_restart_requested)
             container.sig_redirect_stdio_requested.connect(
                 self.sig_redirect_stdio_requested)
             container.sig_exception_occurred.connect(
                 self.sig_exception_occurred)
             container.sig_unmaximize_plugin_requested.connect(
                 self.sig_unmaximize_plugin_requested)
-
-            # FIXME: This is semi-broken
-            # container.sig_restart_requested.connect(
-            #     self.sig_restart_requested)
 
             self.after_container_creation()
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1911,20 +1911,8 @@ class MainWindow(QMainWindow):
             self.sig_open_external_file.emit(fname)
             req.sendall(b' ')
 
-    # ---- Quit and restart, and reset spyder defaults
+    # ---- Restart Spyder
     # -------------------------------------------------------------------------
-    @Slot()
-    def reset_spyder(self):
-        """
-        Quit and reset Spyder and then Restart application.
-        """
-        answer = QMessageBox.warning(self, _("Warning"),
-             _("Spyder will restart and reset to default settings: <br><br>"
-               "Do you want to continue?"),
-             QMessageBox.Yes | QMessageBox.No)
-        if answer == QMessageBox.Yes:
-            self.restart(reset=True)
-
     @Slot()
     def restart(self, reset=False, close_immediately=False):
         """Wrapper to handle plugins request to restart Spyder."""

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -414,6 +414,7 @@ class MainWindow(QMainWindow):
         plugin.sig_exception_occurred.connect(self.handle_exception)
         plugin.sig_free_memory_requested.connect(self.free_memory)
         plugin.sig_quit_requested.connect(self.close)
+        plugin.sig_restart_requested.connect(self.restart)
         plugin.sig_redirect_stdio_requested.connect(
             self.redirect_internalshell_stdio)
         plugin.sig_status_message_requested.connect(self.show_status_message)
@@ -1913,7 +1914,6 @@ class MainWindow(QMainWindow):
 
     # ---- Restart Spyder
     # -------------------------------------------------------------------------
-    @Slot()
     def restart(self, reset=False, close_immediately=False):
         """Wrapper to handle plugins request to restart Spyder."""
         self.application.restart(

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -65,8 +65,6 @@ class Application(SpyderPluginV2):
         container.sig_report_issue_requested.connect(self.report_issue)
         container.set_window(self._window)
 
-        self.sig_restart_requested.connect(self.restart)
-
     # --------------------- PLUGIN INITIALIZATION -----------------------------
     @on_plugin_available(plugin=Plugins.Shortcuts)
     def on_shortcuts_available(self):

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -71,7 +71,7 @@ class CompletionPlugin(SpyderPluginV2):
     NAME = 'completions'
     CONF_SECTION = 'completions'
     REQUIRES = [Plugins.Preferences, Plugins.MainInterpreter]
-    OPTIONAL = [Plugins.Application, Plugins.StatusBar, Plugins.MainMenu]
+    OPTIONAL = [Plugins.StatusBar, Plugins.MainMenu]
 
     CONF_FILE = False
 
@@ -313,12 +313,6 @@ class CompletionPlugin(SpyderPluginV2):
         for sb in container.all_statusbar_widgets():
             self.statusbar.add_status_widget(sb)
         self.statusbar.add_status_widget(self.completion_status)
-
-    @on_plugin_available(plugin=Plugins.Application)
-    def on_application_available(self):
-        application = self.get_plugin(Plugins.Application)
-        self.sig_restart_requested.connect(
-            application.sig_restart_requested)
 
     @on_plugin_available(plugin=Plugins.MainMenu)
     def on_mainmenu_available(self):

--- a/spyder/plugins/completion/providers/languageserver/widgets/messagebox.py
+++ b/spyder/plugins/completion/providers/languageserver/widgets/messagebox.py
@@ -6,9 +6,6 @@
 
 """Language Server Protocol message boxes."""
 
-# Standard library imports
-import os
-
 # Third party imports
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QMessageBox

--- a/spyder/plugins/completion/tests/conftest.py
+++ b/spyder/plugins/completion/tests/conftest.py
@@ -66,9 +66,6 @@ class MainWindowMock(QMainWindow):
     def set_prefs_size(self, size):
         pass
 
-    def reset_spyder(self):
-        pass
-
 
 @pytest.fixture(scope="module")
 def qtbot_module(qapp, request):

--- a/spyder/plugins/preferences/plugin.py
+++ b/spyder/plugins/preferences/plugin.py
@@ -53,7 +53,6 @@ class Preferences(SpyderPluginV2):
 
     NAME = 'preferences'
     CONF_SECTION = 'preferences'
-    REQUIRES = [Plugins.Application]
     OPTIONAL = [Plugins.MainMenu, Plugins.Toolbar]
     CONF_FILE = False
     CONTAINER_CLASS = PreferencesContainer
@@ -274,6 +273,7 @@ class Preferences(SpyderPluginV2):
 
         container.sig_show_preferences_requested.connect(
             lambda: self.open_dialog(main.prefs_dialog_size))
+        container.sig_reset_preferences_requested.connect(self.reset)
 
     @on_plugin_available(plugin=Plugins.MainMenu)
     def on_main_menu_available(self):
@@ -302,12 +302,6 @@ class Preferences(SpyderPluginV2):
             section=MainToolbarSections.ApplicationSection
         )
 
-    @on_plugin_available(plugin=Plugins.Application)
-    def on_application_available(self):
-        container = self.get_container()
-        container.sig_reset_preferences_requested.connect(self.reset)
-
-
     @on_plugin_teardown(plugin=Plugins.MainMenu)
     def on_main_menu_teardown(self):
         main_menu = self.get_plugin(Plugins.MainMenu)
@@ -330,11 +324,6 @@ class Preferences(SpyderPluginV2):
             toolbar_id=ApplicationToolbars.Main
         )
 
-    @on_plugin_teardown(plugin=Plugins.Application)
-    def on_application_teardown(self):
-        container = self.get_container()
-        container.sig_reset_preferences_requested.disconnect(self.reset)
-
     @Slot()
     def reset(self):
         answer = QMessageBox.warning(self.main, _("Warning"),
@@ -343,8 +332,7 @@ class Preferences(SpyderPluginV2):
              QMessageBox.Yes | QMessageBox.No)
         if answer == QMessageBox.Yes:
             os.environ['SPYDER_RESET'] = 'True'
-            application = self.get_plugin(Plugins.Application)
-            application.sig_restart_requested.emit()
+            self.sig_restart_requested.emit()
 
     def on_close(self, cancelable=False):
         container = self.get_container()

--- a/spyder/plugins/preferences/tests/conftest.py
+++ b/spyder/plugins/preferences/tests/conftest.py
@@ -72,9 +72,6 @@ class MainWindowMock(QMainWindow):
     def set_prefs_size(self, size):
         pass
 
-    def reset_spyder(self):
-        pass
-
 
 class ConfigDialogTester(QWidget):
     def __init__(self, parent, main_class,
@@ -85,9 +82,6 @@ class ConfigDialogTester(QWidget):
             self._main = MainWindowMock(self)
 
         def set_prefs_size(self, size):
-            pass
-
-        def reset_spyder(self):
             pass
 
         def register_plugin(self, plugin_name, external=False):
@@ -103,8 +97,6 @@ class ConfigDialogTester(QWidget):
                 types.MethodType(register_plugin, self._main))
         setattr(self._main, 'get_plugin',
                 types.MethodType(get_plugin, self._main))
-        setattr(self._main, 'reset_spyder',
-                types.MethodType(reset_spyder, self._main))
         setattr(self._main, 'set_prefs_size',
                 types.MethodType(set_prefs_size, self._main))
 

--- a/spyder/plugins/preferences/widgets/container.py
+++ b/spyder/plugins/preferences/widgets/container.py
@@ -4,9 +4,6 @@
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
 
-# Standard library imports
-import sys
-
 # Third party imports
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QAction


### PR DESCRIPTION
## Description of Changes

- Instances of `SpyderPluginV2`, `PluginMainWidget` and `PluginMainContainer` now only need to emit `sig_restart_requested` to ask for a Spyder restart.
- This was changed in PR #15629 to require the `Application` plugin, but it makes things more complicated.
- Remove `reset_spyder` method of `MainWindow` because it was not doing anything.
- Fix requesting multiple restarts when Spyder is started from `bootstrap.py`. Before only a single restart was possible.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
