### PR TITLE
PR: Add cast for custom syntax highlighting themes names to string (Appereance)

### DIFF
--- a/spyder/plugins/appearance/confpage.py
+++ b/spyder/plugins/appearance/confpage.py
@@ -245,7 +245,12 @@ class AppearanceConfigPage(PluginConfigPage):
 
         # Useful for retrieving the actual data
         for n in names + custom_names:
-            self.scheme_choices_dict[self.get_option('{0}/name'.format(n))] = n
+            # Make option value a string to prevent errors when using it
+            # as widget text.
+            # See spyder-ide/spyder#18929
+            self.scheme_choices_dict[
+                str(self.get_option('{0}/name'.format(n)))
+            ] = n
 
         if custom_names:
             choices = names + [None] + custom_names
@@ -258,7 +263,11 @@ class AppearanceConfigPage(PluginConfigPage):
         for name in choices:
             if name is None:
                 continue
-            combobox.addItem(self.get_option('{0}/name'.format(name)), name)
+            # Make option value a string to prevent errors when using it
+            # as widget text.
+            # See spyder-ide/spyder#18929
+            item_name = str(self.get_option('{0}/name'.format(name)))
+            combobox.addItem(item_name, name)
 
         if custom_names:
             combobox.insertSeparator(len(names))
@@ -379,9 +388,11 @@ class AppearanceConfigPage(PluginConfigPage):
         if answer == QMessageBox.Yes:
             # Put the combobox in Spyder by default, when deleting a scheme
             names = self.get_option('names')
-            self.set_scheme('spyder')
-            self.schemes_combobox.setCurrentIndex(names.index('spyder'))
-            self.set_option('selected', 'spyder')
+            default_theme = 'spyder'
+            if self.is_dark_interface():
+                default_theme = 'spyder/dark'
+            self.schemes_combobox.setCurrentIndex(names.index(default_theme))
+            self.set_option('selected', default_theme)
 
             # Delete from custom_names
             custom_names = self.get_option('custom_names', [])

--- a/spyder/plugins/preferences/api.py
+++ b/spyder/plugins/preferences/api.py
@@ -241,6 +241,11 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
             data = self.get_option(option, default, section=sec)
             if getattr(lineedit, 'content_type', None) == list:
                 data = ', '.join(data)
+            else:
+                # Make option value a string to prevent errors when using it
+                # as widget text.
+                # See spyder-ide/spyder#18929
+                data = str(data)
             lineedit.setText(data)
             lineedit.textChanged.connect(lambda _, opt=option, sect=sec:
                                          self.has_been_modified(sect, opt))


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->

* If a custom syntax highlighting theme was named with a number errors could raise when trying to use the name to set widgets text/properties 
* Also, fix setting a default light theme when the current selected syntax highlighting theme is deleted


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #18929


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
