### PR TITLE
PR: Set elide mode to prevent tabs text eliding on MacOS (Tabs)

### DIFF
--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -12,9 +12,7 @@
 # pylint: disable=R0201
 
 # Standard library imports
-import os
 import os.path as osp
-import sys
 
 # Third party imports
 from qtpy import PYQT5
@@ -245,6 +243,9 @@ class BaseTabs(QTabWidget):
                  corner_widgets=None, menu_use_tooltips=False):
         QTabWidget.__init__(self, parent)
         self.setUsesScrollButtons(True)
+        # Needed to prevent eliding tabs text on MacOS
+        # See spyder-ide/spyder#18817
+        self.setElideMode(Qt.ElideNone)
         self.tabBar().setObjectName('pane-tabbar')
 
         self.corner_widgets = {}


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

* Seems like on MacOS the elide mode for QTabWidget is different from `Qt.ElideNone` which caused the tabs text to be elided at the right on MacOS.
* Clean/remove unused imports (`os` and `sys`  modules)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #18817


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
