### PR TITLE
Fixed a syntax error

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -210,7 +210,7 @@ class MainWindow(QMainWindow):
         plugin.get_description()
 
         if not is_compatible:
-            self.show_compatibility_message(message)
+            self.show_plugin_compatibility_message(message)
             return
 
         # Connect Plugin Signals to main window methods


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Modified spyder/app/mainwindow.py line 213. Corrected the show_compatibility_message with show_plugin_compatibility_message



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #
Exception thrown at startup when failed compatibility check of a plugin:

Traceback (most recent call last):
  File "C:\Users\elog-admin\AppData\Local\Programs\Spyder\pkgs\spyder\app\mainwindow.py", line 753, in <lambda>
    lambda plugin_name, omit_conf: self.register_plugin(
  File "C:\Users\elog-admin\AppData\Local\Programs\Spyder\pkgs\spyder\app\mainwindow.py", line 213, in register_plugin
    self.show_compatibility_message(message)
  File "C:\Users\elog-admin\AppData\Local\Programs\Spyder\pkgs\spyder\app\mainwindow.py", line 1069, in __getattr__
    return super().__getattr__(attr)
AttributeError: 'MainWindow' object has no attribute 'show_compatibility_message'

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
abulgher
<!--- Thanks for your help making Spyder better for everyone! --->
