### PR TITLE
PR: Add regex check for interpreter info output (Programs)

### DIFF
--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -1052,7 +1052,8 @@ def get_interpreter_info(path):
     try:
         out, __ = run_program(path, ['-V']).communicate()
         out = out.decode()
-        # Needed to prevent showing unexpected output.
+
+        # This is necessary to prevent showing unexpected output.
         # See spyder-ide/spyder#19000
         if not re.search(r'^Python \d+\.\d+\.\d+$', out):
             out = ''

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -1052,6 +1052,10 @@ def get_interpreter_info(path):
     try:
         out, __ = run_program(path, ['-V']).communicate()
         out = out.decode()
+        # Needed to prevent showing unexpected output.
+        # See spyder-ide/spyder#19000
+        if not re.search(r'^Python \d+\.\d+\.\d+$', out):
+            out = ''
     except Exception:
         out = ''
     return out.strip()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Prevent showing text that is not expected when doing `<interpreter_path> -V` to get interpreter info. The expected result should pass the following regex: `^Python \d+\.\d+\.\d+$`. For example: `Python 3.10.5`


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19000


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
