### PR TITLE
PR: Handle default Win installer pythonw interpreter to get Python version (Status)

### DIFF
--- a/spyder/plugins/maininterpreter/widgets/status.py
+++ b/spyder/plugins/maininterpreter/widgets/status.py
@@ -49,6 +49,7 @@ class InterpreterStatus(BaseTimerStatus):
         self.envs = {}
         self.value = ''
         self.default_interpreter = sys.executable
+
         if is_pynsist():
             # Be sure to use 'python' executable instead of 'pythonw' since
             # no output is generated with 'pythonw'.
@@ -129,8 +130,10 @@ class InterpreterStatus(BaseTimerStatus):
         try:
             name = self.path_to_env[path]
         except KeyError:
-            if (self.default_interpreter == path and
-                    (running_in_mac_app() or is_pynsist())):
+            if (
+                self.default_interpreter == path
+                and (running_in_mac_app() or is_pynsist())
+            ):
                 name = 'internal'
             elif 'conda' in path:
                 name = 'conda'

--- a/spyder/plugins/maininterpreter/widgets/status.py
+++ b/spyder/plugins/maininterpreter/widgets/status.py
@@ -18,6 +18,7 @@ from qtpy.QtCore import QTimer, Signal
 # Local imports
 from spyder.api.translations import get_translation
 from spyder.api.widgets.status import BaseTimerStatus
+from spyder.config.base import is_pynsist
 from spyder.utils.conda import get_list_conda_envs
 from spyder.utils.programs import get_interpreter_info
 from spyder.utils.pyenv import get_list_pyenv_envs
@@ -108,8 +109,14 @@ class InterpreterStatus(BaseTimerStatus):
         # Compute info of default interpreter to have it available in
         # case we need to switch to it. This will avoid lags when
         # doing that in get_value.
-        if sys.executable not in self.path_to_env:
-            self._get_env_info(sys.executable)
+        default_executable = sys.executable
+        if is_pynsist():
+            # Be sure to use 'python' executable instead of 'pythonw' since
+            # no ouput is generated with 'pythonw'.
+            default_executable = default_executable.replace(
+                'pythonw', 'python')
+        if default_executable not in self.path_to_env:
+            self._get_env_info(default_executable)
 
         # Get envs
         conda_env = get_list_conda_envs()

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -1051,7 +1051,7 @@ def get_interpreter_info(path):
     """Return version information of the selected Python interpreter."""
     try:
         out, __ = run_program(path, ['-V']).communicate()
-        out = out.decode()
+        out = out.decode().strip()
 
         # This is necessary to prevent showing unexpected output.
         # See spyder-ide/spyder#19000


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Checking #19082 I noticed that the info for the default interpreter for the Windows standalone installer was not showing (it was empty - `Custom ()`). Checking this seems being caused due to the launch of Spyder from the shortcut using `pythonw.exe` instead of `python.exe` (to prevent showing any cmd/terminal) and also some logic trying to check for a fixed path for the Windows installer.

The actual value that should appear for the current Windows installer is `internal (Python 3.8.10)`


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
