### PR TITLE
PR: Restore the previous way of closing all clients (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1938,13 +1938,20 @@ class IPythonConsoleWidget(PluginMainWidget):
         bool
             If the closing action was succesful.
         """
-        while self.clients:
-            client = self.clients.pop()
-            is_last_client = len(self.get_related_clients(client)) == 0
+        # IMPORTANT: **Do not** change this way of closing clients, which uses
+        # a copy of `self.clients`, because it preserves the main window layout
+        # when Spyder is closed.
+        # Fixes spyder-ide/spyder#19084
+        open_clients = self.clients.copy()
+        for client in self.clients:
+            is_last_client = (
+                len(self.get_related_clients(client, open_clients)) == 0)
             client.close_client(is_last_client)
+            open_clients.remove(client)
 
         # Close all closing shellwidgets.
         ShellWidget.wait_all_shutdown()
+
         # Close cached kernel
         self.close_cached_kernel()
         self.filenames = []


### PR DESCRIPTION
## Description of Changes

- After doing `git bisect`, I noticed that the problem reported on issue #19084 was introduced by PR #18781.
- The simplest way to fix it is to restore the changes done in it to the way all clients are closed.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19084.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
