### PR TITLE
PR: Avoid a ValueError when splitting a string (Completions)

### DIFF
--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -515,7 +515,7 @@ class CompletionPlugin(SpyderPluginV2):
         tool_tip = mi_status._interpreter
 
         if '(' in value:
-            value, _ = value.split('(')
+            value = value.split('(')[0]
 
         if ':' in value:
             kind, name = value.split(':')


### PR DESCRIPTION
## Description of Changes

- It seems that sometimes the text of the Main Interpreter status bar widget can contain several parenthesis (see issue #19000), which causes an error when trying to only take the first value after splitting a string according to open parenthesis.
- This probably doesn't fix the whole problem, but it solves the one reported by users for now.

# Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19087 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
