### PR TITLE
PR: Recreate config in case of errors while reading it (Projects)

### DIFF
--- a/spyder/plugins/projects/api.py
+++ b/spyder/plugins/projects/api.py
@@ -9,8 +9,10 @@ Projects Plugin API.
 """
 
 # Standard library imports
-import os.path as osp
 from collections import OrderedDict
+import configparser
+import os.path as osp
+import shutil
 
 # Local imports
 from spyder.api.translations import get_translation
@@ -39,17 +41,20 @@ class BaseProjectType:
         self.root_path = root_path
         self.open_project_files = []
         self.open_non_project_files = []
+
+        # Path to project's config directory
         path = osp.join(root_path, get_project_config_folder(), 'config')
-        self.config = ProjectMultiConfig(
-            PROJECT_NAME_MAP,
-            path=path,
-            defaults=PROJECT_DEFAULTS,
-            load=True,
-            version=PROJECT_CONF_VERSION,
-            backup=True,
-            raw_mode=True,
-            remove_obsolete=False,
-        )
+
+        # This is necessary to avoid any issues while reading the project's
+        # config files.
+        # Fixes spyder-ide/spyder#17907
+        try:
+            self.config = self.create_config(path)
+        except configparser.Error:
+            # Remove config directory in case of errors and recreate it again.
+            shutil.rmtree(path)
+            self.config = self.create_config(path)
+
         act_name = self.get_option("project_type")
         if not act_name:
             self.set_option("project_type", self.ID)
@@ -99,6 +104,19 @@ class BaseProjectType:
                 recent_files.remove(recent_file)
 
         return list(OrderedDict.fromkeys(recent_files))
+
+    def create_config(self, path):
+        """Create the project's configuration object."""
+        return ProjectMultiConfig(
+            PROJECT_NAME_MAP,
+            path=path,
+            defaults=PROJECT_DEFAULTS,
+            load=True,
+            version=PROJECT_CONF_VERSION,
+            backup=True,
+            raw_mode=True,
+            remove_obsolete=False,
+        )
 
     # --- API
     # ------------------------------------------------------------------------

--- a/spyder/plugins/projects/api.py
+++ b/spyder/plugins/projects/api.py
@@ -105,7 +105,8 @@ class BaseProjectType:
 
         return list(OrderedDict.fromkeys(recent_files))
 
-    def create_config(self, path):
+    @staticmethod
+    def create_config(path):
         """Create the project's configuration object."""
         return ProjectMultiConfig(
             PROJECT_NAME_MAP,

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -433,6 +433,7 @@ class Projects(SpyderDockablePlugin):
         project_type = data.get("project_type", EmptyProject.ID)
 
         if result:
+            logger.debug(f'Creating a project at {root_path}')
             self._create_project(root_path, project_type_id=project_type)
             dlg.close()
 
@@ -937,11 +938,11 @@ class Projects(SpyderDockablePlugin):
 
             # This is necessary to catch an error for projects created in
             # Spyder 4 or older versions.
-            # Fixes spyder-ide/spyder17097
+            # Fixes spyder-ide/spyder#17097
             try:
                 project_type_id = config[WORKSPACE].get(
                     "project_type", EmptyProject.ID)
-            except KeyError:
+            except Exception:
                 pass
 
         EmptyProject._PARENT_PLUGIN = self


### PR DESCRIPTION
## Description of Changes

- Remove the project's config directory in case of errors and generate it again.
- This makes the process of opening projects more robust, which should avoid crashes at startup when a project is left open in the previous session and we can't read its config during the next one.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17907.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
