### PR TITLE
PR: Fix a couple of bugs in the Find plugin

### DIFF
--- a/spyder/plugins/findinfiles/tests/test_plugin.py
+++ b/spyder/plugins/findinfiles/tests/test_plugin.py
@@ -19,10 +19,8 @@ from spyder.config.manager import CONF
 from spyder.plugins.findinfiles.plugin import FindInFiles
 from spyder.plugins.findinfiles.widgets.combobox import SELECT_OTHER
 
+
 LOCATION = osp.realpath(osp.join(os.getcwd(), osp.dirname(__file__)))
-NONASCII_DIR = osp.join(LOCATION, "èáïü Øαôå 字分误")
-if not osp.exists(NONASCII_DIR):
-    os.makedirs(NONASCII_DIR)
 
 
 @pytest.fixture
@@ -39,13 +37,14 @@ def findinfiles(qtbot):
 
 # ---- Tests for FindInFiles plugin
 @pytest.mark.order(1)
-def test_closing_plugin(findinfiles, qtbot, mocker):
+def test_closing_plugin(findinfiles, qtbot, mocker, tmpdir):
     """
     Test that the external paths listed in the combobox are saved and loaded
     correctly from the spyder config file.
     """
     path_selection_combo = findinfiles.get_widget().path_selection_combo
     path_selection_combo.clear_external_paths()
+    nonascii_dir = str(tmpdir.mkdir("èáïü Øαôå 字分误"))
     assert path_selection_combo.get_external_paths() == []
 
     # Add external paths to the path_selection_combo.
@@ -53,7 +52,7 @@ def test_closing_plugin(findinfiles, qtbot, mocker):
         LOCATION,
         osp.dirname(LOCATION),
         osp.dirname(osp.dirname(LOCATION)),
-        NONASCII_DIR,
+        nonascii_dir,
     ]
     for external_path in expected_results:
         mocker.patch(

--- a/spyder/plugins/findinfiles/widgets/main_widget.py
+++ b/spyder/plugins/findinfiles/widgets/main_widget.py
@@ -589,7 +589,12 @@ class FindInFilesWidget(PluginMainWidget):
         # Start
         self.running = True
         self.start_spinner()
-        self.search_thread = SearchThread(None, search_text, self.text_color)
+        self.search_thread = SearchThread(
+            None,
+            search_text,
+            self.text_color,
+            self.get_conf('max_results')
+        )
         self.search_thread.sig_finished.connect(self._handle_search_complete)
         self.search_thread.sig_file_match.connect(
             self.result_browser.append_file_result
@@ -630,7 +635,7 @@ class FindInFilesWidget(PluginMainWidget):
             dialog.setWindowTitle(_('Max results'))
             dialog.setLabelText(_('Set maximum number of results: '))
             dialog.setInputMode(QInputDialog.IntInput)
-            dialog.setIntRange(1, 10000)
+            dialog.setIntRange(5, 10000)
             dialog.setIntStep(1)
             dialog.setIntValue(self.get_conf('max_results'))
 

--- a/spyder/plugins/findinfiles/widgets/main_widget.py
+++ b/spyder/plugins/findinfiles/widgets/main_widget.py
@@ -635,9 +635,15 @@ class FindInFilesWidget(PluginMainWidget):
             dialog.setWindowTitle(_('Max results'))
             dialog.setLabelText(_('Set maximum number of results: '))
             dialog.setInputMode(QInputDialog.IntInput)
-            dialog.setIntRange(5, 10000)
             dialog.setIntStep(1)
             dialog.setIntValue(self.get_conf('max_results'))
+
+            # In order to show the right number of results when max_results is
+            # reached, we can't allow users to introduce less than 2 in this
+            # dialog. Since that value seems a bit arbitrary, we decided to set
+            # it to 5.
+            # See spyder-ide/spyder#16256
+            dialog.setIntRange(5, 10000)
 
             # Connect slot
             dialog.intValueSelected.connect(

--- a/spyder/plugins/findinfiles/widgets/results_browser.py
+++ b/spyder/plugins/findinfiles/widgets/results_browser.py
@@ -260,13 +260,20 @@ class ResultsBrowser(OneColumnTree):
     def append_file_result(self, filename):
         """Real-time update of file items."""
         if len(self.data) < self.max_results:
-            self.files[filename] = item = FileMatchItem(
-                self,
-                self.path,
-                filename,
-                self.sorting,
-                self.text_color
-            )
+            # Catch any error while creating file items.
+            # Fixes spyder-ide/spyder#17443
+            try:
+                item = FileMatchItem(
+                    self,
+                    self.path,
+                    filename,
+                    self.sorting,
+                    self.text_color
+                )
+            except Exception:
+                return
+
+            self.files[filename] = item
 
             item.setExpanded(True)
             self.num_files += 1

--- a/spyder/plugins/findinfiles/widgets/results_browser.py
+++ b/spyder/plugins/findinfiles/widgets/results_browser.py
@@ -11,8 +11,8 @@ import os.path as osp
 
 # Third party imports
 from qtpy.QtCore import QPoint, QSize, Qt, Signal, Slot
-from qtpy.QtGui import (QAbstractTextDocumentLayout, QColor, QBrush,
-                        QFontMetrics, QPalette, QTextDocument)
+from qtpy.QtGui import (QAbstractTextDocumentLayout, QColor, QFontMetrics,
+                        QTextDocument)
 from qtpy.QtWidgets import (QApplication, QStyle, QStyledItemDelegate,
                             QStyleOptionViewItem, QTreeWidgetItem)
 

--- a/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
+++ b/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
@@ -20,6 +20,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports
+from spyder.config.base import running_in_ci
 from spyder.config.manager import CONF
 from spyder.plugins.findinfiles.widgets.main_widget import FindInFilesWidget
 from spyder.plugins.findinfiles.widgets.combobox import (
@@ -27,6 +28,7 @@ from spyder.plugins.findinfiles.widgets.combobox import (
     SELECT_OTHER)
 from spyder.plugins.findinfiles.widgets.search_thread import SearchThread
 from spyder.utils.palette import QStylePalette, SpyderPalette
+from spyder.utils.stylesheet import APP_STYLESHEET
 
 
 LOCATION = osp.realpath(osp.join(os.getcwd(), osp.dirname(__file__)))
@@ -84,6 +86,7 @@ def findinfiles(qtbot, request):
         widget.setup()
 
     widget.resize(640, 480)
+    widget.setStyleSheet(str(APP_STYLESHEET))
     qtbot.addWidget(widget)
     widget.show()
     return widget
@@ -308,6 +311,41 @@ def test_exclude_regexp_error(findinfiles, qtbot):
     findinfiles.find()
     tooltip = findinfiles.exclude_pattern_edit.toolTip()
     assert findinfiles.REGEX_ERROR in tooltip
+
+
+@flaky(max_runs=5)
+@pytest.mark.skipif(not running_in_ci(), reason="Only works on CIs")
+@pytest.mark.skipif(os.name == 'nt', reason="Fails on Windows")
+def test_no_empty_file_items(findinfiles, qtbot):
+    """
+    Test that a search that hits the max number of results doesn't generate
+    empty file items.
+
+    This is a regression test for issue spyder-ide/spyder#16256
+    """
+    findinfiles.set_search_text("spam")
+    findinfiles.set_directory(osp.join(LOCATION, "data"))
+    findinfiles.set_conf('max_results', 6)
+
+    with qtbot.waitSignal(findinfiles.sig_max_results_reached):
+        findinfiles.find()
+
+    # Assert the results are the expected ones to reproduce the bug this test
+    # tries to catch. In other words, this is here to prevent future changes to
+    # our test files that would render this test useless.
+    results = {
+        'spam.py': [(2, 7), (5, 1), (7, 12)],
+        'spam.txt': [(1, 0), (1, 5), (3, 22)]
+    }
+    assert process_search_results(findinfiles.result_browser.data) == results
+
+    # Assert that the files with results are exactly the same as those
+    # displayed in the results browser.
+    files_with_results = set(
+        [v[0] for v in findinfiles.result_browser.data.values()]
+    )
+    displayed_files = set(findinfiles.result_browser.files.keys())
+    assert files_with_results == displayed_files
 
 
 # ---- Tests for SearchInComboBox


### PR DESCRIPTION
## Description of Changes

- Catch any error when trying to create file items.
- Prevent showing file entries without any match. This was happening sometimes when the maximum number of results is reached.

    For example, searching for `self` in the main Spyder repo when the max results is 15 was giving this

    ![image](https://user-images.githubusercontent.com/365293/185766626-a2e224b0-84f5-4882-b496-625b5c6379d9.png)

    Now it gives this

    ![image](https://user-images.githubusercontent.com/365293/185766660-46741021-d4dc-4329-8c51-24ebe4b936e1.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17443
Fixes #16256 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
