### PR TITLE
PR: Several fixes related to the tabify plugins functionality

### DIFF
--- a/spyder/api/plugins/__init__.py
+++ b/spyder/api/plugins/__init__.py
@@ -21,6 +21,6 @@ There are two types of plugins available:
    Spyder's main window.
 """
 
-from .enum import Plugins  # noqa
+from .enum import Plugins, DockablePlugins  # noqa
 from .old_api import SpyderPlugin, SpyderPluginWidget  # noqa
 from .new_api import SpyderDockablePlugin, SpyderPluginV2  # noqa

--- a/spyder/api/plugins/enum.py
+++ b/spyder/api/plugins/enum.py
@@ -40,3 +40,21 @@ class Plugins:
     Tours = 'tours'
     VariableExplorer = 'variable_explorer'
     WorkingDirectory = 'workingdir'
+
+
+class DockablePlugins:
+    Breakpoints = 'breakpoints'
+    Console = 'internal_console'
+    Editor = 'editor'
+    Explorer = 'explorer'
+    Find = 'find_in_files'
+    Help = 'help'
+    History = 'historylog'
+    IPythonConsole = 'ipython_console'
+    OnlineHelp = 'onlinehelp'
+    OutlineExplorer = 'outline_explorer'
+    Plots = 'plots'
+    Profiler = 'profiler'
+    Projects = 'project_explorer'
+    Pylint = 'pylint'
+    VariableExplorer = 'variable_explorer'

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -404,9 +404,17 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
         """
         return self._main
 
-    def get_plugin(self, plugin_name):
+    def get_plugin(self, plugin_name, error=True):
         """
-        Return a plugin instance by providing the plugin's NAME.
+        Get a plugin instance by providing its name.
+
+        Parameters
+        ----------
+        plugin_name: str
+            Name of the plugin from which its instance will be returned.
+        error: bool
+            Whether to raise errors when trying to return the plugin's
+            instance.
         """
         # Ensure that this plugin has the plugin corresponding to
         # `plugin_name` listed as required or optional.
@@ -416,7 +424,7 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
 
         if plugin_name in full_set or Plugins.All in full_set:
             try:
-                return self._main.get_plugin(plugin_name)
+                return self._main.get_plugin(plugin_name, error=error)
             except SpyderAPIError as e:
                 if plugin_name in optional:
                     return None

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1012,19 +1012,8 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
                     pass
 
         # Register custom layouts
-        for plugin_name in PLUGIN_REGISTRY.external_plugins:
-            plugin_instance = PLUGIN_REGISTRY.get_plugin(plugin_name)
-            if hasattr(plugin_instance, 'CUSTOM_LAYOUTS'):
-                if isinstance(plugin_instance.CUSTOM_LAYOUTS, list):
-                    for custom_layout in plugin_instance.CUSTOM_LAYOUTS:
-                        self.layouts.register_layout(
-                            self.layouts, custom_layout)
-                else:
-                    logger.info(
-                        'Unable to load custom layouts for {}. '
-                        'Expecting a list of layout classes but got {}'
-                        .format(plugin_name, plugin_instance.CUSTOM_LAYOUTS)
-                    )
+        if self.layouts is not None:
+            self.layouts.register_custom_layouts()
 
         # Needed to ensure dockwidgets/panes layout size distribution
         # when a layout state is already present.

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1018,7 +1018,7 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
                 if isinstance(plugin_instance.CUSTOM_LAYOUTS, list):
                     for custom_layout in plugin_instance.CUSTOM_LAYOUTS:
                         self.layouts.register_layout(
-                            self, custom_layout)
+                            self.layouts, custom_layout)
                 else:
                     logger.info(
                         'Unable to load custom layouts for {}. '

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -589,66 +589,6 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         except ValueError:
             pass
 
-    def tabify_plugins(self, first, second):
-        """Tabify plugin dockwigdets."""
-        self.tabifyDockWidget(first.dockwidget, second.dockwidget)
-
-    def tabify_plugin(self, plugin, default=None):
-        """
-        Tabify the plugin using the list of possible TABIFY options.
-
-        Only do this if the dockwidget does not have more dockwidgets
-        in the same position and if the plugin is using the New API.
-        """
-        def tabify_helper(plugin, next_to_plugins):
-            for next_to_plugin in next_to_plugins:
-                try:
-                    self.tabify_plugins(next_to_plugin, plugin)
-                    break
-                except SpyderAPIError as err:
-                    logger.error(err)
-
-        # If TABIFY not defined use the [default]
-        tabify = getattr(plugin, 'TABIFY', [default])
-        if not isinstance(tabify, list):
-            next_to_plugins = [tabify]
-        else:
-            next_to_plugins = tabify
-
-        # Check if TABIFY is not a list with None as unique value or a default
-        # list
-        if tabify in [[None], []]:
-            return False
-
-        # Get the actual plugins from the names
-        next_to_plugins = [self.get_plugin(p) for p in next_to_plugins]
-
-        # First time plugin starts
-        if plugin.get_conf('first_time', True):
-            if (isinstance(plugin, SpyderDockablePlugin)
-                    and plugin.NAME != Plugins.Console):
-                logger.info(
-                    f"Tabifying {plugin.NAME} plugin for the first time next "
-                    f"to {next_to_plugins}"
-                )
-                tabify_helper(plugin, next_to_plugins)
-
-                # Show external plugins
-                if plugin.NAME in PLUGIN_REGISTRY.external_plugins:
-                    plugin.get_widget().toggle_view(True)
-
-            plugin.set_conf('enable', True)
-            plugin.set_conf('first_time', False)
-        else:
-            # This is needed to ensure plugins are placed correctly when
-            # switching layouts.
-            logger.info(f"Tabifying {plugin.NAME} plugin")
-            # Check if plugin has no other dockwidgets in the same position
-            if not bool(self.tabifiedDockWidgets(plugin.dockwidget)):
-                tabify_helper(plugin, next_to_plugins)
-
-        return True
-
     def handle_exception(self, error_data):
         """
         This method will call the handle exception method of the Console

--- a/spyder/plugins/base.py
+++ b/spyder/plugins/base.py
@@ -485,7 +485,7 @@ class BasePluginWidgetMixin(object):
 
     def _tabify(self, core_plugin):
         """Tabify plugin next to a core plugin."""
-        self.main.tabify_plugins(core_plugin, self)
+        self.main.layouts.tabify_plugins(core_plugin, self)
 
     def _lock_unlock_position(self):
         """Show/hide title bar to move/lock position."""

--- a/spyder/plugins/completion/tests/conftest.py
+++ b/spyder/plugins/completion/tests/conftest.py
@@ -59,7 +59,7 @@ class MainWindowMock(QMainWindow):
         plugin = PLUGIN_REGISTRY.get_plugin(plugin_name)
         plugin._register()
 
-    def get_plugin(self, plugin_name):
+    def get_plugin(self, plugin_name, error=True):
         if plugin_name in PLUGIN_REGISTRY:
             return PLUGIN_REGISTRY.get_plugin(plugin_name)
 

--- a/spyder/plugins/layout/api.py
+++ b/spyder/plugins/layout/api.py
@@ -42,7 +42,6 @@ class BaseGridLayoutType:
 
     def __init__(self, parent_plugin):
         self.plugin = parent_plugin
-        self._plugin = parent_plugin
         self._areas = []
         self._area_rects = []
         self._column_stretchs = {}

--- a/spyder/plugins/layout/api.py
+++ b/spyder/plugins/layout/api.py
@@ -451,7 +451,7 @@ class BaseGridLayoutType:
                             plugins_to_tabify.append(
                                 (current_plugin, base_plugin))
                         else:
-                            main_window.tabify_plugins(
+                            self.plugin.tabify_plugins(
                                 base_plugin, current_plugin)
                             if plugin_id not in hidden_plugin_ids:
                                 current_plugin.toggle_view(area_visible)
@@ -466,8 +466,8 @@ class BaseGridLayoutType:
         # try to use the TABIFY attribute to add the plugin to the layout.
         # Otherwise use the default area base plugin
         for plugin, base_plugin in plugins_to_tabify:
-            if not main_window.tabify_plugin(plugin):
-                main_window.tabify_plugins(base_plugin, plugin)
+            if not self.plugin.tabify_plugin(plugin):
+                self.plugin.tabify_plugins(base_plugin, plugin)
             current_plugin.toggle_view(False)
 
         column_docks = []

--- a/spyder/plugins/layout/layouts.py
+++ b/spyder/plugins/layout/layouts.py
@@ -8,11 +8,6 @@
 Default layout definitions.
 """
 
-# Third party imports
-from qtpy.QtCore import QRect, QRectF, Qt
-from qtpy.QtWidgets import (QApplication, QDockWidget, QGridLayout,
-                            QMainWindow, QPlainTextEdit, QWidget)
-
 # Local imports
 from spyder.api.plugins import Plugins
 from spyder.api.translations import get_translation

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -947,7 +947,7 @@ class Layout(SpyderPluginV2):
 
         # Restore visible plugins
         for plugin in visible_plugins:
-            plugin_class = self.get_plugin(plugin)
+            plugin_class = self.main.get_plugin(plugin, error=False)
             if plugin_class and plugin_class.dockwidget.isVisible():
                 plugin_class.dockwidget.raise_()
 

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -285,6 +285,21 @@ class Layout(SpyderPluginV2):
         """
         self.get_container().register_layout(parent_plugin, layout_type)
 
+    def register_custom_layouts(self):
+        """Register custom layouts provided by external plugins."""
+        for plugin_name in PLUGIN_REGISTRY.external_plugins:
+            plugin_instance = self.get_plugin(plugin_name)
+            if hasattr(plugin_instance, 'CUSTOM_LAYOUTS'):
+                if isinstance(plugin_instance.CUSTOM_LAYOUTS, list):
+                    for custom_layout in plugin_instance.CUSTOM_LAYOUTS:
+                        self.register_layout(self, custom_layout)
+                else:
+                    logger.info(
+                        f'Unable to load custom layouts for plugin '
+                        f'{plugin_name}. Expecting a list of layout classes '
+                        f'but got {plugin_instance.CUSTOM_LAYOUTS}.'
+                    )
+
     def get_layout(self, layout_id):
         """
         Get a registered layout by his ID.

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -219,7 +219,31 @@ class Layout(SpyderPluginV2):
         """Get the list of internal dockable plugins"""
         return get_class_values(DockablePlugins)
 
-    # ---- Plubic API
+    def _update_fullscreen_action(self):
+        if self._fullscreen_flag:
+            icon = self.create_icon('window_nofullscreen')
+        else:
+            icon = self.create_icon('window_fullscreen')
+        self.get_container()._fullscreen_action.setIcon(icon)
+
+    def _update_lock_interface_action(self):
+        """
+        Helper method to update the locking of panes/dockwidgets and toolbars.
+
+        Returns
+        -------
+        None.
+        """
+        if self._interface_locked:
+            icon = self.create_icon('drag_dock_widget')
+            text = _('Unlock panes and toolbars')
+        else:
+            icon = self.create_icon('lock')
+            text = _('Lock panes and toolbars')
+        self.lock_interface_action.setIcon(icon)
+        self.lock_interface_action.setText(text)
+
+    # ---- Helper methods
     # -------------------------------------------------------------------------
     def get_last_plugin(self):
         """
@@ -245,6 +269,8 @@ class Layout(SpyderPluginV2):
         """
         return self._fullscreen_flag
 
+    # ---- Layout handling
+    # -------------------------------------------------------------------------
     def register_layout(self, parent_plugin, layout_type):
         """
         Register a new layout type.
@@ -593,6 +619,8 @@ class Layout(SpyderPluginV2):
             section=section,
         )
 
+    # ---- Maximize, close, switch to dockwidgets/plugins
+    # -------------------------------------------------------------------------
     @Slot()
     def close_current_dockwidget(self):
         """Search for the currently focused plugin and close it."""
@@ -791,13 +819,8 @@ class Layout(SpyderPluginV2):
 
         plugin.change_visibility(True, force_focus=force_focus)
 
-    def _update_fullscreen_action(self):
-        if self._fullscreen_flag:
-            icon = self.create_icon('window_nofullscreen')
-        else:
-            icon = self.create_icon('window_fullscreen')
-        self.get_container()._fullscreen_action.setIcon(icon)
-
+    # ---- Menus and actions
+    # -------------------------------------------------------------------------
     @Slot()
     def toggle_fullscreen(self):
         """
@@ -886,23 +909,6 @@ class Layout(SpyderPluginV2):
     def lock_interface_action(self):
         return self.get_container()._lock_interface_action
 
-    def _update_lock_interface_action(self):
-        """
-        Helper method to update the locking of panes/dockwidgets and toolbars.
-
-        Returns
-        -------
-        None.
-        """
-        if self._interface_locked:
-            icon = self.create_icon('drag_dock_widget')
-            text = _('Unlock panes and toolbars')
-        else:
-            icon = self.create_icon('lock')
-            text = _('Lock panes and toolbars')
-        self.lock_interface_action.setIcon(icon)
-        self.lock_interface_action.setText(text)
-
     def toggle_lock(self, value=None):
         """Lock/Unlock dockwidgets and toolbars."""
         self._interface_locked = (
@@ -924,6 +930,8 @@ class Layout(SpyderPluginV2):
         if toolbar:
             toolbar.toggle_lock(value=self._interface_locked)
 
+    # ---- Visible dockable plugins
+    # -------------------------------------------------------------------------
     def restore_visible_plugins(self):
         """
         Restore dockable plugins that were visible during the previous session.
@@ -959,6 +967,8 @@ class Layout(SpyderPluginV2):
 
         self.set_conf('last_visible_plugins', visible_plugins)
 
+    # ---- Tabify plugins
+    # -------------------------------------------------------------------------
     def tabify_new_plugins(self):
         """
         Tabify new dockable plugins, i.e. plugins that were not part of the

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -1004,8 +1004,10 @@ class Layout(SpyderPluginV2):
         # Get the actual plugins from their names
         next_to_plugins = [self.get_plugin(p) for p in next_to_plugins]
 
-        # First time plugin starts
         if plugin.get_conf('first_time', True):
+            # This tabifies external and internal plugins that are loaded for
+            # the first time, and internal ones that are not part of the
+            # default layout.
             if (
                 isinstance(plugin, SpyderDockablePlugin)
                 and plugin.NAME != Plugins.Console
@@ -1023,12 +1025,13 @@ class Layout(SpyderPluginV2):
             plugin.set_conf('enable', True)
             plugin.set_conf('first_time', False)
         else:
-            # This is needed to ensure plugins are placed correctly when
-            # switching layouts.
-            logger.info(f"Tabifying {plugin.NAME} plugin")
-
-            # Check if plugin has no other dockwidgets in the same position
+            # This is needed to ensure that, when switching to a different
+            # layout, any plugin (external or internal) not part of its
+            # declared areas is tabified as expected.
+            # Note: Check if `plugin` has no other dockwidgets in the same
+            # position before proceeding.
             if not bool(self.main.tabifiedDockWidgets(plugin.dockwidget)):
+                logger.info(f"Tabifying {plugin.NAME} plugin")
                 tabify_helper(plugin, next_to_plugins)
 
         return True

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -947,7 +947,7 @@ class Layout(SpyderPluginV2):
 
         # Restore visible plugins
         for plugin in visible_plugins:
-            plugin_class = self.main.get_plugin(plugin, error=False)
+            plugin_class = self.get_plugin(plugin, error=False)
             if plugin_class and plugin_class.dockwidget.isVisible():
                 plugin_class.dockwidget.raise_()
 
@@ -1084,7 +1084,7 @@ class Layout(SpyderPluginV2):
         # Tabify new internal plugins
         for plugin_name in self._get_internal_dockable_plugins():
             if plugin_name not in last_internal_dockable_plugins:
-                plugin = self.main.get_plugin(plugin_name, error=False)
+                plugin = self.get_plugin(plugin_name, error=False)
                 if plugin:
                     self.tabify_plugin(plugin, Plugins.Console)
 

--- a/spyder/plugins/preferences/tests/conftest.py
+++ b/spyder/plugins/preferences/tests/conftest.py
@@ -65,7 +65,7 @@ class MainWindowMock(QMainWindow):
         plugin = PLUGIN_REGISTRY.get_plugin(plugin_name)
         plugin._register(omit_conf=True)
 
-    def get_plugin(self, plugin_name):
+    def get_plugin(self, plugin_name, error=True):
         if plugin_name in PLUGIN_REGISTRY:
             return PLUGIN_REGISTRY.get_plugin(plugin_name)
 
@@ -88,7 +88,7 @@ class ConfigDialogTester(QWidget):
             plugin = PLUGIN_REGISTRY.get_plugin(plugin_name)
             plugin._register()
 
-        def get_plugin(self, plugin_name, error=False):
+        def get_plugin(self, plugin_name, error=True):
             if plugin_name in PLUGIN_REGISTRY:
                 return PLUGIN_REGISTRY.get_plugin(plugin_name)
             return None

--- a/spyder/plugins/profiler/plugin.py
+++ b/spyder/plugins/profiler/plugin.py
@@ -42,7 +42,7 @@ class Profiler(SpyderDockablePlugin):
     NAME = 'profiler'
     REQUIRES = [Plugins.Preferences, Plugins.Editor]
     OPTIONAL = [Plugins.MainMenu]
-    TABIFY = Plugins.Help
+    TABIFY = [Plugins.Help]
     WIDGET_CLASS = ProfilerWidget
     CONF_SECTION = NAME
     CONF_WIDGET_CLASS = ProfilerConfigPage

--- a/spyder/plugins/profiler/plugin.py
+++ b/spyder/plugins/profiler/plugin.py
@@ -8,9 +8,6 @@
 Profiler Plugin.
 """
 
-# Standard library imports
-import os.path as osp
-
 # Third party imports
 from qtpy.QtCore import Signal
 
@@ -22,7 +19,6 @@ from spyder.api.translations import get_translation
 from spyder.plugins.mainmenu.api import ApplicationMenus
 from spyder.plugins.profiler.confpage import ProfilerConfigPage
 from spyder.plugins.profiler.widgets.main_widget import (ProfilerWidget,
-                                                         ProfilerWidgetActions,
                                                          is_profiler_installed)
 from spyder.plugins.run.widgets import get_run_configuration
 

--- a/spyder/plugins/pylint/plugin.py
+++ b/spyder/plugins/pylint/plugin.py
@@ -8,9 +8,6 @@
 Pylint Code Analysis Plugin.
 """
 
-# Standard library imports
-import os.path as osp
-
 # Third party imports
 from qtpy.QtCore import Qt, Signal, Slot
 
@@ -23,8 +20,7 @@ from spyder.api.translations import get_translation
 from spyder.utils.programs import is_module_installed
 from spyder.plugins.mainmenu.api import ApplicationMenus
 from spyder.plugins.pylint.confpage import PylintConfigPage
-from spyder.plugins.pylint.main_widget import (PylintWidget,
-                                               PylintWidgetActions)
+from spyder.plugins.pylint.main_widget import PylintWidget
 
 
 # Localization
@@ -113,8 +109,6 @@ class Pylint(SpyderDockablePlugin):
 
     @on_plugin_available(plugin=Plugins.Projects)
     def on_projects_available(self):
-        widget = self.get_widget()
-
         # Connect to projects
         projects = self.get_plugin(Plugins.Projects)
 

--- a/spyder/plugins/pylint/plugin.py
+++ b/spyder/plugins/pylint/plugin.py
@@ -39,6 +39,7 @@ class Pylint(SpyderDockablePlugin):
     CONF_WIDGET_CLASS = PylintConfigPage
     REQUIRES = [Plugins.Preferences, Plugins.Editor]
     OPTIONAL = [Plugins.MainMenu, Plugins.Projects]
+    TABIFY = [Plugins.Help]
     CONF_FILE = False
     DISABLE_ACTIONS_WHEN_HIDDEN = False
 

--- a/spyder/plugins/pylint/tests/test_pylint.py
+++ b/spyder/plugins/pylint/tests/test_pylint.py
@@ -75,7 +75,7 @@ class MainWindowMock(QMainWindow):
             'projects': self.projects
         }
 
-    def get_plugin(self, plugin_name):
+    def get_plugin(self, plugin_name, error=True):
         return PLUGIN_REGISTRY.get_plugin(plugin_name)
 
 

--- a/spyder/plugins/workingdirectory/tests/test_workingdirectory.py
+++ b/spyder/plugins/workingdirectory/tests/test_workingdirectory.py
@@ -32,7 +32,7 @@ class MainWindow(QMainWindow):
         self._cli_options = get_options(sys_argv)[0]
         super().__init__()
 
-    def get_plugin(self, plugin):
+    def get_plugin(self, plugin, error=True):
         return Mock()
 
 


### PR DESCRIPTION
## Description of Changes

- Fix tabifying external and internal plugins (e.g. Spyder-notebook and Debugger) that are loaded after Spyder runs for the first time.
- Move methods related to tabifying plugins from MainWindow to the Layout plugin.
- Fix error when trying to restore visible plugins that are no longer available (this error was reported by @dalthviz).
- Show visible external plugins when switching layouts. For instance, if Spyder-notebook is displayed in the interface and the user switches to the Matlab layout, then that plugin is displayed again (it was not before).
- Fix `TABIFY` class attribute for the Pylint and Profiler plugins.
- Reorganize code a bit in the Layout plugin.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
