### PR TITLE
PR: Ensure that project path is added to `spyder_pythonpath`

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1666,11 +1666,13 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         # Load new path plus project path
         new_path_dict_p = self.get_spyder_pythonpath_dict()
 
-        self.set_conf('spyder_pythonpath', self.get_spyder_pythonpath())
+        if new_path_dict_p != old_path_dict_p:
+            # Do not notify observers unless necessary
+            self.set_conf('spyder_pythonpath', self.get_spyder_pythonpath())
 
-        # Any plugin that needs to do some work based on this signal should
-        # connect to it on plugin registration
-        self.sig_pythonpath_changed.emit(old_path_dict_p, new_path_dict_p)
+            # Any plugin that needs to do some work based on this signal should
+            # connect to it on plugin registration
+            self.sig_pythonpath_changed.emit(old_path_dict_p, new_path_dict_p)
 
     @Slot()
     def show_path_manager(self):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1641,22 +1641,30 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         path = [k for k, v in path_dict.items() if v]
         return path
 
-    def update_python_path(self, new_path_dict):
-        """Update python path on Spyder interpreter and kernels."""
-        # Load previous path
-        path_dict = self.get_spyder_pythonpath_dict()
+    def update_python_path(self, new_path_dict=None):
+        """
+        Update python path on Spyder interpreter and kernels.
 
-        # Save path
-        if path_dict != new_path_dict:
-            # It doesn't include the project_path
+        The new_path_dict should not include the project path.
+        """
+        # Load existing path plus project path
+        old_path_dict_p = self.get_spyder_pythonpath_dict()
+
+        # Save new path
+        if new_path_dict is not None:
             self.save_python_path(new_path_dict)
 
-        # Load new path
-        new_path_dict_p = self.get_spyder_pythonpath_dict()  # Includes project
+        # Update project path
+        projects = self.get_plugin(Plugins.Projects, error=False)
+        if projects:
+            self.project_path = tuple(projects.get_pythonpath())
+
+        # Load new path plus project path
+        new_path_dict_p = self.get_spyder_pythonpath_dict()
 
         # Any plugin that needs to do some work based on this signal should
         # connect to it on plugin registration
-        self.sig_pythonpath_changed.emit(path_dict, new_path_dict_p)
+        self.sig_pythonpath_changed.emit(old_path_dict_p, new_path_dict_p)
 
     @Slot()
     def show_path_manager(self):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1597,7 +1597,7 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
 
     def save_python_path(self, new_path_dict):
         """
-        Save path in Spyder configuration folder.
+        Save Spyder PYTHONPATH to configuration folder and update attributes.
 
         `new_path_dict` is an OrderedDict that has the new paths as keys and
         the state as values. The state is `True` for active and `False` for
@@ -1620,7 +1620,7 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
 
     def get_spyder_pythonpath_dict(self):
         """
-        Return Spyder PYTHONPATH.
+        Return Spyder PYTHONPATH plus project path as dictionary of paths.
 
         The returned ordered dictionary has the paths as keys and the state
         as values. The state is `True` for active and `False` for inactive.
@@ -1639,7 +1639,7 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
 
     def get_spyder_pythonpath(self):
         """
-        Return Spyder PYTHONPATH.
+        Return active Spyder PYTHONPATH plus project path as list of paths.
         """
         path_dict = self.get_spyder_pythonpath_dict()
         path = [k for k, v in path_dict.items() if v]

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1606,6 +1606,7 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         path = tuple(p for p in new_path_dict)
         not_active_path = tuple(p for p in new_path_dict
                                 if not new_path_dict[p])
+
         if path != self.path or not_active_path != self.not_active_path:
             # Do not write unless necessary
             try:
@@ -1639,7 +1640,7 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
 
     def get_spyder_pythonpath(self):
         """
-        Return active Spyder PYTHONPATH plus project path as list of paths.
+        Return active Spyder PYTHONPATH plus project path as a list of paths.
         """
         path_dict = self.get_spyder_pythonpath_dict()
         path = [k for k, v in path_dict.items() if v]

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1606,14 +1606,17 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         path = tuple(p for p in new_path_dict)
         not_active_path = tuple(p for p in new_path_dict
                                 if not new_path_dict[p])
-        try:
-            encoding.writelines(path, self.SPYDER_PATH)
-            encoding.writelines(not_active_path, self.SPYDER_NOT_ACTIVE_PATH)
-        except EnvironmentError as e:
-            logger.error(str(e))
+        if path != self.path or not_active_path != self.not_active_path:
+            # Do not write unless necessary
+            try:
+                encoding.writelines(path, self.SPYDER_PATH)
+                encoding.writelines(not_active_path,
+                                    self.SPYDER_NOT_ACTIVE_PATH)
+            except EnvironmentError as e:
+                logger.error(str(e))
 
-        self.path = path
-        self.not_active_path = not_active_path
+            self.path = path
+            self.not_active_path = not_active_path
 
     def get_spyder_pythonpath_dict(self):
         """

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -674,8 +674,8 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         from spyder.plugins.help.utils.sphinxify import CSS_PATH, DARK_CSS_PATH
         logger.info("*** Start of MainWindow setup ***")
         logger.info("Updating PYTHONPATH")
-        path_dict = self.get_spyder_pythonpath_dict()
-        self.update_python_path(path_dict)
+        self.load_python_path()
+        self.update_python_path()
 
         logger.info("Applying theme configuration...")
         ui_theme = self.get_conf('ui_theme', section='appearance')
@@ -1628,8 +1628,6 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         Example:
             OrderedDict([('/some/path, True), ('/some/other/path, False)])
         """
-        self.load_python_path()
-
         path_dict = OrderedDict()
         for path in self.path:
             path_dict[path] = path not in self.not_active_path

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1603,14 +1603,17 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         the state as values. The state is `True` for active and `False` for
         inactive.
         """
-        path = [p for p in new_path_dict]
-        not_active_path = [p for p in new_path_dict if not new_path_dict[p]]
+        path = tuple(p for p in new_path_dict)
+        not_active_path = tuple(p for p in new_path_dict
+                                if not new_path_dict[p])
         try:
             encoding.writelines(path, self.SPYDER_PATH)
             encoding.writelines(not_active_path, self.SPYDER_NOT_ACTIVE_PATH)
         except EnvironmentError as e:
             logger.error(str(e))
-        self.set_conf('spyder_pythonpath', self.get_spyder_pythonpath())
+
+        self.path = path
+        self.not_active_path = not_active_path
 
     def get_spyder_pythonpath_dict(self):
         """
@@ -1661,6 +1664,8 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
 
         # Load new path plus project path
         new_path_dict_p = self.get_spyder_pythonpath_dict()
+
+        self.set_conf('spyder_pythonpath', self.get_spyder_pythonpath())
 
         # Any plugin that needs to do some work based on this signal should
         # connect to it on plugin registration

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1685,16 +1685,6 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
             self._path_manager.raise_()
             self._path_manager.setFocus()
 
-    def pythonpath_changed(self):
-        """Project's PYTHONPATH contribution has changed."""
-        projects = self.get_plugin(Plugins.Projects, error=False)
-
-        self.project_path = ()
-        if projects:
-            self.project_path = tuple(projects.get_pythonpath())
-        path_dict = self.get_spyder_pythonpath_dict()
-        self.update_python_path(path_dict)
-
     # ---- Preferences
     # -------------------------------------------------------------------------
     def apply_settings(self):

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1448,7 +1448,7 @@ def test_project_path(main_window, tmpdir, qtbot):
     projects = main_window.projects
 
     # Create a project
-    path = to_text_string(tmpdir.mkdir('project_path'))
+    path = str(tmpdir.mkdir('project_path'))
 
     assert path not in projects.get_conf('spyder_pythonpath', section='main')
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1452,20 +1452,15 @@ def test_project_path(main_window, tmpdir, qtbot):
 
     # Ensure project path is added to IPython console
     shell = main_window.ipyconsole.get_current_shellwidget()
-    control = shell._control
     qtbot.waitUntil(
         lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
 
     with qtbot.waitSignal(shell.executed):
-        shell.execute("import sys; sys.path")
-    assert path in control.toPlainText()
-
-    with qtbot.waitSignal(shell.executed):
-        shell.execute("clear")
-
-    with qtbot.waitSignal(shell.executed):
-        shell.execute("import os; os.environ.get('PYTHONPATH')")
-    assert path in control.toPlainText()
+        shell.execute("import sys; import os; "
+                      "sys_path = sys.path; "
+                      "os_path = os.environ.get('PYTHONPATH', [])")
+    assert path in shell.get_value("sys_path")
+    assert path in shell.get_value("os_path")
 
     projects.close_project()
 
@@ -1474,20 +1469,15 @@ def test_project_path(main_window, tmpdir, qtbot):
 
     # Ensure that project path is removed from IPython console
     shell = main_window.ipyconsole.get_current_shellwidget()
-    control = shell._control
     qtbot.waitUntil(
         lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
 
     with qtbot.waitSignal(shell.executed):
-        shell.execute("import sys; sys.path")
-    assert path not in control.toPlainText()
-
-    with qtbot.waitSignal(shell.executed):
-        shell.execute("clear")
-
-    with qtbot.waitSignal(shell.executed):
-        shell.execute("import os; os.environ.get('PYTHONPATH')")
-    assert path not in control.toPlainText()
+        shell.execute("import sys; import os; "
+                      "sys_path = sys.path; "
+                      "os_path = os.environ.get('PYTHONPATH', [])")
+    assert path not in shell.get_value("sys_path")
+    assert path not in shell.get_value("os_path")
 
 
 @pytest.mark.slow

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1438,6 +1438,28 @@ def test_run_cython_code(main_window, qtbot):
 
 
 @pytest.mark.slow
+def test_project_path(main_window, tmpdir, qtbot):
+    """Test project path added to spyder_pythonpath."""
+    # Wait until the window is fully up
+    shell = main_window.ipyconsole.get_current_shellwidget()
+    qtbot.waitUntil(
+        lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
+
+    projects = main_window.projects
+
+    # Create a project
+    path = to_text_string(tmpdir.mkdir('project_path'))
+
+    assert path not in projects.get_conf('spyder_pythonpath', section='main')
+
+    projects.open_project(path=path)
+
+    assert path in projects.get_conf('spyder_pythonpath', section='main')
+
+    projects.close_project()
+
+
+@pytest.mark.slow
 @flaky(max_runs=3)
 @pytest.mark.skipif(os.name == 'nt', reason="It fails on Windows.")
 def test_open_notebooks_from_project_explorer(main_window, qtbot, tmpdir):

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -174,7 +174,7 @@ class Projects(SpyderDockablePlugin):
                 lambda v: self.main.set_window_title())
             self.main.restore_scrollbar_position.connect(
                 self.restore_scrollbar_position)
-            self.sig_pythonpath_changed.connect(self.main.pythonpath_changed)
+            self.sig_pythonpath_changed.connect(self.main.update_python_path)
 
         self.register_project_type(self, EmptyProject)
         self.setup()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

- Projects plugin now calls `update_python_path` instead of `pythonpath_changed` because `pythonpath_changed` only had the effect of ensuring that the project path never made it into `spyder_pythonpath`.
- `update_python_path` now correctly retrieves the existing path dictionary _before_ it is updated.
- Existing and new path dictionaries are compared to avoid unnecessary file read/writes and unnecessary notifications.
- Regression test added to the mainwindow test ensuring that project path is added to `spyder_pythonpath`.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19205


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary

<!--- Thanks for your help making Spyder better for everyone! --->
