### PR TITLE
PR: Catch error when removing autosave files (Editor)

### DIFF
--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -315,7 +315,15 @@ class AutosaveForStack(object):
             msgbox = AutosaveErrorDialog(action, error)
             msgbox.exec_if_enabled()
         del self.name_mapping[filename]
-        del self.file_hashes[autosave_filename]
+
+        # This is necessary to catch an error when a file is changed externally
+        # but it's left unsaved in Spyder.
+        # Fixes spyder-ide/spyder#19283
+        try:
+            del self.file_hashes[autosave_filename]
+        except KeyError:
+            pass
+
         self.save_autosave_mapping()
         logger.debug('Removing autosave file %s', autosave_filename)
 


### PR DESCRIPTION
## Description of Changes

This error can happen when a file is changed externally but it's left unsaved in Spyder.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19283.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
