### PR TITLE
PR: Remove `main_toolbar` and `main_toolbar_actions` attributes (Main Window)

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -253,8 +253,6 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         self.debug_menu_actions = []
 
         # TODO: Move to corresponding Plugins
-        self.main_toolbar = None
-        self.main_toolbar_actions = []
         self.file_toolbar = None
         self.file_toolbar_actions = []
         self.run_toolbar = None
@@ -916,7 +914,6 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         self.file_toolbar = toolbar.get_application_toolbar("file_toolbar")
         self.run_toolbar = toolbar.get_application_toolbar("run_toolbar")
         self.debug_toolbar = toolbar.get_application_toolbar("debug_toolbar")
-        self.main_toolbar = toolbar.get_application_toolbar("main_toolbar")
 
         # Tools + External Tools (some of this depends on the Application
         # plugin)

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -61,6 +61,7 @@ from spyder.plugins.help.tests.test_plugin import check_text
 from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec
 from spyder.plugins.layout.layouts import DefaultLayouts
 from spyder.plugins.projects.api import EmptyProject
+from spyder.plugins.toolbar.api import ApplicationToolbars
 from spyder.py3compat import PY2, qbytearray_to_str, to_text_string
 from spyder.utils import encoding
 from spyder.utils.misc import remove_backslashes
@@ -1932,7 +1933,9 @@ def test_maximize_minimize_plugins(main_window, qtbot):
 
     # Grab maximize button
     max_action = main_window.layouts.maximize_action
-    max_button = main_window.main_toolbar.widgetForAction(max_action)
+    toolbar = main_window.get_plugin(Plugins.Toolbar)
+    main_toolbar = toolbar.get_application_toolbar(ApplicationToolbars.Main)
+    max_button = main_toolbar.widgetForAction(max_action)
 
     # Maximize a random plugin
     plugin_1 = get_random_plugin()

--- a/spyder/plugins/toolbar/plugin.py
+++ b/spyder/plugins/toolbar/plugin.py
@@ -13,7 +13,6 @@ from spyder.utils.qthelpers import SpyderAction
 from typing import Union, Optional
 
 # Local imports
-from spyder.api.exceptions import SpyderAPIError
 from spyder.api.plugins import SpyderPluginV2, Plugins
 from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)


### PR DESCRIPTION
## Description of Changes

Those attributes are no longer needed because the Main toolbar was migrated to the new API a long time ago.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
