### PR TITLE
PR: Improve style of the IPython console a bit

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -327,10 +327,9 @@ class IPythonConsoleWidget(PluginMainWidget):
 
         layout = QVBoxLayout()
         layout.setSpacing(0)
-        self.tabwidget = Tabs(self, menu=self._options_menu,
-                              actions=self.menu_actions,
-                              rename_tabs=True,
-                              split_char='/', split_index=0)
+
+        self.tabwidget = Tabs(self, rename_tabs=True, split_char='/',
+                              split_index=0)
         if (hasattr(self.tabwidget, 'setDocumentMode')
                 and not sys.platform == 'darwin'):
             # Don't set document mode to true on OSX because it generates
@@ -617,9 +616,9 @@ class IPythonConsoleWidget(PluginMainWidget):
         self.time_label = QLabel("")
 
         # Add tab corner widgets.
+        self.add_corner_widget('timer', self.time_label)
         self.add_corner_widget('reset', self.reset_button)
         self.add_corner_widget('start_interrupt', self.stop_button)
-        self.add_corner_widget('timer', self.time_label)
 
         # Create IPython documentation menu
         self.ipython_menu = self.create_menu(

--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -277,6 +277,12 @@ class PanesTabBarStyleSheet(PanesToolbarStyleSheet):
         css = self.get_stylesheet()
         is_macos = sys.platform == 'darwin'
 
+        # This removes a white dot that appears to the left of right corner
+        # widgets
+        css.QToolBar.setValues(
+            marginLeft='-1px',
+        )
+
         # QTabBar forces the corner widgets to be smaller than they should.
         # be. The added top margin allows the toolbuttons to expand to their
         # normal size.
@@ -350,7 +356,7 @@ class PanesTabBarStyleSheet(PanesToolbarStyleSheet):
         css['QTabWidget::right-corner'].setValues(
             top='-1px',
             bottom='-2px',
-            right='1px'
+            right='-1px'
         )
 
     def to_string(self):


### PR DESCRIPTION
## Description of Changes

- Remove blank pixels in widgets with tabs (i.e. the IPython console and the editor).
- Move time label to be first from left to right in the IPython console. That avoids a space wider than normal between the options button and the stop one. 

**Before**

![image](https://user-images.githubusercontent.com/365293/188281377-980ce16d-cb90-4345-a835-642d479e4d0f.png)

**After**

![image](https://user-images.githubusercontent.com/365293/188281427-1437eb63-4228-404a-a531-004a95c2e97d.png)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
