### PR TITLE
PR: Add button to debugger plugin to go to editor

### DIFF
--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -36,6 +36,7 @@ class DebuggerWidgetActions:
     Step = "step"
     Return = "return"
     Stop = "stop"
+    GotoCursor = "go to editor"
 
     # Toggles
     ToggleExcludeInternal = 'toggle_exclude_internal_action'
@@ -263,6 +264,14 @@ class DebuggerWidget(ShellConnectMainWidget):
             register_shortcut=True
         )
 
+        goto_cursor_action = self.create_action(
+            DebuggerWidgetActions.GotoCursor,
+            text=_("Show in editor"),
+            icon=self.create_icon('fromcursor'),
+            triggered=self.goto_current_step,
+            register_shortcut=True
+        )
+
         self.create_action(
             DebuggerToolbarActions.DebugCurrentFile,
             text=_("&Debug file"),
@@ -333,6 +342,7 @@ class DebuggerWidget(ShellConnectMainWidget):
                      step_action,
                      return_action,
                      stop_action,
+                     goto_cursor_action,
                      enter_debug_action,
                      inspect_action,
                      search_action]:
@@ -395,7 +405,9 @@ class DebuggerWidget(ShellConnectMainWidget):
                 DebuggerWidgetActions.Continue,
                 DebuggerWidgetActions.Step,
                 DebuggerWidgetActions.Return,
-                DebuggerWidgetActions.Stop]:
+                DebuggerWidgetActions.Stop,
+                DebuggerWidgetActions.GotoCursor,
+                ]:
             action = self.get_action(action_name)
             action.setEnabled(pdb_prompt)
 
@@ -492,6 +504,12 @@ class DebuggerWidget(ShellConnectMainWidget):
 
     # ---- Public API
     # ------------------------------------------------------------------------
+    def goto_current_step(self):
+        """Go to last pdb step."""
+        fname, lineno = self.get_pdb_last_step()
+        if fname:
+            self.sig_load_pdb_file.emit(fname, lineno)
+
     def print_debug_file_msg(self):
         """Print message in the current console when a file can't be closed."""
         widget = self.current_widget()

--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -266,7 +266,8 @@ class DebuggerWidget(ShellConnectMainWidget):
 
         goto_cursor_action = self.create_action(
             DebuggerWidgetActions.GotoCursor,
-            text=_("Show in editor"),
+            text=_("Show in the editor the file and line where the debugger "
+                   "is placed"),
             icon=self.create_icon('fromcursor'),
             triggered=self.goto_current_step,
             register_shortcut=True


### PR DESCRIPTION
## Description of Changes

Add a button to go to the currently debugged line if the editor was moved.
![goto_editor](https://user-images.githubusercontent.com/6740194/191172545-f049255f-f52d-4f46-b73b-93885dac0813.gif)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: impact27

<!--- Thanks for your help making Spyder better for everyone! --->
