### PR TITLE
PR: Change colours in Dependencies dialog window

### DIFF
--- a/spyder/widgets/dependencies.py
+++ b/spyder/widgets/dependencies.py
@@ -60,10 +60,10 @@ class DependenciesTreeWidget(QTreeWidget):
                 item.setIcon(0, ima.icon('dependency_ok'))
             elif dependency.kind == OPTIONAL:
                 item.setIcon(0, ima.icon('dependency_warning'))
-                item.setForeground(2, QColor(SpyderPalette.COLOR_WARN_1))
+                item.setBackground(2, QColor(SpyderPalette.COLOR_WARN_1))
             else:
                 item.setIcon(0, ima.icon('dependency_error'))
-                item.setForeground(2, QColor(SpyderPalette.COLOR_ERROR_1))
+                item.setBackground(2, QColor(SpyderPalette.COLOR_ERROR_1))
 
             # Add to tree
             if dependency.kind == OPTIONAL:


### PR DESCRIPTION
## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

Use the error and warning colour that indicate that a dependency is not met, as background instead of foreground colours. This increases readability and seems to be in keeping with the discussion at spyder-ide/ux-improvements#13.

Screenshot of the Dependencies dialog after the PR is applied (I changed the required version of three-merge for the picture):
![deps-dark-new](https://user-images.githubusercontent.com/7941918/188322475-4086f064-97ba-4a6f-9337-2a6bd6737c6b.png)

For comparison, here is the corresponding screenshot of the current version:
![deps-dark-now](https://user-images.githubusercontent.com/7941918/188322531-a6136bbe-b8b4-4a93-a899-fb6cafd55cd5.png)

### Issue(s) Resolved

Fixes #13090

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
