### PR TITLE
PR: Show symbols for namespace packages in the Outline

### DIFF
--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/python-lsp/python-lsp-server.git
-	branch = more-symbol-fixes
-	commit = 0d654c2871f00134ab21df2dd092d963b8b418e8
-	parent = f989afead6a98c11cbf9f1ed3ac613b33d1962b4
+	branch = develop
+	commit = 6501e9eb80c7c3b35cf93f634834558fc88dee68
+	parent = 13da995dc08e14f82c07d018ca7130021fc7ad56
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/python-lsp/python-lsp-server.git
-	branch = develop
-	commit = 9a2cacf3bb2660de8e086f47f1059dc47f88e80b
-	parent = a7fd9495c2aff823e9c61313148c17f35ace2660
+	branch = more-symbol-fixes
+	commit = 0d654c2871f00134ab21df2dd092d963b8b418e8
+	parent = f989afead6a98c11cbf9f1ed3ac613b33d1962b4
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/CHANGELOG.md
+++ b/external-deps/python-lsp-server/CHANGELOG.md
@@ -1,5 +1,54 @@
 # History of changes
 
+## Version 1.5.0 (2022/07/10)
+
+### New features
+
+* Add `DiagnosticTag` tags for Pylint, Pycodestyle, and Flake8 plugins.
+* Add support to connect to the server through websockets.
+* Allow multiple per-file-ignores for the same pattern in Flake8 plugin.
+* Parse YAPF diffs into TextEdits.
+* Add support for LSP formatting `options` parameter.
+
+### Issues Closed
+
+* [Issue 230](https://github.com/python-lsp/python-lsp-server/issues/230) - Flake8 reports wrong severity level for code Fxxx ([PR 234](https://github.com/python-lsp/python-lsp-server/pull/234) by [@lcheylus](https://github.com/lcheylus))
+* [Issue 220](https://github.com/python-lsp/python-lsp-server/issues/220) - Flake8 reports wrong severity level for E999 ([PR 223](https://github.com/python-lsp/python-lsp-server/pull/223) by [@jhossbach](https://github.com/jhossbach))
+* [Issue 219](https://github.com/python-lsp/python-lsp-server/issues/219) - Add .flake8 to the discovery paths ([PR 233](https://github.com/python-lsp/python-lsp-server/pull/233) by [@lcheylus](https://github.com/lcheylus))
+* [Issue 209](https://github.com/python-lsp/python-lsp-server/issues/209) - Rope completions enabled or disabled by default? ([PR 210](https://github.com/python-lsp/python-lsp-server/pull/210) by [@rchl](https://github.com/rchl))
+* [Issue 157](https://github.com/python-lsp/python-lsp-server/issues/157) - Please add basic usage documentation ([PR 185](https://github.com/python-lsp/python-lsp-server/pull/185) by [@jgollenz](https://github.com/jgollenz))
+* [Issue 144](https://github.com/python-lsp/python-lsp-server/issues/144) - Add `DiagnosticTag` tags for pylint, pycodestyle, and flake8 ([PR 229](https://github.com/python-lsp/python-lsp-server/pull/229) by [@krassowski](https://github.com/krassowski))
+* [Issue 140](https://github.com/python-lsp/python-lsp-server/issues/140) - Flake8 plugins issues ([PR 215](https://github.com/python-lsp/python-lsp-server/pull/215) by [@yeraydiazdiaz](https://github.com/yeraydiazdiaz))
+* [Issue 117](https://github.com/python-lsp/python-lsp-server/issues/117) - Websockets built-in support ([PR 128](https://github.com/python-lsp/python-lsp-server/pull/128) by [@npradeep357](https://github.com/npradeep357))
+
+In this release 8 issues were closed.
+
+### Pull Requests Merged
+
+* [PR 234](https://github.com/python-lsp/python-lsp-server/pull/234) - Report Flake8 errors with Error severity level, by [@lcheylus](https://github.com/lcheylus) ([230](https://github.com/python-lsp/python-lsp-server/issues/230))
+* [PR 233](https://github.com/python-lsp/python-lsp-server/pull/233) - Fix documentation for location of Flake8 configuration files, by [@lcheylus](https://github.com/lcheylus) ([219](https://github.com/python-lsp/python-lsp-server/issues/219))
+* [PR 231](https://github.com/python-lsp/python-lsp-server/pull/231) - Use Numpy less than 1.23 in our tests, by [@ccordoba12](https://github.com/ccordoba12)
+* [PR 229](https://github.com/python-lsp/python-lsp-server/pull/229) - Add `DiagnosticTag` support, by [@krassowski](https://github.com/krassowski) ([144](https://github.com/python-lsp/python-lsp-server/issues/144))
+* [PR 228](https://github.com/python-lsp/python-lsp-server/pull/228) - Improve schema type compliance, improve CONFIGURATION.md, by [@krassowski](https://github.com/krassowski)
+* [PR 225](https://github.com/python-lsp/python-lsp-server/pull/225) - Add autopep8.enabled to the configuration schema, by [@j2kun](https://github.com/j2kun)
+* [PR 223](https://github.com/python-lsp/python-lsp-server/pull/223) - Change severity level for flake8 errors, by [@jhossbach](https://github.com/jhossbach) ([220](https://github.com/python-lsp/python-lsp-server/issues/220))
+* [PR 221](https://github.com/python-lsp/python-lsp-server/pull/221) - Remove preload module from Readme, by [@bageljrkhanofemus](https://github.com/bageljrkhanofemus)
+* [PR 217](https://github.com/python-lsp/python-lsp-server/pull/217) - Allow multiple per-file-ignores for the same pattern in flake8 plugin, by [@dedi](https://github.com/dedi)
+* [PR 215](https://github.com/python-lsp/python-lsp-server/pull/215) - Remove reference to pyls-flake8 in Readme, by [@yeraydiazdiaz](https://github.com/yeraydiazdiaz) ([140](https://github.com/python-lsp/python-lsp-server/issues/140))
+* [PR 211](https://github.com/python-lsp/python-lsp-server/pull/211) - Restore the copyright headers in `setup.cfg` and `pyproject.toml`, by [@KOLANICH](https://github.com/KOLANICH)
+* [PR 210](https://github.com/python-lsp/python-lsp-server/pull/210) - Match rope_completions setting documentation with reality, by [@rchl](https://github.com/rchl) ([209](https://github.com/python-lsp/python-lsp-server/issues/209))
+* [PR 207](https://github.com/python-lsp/python-lsp-server/pull/207) - Move the project metadata into `PEP 621`-compliant `pyproject.toml`, by [@KOLANICH](https://github.com/KOLANICH)
+* [PR 187](https://github.com/python-lsp/python-lsp-server/pull/187) - Add plugins for pylint and flake8 to readme, by [@bageljrkhanofemus](https://github.com/bageljrkhanofemus)
+* [PR 185](https://github.com/python-lsp/python-lsp-server/pull/185) - Mention `pylsp` command in README, by [@jgollenz](https://github.com/jgollenz) ([157](https://github.com/python-lsp/python-lsp-server/issues/157))
+* [PR 181](https://github.com/python-lsp/python-lsp-server/pull/181) - Fix section that was misplaced in changelog, by [@ccordoba12](https://github.com/ccordoba12)
+* [PR 136](https://github.com/python-lsp/python-lsp-server/pull/136) - Parse YAPF diffs into TextEdits (instead of sending the full doc), by [@masad-frost](https://github.com/masad-frost)
+* [PR 134](https://github.com/python-lsp/python-lsp-server/pull/134) - Add support for LSP formatting `options` parameter, by [@masad-frost](https://github.com/masad-frost)
+* [PR 128](https://github.com/python-lsp/python-lsp-server/pull/128) - Add web sockets support, by [@npradeep357](https://github.com/npradeep357) ([117](https://github.com/python-lsp/python-lsp-server/issues/117))
+
+In this release 19 pull requests were closed.
+
+----
+
 ## Version 1.4.1 (2022/03/27)
 
 ### Pull Requests Merged

--- a/external-deps/python-lsp-server/CONFIGURATION.md
+++ b/external-deps/python-lsp-server/CONFIGURATION.md
@@ -22,6 +22,7 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 | `pylsp.plugins.jedi_completion.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.jedi_completion.include_params` | `boolean` | Auto-completes methods and classes with tabstops for each parameter. | `true` |
 | `pylsp.plugins.jedi_completion.include_class_objects` | `boolean` | Adds class objects as a separate completion item. | `true` |
+| `pylsp.plugins.jedi_completion.include_function_objects` | `boolean` | Adds function objects as a separate completion item. | `true` |
 | `pylsp.plugins.jedi_completion.fuzzy` | `boolean` | Enable fuzzy when requesting autocomplete. | `false` |
 | `pylsp.plugins.jedi_completion.eager` | `boolean` | Resolve documentation and detail eagerly. | `false` |
 | `pylsp.plugins.jedi_completion.resolve_at_most` | `number`  | How many labels and snippets (at most) should be resolved? | `25` |

--- a/external-deps/python-lsp-server/README.md
+++ b/external-deps/python-lsp-server/README.md
@@ -43,6 +43,34 @@ If you get an error similar to `'install_requires' must be a string or list of s
 pip install -U setuptools
 ```
 
+### Windows and Linux installation
+
+If you use Anaconda/Miniconda, you can install `python-lsp-server` using this conda command
+
+```
+conda install -c conda-forge python-lsp-server 
+```
+
+Python-lsp-server is available in the repos of every major Linux distribution, and it is usually called `python-lsp-server`.
+
+For example, here is how to install it in Debian and Debian-based distributions (E.g. Ubuntu, Pop!_OS, Linux Mint)
+
+```
+sudo apt-get install python-lsp-server
+```
+
+or Fedora Linux
+
+```
+sudo dnf install python-lsp-server
+```
+
+Only on Alpine Linux the package is named differently. You can install it there by typing this command in your terminal:
+
+```
+apk add py3-lsp-server
+```
+
 ### 3rd Party Plugins
 
 Installing these plugins will add extra functionality to the language server:

--- a/external-deps/python-lsp-server/RELEASE.md
+++ b/external-deps/python-lsp-server/RELEASE.md
@@ -12,8 +12,10 @@
 2. Close milestone on GitHub
 3. git clean -xfdi
 4. git tag -a vX.X.X -m "Release vX.X.X"
-5. python setup.py sdist
-6. python setup.py bdist_wheel
-7. twine check dist/*
-8. twine upload dist/*
-9. git push upstream --tags
+5. python -m pip install --upgrade pip
+6. pip install --upgrade --upgrade-strategy eager build setuptools twine wheel
+7. python -bb -X dev -W error -m build
+8. twine check --strict dist/*
+9. twine upload dist/*
+10. git push upstream --tags
+11. Create release on Github

--- a/external-deps/python-lsp-server/pylsp/config/config.py
+++ b/external-deps/python-lsp-server/pylsp/config/config.py
@@ -32,7 +32,7 @@ class PluginManager(pluggy.PluginManager):
         try:
             return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
         except Exception as e:  # pylint: disable=broad-except
-            log.warning(f"Failed to load hook {hook_name}: {e}")
+            log.warning(f"Failed to load hook {hook_name}: {e}", exc_info=True)
             return []
 
 

--- a/external-deps/python-lsp-server/pylsp/config/schema.json
+++ b/external-deps/python-lsp-server/pylsp/config/schema.json
@@ -120,6 +120,11 @@
       "default": true,
       "description": "Adds class objects as a separate completion item."
     },
+    "pylsp.plugins.jedi_completion.include_function_objects": {
+      "type": "boolean",
+      "default": true,
+      "description": "Adds function objects as a separate completion item."
+    },
     "pylsp.plugins.jedi_completion.fuzzy": {
       "type": "boolean",
       "default": false,

--- a/external-deps/python-lsp-server/pylsp/plugins/jedi_completion.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/jedi_completion.py
@@ -54,6 +54,7 @@ def pylsp_completions(config, document, position):
 
     should_include_params = settings.get('include_params')
     should_include_class_objects = settings.get('include_class_objects', True)
+    should_include_function_objects = settings.get('include_function_objects', True)
 
     max_to_resolve = settings.get('resolve_at_most', 25)
     modules_to_cache_for = settings.get('cache_for', None)
@@ -63,6 +64,7 @@ def pylsp_completions(config, document, position):
 
     include_params = snippet_support and should_include_params and use_snippets(document, position)
     include_class_objects = snippet_support and should_include_class_objects and use_snippets(document, position)
+    include_function_objects = snippet_support and should_include_function_objects and use_snippets(document, position)
 
     ready_completions = [
         _format_completion(
@@ -78,6 +80,19 @@ def pylsp_completions(config, document, position):
     if include_class_objects:
         for i, c in enumerate(completions):
             if c.type == 'class':
+                completion_dict = _format_completion(
+                    c,
+                    False,
+                    resolve=resolve_eagerly,
+                    resolve_label_or_snippet=(i < max_to_resolve)
+                )
+                completion_dict['kind'] = lsp.CompletionItemKind.TypeParameter
+                completion_dict['label'] += ' object'
+                ready_completions.append(completion_dict)
+
+    if include_function_objects:
+        for i, c in enumerate(completions):
+            if c.type == 'function':
                 completion_dict = _format_completion(
                     c,
                     False,

--- a/external-deps/python-lsp-server/pylsp/plugins/symbols.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/symbols.py
@@ -38,8 +38,9 @@ def pylsp_document_symbols(config, document):
 
             # Skip imported symbols comparing module names.
             sym_full_name = d.full_name
-            document_dot_path = document.dot_path
             if sym_full_name is not None:
+                document_dot_path = document.dot_path
+
                 # We assume a symbol is imported from another module to start
                 # with.
                 imported_symbol = True
@@ -48,6 +49,8 @@ def pylsp_document_symbols(config, document):
                 # we need to discard it to do module comparisons below.
                 if '.' in sym_full_name:
                     sym_module_name = sym_full_name.rpartition('.')[0]
+                else:
+                    sym_module_name = sym_full_name
 
                 # This is necessary to display symbols in init files (the checks
                 # below fail without it).
@@ -56,9 +59,9 @@ def pylsp_document_symbols(config, document):
 
                 # document_dot_path is the module where the symbol is imported,
                 # whereas sym_module_name is the one where it was declared.
-                if sym_module_name.startswith(document_dot_path):
-                    # If sym_module_name starts with the same string as document_dot_path,
-                    # we can safely assume it was declared in the document.
+                if document_dot_path in sym_module_name:
+                    # If document_dot_path is in sym_module_name, we can safely assume
+                    # that the symbol was declared in the document.
                     imported_symbol = False
                 elif sym_module_name.split('.')[0] in document_dot_path.split('.'):
                     # If the first module in sym_module_name is one of the modules in
@@ -74,10 +77,19 @@ def pylsp_document_symbols(config, document):
                 # When there's no __init__.py next to a file or in one of its
                 # parents, the checks above fail. However, Jedi has a nice way
                 # to tell if the symbol was declared in the same file: if
-                # full_name starts by __main__.
+                # sym_module_name starts by __main__.
                 if imported_symbol:
                     if not sym_module_name.startswith('__main__'):
                         continue
+            else:
+                # We need to skip symbols if their definition doesn't have `full_name` info, they
+                # are detected as a definition, but their description (e.g. `class Foo`) doesn't
+                # match the code where they're detected by Jedi. This happens for relative imports.
+                if _include_def(d):
+                    if d.description not in d.get_line_code():
+                        continue
+                else:
+                    continue
 
         try:
             docismodule = os.path.samefile(document.path, d.module_path)

--- a/external-deps/python-lsp-server/pyproject.toml
+++ b/external-deps/python-lsp-server/pyproject.toml
@@ -2,7 +2,7 @@
 # Copyright 2021- Python Language Server Contributors.
 
 [build-system]
-requires = ["setuptools>=61.2.0", "wheel", "setuptools_scm[toml]>=3.4.3"]
+requires = ["setuptools>=61.2.0", "setuptools_scm[toml]>=3.4.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -27,22 +27,22 @@ Homepage = "https://github.com/python-lsp/python-lsp-server"
 [project.optional-dependencies]
 all = [
     "autopep8>=1.6.0,<1.7.0",
-    "flake8>=4.0.0,<4.1.0",
-    "mccabe>=0.6.0,<0.7.0",
-    "pycodestyle>=2.8.0,<2.9.0",
+    "flake8>=5.0.0,<5.1.0",
+    "mccabe>=0.7.0,<0.8.0",
+    "pycodestyle>=2.9.0,<2.10.0",
     "pydocstyle>=2.0.0",
-    "pyflakes>=2.4.0,<2.5.0",
+    "pyflakes>=2.5.0,<2.6.0",
     "pylint>=2.5.0",
     "rope>=0.10.5",
     "yapf",
     "whatthepatch"
 ]
 autopep8 = ["autopep8>=1.6.0,<1.7.0"]
-flake8 = ["flake8>=4.0.0,<4.1.0"]
-mccabe = ["mccabe>=0.6.0,<0.7.0"]
-pycodestyle = ["pycodestyle>=2.8.0,<2.9.0"]
+flake8 = ["flake8>=5.0.0,<5.1.0"]
+mccabe = ["mccabe>=0.7.0,<0.8.0"]
+pycodestyle = ["pycodestyle>=2.9.0,<2.10.0"]
 pydocstyle = ["pydocstyle>=2.0.0"]
-pyflakes = ["pyflakes>=2.4.0,<2.5.0"]
+pyflakes = ["pyflakes>=2.5.0,<2.6.0"]
 pylint = ["pylint>=2.5.0"]
 rope = ["rope>0.10.5"]
 yapf = ["yapf", "whatthepatch>=1.0.2,<2.0.0"]

--- a/external-deps/python-lsp-server/test/__init__.py
+++ b/external-deps/python-lsp-server/test/__init__.py
@@ -1,13 +1,9 @@
 # Copyright 2017-2020 Palantir Technologies, Inc.
 # Copyright 2021- Python Language Server Contributors.
 
-import sys
 import pytest
 from pylsp import IS_WIN
 
-IS_PY3 = sys.version_info.major == 3
 
 unix_only = pytest.mark.skipif(IS_WIN, reason="Unix only")
 windows_only = pytest.mark.skipif(not IS_WIN, reason="Windows only")
-py3_only = pytest.mark.skipif(not IS_PY3, reason="Python3 only")
-py2_only = pytest.mark.skipif(IS_PY3, reason="Python2 only")

--- a/external-deps/python-lsp-server/test/plugins/test_completion.py
+++ b/external-deps/python-lsp-server/test/plugins/test_completion.py
@@ -356,6 +356,26 @@ def test_completion_with_class_objects(config, workspace):
     assert completions[1]['kind'] == lsp.CompletionItemKind.TypeParameter
 
 
+def test_completion_with_function_objects(config, workspace):
+    doc_text = 'def foobar(): pass\nfoob'
+    com_position = {'line': 1, 'character': 4}
+    doc = Document(DOC_URI, workspace, doc_text)
+    config.capabilities['textDocument'] = {
+        'completion': {'completionItem': {'snippetSupport': True}}}
+    config.update({'plugins': {'jedi_completion': {
+        'include_params': True,
+        'include_function_objects': True,
+    }}})
+    completions = pylsp_jedi_completions(config, doc, com_position)
+    assert len(completions) == 2
+
+    assert completions[0]['label'] == 'foobar()'
+    assert completions[0]['kind'] == lsp.CompletionItemKind.Function
+
+    assert completions[1]['label'] == 'foobar() object'
+    assert completions[1]['kind'] == lsp.CompletionItemKind.TypeParameter
+
+
 def test_snippet_parsing(config, workspace):
     doc = 'divmod'
     completion_position = {'line': 0, 'character': 6}

--- a/spyder/app/tests/conftest.py
+++ b/spyder/app/tests/conftest.py
@@ -5,9 +5,48 @@
 # Licensed under the terms of the MIT License
 # ----------------------------------------------------------------------------
 
+# Standard library imports
+import os
+import os.path as osp
+import sys
+import threading
+import traceback
+
+# Third-party imports
+from qtpy.QtWidgets import QApplication
+import psutil
 import pytest
 
+# Spyder imports
+from spyder.app import start
+from spyder.config.base import get_home_dir
+from spyder.config.manager import CONF
+from spyder.plugins.projects.api import EmptyProject
+from spyder.utils import encoding
 
+
+# =============================================================================
+# ---- Constants
+# =============================================================================
+# Location of this file
+LOCATION = osp.realpath(osp.join(os.getcwd(), osp.dirname(__file__)))
+
+# Time to wait until the IPython console is ready to receive input
+# (in milliseconds)
+SHELL_TIMEOUT = 40000 if os.name == 'nt' else 20000
+
+
+# =============================================================================
+# ---- Auxiliary functions
+# =============================================================================
+def read_asset_file(filename):
+    """Read contents of an asset file."""
+    return encoding.read(osp.join(LOCATION, filename))[0]
+
+
+# =============================================================================
+# ---- Pytest hooks
+# =============================================================================
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     # execute all other hooks to obtain the report object
@@ -17,3 +56,337 @@ def pytest_runtest_makereport(item, call):
     # set a report attribute for each phase of a call, which can
     # be "setup", "call", "teardown"
     setattr(item, "rep_" + rep.when, rep)
+
+
+# =============================================================================
+# ---- Fixtures
+# =============================================================================
+@pytest.fixture(scope="session", autouse=True)
+def cleanup(request, qapp):
+    """Cleanup the testing setup once we are finished."""
+
+    def close_window():
+        # Close last used mainwindow and QApplication if needed
+        if hasattr(main_window, 'window') and main_window.window is not None:
+            window = main_window.window
+            main_window.window = None
+            window.close()
+            window = None
+            CONF.reset_to_defaults(notification=False)
+        if qapp.instance():
+            qapp.quit()
+
+    request.addfinalizer(close_window)
+
+
+@pytest.fixture
+def main_window(request, tmpdir, qtbot):
+    """Main Window fixture"""
+
+    # Get original processEvents function in case the test that overrides it
+    # fails
+    super_processEvents = QApplication.processEvents
+
+    # Disable Kite provider
+    CONF.set('completions', 'enabled_providers', {'kite': False})
+
+    # Don't show tours message
+    CONF.set('tours', 'show_tour_message', False)
+
+    # Tests assume inline backend
+    CONF.set('ipython_console', 'pylab/backend', 0)
+
+    # Test assume the plots are rendered in the console as png
+    CONF.set('plots', 'mute_inline_plotting', False)
+    CONF.set('ipython_console', 'pylab/inline/figure_format', 0)
+
+    # Set exclamation mark to True
+    CONF.set('ipython_console', 'pdb_use_exclamation_mark', True)
+
+    # Check if we need to use introspection in a given test
+    # (it's faster and less memory consuming not to use it!)
+    use_introspection = request.node.get_closest_marker('use_introspection')
+
+    if use_introspection:
+        os.environ['SPY_TEST_USE_INTROSPECTION'] = 'True'
+    else:
+        try:
+            os.environ.pop('SPY_TEST_USE_INTROSPECTION')
+        except KeyError:
+            pass
+
+    # Only use single_instance mode for tests that require it
+    single_instance = request.node.get_closest_marker('single_instance')
+
+    if single_instance:
+        CONF.set('main', 'single_instance', True)
+    else:
+        CONF.set('main', 'single_instance', False)
+
+    # Check if we need to load a simple project to the interface
+    preload_project = request.node.get_closest_marker('preload_project')
+
+    if preload_project:
+        # Create project directory
+        project = tmpdir.mkdir('test_project')
+        project_path = str(project)
+
+        # Create Spyder project
+        spy_project = EmptyProject(project_path)
+        CONF.set('project_explorer', 'current_project_path', project_path)
+
+        # Add a file to the project
+        p_file = project.join('file.py')
+        p_file.write(read_asset_file('script_outline_1.py'))
+        spy_project.set_recent_files([str(p_file)])
+    else:
+        CONF.set('project_explorer', 'current_project_path', None)
+
+    # Check if we need to preload a complex project in a give test
+    preload_complex_project = request.node.get_closest_marker(
+        'preload_complex_project')
+
+    if preload_complex_project:
+        # Create project
+        project = tmpdir.mkdir('test_project')
+        project_subdir = project.mkdir('subdir')
+        project_sub_subdir = project_subdir.mkdir('sub_subdir')
+
+        # Create directories out of the project
+        out_of_project_1 = tmpdir.mkdir('out_of_project_1')
+        out_of_project_2 = tmpdir.mkdir('out_of_project_2')
+        out_of_project_1_subdir = out_of_project_1.mkdir('subdir')
+        out_of_project_2_subdir = out_of_project_2.mkdir('subdir')
+
+        project_path = str(project)
+        spy_project = EmptyProject(project_path)
+        CONF.set('project_explorer', 'current_project_path', project_path)
+
+        # Add some files to project. This is necessary to test that we get
+        # symbols for all these files.
+        abs_filenames = []
+        filenames_to_create = {
+            project: ['file1.py', 'file2.py', 'file3.txt', '__init__.py'],
+            project_subdir: ['a.py', '__init__.py'],
+            project_sub_subdir: ['b.py', '__init__.py'],
+            out_of_project_1: ['c.py'],
+            out_of_project_2: ['d.py', '__init__.py'],
+            out_of_project_1_subdir: ['e.py', '__init__.py'],
+            out_of_project_2_subdir: ['f.py']
+        }
+
+        for path in filenames_to_create.keys():
+            filenames = filenames_to_create[path]
+            for filename in filenames:
+                p_file = path.join(filename)
+                abs_filenames.append(str(p_file))
+                if osp.splitext(filename)[1] == '.py':
+                    if path == project_subdir:
+                        code = read_asset_file('script_outline_2.py')
+                    elif path == project_sub_subdir:
+                        code = read_asset_file('script_outline_3.py')
+                    else:
+                        code = read_asset_file('script_outline_1.py')
+                    p_file.write(code)
+                else:
+                    p_file.write("Hello world!")
+
+        spy_project.set_recent_files(abs_filenames)
+    else:
+        if not preload_project:
+            CONF.set('project_explorer', 'current_project_path', None)
+
+    # Get config values passed in parametrize and apply them
+    try:
+        param = request.param
+        if isinstance(param, dict) and 'spy_config' in param:
+            CONF.set(*param['spy_config'])
+    except AttributeError:
+        # Not all tests that use this fixture define request.param
+        pass
+
+    QApplication.processEvents()
+
+    if not hasattr(main_window, 'window') or main_window.window is None:
+        from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
+        PLUGIN_REGISTRY.reset()
+
+        # Start the window
+        window = start.main()
+        main_window.window = window
+
+    else:
+        window = main_window.window
+
+        if not request.node.get_closest_marker('no_new_console'):
+            # Create a new console to ensure new config is loaded
+            # even if the same mainwindow instance is reused
+            window.ipyconsole.create_new_client(give_focus=True)
+
+    QApplication.processEvents()
+
+    if os.name != 'nt':
+        # _DummyThread are created if current_thread() is called from them.
+        # They will always leak (From python doc) so we ignore them.
+        init_threads = [
+            repr(thread) for thread in threading.enumerate()
+            if not isinstance(thread, threading._DummyThread)]
+        proc = psutil.Process()
+        init_files = [repr(f) for f in proc.open_files()]
+        init_subprocesses = [repr(f) for f in proc.children()]
+
+    yield window
+
+    # Remap original QApplication.processEvents function
+    QApplication.processEvents = super_processEvents
+
+    # Print shell content if failed
+    if request.node.rep_setup.passed:
+        if request.node.rep_call.failed:
+            # Print content of shellwidget and close window
+            print(window.ipyconsole.get_current_shellwidget(
+                )._control.toPlainText())
+            # Print info page content is not blank
+            console = window.ipyconsole
+            client = console.get_current_client()
+            if client.info_page != client.blank_page:
+                print('info_page')
+                print(client.info_page)
+            main_window.window = None
+            window.close()
+            window = None
+            CONF.reset_to_defaults(notification=False)
+        else:
+            # Try to close used mainwindow directly on fixture
+            # after running test that uses the fixture
+            # Currently 'test_out_runfile_runcell' is the last tests so
+            # in order to prevent errors finalizing the test suit such test has
+            # this marker
+            close_main_window = request.node.get_closest_marker(
+                'close_main_window')
+            if close_main_window:
+                main_window.window = None
+                window.close()
+                window = None
+                CONF.reset_to_defaults(notification=False)
+            else:
+                try:
+                    # Close everything we can think of
+                    window.switcher.close()
+
+                    # Close editor related elements
+                    window.editor.close_all_files()
+                    # force close all files
+                    while window.editor.editorstacks[0].close_file(force=True):
+                        pass
+                    for editorwindow in window.editor.editorwindows:
+                        editorwindow.close()
+                    editorstack = window.editor.get_current_editorstack()
+                    if editorstack.switcher_dlg:
+                        editorstack.switcher_dlg.close()
+
+                    window.projects.close_project()
+
+                    if window.console.error_dialog:
+                        window.console.close_error_dialog()
+
+                    # Reset cwd
+                    window.explorer.chdir(get_home_dir())
+
+                    # Restore default Spyder Python Path
+                    CONF.set(
+                        'main', 'spyder_pythonpath',
+                        CONF.get_default('main', 'spyder_pythonpath'))
+
+                    # Restore run configurations
+                    CONF.set('run', 'configurations', [])
+
+                    # Close consoles
+                    (window.ipyconsole.get_widget()
+                        .create_new_client_if_empty) = False
+                    window.ipyconsole.restart()
+
+                except Exception:
+                    main_window.window = None
+                    window.close()
+                    window = None
+                    CONF.reset_to_defaults(notification=False)
+                    return
+
+                if os.name == 'nt':
+                    # Do not test leaks on windows
+                    return
+
+                known_leak = request.node.get_closest_marker(
+                    'known_leak')
+                if known_leak:
+                    # This test has a known leak
+                    return
+
+                def show_diff(init_list, now_list, name):
+                    sys.stderr.write(f"Extra {name} before test:\n")
+                    for item in init_list:
+                        if item in now_list:
+                            now_list.remove(item)
+                        else:
+                            sys.stderr.write(item + "\n")
+                    sys.stderr.write(f"Extra {name} after test:\n")
+                    for item in now_list:
+                        sys.stderr.write(item + "\n")
+
+                # The test is not allowed to open new files or threads.
+                try:
+                    def threads_condition():
+                        threads = [
+                            thread for thread in threading.enumerate()
+                            if not isinstance(thread, threading._DummyThread)]
+                        return (len(init_threads) >= len(threads))
+
+                    qtbot.waitUntil(threads_condition, timeout=SHELL_TIMEOUT)
+                except Exception:
+                    now_threads = [
+                        thread for thread in threading.enumerate()
+                        if not isinstance(thread, threading._DummyThread)]
+                    threads = [repr(t) for t in now_threads]
+                    show_diff(init_threads, threads, "thread")
+                    sys.stderr.write("Running Threads stacks:\n")
+                    now_thread_ids = [t.ident for t in now_threads]
+                    for threadId, frame in sys._current_frames().items():
+                        if threadId in now_thread_ids:
+                            sys.stderr.write(
+                                "\nThread " + str(threads) + ":\n")
+                            traceback.print_stack(frame)
+                    main_window.window = None
+                    window.close()
+                    window = None
+                    CONF.reset_to_defaults(notification=False)
+                    raise
+
+                try:
+                    qtbot.waitUntil(lambda: (
+                        len(init_subprocesses) >= len(proc.children())),
+                        timeout=SHELL_TIMEOUT)
+                except Exception:
+                    subprocesses = [repr(f) for f in proc.children()]
+                    show_diff(init_subprocesses, subprocesses, "processes")
+                    main_window.window = None
+                    window.close()
+                    window = None
+                    CONF.reset_to_defaults(notification=False)
+                    raise
+
+                try:
+                    files = [
+                        repr(f) for f in proc.open_files()
+                        if 'QtWebEngine' not in repr(f)
+                    ]
+                    qtbot.waitUntil(
+                        lambda: (len(init_files) >= len(files)),
+                        timeout=SHELL_TIMEOUT)
+                except Exception:
+                    show_diff(init_files, files, "files")
+                    main_window.window = None
+                    window.close()
+                    window = None
+                    CONF.reset_to_defaults(notification=False)
+                    raise

--- a/spyder/app/tests/script_outline_3.py
+++ b/spyder/app/tests/script_outline_3.py
@@ -5,6 +5,16 @@ from numpy import (
 from subdir.a import (
     bar)
 
+# We shouldn't show symbols for relative imports in the Outline.
+# This is a regression test for issue spyder-ide/spyder#16352.
+from ..a import (
+    MyOtherClass)
+
+from ...file2 import (
+    MyClass,
+    foo
+)
+
 def baz(x):
     return x
 

--- a/spyder/app/tests/script_outline_4.py
+++ b/spyder/app/tests/script_outline_4.py
@@ -1,0 +1,18 @@
+# Taken from the following comment:
+# https://github.com/spyder-ide/spyder/issues/16406#issuecomment-917992317
+#
+# This helps to test a regression for issue spyder-ide/spyder#16406
+
+import logging
+
+
+def some_function():
+    logging.info('Some message')
+
+
+class SomeClass:
+    def __init__(self):
+        pass
+
+    def some_method(self):
+        pass

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -14,15 +14,12 @@ Tests for the main window.
 import gc
 import os
 import os.path as osp
-import psutil
 import random
 import re
 import shutil
 import sys
 import tempfile
 from textwrap import dedent
-import threading
-import traceback
 from unittest.mock import Mock
 import uuid
 
@@ -51,7 +48,7 @@ from spyder import __trouble_url__
 from spyder.api.utils import get_class_values
 from spyder.api.widgets.auxiliary_widgets import SpyderWindowWidget
 from spyder.api.plugins import Plugins
-from spyder.app import start
+from spyder.app.tests.conftest import LOCATION, read_asset_file, SHELL_TIMEOUT
 from spyder.config.base import (
     get_home_dir, get_conf_path, get_module_path, running_in_ci)
 from spyder.config.manager import CONF
@@ -60,10 +57,8 @@ from spyder.plugins.help.widgets import ObjectComboBox
 from spyder.plugins.help.tests.test_plugin import check_text
 from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec
 from spyder.plugins.layout.layouts import DefaultLayouts
-from spyder.plugins.projects.api import EmptyProject
 from spyder.plugins.toolbar.api import ApplicationToolbars
 from spyder.py3compat import PY2, qbytearray_to_str, to_text_string
-from spyder.utils import encoding
 from spyder.utils.misc import remove_backslashes
 from spyder.utils.clipboard_helper import CLIPBOARD_HELPER
 from spyder.widgets.dock import DockTitleBar
@@ -72,13 +67,6 @@ from spyder.widgets.dock import DockTitleBar
 # =============================================================================
 # ---- Constants
 # =============================================================================
-# Location of this file
-LOCATION = osp.realpath(osp.join(os.getcwd(), osp.dirname(__file__)))
-
-# Time to wait until the IPython console is ready to receive input
-# (in milliseconds)
-SHELL_TIMEOUT = 40000 if os.name == 'nt' else 20000
-
 # Need longer EVAL_TIMEOUT, because need to cythonize and C compile ".pyx" file
 # before import and eval it
 COMPILE_AND_EVAL_TIMEOUT = 30000
@@ -146,345 +134,6 @@ def find_desired_tab_in_window(tab_name, window):
             if current_tabbar.tabText(tab_index) == str(tab_name):
                 return current_tabbar, tab_index
     return None, None
-
-
-def read_asset_file(filename):
-    """Read contents of an asset file."""
-    return encoding.read(osp.join(LOCATION, filename))[0]
-
-
-# =============================================================================
-# ---- Fixtures
-# =============================================================================
-@pytest.fixture
-def main_window(request, tmpdir, qtbot):
-    """Main Window fixture"""
-
-    # Get original processEvents function in case the test that overrides it
-    # fails
-    super_processEvents = QApplication.processEvents
-
-    # Disable Kite provider
-    CONF.set('completions', 'enabled_providers', {'kite': False})
-
-    # Don't show tours message
-    CONF.set('tours', 'show_tour_message', False)
-
-    # Tests assume inline backend
-    CONF.set('ipython_console', 'pylab/backend', 0)
-
-    # Test assume the plots are rendered in the console as png
-    CONF.set('plots', 'mute_inline_plotting', False)
-    CONF.set('ipython_console', 'pylab/inline/figure_format', 0)
-
-    # Set exclamation mark to True
-    CONF.set('ipython_console', 'pdb_use_exclamation_mark', True)
-
-    # Check if we need to use introspection in a given test
-    # (it's faster and less memory consuming not to use it!)
-    use_introspection = request.node.get_closest_marker('use_introspection')
-
-    if use_introspection:
-        os.environ['SPY_TEST_USE_INTROSPECTION'] = 'True'
-    else:
-        try:
-            os.environ.pop('SPY_TEST_USE_INTROSPECTION')
-        except KeyError:
-            pass
-
-    # Only use single_instance mode for tests that require it
-    single_instance = request.node.get_closest_marker('single_instance')
-
-    if single_instance:
-        CONF.set('main', 'single_instance', True)
-    else:
-        CONF.set('main', 'single_instance', False)
-
-    # Check if we need to load a simple project to the interface
-    preload_project = request.node.get_closest_marker('preload_project')
-
-    if preload_project:
-        # Create project directory
-        project = tmpdir.mkdir('test_project')
-        project_path = str(project)
-
-        # Create Spyder project
-        spy_project = EmptyProject(project_path)
-        CONF.set('project_explorer', 'current_project_path', project_path)
-
-        # Add a file to the project
-        p_file = project.join('file.py')
-        p_file.write(read_asset_file('script_outline_1.py'))
-        spy_project.set_recent_files([str(p_file)])
-    else:
-        CONF.set('project_explorer', 'current_project_path', None)
-
-    # Check if we need to preload a complex project in a give test
-    preload_complex_project = request.node.get_closest_marker(
-        'preload_complex_project')
-
-    if preload_complex_project:
-        # Create project
-        project = tmpdir.mkdir('test_project')
-        project_subdir = project.mkdir('subdir')
-        project_sub_subdir = project_subdir.mkdir('sub_subdir')
-
-        # Create directories out of the project
-        out_of_project_1 = tmpdir.mkdir('out_of_project_1')
-        out_of_project_2 = tmpdir.mkdir('out_of_project_2')
-        out_of_project_1_subdir = out_of_project_1.mkdir('subdir')
-        out_of_project_2_subdir = out_of_project_2.mkdir('subdir')
-
-        project_path = str(project)
-        spy_project = EmptyProject(project_path)
-        CONF.set('project_explorer', 'current_project_path', project_path)
-
-        # Add some files to project. This is necessary to test that we get
-        # symbols for all these files.
-        abs_filenames = []
-        filenames_to_create = {
-            project: ['file1.py', 'file2.py', 'file3.txt', '__init__.py'],
-            project_subdir: ['a.py', '__init__.py'],
-            project_sub_subdir: ['b.py', '__init__.py'],
-            out_of_project_1: ['c.py'],
-            out_of_project_2: ['d.py', '__init__.py'],
-            out_of_project_1_subdir: ['e.py', '__init__.py'],
-            out_of_project_2_subdir: ['f.py']
-        }
-
-        for path in filenames_to_create.keys():
-            filenames = filenames_to_create[path]
-            for filename in filenames:
-                p_file = path.join(filename)
-                abs_filenames.append(str(p_file))
-                if osp.splitext(filename)[1] == '.py':
-                    if path == project_subdir:
-                        code = read_asset_file('script_outline_2.py')
-                    elif path == project_sub_subdir:
-                        code = read_asset_file('script_outline_3.py')
-                    else:
-                        code = read_asset_file('script_outline_1.py')
-                    p_file.write(code)
-                else:
-                    p_file.write("Hello world!")
-
-        spy_project.set_recent_files(abs_filenames)
-    else:
-        if not preload_project:
-            CONF.set('project_explorer', 'current_project_path', None)
-
-    # Get config values passed in parametrize and apply them
-    try:
-        param = request.param
-        if isinstance(param, dict) and 'spy_config' in param:
-            CONF.set(*param['spy_config'])
-    except AttributeError:
-        # Not all tests that use this fixture define request.param
-        pass
-
-    QApplication.processEvents()
-
-    if not hasattr(main_window, 'window') or main_window.window is None:
-        from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
-        PLUGIN_REGISTRY.reset()
-
-        # Start the window
-        window = start.main()
-        main_window.window = window
-
-    else:
-        window = main_window.window
-
-        if not request.node.get_closest_marker('no_new_console'):
-            # Create a new console to ensure new config is loaded
-            # even if the same mainwindow instance is reused
-            window.ipyconsole.create_new_client(give_focus=True)
-
-    QApplication.processEvents()
-
-    if os.name != 'nt':
-        # _DummyThread are created if current_thread() is called from them.
-        # They will always leak (From python doc) so we ignore them.
-        init_threads = [
-            repr(thread) for thread in threading.enumerate()
-            if not isinstance(thread, threading._DummyThread)]
-        proc = psutil.Process()
-        init_files = [repr(f) for f in proc.open_files()]
-        init_subprocesses = [repr(f) for f in proc.children()]
-
-    yield window
-
-    # Remap original QApplication.processEvents function
-    QApplication.processEvents = super_processEvents
-
-    # Print shell content if failed
-    if request.node.rep_setup.passed:
-        if request.node.rep_call.failed:
-            # Print content of shellwidget and close window
-            print(window.ipyconsole.get_current_shellwidget(
-                )._control.toPlainText())
-            # Print info page content is not blank
-            console = window.ipyconsole
-            client = console.get_current_client()
-            if client.info_page != client.blank_page:
-                print('info_page')
-                print(client.info_page)
-            main_window.window = None
-            window.close()
-            window = None
-            CONF.reset_to_defaults(notification=False)
-        else:
-            # Try to close used mainwindow directly on fixture
-            # after running test that uses the fixture
-            # Currently 'test_out_runfile_runcell' is the last tests so
-            # in order to prevent errors finalizing the test suit such test has
-            # this marker
-            close_main_window = request.node.get_closest_marker(
-                'close_main_window')
-            if close_main_window:
-                main_window.window = None
-                window.close()
-                window = None
-                CONF.reset_to_defaults(notification=False)
-            else:
-                try:
-                    # Close everything we can think of
-                    window.switcher.close()
-
-                    # Close editor related elements
-                    window.editor.close_all_files()
-                    # force close all files
-                    while window.editor.editorstacks[0].close_file(force=True):
-                        pass
-                    for editorwindow in window.editor.editorwindows:
-                        editorwindow.close()
-                    editorstack = window.editor.get_current_editorstack()
-                    if editorstack.switcher_dlg:
-                        editorstack.switcher_dlg.close()
-
-                    window.projects.close_project()
-
-                    if window.console.error_dialog:
-                        window.console.close_error_dialog()
-
-                    # Reset cwd
-                    window.explorer.chdir(get_home_dir())
-
-                    # Restore default Spyder Python Path
-                    CONF.set(
-                        'main', 'spyder_pythonpath',
-                        CONF.get_default('main', 'spyder_pythonpath'))
-
-                    # Restore run configurations
-                    CONF.set('run', 'configurations', [])
-
-                    # Close consoles
-                    (window.ipyconsole.get_widget()
-                        .create_new_client_if_empty) = False
-                    window.ipyconsole.restart()
-
-                except Exception:
-                    main_window.window = None
-                    window.close()
-                    window = None
-                    CONF.reset_to_defaults(notification=False)
-                    return
-
-                if os.name == 'nt':
-                    # Do not test leaks on windows
-                    return
-
-                known_leak = request.node.get_closest_marker(
-                    'known_leak')
-                if known_leak:
-                    # This test has a known leak
-                    return
-
-                def show_diff(init_list, now_list, name):
-                    sys.stderr.write(f"Extra {name} before test:\n")
-                    for item in init_list:
-                        if item in now_list:
-                            now_list.remove(item)
-                        else:
-                            sys.stderr.write(item + "\n")
-                    sys.stderr.write(f"Extra {name} after test:\n")
-                    for item in now_list:
-                        sys.stderr.write(item + "\n")
-
-                # The test is not allowed to open new files or threads.
-                try:
-                    def threads_condition():
-                        threads = [
-                            thread for thread in threading.enumerate()
-                            if not isinstance(thread, threading._DummyThread)]
-                        return (len(init_threads) >= len(threads))
-
-                    qtbot.waitUntil(threads_condition, timeout=SHELL_TIMEOUT)
-                except Exception:
-                    now_threads = [
-                        thread for thread in threading.enumerate()
-                        if not isinstance(thread, threading._DummyThread)]
-                    threads = [repr(t) for t in now_threads]
-                    show_diff(init_threads, threads, "thread")
-                    sys.stderr.write("Running Threads stacks:\n")
-                    now_thread_ids = [t.ident for t in now_threads]
-                    for threadId, frame in sys._current_frames().items():
-                        if threadId in now_thread_ids:
-                            sys.stderr.write(
-                                "\nThread " + str(threads) + ":\n")
-                            traceback.print_stack(frame)
-                    main_window.window = None
-                    window.close()
-                    window = None
-                    CONF.reset_to_defaults(notification=False)
-                    raise
-
-                try:
-                    qtbot.waitUntil(lambda: (
-                        len(init_subprocesses) >= len(proc.children())),
-                        timeout=SHELL_TIMEOUT)
-                except Exception:
-                    subprocesses = [repr(f) for f in proc.children()]
-                    show_diff(init_subprocesses, subprocesses, "processes")
-                    main_window.window = None
-                    window.close()
-                    window = None
-                    CONF.reset_to_defaults(notification=False)
-                    raise
-
-                try:
-                    files = [
-                        repr(f) for f in proc.open_files()
-                        if 'QtWebEngine' not in repr(f)
-                    ]
-                    qtbot.waitUntil(
-                        lambda: (len(init_files) >= len(files)),
-                        timeout=SHELL_TIMEOUT)
-                except Exception:
-                    show_diff(init_files, files, "files")
-                    main_window.window = None
-                    window.close()
-                    window = None
-                    CONF.reset_to_defaults(notification=False)
-                    raise
-
-
-@pytest.fixture(scope="session", autouse=True)
-def cleanup(request, qapp):
-    """Cleanup the testing setup once we are finished."""
-
-    def close_window():
-        # Close last used mainwindow and QApplication if needed
-        if hasattr(main_window, 'window') and main_window.window is not None:
-            window = main_window.window
-            main_window.window = None
-            window.close()
-            window = None
-            CONF.reset_to_defaults(notification=False)
-        if qapp.instance():
-            qapp.quit()
-
-    request.addfinalizer(close_window)
 
 
 # =============================================================================

--- a/spyder/config/lsp.py
+++ b/spyder/config/lsp.py
@@ -84,7 +84,8 @@ PYTHON_CONFIG = {
                     'enabled': True,
                     'include_params': False,
                     'include_class_objects': False,
-                    'fuzzy': False
+                    'include_function_objects': False,
+                    'fuzzy': False,
                 },
                 'jedi_definition': {
                     'enabled': True,


### PR DESCRIPTION
## Description of Changes

- Those are packages that don't have an `__init__.py` in the root of their repository.
- Also avoid showing relative imports in the Outline.
- Move `main_window` fixture to its corresponding `conftest.py` file to make it easier to contribute to it.
- Add tests to catch future regressions for these bugs.
- Depends on https://github.com/python-lsp/python-lsp-server/pull/261.

### Before

- No symbols for namespace packages

    ![image](https://user-images.githubusercontent.com/365293/188663486-3b6c5caf-8cb8-4897-a145-f1802fd9b838.png)

- Showing relative imports in multiple lines as symbols

    ![image](https://user-images.githubusercontent.com/365293/188664705-1ff100cf-ac0b-4e05-9e47-bc28ae68e762.png)

### After

- Symbols are shown for namespace packages

    ![image](https://user-images.githubusercontent.com/365293/188663895-9cb18403-f8ca-4b35-a008-d40a4fd49fde.png)

- Relative imports in multiple lines are not shown

    ![image](https://user-images.githubusercontent.com/365293/188664280-031f0d6b-4bd0-4733-91b5-7cf0af099efe.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16406.
Fixes #16352.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
