### PR TITLE
PR: Use new API to handle creation and removal of debug toolbar and menu

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -250,8 +250,6 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         self.source_menu_actions = []
         self.run_menu = None
         self.run_menu_actions = []
-        self.debug_menu = None
-        self.debug_menu_actions = []
 
         # TODO: Move to corresponding Plugins
         self.file_toolbar = None
@@ -839,7 +837,6 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         self.source_menu = mainmenu.get_application_menu("source_menu")
         self.source_menu.aboutToShow.connect(self.update_source_menu)
         self.run_menu = mainmenu.get_application_menu("run_menu")
-        self.debug_menu = mainmenu.get_application_menu("debug_menu")
 
         # Switcher shortcuts
         self.file_switcher_action = create_action(
@@ -954,7 +951,6 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         add_actions(self.search_menu, self.search_menu_actions)
         add_actions(self.source_menu, self.source_menu_actions)
         add_actions(self.run_menu, self.run_menu_actions)
-        add_actions(self.debug_menu, self.debug_menu_actions)
 
         # Emitting the signal notifying plugins that main window menu and
         # toolbar actions are all defined:

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -258,8 +258,6 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         self.file_toolbar_actions = []
         self.run_toolbar = None
         self.run_toolbar_actions = []
-        self.debug_toolbar = None
-        self.debug_toolbar_actions = []
 
         self.menus = []
 
@@ -914,7 +912,6 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         toolbar = self.toolbar
         self.file_toolbar = toolbar.get_application_toolbar("file_toolbar")
         self.run_toolbar = toolbar.get_application_toolbar("run_toolbar")
-        self.debug_toolbar = toolbar.get_application_toolbar("debug_toolbar")
 
         # Tools + External Tools (some of this depends on the Application
         # plugin)

--- a/spyder/plugins/breakpoints/plugin.py
+++ b/spyder/plugins/breakpoints/plugin.py
@@ -22,7 +22,7 @@ from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
 from spyder.api.translations import get_translation
 from spyder.plugins.breakpoints.widgets.main_widget import BreakpointWidget
-from spyder.plugins.mainmenu.api import ApplicationMenus
+from spyder.plugins.mainmenu.api import ApplicationMenus, DebugMenuSections
 
 # Localization
 _ = get_translation('spyder')
@@ -168,13 +168,16 @@ class Breakpoints(SpyderDockablePlugin):
         mainmenu = self.get_plugin(Plugins.MainMenu)
         list_action = self.get_action(BreakpointsActions.ListBreakpoints)
         mainmenu.add_item_to_application_menu(
-            list_action, menu_id=ApplicationMenus.Debug)
+            list_action,
+            menu_id=ApplicationMenus.Debug,
+            section=DebugMenuSections.ListBreakpoints)
 
     @on_plugin_teardown(plugin=Plugins.MainMenu)
     def on_main_menu_teardown(self):
         mainmenu = self.get_plugin(Plugins.MainMenu)
         mainmenu.remove_item_from_application_menu(
-            BreakpointsActions.ListBreakpoints, menu_id=ApplicationMenus.Debug)
+            BreakpointsActions.ListBreakpoints,
+            menu_id=ApplicationMenus.Debug)
 
     # --- Private API
     # ------------------------------------------------------------------------

--- a/spyder/plugins/debugger/api.py
+++ b/spyder/plugins/debugger/api.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Debugger Plugin API.
+"""
+
+from spyder.plugins.debugger.widgets.main_widget import (
+    DebuggerWidgetActions, DebuggerToolbarActions, DebuggerBreakpointActions,
+    DebuggerWidgetOptionsMenuSections, DebuggerWidgetMainToolBarSections,
+    DebuggerWidgetMenus, DebuggerContextMenuSections,
+    DebuggerContextMenuActions)

--- a/spyder/plugins/debugger/confpage.py
+++ b/spyder/plugins/debugger/confpage.py
@@ -39,7 +39,7 @@ class DebuggerConfigPage(PluginConfigPage):
         pdb_run_lines_group.setLayout(pdb_run_lines_layout)
 
         # Debug Group
-        debug_group = QGroupBox(_("Debug"))
+        debug_group = QGroupBox(_("Interaction"))
         debug_layout = QVBoxLayout()
 
         prevent_closing_box = newcb(

--- a/spyder/plugins/debugger/plugin.py
+++ b/spyder/plugins/debugger/plugin.py
@@ -14,17 +14,22 @@ from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
 from spyder.api.shellconnect.mixins import ShellConnectMixin
-from spyder.config.base import _
+from spyder.api.translations import get_translation
 from spyder.config.manager import CONF
 from spyder.plugins.debugger.confpage import DebuggerConfigPage
 from spyder.plugins.debugger.utils.breakpointsmanager import (
     BreakpointsManager, clear_all_breakpoints, clear_breakpoint)
 from spyder.plugins.debugger.widgets.main_widget import (
-    DebuggerWidget, DebuggerToolbarActions, DebuggerBreakpointActions)
+    DebuggerBreakpointActions, DebuggerToolbarActions, DebuggerWidget,
+    DebuggerWidgetActions)
 from spyder.plugins.editor.utils.editor import get_file_language
 from spyder.plugins.editor.utils.languages import ALL_LANGUAGES
 from spyder.plugins.mainmenu.api import ApplicationMenus, DebugMenuSections
 from spyder.plugins.toolbar.api import ApplicationToolbars
+
+
+# Localization
+_ = get_translation("spyder")
 
 
 class Debugger(SpyderDockablePlugin, ShellConnectMixin):
@@ -144,13 +149,25 @@ class Debugger(SpyderDockablePlugin, ShellConnectMixin):
     def on_main_menu_available(self):
         mainmenu = self.get_plugin(Plugins.MainMenu)
 
-        # Debug section
+        # StartDebug section
         for action in [DebuggerToolbarActions.DebugCurrentFile,
                        DebuggerToolbarActions.DebugCurrentCell]:
             mainmenu.add_item_to_application_menu(
                 self.get_action(action),
                 menu_id=ApplicationMenus.Debug,
                 section=DebugMenuSections.StartDebug,
+                before_section=DebugMenuSections.ControlDebug)
+
+        # ControlDebug section
+        for action in [DebuggerWidgetActions.Next,
+                       DebuggerWidgetActions.Step,
+                       DebuggerWidgetActions.Return,
+                       DebuggerWidgetActions.Continue,
+                       DebuggerWidgetActions.Stop]:
+            mainmenu.add_item_to_application_menu(
+                self.get_action(action),
+                menu_id=ApplicationMenus.Debug,
+                section=DebugMenuSections.ControlDebug,
                 before_section=DebugMenuSections.EditBreakpoints)
 
         # Breakpoints section
@@ -170,6 +187,11 @@ class Debugger(SpyderDockablePlugin, ShellConnectMixin):
         names = [
             DebuggerToolbarActions.DebugCurrentFile,
             DebuggerToolbarActions.DebugCurrentCell,
+            DebuggerWidgetActions.Next,
+            DebuggerWidgetActions.Step,
+            DebuggerWidgetActions.Return,
+            DebuggerWidgetActions.Continue,
+            DebuggerWidgetActions.Stop,
             DebuggerBreakpointActions.ToggleBreakpoint,
             DebuggerBreakpointActions.ToggleConditionalBreakpoint,
             DebuggerBreakpointActions.ClearAllBreakpoints

--- a/spyder/plugins/debugger/plugin.py
+++ b/spyder/plugins/debugger/plugin.py
@@ -23,9 +23,8 @@ from spyder.plugins.debugger.widgets.main_widget import (
     DebuggerWidget, DebuggerToolbarActions, DebuggerBreakpointActions)
 from spyder.plugins.editor.utils.editor import get_file_language
 from spyder.plugins.editor.utils.languages import ALL_LANGUAGES
-from spyder.plugins.mainmenu.api import ApplicationMenus
+from spyder.plugins.mainmenu.api import ApplicationMenus, DebugMenuSections
 from spyder.plugins.toolbar.api import ApplicationToolbars
-from spyder.utils.qthelpers import MENU_SEPARATOR
 
 
 class Debugger(SpyderDockablePlugin, ShellConnectMixin):
@@ -143,27 +142,26 @@ class Debugger(SpyderDockablePlugin, ShellConnectMixin):
 
     @on_plugin_available(plugin=Plugins.MainMenu)
     def on_main_menu_available(self):
-        names = [
-            DebuggerToolbarActions.DebugCurrentFile,
-            DebuggerToolbarActions.DebugCurrentCell,
-            MENU_SEPARATOR,
-            DebuggerBreakpointActions.ToggleBreakpoint,
-            DebuggerBreakpointActions.ToggleConditionalBreakpoint,
-            DebuggerBreakpointActions.ClearAllBreakpoints,
-            MENU_SEPARATOR,
-        ]
+        mainmenu = self.get_plugin(Plugins.MainMenu)
 
-        debug_menu_actions = []
+        # Debug section
+        for action in [DebuggerToolbarActions.DebugCurrentFile,
+                       DebuggerToolbarActions.DebugCurrentCell]:
+            mainmenu.add_item_to_application_menu(
+                self.get_action(action),
+                menu_id=ApplicationMenus.Debug,
+                section=DebugMenuSections.StartDebug,
+                before_section=DebugMenuSections.EditBreakpoints)
 
-        for name in names:
-            if name is MENU_SEPARATOR:
-                action = name
-            else:
-                action = self.get_action(name)
-            debug_menu_actions.append(action)
-
-        self.main.debug_menu_actions = (
-            debug_menu_actions + self.main.debug_menu_actions)
+        # Breakpoints section
+        for action in [DebuggerBreakpointActions.ToggleBreakpoint,
+                       DebuggerBreakpointActions.ToggleConditionalBreakpoint,
+                       DebuggerBreakpointActions.ClearAllBreakpoints]:
+            mainmenu.add_item_to_application_menu(
+                self.get_action(action),
+                menu_id=ApplicationMenus.Debug,
+                section=DebugMenuSections.EditBreakpoints,
+                before_section=DebugMenuSections.ListBreakpoints)
 
     @on_plugin_teardown(plugin=Plugins.MainMenu)
     def on_main_menu_teardown(self):

--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -90,6 +90,7 @@ class DebuggerWidget(ShellConnectMainWidget):
 
     sig_debug_file = Signal()
     """This signal is emitted to request the current file to be debugged."""
+
     sig_debug_cell = Signal()
     """This signal is emitted to request the current cell to be debugged."""
 
@@ -178,7 +179,7 @@ class DebuggerWidget(ShellConnectMainWidget):
 
         next_action = self.create_action(
             DebuggerWidgetActions.Next,
-            text=_("Run current line"),
+            text=_("Execute current line"),
             icon=self.create_icon('arrow-step-over'),
             triggered=lambda: self.debug_command("next"),
             register_shortcut=True
@@ -194,7 +195,7 @@ class DebuggerWidget(ShellConnectMainWidget):
 
         step_action = self.create_action(
             DebuggerWidgetActions.Step,
-            text=_("Step into function or method of current line"),
+            text=_("Step into function or method"),
             icon=self.create_icon('arrow-step-in'),
             triggered=lambda: self.debug_command("step"),
             register_shortcut=True
@@ -202,7 +203,7 @@ class DebuggerWidget(ShellConnectMainWidget):
 
         return_action = self.create_action(
             DebuggerWidgetActions.Return,
-            text=_("Run until current function or method returns"),
+            text=_("Execute until function or method returns"),
             icon=self.create_icon('arrow-step-out'),
             triggered=lambda: self.debug_command("return"),
             register_shortcut=True

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1577,12 +1577,20 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         help_menu_actions = self.main.mainmenu.get_application_menu(
             ApplicationMenus.Help).get_actions()
 
+        # TODO: Rewrite when the editor is moved to the new API
+        from spyder.plugins.debugger.api import DebuggerToolbarActions
+        debug_toolbar_actions = []
+        for action_name in [DebuggerToolbarActions.DebugCurrentFile,
+                            DebuggerToolbarActions.DebugCurrentCell]:
+            action = self.main.debugger.get_action(action_name)
+            debug_toolbar_actions.append(action)
+
         self.toolbar_list = ((_("File toolbar"), "file_toolbar",
                               self.main.file_toolbar_actions),
                              (_("Run toolbar"), "run_toolbar",
                               self.main.run_toolbar_actions),
                              (_("Debug toolbar"), "debug_toolbar",
-                              self.main.debug_toolbar_actions))
+                              debug_toolbar_actions))
 
         self.menu_list = ((_("&File"), file_menu_actions),
                           (_("&Edit"), self.main.edit_menu_actions),

--- a/spyder/plugins/editor/tests/test_editor_config_dialog.py
+++ b/spyder/plugins/editor/tests/test_editor_config_dialog.py
@@ -25,7 +25,6 @@ class MainWindowMock(QMainWindow):
     edit_toolbar_actions = []
     run_menu_actions = []
     run_toolbar_actions = []
-    debug_menu_actions = []
     source_menu_actions = []
     source_toolbar_actions = []
     search_menu_actions = []

--- a/spyder/plugins/editor/tests/test_editor_config_dialog.py
+++ b/spyder/plugins/editor/tests/test_editor_config_dialog.py
@@ -26,7 +26,6 @@ class MainWindowMock(QMainWindow):
     run_menu_actions = []
     run_toolbar_actions = []
     debug_menu_actions = []
-    debug_toolbar_actions = []
     source_menu_actions = []
     source_toolbar_actions = []
     search_menu_actions = []

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -13,7 +13,6 @@ import ast
 import os
 import os.path as osp
 import time
-import uuid
 from textwrap import dedent
 from threading import Lock
 
@@ -103,38 +102,38 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
     # For DebuggingWidget
     sig_pdb_step = Signal(str, int)
     """
-    Called when pdb reaches a new line
+    This signal is emitted when Pdb reaches a new line.
 
     Parameters
     ----------
     filename: str
-        The filename the debugger stepped in
+        The filename the debugger stepped in.
     line_number: int
-        The line number the debugger stepped in
+        The line number the debugger stepped in.
     """
 
     sig_pdb_stack = Signal(object, int)
     """
-    Called when the pdb stack changed
+    This signal is emitted when the Pdb stack changed.
 
     Parameters
     ----------
     pdb_stack: traceback.StackSummary
-        The current pdb stack
+        The current pdb stack.
     pdb_index: int
-        The index in the stack
+        The index in the stack.
     """
 
     sig_pdb_state_changed = Signal(bool, dict)
     """
-    Called every time a pdb interaction happens
+    This signal is emitted every time a Pdb interaction happens.
 
     Parameters
     ----------
     pdb_state: bool
-        wether the debugger is waiting for input
+        Whether the debugger is waiting for input.
     pdb_step: dict
-        filename and line number of the last step
+        Filename and line number of the last step.
     """
 
     sig_pdb_prompt_ready = Signal()
@@ -145,6 +144,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
     new_client = Signal()
     sig_is_spykernel = Signal(object)
     sig_kernel_restarted_message = Signal(str)
+
     # Kernel died and restarted (not user requested)
     sig_kernel_died_restarted = Signal()
     sig_prompt_ready = Signal()

--- a/spyder/plugins/mainmenu/api.py
+++ b/spyder/plugins/mainmenu/api.py
@@ -66,8 +66,9 @@ class RunMenuSections:
 
 
 class DebugMenuSections:
-    Run = 'debug_section'
-    Options = 'options_section'
+    Debug = 'debug_section'
+    EditBreakpoints = 'edit_breakpoints_section'
+    ListBreakpoints = 'list_breakpoints_section'
 
 
 class ConsolesMenuSections:

--- a/spyder/plugins/mainmenu/api.py
+++ b/spyder/plugins/mainmenu/api.py
@@ -66,7 +66,8 @@ class RunMenuSections:
 
 
 class DebugMenuSections:
-    Debug = 'debug_section'
+    StartDebug = 'start_debug_section'
+    ControlDebug = 'control_debug_section'
     EditBreakpoints = 'edit_breakpoints_section'
     ListBreakpoints = 'list_breakpoints_section'
 

--- a/spyder/plugins/mainmenu/plugin.py
+++ b/spyder/plugins/mainmenu/plugin.py
@@ -249,7 +249,6 @@ class MainMenu(SpyderPluginV2):
             ApplicationMenus.Search: self._main.search_menu_actions,
             ApplicationMenus.Source: self._main.source_menu_actions,
             ApplicationMenus.Run: self._main.run_menu_actions,
-            ApplicationMenus.Debug: self._main.debug_menu_actions,
         }
 
         if menu_id in app_menu_actions:
@@ -306,8 +305,6 @@ class MainMenu(SpyderPluginV2):
                 self._main.source_menu_actions, self._main.source_menu),
             ApplicationMenus.Run: (
                 self._main.run_menu_actions, self._main.run_menu),
-            ApplicationMenus.Debug: (
-                self._main.debug_menu_actions, self._main.debug_menu),
         }
 
         app_menus = {
@@ -315,7 +312,6 @@ class MainMenu(SpyderPluginV2):
             ApplicationMenus.Search: self._main.search_menu,
             ApplicationMenus.Source: self._main.source_menu,
             ApplicationMenus.Run: self._main.run_menu,
-            ApplicationMenus.Debug: self._main.debug_menu
         }
 
         menu = self.get_application_menu(menu_id)

--- a/spyder/plugins/toolbar/plugin.py
+++ b/spyder/plugins/toolbar/plugin.py
@@ -91,7 +91,6 @@ class Toolbar(SpyderPluginV2):
         # TODO: Until all core plugins are migrated, this is needed.
         ACTION_MAP = {
             ApplicationToolbars.File: self._main.file_toolbar_actions,
-            ApplicationToolbars.Debug: self._main.debug_toolbar_actions,
             ApplicationToolbars.Run: self._main.run_toolbar_actions,
         }
         for toolbar in container.get_application_toolbars():


### PR DESCRIPTION
## Description of Changes

- Complement the work done by @impact27 on the Debugger plugin by using the new API to handle its toolbar and menu. 
- Remove old references to them on MainWindow.
- Add actions that control the debugger (i.e. Step into, Continue, etc) to the Debug menu. This restores feature parity with Spyder 5.

    **Before**

    ![image](https://user-images.githubusercontent.com/365293/188672202-2c1a22fe-0105-44e2-a730-5095b0c0fc64.png)

    **After**

    ![image](https://user-images.githubusercontent.com/365293/188671962-c0fd330a-438b-498f-b238-f194048adcf6.png)
 
### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
