### PR TITLE
PR: Only autoformat on save if the file is a Python file (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1919,8 +1919,13 @@ class EditorStack(QWidget):
             self.set_os_eol_chars(osname=osname)
 
         try:
-            if self.format_on_save and finfo.editor.formatting_enabled:
-                # Wait for document autoformat and then save
+            if (self.format_on_save and
+                    finfo.editor.formatting_enabled and
+                    finfo.editor.is_python()):
+                # Wait for document autoformat in case it is a Python file
+                # and then save.
+                # Just trigger the autoformat for Python files.
+                # See spyder-ide/spyder#19344
 
                 # Waiting for the autoformat to complete is needed
                 # when the file is going to be closed after saving.

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1919,9 +1919,11 @@ class EditorStack(QWidget):
             self.set_os_eol_chars(osname=osname)
 
         try:
-            if (self.format_on_save and
-                    finfo.editor.formatting_enabled and
-                    finfo.editor.is_python()):
+            if (
+                self.format_on_save
+                and finfo.editor.formatting_enabled
+                and finfo.editor.is_python()
+            ):
                 # Wait for document autoformat in case it is a Python file
                 # and then save.
                 # Just trigger the autoformat for Python files.


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->

Autoformat is meant to be done only to Python files, trying do it on non Python files ends up in the launch of a never ending autoformat process


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19344
Fixes #19248
Fixes #17577
Fixes #16166 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
