### PR TITLE
PR: Greatly improve Outline performance and update it correctly when it becomes visible

### DIFF
--- a/spyder/api/widgets/auxiliary_widgets.py
+++ b/spyder/api/widgets/auxiliary_widgets.py
@@ -9,7 +9,7 @@ Spyder API auxiliary widgets.
 """
 
 # Third party imports
-from qtpy.QtCore import Signal, QSize
+from qtpy.QtCore import QEvent, Qt, QSize, Signal
 from qtpy.QtWidgets import QMainWindow, QSizePolicy, QToolBar, QWidget
 
 # Local imports
@@ -18,12 +18,23 @@ from spyder.utils.stylesheet import APP_STYLESHEET
 
 
 class SpyderWindowWidget(QMainWindow):
-    """MainWindow subclass that contains a Spyder Plugin."""
+    """MainWindow subclass that contains a SpyderDockablePlugin."""
 
     # ---- Signals
     # ------------------------------------------------------------------------
     sig_closed = Signal()
     """This signal is emitted when the close event is fired."""
+
+    sig_window_state_changed = Signal(Qt.WindowStates)
+    """
+    This signal is emitted when the window state has changed (for instance,
+    between maximized and minimized states).
+
+    Parameters
+    ----------
+    window_state: Qt.WindowStates
+        The window state.
+    """
 
     def __init__(self, widget):
         super().__init__()
@@ -36,6 +47,15 @@ class SpyderWindowWidget(QMainWindow):
         """Override Qt method to emit a custom `sig_close` signal."""
         super().closeEvent(event)
         self.sig_closed.emit()
+
+    def changeEvent(self, event):
+        """
+        Override Qt method to emit a custom `sig_windowstate_changed` signal
+        when there's a change in the window state.
+        """
+        if event.type() == QEvent.WindowStateChange:
+            self.sig_window_state_changed.emit(self.windowState())
+        super().changeEvent(event)
 
 
 class MainCornerWidget(QToolBar):

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -885,6 +885,10 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
         if not self.dockwidget:
             return
 
+        # Dock plugin if it's undocked before hiding it.
+        if self.windowwidget is not None:
+            self.close_window(save_undocked=True)
+
         if checked:
             self.dockwidget.show()
             self.dockwidget.raise_()

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -4343,6 +4343,118 @@ def test_update_outline(main_window, qtbot, tmpdir):
 
 @pytest.mark.slow
 @flaky(max_runs=3)
+@pytest.mark.use_introspection
+@pytest.mark.order(after="test_debug_unsaved_function")
+@pytest.mark.preload_namespace_project
+@pytest.mark.skipif(not sys.platform.startswith('linux'),
+                    reason="Only works on Linux")
+@pytest.mark.known_leak
+def test_no_update_outline(main_window, qtbot, tmpdir):
+    """
+    Test the Outline is not updated in different scenarios.
+    """
+    # Wait until the window is fully up
+    shell = main_window.ipyconsole.get_current_shellwidget()
+    qtbot.waitUntil(
+        lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
+
+    # Main variables
+    outline_explorer = main_window.outlineexplorer
+    treewidget = outline_explorer.get_widget().treewidget
+    proxy_editors = treewidget.editor_ids.keys()
+    editor_stack = main_window.editor.get_current_editorstack()
+
+    # Hide the outline explorer just in case
+    outline_explorer.toggle_view_action.setChecked(False)
+
+    # Helper functions
+    def trees_update_state():
+        return [pe.is_tree_updated for pe in proxy_editors]
+
+    def write_code(code):
+        for i, pe in enumerate(proxy_editors):
+            code_editor = pe._editor
+            with qtbot.waitSignal(pe.sig_outline_explorer_data_changed,
+                                  timeout=5000):
+                editor_stack.tabs.setCurrentIndex(i)
+                qtbot.mouseClick(editor_stack.tabs.currentWidget(),
+                                 Qt.LeftButton)
+                code_editor.set_text(code.format(i=i))
+                # This is to make changes visible when running the test locally
+                qtbot.wait(300)
+
+    def check_symbols_number(number):
+        assert all(
+            [len(treewidget.editor_tree_cache[pe.get_id()]) == number
+             for pe in proxy_editors]
+        )
+
+    # Wait until symbol services are up
+    qtbot.waitUntil(lambda: not treewidget.starting.get('python', True),
+                    timeout=10000)
+
+    # Trees shouldn't be updated at startup
+    assert not any(trees_update_state())
+
+    # Write some code to the current files
+    write_code("def foo{i}(x):\n    return x")
+
+    # Trees shouldn't be updated after new symbols arrive
+    assert not any(trees_update_state())
+
+    # Make outline visible
+    outline_explorer.toggle_view_action.setChecked(True)
+
+    # Trees should be filled now
+    qtbot.waitUntil(lambda: all(trees_update_state()))
+    check_symbols_number(1)
+
+    # Undock Outline
+    outline_explorer.create_window()
+
+    # Change code in files.
+    # NOTE: By necessity users need to make the main window active to perform
+    # these actions. So we need to emulate that (else the test below throws an
+    # error).
+    main_window.activateWindow()
+    write_code("def bar{i}(y):\n    return y\n\ndef baz{i}(z):\n    return z")
+
+    # Assert trees are updated. This is a regression for issue
+    # spyder-ide/spyder#16634
+    check_symbols_number(2)
+
+    # Minimize undocked window and change code
+    outline_explorer.get_widget().windowwidget.showMinimized()
+    write_code("def func{i}(x):\n    return x")
+
+    # Trees shouldn't be updated in this case
+    assert not any(trees_update_state())
+
+    # Restore undocked window to normal state
+    outline_explorer.get_widget().windowwidget.showNormal()
+
+    # The trees should be updated now with the new code
+    qtbot.waitUntil(lambda: all(trees_update_state()))
+    check_symbols_number(1)
+
+    # Hide outline from view
+    outline_explorer.toggle_view_action.setChecked(False)
+    assert outline_explorer.get_widget().windowwidget is None
+
+    # Change code again and save it to emulate what users need to do to close
+    # the current project during the next step.
+    write_code("def blah{i}(x):\n    return x")
+    editor_stack.save_all()
+    assert not any(trees_update_state())
+
+    # Show Outline and close project immediately. This checks that no errors
+    # are generated after doing that.
+    outline_explorer.toggle_view_action.setChecked(True)
+    main_window.projects.close_project()
+
+
+@pytest.mark.slow
+@flaky(max_runs=3)
 def test_prevent_closing(main_window, qtbot):
     """
     Check we can bypass prevent closing.

--- a/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor_and_outline.py
@@ -292,6 +292,7 @@ def test_editor_outlineexplorer(qtbot, completions_codeeditor_outline):
     """Tests that the outline explorer reacts to editor changes."""
     code_editor, outlineexplorer = completions_codeeditor_outline
     treewidget = outlineexplorer.treewidget
+    treewidget.is_visible = True
 
     case_info = CASES['text']
     filename = case_info['file']
@@ -411,6 +412,7 @@ def test_empty_file(qtbot, completions_codeeditor_outline):
     """
     code_editor, outlineexplorer = completions_codeeditor_outline
     treewidget = outlineexplorer.treewidget
+    treewidget.is_visible = True
 
     code_editor.toggle_automatic_completions(False)
     code_editor.toggle_code_snippets(False)

--- a/spyder/plugins/editor/widgets/tests/test_save.py
+++ b/spyder/plugins/editor/widgets/tests/test_save.py
@@ -312,6 +312,8 @@ def test_save_as_with_outline(completions_editor, mocker, qtbot, tmpdir):
     outline_explorer = OutlineExplorerWidget(None, None, None)
     treewidget = outline_explorer.treewidget
     outline_explorer.show()
+    treewidget.is_visible = True
+
     editorstack.set_outlineexplorer(outline_explorer)
     qtbot.addWidget(editorstack.outlineexplorer)
     editorstack.outlineexplorer.register_editor(proxy)

--- a/spyder/plugins/outlineexplorer/editor.py
+++ b/spyder/plugins/outlineexplorer/editor.py
@@ -21,6 +21,10 @@ class OutlineExplorerProxyEditor(OutlineExplorerProxy):
         # This saves the symbols info that comes from the server.
         self.info = None
 
+        # This is used to tell if the associated tree is updated with the
+        # latest info available here
+        self.is_tree_updated = False
+
     def update_outline_info(self, info):
         self.sig_outline_explorer_data_changed.emit(info)
         self.info = info

--- a/spyder/plugins/outlineexplorer/main_widget.py
+++ b/spyder/plugins/outlineexplorer/main_widget.py
@@ -165,11 +165,18 @@ class OutlineExplorerWidget(PluginMainWidget):
         pass
 
     def change_visibility(self, enable, force_focus=None):
-        """
-        Reimplemented to tell treewidget what the visibility state is.
-        """
+        """Reimplemented to tell treewidget what the visibility state is."""
         super().change_visibility(enable, force_focus)
-        self._change_treewidget_visibility(self.is_visible)
+
+        if self.windowwidget is not None:
+            # When the plugin is undocked Qt changes its visibility to False,
+            # probably because it's not part of the main window anymore. So, we
+            # need to set the treewidget visibility to True for it to be
+            # updated after writing new content in the editor.
+            # Fixes spyder-ide/spyder#16634
+            self._change_treewidget_visibility(True)
+        else:
+            self._change_treewidget_visibility(self.is_visible)
 
     # ---- Public API
     # -------------------------------------------------------------------------

--- a/spyder/plugins/outlineexplorer/main_widget.py
+++ b/spyder/plugins/outlineexplorer/main_widget.py
@@ -174,9 +174,9 @@ class OutlineExplorerWidget(PluginMainWidget):
             # need to set the treewidget visibility to True for it to be
             # updated after writing new content in the editor.
             # Fixes spyder-ide/spyder#16634
-            self._change_treewidget_visibility(True)
+            self.treewidget.change_visibility(True)
         else:
-            self._change_treewidget_visibility(self.is_visible)
+            self.treewidget.change_visibility(self.is_visible)
 
     def create_window(self):
         """
@@ -218,12 +218,6 @@ class OutlineExplorerWidget(PluginMainWidget):
 
     # ---- Private API
     # -------------------------------------------------------------------------
-    def _change_treewidget_visibility(self, is_visible):
-        """Set visibility state in treewidget."""
-        self.treewidget.is_visible = is_visible
-        if is_visible:
-            self.treewidget.update_all_editors()
-
     @Slot(Qt.WindowStates)
     def _handle_undocked_window_state(self, window_state):
         """
@@ -233,6 +227,6 @@ class OutlineExplorerWidget(PluginMainWidget):
         if window_state == Qt.WindowMinimized:
             # There's no need to update the treewidget when the plugin is
             # minimized.
-            self._change_treewidget_visibility(False)
+            self.treewidget.change_visibility(False)
         else:
-            self._change_treewidget_visibility(True)
+            self.treewidget.change_visibility(True)

--- a/spyder/plugins/outlineexplorer/main_widget.py
+++ b/spyder/plugins/outlineexplorer/main_widget.py
@@ -6,7 +6,7 @@
 
 """Outline explorer main widget."""
 
-from qtpy.QtCore import Signal
+from qtpy.QtCore import Qt, Signal, Slot
 from qtpy.QtWidgets import QHBoxLayout
 
 from spyder.api.widgets.main_widget import PluginMainWidget
@@ -178,6 +178,15 @@ class OutlineExplorerWidget(PluginMainWidget):
         else:
             self._change_treewidget_visibility(self.is_visible)
 
+    def create_window(self):
+        """
+        Reimplemented to tell treewidget what the visibility of the undocked
+        plugin is.
+        """
+        super().create_window()
+        self.windowwidget.sig_window_state_changed.connect(
+            self._handle_undocked_window_state)
+
     # ---- Public API
     # -------------------------------------------------------------------------
     def set_current_editor(self, editor, update, clear):
@@ -214,3 +223,16 @@ class OutlineExplorerWidget(PluginMainWidget):
         self.treewidget.is_visible = is_visible
         if is_visible:
             self.treewidget.update_all_editors()
+
+    @Slot(Qt.WindowStates)
+    def _handle_undocked_window_state(self, window_state):
+        """
+        Change treewidget visibility when the plugin is undocked and its
+        window state changes.
+        """
+        if window_state == Qt.WindowMinimized:
+            # There's no need to update the treewidget when the plugin is
+            # minimized.
+            self._change_treewidget_visibility(False)
+        else:
+            self._change_treewidget_visibility(True)

--- a/spyder/plugins/outlineexplorer/tests/test_widgets.py
+++ b/spyder/plugins/outlineexplorer/tests/test_widgets.py
@@ -77,6 +77,7 @@ def create_outlineexplorer(qtbot):
         outlineexplorer.set_current_editor(editor, False, False)
         outlineexplorer.show()
         outlineexplorer.setFixedSize(400, 350)
+        outlineexplorer.treewidget.is_visible = True
 
         editor.update_outline_info(symbol_info)
         qtbot.addWidget(outlineexplorer)

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -427,18 +427,19 @@ class OutlineExplorerTreeWidget(OneColumnTree):
             self.scrollToItem(item)
             self.root_item_selected(item)
             self.__hide_or_show_root_items(item)
-        if update:
-            self.save_expanded_state()
-            self.restore_expanded_state()
 
+        logger.debug(f"Set current editor to file {editor.fname}")
         self.current_editor = editor
 
         # Update tree with currently stored info or require symbols if
         # necessary.
-        if (editor.get_language().lower() in self._languages and
-                len(self.editor_tree_cache[editor_id]) == 0):
+        if (
+            editor.get_language().lower() in self._languages
+            and len(self.editor_tree_cache[editor_id]) == 0
+        ):
             if editor.info is not None:
-                self.update_editor(editor.info)
+                if update:
+                    self.update_editor(editor.info)
             elif editor.is_cloned:
                 editor.request_symbols()
 

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -850,3 +850,9 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         for editor in self.editor_ids.keys():
             if editor.get_language().lower() == language:
                 editor.info = None
+
+    def change_visibility(self, is_visible):
+        """Actions to take when the widget visibility has changed."""
+        self.is_visible = is_visible
+        if is_visible:
+            self.update_all_editors()

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -264,7 +264,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         self.ordered_editor_ids = []
         self._current_editor = None
         self._languages = []
-        self.is_visible = True
+        self.is_visible = False
 
         self.currentItemChanged.connect(self.selection_switched)
         self.itemExpanded.connect(self.tree_item_expanded)


### PR DESCRIPTION
## Description of Changes

* Simplify and greatly speed up updating trees when new symbols arrive from PyLSP. For instance, this decreases the time necessary to update the tree of our `codeeditor.py` file from 700 ms to 30 ms in my laptop.
* Update trees when the Outline is undocked, but not if its window is minimized.
* Avoid the Editor plugin to update current tree when given focus (this was very inefficient).
* Dock plugins if they are undocked before hiding them when going to the `Panes > View` menu. I discovered that UX bug while working on this PR.
* Add a test to check that we update (don't update) the Outline when it becomes visible (is not visible) under different circumstances.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #16634

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
