### PR TITLE
PR: Remove lambdas in Qt slots

### DIFF
--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -1053,6 +1053,7 @@ class SpyderDockablePlugin(SpyderPluginV2):
         """
         self.get_widget().update_margins(margin)
 
+    @Slot()
     def switch_to_plugin(self, force_focus=False):
         """
         Switch to plugin and define if focus should be given or not.

--- a/spyder/plugins/breakpoints/plugin.py
+++ b/spyder/plugins/breakpoints/plugin.py
@@ -113,7 +113,7 @@ class Breakpoints(SpyderDockablePlugin):
         self.create_action(
             BreakpointsActions.ListBreakpoints,
             _("List breakpoints"),
-            triggered=lambda: self.switch_to_plugin(),
+            triggered=self.switch_to_plugin,
             icon=self.get_icon(),
         )
 

--- a/spyder/plugins/breakpoints/plugin.py
+++ b/spyder/plugins/breakpoints/plugin.py
@@ -113,7 +113,7 @@ class Breakpoints(SpyderDockablePlugin):
         self.create_action(
             BreakpointsActions.ListBreakpoints,
             _("List breakpoints"),
-            triggered=self.switch_to_plugin,
+            triggered=self.sig_switch_to_plugin_requested,
             icon=self.get_icon(),
         )
 

--- a/spyder/plugins/breakpoints/plugin.py
+++ b/spyder/plugins/breakpoints/plugin.py
@@ -113,7 +113,7 @@ class Breakpoints(SpyderDockablePlugin):
         self.create_action(
             BreakpointsActions.ListBreakpoints,
             _("List breakpoints"),
-            triggered=self.sig_switch_to_plugin_requested,
+            triggered=self.switch_to_plugin,
             icon=self.get_icon(),
         )
 

--- a/spyder/plugins/completion/providers/kite/widgets/install.py
+++ b/spyder/plugins/completion/providers/kite/widgets/install.py
@@ -257,10 +257,8 @@ class KiteInstallation(QWidget):
         self.setLayout(general_layout)
 
         # Signals
-        self._progress_filter.sig_hover_enter.connect(
-            lambda: self.cancel_button.show())
-        self._progress_filter.sig_hover_leave.connect(
-            lambda: self.cancel_button.hide())
+        self._progress_filter.sig_hover_enter.connect(self.cancel_button.show)
+        self._progress_filter.sig_hover_leave.connect(self.cancel_button.hide)
 
     def update_installation_status(self, status):
         """Update installation status (downloading, installing, finished)."""

--- a/spyder/plugins/console/widgets/shell.py
+++ b/spyder/plugins/console/widgets/shell.py
@@ -673,12 +673,12 @@ class PythonShellWidget(TracebackLinksMixin, ShellBaseWidget,
 
     def create_shortcuts(self):
         array_inline = CONF.config_shortcut(
-            lambda: self.enter_array_inline(),
+            self.enter_array_inline,
             context='array_builder',
             name='enter array inline',
             parent=self)
         array_table = CONF.config_shortcut(
-            lambda: self.enter_array_table(),
+            self.enter_array_table,
             context='array_builder',
             name='enter array table',
             parent=self)

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1298,8 +1298,8 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         self.switcher_manager = EditorSwitcherManager(
             self,
             self.main.switcher,
-            lambda: self.get_current_editor(),
-            lambda: self.get_current_editorstack(),
+            self.get_current_editor,
+            self.get_current_editorstack,
             section=self.get_plugin_title())
 
     def update_source_menu(self, options, **kwargs):
@@ -1573,8 +1573,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         editorstack.run_cell_in_ipyclient.connect(self.run_cell_in_ipyclient)
         editorstack.debug_cell_in_ipyclient.connect(
             self.debug_cell_in_ipyclient)
-        editorstack.update_plugin_title.connect(
-                                   lambda: self.sig_update_plugin_title.emit())
+        editorstack.update_plugin_title.connect(self.sig_update_plugin_title)
         editorstack.editor_focus_changed.connect(self.save_focused_editorstack)
         editorstack.editor_focus_changed.connect(self.main.plugin_focus_changed)
         editorstack.editor_focus_changed.connect(self.sig_editor_focus_changed)
@@ -1599,9 +1598,9 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         editorstack.sig_perform_completion_request.connect(
             self.send_completion_request)
         editorstack.todo_results_changed.connect(self.todo_results_changed)
-        editorstack.update_code_analysis_actions.connect(
+        editorstack.sig_update_code_analysis_actions.connect(
             self.update_code_analysis_actions)
-        editorstack.update_code_analysis_actions.connect(
+        editorstack.sig_update_code_analysis_actions.connect(
             self.update_todo_actions)
         editorstack.refresh_file_dependent_actions.connect(
                                            self.refresh_file_dependent_actions)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -176,7 +176,7 @@ class CodeEditor(TextEditBaseWidget):
     sig_filename_changed = Signal(str)
     sig_bookmarks_changed = Signal()
     go_to_definition = Signal(str, int, int)
-    sig_show_object_info = Signal(int)
+    sig_show_object_info = Signal(bool)
     sig_run_selection = Signal()
     sig_run_to_line = Signal()
     sig_run_from_line = Signal()
@@ -2324,8 +2324,7 @@ class CodeEditor(TextEditBaseWidget):
         elif self.in_comment_or_string():
             self.unindent()
         elif leading_text[-1] in '(,' or leading_text.endswith(', '):
-            position = self.get_position('cursor')
-            self.show_object_info(position)
+            self.show_object_info()
         else:
             # if the line ends with any other character but comma
             self.unindent()
@@ -2761,9 +2760,10 @@ class CodeEditor(TextEditBaseWidget):
         force = True
         self.sig_show_completion_object_info.emit(name, signature, force)
 
-    def show_object_info(self, position):
+    @Slot()
+    def show_object_info(self):
         """Trigger a calltip"""
-        self.sig_show_object_info.emit(position)
+        self.sig_show_object_info.emit(True)
 
     # -----blank spaces
     def set_blanks_enabled(self, state):

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4423,7 +4423,7 @@ class CodeEditor(TextEditBaseWidget):
             self, _("Inspect current object"),
             icon=ima.icon('MessageBoxInformation'),
             shortcut=CONF.get_shortcut('editor', 'inspect current object'),
-            triggered=self.sig_show_object_info.emit)
+            triggered=self.sig_show_object_info)
 
         # Run actions
         self.run_cell_action = create_action(

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -193,7 +193,7 @@ class EditorStack(QWidget):
     opened_files_list_changed = Signal()
     active_languages_stats = Signal(set)
     todo_results_changed = Signal()
-    update_code_analysis_actions = Signal()
+    sig_update_code_analysis_actions = Signal()
     refresh_file_dependent_actions = Signal()
     refresh_save_all_action = Signal()
     sig_breakpoints_saved = Signal()
@@ -492,13 +492,13 @@ class EditorStack(QWidget):
             parent=self)
 
         new_file = CONF.config_shortcut(
-            lambda: self.sig_new_file[()].emit(),
+            self.sig_new_file[()],
             context='Editor',
             name='New file',
             parent=self)
 
         open_file = CONF.config_shortcut(
-            lambda: self.plugin_load[()].emit(),
+            self.plugin_load[()],
             context='Editor',
             name='Open file',
             parent=self)
@@ -516,7 +516,7 @@ class EditorStack(QWidget):
             parent=self)
 
         save_as = CONF.config_shortcut(
-            lambda: self.sig_save_as.emit(),
+            self.sig_save_as,
             context='Editor',
             name='Save As',
             parent=self)
@@ -528,43 +528,43 @@ class EditorStack(QWidget):
             parent=self)
 
         prev_edit_pos = CONF.config_shortcut(
-            lambda: self.sig_prev_edit_pos.emit(),
+            self.sig_prev_edit_pos,
             context="Editor",
             name="Last edit location",
             parent=self)
 
         prev_cursor = CONF.config_shortcut(
-            lambda: self.sig_prev_cursor.emit(),
+            self.sig_prev_cursor,
             context="Editor",
             name="Previous cursor position",
             parent=self)
 
         next_cursor = CONF.config_shortcut(
-            lambda: self.sig_next_cursor.emit(),
+            self.sig_next_cursor,
             context="Editor",
             name="Next cursor position",
             parent=self)
 
         zoom_in_1 = CONF.config_shortcut(
-            lambda: self.zoom_in.emit(),
+            self.zoom_in,
             context="Editor",
             name="zoom in 1",
             parent=self)
 
         zoom_in_2 = CONF.config_shortcut(
-            lambda: self.zoom_in.emit(),
+            self.zoom_in,
             context="Editor",
             name="zoom in 2",
             parent=self)
 
         zoom_out = CONF.config_shortcut(
-            lambda: self.zoom_out.emit(),
+            self.zoom_out,
             context="Editor",
             name="zoom out",
             parent=self)
 
         zoom_reset = CONF.config_shortcut(
-            lambda: self.zoom_reset.emit(),
+            self.zoom_reset,
             context="Editor",
             name="zoom reset",
             parent=self)
@@ -618,25 +618,25 @@ class EditorStack(QWidget):
             parent=self)
 
         prev_warning = CONF.config_shortcut(
-            lambda: self.sig_prev_warning.emit(),
+            self.sig_prev_warning,
             context="Editor",
             name="Previous warning",
             parent=self)
 
         next_warning = CONF.config_shortcut(
-            lambda: self.sig_next_warning.emit(),
+            self.sig_next_warning,
             context="Editor",
             name="Next warning",
             parent=self)
 
         split_vertically = CONF.config_shortcut(
-            lambda: self.sig_split_vertically.emit(),
+            self.sig_split_vertically,
             context="Editor",
             name="split vertically",
             parent=self)
 
         split_horizontally = CONF.config_shortcut(
-            lambda: self.sig_split_horizontally.emit(),
+            self.sig_split_horizontally,
             context="Editor",
             name="split horizontally",
             parent=self)
@@ -820,7 +820,7 @@ class EditorStack(QWidget):
             self.switcher_manager = EditorSwitcherManager(
                 self.get_plugin(),
                 self.switcher_dlg,
-                lambda: self.get_current_editor(),
+                self.get_current_editor,
                 lambda: self,
                 section=self.get_plugin_title())
 
@@ -1439,7 +1439,7 @@ class EditorStack(QWidget):
             _("Split vertically"),
             icon=ima.icon('versplit'),
             tip=_("Split vertically this editor window"),
-            triggered=lambda: self.sig_split_vertically.emit(),
+            triggered=self.sig_split_vertically,
             shortcut=CONF.get_shortcut(context='Editor',
                                        name='split vertically'),
             context=Qt.WidgetShortcut)
@@ -1449,7 +1449,7 @@ class EditorStack(QWidget):
             _("Split horizontally"),
             icon=ima.icon('horsplit'),
             tip=_("Split horizontally this editor window"),
-            triggered=lambda: self.sig_split_horizontally.emit(),
+            triggered=self.sig_split_horizontally,
             shortcut=CONF.get_shortcut(context='Editor',
                                        name='split horizontally'),
             context=Qt.WidgetShortcut)
@@ -1664,7 +1664,7 @@ class EditorStack(QWidget):
             self.sig_close_file.emit(str(id(self)), filename)
 
             self.opened_files_list_changed.emit()
-            self.update_code_analysis_actions.emit()
+            self.sig_update_code_analysis_actions.emit()
             self.refresh_file_dependent_actions.emit()
             self.update_plugin_title.emit()
 
@@ -2407,7 +2407,7 @@ class EditorStack(QWidget):
             editor = finfo.editor
             editor.setFocus()
             self._refresh_outlineexplorer(index, update=False)
-            self.update_code_analysis_actions.emit()
+            self.sig_update_code_analysis_actions.emit()
             self.__refresh_statusbar(index)
             self.__refresh_readonly(index)
             self.__check_file_status(index)
@@ -2512,8 +2512,7 @@ class EditorStack(QWidget):
         self.add_to_data(finfo, set_current, add_where)
         finfo.sig_send_to_help.connect(self.send_to_help)
         finfo.sig_show_object_info.connect(self.inspect_current_object)
-        finfo.todo_results_changed.connect(
-            lambda: self.todo_results_changed.emit())
+        finfo.todo_results_changed.connect(self.todo_results_changed)
         finfo.edit_goto.connect(lambda fname, lineno, name:
                                 self.edit_goto.emit(fname, lineno, name))
         finfo.sig_save_bookmarks.connect(lambda s1, s2:
@@ -2528,7 +2527,7 @@ class EditorStack(QWidget):
         editor.sig_new_file.connect(self.sig_new_file)
         editor.sig_breakpoints_saved.connect(self.sig_breakpoints_saved)
         editor.sig_process_code_analysis.connect(
-            lambda: self.update_code_analysis_actions.emit())
+            self.sig_update_code_analysis_actions)
         editor.sig_refresh_formatting.connect(self.sig_refresh_formatting)
         language = get_file_language(fname, txt)
         editor.setup_editor(
@@ -2599,9 +2598,9 @@ class EditorStack(QWidget):
             lambda state: self.modification_changed(
                 state, editor_id=id(editor)))
         editor.focus_in.connect(self.focus_changed)
-        editor.zoom_in.connect(lambda: self.zoom_in.emit())
-        editor.zoom_out.connect(lambda: self.zoom_out.emit())
-        editor.zoom_reset.connect(lambda: self.zoom_reset.emit())
+        editor.zoom_in.connect(self.zoom_in)
+        editor.zoom_out.connect(self.zoom_out)
+        editor.zoom_reset.connect(self.zoom_reset)
         editor.sig_eol_chars_changed.connect(
             lambda eol_chars: self.refresh_eol_chars(eol_chars))
         editor.sig_next_cursor.connect(self.sig_next_cursor)
@@ -3037,7 +3036,7 @@ class EditorSplitter(QSplitter):
         self.register_editorstack_cb(self.editorstack)
         if not first:
             self.plugin.clone_editorstack(editorstack=self.editorstack)
-        self.editorstack.destroyed.connect(lambda: self.editorstack_closed())
+        self.editorstack.destroyed.connect(self.editorstack_closed)
         self.editorstack.sig_split_vertically.connect(
                      lambda: self.split(orientation=Qt.Vertical))
         self.editorstack.sig_split_horizontally.connect(

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -3063,6 +3063,7 @@ class EditorSplitter(QSplitter):
         if focus_widget is not None:
             focus_widget.setFocus()
 
+    @Slot()
     def editorstack_closed(self):
         try:
             logger.debug("method 'editorstack_closed':")

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -879,13 +879,15 @@ class EditorStack(QWidget):
             editor = self.get_current_editor()
             editor.add_bookmark(slot_num)
 
-    def inspect_current_object(self, pos=None):
+    @Slot()
+    @Slot(bool)
+    def inspect_current_object(self, clicked=False):
         """Inspect current object in the Help plugin"""
         editor = self.get_current_editor()
         editor.sig_display_object_info.connect(self.display_help)
         cursor = None
         offset = editor.get_position('cursor')
-        if pos:
+        if clicked:
             cursor = editor.get_last_hover_cursor()
             if cursor:
                 offset = cursor.position()
@@ -894,7 +896,7 @@ class EditorStack(QWidget):
 
         line, col = editor.get_cursor_line_column(cursor)
         editor.request_hover(line, col, offset,
-                             show_hint=False, clicked=bool(pos))
+                             show_hint=False, clicked=clicked)
 
     @Slot(str, bool)
     def display_help(self, help_text, clicked):

--- a/spyder/plugins/editor/widgets/editorstack_helpers.py
+++ b/spyder/plugins/editor/widgets/editorstack_helpers.py
@@ -122,7 +122,7 @@ class FileInfo(QObject):
     edit_goto = Signal(str, int, str)
     sig_send_to_help = Signal(str, str, bool)
     sig_filename_changed = Signal(str)
-    sig_show_object_info = Signal(int)
+    sig_show_object_info = Signal(bool)
     sig_show_completion_object_info = Signal(str, str)
 
     def __init__(self, filename, encoding, editor, new, threadmanager):

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -322,28 +322,28 @@ class DirView(QTreeView, SpyderWidgetMixin):
             DirViewActions.NewFile,
             text=_("File..."),
             icon=self.create_icon('TextFileIcon'),
-            triggered=lambda: self.new_file(),
+            triggered=self.new_file,
         )
 
         new_module_action = self.create_action(
             DirViewActions.NewModule,
             text=_("Python file..."),
             icon=self.create_icon('python'),
-            triggered=lambda: self.new_module(),
+            triggered=self.new_module,
         )
 
         new_folder_action = self.create_action(
             DirViewActions.NewFolder,
             text=_("Folder..."),
             icon=self.create_icon('folder_new'),
-            triggered=lambda: self.new_folder(),
+            triggered=self.new_folder,
         )
 
         new_package_action = self.create_action(
             DirViewActions.NewPackage,
             text=_("Python Package..."),
             icon=self.create_icon('package_new'),
-            triggered=lambda: self.new_package(),
+            triggered=self.new_package,
         )
 
         # Open actions
@@ -351,19 +351,19 @@ class DirView(QTreeView, SpyderWidgetMixin):
             DirViewActions.OpenWithSpyder,
             text=_("Open in Spyder"),
             icon=self.create_icon('edit'),
-            triggered=lambda: self.open(),
+            triggered=self.open,
         )
 
         self.open_external_action = self.create_action(
             DirViewActions.OpenWithSystem,
             text=_("Open externally"),
-            triggered=lambda: self.open_external(),
+            triggered=self.open_external,
         )
 
         self.open_external_action_2 = self.create_action(
             DirViewActions.OpenWithSystem2,
             text=_("Default external application"),
-            triggered=lambda: self.open_external(),
+            triggered=self.open_external,
             register_shortcut=False,
         )
 
@@ -372,21 +372,21 @@ class DirView(QTreeView, SpyderWidgetMixin):
             DirViewActions.Delete,
             text=_("Delete..."),
             icon=self.create_icon('editdelete'),
-            triggered=lambda: self.delete(),
+            triggered=self.delete,
         )
 
         rename_action = self.create_action(
             DirViewActions.Rename,
             text=_("Rename..."),
             icon=self.create_icon('rename'),
-            triggered=lambda: self.rename(),
+            triggered=self.rename,
         )
 
         self.move_action = self.create_action(
             DirViewActions.Move,
             text=_("Move..."),
             icon=self.create_icon('move'),
-            triggered=lambda: self.move(),
+            triggered=self.move,
         )
 
         # Copy/Paste actions
@@ -394,26 +394,26 @@ class DirView(QTreeView, SpyderWidgetMixin):
             DirViewActions.Copy,
             text=_("Copy"),
             icon=self.create_icon('editcopy'),
-            triggered=lambda: self.copy_file_clipboard(),
+            triggered=self.copy_file_clipboard,
         )
 
         self.paste_action = self.create_action(
             DirViewActions.Paste,
             text=_("Paste"),
             icon=self.create_icon('editpaste'),
-            triggered=lambda: self.save_file_clipboard(),
+            triggered=self.save_file_clipboard,
         )
 
         copy_absolute_path_action = self.create_action(
             DirViewActions.CopyAbsolutePath,
             text=_("Copy Absolute Path"),
-            triggered=lambda: self.copy_absolute_path(),
+            triggered=self.copy_absolute_path,
         )
 
         copy_relative_path_action = self.create_action(
             DirViewActions.CopyRelativePath,
             text=_("Copy Relative Path"),
-            triggered=lambda: self.copy_relative_path(),
+            triggered=self.copy_relative_path,
         )
 
         # Show actions
@@ -425,7 +425,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
         show_in_system_explorer_action = self.create_action(
             DirViewActions.ShowInSystemExplorer,
             text=show_in_finder_text,
-            triggered=lambda: self.show_in_external_file_explorer(),
+            triggered=self.show_in_external_file_explorer,
         )
 
         # Version control actions
@@ -455,7 +455,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             DirViewActions.EditNameFilters,
             text=_("Edit filter settings..."),
             icon=self.create_icon('filter'),
-            triggered=lambda: self.edit_filter(),
+            triggered=self.edit_filter,
         )
 
         self.create_action(
@@ -472,7 +472,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             DirViewActions.OpenInterpreter,
             text=_("Open IPython console here"),
             icon=self.create_icon('ipython_console'),
-            triggered=lambda: self.open_interpreter(),
+            triggered=self.open_interpreter,
         )
 
         # TODO: Move this option to the ipython console setup
@@ -480,7 +480,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             DirViewActions.Run,
             text=_("Run"),
             icon=self.create_icon('run'),
-            triggered=lambda: self.run(),
+            triggered=self.run,
         )
 
         # Notebook Actions
@@ -488,7 +488,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             DirViewActions.ConvertNotebook,
             _("Convert to Python file"),
             icon=ima.icon('python'),
-            triggered=lambda: self.convert_notebooks()
+            triggered=self.convert_notebooks
         )
 
         # Header Actions

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -1247,6 +1247,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             selected_path = osp.dirname(selected_path)
         return fixpath(selected_path)
 
+    @Slot()
     def new_folder(self, basedir=None):
         """New folder."""
 
@@ -1278,6 +1279,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
                       "</b><br><br>Error message:<br>%s"
                       ) % (fname, str(error)))
 
+    @Slot()
     def new_file(self, basedir=None):
         """New file"""
 
@@ -1457,6 +1459,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             else:
                 pass
 
+    @Slot()
     def open_interpreter(self, fnames=None):
         """Open interpreter"""
         if fnames is None:
@@ -1683,6 +1686,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             return
         self.sig_file_created.emit(script)
 
+    @Slot()
     def convert_notebooks(self):
         """Convert IPython notebooks to Python scripts in editor"""
         fnames = self.get_selected_filenames()
@@ -1691,6 +1695,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
         for fname in fnames:
             self.convert_notebook(fname)
 
+    @Slot()
     def new_package(self, basedir=None):
         """New package"""
 
@@ -1701,6 +1706,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
         subtitle = _('Package name:')
         self.create_new_folder(basedir, title, subtitle, is_package=True)
 
+    @Slot()
     def new_module(self, basedir=None):
         """New module"""
 

--- a/spyder/plugins/explorer/widgets/fileassociations.py
+++ b/spyder/plugins/explorer/widgets/fileassociations.py
@@ -337,7 +337,7 @@ class FileAssociationsWidget(QWidget):
         self.setLayout(layout)
 
         # Signals
-        self.button_add.clicked.connect(lambda: self.add_association())
+        self.button_add.clicked.connect(self.add_association)
         self.button_remove.clicked.connect(self.remove_association)
         self.button_edit.clicked.connect(self.edit_association)
         self.button_add_application.clicked.connect(self.add_application)

--- a/spyder/plugins/explorer/widgets/fileassociations.py
+++ b/spyder/plugins/explorer/widgets/fileassociations.py
@@ -17,7 +17,7 @@ import sys
 
 # Third party imports
 from qtpy.compat import getopenfilename
-from qtpy.QtCore import QRegExp, QSize, Qt, Signal
+from qtpy.QtCore import QRegExp, QSize, Qt, Signal, Slot
 from qtpy.QtGui import QCursor, QRegExpValidator
 from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
                             QHBoxLayout, QLabel, QLineEdit,
@@ -442,6 +442,7 @@ class FileAssociationsWidget(QWidget):
         self._data = {} if data is None else data
         self._update_extensions()
 
+    @Slot()
     def add_association(self, value=None):
         """Add extension file association."""
         if value is None:

--- a/spyder/plugins/history/widgets.py
+++ b/spyder/plugins/history/widgets.py
@@ -273,7 +273,7 @@ class HistoryWidget(PluginMainWidget):
         self.tabwidget.setTabToolTip(index, filename)
 
         # Signals
-        editor.sig_focus_changed.connect(lambda: self.sig_focus_changed.emit())
+        editor.sig_focus_changed.connect(self.sig_focus_changed)
 
     @Slot(str, str)
     def append_to_history(self, filename, command):

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1840,7 +1840,7 @@ class IPythonConsoleWidget(PluginMainWidget):
         control = shellwidget._control
 
         # Create new clients with Ctrl+T shortcut
-        shellwidget.new_client.connect(self.create_new_client)
+        shellwidget.sig_new_client.connect(self.create_new_client)
 
         # For tracebacks
         control.sig_go_to_error_requested.connect(self.go_to_error)

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -16,7 +16,7 @@ from textwrap import dedent
 from threading import Lock
 
 # Third party imports
-from qtpy.QtCore import Signal, QThread
+from qtpy.QtCore import Signal, QThread, Slot
 from qtpy.QtWidgets import QMessageBox
 from qtpy import QtCore, QtWidgets, QtGui
 from traitlets import observe
@@ -519,6 +519,7 @@ the sympy module (e.g. plot)
         # Stop reading as any input has been removed.
         self._reading = False
 
+    @Slot()
     def _reset_namespace(self):
         warning = self.get_conf('show_reset_namespace_warning')
         self.reset_namespace(warning=warning)

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -66,7 +66,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
 
     # For ShellWidget
     sig_focus_changed = Signal()
-    new_client = Signal()
+    sig_new_client = Signal()
     sig_is_spykernel = Signal(object)
     sig_kernel_restarted_message = Signal(str)
     sig_kernel_restarted = Signal()
@@ -657,13 +657,13 @@ the sympy module (e.g. plot)
             parent=self)
 
         new_tab = self.config_shortcut(
-            lambda: self.new_client.emit(),
+            self.sig_new_client,
             context='ipython_console',
             name='new tab',
             parent=self)
 
         reset_namespace = self.config_shortcut(
-            lambda: self._reset_namespace(),
+            self._reset_namespace,
             context='ipython_console',
             name='reset namespace',
             parent=self)

--- a/spyder/plugins/layout/container.py
+++ b/spyder/plugins/layout/container.py
@@ -282,6 +282,7 @@ class LayoutContainer(PluginMainContainer):
 
         return self._spyder_layouts[layout_id]
 
+    @Slot()
     def show_save_layout(self):
         """Show the save layout dialog."""
         names = self.get_conf('names')
@@ -341,6 +342,7 @@ class LayoutContainer(PluginMainContainer):
 
             self.update_layout_menu_actions()
 
+    @Slot()
     def show_layout_settings(self):
         """Layout settings dialog."""
         names = self.get_conf('names')

--- a/spyder/plugins/layout/container.py
+++ b/spyder/plugins/layout/container.py
@@ -124,14 +124,14 @@ class LayoutContainer(PluginMainContainer):
         self._save_layout_action = self.create_action(
             LayoutContainerActions.SaveLayoutAction,
             _("Save current layout"),
-            triggered=lambda: self.show_save_layout(),
+            triggered=self.show_save_layout,
             context=Qt.ApplicationShortcut,
             register_shortcut=False,
         )
         self._show_preferences_action = self.create_action(
             LayoutContainerActions.ShowLayoutPreferencesAction,
             text=_("Layout preferences"),
-            triggered=lambda: self.show_layout_settings(),
+            triggered=self.show_layout_settings,
             context=Qt.ApplicationShortcut,
             register_shortcut=False,
         )

--- a/spyder/plugins/projects/widgets/qcookiecutter.py
+++ b/spyder/plugins/projects/widgets/qcookiecutter.py
@@ -217,7 +217,7 @@ class CookiecutterWidget(QtWidgets.QWidget):
             box.setText(default)
             box.textChanged.connect(lambda x=None: self.render())
 
-        box.get_value = lambda: box.text()
+        box.get_value = box.text
         box.set_value = lambda text: box.setText(text)
 
         return box
@@ -257,7 +257,7 @@ class CookiecutterWidget(QtWidgets.QWidget):
                 box.addItem(choice, choice)
 
         box.setting = setting
-        box.get_value = lambda: box.currentData()
+        box.get_value = box.currentData
 
         return box
 

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -690,6 +690,7 @@ class PylintWidget(PluginMainWidget):
 
         self.filecombo.selected()
 
+    @Slot()
     def start_code_analysis(self, filename=None):
         """
         Perform code analysis for given `filename`.

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -690,7 +690,6 @@ class PylintWidget(PluginMainWidget):
 
         self.filecombo.selected()
 
-    @Slot()
     def start_code_analysis(self, filename=None):
         """
         Perform code analysis for given `filename`.

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -500,7 +500,7 @@ class PylintWidget(PluginMainWidget):
             text=_("Run code analysis"),
             tip=_("Run code analysis"),
             icon=self.create_icon("run"),
-            triggered=lambda: self.sig_start_analysis_requested.emit(),
+            triggered=self.sig_start_analysis_requested,
         )
         self.browse_action = self.create_action(
             PylintWidgetActions.BrowseFile,

--- a/spyder/plugins/pylint/plugin.py
+++ b/spyder/plugins/pylint/plugin.py
@@ -74,8 +74,7 @@ class Pylint(SpyderDockablePlugin):
 
         # Expose widget signals at the plugin level
         widget.sig_edit_goto_requested.connect(self.sig_edit_goto_requested)
-        widget.sig_start_analysis_requested.connect(
-            lambda: self.start_code_analysis())
+        widget.sig_start_analysis_requested.connect(self.start_code_analysis)
 
         # Add action to application menus
         pylint_act = self.create_action(
@@ -83,7 +82,7 @@ class Pylint(SpyderDockablePlugin):
             text=_("Run code analysis"),
             tip=_("Run code analysis"),
             icon=self.create_icon("pylint"),
-            triggered=lambda: self.start_code_analysis(),
+            triggered=self.start_code_analysis,
             context=Qt.ApplicationShortcut,
             register_shortcut=True
         )

--- a/spyder/plugins/pylint/plugin.py
+++ b/spyder/plugins/pylint/plugin.py
@@ -201,6 +201,7 @@ class Pylint(SpyderDockablePlugin):
         """
         return self.get_widget().get_filename()
 
+    @Slot()
     def start_code_analysis(self, filename=None):
         """
         Perform code analysis for given `filename`.

--- a/spyder/plugins/shortcuts/plugin.py
+++ b/spyder/plugins/shortcuts/plugin.py
@@ -15,7 +15,7 @@ import configparser
 import sys
 
 # Third party imports
-from qtpy.QtCore import Qt, Signal
+from qtpy.QtCore import Qt, Signal, Slot
 from qtpy.QtGui import QKeySequence
 from qtpy.QtWidgets import QAction, QShortcut
 
@@ -129,6 +129,7 @@ class Shortcuts(SpyderPluginV2):
         if self._conf:
             self._conf.reset_shortcuts()
 
+    @Slot()
     def show_summary(self):
         """Reset shortcuts."""
         dlg = ShortcutsSummaryDialog(None)

--- a/spyder/plugins/shortcuts/plugin.py
+++ b/spyder/plugins/shortcuts/plugin.py
@@ -77,7 +77,7 @@ class Shortcuts(SpyderPluginV2):
         self.create_action(
             ShortcutActions.ShortcutSummaryAction,
             text=_("Shortcuts Summary"),
-            triggered=lambda: self.show_summary(),
+            triggered=self.show_summary,
             register_shortcut=True,
             context=Qt.ApplicationShortcut,
         )

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -512,6 +512,7 @@ class ArrayView(QTableView):
             # See isue 7880
             pass
 
+    @Slot()
     def resize_to_contents(self):
         """Resize cells to contents"""
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
@@ -616,6 +617,7 @@ class ArrayEditorWidget(QWidget):
         if self.old_data_shape is not None:
             self.data.shape = self.old_data_shape
 
+    @Slot()
     def change_format(self):
         """Change display format"""
         format, valid = QInputDialog.getText(self, _( 'Format'),

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -801,12 +801,11 @@ class ArrayEditor(BaseDialog):
         # disable format button for int type
         btn_format.setEnabled(is_float(self.arraywidget.data.dtype))
         btn_layout_bottom.addWidget(btn_format)
-        btn_format.clicked.connect(lambda: self.arraywidget.change_format())
+        btn_format.clicked.connect(self.arraywidget.change_format)
 
         btn_resize = QPushButton(_("Resize"))
         btn_layout_bottom.addWidget(btn_resize)
-        btn_resize.clicked.connect(
-            lambda: self.arraywidget.view.resize_to_contents())
+        btn_resize.clicked.connect(self.arraywidget.view.resize_to_contents)
 
         self.bgcolor = QCheckBox(_('Background color'))
         self.bgcolor.setEnabled(self.arraywidget.model.bgcolor_enabled)

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -1297,6 +1297,7 @@ class DataFrameEditor(BaseDialog, SpyderConfigurationAccessor):
         self.dataModel.bgcolor(state)
         self.bgcolor_global.setEnabled(not self.is_series and state > 0)
 
+    @Slot()
     def change_format(self):
         """
         Ask user for display format for floats and use it.
@@ -1365,6 +1366,7 @@ class DataFrameEditor(BaseDialog, SpyderConfigurationAccessor):
         """Fetch more data for the index (rows)."""
         self.table_index.model().fetch_more()
 
+    @Slot()
     def resize_to_contents(self):
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
         self.dataTable.resizeColumnsToContents()

--- a/spyder/requirements.py
+++ b/spyder/requirements.py
@@ -24,7 +24,7 @@ def show_warning(message):
         root.title("Spyder")
         label = tk.Label(root, text=message, justify='left')
         label.pack(side="top", fill="both", expand=True, padx=20, pady=20)
-        button = tk.Button(root, text="OK", command=lambda: root.destroy())
+        button = tk.Button(root, text="OK", command=root.destroy)
         button.pack(side="bottom", fill="none", expand=True)
         root.mainloop()
     except Exception:

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -128,7 +128,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
             name=WebViewActions.Back,
             text=_("Back"),
             icon=self.create_icon('previous'),
-            triggered=lambda: original_back_action.trigger(),
+            triggered=original_back_action.trigger,
             context=Qt.WidgetWithChildrenShortcut,
         )
 
@@ -137,7 +137,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
             name=WebViewActions.Forward,
             text=_("Forward"),
             icon=self.create_icon('next'),
-            triggered=lambda: original_forward_action.trigger(),
+            triggered=original_forward_action.trigger,
             context=Qt.WidgetWithChildrenShortcut,
         )
 
@@ -145,7 +145,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
         select_all_action = self.create_action(
             name=WebViewActions.SelectAll,
             text=_("Select all"),
-            triggered=lambda: original_select_action.trigger(),
+            triggered=original_select_action.trigger,
             context=Qt.WidgetWithChildrenShortcut,
         )
 
@@ -153,7 +153,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
         copy_action = self.create_action(
             name=WebViewActions.Copy,
             text=_("Copy"),
-            triggered=lambda: original_copy_action.trigger(),
+            triggered=original_copy_action.trigger,
             context=Qt.WidgetWithChildrenShortcut,
         )
 
@@ -178,7 +178,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
         inspect_action = self.create_action(
             name=WebViewActions.Inspect,
             text=_("Inspect"),
-            triggered=lambda: original_inspect_action.trigger(),
+            triggered=original_inspect_action.trigger,
             context=Qt.WidgetWithChildrenShortcut,
         )
 
@@ -187,7 +187,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
             name=WebViewActions.Refresh,
             text=_("Refresh"),
             icon=self.create_icon('refresh'),
-            triggered=lambda: original_refresh_action.trigger(),
+            triggered=original_refresh_action.trigger,
             context=Qt.WidgetWithChildrenShortcut,
         )
 
@@ -196,7 +196,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
             name=WebViewActions.Stop,
             text=_("Stop"),
             icon=self.create_icon('stop'),
-            triggered=lambda: original_stop_action.trigger(),
+            triggered=original_stop_action.trigger,
             context=Qt.WidgetWithChildrenShortcut,
         )
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Remove unnecessary lambdas from signals

A lambda prevents qt from keeping a reference to the object, leading to:

```
RuntimeError: wrapped C/C++ object of type xxxx has been deleted
```

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19393


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
