### PR TITLE
PR: Add `APPDATA` environment variable to Pylint process (Pylint)

### DIFF
--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -31,7 +31,8 @@ from qtpy.QtWidgets import (QInputDialog, QLabel, QMessageBox, QTreeWidgetItem,
 from spyder.api.config.decorators import on_conf_change
 from spyder.api.translations import get_translation
 from spyder.api.widgets.main_widget import PluginMainWidget
-from spyder.config.base import get_conf_path, running_in_mac_app
+from spyder.config.base import get_conf_path, is_pynsist, running_in_mac_app
+from spyder.config.utils import is_anaconda
 from spyder.plugins.pylint.utils import get_pylintrc_path
 from spyder.plugins.variableexplorer.widgets.texteditor import TextEditor
 from spyder.utils.icon_manager import ima
@@ -373,7 +374,8 @@ class PylintWidget(PluginMainWidget):
             processEnvironment.insert("USERPROFILE", user_profile)
             # Needed for Windows installations using standalone Python and pip.
             # See spyder-ide/spyder#19385
-            processEnvironment.insert("APPDATA", os.environ.get("APPDATA"))
+            if not is_pynsist() and not is_anaconda():
+                processEnvironment.insert("APPDATA", os.environ.get("APPDATA"))
 
         # resolve spyder-ide/spyder#14262
         if running_in_mac_app():

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -365,12 +365,15 @@ class PylintWidget(PluginMainWidget):
         processEnvironment = QProcessEnvironment()
         processEnvironment.insert("PYTHONIOENCODING", "utf8")
 
-        # Needed due to changes in Pylint 2.14.0
-        # See spyder-ide/spyder#18175
         if os.name == 'nt':
+            # Needed due to changes in Pylint 2.14.0
+            # See spyder-ide/spyder#18175
             home_dir = get_home_dir()
             user_profile = os.environ.get("USERPROFILE", home_dir)
             processEnvironment.insert("USERPROFILE", user_profile)
+            # Needed for Windows installations using standalone Python and pip.
+            # See spyder-ide/spyder#19385
+            processEnvironment.insert("APPDATA", os.environ.get("APPDATA"))
 
         # resolve spyder-ide/spyder#14262
         if running_in_mac_app():


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

The process from where Pylint is launched didn't include the APPDATA dir on Windows which caused some installations to not recognie the installed Pylint version.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19385


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
