### PR TITLE
PR: Group everything the Layout plugin does before the main window is visible on it

### DIFF
--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -196,8 +196,24 @@ class Layout(SpyderPluginV2):
     def before_mainwindow_visible(self):
         # Update layout menu
         self.update_layout_menu_actions()
+
         # Setup layout
         self.setup_layout(default=False)
+
+        # Register custom layouts
+        self.register_custom_layouts()
+
+        # Needed to ensure dockwidgets/panes layout size distribution when a
+        # layout state is already present.
+        # See spyder-ide/spyder#17945
+        if self.get_conf('window/state', section='main', default=None):
+            self.setup_layout(default=False)
+
+        # Tabify new plugins which were installed or created after Spyder runs
+        # for the first time.
+        # Note: **DO NOT** make layout changes after this point or new plugins
+        # won't be tabified correctly.
+        self.tabify_new_plugins()
 
     def on_mainwindow_visible(self):
         # Populate `Panes > View` menu.


### PR DESCRIPTION
## Description of Changes

This is a small refactoring that continues the trend of consolidating everything related to adjusting the main window layout in the Layout plugin and not on `MainWindow`.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
