### PR TITLE
PR: Fix showing pixelated SVG icons on high dpi screens

### DIFF
--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -12,7 +12,7 @@ import sys
 
 # Third party imports
 from qtpy.QtCore import QBuffer, QByteArray
-from qtpy.QtGui import QColor, QIcon, QImage, QPainter, QPixmap
+from qtpy.QtGui import QColor, QIcon, QImage, QPainter
 from qtpy.QtWidgets import QStyle, QWidget
 
 # Local imports
@@ -380,22 +380,28 @@ class IconManager():
             QMainWindow icons created from SVG images on non-Windows
             platforms due to a Qt bug. See spyder-ide/spyder#1314.
         """
+        # Icon image path
         icon_path = get_image_path(name)
-        icon = QIcon(icon_path)
-        icon0 = QIcon()
+
+        # This is used to wrap the image into a QIcon container so we can get
+        # pixmaps for it.
+        wrapping_icon = QIcon(icon_path)
+
+        # This is the icon object that will be returned by this method.
+        icon = QIcon()
 
         if resample:
             # This only applies to the Spyder 2 icons
             for size in (16, 24, 32, 48, 96, 128, 256, 512):
-                icon0.addPixmap(icon.pixmap(size, size))
-            return icon0
+                icon.addPixmap(wrapping_icon.pixmap(size, size))
+            return icon
         else:
             # Normal state
             # NOTE: We take pixmaps as large as the ones below to not have
             # pixelated icons on high dpi screens.
             # Fixes spyder-ide/spyder#19520
-            normal_state = icon.pixmap(512, 512)
-            icon0.addPixmap(normal_state, QIcon.Normal)
+            normal_state = wrapping_icon.pixmap(512, 512)
+            icon.addPixmap(normal_state, QIcon.Normal)
 
             # This is the color GammaRay reports for icons in disabled
             # buttons, both for the dark and light themes
@@ -403,14 +409,14 @@ class IconManager():
 
             # Paint icon with the previous color to get the disabled state.
             # Taken from https://stackoverflow.com/a/65618075/438386
-            disabled_state = icon.pixmap(512, 512)
+            disabled_state = wrapping_icon.pixmap(512, 512)
             qp = QPainter(disabled_state)
             qp.setCompositionMode(QPainter.CompositionMode_SourceIn)
             qp.fillRect(disabled_state.rect(), disabled_color)
             qp.end()
-            icon0.addPixmap(disabled_state, QIcon.Disabled)
+            icon.addPixmap(disabled_state, QIcon.Disabled)
 
-            return icon0
+            return icon
 
     def icon(self, name, scale_factor=None, resample=False):
         theme = CONF.get('appearance', 'icon_theme')

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -381,19 +381,21 @@ class IconManager():
             platforms due to a Qt bug. See spyder-ide/spyder#1314.
         """
         icon_path = get_image_path(name)
+        icon = QIcon(icon_path)
+        icon0 = QIcon()
+
         if resample:
             # This only applies to the Spyder 2 icons
-            icon = QIcon(icon_path)
-            icon0 = QIcon()
             for size in (16, 24, 32, 48, 96, 128, 256, 512):
                 icon0.addPixmap(icon.pixmap(size, size))
             return icon0
         else:
-            icon = QIcon()
-
             # Normal state
-            normal_state = QPixmap(icon_path)
-            icon.addPixmap(normal_state, QIcon.Normal)
+            # NOTE: We take pixmaps as large as the ones below to not have
+            # pixelated icons on high dpi screens.
+            # Fixes spyder-ide/spyder#19520
+            normal_state = icon.pixmap(512, 512)
+            icon0.addPixmap(normal_state, QIcon.Normal)
 
             # This is the color GammaRay reports for icons in disabled
             # buttons, both for the dark and light themes
@@ -401,14 +403,14 @@ class IconManager():
 
             # Paint icon with the previous color to get the disabled state.
             # Taken from https://stackoverflow.com/a/65618075/438386
-            disabled_state = QPixmap(icon_path)
+            disabled_state = icon.pixmap(512, 512)
             qp = QPainter(disabled_state)
             qp.setCompositionMode(QPainter.CompositionMode_SourceIn)
             qp.fillRect(disabled_state.rect(), disabled_color)
             qp.end()
-            icon.addPixmap(disabled_state, QIcon.Disabled)
+            icon0.addPixmap(disabled_state, QIcon.Disabled)
 
-            return icon
+            return icon0
 
     def icon(self, name, scale_factor=None, resample=False):
         theme = CONF.get('appearance', 'icon_theme')


### PR DESCRIPTION
## Description of Changes

- SVG icons were looking like this in high dpi screens or when Spyder's `custom high DPI scaling` is set to `2.0` in Preferences:

    ![image](https://user-images.githubusercontent.com/365293/191419053-b6d35217-325b-4c9b-abc3-906b94c2ab07.png)

    Now they look like this

    ![image](https://user-images.githubusercontent.com/365293/191419222-9bcdd657-d827-4f64-bcdc-7fcec1dd7425.png)

- This regression was introduced in PR #17811, when trying to set the disabled state of SVG icons.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19520.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
