### PR TITLE
PR: Update Tkinter assets copy logic for the Windows installer and fix Tkinter backend handling when debugging

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = 2.x
-	commit = 3172aada37ab0bdb7a1142acdbcfdad193d06244
-	parent = 3ea2d236785c4797a545b0f2b6b673c7fdc8abce
+	commit = 3b909ab8e996d2da271c6cf818f5275a680db2ff
+	parent = 7b37f38bdcbc89ac8abfe05b5a2a6c82e2e0c2fe
 	method = merge
-	cmdver = 0.4.1
+	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spyderpdb.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spyderpdb.py
@@ -10,6 +10,7 @@
 import ast
 import bdb
 import logging
+import os
 import sys
 import traceback
 import threading
@@ -703,7 +704,13 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         if is_main_thread and kernel.eventloop:
             while self._cmd_input_line is None:
                 eventloop = kernel.eventloop
-                if eventloop:
+                # Check if the current backend is Tk on Windows
+                # to let GUI update.
+                # See spyder-ide/spyder#17523
+                if (eventloop and hasattr(kernel, "app_wrapper") and
+                        os.name == "nt"):
+                    kernel.app_wrapper.app.update()
+                elif eventloop:
                     eventloop(kernel)
                 else:
                     break

--- a/installers/Windows/installer.py
+++ b/installers/Windows/installer.py
@@ -102,8 +102,6 @@ files={package_dist_info} > $INSTDIR/pkgs
     __main__.py > $INSTDIR/pkgs/jedi/inference/compiled/subprocess
     __init__.py > $INSTDIR/pkgs/pylint
     lib
-    tcl86t.dll > $INSTDIR/pkgs
-    tk86t.dll > $INSTDIR/pkgs
     micromamba.exe > $INSTDIR/pkgs/spyder/bin
 [Build]
 installer_name={installer_name}
@@ -355,14 +353,11 @@ def run(python_version, bitness, repo_root, entrypoint, package, icon_path,
 
             print("Copying required assets for Tkinter to work")
             shutil.copytree(
-                "installers/Windows/assets/tcl/lib",
+                "installers/Windows/assets/tkinter/lib",
                 os.path.join(work_dir, "lib"))
-            shutil.copy(
-                "installers/Windows/assets/tcl/tcl86t.dll",
-                os.path.join(work_dir, "tcl86t.dll"))
-            shutil.copy(
-                "installers/Windows/assets/tcl/tk86t.dll",
-                os.path.join(work_dir, "tk86t.dll"))
+            shutil.copytree(
+                "installers/Windows/assets/tkinter/pynsist_pkgs",
+                os.path.join(work_dir, "pynsist_pkgs"))
 
             print("Copying micromamba assets")
             shutil.copy(

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1869,8 +1869,6 @@ def test_startup_code_pdb(ipyconsole, qtbot):
 def test_pdb_eventloop(ipyconsole, qtbot, backend):
     """Check if setting an event loop while debugging works."""
     # Skip failing tests
-    if backend == 'tk' and os.name == 'nt':
-        return
     if backend == 'osx' and sys.platform != "darwin":
         return
     if backend == 'qt5' and not os.name == "nt" and running_in_ci():


### PR DESCRIPTION
## Description of Changes

- Update way tkinter assets are copy to build Windows installers
- Fix spyder-kernels debug handling of the Tkinter backend
- Depends on spyder-ide/spyder-kernels#415.
- Depends on [spyder-ide/windows-installer-assets release 0.9.0](https://github.com/spyder-ide/windows-installer-assets/milestone/2)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #17523


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
