### PR TITLE
PR: Fix errors when Projects plugin is disabled

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -477,7 +477,8 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         if self.projects is not None:
             active_project_path = self.projects.get_active_project_path()
         if not active_project_path:
-            self.set_open_filenames()
+            filenames = self.get_open_filenames()
+            self.set_option('filenames', filenames)
         else:
             self.projects.set_project_filenames(
                 [finfo.filename for finfo in editorstack.data])
@@ -3432,18 +3433,6 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         filenames = []
         filenames += [finfo.filename for finfo in editorstack.data]
         return filenames
-
-    def set_open_filenames(self):
-        """
-        Set the recent opened files on editor based on active project.
-
-        If no project is active, then editor filenames are saved, otherwise
-        the opened filenames are stored in the project config info.
-        """
-        if self.projects is not None:
-            if not self.projects.get_active_project():
-                filenames = self.get_open_filenames()
-                self.set_option('filenames', filenames)
 
     def setup_open_files(self, close_previous_files=True):
         """

--- a/spyder/plugins/editor/tests/conftest.py
+++ b/spyder/plugins/editor/tests/conftest.py
@@ -129,8 +129,10 @@ def editor_plugin_open_files(request, editor_plugin, python_files):
 
         def get_option(option, default=None):
             return options_dict.get(option)
+
         def set_option(option, value):
             options_dict[option] = value
+
         editor.get_option = get_option
         editor.set_option = set_option
 

--- a/spyder/plugins/editor/tests/conftest.py
+++ b/spyder/plugins/editor/tests/conftest.py
@@ -129,7 +129,10 @@ def editor_plugin_open_files(request, editor_plugin, python_files):
 
         def get_option(option, default=None):
             return options_dict.get(option)
+        def set_option(option, value):
+            options_dict[option] = value
         editor.get_option = get_option
+        editor.set_option = set_option
 
         editor.setup_open_files()
         return editor, expected_filenames, expected_current_filename

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -61,6 +61,36 @@ def test_setup_open_files(editor_plugin_open_files, last_focused_filename,
     assert filenames == expected_filenames
 
 
+def test_restore_open_files(qtbot, editor_plugin_open_files):
+    """Test restoring of opened files without Projects plugin"""
+    editor_factory = editor_plugin_open_files
+    editor, expected_filenames, expected_current_filename = (
+        editor_factory(None, None))
+
+    # Pre-condition: Projects plugin is disabled
+    assert editor.projects is None
+
+    # `expected_filenames` is modified. A copy is required because
+    # `expected_filenames` and `editor.get_option("filesnames")` are the same
+    # object.
+    expected_filenames = expected_filenames.copy()
+    assert expected_filenames is not editor.get_option("filenames")
+    for i in range(2):
+        filename = expected_filenames.pop()
+        editor.close_file_from_name(filename)
+
+    # Close editor and check that opened files are saved
+    editor.closing_plugin()
+    filenames = [osp.normcase(f) for f in editor.get_option("filenames")]
+    assert filenames == expected_filenames
+
+    # “Re-open” editor and check the opened files are restored
+    editor.setup_open_files(close_previous_files=True)
+    filenames = editor.get_current_editorstack().get_filenames()
+    filenames = [osp.normcase(f) for f in filenames]
+    assert filenames == expected_filenames
+
+
 def test_setup_open_files_cleanprefs(editor_plugin_open_files):
     """Test that Editor successfully opens files if layout is not defined.
 

--- a/spyder/plugins/mainmenu/plugin.py
+++ b/spyder/plugins/mainmenu/plugin.py
@@ -19,7 +19,7 @@ from qtpy.QtGui import QKeySequence
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
-from spyder.api.plugins import SpyderPluginV2, SpyderDockablePlugin
+from spyder.api.plugins import SpyderPluginV2, SpyderDockablePlugin, Plugins
 from spyder.api.translations import get_translation
 from spyder.api.widgets.menus import MENU_SEPARATOR, SpyderMenu
 from spyder.plugins.mainmenu.api import ApplicationMenu, ApplicationMenus
@@ -70,7 +70,8 @@ class MainMenu(SpyderPluginV2):
         create_app_menu(ApplicationMenus.Run, _("&Run"), dynamic=False)
         create_app_menu(ApplicationMenus.Debug, _("&Debug"), dynamic=False)
         create_app_menu(ApplicationMenus.Consoles, _("C&onsoles"))
-        create_app_menu(ApplicationMenus.Projects, _("&Projects"))
+        if self.is_plugin_enabled(Plugins.Projects):
+            create_app_menu(ApplicationMenus.Projects, _("&Projects"))
         create_app_menu(ApplicationMenus.Tools, _("&Tools"))
         create_app_menu(ApplicationMenus.View, _("&View"))
         create_app_menu(ApplicationMenus.Help, _("&Help"))


### PR DESCRIPTION
## Description of Changes
Fix two issues when Projects plugin is disabled:
* Fix re-opening of files from previous session when Projects plugin is disabled. Added test.
* Don’t add empty Projects menu when Projects plugin is disabled

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:

rear1019