### PR TITLE
PR: Temporary fix for function `test_no_empty_file_items`

### DIFF
--- a/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
+++ b/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
@@ -341,11 +341,21 @@ def test_no_empty_file_items(findinfiles, qtbot):
         },
         {
             'spam.cpp': [(2, 9), (6, 15), (8, 2), (11, 4), (11, 10), (13, 12)]
+        },
+        {
+            'spam.txt': [(1, 0), (1, 5), (3, 22)],
+            'spam.cpp': [(2, 9), (6, 15), (8, 2)]
+        },
+        {
+            'spam.py': [(2, 7), (5, 1), (7, 12)],
+            'spam.cpp': [(2, 9), (6, 15), (8, 2)]
         }
-    ]    
+    ]
     assert (
         process_search_results(findinfiles.result_browser.data) == results[0] or
-        process_search_results(findinfiles.result_browser.data) == results[1]
+        process_search_results(findinfiles.result_browser.data) == results[1] or
+        process_search_results(findinfiles.result_browser.data) == results[2] or
+        process_search_results(findinfiles.result_browser.data) == results[3]
     )
 
     # Assert that the files with results are exactly the same as those


### PR DESCRIPTION
looks like the results of findinfiles.find() aren't deterministic and it's causing test_no_empty_file_items to fail

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19602


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
stevetracvc
<!--- Thanks for your help making Spyder better for everyone! --->
