### PR TITLE
PR: Show Spyder-kernels message on restarts (IPython console)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -111,7 +111,7 @@ To release a new version of Spyder you need to follow these steps:
   - `spyder/dependencies.py`
   - `requirements/{main,windows,macos,linux}.yml`
   - `binder/environment.yml`
-  - `spyder/plugins/ipythonconsole/widgets/main_widget.py` (look up for the constants `SPYDER_KERNELS_MIN_VERSION` and `SPYDER_KERNELS_MAX_VERSION`)
+  - `spyder/plugins/ipythonconsole/widgets/__init__.py` (look up for the constants `SPYDER_KERNELS_MIN_VERSION` and `SPYDER_KERNELS_MAX_VERSION`)
 
 **Note**: Usually, the version of `spyder-kernels` for validation in the IPython Console only needs to be updated for minor or major releases of that package. For bugfix releases the value should remain the same to not hassle users using custom interpreters into updating `spyder-kernels` in their environments. However, this depends on the type of bugs resolved and if it's worthy to reinforce the need of an update even for those versions.
 

--- a/spyder/plugins/ipythonconsole/__init__.py
+++ b/spyder/plugins/ipythonconsole/__init__.py
@@ -10,3 +10,13 @@ spyder.plugins.ipythonconsole
 
 IPython Console plugin based on QtConsole
 """
+
+# Required version of Spyder-kernels
+SPYDER_KERNELS_MIN_VERSION = '2.3.0'
+SPYDER_KERNELS_MAX_VERSION = '2.4.0'
+SPYDER_KERNELS_VERSION = (
+    f'>={SPYDER_KERNELS_MIN_VERSION};<{SPYDER_KERNELS_MAX_VERSION}')
+SPYDER_KERNELS_CONDA = (
+    f'conda install spyder&#45;kernels={SPYDER_KERNELS_MIN_VERSION[:-2]}')
+SPYDER_KERNELS_PIP = (
+    f'pip install spyder&#45;kernels=={SPYDER_KERNELS_MIN_VERSION[:-1]}*')

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -2440,5 +2440,47 @@ def test_run_script(ipyconsole, qtbot, tmp_path):
         assert sw.get_value(variable_name) == 1
 
 
+@pytest.mark.skipif(
+    not sys.platform.startswith('linux'),
+    reason="Only runs on Linux")
+def test_show_spyder_kernels_error_on_restart(ipyconsole, qtbot):
+    """Test that we show Spyder-kernels error message on restarts."""
+    # Wait until the window is fully up
+    shell = ipyconsole.get_current_shellwidget()
+    qtbot.waitUntil(
+        lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
+
+    # Point to an interpreter without Spyder-kernels
+    ipyconsole.set_conf('default', False, section='main_interpreter')
+    ipyconsole.set_conf('executable', '/usr/bin/python3',
+                        section='main_interpreter')
+
+    # Restart kernel
+    os.environ['SPY_TEST_SHOW_RESTART_MESSAGE'] = 'true'
+    ipyconsole.restart_kernel()
+
+    # Assert we show a kernel error
+    info_page = ipyconsole.get_current_client().infowidget.page()
+
+    qtbot.waitUntil(
+        lambda: check_text(
+            info_page,
+            "The Python environment or installation"
+        ),
+        timeout=6000
+    )
+
+    # To check kernel error visually
+    qtbot.wait(500)
+
+    # Check kernel related actions are disabled
+    main_widget = ipyconsole.get_widget()
+    assert not main_widget.restart_action.isEnabled()
+    assert not main_widget.reset_action.isEnabled()
+    assert not main_widget.env_action.isEnabled()
+    assert not main_widget.syspath_action.isEnabled()
+    assert not main_widget.show_time_action.isEnabled()
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -328,11 +328,16 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
 
         We also ignore errors about comms, which are irrelevant.
         """
+        if not self.has_spyder_kernels():
+            return True
+
         if self.start_successful:
             return False
+
         stderr = self.stderr_obj.get_contents()
         if not stderr:
             return False
+
         # There is an error. If it is benign, ignore.
         for line in stderr.splitlines():
             if line and not self.is_benign_error(line):

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -833,7 +833,12 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
                 interpreter=pyexec,
                 version=SPYDER_KERNELS_VERSION)
 
-            if not has_spyder_kernels and not running_under_pytest():
+            if (
+                not has_spyder_kernels
+                # This is necessary to show this message for some tests and not
+                # do it for others.
+                and os.environ.get('SPY_TEST_SHOW_RESTART_MESSAGE')
+            ):
                 self.show_kernel_error(
                     _("The Python environment or installation whose "
                       "interpreter is located at"

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -37,8 +37,12 @@ from spyder.utils.installers import InstallerIPythonKernelError
 from spyder.utils.encoding import get_coding
 from spyder.utils.environ import RemoteEnvDialog
 from spyder.utils.palette import QStylePalette
+from spyder.utils import programs
 from spyder.utils.qthelpers import add_actions, DialogManager
 from spyder.py3compat import to_text_string
+from spyder.plugins.ipythonconsole import (
+    SPYDER_KERNELS_CONDA, SPYDER_KERNELS_MAX_VERSION,
+    SPYDER_KERNELS_MIN_VERSION, SPYDER_KERNELS_PIP, SPYDER_KERNELS_VERSION)
 from spyder.plugins.ipythonconsole.widgets import ShellWidget
 from spyder.widgets.collectionseditor import CollectionsEditor
 from spyder.widgets.mixins import SaveHistoryMixin
@@ -62,6 +66,9 @@ TEMPLATES_PATH = osp.join(
 BLANK = open(osp.join(TEMPLATES_PATH, 'blank.html')).read()
 LOADING = open(osp.join(TEMPLATES_PATH, 'loading.html')).read()
 KERNEL_ERROR = open(osp.join(TEMPLATES_PATH, 'kernel_error.html')).read()
+SPYDER_KERNELS_VERSION_MSG = _(
+    '>= {0} and < {1}').format(
+        SPYDER_KERNELS_MIN_VERSION, SPYDER_KERNELS_MAX_VERSION)
 
 try:
     time.monotonic  # time.monotonic new in 3.3
@@ -808,6 +815,51 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
         self._hide_loading_page()
         self.restart_thread = None
         self.sig_execution_state_changed.emit()
+
+    def has_spyder_kernels(self):
+        """
+        Check if the kernel has the right Spyder-kernels version and show a
+        message in case that's not the true.
+        """
+        if not self.get_conf('default', section='main_interpreter'):
+            pyexec = self.get_conf('executable', section='main_interpreter')
+            has_spyder_kernels = programs.is_module_installed(
+                'spyder_kernels',
+                interpreter=pyexec,
+                version=SPYDER_KERNELS_VERSION)
+
+            if not has_spyder_kernels and not running_under_pytest():
+                self.show_kernel_error(
+                    _("The Python environment or installation whose "
+                      "interpreter is located at"
+                      "<pre>"
+                      "    <tt>{0}</tt>"
+                      "</pre>"
+                      "doesn't have the <tt>spyder-kernels</tt> module or the "
+                      "right version of it installed ({1}). "
+                      "Without this module is not possible for Spyder to "
+                      "create a console for you.<br><br>"
+                      "You can install it by activating your environment (if "
+                      "necessary) and then running in a system terminal:"
+                      "<pre>"
+                      "    <tt>{2}</tt>"
+                      "</pre>"
+                      "or"
+                      "<pre>"
+                      "    <tt>{3}</tt>"
+                      "</pre>").format(
+                          pyexec,
+                          SPYDER_KERNELS_VERSION_MSG,
+                          SPYDER_KERNELS_CONDA,
+                          SPYDER_KERNELS_PIP
+                      )
+                )
+
+                return False
+            else:
+                return True
+        else:
+            return True
 
     def filter_fault(self, fault):
         """Get a fault from a previous session."""

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -642,9 +642,22 @@ class IPythonConsoleWidget(PluginMainWidget):
     def update_actions(self):
         client = self.get_current_client()
         if client is not None:
+            # Executing state
             executing = client.is_client_executing()
             self.interrupt_action.setEnabled(executing)
             self.stop_button.setEnabled(executing)
+
+            # Client is loading or showing a kernel error
+            if (
+                client.infowidget is not None
+                and client.info_page is not None
+            ):
+                error_or_loading = client.info_page != client.blank_page
+                self.restart_action.setEnabled(not error_or_loading)
+                self.reset_action.setEnabled(not error_or_loading)
+                self.env_action.setEnabled(not error_or_loading)
+                self.syspath_action.setEnabled(not error_or_loading)
+                self.show_time_action.setEnabled(not error_or_loading)
 
     # ---- GUI options
     @on_conf_change(section='help', option='connect/ipython_console')

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -58,17 +58,6 @@ _ = get_translation('spyder')
 # ---- Constants
 # =============================================================================
 MAIN_BG_COLOR = QStylePalette.COLOR_BACKGROUND_1
-SPYDER_KERNELS_MIN_VERSION = '2.3.0'
-SPYDER_KERNELS_MAX_VERSION = '2.4.0'
-SPYDER_KERNELS_VERSION = (
-    f'>={SPYDER_KERNELS_MIN_VERSION};<{SPYDER_KERNELS_MAX_VERSION}')
-SPYDER_KERNELS_VERSION_MSG = _(
-    '>= {0} and < {1}').format(
-        SPYDER_KERNELS_MIN_VERSION, SPYDER_KERNELS_MAX_VERSION)
-SPYDER_KERNELS_CONDA = (
-    f'conda install spyder&#45;kernels={SPYDER_KERNELS_MIN_VERSION[:-2]}')
-SPYDER_KERNELS_PIP = (
-    f'pip install spyder&#45;kernels=={SPYDER_KERNELS_MIN_VERSION[:-1]}*')
 
 
 class IPythonConsoleWidgetActions:
@@ -1470,39 +1459,8 @@ class IPythonConsoleWidget(PluginMainWidget):
 
         # Check if ipykernel is present in the external interpreter.
         # Else we won't be able to create a client
-        if not self.get_conf('default', section='main_interpreter'):
-            pyexec = self.get_conf('executable', section='main_interpreter')
-            has_spyder_kernels = programs.is_module_installed(
-                'spyder_kernels',
-                interpreter=pyexec,
-                version=SPYDER_KERNELS_VERSION)
-            if not has_spyder_kernels and not running_under_pytest():
-                client.show_kernel_error(
-                    _("The Python environment or installation whose "
-                      "interpreter is located at"
-                      "<pre>"
-                      "    <tt>{0}</tt>"
-                      "</pre>"
-                      "doesn't have the <tt>spyder-kernels</tt> module or the "
-                      "right version of it installed ({1}). "
-                      "Without this module is not possible for Spyder to "
-                      "create a console for you.<br><br>"
-                      "You can install it by activating your environment (if "
-                      "necessary) and then running in a system terminal:"
-                      "<pre>"
-                      "    <tt>{2}</tt>"
-                      "</pre>"
-                      "or"
-                      "<pre>"
-                      "    <tt>{3}</tt>"
-                      "</pre>").format(
-                          pyexec,
-                          SPYDER_KERNELS_VERSION_MSG,
-                          SPYDER_KERNELS_CONDA,
-                          SPYDER_KERNELS_PIP
-                      )
-                )
-                return
+        if not client.has_spyder_kernels():
+            return
 
         self.connect_client_to_kernel(client, km, kc)
         if client.shellwidget.kernel_manager is None:


### PR DESCRIPTION
## Description of Changes

- If users change their interpreter in `Preferences > Main Interpreter` to one without Spyder-kernels or the right version of it, we were showing the following after a restart:

     ![image](https://user-images.githubusercontent.com/365293/192809771-5ad115c3-79a1-4523-a98c-f83f94ba9431.png)

    Now we show this

    ![image](https://user-images.githubusercontent.com/365293/192810210-88f3384e-bab0-4f5f-9c00-53de620ff00e.png)

- Disable kernel related actions when it fails to start because it makes no sense to have them enabled.

    ![image](https://user-images.githubusercontent.com/365293/192810645-7daf3205-211b-4e94-83b4-22cca95207f2.png)

- Add a test that checks this.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
