### PR TITLE
PR: Simplify `test_no_empty_file_items` to only check filenames and total number of results

### DIFF
--- a/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
+++ b/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
@@ -322,41 +322,22 @@ def test_no_empty_file_items(findinfiles, qtbot):
 
     This is a regression test for issue spyder-ide/spyder#16256
     """
+    max_results = 6
     findinfiles.set_search_text("spam")
     findinfiles.set_directory(osp.join(LOCATION, "data"))
-    findinfiles.set_conf('max_results', 6)
+    findinfiles.set_conf('max_results', max_results)
 
     with qtbot.waitSignal(findinfiles.sig_max_results_reached):
         findinfiles.find()
 
-    # Assert the results are the expected ones to reproduce the bug this test
-    # tries to catch. In other words, this is here to prevent future changes to
-    # our test files that would render this test useless.
-    # Depending on OS the results could differ so here the only two possible
-    # results get listed:
-    results = [
-        {
-            'spam.py': [(2, 7), (5, 1), (7, 12)],
-            'spam.txt': [(1, 0), (1, 5), (3, 22)]
-        },
-        {
-            'spam.cpp': [(2, 9), (6, 15), (8, 2), (11, 4), (11, 10), (13, 12)]
-        },
-        {
-            'spam.txt': [(1, 0), (1, 5), (3, 22)],
-            'spam.cpp': [(2, 9), (6, 15), (8, 2)]
-        },
-        {
-            'spam.py': [(2, 7), (5, 1), (7, 12)],
-            'spam.cpp': [(2, 9), (6, 15), (8, 2)]
-        }
-    ]
-    assert (
-        process_search_results(findinfiles.result_browser.data) == results[0] or
-        process_search_results(findinfiles.result_browser.data) == results[1] or
-        process_search_results(findinfiles.result_browser.data) == results[2] or
-        process_search_results(findinfiles.result_browser.data) == results[3]
-    )
+    # Assert that the results all come from the expected files and that there
+    # are the correct number of them.  (We do not list the exact results
+    # expected because os.walk (used by findinfiles) gives an arbitrary file
+    # ordering.)
+    spamfiles = set(['spam.py', 'spam.txt', 'spam.cpp'])
+    find_results = process_search_results(findinfiles.result_browser.data)
+    assert set(find_results.keys()).issubset(spamfiles)
+    assert sum(len(finds) for finds in find_results.values()) == max_results
 
     # Assert that the files with results are exactly the same as those
     # displayed in the results browser.


### PR DESCRIPTION
## Description of Changes

This is the alternative simplification to this test discussed in #19602.  Since the purpose of this test is to ensure that there are no results picked up from files which do not match the search string, this simplified test only tests that rather than the precise details of the results obtained.  (Since `findinfiles` returns a non-deterministic result, the alternative is the current approach of listing all possible results.)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @juliangilbey 

<!--- Thanks for your help making Spyder better for everyone! --->
