### PR TITLE
PR: Catch error when trying to load unsupported data files (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
@@ -12,6 +12,7 @@ the Variable Explorer
 # Standard library imports
 import logging
 from pickle import PicklingError, UnpicklingError
+import tarfile
 import time
 
 # Third-party imports
@@ -21,6 +22,7 @@ from spyder_kernels.comms.commbase import CommError
 
 # Local imports
 from spyder.config.base import _
+from spyder.config.utils import IMPORT_EXT
 
 
 # For logging
@@ -165,6 +167,13 @@ class NamepaceBrowserWidget(RichJupyterWidget):
             return msg
         except TimeoutError:
             msg = _("Data is too big to be loaded")
+            return msg
+        except tarfile.ReadError:
+            # Fixes spyder-ide/spyder#19126
+            msg = _(f"The file could not be opened successfully. Recall that "
+                    f"the Variable Explorer supports the following file "
+                    f"extensions to import data:"
+                    f"<br><br><tt>{', '.join(IMPORT_EXT)}</tt>")
             return msg
         except (UnpicklingError, RuntimeError, CommError):
             return None

--- a/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
@@ -9,24 +9,21 @@ Widget that handle communications between the IPython Console and
 the Variable Explorer
 """
 
+# Standard library imports
 import logging
-import time
-try:
-    time.monotonic  # time.monotonic new in 3.3
-except AttributeError:
-    time.monotonic = time.time
-
 from pickle import PicklingError, UnpicklingError
+import time
 
-from qtpy.QtWidgets import QMessageBox
-
+# Third-party imports
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
-
-from spyder.config.base import _
-from spyder.py3compat import PY2, to_text_string, TimeoutError
+from qtpy.QtWidgets import QMessageBox
 from spyder_kernels.comms.commbase import CommError
 
+# Local imports
+from spyder.config.base import _
 
+
+# For logging
 logger = logging.getLogger(__name__)
 
 # Max time before giving up when making a blocking call to the kernel


### PR DESCRIPTION
## Description of Changes

- Even though we warn about unsupported file extensions when users try to use them to load data to the Variable Explorer (e.g. a Python file), we were throwing an error about it, which is incorrect.
- This PR catches that error and shows an appropriate message instead:

    **Before**

    ![image](https://user-images.githubusercontent.com/365293/193957102-4b950bde-1ed7-4bb3-98a3-136804a4cc48.png)

    **After**

    ![image](https://user-images.githubusercontent.com/365293/193956895-dcbe61cd-d68d-4ade-8f84-ff91ef94f373.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19126

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
