### PR TITLE
PR: Conform "find next" and "find previous" shortcuts to macOS standards

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -400,13 +400,14 @@ DEFAULTS = [
               '_/switch to variable_explorer': "Ctrl+Shift+V",
               '_/switch to find_in_files': "Ctrl+Shift+F",
               '_/switch to explorer': "Ctrl+Shift+X",
-              '_/switch to plots': "Ctrl+Shift+G",
+              '_/switch to plots': "Ctrl+Shift+J" if MAC else "Ctrl+Shift+G",
               '_/switch to pylint': "Ctrl+Shift+C",
               '_/switch to profiler': "Ctrl+Shift+R",
               # -- In widgets/findreplace.py
               'find_replace/find text': "Ctrl+F",
-              'find_replace/find next': "F3",
-              'find_replace/find previous': "Shift+F3",
+              'find_replace/find next': "Ctrl+G" if MAC else "F3",
+              'find_replace/find previous': (
+                  "Ctrl+Shift+G" if MAC else "Shift+F3"),
               'find_replace/replace text': "Ctrl+R",
               'find_replace/hide find and replace': "Escape",
               # ---- Editor ----
@@ -424,7 +425,7 @@ DEFAULTS = [
               'editor/move line up': "Alt+Up",
               'editor/move line down': "Alt+Down",
               'editor/go to new line': "Ctrl+Shift+Return",
-              'editor/go to definition': "Ctrl+G",
+              'editor/go to definition': "F3" if MAC else "Ctrl+G",
               'editor/toggle comment': "Ctrl+1",
               'editor/blockcomment': "Ctrl+4",
               'editor/unblockcomment': "Ctrl+5",
@@ -639,4 +640,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '71.0.0'
+CONF_VERSION = '71.1.0'


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

- Changed "find next" to "Ctrl+G" and "find previous" to "Ctrl+Shift+G" for macOS in the `find_replace` context.
- Changed "switch to plots" to "Shift+F3" and "go to definition" to "F3" for macOS.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15437


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary 

<!--- Thanks for your help making Spyder better for everyone! --->
