### PR TITLE
PR: Catch an error when loading pages in `WebView` widgets

### DIFF
--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -385,7 +385,14 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
         url is loaded.
         """
         super().load(url)
-        self.focusProxy().installEventFilter(self)
+
+        # This is required to catch an error with some compilations of Qt/PyQt
+        # packages, for which it seems this functionality is not working.
+        # Fixes spyder-ide/spyder#19818
+        try:
+            self.focusProxy().installEventFilter(self)
+        except AttributeError:
+            pass
 
     def eventFilter(self, widget, event):
         """


### PR DESCRIPTION
## Description of Changes

It seems Web widgets of MSys2 packages don't provide the `focusProxy` method. So, we need to catch the error generated due to that.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19818.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
