### PR TITLE
PR: Fix detecting that python-lsp-server is installed in editable mode (Development)

### DIFF
--- a/install_dev_repos.py
+++ b/install_dev_repos.py
@@ -38,12 +38,21 @@ for p in [DEVPATH] + list(DEPS_PATH.iterdir()):
         continue
 
     try:
-        dist = distribution(p.name)._path
+        dist = distribution(p.name)
     except PackageNotFoundError:
         dist = None
         editable = None
     else:
-        editable = (p == dist or p in dist.parents)
+        editable = (p == dist._path or p in dist._path.parents)
+
+        # This fixes detecting that PyLSP was installed in editable mode under
+        # some scenarios.
+        # Fixes spyder-ide/spyder#19712
+        if p.name == 'python-lsp-server':
+            for f in dist.files:
+                if 'editable' in f.name:
+                    editable = True
+                    break
 
     REPOS[p.name] = {'repo': p, 'dist': dist, 'editable': editable}
 


### PR DESCRIPTION
## Description of Changes

- I don't know when this stopped working, but now it introduces a huge delay when using `bootstrap.py`.
- I'm going to merge this to keep working during the weekend. But if someone else finds a better solution, please submit another PR for it.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19712 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
