### PR TITLE
PR: Improve how to save a file when the completion widget is visible (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -284,6 +284,9 @@ class CodeEditor(TextEditBaseWidget):
     # Used to signal font change
     sig_font_changed = Signal()
 
+    # Used to request saving a file
+    sig_save_requested = Signal()
+
     def __init__(self, parent=None):
         TextEditBaseWidget.__init__(self, parent)
 
@@ -4627,12 +4630,6 @@ class CodeEditor(TextEditBaseWidget):
             # Shift or Alt don't generate any text.
             # Fixes spyder-ide/spyder#11021
             self._start_completion_timer()
-
-        if event.modifiers() and self.is_completion_widget_visible():
-            # Hide completion widget before passing event modifiers
-            # since the keypress could be then a shortcut
-            # See spyder-ide/spyder#14806
-            self.completion_widget.hide()
 
         if key in {Qt.Key_Up, Qt.Key_Left, Qt.Key_Right, Qt.Key_Down}:
             self.hide_tooltip()

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2531,6 +2531,7 @@ class EditorStack(QWidget):
         editor.sig_process_code_analysis.connect(
             self.sig_update_code_analysis_actions)
         editor.sig_refresh_formatting.connect(self.sig_refresh_formatting)
+        editor.sig_save_requested.connect(self.save)
         language = get_file_language(fname, txt)
         editor.setup_editor(
             linenumbers=self.linenumbers_enabled,

--- a/spyder/plugins/editor/widgets/tests/test_completions_hide.py
+++ b/spyder/plugins/editor/widgets/tests/test_completions_hide.py
@@ -6,17 +6,10 @@
 
 """Tests some cases were completions need to be hidden."""
 
-# Standard lirary imports
-import sys
-
 # Third party imports
 from flaky import flaky
 import pytest
-
 from qtpy.QtCore import Qt
-
-# Local imports
-from spyder.config.base import running_in_ci
 
 
 @pytest.mark.slow
@@ -123,39 +116,6 @@ def test_automatic_completions_widget_visible(completions_codeeditor, qtbot):
     qtbot.keyPress(code_editor, Qt.Key_Backspace, delay=300)
     qtbot.wait(500)
     assert completion.isVisible()
-
-    code_editor.toggle_code_snippets(True)
-
-
-@pytest.mark.slow
-@pytest.mark.order(1)
-@flaky(max_runs=5)
-@pytest.mark.skipif(running_in_ci() and sys.platform.startswith('linux'),
-                    reason="Stalls test suite with Linux on CI")
-def test_automatic_completions_hide_on_save(completions_codeeditor, qtbot):
-    """Test on-the-fly completion closing when using save shortcut (Ctrl + S).
-
-    Regression test for issue #14806.
-    """
-    code_editor, _ = completions_codeeditor
-    completion = code_editor.completion_widget
-    code_editor.toggle_code_snippets(False)
-
-    code_editor.set_text('some = 0\nsomething = 1\n')
-    cursor = code_editor.textCursor()
-    code_editor.moveCursor(cursor.End)
-
-    # Complete some -> [some, something]
-    with qtbot.waitSignal(completion.sig_show_completions,
-                          timeout=10000) as sig:
-        qtbot.keyClicks(code_editor, 'some')
-    assert "some" in [x['label'] for x in sig.args[0]]
-    assert "something" in [x['label'] for x in sig.args[0]]
-
-    # Hide completion widget when saving
-    qtbot.keyPress(
-        code_editor, Qt.Key_S, modifier=Qt.ControlModifier, delay=300)
-    qtbot.waitUntil(lambda: completion.isHidden())
 
     code_editor.toggle_code_snippets(True)
 


### PR DESCRIPTION
## Description of Changes

- The previous solution hid the widget so the corresponding shortcut could take effect on its parent. However, that had some odd side effects, like for example that pressing `Shift` to get an underscore or a capitalized letter hid and showed the completion widget, which was annoying:

    ![completion-odd](https://user-images.githubusercontent.com/365293/196044627-2bb94085-9ca0-4c1c-99c8-f2374c628ef5.gif)

- Now we detect the keyboard shortcut corresponding to Save in the Completion widget and ask its CodeEditor to perform that operation, so there are no side effects involved (the gif shows both saving and pressing `Shift`):

    ![completion-new](https://user-images.githubusercontent.com/365293/196044783-2d796d5f-f08f-47c0-b1a3-b8860bcd838d.gif)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19372 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
