### PR TITLE
PR: Prevent error when multiple threads try to write messages from comm handlers (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = reentrant_lock
-	commit = fd431a43862749b817250118dd5de0b2a9d0acaa
-	parent = 0dcbbcef9606e5101ac8b2147e0e52d26a96d132
+	branch = 2.x
+	commit = 26c5e2303ad527697bb407cd0d54bad4357b3821
+	parent = 6c121ac659d90d73da58f926510074163a1ada88
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 2.x
-	commit = 53740c4919828ad65ebd4bf6457e0b394c252125
-	parent = 1cae0a52c37d602f7ec852e3150bfb789aaace03
+	branch = reentrant_lock
+	commit = fd431a43862749b817250118dd5de0b2a9d0acaa
+	parent = 0dcbbcef9606e5101ac8b2147e0e52d26a96d132
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/comms/frontendcomm.py
+++ b/external-deps/spyder-kernels/spyder_kernels/comms/frontendcomm.py
@@ -64,7 +64,7 @@ class FrontendComm(CommBase):
         self.register_call_handler('_send_comm_config',
                                    self._send_comm_config)
 
-        self.comm_lock = threading.Lock()
+        self.comm_lock = threading.RLock()
 
         # self.kernel.parent is IPKernelApp unless we are in tests
         if self.kernel.parent:
@@ -259,19 +259,22 @@ class FrontendComm(CommBase):
 
     def _remote_callback(self, call_name, call_args, call_kwargs):
         """Call the callback function for the remote call."""
-        saved_stdout_write = sys.stdout.write
-        saved_stderr_write = sys.stderr.write
-        thread_id = threading.get_ident()
-        sys.stdout.write = WriteWrapper(
-            saved_stdout_write, call_name, thread_id)
-        sys.stderr.write = WriteWrapper(
-            saved_stderr_write, call_name, thread_id)
-        try:
-            return super(FrontendComm, self)._remote_callback(
-                call_name, call_args, call_kwargs)
-        finally:
-            sys.stdout.write = saved_stdout_write
-            sys.stderr.write = saved_stderr_write
+        with self.comm_lock:
+            current_stdout = sys.stdout
+            current_stderr = sys.stderr
+            saved_stdout_write = current_stdout.write
+            saved_stderr_write = current_stderr.write
+            thread_id = threading.get_ident()
+            current_stdout.write = WriteWrapper(
+                saved_stdout_write, call_name, thread_id)
+            current_stderr.write = WriteWrapper(
+                saved_stderr_write, call_name, thread_id)
+            try:
+                return super(FrontendComm, self)._remote_callback(
+                    call_name, call_args, call_kwargs)
+            finally:
+                current_stdout.write = saved_stdout_write
+                current_stderr.write = saved_stderr_write
 
 
 class WriteWrapper(object):


### PR DESCRIPTION
## Description of Changes

- We're not sure if this will solve the problem (see https://github.com/spyder-ide/spyder/issues/19735#issuecomment-1277218194), but it's the best we can do at the moment.
- Depends on spyder-ide/spyder-kernels#420 and spyder-ide/spyder-kernels#422

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19735 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
