### PR TITLE
PR: Fix `test_kernel_crash` to work with IPython 8+

### DIFF
--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1365,7 +1365,6 @@ def test_stderr_file_remains_two_kernels(ipyconsole, qtbot, monkeypatch):
     ipyconsole.close_client(client=client)
     assert osp.exists(client.stderr_obj.filename)
 
-
 @flaky(max_runs=3)
 @pytest.mark.skipif(sys.platform == 'darwin',
                     reason="Fails sometimes on macOS")
@@ -1373,11 +1372,11 @@ def test_kernel_crash(ipyconsole, qtbot):
     """Test that we show an error message when a kernel crash occurs."""
     # Create an IPython kernel config file with a bad config
     ipy_kernel_cfg = osp.join(get_ipython_dir(), 'profile_default',
-                              'ipython_kernel_config.py')
+                              'ipython_config.py')
     try:
         with open(ipy_kernel_cfg, 'w') as f:
             # This option must be a string, not an int
-            f.write("c.InteractiveShellApp.extra_extension = 1")
+            f.write("c.InteractiveShellApp.extra_extensions = 1")
 
         ipyconsole.get_widget().close_cached_kernel()
         ipyconsole.create_new_client()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

This PR fixes the `test_kernel_crash` for usage with ipython>=8. (one of the failing tests from https://github.com/spyder-ide/spyder/pull/19817) 

It now uses one of the documented properties (e.g. `c.InteractiveShellApp.extra_extensions`, instead of ` c.InteractiveShellApp.extra_extension` , https://ipython.readthedocs.io/en/stable/config/options/terminal.html), but setting it to an invalid value to trigger an error.

The updated test is not actually executed with ipython8+, but has been tested locally. Addition of ipython 8+ is explored in https://github.com/spyder-ide/spyder/pull/19817

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
