### PR TITLE
PR: Some fixes to make Spyder work with the latest changes in PyLSP

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -38,6 +38,9 @@ if [ "$USE_CONDA" = "true" ]; then
     else
         mamba install 'numpy<1.23'
     fi
+
+    # Install docstring-to-markdown until we release PyLSP 1.6.0
+    mamba install docstring-to-markdown
 else
     # Update pip and setuptools
     python -m pip install -U pip setuptools wheel build
@@ -63,6 +66,8 @@ else
         pip install pyqt5==5.12.* pyqtwebengine==5.12.*
     fi
 
+    # Install docstring-to-markdown until we release PyLSP 1.6.0
+    pip install docstring-to-markdown
 fi
 
 # Install subrepos from source

--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/python-lsp/python-lsp-server.git
 	branch = develop
-	commit = 6501e9eb80c7c3b35cf93f634834558fc88dee68
-	parent = 13da995dc08e14f82c07d018ca7130021fc7ad56
+	commit = 5c37673ce1a49651bb0e0866a8602a994f434b45
+	parent = ef4a41ee7fb7f0afe03311e856f04650930555c5
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/CONFIGURATION.md
+++ b/external-deps/python-lsp-server/CONFIGURATION.md
@@ -1,9 +1,9 @@
 # Python Language Server Configuration
-This server can be configured using `workspace/didChangeConfiguration` method. Each configuration option is described below:
+This server can be configured using the `workspace/didChangeConfiguration` method. Each configuration option is described below. Note, a value of `null` means that we do not set a value and thus use the plugin's default value.
 
 | **Configuration Key** | **Type** | **Description** | **Default** 
 |----|----|----|----|
-| `pylsp.configurationSources` | `array` of unique `string` (one of: `pycodestyle`, `pyflakes`) items | List of configuration sources to use. | `["pycodestyle"]` |
+| `pylsp.configurationSources` | `array` of unique `string` (one of: `'pycodestyle'`, `'flake8'`) items | List of configuration sources to use. | `["pycodestyle"]` |
 | `pylsp.plugins.autopep8.enabled` | `boolean` | Enable or disable the plugin (disabling required to use `yapf`). | `true` |
 | `pylsp.plugins.flake8.config` | `string` | Path to the config file that will be the authoritative config source. | `null` |
 | `pylsp.plugins.flake8.enabled` | `boolean` | Enable or disable the plugin. | `false` |
@@ -16,16 +16,17 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 | `pylsp.plugins.flake8.indentSize` | `integer` | Set indentation spaces. | `null` |
 | `pylsp.plugins.flake8.perFileIgnores` | `array` of `string` items | A pairing of filenames and violation codes that defines which violations to ignore in a particular file, for example: `["file_path.py:W305,W304"]`). | `[]` |
 | `pylsp.plugins.flake8.select` | `array` of unique `string` items | List of errors and warnings to enable. | `null` |
+| `pylsp.plugins.jedi.auto_import_modules` | `array` of `string` items | List of module names for jedi.settings.auto_import_modules. | `["numpy"]` |
 | `pylsp.plugins.jedi.extra_paths` | `array` of `string` items | Define extra paths for jedi.Script. | `[]` |
 | `pylsp.plugins.jedi.env_vars` | `object` | Define environment variables for jedi.Script and Jedi.names. | `null` |
 | `pylsp.plugins.jedi.environment` | `string` | Define environment for jedi.Script and Jedi.names. | `null` |
 | `pylsp.plugins.jedi_completion.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.jedi_completion.include_params` | `boolean` | Auto-completes methods and classes with tabstops for each parameter. | `true` |
-| `pylsp.plugins.jedi_completion.include_class_objects` | `boolean` | Adds class objects as a separate completion item. | `true` |
-| `pylsp.plugins.jedi_completion.include_function_objects` | `boolean` | Adds function objects as a separate completion item. | `true` |
+| `pylsp.plugins.jedi_completion.include_class_objects` | `boolean` | Adds class objects as a separate completion item. | `false` |
+| `pylsp.plugins.jedi_completion.include_function_objects` | `boolean` | Adds function objects as a separate completion item. | `false` |
 | `pylsp.plugins.jedi_completion.fuzzy` | `boolean` | Enable fuzzy when requesting autocomplete. | `false` |
 | `pylsp.plugins.jedi_completion.eager` | `boolean` | Resolve documentation and detail eagerly. | `false` |
-| `pylsp.plugins.jedi_completion.resolve_at_most` | `number`  | How many labels and snippets (at most) should be resolved? | `25` |
+| `pylsp.plugins.jedi_completion.resolve_at_most` | `integer` | How many labels and snippets (at most) should be resolved? | `25` |
 | `pylsp.plugins.jedi_completion.cache_for` | `array` of `string` items | Modules for which labels and snippets should be cached. | `["pandas", "numpy", "tensorflow", "matplotlib"]` |
 | `pylsp.plugins.jedi_definition.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.jedi_definition.follow_imports` | `boolean` | The goto call will follow imports. | `true` |
@@ -37,23 +38,23 @@ This server can be configured using `workspace/didChangeConfiguration` method. E
 | `pylsp.plugins.jedi_symbols.all_scopes` | `boolean` | If True lists the names of all scopes instead of only the module namespace. | `true` |
 | `pylsp.plugins.jedi_symbols.include_import_symbols` | `boolean` | If True includes symbols imported from other libraries. | `true` |
 | `pylsp.plugins.mccabe.enabled` | `boolean` | Enable or disable the plugin. | `true` |
-| `pylsp.plugins.mccabe.threshold` | `number`  | The minimum threshold that triggers warnings about cyclomatic complexity. | `15` |
+| `pylsp.plugins.mccabe.threshold` | `integer` | The minimum threshold that triggers warnings about cyclomatic complexity. | `15` |
 | `pylsp.plugins.preload.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.preload.modules` | `array` of unique `string` items | List of modules to import on startup | `[]` |
 | `pylsp.plugins.pycodestyle.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.pycodestyle.exclude` | `array` of unique `string` items | Exclude files or directories which match these patterns. | `[]` |
 | `pylsp.plugins.pycodestyle.filename` | `array` of unique `string` items | When parsing directories, only check filenames matching these patterns. | `[]` |
-| `pylsp.plugins.pycodestyle.select` | `array` of unique `string` items | Select errors and warnings | `[]` |
+| `pylsp.plugins.pycodestyle.select` | `array` of unique `string` items | Select errors and warnings | `null` |
 | `pylsp.plugins.pycodestyle.ignore` | `array` of unique `string` items | Ignore errors and warnings | `[]` |
 | `pylsp.plugins.pycodestyle.hangClosing` | `boolean` | Hang closing bracket instead of matching indentation of opening bracket's line. | `null` |
-| `pylsp.plugins.pycodestyle.maxLineLength` | `number`  | Set maximum allowed line length. | `null` |
+| `pylsp.plugins.pycodestyle.maxLineLength` | `integer` | Set maximum allowed line length. | `null` |
 | `pylsp.plugins.pycodestyle.indentSize` | `integer` | Set indentation spaces. | `null` |
 | `pylsp.plugins.pydocstyle.enabled` | `boolean` | Enable or disable the plugin. | `false` |
-| `pylsp.plugins.pydocstyle.convention` | `string` (one of: `pep257`, `numpy`, `None`) | Choose the basic list of checked errors by specifying an existing convention. | `null` |
+| `pylsp.plugins.pydocstyle.convention` | `string` (one of: `'pep257'`, `'numpy'`, `None`) | Choose the basic list of checked errors by specifying an existing convention. | `null` |
 | `pylsp.plugins.pydocstyle.addIgnore` | `array` of unique `string` items | Ignore errors and warnings in addition to the specified convention. | `[]` |
 | `pylsp.plugins.pydocstyle.addSelect` | `array` of unique `string` items | Select errors and warnings in addition to the specified convention. | `[]` |
 | `pylsp.plugins.pydocstyle.ignore` | `array` of unique `string` items | Ignore errors and warnings | `[]` |
-| `pylsp.plugins.pydocstyle.select` | `array` of unique `string` items | Select errors and warnings | `[]` |
+| `pylsp.plugins.pydocstyle.select` | `array` of unique `string` items | Select errors and warnings | `null` |
 | `pylsp.plugins.pydocstyle.match` | `string` | Check only files that exactly match the given regular expression; default is to match files that don't start with 'test_' but end with '.py'. | `"(?!test_).*\\.py"` |
 | `pylsp.plugins.pydocstyle.matchDir` | `string` | Search only dirs that exactly match the given regular expression; default is to match dirs which do not begin with a dot. | `"[^\\.].*"` |
 | `pylsp.plugins.pyflakes.enabled` | `boolean` | Enable or disable the plugin. | `true` |

--- a/external-deps/python-lsp-server/pylsp/config/config.py
+++ b/external-deps/python-lsp-server/pylsp/config/config.py
@@ -71,7 +71,7 @@ class Config:
             try:
                 entry_point.load()
             except Exception as e:  # pylint: disable=broad-except
-                log.warning("Failed to load %s entry point '%s': %s", PYLSP, entry_point.name, e)
+                log.info("Failed to load %s entry point '%s': %s", PYLSP, entry_point.name, e)
                 self._pm.set_blocked(entry_point.name)
 
         # Load the entry points into pluggy, having blocked any failing ones

--- a/external-deps/python-lsp-server/pylsp/config/schema.json
+++ b/external-deps/python-lsp-server/pylsp/config/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Python Language Server Configuration",
-  "description": "This server can be configured using `workspace/didChangeConfiguration` method. Each configuration option is described below:",
+  "description": "This server can be configured using the `workspace/didChangeConfiguration` method. Each configuration option is described below. Note, a value of `null` means that we do not set a value and thus use the plugin's default value.",
   "type": "object",
   "properties": {
     "pylsp.configurationSources": {
@@ -10,7 +10,7 @@
       "description": "List of configuration sources to use.",
       "items": {
         "type": "string",
-        "enum": ["pycodestyle", "pyflakes"]
+        "enum": ["pycodestyle", "flake8"]
       },
       "uniqueItems": true
     },
@@ -87,6 +87,14 @@
       "uniqueItems": true,
       "description": "List of errors and warnings to enable."
     },
+    "pylsp.plugins.jedi.auto_import_modules": {
+      "type": "array",
+      "default": ["numpy"],
+      "items": {
+        "type": "string"
+      },
+      "description": "List of module names for jedi.settings.auto_import_modules."
+    },
     "pylsp.plugins.jedi.extra_paths": {
       "type": "array",
       "default": [],
@@ -117,12 +125,12 @@
     },
     "pylsp.plugins.jedi_completion.include_class_objects": {
       "type": "boolean",
-      "default": true,
+      "default": false,
       "description": "Adds class objects as a separate completion item."
     },
     "pylsp.plugins.jedi_completion.include_function_objects": {
       "type": "boolean",
-      "default": true,
+      "default": false,
       "description": "Adds function objects as a separate completion item."
     },
     "pylsp.plugins.jedi_completion.fuzzy": {
@@ -136,7 +144,7 @@
       "description": "Resolve documentation and detail eagerly."
     },
     "pylsp.plugins.jedi_completion.resolve_at_most": {
-      "type": "number",
+      "type": "integer",
       "default": 25,
       "description": "How many labels and snippets (at most) should be resolved?"
     },
@@ -199,7 +207,7 @@
       "description": "Enable or disable the plugin."
     },
     "pylsp.plugins.mccabe.threshold": {
-      "type": "number",
+      "type": "integer",
       "default": 15,
       "description": "The minimum threshold that triggers warnings about cyclomatic complexity."
     },
@@ -241,8 +249,8 @@
       "description": "When parsing directories, only check filenames matching these patterns."
     },
     "pylsp.plugins.pycodestyle.select": {
-      "type": "array",
-      "default": [],
+      "type": ["array", "null"],
+      "default": null,
       "items": {
         "type": "string"
       },
@@ -264,7 +272,7 @@
       "description": "Hang closing bracket instead of matching indentation of opening bracket's line."
     },
     "pylsp.plugins.pycodestyle.maxLineLength": {
-      "type": ["number", "null"],
+      "type": ["integer", "null"],
       "default": null,
       "description": "Set maximum allowed line length."
     },
@@ -312,8 +320,8 @@
       "description": "Ignore errors and warnings"
     },
     "pylsp.plugins.pydocstyle.select": {
-      "type": "array",
-      "default": [],
+      "type": ["array", "null"],
+      "default": null,
       "items": {
         "type": "string"
       },
@@ -370,12 +378,12 @@
       "description": "Enable or disable the plugin."
     },
     "pylsp.rope.extensionModules": {
-      "type": ["null", "string"],
+      "type": ["string", "null"],
       "default": null,
       "description": "Builtin and c-extension modules that are allowed to be imported and inspected by rope."
     },
     "pylsp.rope.ropeFolder": {
-      "type": ["null", "array"],
+      "type": ["array", "null"],
       "default": null,
       "items": {
         "type": "string"

--- a/external-deps/python-lsp-server/pylsp/plugins/autopep8_format.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/autopep8_format.py
@@ -13,13 +13,13 @@ log = logging.getLogger(__name__)
 
 
 @hookimpl(tryfirst=True)  # Prefer autopep8 over YAPF
-def pylsp_format_document(config, document, options=None):  # pylint: disable=unused-argument
+def pylsp_format_document(config, document, options):  # pylint: disable=unused-argument
     log.info("Formatting document %s with autopep8", document)
     return _format(config, document)
 
 
 @hookimpl(tryfirst=True)  # Prefer autopep8 over YAPF
-def pylsp_format_range(config, document, range, options=None):  # pylint: disable=redefined-builtin,unused-argument
+def pylsp_format_range(config, document, range, options):  # pylint: disable=redefined-builtin,unused-argument
     log.info("Formatting document %s in range %s with autopep8", document, range)
 
     # First we 'round' the range up/down to full lines only

--- a/external-deps/python-lsp-server/pylsp/plugins/jedi_completion.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/jedi_completion.py
@@ -50,11 +50,14 @@ def pylsp_completions(config, document, position):
         return None
 
     completion_capabilities = config.capabilities.get('textDocument', {}).get('completion', {})
-    snippet_support = completion_capabilities.get('completionItem', {}).get('snippetSupport')
+    item_capabilities = completion_capabilities.get('completionItem', {})
+    snippet_support = item_capabilities.get('snippetSupport')
+    supported_markup_kinds = item_capabilities.get('documentationFormat', ['markdown'])
+    preferred_markup_kind = _utils.choose_markup_kind(supported_markup_kinds)
 
     should_include_params = settings.get('include_params')
-    should_include_class_objects = settings.get('include_class_objects', True)
-    should_include_function_objects = settings.get('include_function_objects', True)
+    should_include_class_objects = settings.get('include_class_objects', False)
+    should_include_function_objects = settings.get('include_function_objects', False)
 
     max_to_resolve = settings.get('resolve_at_most', 25)
     modules_to_cache_for = settings.get('cache_for', None)
@@ -69,7 +72,8 @@ def pylsp_completions(config, document, position):
     ready_completions = [
         _format_completion(
             c,
-            include_params,
+            markup_kind=preferred_markup_kind,
+            include_params=include_params if c.type in ["class", "function"] else False,
             resolve=resolve_eagerly,
             resolve_label_or_snippet=(i < max_to_resolve)
         )
@@ -82,7 +86,8 @@ def pylsp_completions(config, document, position):
             if c.type == 'class':
                 completion_dict = _format_completion(
                     c,
-                    False,
+                    markup_kind=preferred_markup_kind,
+                    include_params=False,
                     resolve=resolve_eagerly,
                     resolve_label_or_snippet=(i < max_to_resolve)
                 )
@@ -119,12 +124,18 @@ def pylsp_completions(config, document, position):
 
 
 @hookimpl
-def pylsp_completion_item_resolve(completion_item, document):
+def pylsp_completion_item_resolve(config, completion_item, document):
     """Resolve formatted completion for given non-resolved completion"""
     shared_data = document.shared_data['LAST_JEDI_COMPLETIONS'].get(completion_item['label'])
+
+    completion_capabilities = config.capabilities.get('textDocument', {}).get('completion', {})
+    item_capabilities = completion_capabilities.get('completionItem', {})
+    supported_markup_kinds = item_capabilities.get('documentationFormat', ['markdown'])
+    preferred_markup_kind = _utils.choose_markup_kind(supported_markup_kinds)
+
     if shared_data:
         completion, data = shared_data
-        return _resolve_completion(completion, data)
+        return _resolve_completion(completion, data, markup_kind=preferred_markup_kind)
     return completion_item
 
 
@@ -178,18 +189,25 @@ def use_snippets(document, position):
             not (expr_type in _ERRORS and 'import' in code))
 
 
-def _resolve_completion(completion, d):
+def _resolve_completion(completion, d, markup_kind: str):
     # pylint: disable=broad-except
     completion['detail'] = _detail(d)
     try:
-        docs = _utils.format_docstring(d.docstring())
+        docs = _utils.format_docstring(
+            d.docstring(raw=True),
+            signatures=[
+                signature.to_string()
+                for signature in d.get_signatures()
+            ],
+            markup_kind=markup_kind
+        )
     except Exception:
         docs = ''
     completion['documentation'] = docs
     return completion
 
 
-def _format_completion(d, include_params=True, resolve=False, resolve_label_or_snippet=False):
+def _format_completion(d, markup_kind: str, include_params=True, resolve=False, resolve_label_or_snippet=False):
     completion = {
         'label': _label(d, resolve_label_or_snippet),
         'kind': _TYPE_MAP.get(d.type),
@@ -198,7 +216,7 @@ def _format_completion(d, include_params=True, resolve=False, resolve_label_or_s
     }
 
     if resolve:
-        completion = _resolve_completion(completion, d)
+        completion = _resolve_completion(completion, d, markup_kind)
 
     if d.type == 'path':
         path = osp.normpath(d.name)

--- a/external-deps/python-lsp-server/pylsp/plugins/rope_completion.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/rope_completion.py
@@ -4,7 +4,7 @@
 import logging
 from rope.contrib.codeassist import code_assist, sorted_proposals
 
-from pylsp import hookimpl, lsp
+from pylsp import _utils, hookimpl, lsp
 
 
 log = logging.getLogger(__name__)
@@ -16,10 +16,13 @@ def pylsp_settings():
     return {'plugins': {'rope_completion': {'enabled': False, 'eager': False}}}
 
 
-def _resolve_completion(completion, data):
+def _resolve_completion(completion, data, markup_kind):
     # pylint: disable=broad-except
     try:
-        doc = data.get_doc()
+        doc = _utils.format_docstring(
+            data.get_doc(),
+            markup_kind=markup_kind
+        )
     except Exception as e:
         log.debug("Failed to resolve Rope completion: %s", e)
         doc = ""
@@ -49,6 +52,11 @@ def pylsp_completions(config, workspace, document, position):
     rope_project = workspace._rope_project_builder(rope_config)
     document_rope = document._rope_resource(rope_config)
 
+    completion_capabilities = config.capabilities.get('textDocument', {}).get('completion', {})
+    item_capabilities = completion_capabilities.get('completionItem', {})
+    supported_markup_kinds = item_capabilities.get('documentationFormat', ['markdown'])
+    preferred_markup_kind = _utils.choose_markup_kind(supported_markup_kinds)
+
     try:
         definitions = code_assist(rope_project, document.source, offset, document_rope, maxfixes=3)
     except Exception as e:  # pylint: disable=broad-except
@@ -67,7 +75,7 @@ def pylsp_completions(config, workspace, document, position):
             }
         }
         if resolve_eagerly:
-            item = _resolve_completion(item, d)
+            item = _resolve_completion(item, d, preferred_markup_kind)
         new_definitions.append(item)
 
     # most recently retrieved completion items, used for resolution
@@ -83,12 +91,18 @@ def pylsp_completions(config, workspace, document, position):
 
 
 @hookimpl
-def pylsp_completion_item_resolve(completion_item, document):
+def pylsp_completion_item_resolve(config, completion_item, document):
     """Resolve formatted completion for given non-resolved completion"""
     shared_data = document.shared_data['LAST_ROPE_COMPLETIONS'].get(completion_item['label'])
+
+    completion_capabilities = config.capabilities.get('textDocument', {}).get('completion', {})
+    item_capabilities = completion_capabilities.get('completionItem', {})
+    supported_markup_kinds = item_capabilities.get('documentationFormat', ['markdown'])
+    preferred_markup_kind = _utils.choose_markup_kind(supported_markup_kinds)
+
     if shared_data:
         completion, data = shared_data
-        return _resolve_completion(completion, data)
+        return _resolve_completion(completion, data, preferred_markup_kind)
     return completion_item
 
 

--- a/external-deps/python-lsp-server/pylsp/plugins/yapf_format.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/yapf_format.py
@@ -16,12 +16,12 @@ log = logging.getLogger(__name__)
 
 
 @hookimpl
-def pylsp_format_document(document, options=None):
+def pylsp_format_document(document, options):
     return _format(document, options=options)
 
 
 @hookimpl
-def pylsp_format_range(document, range, options=None):  # pylint: disable=redefined-builtin
+def pylsp_format_range(document, range, options):  # pylint: disable=redefined-builtin
     # First we 'round' the range up/down to full lines only
     range['start']['character'] = 0
     range['end']['line'] += 1

--- a/external-deps/python-lsp-server/pylsp/workspace.py
+++ b/external-deps/python-lsp-server/pylsp/workspace.py
@@ -14,6 +14,8 @@ from . import lsp, uris, _utils
 
 log = logging.getLogger(__name__)
 
+DEFAULT_AUTO_IMPORT_MODULES = ["numpy"]
+
 # TODO: this is not the best e.g. we capture numbers
 RE_START_WORD = re.compile('[A-Za-z_0-9]*$')
 RE_END_WORD = re.compile('^[A-Za-z_0-9]*')
@@ -252,6 +254,8 @@ class Document:
 
         if self._config:
             jedi_settings = self._config.plugin_settings('jedi', document_path=self.path)
+            jedi.settings.auto_import_modules = jedi_settings.get('auto_import_modules',
+                                                                  DEFAULT_AUTO_IMPORT_MODULES)
             environment_path = jedi_settings.get('environment')
             extra_paths = jedi_settings.get('extra_paths') or []
             env_vars = jedi_settings.get('env_vars')

--- a/external-deps/python-lsp-server/pyproject.toml
+++ b/external-deps/python-lsp-server/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "jedi>=0.17.2,<0.19.0",
     "python-lsp-jsonrpc>=1.0.0",
     "pluggy>=1.0.0",
+    "docstring-to-markdown",
     "ujson>=3.0.0",
     "setuptools>=39.0.0",
 ]
@@ -52,7 +53,7 @@ test = [
     "pytest",
     "pytest-cov",
     "coverage",
-    "numpy<1.23",
+    "numpy",
     "pandas",
     "matplotlib",
     "pyqt5",

--- a/external-deps/python-lsp-server/scripts/jsonschema2md.py
+++ b/external-deps/python-lsp-server/scripts/jsonschema2md.py
@@ -41,7 +41,7 @@ def describe_type(prop: dict) -> str:
         if  option in EXTRA_DESCRIPTORS:
             parts.append(EXTRA_DESCRIPTORS[option](prop))
     if "enum" in prop:
-        allowed_values = [f"`{value}`" for value in prop["enum"]]
+        allowed_values = [f"`{value!r}`" for value in prop["enum"]]
         parts.append("(one of: " + ", ".join(allowed_values) + ")")
     return " ".join(parts)
 

--- a/external-deps/python-lsp-server/setup.py
+++ b/external-deps/python-lsp-server/setup.py
@@ -5,6 +5,7 @@
 
 from setuptools import setup, find_packages
 
+
 if __name__ == "__main__":
     setup(
         name="python-lsp-server",  # to allow GitHub dependency tracking work

--- a/external-deps/python-lsp-server/test/plugins/test_autopep8_format.py
+++ b/external-deps/python-lsp-server/test/plugins/test_autopep8_format.py
@@ -41,7 +41,7 @@ bar = {'foo': foo
 
 def test_format(config, workspace):
     doc = Document(DOC_URI, workspace, DOC)
-    res = pylsp_format_document(config, doc)
+    res = pylsp_format_document(config, doc, options=None)
 
     assert len(res) == 1
     assert res[0]['newText'] == "a = 123\n\n\ndef func():\n    pass\n"
@@ -54,7 +54,7 @@ def test_range_format(config, workspace):
         'start': {'line': 0, 'character': 0},
         'end': {'line': 2, 'character': 0}
     }
-    res = pylsp_format_range(config, doc, def_range)
+    res = pylsp_format_range(config, doc, def_range, options=None)
 
     assert len(res) == 1
 
@@ -64,12 +64,12 @@ def test_range_format(config, workspace):
 
 def test_no_change(config, workspace):
     doc = Document(DOC_URI, workspace, GOOD_DOC)
-    assert not pylsp_format_document(config, doc)
+    assert not pylsp_format_document(config, doc, options=None)
 
 
 def test_hanging_indentation(config, workspace):
     doc = Document(DOC_URI, workspace, INDENTED_DOC)
-    res = pylsp_format_document(config, doc)
+    res = pylsp_format_document(config, doc, options=None)
 
     assert len(res) == 1
     assert res[0]['newText'] == CORRECT_INDENTED_DOC
@@ -78,6 +78,6 @@ def test_hanging_indentation(config, workspace):
 @pytest.mark.parametrize('newline', ['\r\n', '\r'])
 def test_line_endings(config, workspace, newline):
     doc = Document(DOC_URI, workspace, f'import os;import sys{2 * newline}dict(a=1)')
-    res = pylsp_format_document(config, doc)
+    res = pylsp_format_document(config, doc, options=None)
 
     assert res[0]['newText'] == f'import os{newline}import sys{2 * newline}dict(a=1){newline}'

--- a/external-deps/python-lsp-server/test/plugins/test_completion.py
+++ b/external-deps/python-lsp-server/test/plugins/test_completion.py
@@ -160,10 +160,15 @@ def test_jedi_completion_item_resolve(config, workspace):
     assert 'detail' not in documented_hello_item
 
     resolved_documented_hello = pylsp_jedi_completion_item_resolve(
+        doc._config,
         completion_item=documented_hello_item,
         document=doc
     )
-    assert 'Sends a polite greeting' in resolved_documented_hello['documentation']
+    expected_doc = {
+        'kind': 'markdown',
+        'value': '```python\ndocumented_hello()\n```\n\n\nSends a polite greeting'
+    }
+    assert resolved_documented_hello['documentation'] == expected_doc
 
 
 def test_jedi_completion_with_fuzzy_enabled(config, workspace):
@@ -498,8 +503,8 @@ def test_jedi_completion_environment(workspace):
     completions = pylsp_jedi_completions(doc._config, doc, com_position)
     assert completions[0]['label'] == 'loghub'
 
-    resolved = pylsp_jedi_completion_item_resolve(completions[0], doc)
-    assert 'changelog generator' in resolved['documentation'].lower()
+    resolved = pylsp_jedi_completion_item_resolve(doc._config, completions[0], doc)
+    assert 'changelog generator' in resolved['documentation']['value'].lower()
 
 
 def test_document_path_completions(tmpdir, workspace_other_root_path):

--- a/external-deps/python-lsp-server/test/plugins/test_hover.py
+++ b/external-deps/python-lsp-server/test/plugins/test_hover.py
@@ -38,16 +38,16 @@ def test_numpy_hover(workspace):
     doc = Document(DOC_URI, workspace, NUMPY_DOC)
 
     contents = ''
-    assert contents in pylsp_hover(doc, no_hov_position)['contents']
+    assert contents in pylsp_hover(doc._config, doc, no_hov_position)['contents']
 
     contents = 'NumPy\n=====\n\nProvides\n'
-    assert contents in pylsp_hover(doc, numpy_hov_position_1)['contents'][0]
+    assert contents in pylsp_hover(doc._config, doc, numpy_hov_position_1)['contents']['value']
 
     contents = 'NumPy\n=====\n\nProvides\n'
-    assert contents in pylsp_hover(doc, numpy_hov_position_2)['contents'][0]
+    assert contents in pylsp_hover(doc._config, doc, numpy_hov_position_2)['contents']['value']
 
     contents = 'NumPy\n=====\n\nProvides\n'
-    assert contents in pylsp_hover(doc, numpy_hov_position_3)['contents'][0]
+    assert contents in pylsp_hover(doc._config, doc, numpy_hov_position_3)['contents']['value']
 
     # https://github.com/davidhalter/jedi/issues/1746
     # pylint: disable=import-outside-toplevel
@@ -55,8 +55,8 @@ def test_numpy_hover(workspace):
 
     if np.lib.NumpyVersion(np.__version__) < '1.20.0':
         contents = 'Trigonometric sine, element-wise.\n\n'
-        assert contents in pylsp_hover(
-            doc, numpy_sin_hov_position)['contents'][0]
+        assert contents in pylsp_hover(doc._config,
+                                       doc, numpy_sin_hov_position)['contents']['value']
 
 
 def test_hover(workspace):
@@ -67,13 +67,13 @@ def test_hover(workspace):
 
     doc = Document(DOC_URI, workspace, DOC)
 
-    contents = [{'language': 'python', 'value': 'main()'}, 'hello world']
+    contents = {'kind': 'markdown', 'value': '```python\nmain()\n```\n\n\nhello world'}
 
     assert {
         'contents': contents
-    } == pylsp_hover(doc, hov_position)
+    } == pylsp_hover(doc._config, doc, hov_position)
 
-    assert {'contents': ''} == pylsp_hover(doc, no_hov_position)
+    assert {'contents': ''} == pylsp_hover(doc._config, doc, no_hov_position)
 
 
 def test_document_path_hover(workspace_other_root_path, tmpdir):
@@ -96,6 +96,6 @@ foo"""
     doc = Document(doc_uri, workspace_other_root_path, doc_content)
 
     cursor_pos = {'line': 1, 'character': 3}
-    contents = pylsp_hover(doc, cursor_pos)['contents']
+    contents = pylsp_hover(doc._config, doc, cursor_pos)['contents']
 
-    assert contents[1] == 'A docstring for foo.'
+    assert 'A docstring for foo.' in contents['value']

--- a/external-deps/python-lsp-server/test/plugins/test_signature.py
+++ b/external-deps/python-lsp-server/test/plugins/test_signature.py
@@ -46,7 +46,7 @@ def test_no_signature(workspace):
     sig_position = {'line': 9, 'character': 0}
     doc = Document(DOC_URI, workspace, DOC)
 
-    sigs = signature.pylsp_signature_help(doc, sig_position)['signatures']
+    sigs = signature.pylsp_signature_help(doc._config, doc, sig_position)['signatures']
     assert not sigs
 
 
@@ -55,13 +55,13 @@ def test_signature(workspace):
     sig_position = {'line': 10, 'character': 5}
     doc = Document(DOC_URI, workspace, DOC)
 
-    sig_info = signature.pylsp_signature_help(doc, sig_position)
+    sig_info = signature.pylsp_signature_help(doc._config, doc, sig_position)
 
     sigs = sig_info['signatures']
     assert len(sigs) == 1
     assert sigs[0]['label'] == 'main(param1, param2)'
     assert sigs[0]['parameters'][0]['label'] == 'param1'
-    assert sigs[0]['parameters'][0]['documentation'] == 'Docs for param1'
+    assert sigs[0]['parameters'][0]['documentation'] == {'kind': 'markdown', 'value': 'Docs for param1'}
 
     assert sig_info['activeParameter'] == 0
 
@@ -71,7 +71,7 @@ def test_multi_line_signature(workspace):
     sig_position = {'line': 17, 'character': 5}
     doc = Document(DOC_URI, workspace, MULTI_LINE_DOC)
 
-    sig_info = signature.pylsp_signature_help(doc, sig_position)
+    sig_info = signature.pylsp_signature_help(doc._config, doc, sig_position)
 
     sigs = sig_info['signatures']
     assert len(sigs) == 1
@@ -80,7 +80,7 @@ def test_multi_line_signature(workspace):
         'param5=None, param6=None, param7=None, param8=None)'
     )
     assert sigs[0]['parameters'][0]['label'] == 'param1'
-    assert sigs[0]['parameters'][0]['documentation'] == 'Docs for param1'
+    assert sigs[0]['parameters'][0]['documentation'] == {'kind': 'markdown', 'value': 'Docs for param1'}
 
     assert sig_info['activeParameter'] == 0
 

--- a/external-deps/python-lsp-server/test/plugins/test_yapf_format.py
+++ b/external-deps/python-lsp-server/test/plugins/test_yapf_format.py
@@ -29,7 +29,7 @@ FOUR_SPACE_DOC = """def hello():
 
 def test_format(workspace):
     doc = Document(DOC_URI, workspace, DOC)
-    res = pylsp_format_document(doc)
+    res = pylsp_format_document(doc, None)
 
     assert apply_text_edits(doc, res) == "A = ['h', 'w', 'a']\n\nB = ['h', 'w']\n"
 
@@ -41,7 +41,7 @@ def test_range_format(workspace):
         'start': {'line': 0, 'character': 0},
         'end': {'line': 4, 'character': 10}
     }
-    res = pylsp_format_range(doc, def_range)
+    res = pylsp_format_range(doc, def_range, None)
 
     # Make sure B is still badly formatted
     assert apply_text_edits(doc, res) == "A = ['h', 'w', 'a']\n\nB = ['h',\n\n\n'w']\n"
@@ -49,7 +49,7 @@ def test_range_format(workspace):
 
 def test_no_change(workspace):
     doc = Document(DOC_URI, workspace, GOOD_DOC)
-    assert not pylsp_format_document(doc)
+    assert not pylsp_format_document(doc, options=None)
 
 
 def test_config_file(tmpdir, workspace):
@@ -59,7 +59,7 @@ def test_config_file(tmpdir, workspace):
     src = tmpdir.join('test.py')
     doc = Document(uris.from_fs_path(src.strpath), workspace, DOC)
 
-    res = pylsp_format_document(doc)
+    res = pylsp_format_document(doc, options=None)
 
     # A was split on multiple lines because of column_limit from config file
     assert apply_text_edits(doc, res) == "A = [\n    'h', 'w',\n    'a'\n]\n\nB = ['h', 'w']\n"
@@ -68,7 +68,7 @@ def test_config_file(tmpdir, workspace):
 @pytest.mark.parametrize('newline', ['\r\n'])
 def test_line_endings(workspace, newline):
     doc = Document(DOC_URI, workspace, f'import os;import sys{2 * newline}dict(a=1)')
-    res = pylsp_format_document(doc)
+    res = pylsp_format_document(doc, options=None)
 
     assert apply_text_edits(doc, res) == f'import os{newline}import sys{2 * newline}dict(a=1){newline}'
 
@@ -99,7 +99,7 @@ def test_format_returns_text_edit_per_line(workspace):
  log("x")
  log("hi")"""
     doc = Document(DOC_URI, workspace, single_space_indent)
-    res = pylsp_format_document(doc)
+    res = pylsp_format_document(doc, options=None)
 
     # two removes and two adds
     assert len(res) == 4

--- a/installers/macOS/req-extras.txt
+++ b/installers/macOS/req-extras.txt
@@ -1,5 +1,6 @@
 # Spyder extra packages
 autopep8
+docstring-to-markdown
 flake8
 Paramiko
 pycodestyle

--- a/spyder/plugins/completion/api.py
+++ b/spyder/plugins/completion/api.py
@@ -229,13 +229,16 @@ TEXT_EDITOR_CAPABILITES = {
         # Code completion can be turned on/off dynamically.
         "dynamicRegistration": True,
 
-        # Client (Spyder) supports snippets as insert text.
-        # A snippet can define tab stops and placeholders with `$1`, `$2`
-        # and `${3:foo}`. `$0` defines the final tab stop, it defaults to
-        # the end of the snippet. Placeholders with equal identifiers are
-        # linked, that is typing in one will update others too.
         "completionItem": {
-            "snippetSupport": True
+            # Client (Spyder) supports snippets as insert text.
+            # A snippet can define tab stops and placeholders with `$1`, `$2`
+            # and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+            # the end of the snippet. Placeholders with equal identifiers are
+            # linked, that is typing in one will update others too.
+            "snippetSupport": True,
+
+            # Completion item docs can only be handled in plain text
+            "documentationFormat": ['plaintext'],
         }
     },
 
@@ -243,7 +246,10 @@ TEXT_EDITOR_CAPABILITES = {
     # hover information at a given text document position.
     "hover": {
         # Hover introspection can be turned on/off dynamically.
-        "dynamicRegistration": True
+        "dynamicRegistration": True,
+
+        # Hover contents can only be handled in plain text by Spyder
+        "contentFormat": ['plaintext'],
     },
 
     # The signature help request is sent from the client to the server to
@@ -251,7 +257,12 @@ TEXT_EDITOR_CAPABILITES = {
     "signatureHelp": {
         # Function/Class/Method signature hinting can be turned on/off
         # dynamically.
-        "dynamicRegistration": True
+        "dynamicRegistration": True,
+
+        # Signature docs can only be handled in plain text by Spyder
+        "signatureInformation": {
+            "documentationFormat": ['plaintext'],
+        }
     },
 
     # Editor allows to find references.

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -543,6 +543,10 @@ class CompletionWidget(QListWidget, SpyderConfigurationAccessor):
     def augment_completion_info(self, item):
         if self.current_selected_item_label == item['label']:
             insert_text = self._get_insert_text(item)
+
+            if isinstance(item['documentation'], dict):
+                item['documentation'] = item['documentation']['value']
+
             self.sig_completion_hint.emit(
                 insert_text,
                 item['documentation'],

--- a/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
+++ b/spyder/plugins/editor/widgets/tests/test_hints_and_calltips.py
@@ -10,7 +10,6 @@ import os
 import sys
 
 # Third party imports
-from qtpy import PYQT_VERSION
 from qtpy.QtCore import Qt, QPoint
 from qtpy.QtGui import QTextCursor
 import pytest

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -465,7 +465,7 @@ class BaseEditMixin(object):
         language = getattr(self, 'language', language).lower()
         signature_or_text = signature_or_text.replace('\\*', '*')
 
-        # Remove special symbols that could itefere with ''.format
+        # Remove special symbols that could interfere with ''.format
         signature_or_text = signature_or_text.replace('{', '&#123;')
         signature_or_text = signature_or_text.replace('}', '&#125;')
 
@@ -521,6 +521,8 @@ class BaseEditMixin(object):
             else:
                 signature = '\n'.join(lines[:i])
                 extra_text = '\n'.join(lines[i:])
+                if extra_text == '\n':
+                    extra_text = None
 
             if signature:
                 new_signature = self._format_signature(


### PR DESCRIPTION
## Description of Changes

- Request documentation in plain text to the server because it sends it now by default as Markdown, which we can't handle.
- Fix error when showing completion hints due to the previous change in the server as well.
- Fix not showing hovers for objects without docstrings. Signatures that come from the server are now separated from two LF characters, which was causing this problem.
- Update outline if a tree is empty but it has cached items from the server. I discovered this bug while working with Spyder these days and although it's not caused by a server update, I think it's important to fix it because it makes the Outline display files with no symbols when they actually have symbols for it.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
