### PR TITLE
PR: Restore context menu on tabs (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -94,19 +94,28 @@ class IPythonConsoleWidgetActions:
     QuickReference = 'quick reference'
 
 
+class IPythonConsoleWidgetConsolesMenuSections:
+    Main = 'main_section'
+
+
 class IPythonConsoleWidgetOptionsMenus:
     SpecialConsoles = 'special_consoles_submenu'
     Documentation = 'documentation_submenu'
-
-
-class IPythonConsoleWidgetConsolesMenusSection:
-    Main = 'main_section'
 
 
 class IPythonConsoleWidgetOptionsMenuSections:
     Consoles = 'consoles_section'
     Edit = 'edit_section'
     View = 'view_section'
+
+
+class IPythonConsoleWidgetMenus:
+    TabsContextMenu = 'tabs_context_menu'
+
+
+class IPythonConsoleWidgetTabsContextMenuSections:
+    Consoles = 'tabs_consoles_section'
+    Edit = 'tabs_edit_section'
 
 
 # --- Widgets
@@ -405,7 +414,7 @@ class IPythonConsoleWidget(PluginMainWidget):
             return client.get_control()
 
     def setup(self):
-        # Options menu actions
+        # --- Options menu actions
         self.create_client_action = self.create_action(
             IPythonConsoleWidgetActions.CreateNewClient,
             text=_("New console (default settings)"),
@@ -447,7 +456,7 @@ class IPythonConsoleWidget(PluginMainWidget):
             triggered=self.tab_name_editor,
         )
 
-        # For the client
+        # --- For the client
         self.env_action = self.create_action(
             IPythonConsoleWidgetActions.ShowEnvironmentVariables,
             text=_("Show environment variables"),
@@ -473,7 +482,7 @@ class IPythonConsoleWidget(PluginMainWidget):
             initial=self.get_conf('show_elapsed_time')
         )
 
-        # Context menu actions
+        # --- Context menu actions
         # TODO: Shortcut registration not working
         self.inspect_action = self.create_action(
             IPythonConsoleWidgetActions.InspectObject,
@@ -500,7 +509,7 @@ class IPythonConsoleWidget(PluginMainWidget):
             icon=self.create_icon('exit'),
             triggered=self.current_client_quit)
 
-        # Other actions with shortcuts
+        # --- Other actions with shortcuts
         self.array_table_action = self.create_action(
             IPythonConsoleWidgetActions.ArrayTable,
             text=_("Enter array table"),
@@ -525,6 +534,7 @@ class IPythonConsoleWidget(PluginMainWidget):
             self.quit_action
         )
 
+        # --- Setting options menu
         options_menu = self.get_options_menu()
         self.special_console_menu = self.create_menu(
             IPythonConsoleWidgetOptionsMenus.SpecialConsoles,
@@ -587,10 +597,10 @@ class IPythonConsoleWidget(PluginMainWidget):
             self.add_item_to_menu(
                 item,
                 menu=self.special_console_menu,
-                section=IPythonConsoleWidgetConsolesMenusSection.Main,
+                section=IPythonConsoleWidgetConsolesMenuSections.Main,
             )
 
-        # Widgets for the tab corner
+        # --- Widgets for the tab corner
         self.reset_button = self.create_toolbutton(
             'reset',
             text=_("Remove all variables"),
@@ -607,12 +617,39 @@ class IPythonConsoleWidget(PluginMainWidget):
         )
         self.time_label = QLabel("")
 
-        # Add tab corner widgets.
+        # --- Add tab corner widgets.
         self.add_corner_widget('timer', self.time_label)
         self.add_corner_widget('reset', self.reset_button)
         self.add_corner_widget('start_interrupt', self.stop_button)
 
-        # Create IPython documentation menu
+        # --- Tabs context menu
+        tabs_context_menu = self.create_menu(
+            IPythonConsoleWidgetMenus.TabsContextMenu)
+
+        for item in [
+                self.create_client_action,
+                self.special_console_menu,
+                self.connect_to_kernel_action]:
+            self.add_item_to_menu(
+                item,
+                menu=tabs_context_menu,
+                section=IPythonConsoleWidgetTabsContextMenuSections.Consoles,
+            )
+
+        for item in [
+                self.interrupt_action,
+                self.restart_action,
+                self.reset_action,
+                self.rename_tab_action]:
+            self.add_item_to_menu(
+                item,
+                menu=tabs_context_menu,
+                section=IPythonConsoleWidgetTabsContextMenuSections.Edit,
+            )
+
+        self.tabwidget.menu = tabs_context_menu
+
+        # --- Create IPython documentation menu
         self.ipython_menu = self.create_menu(
             menu_id=IPythonConsoleWidgetOptionsMenus.Documentation,
             title=_("IPython documentation"))


### PR DESCRIPTION
## Description of Changes

- This uses the new API to build it instead of passing the Options menu actions to the `Tabs` widget, as before.
- That way we don't need to show the entire Options menu on the tabs context one. Instead, I decided to show only its first two sections, which are the most important ones.

    ![imagen](https://user-images.githubusercontent.com/365293/200372625-794175c6-0740-4f28-ae70-75fc6a52248a.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19991.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
