### PR TITLE
PR: Add validation to prevent calling uninitialized `application_update_status` widget on conda installations (Application)

### DIFF
--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -297,10 +297,10 @@ class ApplicationContainer(PluginMainContainer):
             box.exec_()
             check_updates = box.is_checked()
         else:
-
             if update_available:
-                self.application_update_status.set_status_pending(
-                    latest_release=latest_release)
+                if self.application_update_status:
+                    self.application_update_status.set_status_pending(
+                        latest_release=latest_release)
 
                 header = _("<b>Spyder {} is available!</b> "
                            "<i>(you have {})</i><br><br>").format(
@@ -332,13 +332,13 @@ class ApplicationContainer(PluginMainContainer):
                 box.setText(msg)
                 box.set_check_visible(True)
                 box.exec_()
-
-                if box.result() == QMessageBox.Yes:
-                    self.application_update_status.start_installation(
-                        latest_release=latest_release)
-                elif(box.result() == QMessageBox.No):
-                    self.application_update_status.set_status_pending(
-                        latest_release=latest_release)
+                if self.application_update_status:
+                    if box.result() == QMessageBox.Yes:
+                        self.application_update_status.start_installation(
+                            latest_release=latest_release)
+                    elif box.result() == QMessageBox.No:
+                        self.application_update_status.set_status_pending(
+                            latest_release=latest_release)
                 check_updates = box.is_checked()
             elif feedback:
                 msg = _("Spyder is up to date.")
@@ -346,9 +346,11 @@ class ApplicationContainer(PluginMainContainer):
                 box.set_check_visible(False)
                 box.exec_()
                 check_updates = box.is_checked()
-                self.application_update_status.set_no_status()
+                if self.application_update_status:
+                    self.application_update_status.set_no_status()
             else:
-                self.application_update_status.set_no_status()
+                if self.application_update_status:
+                    self.application_update_status.set_no_status()
         # Update checkbox based on user interaction
         self.set_conf(option, check_updates)
 
@@ -363,7 +365,8 @@ class ApplicationContainer(PluginMainContainer):
         """Check for spyder updates on github releases using a QThread."""
         # Disable check_updates_action while the thread is working
         self.check_updates_action.setDisabled(True)
-        self.application_update_status.set_status_checking()
+        if self.application_update_status:
+            self.application_update_status.set_status_checking()
 
         if self.thread_updates is not None:
             self.thread_updates.quit()


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

The application update status bar is only initialized for the standalone installers but no validations were added to prevent calling it inside the check updates logic available for all types of Spyder installations (standalone installers, conda, pip, etc).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20035

I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
