### PR TITLE
PR: Fix QIntValidator to handle '+' sign

### DIFF
--- a/spyder/plugins/editor/widgets/gotoline.py
+++ b/spyder/plugins/editor/widgets/gotoline.py
@@ -62,8 +62,10 @@ class GoToLineDialog(QDialog):
 
         ok_button = bbox.button(QDialogButtonBox.Ok)
         ok_button.setEnabled(False)
+        # QIntValidator does not handle '+' sign
+        # See Spyder PR #20070
         self.lineedit.textChanged.connect(
-                     lambda text: ok_button.setEnabled(len(text) > 0))
+                     lambda text: ok_button.setEnabled(len(text) > 0 and text != '+'))
 
         layout = QHBoxLayout()
         layout.addLayout(glayout)
@@ -75,10 +77,14 @@ class GoToLineDialog(QDialog):
     def text_has_changed(self, text):
         """Line edit's text has changed."""
         text = str(text)
-        if text:
+
+        # QIntValidator does not handle '+' sign
+        # See Spyder PR #20070
+        if text and text != '+':
             self.lineno = int(text)
         else:
             self.lineno = None
+            self.lineedit.clear()
 
     def get_line_number(self):
         """Return line number."""

--- a/spyder/plugins/editor/widgets/gotoline.py
+++ b/spyder/plugins/editor/widgets/gotoline.py
@@ -63,7 +63,7 @@ class GoToLineDialog(QDialog):
         ok_button = bbox.button(QDialogButtonBox.Ok)
         ok_button.setEnabled(False)
         # QIntValidator does not handle '+' sign
-        # See Spyder PR #20070
+        # See spyder-ide/spyder#20070
         self.lineedit.textChanged.connect(
                      lambda text: ok_button.setEnabled(len(text) > 0 and text != '+'))
 
@@ -79,7 +79,7 @@ class GoToLineDialog(QDialog):
         text = str(text)
 
         # QIntValidator does not handle '+' sign
-        # See Spyder PR #20070
+        # See spyder-ide/spyder#12693
         if text and text != '+':
             self.lineno = int(text)
         else:

--- a/spyder/plugins/editor/widgets/tests/test_gotoline.py
+++ b/spyder/plugins/editor/widgets/tests/test_gotoline.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""Tests for gotoline.py"""
+
+# Third party imports
+from qtpy.QtWidgets import QDialogButtonBox, QPushButton, QTableWidget, QLineEdit
+
+# Local imports
+from spyder.plugins.editor.widgets.gotoline import GoToLineDialog
+
+def test_gotolinedialog_has_cancel_button(codeeditor, qtbot, tmpdir):
+    """
+    Test that GoToLineDialog has a Cancel button.
+
+    Test that a GoToLineDialog has a button in a dialog button box and that
+    this button cancels the dialog window.
+    """
+    editor = codeeditor
+    dialog = GoToLineDialog(editor)
+    qtbot.addWidget(dialog)
+    ok_button = dialog.findChild(QDialogButtonBox).button(QDialogButtonBox.Ok)
+    cancel_button = dialog.findChild(QDialogButtonBox).button(QDialogButtonBox.Cancel)
+    assert not ok_button.isEnabled()
+    with qtbot.waitSignal(dialog.rejected):
+        cancel_button.click()
+
+
+def test_gotolinedialog_enter_plus(codeeditor, qtbot):
+    """
+    Regression test for spyder-ide/spyder#12693
+    """
+    editor = codeeditor
+    dialog = GoToLineDialog(editor)
+    qtbot.addWidget(dialog)
+    ok_button = dialog.findChild(QDialogButtonBox).button(QDialogButtonBox.Ok)
+    cancel_button = dialog.findChild(QDialogButtonBox).button(QDialogButtonBox.Cancel)
+    lineedit = dialog.findChild(QLineEdit)
+    lineedit.setText('+')
+
+    # Check + sign being cleared and ok button still is disabled
+    lineedit.setText("+")
+    assert lineedit.text() == ""
+    assert not ok_button.isEnabled()
+
+def test_gotolinedialog_check_valid(codeeditor, qtbot):
+    """
+    Check ok button enabled if valid text entered
+    """
+    editor = codeeditor
+    dialog = GoToLineDialog(editor)
+    qtbot.addWidget(dialog)
+    ok_button = dialog.findChild(QDialogButtonBox).button(QDialogButtonBox.Ok)
+    lineedit = dialog.findChild(QLineEdit)
+    lineedit.setText("1")
+    assert lineedit.text() == "1"
+    assert ok_button.isEnabled()
+    with qtbot.waitSignal(dialog.accepted):
+        ok_button.click()
+    assert dialog.get_line_number() == 1

--- a/spyder/plugins/editor/widgets/tests/test_gotoline.py
+++ b/spyder/plugins/editor/widgets/tests/test_gotoline.py
@@ -7,10 +7,11 @@
 """Tests for gotoline.py"""
 
 # Third party imports
-from qtpy.QtWidgets import QDialogButtonBox, QPushButton, QTableWidget, QLineEdit
+from qtpy.QtWidgets import QDialogButtonBox, QLineEdit
 
 # Local imports
 from spyder.plugins.editor.widgets.gotoline import GoToLineDialog
+
 
 def test_gotolinedialog_has_cancel_button(codeeditor, qtbot, tmpdir):
     """

--- a/spyder/plugins/variableexplorer/widgets/importwizard.py
+++ b/spyder/plugins/variableexplorer/widgets/importwizard.py
@@ -176,6 +176,8 @@ class ContentsWidget(QWidget):
         intvalid = QIntValidator(0, len(to_text_string(text).splitlines()),
                                  self.skiprows_edt)
         self.skiprows_edt.setValidator(intvalid)
+        self.skiprows_edt.textChanged.connect(
+                     lambda text: self.get_skiprows())
         other_layout.addWidget(self.skiprows_edt, 0, 1)
 
         other_layout.setColumnMinimumWidth(2, 5)
@@ -236,7 +238,14 @@ class ContentsWidget(QWidget):
 
     def get_skiprows(self):
         """Return number of lines to be skipped"""
-        return int(to_text_string(self.skiprows_edt.text()))
+        skip_rows = to_text_string(self.skiprows_edt.text())
+        # QIntValidator does not handle '+' sign
+        # See Spyder PR #20070
+        if skip_rows and skip_rows != '+':
+            return int(skip_rows)
+        else:
+            self.skiprows_edt.clear()
+            return 0
 
     def get_comments(self):
         """Return comment string"""

--- a/spyder/plugins/variableexplorer/widgets/importwizard.py
+++ b/spyder/plugins/variableexplorer/widgets/importwizard.py
@@ -373,12 +373,15 @@ class PreviewTable(QTableView):
     def _shape_text(self, text, colsep=u"\t", rowsep=u"\n",
                     transpose=False, skiprows=0, comments='#'):
         """Decode the shape of the given text"""
-        assert colsep != rowsep
+        assert colsep != rowsep, 'Column sep should not equal Row sep'
         out = []
-        text_rows = text.split(rowsep)[skiprows:]
+        text_rows = text.split(rowsep)
+        assert skiprows < len(text_rows), 'Skip Rows > Line Count'
+        text_rows = text_rows[skiprows:]
         for row in text_rows:
             stripped = to_text_string(row).strip()
-            if len(stripped) == 0 or stripped.startswith(comments):
+            if len(stripped) == 0 or (comments and
+                                      stripped.startswith(comments)):
                 continue
             line = to_text_string(row).split(colsep)
             line = [try_to_parse(to_text_string(x)) for x in line]

--- a/spyder/plugins/variableexplorer/widgets/importwizard.py
+++ b/spyder/plugins/variableexplorer/widgets/importwizard.py
@@ -240,7 +240,7 @@ class ContentsWidget(QWidget):
         """Return number of lines to be skipped"""
         skip_rows = to_text_string(self.skiprows_edt.text())
         # QIntValidator does not handle '+' sign
-        # See Spyder PR #20070
+        # See spyder-ide/spyder#20070
         if skip_rows and skip_rows != '+':
             return int(skip_rows)
         else:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Somehow Qt QIntValidator allows to enter only a plus sign: '+'

While searching for QIntValidator, I found another occurance in the import dialog of the variable explorer.

* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Supersedes #13333
Fixes #12693


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Florian Maurer

<!--- Thanks for your help making Spyder better for everyone! --->
