### PR TITLE
PR: Prevent crash at startup if importing `pylint.config` fails (Code Analysis)

### DIFF
--- a/spyder/plugins/pylint/utils.py
+++ b/spyder/plugins/pylint/utils.py
@@ -37,11 +37,15 @@ def get_pylintrc_path(search_paths=None, home_path=None):
     # Iterate through the search paths until a unique pylintrc file is found
     try:
         pylintrc_paths = [
-            _find_pylintrc_path(path) for path in search_paths if path]
+            _find_pylintrc_path(path) for path in search_paths if path
+        ]
         pylintrc_path_home = _find_pylintrc_path(home_path)
+
         for pylintrc_path in pylintrc_paths:
-            if (pylintrc_path is not None
-                    and pylintrc_path != pylintrc_path_home):
+            if (
+                pylintrc_path is not None
+                and pylintrc_path != pylintrc_path_home
+            ):
                 break
     finally:  # Ensure working directory is restored if any an error occurs
         os.chdir(current_cwd)

--- a/spyder/plugins/pylint/utils.py
+++ b/spyder/plugins/pylint/utils.py
@@ -13,12 +13,18 @@ import os
 import os.path as osp
 
 # Third party imports
-import pylint.config
+# This is necessary to avoid a crash at startup
+# Fixes spyder-ide/spyder#20079
+try:
+    from pylint import config as pylint_config
+except Exception:
+    pylint_config = None
 
 
 def _find_pylintrc_path(path):
-    os.chdir(path)
-    return pylint.config.find_pylintrc()
+    if pylint_config is not None:
+        os.chdir(path)
+        return pylint_config.find_pylintrc()
 
 
 def get_pylintrc_path(search_paths=None, home_path=None):


### PR DESCRIPTION
## Description of Changes

- That module has some global constants that depend on the filesystem and can fail to be initialized due to e.g. a `PermissionError` (see issue #20079 for more context).
- Small style improvements to the module that imports `pylint.config`

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20079

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
