### PR TITLE
PR: Catch a couple of reported RuntimeError's (Editor)

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1984,7 +1984,6 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         fname=<basestring> --> create file
         """
         # If no text is provided, create default content
-        empty = False
         try:
             if text is None:
                 default_content = True
@@ -2140,10 +2139,13 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         """
         cursor_history_state = self.__ignore_cursor_history
         self.__ignore_cursor_history = True
-        # Switch to editor before trying to load a file
+
+        # Switch to editor before trying to load a file.
+        # Here we catch RuntimeError to avoid an issue when loading files.
+        # Fixes spyder-ide/spyder#20055
         try:
             self.switch_to_plugin()
-        except AttributeError:
+        except (AttributeError, RuntimeError):
             pass
 
         editor0 = self.get_current_editor()

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -2028,7 +2028,14 @@ class CodeEditor(TextEditBaseWidget):
     def notify_close(self):
         """Send close request."""
         self._pending_server_requests = []
-        self._server_requests_timer.stop()
+
+        # This is necessary to prevent an error when closing the file.
+        # Fixes spyder-ide/spyder#20071
+        try:
+            self._server_requests_timer.stop()
+        except RuntimeError:
+            pass
+
         if self.completions_available:
             # This is necessary to prevent an error in our tests.
             try:


### PR DESCRIPTION
## Description of Changes

This kind of errors are usually generated when the user closes the current `EditorStack` or `EditorMainWindow` before a method that access those objects can be processed completely.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20071
Fixes #20055

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
