### PR TITLE
PR: Remove check_path to allow running in debugger

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -37,7 +37,6 @@ import traceback
 # Check requirements before proceeding
 #==============================================================================
 from spyder import requirements
-requirements.check_path()
 requirements.check_qt()
 
 #==============================================================================

--- a/spyder/requirements.py
+++ b/spyder/requirements.py
@@ -32,16 +32,6 @@ def show_warning(message):
     raise RuntimeError(message)
 
 
-def check_path():
-    """Check sys.path: is Spyder properly installed?"""
-    dirname = osp.abspath(osp.join(osp.dirname(__file__), osp.pardir))
-    if dirname not in sys.path:
-        show_warning("Spyder must be installed properly "
-                     "(e.g. from source: 'python setup.py install'),\n"
-                     "or directory '%s' must be in PYTHONPATH "
-                     "environment variable." % dirname)
-
-
 def check_qt():
     """Check Qt binding requirements"""
     qt_infos = dict(pyqt5=("PyQt5", "5.9"), pyside2=("PySide2", "5.12"))


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

PYTHONPATH entries are removed on start, resulting in a the warning shown on `check_path` in requirements - program does not start.
Removing pythonpath was added to disable shadowed base libraries, but I think thats exactly how the PYTHONPATH could and would behave.
Still it makes sense to remove them so that it does not create problems.

Yet the resulting warning
"Spyder must be installed properly (e.g. from source: 'python setup.py install'), or directory 'dir' must be in PYTHONPATH environment variable."
is not helpful and is removed through this PR

~~I would therefore not remove entries on PYTHONPATH from PATH~~

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Florian Maurer

<!--- Thanks for your help making Spyder better for everyone! --->
