### PR TITLE
PR: Fix issue where user environment variables with line endings were not parsed correctly on Unix platforms

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,7 +11,6 @@ NOTE: DO NOT add fixtures here. It could generate problems with
       QtAwesome being called before a QApplication is created.
 """
 
-# Standard libary imports
 import os
 import os.path as osp
 import re
@@ -23,11 +22,6 @@ os.environ['SPYDER_PYTEST'] = 'True'
 
 # ---- Pytest adjustments
 import pytest
-
-# Spyder imports
-from spyder.config.base import running_in_ci
-from spyder.utils.environ import (get_user_env, set_user_env,
-                                  amend_user_shell_init)
 
 
 def pytest_addoption(parser):
@@ -142,20 +136,3 @@ def reset_conf_before_test():
 
     CONF.set('completions', 'provider_configuration', provider_configurations,
              notification=False)
-
-
-@pytest.fixture
-def restore_user_env():
-    """Set user environment variables and restore upon test exit"""
-    if not running_in_ci():
-        pytest.skip("Skipped because not in CI.")
-
-    if os.name == "nt":
-        orig_env = get_user_env()
-
-    yield
-
-    if os.name == "nt":
-        set_user_env(orig_env)
-    else:
-        amend_user_shell_init(restore=True)

--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,7 @@ NOTE: DO NOT add fixtures here. It could generate problems with
       QtAwesome being called before a QApplication is created.
 """
 
+# Standard libary imports
 import os
 import os.path as osp
 import re
@@ -22,6 +23,11 @@ os.environ['SPYDER_PYTEST'] = 'True'
 
 # ---- Pytest adjustments
 import pytest
+
+# Spyder imports
+from spyder.config.base import running_in_ci
+from spyder.utils.environ import (get_user_env, set_user_env,
+                                  amend_user_shell_init)
 
 
 def pytest_addoption(parser):
@@ -136,3 +142,20 @@ def reset_conf_before_test():
 
     CONF.set('completions', 'provider_configuration', provider_configurations,
              notification=False)
+
+
+@pytest.fixture
+def restore_user_env():
+    """Set user environment variables and restore upon test exit"""
+    if not running_in_ci():
+        pytest.skip("Skipped because not in CI.")
+
+    if os.name == "nt":
+        orig_env = get_user_env()
+
+    yield
+
+    if os.name == "nt":
+        set_user_env(orig_env)
+    else:
+        amend_user_shell_init(restore=True)

--- a/spyder/app/tests/conftest.py
+++ b/spyder/app/tests/conftest.py
@@ -24,11 +24,13 @@ import pytest
 
 # Spyder imports
 from spyder.app import start
-from spyder.config.base import get_home_dir
+from spyder.config.base import get_home_dir, running_in_ci
 from spyder.config.manager import CONF
 from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec
 from spyder.plugins.projects.api import EmptyProject
 from spyder.utils import encoding
+from spyder.utils.environ import (get_user_env, set_user_env,
+                                  amend_user_shell_init)
 
 
 # =============================================================================
@@ -536,3 +538,20 @@ def main_window(request, tmpdir, qtbot):
                     window = None
                     CONF.reset_to_defaults(notification=False)
                     raise
+
+
+@pytest.fixture
+def restore_user_env():
+    """Set user environment variables and restore upon test exit"""
+    if not running_in_ci():
+        pytest.skip("Skipped because not in CI.")
+
+    if os.name == "nt":
+        orig_env = get_user_env()
+
+    yield
+
+    if os.name == "nt":
+        set_user_env(orig_env)
+    else:
+        amend_user_shell_init(restore=True)

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -59,6 +59,7 @@ from spyder.plugins.help.tests.test_plugin import check_text
 from spyder.plugins.layout.layouts import DefaultLayouts
 from spyder.plugins.toolbar.api import ApplicationToolbars
 from spyder.py3compat import qbytearray_to_str, to_text_string
+from spyder.utils.environ import set_user_env, amend_user_shell_init
 from spyder.utils.misc import remove_backslashes
 from spyder.utils.clipboard_helper import CLIPBOARD_HELPER
 from spyder.widgets.dock import DockTitleBar
@@ -718,7 +719,7 @@ def test_dedicated_consoles(main_window, qtbot):
 
     # --- Set run options for this file ---
     rc = RunConfiguration().get()
-    
+
     # A dedicated console is used when these three options are False
     rc['default'] = rc['current'] = rc['systerm'] = False
     rc['clear_namespace'] = False
@@ -1401,7 +1402,7 @@ def test_run_code(main_window, qtbot, tmpdir):
     qtbot.waitUntil(lambda: nsb.editor.source_model.rowCount() == 1,
                     timeout=EVAL_TIMEOUT)
     assert shell.get_value('li') == [1, 2, 3]
-    
+
     # try running cell without file name
     shell.clear()
     # Clean namespace
@@ -5342,7 +5343,8 @@ def test_switch_to_plugin(main_window, qtbot):
 
 
 @flaky(max_runs=5)
-def test_PYTHONPATH_in_consoles(main_window, qtbot, tmp_path):
+def test_PYTHONPATH_in_consoles(main_window, qtbot, tmp_path,
+                                restore_user_env):
     """
     Test that PYTHONPATH is passed to IPython consoles under different
     scenarios.
@@ -5356,7 +5358,10 @@ def test_PYTHONPATH_in_consoles(main_window, qtbot, tmp_path):
     # Add a new directory to PYTHONPATH
     new_dir = tmp_path / 'new_dir'
     new_dir.mkdir()
-    os.environ['PYTHONPATH'] = str(new_dir)
+    if os.name == "nt":
+        set_user_env({"PYTHONPATH": str(new_dir)})
+    else:
+        amend_user_shell_init(f"export PYTHONPATH={new_dir}")
 
     # Open Pythonpath dialog to detect new_dir
     ppm = main_window.get_plugin(Plugins.PythonpathManager)

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -59,7 +59,7 @@ from spyder.plugins.help.tests.test_plugin import check_text
 from spyder.plugins.layout.layouts import DefaultLayouts
 from spyder.plugins.toolbar.api import ApplicationToolbars
 from spyder.py3compat import qbytearray_to_str, to_text_string
-from spyder.utils.environ import set_user_env, amend_user_shell_init
+from spyder.utils.environ import set_user_env
 from spyder.utils.misc import remove_backslashes
 from spyder.utils.clipboard_helper import CLIPBOARD_HELPER
 from spyder.widgets.dock import DockTitleBar
@@ -5358,10 +5358,7 @@ def test_PYTHONPATH_in_consoles(main_window, qtbot, tmp_path,
     # Add a new directory to PYTHONPATH
     new_dir = tmp_path / 'new_dir'
     new_dir.mkdir()
-    if os.name == "nt":
-        set_user_env({"PYTHONPATH": str(new_dir)})
-    else:
-        amend_user_shell_init(f"export PYTHONPATH={new_dir}")
+    set_user_env({"PYTHONPATH": str(new_dir)})
 
     # Open Pythonpath dialog to detect new_dir
     ppm = main_window.get_plugin(Plugins.PythonpathManager)

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -22,7 +22,7 @@ except Exception:
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports
-from spyder.config.base import _
+from spyder.config.base import _, running_in_ci
 from spyder.widgets.collectionseditor import CollectionsEditor
 from spyder.utils.icon_manager import ima
 from spyder.utils.programs import run_shell_command
@@ -57,8 +57,10 @@ def get_user_environment_variables():
     try:
         if os.name == 'nt':
             key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Environment")
-            N = winreg.QueryInfoKey(key)[1]
-            env_var = dict([winreg.EnumValue(key, k)[:2] for k in range(N)])
+            num_values = winreg.QueryInfoKey(key)[1]
+            env_var = dict(
+                [winreg.EnumValue(key, k)[:2] for k in range(num_values)]
+            )
         else:
             shell = os.environ.get("SHELL", "/bin/bash")
             cmd = (
@@ -82,8 +84,8 @@ def get_user_env():
 
 def set_user_env(env, parent=None):
     """
-    Set user environment variables via HKCU (Windows) or
-    shell startup file (unix).
+    Set user environment variables via HKCU (Windows) or shell startup file
+    (Unix).
     """
     env_dict = listdict2envdict(env)
 
@@ -112,7 +114,7 @@ def set_user_env(env, parent=None):
                   "Please restart this Windows <i>session</i> "
                   "(not the computer) for changes to take effect.")
             )
-    elif os.name == 'posix':
+    elif os.name == 'posix' and running_in_ci():
         text = "\n".join([f"export {k}={v}" for k, v in env_dict.items()])
         amend_user_shell_init(text)
     else:
@@ -120,7 +122,7 @@ def set_user_env(env, parent=None):
 
 
 def amend_user_shell_init(text="", restore=False):
-    """Set user environment variable for pytests on unix platforms"""
+    """Set user environment variable for pytests on Unix platforms"""
     if os.name == "nt":
         return
 

--- a/spyder/utils/tests/test_environ.py
+++ b/spyder/utils/tests/test_environ.py
@@ -7,6 +7,8 @@
 """
 Tests for environ.py
 """
+# Standard imports
+import os
 
 # Test library imports
 import pytest
@@ -15,7 +17,8 @@ import pytest
 from qtpy.QtCore import QTimer
 
 # Local imports
-from spyder.utils.environ import get_user_environment_variables, UserEnvDialog
+from spyder.utils.environ import (get_user_environment_variables,
+                                  UserEnvDialog, amend_user_shell_init)
 from spyder.utils.test import close_message_box
 
 
@@ -31,11 +34,21 @@ def environ_dialog(qtbot):
 
 def test_get_user_environment_variables():
     """Test get_user_environment_variables function"""
-
     # All platforms should have a path environment variable, but
     # Windows may have mixed case.
     keys = {k.lower() for k in get_user_environment_variables()}
     assert "path" in keys
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Does not apply to Windows")
+def test_get_user_env_newline(restore_user_env):
+    # Test variable value with newline characters.
+    # Regression test for spyder-ide#20097
+    text = "myfunc() {  echo hello;\n echo world\n}\nexport -f myfunc"
+    amend_user_shell_init(text)
+    user_env = get_user_environment_variables()
+
+    assert user_env['BASH_FUNC_myfunc%%'] in text
 
 
 def test_environ(environ_dialog, qtbot):

--- a/spyder/utils/tests/test_environ.py
+++ b/spyder/utils/tests/test_environ.py
@@ -7,7 +7,8 @@
 """
 Tests for environ.py
 """
-# Standard imports
+
+# Standard library imports
 import os
 
 # Test library imports
@@ -20,6 +21,7 @@ from qtpy.QtCore import QTimer
 from spyder.utils.environ import (get_user_environment_variables,
                                   UserEnvDialog, amend_user_shell_init)
 from spyder.utils.test import close_message_box
+from spyder.app.tests.conftest import restore_user_env
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description of Changes

#20297 unsatisfactorily fixed #20097 by skipping environment variables that do not parse correctly. This PR remedies this.
* For unix, use a clean subprocess environment, invoke a login shell, extract `os.environ` from a python process. This circumvents any parsing issues and should reflect exactly what a user would expect from a python process in a standard terminal.
* For Windows, get environment variables directly from the system registry.
* Add regression test for #20097
  * Modify user environment variables in system registry or shell startup file
  * Restore user environment variables
  * Only run on CI to protect developers' local user environment variables

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

See #20097
