### PR TITLE
PR: Fix random rare error in completion plugin

### DIFF
--- a/spyder/plugins/completion/providers/languageserver/transport/tcp/producer.py
+++ b/spyder/plugins/completion/providers/languageserver/transport/tcp/producer.py
@@ -87,4 +87,9 @@ class TCPLanguageServerClient(LanguageServerClient):
 
             if time.time() - initial_time > self.MAX_TIMEOUT_TIME:
                 break
+
+        if self.socket.getsockname() == self.socket.getpeername():
+            connection_error = Exception("Failed to connect to server: Self-connected socket")
+            connected = False
+
         return connected, connection_error, None


### PR DESCRIPTION
See commit message for details.

Notes:
* We have observed the fixed error on Linux only.
* There is a (remote) possibility that the fixed error is the one reported in #9557, #9755 and #10108.
* The fix in this PR is strictly speaking a workaround. The “proper” fix is to _not_ use a port from the ephemeral port range for the language server. 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

rear1019

<!--- Thanks for your help making Spyder better for everyone! --->
