### PR TITLE
PR: Add default value for `IconLineEdit` helper widget constructor params (Widgets)

### DIFF
--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -222,7 +222,7 @@ class IconLineEdit(QLineEdit):
     text and can also elide it.
     """
 
-    def __init__(self, parent, elide_text, ellipsis_place):
+    def __init__(self, parent, elide_text=False, ellipsis_place=Qt.ElideLeft):
         super().__init__(parent)
 
         self.elide_text = elide_text


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Add default values for new parameters of `IconLineEdit` widget (`elide_text` and `ellipsis_place`). An error occurs when using an `IconLineEdit` on the `spyder-env-manager` plugin when using Spyder dev version. Not giving those params a default value could cause issues to external plugins using that widget (the old constructor signature).


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
