### PR TITLE
PR: Pass Home/End key events from Completion to CodeEditor widget (Editor)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -31,13 +31,6 @@ if [ "$USE_CONDA" = "true" ]; then
 
     # To check our manifest and coverage
     mamba install check-manifest codecov -c conda-forge -q -y
-
-    # Numpy 1.23 is not giving completions on the editor and the console
-    if [ "$OS" = "win" ]; then
-        mamba install numpy=1.22
-    else
-        mamba install 'numpy<1.23'
-    fi
 else
     # Update pip and setuptools
     python -m pip install -U pip setuptools wheel build
@@ -53,9 +46,6 @@ else
 
     # To check our manifest and coverage
     pip install -q check-manifest codecov
-
-    # Numpy 1.23 is not giving completions on the editor and the console
-    pip install 'numpy<1.23'
 
     # This allows the test suite to run more reliably on Linux
     if [ "$OS" = "linux" ]; then

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   build:
     name: Linux - Py${{ matrix.PYTHON_VERSION }}, ${{ matrix.INSTALL_TYPE }}, ${{ matrix.TEST_TYPE }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CI: 'true'
       QTCONSOLE_TESTING: 'true'

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -339,8 +339,10 @@ class CompletionWidget(QListWidget, SpyderConfigurationAccessor):
         elif key in (Qt.Key_Left, Qt.Key_Right) or text in ('.', ':'):
             self.hide()
             self.textedit.keyPressEvent(event)
-        elif key in (Qt.Key_Up, Qt.Key_Down, Qt.Key_PageUp, Qt.Key_PageDown,
-                     Qt.Key_Home, Qt.Key_End) and not modifier:
+        elif (
+            key in (Qt.Key_Up, Qt.Key_Down, Qt.Key_PageUp, Qt.Key_PageDown)
+            and not modifier
+        ):
             self.textedit._completions_hint_idle = True
             if key == Qt.Key_Up and self.currentRow() == 0:
                 self.setCurrentRow(self.count() - 1)
@@ -348,6 +350,12 @@ class CompletionWidget(QListWidget, SpyderConfigurationAccessor):
                 self.setCurrentRow(0)
             else:
                 QListWidget.keyPressEvent(self, event)
+        elif key in (Qt.Key_Home, Qt.Key_End):
+            # This allows users to easily move to the beginning/end of the
+            # current line when this widget is visible.
+            # Fixes spyder-ide/spyder#19989
+            self.hide()
+            self.textedit.keyPressEvent(event)
         elif key == Qt.Key_Backspace:
             self.textedit.keyPressEvent(event)
             self.update_current(new=False)

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -385,6 +385,10 @@ class CompletionWidget(QListWidget, SpyderConfigurationAccessor):
                 if QKeySequence(key_sequence) == QKeySequence(save_shortcut):
                     self.textedit.sig_save_requested.emit()
 
+                    # Hiding the widget reassures users that the save operation
+                    # took place.
+                    self.hide()
+
             self.textedit.keyPressEvent(event)
             self.update_current(new=False)
         elif modifier:

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -367,7 +367,7 @@ def test_banners(ipyconsole, qtbot):
     [("arange",
       ["start", "stop"],
       ["Return evenly spaced values within a given interval.<br>",
-       "<br>Python built-in `range` function, but returns an ndarray ..."]),
+       "open interval ..."]),
      ("vectorize",
       ["pyfunc", "otype", "signature"],
       ["Generalized function class.<br>",


### PR DESCRIPTION
## Description of Changes

- This allows users to easily move to the beginning/end of the current line when this widget is visible.
- Also, hide Completion widget if users press the save shortcut when it's visible to reassure them that that operation took place.
- Select Ubuntu 20.04 to run our tests on Github actions because some are failing with 22.04 (which now corresponds to `ubuntu-latest`).
- Remove restriction on Numpy 1.23 on CIs.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19989.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
