### PR TITLE
PR: Prevent a visual glitch when opening files in the light theme (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2729,6 +2729,13 @@ class EditorStack(QWidget):
         # Set timeout to sync symbols and folding
         finfo.editor.set_sync_symbols_and_folding_timeout()
 
+        # Unhighlight and rehighlight current line to prevent a visual glitch
+        # when opening files.
+        # Fixes spyder-ide/spyder#20033
+        finfo.editor.unhighlight_current_line()
+        if self.highlight_current_line_enabled:
+            finfo.editor.highlight_current_line()
+
         return finfo
 
     def set_os_eol_chars(self, index=None, osname=None):

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -32,6 +32,7 @@ from qtpy.QtWidgets import (QAction, QApplication, QFileDialog, QHBoxLayout,
 # Local imports
 from spyder.api.panel import Panel
 from spyder.config.base import _, running_under_pytest
+from spyder.config.gui import is_dark_interface
 from spyder.config.manager import CONF
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
                                  get_filter, is_kde_desktop, is_anaconda)
@@ -366,11 +367,13 @@ class EditorStack(QWidget):
         self.run_cell_copy = False
         self.create_new_file_if_empty = True
         self.indent_guides = False
-        ccs = 'spyder/dark'
-        if ccs not in syntaxhighlighters.COLOR_SCHEME_NAMES:
-            ccs = syntaxhighlighters.COLOR_SCHEME_NAMES[0]
-        self.color_scheme = ccs
         self.__file_status_flag = False
+
+        # Set default color scheme
+        color_scheme = 'spyder/dark' if is_dark_interface() else 'spyder'
+        if color_scheme not in syntaxhighlighters.COLOR_SCHEME_NAMES:
+            color_scheme = syntaxhighlighters.COLOR_SCHEME_NAMES[0]
+        self.color_scheme = color_scheme
 
         # Real-time code analysis
         self.analysis_timer = QTimer(self)


### PR DESCRIPTION
## Description of Changes

- This is fixed by unhighlighting and rehighlighting the current line when opening a file.
- Set default color scheme according to the interface theme.
- Some style improvements to make the code more readable. 

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20033.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
