### PR TITLE
PR: Restore cursor position after inserting auto-formatted text (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1745,6 +1745,7 @@ class CodeEditor(TextEditBaseWidget):
 
     # ------------- LSP: Document/Selection formatting --------------------
     def format_document_or_range(self):
+        """Format current document or selected text."""
         # Save current cursor position to restore it after the current text has
         # been replaced by the auto-formatted one.
         self.__cursor_position_before_format = self.textCursor().position()
@@ -1756,6 +1757,7 @@ class CodeEditor(TextEditBaseWidget):
 
     @schedule_request(method=CompletionRequestTypes.DOCUMENT_FORMATTING)
     def format_document(self):
+        """Format current document."""
         if not self.formatting_enabled:
             return
         if self.formatting_in_progress:
@@ -1788,6 +1790,7 @@ class CodeEditor(TextEditBaseWidget):
 
     @schedule_request(method=CompletionRequestTypes.DOCUMENT_RANGE_FORMATTING)
     def format_document_range(self):
+        """Format selected text."""
         if not self.range_formatting_enabled or not self.has_selected_text():
             return
         if self.formatting_in_progress:
@@ -1835,6 +1838,7 @@ class CodeEditor(TextEditBaseWidget):
 
     @handles(CompletionRequestTypes.DOCUMENT_FORMATTING)
     def handle_document_formatting(self, edits):
+        """Handle document formatting response."""
         try:
             if self.formatting_in_progress:
                 self._apply_document_edits(edits)
@@ -1856,6 +1860,7 @@ class CodeEditor(TextEditBaseWidget):
 
     @handles(CompletionRequestTypes.DOCUMENT_RANGE_FORMATTING)
     def handle_document_range_formatting(self, edits):
+        """Handle document range formatting response."""
         try:
             if self.formatting_in_progress:
                 self._apply_document_edits(edits)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1054,8 +1054,8 @@ class CodeEditor(TextEditBaseWidget):
 
         self.set_strip_mode(strip_mode)
 
-    # --- Language Server Protocol methods -----------------------------------
-    # ------------------------------------------------------------------------
+    # ---- LSP: Basic methods
+    # -------------------------------------------------------------------------
     @Slot(str, dict)
     def handle_response(self, method, params):
         if method in self.handler_registry:
@@ -1094,7 +1094,8 @@ class CodeEditor(TextEditBaseWidget):
             else:
                 logger.error('%', 1, stack_info=True)
 
-    # ------------- LSP: Configuration and protocol start/end ----------------
+    # ---- LSP: Configuration and start/stop
+    # -------------------------------------------------------------------------
     def start_completion_services(self):
         """Start completion services for this instance."""
         self.completions_available = True
@@ -1195,7 +1196,8 @@ class CodeEditor(TextEditBaseWidget):
         }
         return params
 
-    # ------------- LSP: Symbols ---------------------------------------
+    # ---- LSP: Symbols
+    # -------------------------------------------------------------------------
     @schedule_request(method=CompletionRequestTypes.DOCUMENT_SYMBOL)
     def request_symbols(self):
         """Request document symbols."""
@@ -1222,7 +1224,8 @@ class CodeEditor(TextEditBaseWidget):
         except Exception:
             self.log_lsp_handle_errors("Error when processing symbols")
 
-    # ------------- LSP: Linting ---------------------------------------
+    # ---- LSP: Linting and didChange
+    # -------------------------------------------------------------------------
     def _schedule_document_did_change(self):
         """Schedule a document update."""
         self._document_server_needs_update = True
@@ -1435,7 +1438,8 @@ class CodeEditor(TextEditBaseWidget):
                     )
                 block.setUserData(data)
 
-    # ------------- LSP: Completion ---------------------------------------
+    # ---- LSP: Completion
+    # -------------------------------------------------------------------------
     @schedule_request(method=CompletionRequestTypes.DOCUMENT_COMPLETION)
     def do_completion(self, automatic=False):
         """Trigger completion."""
@@ -1571,7 +1575,8 @@ class CodeEditor(TextEditBaseWidget):
             self.log_lsp_handle_errors(
                 "Error when handling completion item resolution")
 
-    # ------------- LSP: Signature Hints ------------------------------------
+    # ---- LSP: Signature Hints
+    # -------------------------------------------------------------------------
     @schedule_request(method=CompletionRequestTypes.DOCUMENT_SIGNATURE)
     def request_signature(self):
         """Ask for signature."""
@@ -1627,7 +1632,8 @@ class CodeEditor(TextEditBaseWidget):
         except Exception:
             self.log_lsp_handle_errors("Error when processing signature")
 
-    # ------------- LSP: Hover/Mouse ---------------------------------------
+    # ---- LSP: Hover/Cursor
+    # -------------------------------------------------------------------------
     @schedule_request(method=CompletionRequestTypes.DOCUMENT_CURSOR_EVENT)
     def request_cursor_event(self):
         text = self.get_text_with_eol()
@@ -1691,7 +1697,8 @@ class CodeEditor(TextEditBaseWidget):
         except Exception:
             self.log_lsp_handle_errors("Error when processing hover")
 
-    # ------------- LSP: Go To Definition ----------------------------
+    # ---- LSP: Go To Definition
+    # -------------------------------------------------------------------------
     @Slot()
     @schedule_request(method=CompletionRequestTypes.DOCUMENT_DEFINITION)
     def go_to_definition_from_cursor(self, cursor=None):
@@ -1743,7 +1750,8 @@ class CodeEditor(TextEditBaseWidget):
             self.log_lsp_handle_errors(
                 "Error when processing go to definition")
 
-    # ------------- LSP: Document/Selection formatting --------------------
+    # ---- LSP: Document/Selection formatting
+    # -------------------------------------------------------------------------
     def format_document_or_range(self):
         """Format current document or selected text."""
         # Save current cursor position to restore it after the current text has
@@ -1961,7 +1969,8 @@ class CodeEditor(TextEditBaseWidget):
             # End text insertion
             cursor.endEditBlock()
 
-    # ------------- LSP: Code folding ranges -------------------------------
+    # ---- LSP: Code folding
+    # -------------------------------------------------------------------------
     def compute_whitespace(self, line):
         tab_size = self.tab_stop_width_spaces
         whitespace_regex = re.compile(r'(\s+).*')
@@ -2054,7 +2063,8 @@ class CodeEditor(TextEditBaseWidget):
             line, column = self.get_cursor_line_column()
             self.update_whitespace_count(line, column)
 
-    # ------------- LSP: Save/close file -----------------------------------
+    # ---- LSP: Save/close file
+    # -------------------------------------------------------------------------
     @schedule_request(method=CompletionRequestTypes.DOCUMENT_DID_SAVE,
              requires_response=False)
     def notify_save(self):
@@ -2095,6 +2105,7 @@ class CodeEditor(TextEditBaseWidget):
             }
             return params
 
+    # ---- Debug panel
     # -------------------------------------------------------------------------
     def set_debug_panel(self, show_debug_panel, language):
         """Enable/disable debug panel."""
@@ -2120,6 +2131,8 @@ class CodeEditor(TextEditBaseWidget):
                 return
         debugger_panel.stop_clean()
 
+    # ---- Set different attributes
+    # -------------------------------------------------------------------------
     def set_folding_panel(self, folding):
         """Enable/disable folding panel."""
         folding_panel = self.panels.get(FoldingPanel)
@@ -2508,7 +2521,8 @@ class CodeEditor(TextEditBaseWidget):
             self.setTextCursor(cursor)
         self.remove_selected_text()
 
-    #------Find occurrences
+    # ---- Find occurrences
+    # -------------------------------------------------------------------------
     def __find_first(self, text):
         """Find first occurrence: scan whole document"""
         flags = QTextDocument.FindCaseSensitively|QTextDocument.FindWholeWords
@@ -2641,7 +2655,8 @@ class CodeEditor(TextEditBaseWidget):
             self.occurrences.pop(-1)
         self.sig_flags_changed.emit()
 
-    #-----highlight found results (find/replace widget)
+    # ---- Highlight found results
+    # -------------------------------------------------------------------------
     def highlight_found_results(self, pattern, word=False, regexp=False,
                                 case=False):
         """Highlight all found patterns"""
@@ -2755,7 +2770,8 @@ class CodeEditor(TextEditBaseWidget):
 
         self.setTextCursor(cursor)
 
-    # ----- Code bookmarks
+    # ---- Code bookmarks
+    # -------------------------------------------------------------------------
     def add_bookmark(self, slot_num, line=None, column=None):
         """Add bookmark to current block's userData."""
         if line is None:
@@ -2804,7 +2820,8 @@ class CodeEditor(TextEditBaseWidget):
         """Emit signal to update bookmarks."""
         self.sig_bookmarks_changed.emit()
 
-    # -----Code introspection
+    # ---- Code introspection
+    # -------------------------------------------------------------------------
     def show_completion_object_info(self, name, signature):
         """Trigger show completion info in Help Pane."""
         force = True
@@ -2815,7 +2832,8 @@ class CodeEditor(TextEditBaseWidget):
         """Trigger a calltip"""
         self.sig_show_object_info.emit(True)
 
-    # -----blank spaces
+    # ---- Blank spaces
+    # -------------------------------------------------------------------------
     def set_blanks_enabled(self, state):
         """Toggle blanks visibility"""
         self.blanks_enabled = state
@@ -2849,7 +2867,8 @@ class CodeEditor(TextEditBaseWidget):
         super(CodeEditor, self).showEvent(event)
         self.panels.refresh()
 
-    #-----Misc.
+    # ---- Misc.
+    # -------------------------------------------------------------------------
     def _apply_highlighter_color_scheme(self):
         """Apply color scheme from syntax highlighter to the editor"""
         hl = self.highlighter
@@ -3116,9 +3135,8 @@ class CodeEditor(TextEditBaseWidget):
             self.is_redoing = False
             self.skip_rstrip = False
 
-    # =========================================================================
-    #    High-level editor features
-    # =========================================================================
+    # ---- High-level editor features
+    # -------------------------------------------------------------------------
     @Slot()
     def center_cursor_on_next_focus(self):
         """QPlainTextEdit's "centerCursor" requires the widget to be visible"""
@@ -3156,7 +3174,6 @@ class CodeEditor(TextEditBaseWidget):
         self._completions_hint_idle = True
         self.completion_widget.trigger_completion_hint()
 
-    # --- Hint for completions
     def show_hint_for_completion(self, word, documentation, at_point):
         """Show hint for completion element."""
         if self.completions_hint and self._completions_hint_idle:
@@ -3375,7 +3392,8 @@ class CodeEditor(TextEditBaseWidget):
         """Get number of cells in document."""
         return 1 + len(list(self.cell_list()))
 
-    #------Tasks management
+    # ---- Tasks management
+    # -------------------------------------------------------------------------
     def go_to_next_todo(self):
         """Go to next todo and return new cursor position"""
         block = self.textCursor().block()
@@ -3413,7 +3431,8 @@ class CodeEditor(TextEditBaseWidget):
             block.setUserData(data)
         self.sig_flags_changed.emit()
 
-    #------Comments/Indentation
+    # ---- Comments/Indentation
+    # -------------------------------------------------------------------------
     def add_prefix(self, prefix):
         """Add prefix to current line or selected line(s)"""
         cursor = self.textCursor()
@@ -4177,10 +4196,11 @@ class CodeEditor(TextEditBaseWidget):
         cursor3.endEditBlock()
         return True
 
-    #------Kill ring handlers
+    # ---- Kill ring handlers
     # Taken from Jupyter's QtConsole
     # Copyright (c) 2001-2015, IPython Development Team
     # Copyright (c) 2015-, Jupyter Development Team
+    # -------------------------------------------------------------------------
     def kill_line_end(self):
         """Kill the text on the current line from the cursor forward"""
         cursor = self.textCursor()
@@ -4254,7 +4274,8 @@ class CodeEditor(TextEditBaseWidget):
         self._kill_ring.kill_cursor(cursor)
         self.setTextCursor(cursor)
 
-    #------Autoinsertion of quotes/colons
+    # ---- Autoinsertion of quotes/colons
+    # -------------------------------------------------------------------------
     def __get_current_color(self, cursor=None):
         """Get the syntax highlighting color for the current cursor position"""
         if cursor is None:
@@ -4431,7 +4452,8 @@ class CodeEditor(TextEditBaseWidget):
         else:
             return False
 
-    # ------ Qt Event handlers
+    # ---- Qt Event handlers
+    # -------------------------------------------------------------------------
     def setup_context_menu(self):
         """Setup context menu"""
         self.undo_action = create_action(
@@ -5404,7 +5426,8 @@ class CodeEditor(TextEditBaseWidget):
             self._last_hover_pattern_key = None
             self._last_hover_pattern_text = None
 
-    #------ Drag and drop
+    # ---- Drag and drop
+    # -------------------------------------------------------------------------
     def dragEnterEvent(self, event):
         """
         Reimplemented Qt method.
@@ -5435,7 +5458,8 @@ class CodeEditor(TextEditBaseWidget):
             logger.debug("Call TextEditBaseWidget dropEvent method")
             TextEditBaseWidget.dropEvent(self, event)
 
-    #------ Paint event
+    # ---- Paint event
+    # -------------------------------------------------------------------------
     def paintEvent(self, event):
         """Overrides paint event to update the list of visible blocks"""
         self.update_visible_blocks(event)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2397,8 +2397,11 @@ class EditorStack(QWidget):
 
     def refresh(self, index=None):
         """Refresh tabwidget"""
+        logger.debug("Refresh EditorStack")
+
         if index is None:
             index = self.get_stack_index()
+
         # Set current editor
         if self.get_stack_count():
             index = self.get_stack_index()
@@ -2414,8 +2417,10 @@ class EditorStack(QWidget):
             self.update_plugin_title.emit()
         else:
             editor = None
+
         # Update the modification-state-dependent parameters
         self.modification_changed()
+
         # Update FindReplace binding
         self.find_widget.set_editor(editor, refresh=False)
 
@@ -2429,21 +2434,27 @@ class EditorStack(QWidget):
             for index, _finfo in enumerate(self.data):
                 if id(_finfo.editor) == editor_id:
                     break
+
         # This must be done before refreshing save/save all actions:
         # (otherwise Save/Save all actions will always be enabled)
         self.opened_files_list_changed.emit()
-        # --
+
+        # Get index
         if index is None:
             index = self.get_stack_index()
+
         if index == -1:
             return
+
         finfo = self.data[index]
         if state is None:
             state = finfo.editor.document().isModified() or finfo.newly_created
         self.set_stack_title(index, state)
+
         # Toggle save/save all actions state
         self.save_action.setEnabled(state)
         self.refresh_save_all_action.emit()
+
         # Refreshing eol mode
         eol_chars = finfo.editor.get_line_separator()
         self.refresh_eol_chars(eol_chars)


### PR DESCRIPTION
## Description of Changes

- The cursor was placed at the end of the file after auto-formatting took place, even when formatting selections, which was really annoying.
- Fix header comments in CodeEditor so they appear in Spyder's Outline.
- Add docstrings for auto-formatting methods in CodeEditor.
- Improve code style a bit here and there.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19958.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
