### PR TITLE
PR: Simplify the way we add sections to menus (API)

### DIFF
--- a/spyder/plugins/mainmenu/plugin.py
+++ b/spyder/plugins/mainmenu/plugin.py
@@ -69,7 +69,8 @@ class MainMenu(SpyderPluginV2):
         create_app_menu(ApplicationMenus.Source, _("Sour&ce"), dynamic=False)
         create_app_menu(ApplicationMenus.Run, _("&Run"), dynamic=False)
         create_app_menu(ApplicationMenus.Debug, _("&Debug"), dynamic=False)
-        create_app_menu(ApplicationMenus.Consoles, _("C&onsoles"))
+        if self.is_plugin_enabled(Plugins.IPythonConsole):
+            create_app_menu(ApplicationMenus.Consoles, _("C&onsoles"))
         if self.is_plugin_enabled(Plugins.Projects):
             create_app_menu(ApplicationMenus.Projects, _("&Projects"))
         create_app_menu(ApplicationMenus.Tools, _("&Tools"))

--- a/spyder/plugins/shortcuts/plugin.py
+++ b/spyder/plugins/shortcuts/plugin.py
@@ -98,6 +98,7 @@ class Shortcuts(SpyderPluginV2):
             shortcuts_action,
             menu_id=ApplicationMenus.Help,
             section=HelpMenuSections.Documentation,
+            before_section=HelpMenuSections.Support
         )
 
     @on_plugin_teardown(plugin=Plugins.Preferences)

--- a/spyder/plugins/tours/plugin.py
+++ b/spyder/plugins/tours/plugin.py
@@ -64,6 +64,7 @@ class Tours(SpyderPluginV2):
             self.get_container().tour_action,
             menu_id=ApplicationMenus.Help,
             section=HelpMenuSections.Documentation,
+            before_section=HelpMenuSections.Support,
             before=ApplicationActions.SpyderDocumentationAction)
 
     @on_plugin_teardown(plugin=Plugins.MainMenu)


### PR DESCRIPTION
## Description of Changes

- This approach always adds a new section to the menu even if it needs to be inserted before another one which hasn't been added yet.
- The previous approach gave errors if a section required to be inserted before another one which was not added when, for instance, the plugin in charge of doing it is disabled.
- Also, don't show `Consoles` menu if the IPython console is disabled.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19610 
Fixes #16161 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
