### PR TITLE
PR: Several fixes for new Editor windows

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -20,7 +20,7 @@ os.environ['SPYDER_PYTEST'] = 'True'
 # NOTE: This needs to be imported before any QApplication.
 # Don't remove it or change it to a different location!
 # pylint: disable=wrong-import-position
-from qtpy import QtWebEngineWidgets  # pylint: disable=unused-import
+from qtpy import QtWebEngineWidgets  # noqa
 import pytest
 
 

--- a/spyder/api/_version.py
+++ b/spyder/api/_version.py
@@ -6,5 +6,5 @@
 
 """Spyder API Version."""
 
-VERSION_INFO = (0, 8, 0)
+VERSION_INFO = (0, 9, 0)
 __version__ = '.'.join(map(str, VERSION_INFO))

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -279,6 +279,17 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
         Unmaximize plugin only if it is not `plugin_instance`.
     """
 
+    sig_mainwindow_state_changed = Signal(object)
+    """
+    This signal is emitted when the main window state has changed (for
+    instance, between maximized and minimized states).
+
+    Parameters
+    ----------
+    window_state: Qt.WindowStates
+        The window state.
+    """
+
     # --- Private attributes -------------------------------------------------
     # ------------------------------------------------------------------------
     # Define configuration name map for plugin to split configuration

--- a/spyder/api/widgets/auxiliary_widgets.py
+++ b/spyder/api/widgets/auxiliary_widgets.py
@@ -9,7 +9,7 @@ Spyder API auxiliary widgets.
 """
 
 # Third party imports
-from qtpy.QtCore import QEvent, Qt, QSize, Signal
+from qtpy.QtCore import QEvent, QSize, Signal
 from qtpy.QtWidgets import QMainWindow, QSizePolicy, QToolBar, QWidget
 
 # Local imports

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -145,6 +145,17 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
     # To be removed in Spyder 6
     sig_pythonpath_changed = Signal(object, object)
 
+    sig_window_state_changed = Signal(object)
+    """
+    This signal is emitted when the window state has changed (for instance,
+    between maximized and minimized states).
+
+    Parameters
+    ----------
+    window_state: Qt.WindowStates
+        The window state.
+    """
+
     def __init__(self, splash=None, options=None):
         QMainWindow.__init__(self)
         qapp = QApplication.instance()
@@ -422,6 +433,8 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         # Connect Main window Signals to plugin signals
         self.sig_moved.connect(plugin.sig_mainwindow_moved)
         self.sig_resized.connect(plugin.sig_mainwindow_resized)
+        self.sig_window_state_changed.connect(
+            plugin.sig_mainwindow_state_changed)
 
         # Register plugin
         plugin._register(omit_conf=omit_conf)

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1726,7 +1726,9 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
 
     def unregister_editorwindow(self, window):
         logger.debug("Unregistering window")
-        self.editorwindows.pop(self.editorwindows.index(window))
+        idx = self.editorwindows.index(window)
+        self.editorwindows[idx] = None
+        self.editorwindows.pop(idx)
 
 
     #------ Accessors

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -49,7 +49,7 @@ from spyder.plugins.editor.utils.switcher import EditorSwitcherManager
 from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 from spyder.plugins.editor.widgets.editor import (EditorMainWindow,
                                                   EditorSplitter,
-                                                  EditorStack,)
+                                                  EditorStack)
 from spyder.plugins.editor.widgets.printer import (
     SpyderPrinter, SpyderPrintPreviewDialog)
 from spyder.plugins.editor.utils.bookmarks import (load_bookmarks,
@@ -1451,6 +1451,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
 
     # ------ Handling editorstacks
     def register_editorstack(self, editorstack):
+        logger.debug("Registering new EditorStack")
         self.editorstacks.append(editorstack)
         self.register_widget_shortcuts(editorstack)
 
@@ -1626,6 +1627,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
 
     def unregister_editorstack(self, editorstack):
         """Removing editorstack only if it's not the last remaining"""
+        logger.debug("Unregistering EditorStack")
         self.remove_last_focused_editorstack(editorstack)
         if len(self.editorstacks) > 1:
             index = self.editorstacks.index(editorstack)
@@ -1719,9 +1721,11 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         return window
 
     def register_editorwindow(self, window):
+        logger.debug("Registering new window")
         self.editorwindows.append(window)
 
     def unregister_editorwindow(self, window):
+        logger.debug("Unregistering window")
         self.editorwindows.pop(self.editorwindows.index(window))
 
 

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1632,6 +1632,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         if len(self.editorstacks) > 1:
             index = self.editorstacks.index(editorstack)
             self.editorstacks.pop(index)
+            self.find_widget.set_editor(self.get_current_editor())
             return True
         else:
             # editorstack was not removed!

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1709,8 +1709,15 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             super(Editor, self).switch_to_plugin()
 
     def create_new_window(self):
+        """Create a new editor window."""
         window = EditorMainWindow(
-            self, self.stack_menu_actions, self.toolbar_list, self.menu_list)
+            self,
+            self.stack_menu_actions,
+            self.toolbar_list,
+            self.menu_list,
+            outline_plugin=self.outlineexplorer
+        )
+
         window.add_toolbars_to_menu("&View", window.get_toolbars())
         window.load_toolbars()
         window.resize(self.size())
@@ -1721,10 +1728,12 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         return window
 
     def register_editorwindow(self, window):
+        """Register a new editor window."""
         logger.debug("Registering new window")
         self.editorwindows.append(window)
 
     def unregister_editorwindow(self, window):
+        """Unregister editor window."""
         logger.debug("Unregistering window")
         idx = self.editorwindows.index(window)
         self.editorwindows[idx] = None

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2637,7 +2637,7 @@ class EditorStack(QWidget):
             cloned_from.oe_proxy.sig_start_outline_spinner.connect(
                 editor.oe_proxy.emit_request_in_progress)
 
-            # This ensures that symbols will be requested and its infor saved
+            # This ensures that symbols will be requested and its info saved
             # for the clon.
             cloned_from.document_did_change()
 
@@ -3426,6 +3426,9 @@ class EditorWidget(QSplitter):
         """Actions to take when the splitter is moved."""
         # There's no need to update the Outline when the user moves the
         # splitter to hide it.
+        # Note: The 20 below was selected because the Outline can't have that
+        # small width. So, if the splitter position plus that amount is greater
+        # than the total widget width, it means the Outline was collapsed.
         if (position + 20) > self.size().width():
             self.outlineexplorer.change_tree_visibility(False)
         else:

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2629,13 +2629,17 @@ class EditorStack(QWidget):
         if self.outlineexplorer is not None:
             self.outlineexplorer.register_editor(editor.oe_proxy)
 
-        # Connect necessary signals from the cloned editor so that symbols for
-        # are updated as expected.
         if cloned_from is not None:
+            # Connect necessary signals from the original editor so that
+            # symbols for the clon are updated as expected.
             cloned_from.oe_proxy.sig_outline_explorer_data_changed.connect(
                 editor.oe_proxy.update_outline_info)
             cloned_from.oe_proxy.sig_start_outline_spinner.connect(
                 editor.oe_proxy.emit_request_in_progress)
+
+            # This ensures that symbols will be requested and its infor saved
+            # for the clon.
+            cloned_from.document_did_change()
 
         # Needs to reset the highlighting on startup in case the PygmentsSH
         # is in use

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -936,11 +936,6 @@ class EditorStack(QWidget):
     def set_outlineexplorer(self, outlineexplorer):
         self.outlineexplorer = outlineexplorer
 
-    def add_outlineexplorer_button(self, editor_plugin):
-        oe_btn = create_toolbutton(editor_plugin)
-        oe_btn.setDefaultAction(self.outlineexplorer.visibility_action)
-        self.add_corner_widgets_to_tabbar([5, oe_btn])
-
     def set_tempfile_path(self, path):
         self.tempfile_path = path
 
@@ -3305,10 +3300,23 @@ class EditorWidget(QSplitter):
             self,
             context=f'editor_window_{str(id(self))}'
         )
+
+        # Show widget's toolbar
+        self.outlineexplorer.setup()
+        self.outlineexplorer.update_actions()
+        self.outlineexplorer._setup()
+        self.outlineexplorer.render_toolbars()
+
+        # Remove actions related to plugin functionality from Options menu
+        options_menu = self.outlineexplorer.get_options_menu()
+        for action in ['undock_pane', 'close_pane', 'lock_unlock_position']:
+            options_menu.remove_action(action)
+
         self.outlineexplorer.edit_goto.connect(
-                     lambda filenames, goto, word:
-                     plugin.load(filenames=filenames, goto=goto, word=word,
-                                 editorwindow=self.parent()))
+            lambda filenames, goto, word:
+            plugin.load(filenames=filenames, goto=goto, word=word,
+                        editorwindow=self.parent())
+        )
 
         editor_widgets = QWidget(self)
         editor_layout = QVBoxLayout()

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -29,13 +29,14 @@ import IPython
 from IPython.core import release as ipy_release
 from IPython.core.application import get_ipython_dir
 from flaky import flaky
-from pkg_resources import parse_version
+from packaging.version import parse
 from pygments.token import Name
 import pytest
 from qtpy import PYQT5
 from qtpy.QtCore import Qt
 from qtpy.QtWebEngineWidgets import WEBENGINE
 from qtpy.QtWidgets import QMessageBox, QMainWindow
+from spyder_kernels import __version__ as spyder_kernels_version
 import sympy
 
 # Local imports
@@ -483,8 +484,7 @@ def test_pylab_client(ipyconsole, qtbot):
 
 @flaky(max_runs=3)
 @pytest.mark.sympy_client
-@pytest.mark.xfail(parse_version('1.0') < parse_version(sympy.__version__) <
-                   parse_version('1.2'),
+@pytest.mark.xfail(parse('1.0') < parse(sympy.__version__) < parse('1.2'),
                    reason="A bug with sympy 1.1.1 and IPython-Qtconsole")
 def test_sympy_client(ipyconsole, qtbot):
     """Test that the SymPy console is working correctly."""
@@ -516,7 +516,7 @@ def test_sympy_client(ipyconsole, qtbot):
 @pytest.mark.cython_client
 @pytest.mark.skipif(
     (not sys.platform.startswith('linux') or
-     parse_version(ipy_release.version) == parse_version('7.11.0')),
+     parse(ipy_release.version) == parse('7.11.0')),
     reason="It only works reliably on Linux and fails for IPython 7.11.0")
 def test_cython_client(ipyconsole, qtbot):
     """Test that the Cython console is working correctly."""
@@ -2129,6 +2129,9 @@ def test_pdb_out(ipyconsole, qtbot):
 @pytest.mark.skipif(
     running_in_ci() and not os.name == 'nt',
     reason="Times out on Linux and macOS")
+@pytest.mark.skipif(
+    parse(spyder_kernels_version) < parse("3.0.0.dev0"),
+    reason="Not reliable with Spyder-kernels 2")
 def test_shutdown_kernel(ipyconsole, qtbot):
     """
     Check that the kernel is shutdown after creating plots with the

--- a/spyder/plugins/outlineexplorer/editor.py
+++ b/spyder/plugins/outlineexplorer/editor.py
@@ -4,10 +4,17 @@
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
 
-"""Outline explorer editor server"""
+"""Outline explorer editor proxy."""
+
+# Standard library imports
+import logging
 
 # Local imports
 from spyder.plugins.outlineexplorer.api import OutlineExplorerProxy
+
+
+# Logging
+logger = logging.getLogger(__name__)
 
 
 class OutlineExplorerProxyEditor(OutlineExplorerProxy):
@@ -26,8 +33,12 @@ class OutlineExplorerProxyEditor(OutlineExplorerProxy):
         self.is_tree_updated = False
 
     def update_outline_info(self, info):
+        logger.debug(
+            f"Updating info for proxy {id(self)} of file {self.fname}"
+        )
         self.sig_outline_explorer_data_changed.emit(info)
         self.info = info
+        self.is_tree_updated = False
 
     def emit_request_in_progress(self):
         self.sig_start_outline_spinner.emit()

--- a/spyder/plugins/outlineexplorer/main_widget.py
+++ b/spyder/plugins/outlineexplorer/main_widget.py
@@ -216,6 +216,10 @@ class OutlineExplorerWidget(PluginMainWidget):
         """Update all editors with an associated LSP server."""
         self.treewidget.update_all_editors()
 
+    def get_supported_languages(self):
+        """List of languages with symbols support."""
+        return self.treewidget._languages
+
     # ---- Private API
     # -------------------------------------------------------------------------
     @Slot(object)

--- a/spyder/plugins/outlineexplorer/main_widget.py
+++ b/spyder/plugins/outlineexplorer/main_widget.py
@@ -174,9 +174,9 @@ class OutlineExplorerWidget(PluginMainWidget):
             # need to set the treewidget visibility to True for it to be
             # updated after writing new content in the editor.
             # Fixes spyder-ide/spyder#16634
-            self.treewidget.change_visibility(True)
+            self.change_tree_visibility(True)
         else:
-            self.treewidget.change_visibility(self.is_visible)
+            self.change_tree_visibility(self.is_visible)
 
     def create_window(self):
         """
@@ -220,6 +220,10 @@ class OutlineExplorerWidget(PluginMainWidget):
         """List of languages with symbols support."""
         return self.treewidget._languages
 
+    def change_tree_visibility(self, is_visible):
+        "Change treewidget's visibility."
+        self.treewidget.change_visibility(is_visible)
+
     # ---- Private API
     # -------------------------------------------------------------------------
     @Slot(object)
@@ -231,6 +235,6 @@ class OutlineExplorerWidget(PluginMainWidget):
         if window_state == Qt.WindowMinimized:
             # There's no need to update the treewidget when the plugin is
             # minimized.
-            self.treewidget.change_visibility(False)
+            self.change_tree_visibility(False)
         else:
-            self.treewidget.change_visibility(True)
+            self.change_tree_visibility(True)

--- a/spyder/plugins/outlineexplorer/plugin.py
+++ b/spyder/plugins/outlineexplorer/plugin.py
@@ -106,3 +106,7 @@ class OutlineExplorer(SpyderDockablePlugin):
         """Update all editors with an associated LSP server."""
         explorer = self.get_widget()
         explorer.update_all_editors()
+
+    def get_supported_languages(self):
+        """List of languages with symbols support."""
+        return self.get_widget().get_supported_languages()

--- a/spyder/plugins/outlineexplorer/plugin.py
+++ b/spyder/plugins/outlineexplorer/plugin.py
@@ -7,7 +7,7 @@
 """Outline Explorer Plugin."""
 
 # Third party imports
-from qtpy.QtCore import Slot
+from qtpy.QtCore import Qt, Slot
 
 # Local imports
 from spyder.api.plugin_registration.decorators import (
@@ -30,7 +30,7 @@ class OutlineExplorer(SpyderDockablePlugin):
     WIDGET_CLASS = OutlineExplorerWidget
 
     # ---- SpyderDockablePlugin API
-    # ------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     @staticmethod
     def get_name() -> str:
         """Return widget title."""
@@ -47,7 +47,9 @@ class OutlineExplorer(SpyderDockablePlugin):
     def on_initialize(self):
         if self.main:
             self.main.restore_scrollbar_position.connect(
-                self.restore_scrollbar_position)
+                self._restore_scrollbar_position)
+        self.sig_mainwindow_state_changed.connect(
+            self._on_mainwindow_state_changed)
 
     @on_plugin_available(plugin=Plugins.Completions)
     def on_completions_available(self):
@@ -81,14 +83,27 @@ class OutlineExplorer(SpyderDockablePlugin):
         editor.sig_open_files_finished.disconnect(
             self.update_all_editors)
 
-    #------ Public API ---------------------------------------------------------
-    def restore_scrollbar_position(self):
+    # ----- Private API
+    # -------------------------------------------------------------------------
+    @Slot(object)
+    def _on_mainwindow_state_changed(self, window_state):
+        """Actions to take when the main window has changed its state."""
+        if window_state == Qt.WindowMinimized:
+            # There's no need to update the treewidget when the plugin is
+            # minimized.
+            self.get_widget().change_tree_visibility(False)
+        else:
+            self.get_widget().change_tree_visibility(True)
+
+    def _restore_scrollbar_position(self):
         """Restoring scrollbar position after main window is visible"""
         scrollbar_pos = self.get_conf('scrollbar_position', None)
         explorer = self.get_widget()
         if scrollbar_pos is not None:
             explorer.treewidget.set_scrollbar_position(scrollbar_pos)
 
+    # ----- Public API
+    # -------------------------------------------------------------------------
     @Slot(dict, str)
     def start_symbol_services(self, capabilities, language):
         """Enable LSP symbols functionality."""

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -432,17 +432,13 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         logger.debug(f"Set current editor to file {editor.fname}")
         self.current_editor = editor
 
-        # Update tree with currently stored info or require symbols if
-        # necessary.
         if (
-            editor.get_language().lower() in self._languages
-            and len(self.editor_tree_cache[editor_id]) == 0
+            self.is_visible
+            and (editor.get_language().lower() in self._languages)
+            and not editor.is_tree_updated
         ):
             if editor.info is not None:
-                if update:
-                    self.update_editor(editor.info)
-            elif editor.is_cloned:
-                editor.request_symbols()
+                self.update_editor(editor.info)
 
     def register_editor(self, editor):
         """
@@ -542,15 +538,6 @@ class OutlineExplorerTreeWidget(OneColumnTree):
                 f"Don't update tree of file {editor.fname} because plugin is "
                 f"not visible"
             )
-
-            # This keeps track of files that have been modified while the
-            # Outline is hidden. That way we'll only update those when the user
-            # makes it visible.
-            language = editor.get_language().lower()
-            if not self.starting[language]:
-                if editor.is_tree_updated:
-                    editor.is_tree_updated = False
-
             self.sig_hide_spinner.emit()
             return
 

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -661,7 +661,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
             if self.current_editor is editor:
                 self.current_editor = None
 
-            logger.debug(f"Removing tree of file f{editor.fname}")
+            logger.debug(f"Removing tree of file {editor.fname}")
 
             editor_id = self.editor_ids.pop(editor)
             language = editor.get_language().lower()


### PR DESCRIPTION
## Description of Changes

- Remove EditorStacks present on EditorMainWindow when it's closed. We were not removing them from the list of EditorStacks maintained by the plugin, which made the Editor unusable by generating endless RuntimeErrors. 
- Fix Outline displayed on EditorMainWindow, which was not showing any symbol.
- Update Outline for cloned editors after editing text in them (this was not working).
- Update symbols when switching between cloned editors (this was not working either).
- Don't update Outline if EditorMainWindow or MainWindow are minimized (to avoid lags on the main interface if they are not visible).
- Add `sig_mainwindow_state_changed` to plugins so they can take different actions when the main window is maximized/minimized.
- Expand tests to check Outline is working on EditorMainWindow.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20144
Fixes #20101

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
