### PR TITLE
PR: Inform users when kernel can't be interrupted (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -256,7 +256,17 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
         # Empty queue when interrupting
         # Fixes spyder-ide/spyder#7293.
         self._execute_queue = []
-        super(ShellWidget, self).interrupt_kernel()
+
+        # Check if there is a kernel that can be interrupted before trying to
+        # do it.
+        # Fixes spyder-ide/spyder#20212
+        if self.kernel_manager.has_kernel:
+            super(ShellWidget, self).interrupt_kernel()
+        else:
+            self._append_html(
+                _("The kernel appears to be dead, so it can't be interrupted. "
+                  "Please open a new console to keep working.")
+            )
 
     def execute(self, source=None, hidden=False, interactive=False):
         """

--- a/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
@@ -648,7 +648,7 @@ def test_dataframemodel_set_data_bool(monkeypatch):
                      '.dataframeeditor.QMessageBox')
     monkeypatch.setattr(attr_to_patch, MockQMessageBox)
 
-    test_params = [numpy.bool_, numpy.bool, bool]
+    test_params = [numpy.bool_, bool]
     test_strs = ['foo', 'false', 'f', '0', '0.', '0.0', '', ' ']
     expected_df = DataFrame([1, 0, 0, 0, 0, 0, 0, 0, 0], dtype=bool)
 
@@ -676,7 +676,7 @@ def test_dataframeeditor_edit_bool(qtbot, monkeypatch):
                      '.dataframeeditor.QMessageBox')
     monkeypatch.setattr(attr_to_patch, MockQMessageBox)
 
-    test_params = [numpy.bool_, numpy.bool, bool]
+    test_params = [numpy.bool_, bool]
     test_strs = ['foo', 'false', 'f', '0', '0.', '0.0', '', ' ']
     expected_df = DataFrame([1, 0, 0, 0, 0, 0, 0, 0, 0], dtype=bool)
 

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -1870,7 +1870,6 @@ def get_test_data():
             'float16_scalar': np.float16(16),
             'float32_scalar': np.float32(32),
             'float64_scalar': np.float64(64),
-            'bool_scalar': np.bool(8),
             'bool__scalar': np.bool_(8),
             'timestamp': test_timestamp,
             'timedelta_pd': test_pd_td,


### PR DESCRIPTION
## Description of Changes

- Before the kernel manager was raising a RuntimrError if the kernel is no longer available, which was correctly reported by our users here.
- Also, remove usage of `numpy.bool` in our tests because it's no longer present in Numpy 1.24

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20212.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12.

<!--- Thanks for your help making Spyder better for everyone! --->
