### PR TITLE
PR: Prevent Python variable validation to get current word and position when doing completions

### DIFF
--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -23,10 +23,6 @@ from qtpy.QtGui import QTextCursor
 # Local imports
 from spyder.config.base import running_in_ci, running_in_ci_with_conda
 from spyder.config.utils import is_anaconda
-from spyder.plugins.completion.api import (
-    CompletionRequestTypes, CompletionItemKind)
-from spyder.plugins.completion.providers.kite.providers.document import (
-    KITE_COMPLETION)
 from spyder.plugins.completion.providers.kite.utils.status import (
     check_if_kite_installed, check_if_kite_running)
 from spyder.py3compat import PY2
@@ -1063,55 +1059,6 @@ def test_text_snippet_completions(completions_codeeditor, qtbot):
 
     # Assert all retrieved words start with 'f'
     assert all({x['sortText'][1] in {'for', 'from'} for x in results})
-
-    code_editor.toggle_automatic_completions(True)
-    code_editor.toggle_code_snippets(True)
-
-
-@pytest.mark.slow
-@pytest.mark.order(1)
-@flaky(max_runs=5)
-def test_kite_textEdit_completions(mock_completions_codeeditor, qtbot):
-    """Test textEdit completions such as those returned by the Kite provider.
-
-    This mocks out the completions response, and does not test the Kite
-    provider directly.
-    """
-    code_editor, mock_response = mock_completions_codeeditor
-    completion = code_editor.completion_widget
-
-    code_editor.toggle_automatic_completions(False)
-    code_editor.toggle_code_snippets(False)
-
-    # Set cursor to start
-    code_editor.go_to_line(1)
-
-    qtbot.keyClicks(code_editor, 'my_dict.')
-
-    # Complete my_dict. -> my_dict["dict-key"]
-    mock_response.side_effect = lambda lang, method, params: {'params': [{
-        'kind': CompletionItemKind.TEXT,
-        'label': '["dict-key"]',
-        'textEdit': {
-            'newText': '["dict-key"]',
-            'range': {
-                'start': 7,
-                'end': 8,
-            },
-        },
-        'filterText': '',
-        'sortText': '',
-        'documentation': '',
-        'provider': KITE_COMPLETION,
-    }]} if method == CompletionRequestTypes.DOCUMENT_COMPLETION else None
-    with qtbot.waitSignal(completion.sig_show_completions,
-                          timeout=10000) as sig:
-        qtbot.keyPress(code_editor, Qt.Key_Tab, delay=300)
-    mock_response.side_effect = None
-
-    assert '["dict-key"]' in [x['label'] for x in sig.args[0]]
-    qtbot.keyPress(code_editor, Qt.Key_Enter, delay=300)
-    assert code_editor.toPlainText() == 'my_dict["dict-key"]\n'
 
     code_editor.toggle_automatic_completions(True)
     code_editor.toggle_code_snippets(True)

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -1083,7 +1083,7 @@ class BaseEditMixin(object):
         startpos = cursor.selectionStart()
 
         # Find a valid Python variable name
-        if valid_python_variable:
+        if valid_python_variable and not completion:
             match = re.findall(r'([^\d\W]\w*)', text, re.UNICODE)
             if not match:
                 # This is assumed in several places of our codebase,


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

When doing completions, the LSP provides also completions for file names. Files that start with number were not completed correctly since a validation for valid Python variables was being always made when getting the current word and position.

Preview

![file_completion](https://user-images.githubusercontent.com/16781833/208506477-ec920c54-ad03-47ee-b86c-bd5abe6e025a.gif)




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20156 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
