### PR TITLE
PR: Fix showing Spyder-kernels message on kernel restarts (IPython console)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -67,11 +67,11 @@ python -bb -X dev -W error -m build
 python -bb -X dev -W error -m pip install --no-deps dist/spyder*.whl
 
 # Create environment for Jedi environments tests
-mamba create -n jedi-test-env -q -y python=3.6 flask spyder-kernels
+mamba create -n jedi-test-env -q -y python=3.9 flask spyder-kernels
 mamba list -n jedi-test-env
 
 # Create environment to test conda activation before launching a spyder kernel
-mamba create -n spytest-ž -q -y python=3.6 spyder-kernels
+mamba create -n spytest-ž -q -y python=3.9 spyder-kernels
 mamba list -n spytest-ž
 
 # Install pyenv in Posix systems

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -833,38 +833,32 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
                 interpreter=pyexec,
                 version=SPYDER_KERNELS_VERSION)
 
-            if (
-                not has_spyder_kernels
-                # This is necessary to show this message for some tests and not
-                # do it for others.
-                and os.environ.get('SPY_TEST_SHOW_RESTART_MESSAGE')
-            ):
-                self.show_kernel_error(
-                    _("The Python environment or installation whose "
-                      "interpreter is located at"
-                      "<pre>"
-                      "    <tt>{0}</tt>"
-                      "</pre>"
-                      "doesn't have the <tt>spyder-kernels</tt> module or the "
-                      "right version of it installed ({1}). "
-                      "Without this module is not possible for Spyder to "
-                      "create a console for you.<br><br>"
-                      "You can install it by activating your environment (if "
-                      "necessary) and then running in a system terminal:"
-                      "<pre>"
-                      "    <tt>{2}</tt>"
-                      "</pre>"
-                      "or"
-                      "<pre>"
-                      "    <tt>{3}</tt>"
-                      "</pre>").format(
-                          pyexec,
-                          SPYDER_KERNELS_VERSION_MSG,
-                          SPYDER_KERNELS_CONDA,
-                          SPYDER_KERNELS_PIP
-                      )
+            msg = _(
+                "The Python environment or installation whose interpreter is "
+                "located at"
+                "<pre>"
+                "    <tt>{0}</tt>"
+                "</pre>"
+                "doesn't have the <tt>spyder-kernels</tt> module or the right "
+                "version of it installed ({1}). Without this module is not "
+                "possible for Spyder to create a console for you.<br><br>"
+                "You can install it by activating your environment first (if "
+                "necessary) and then running in a system terminal:"
+                "<pre>"
+                "    <tt>{2}</tt>"
+                "</pre>"
+                "or"
+                "<pre>"
+                "    <tt>{3}</tt>"
+                "</pre>").format(
+                    pyexec,
+                    SPYDER_KERNELS_VERSION_MSG,
+                    SPYDER_KERNELS_CONDA,
+                    SPYDER_KERNELS_PIP
                 )
 
+            if not has_spyder_kernels:
+                self.show_kernel_error(msg)
                 return False
             else:
                 return True

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -264,8 +264,9 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
             super(ShellWidget, self).interrupt_kernel()
         else:
             self._append_html(
-                _("The kernel appears to be dead, so it can't be interrupted. "
-                  "Please open a new console to keep working.")
+                _("<br><br>The kernel appears to be dead, so it can't be "
+                  "interrupted. Please open a new console to keep "
+                  "working.<br>")
             )
 
     def execute(self, source=None, hidden=False, interactive=False):


### PR DESCRIPTION
## Description of Changes

- This was failing because I incorrectly set the same check for normal usage and tests, so I removed it.
- Improve test that checks this so that it works for all operating systems.
- Improve a bit the message we show when the kernel can't be interrupted.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20023

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
