### PR TITLE
PR: Fix concurrency for installers-conda workflow

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -24,7 +24,7 @@ concurrency:
 name: Create conda-based installers for Windows, macOS, and Linux
 
 jobs:
-  build-noarch-conda-pkgs:
+  build-noarch-pkgs:
     name: Build ${{ matrix.pkg }}
     runs-on: ubuntu-latest
     if: github.event_name != 'release'
@@ -96,8 +96,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs:
       - build-matrix
-      - build-noarch-conda-pkgs
-    if: ${{ ! failure() }}
+      - build-noarch-pkgs
+    if: contains(fromJson('["success", "skipped"]'), needs.build-noarch-pkgs.result) && needs.build-matrix.result == 'success'
     strategy:
       matrix:
         target-platform: ${{fromJson(needs.build-matrix.outputs.target_platform)}}
@@ -114,7 +114,7 @@ jobs:
       MACOS_INSTALLER_CERTIFICATE: ${{ secrets.MACOS_INSTALLER_CERTIFICATE }}
       APPLICATION_PWD: ${{ secrets.APPLICATION_PWD }}
       CONSTRUCTOR_TARGET_PLATFORM: ${{ matrix.target-platform }}
-      STATUS: ${{ needs.build-noarch-conda-pkgs.result }}
+      STATUS: ${{ needs.build-noarch-pkgs.result }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3


### PR DESCRIPTION
Recent concurrency specifications in Spyder GitHub workflows (spyder-ide/spyder#20254) do not prevent `build-installers` jobs in `installers-conda.yml` from running under a certain circumstance. Example [PR: Cancel runs in progress when pushing new commits (CI) #250](https://github.com/spyder-ide/spyder/actions/runs/3768853668)

Concurrence cancels jobs that are pending or currently running. However, `build-installers` jobs are neither pending nor running until _after_ `build-matrix` and `build-noarch-conda-pkgs` jobs are all complete. In the circumstance that one or more of these jobs is not complete, they will be cancelled but `build-installers` jobs will then commence.

This PR should remedy this by replacing the conditional for `build-installers` jobs with explicit dependence on the results of the needed jobs. `! failure()` returns true for `"success"`, `"skipped"`, and `"cancelled"`, and therefore did not achieve the desired effect.

Note that if `build-installers` jobs are already pending/in process they will not be cancelled immediately. This is because the new `build-installers` jobs will not be queued until completion of the `build-matrix` and `build-noarch-pkgs` jobs. Upon queueing the new `build-installers` jobs, the old ones will be cancelled.
