### PR TITLE
PR: Use a better icon when no matches are found (Find/Replace widget)

### DIFF
--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -113,6 +113,7 @@ class IconManager():
             'drag_dock_widget':        [('mdi.drag-variant',), {'color': self.MAIN_FG_COLOR}],
             'format_letter_case':      [('mdi.format-letter-case',), {'color': self.MAIN_FG_COLOR}],
             'format_letter_matches':   [('mdi.format-letter-matches',), {'color': self.MAIN_FG_COLOR}],
+            'no_matches':              [('mdi.do-not-disturb',), {'color': SpyderPalette.COLOR_WARN_2}],
             'clear_text':              [('mdi.backspace',), {'color': self.MAIN_FG_COLOR}],
             'regex':                   [('mdi.regex',), {'color': self.MAIN_FG_COLOR}],
             'log':                     [('mdi.file-document',), {'color': self.MAIN_FG_COLOR}],

--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -21,7 +21,7 @@ import os.path as osp
 from qtpy.QtCore import QEvent, Qt, QTimer, QUrl, Signal, QSize
 from qtpy.QtGui import QFont
 from qtpy.QtWidgets import (QAction, QComboBox, QCompleter, QLineEdit,
-                            QSizePolicy, QToolTip)
+                            QSizePolicy, QToolButton, QToolTip)
 
 # Local imports
 from spyder.config.base import _
@@ -177,11 +177,15 @@ class PatternComboBox(BaseComboBox):
             self.clear_action, QLineEdit.TrailingPosition
         )
 
+        # Button that corresponds to the clear_action above
+        self.clear_button = self.lineEdit().findChildren(QToolButton)[0]
+
         # Hide clear_action by default because lineEdit is empty when the
         # combobox is created, so it doesn't make sense to show it.
         self.clear_action.setVisible(False)
 
         self.lineEdit().textChanged.connect(self._on_text_changed)
+        self.installEventFilter(self)
 
     def _on_text_changed(self, text):
         """Actions to take when text has changed on the line edit widget."""
@@ -189,6 +193,21 @@ class PatternComboBox(BaseComboBox):
             self.clear_action.setVisible(True)
         else:
             self.clear_action.setVisible(False)
+
+    def eventFilter(self, widget, event):
+        """
+        Event filter for this combobox.
+
+        Notes
+        -----
+        * Reduce space between clear_action and the right border of lineEdit.
+        """
+        if event.type() == QEvent.Paint:
+            self.clear_button.move(
+                self.lineEdit().width() - 22, self.clear_button.y()
+            )
+
+        return super().eventFilter(widget, event)
 
 
 class EditableComboBox(BaseComboBox):

--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -18,7 +18,8 @@ import re
 from qtpy.QtCore import QEvent, QSize, Qt, QTimer, Signal, Slot
 from qtpy.QtGui import QTextCursor
 from qtpy.QtWidgets import (QAction, QGridLayout, QHBoxLayout, QLabel,
-                            QLineEdit, QSizePolicy, QSpacerItem, QWidget)
+                            QLineEdit, QToolButton, QSizePolicy, QSpacerItem,
+                            QWidget)
 
 # Local imports
 from spyder.config.base import _
@@ -112,6 +113,11 @@ class FindReplace(QWidget):
             self.messages_action, QLineEdit.TrailingPosition)
         self.search_text.clear_action.triggered.connect(
             lambda: self.messages_action.setVisible(False)
+        )
+
+        # Button corresponding to the messages_action above
+        self.messages_button = (
+            self.search_text.lineEdit().findChildren(QToolButton)[1]
         )
 
         self.replace_on = False
@@ -249,11 +255,15 @@ class FindReplace(QWidget):
         self.search_text.installEventFilter(self)
 
     def eventFilter(self, widget, event):
-        """Event filter for search_text widget.
+        """
+        Event filter for search_text widget.
 
-        Emits signals when presing Enter and Shift+Enter.
-        This signals are used for search forward and backward.
-        Also, a crude hack to get tab working in the Find/Replace boxes.
+        Notes
+        -----
+        * Emit signals when Enter and Shift+Enter are pressed. These signals
+          are used for search forward and backward.
+        * Add crude hack to get tab working between the find/replace boxes.
+        * Reduce space between the messages_button and the clear one.
         """
 
         # Type check: Prevent error in PySide where 'event' may be of type
@@ -277,7 +287,13 @@ class FindReplace(QWidget):
                         self.search_text.currentText())
                 self.focusNextChild()
 
-        return super(FindReplace, self).eventFilter(widget, event)
+        if event.type() == QEvent.Paint:
+            self.messages_button.move(
+                self.search_text.lineEdit().width() - 42,
+                self.messages_button.y()
+            )
+
+        return super().eventFilter(widget, event)
 
     def create_shortcuts(self, parent):
         """Create shortcuts for this widget"""

--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -104,7 +104,7 @@ class FindReplace(QWidget):
             self.number_matches_text.hide
         )
 
-        self.warning_icon = ima.icon('warning')
+        self.no_matches_icon = ima.icon('no_matches')
         self.error_icon = ima.icon('error')
         self.messages_action = QAction(self)
         self.messages_action.setVisible(False)
@@ -745,7 +745,7 @@ class FindReplace(QWidget):
         else:
             self.number_matches_text.hide()
             if self.search_text.currentText():
-                self.show_warning()
+                self.show_no_matches()
 
     def update_matches(self):
         """Update total number of matches if text has changed in the editor."""
@@ -758,9 +758,9 @@ class FindReplace(QWidget):
             )
             self.change_number_matches(total_matches=number_matches)
 
-    def show_warning(self):
-        """Show a warning message with an icon when no matches can be found."""
-        self._show_icon_message('warning')
+    def show_no_matches(self):
+        """Show a no matches message with an icon."""
+        self._show_icon_message('no_matches')
 
     def show_error(self, error_msg):
         """Show a regexp error message with an icon."""
@@ -774,13 +774,13 @@ class FindReplace(QWidget):
         Parameters
         ----------
         kind: str
-            The kind of message. It can be 'warning' or 'error'.
+            The kind of message. It can be 'no_matches' or 'error'.
         extra_info:
             Extra info to add to the icon's tooltip.
         """
-        if kind == 'warning':
+        if kind == 'no_matches':
             tooltip = self.TOOLTIP['no_matches']
-            icon = self.warning_icon
+            icon = self.no_matches_icon
         else:
             tooltip = self.TOOLTIP['regexp_error']
             icon = self.error_icon

--- a/spyder/widgets/tests/test_findreplace.py
+++ b/spyder/widgets/tests/test_findreplace.py
@@ -117,7 +117,7 @@ def test_messages_action(findreplace_editor, qtbot):
     qtbot.keyClicks(edit, 'foo')
     assert not findreplace.number_matches_text.isVisible()
     assert findreplace.messages_action.icon().cacheKey() == \
-           findreplace.warning_icon.cacheKey()
+           findreplace.no_matches_icon.cacheKey()
     assert findreplace.messages_action.toolTip() == \
            findreplace.TOOLTIP['no_matches']
 


### PR DESCRIPTION
## Description of Changes

- The current icon (the warning one) did not represent correctly the lack of matches after searching for text.

    **Before**

    ![imagen](https://user-images.githubusercontent.com/365293/209702827-329ce12a-f1f0-40a1-a0dc-a554df0ca75c.png)

    **After**

    ![image](https://user-images.githubusercontent.com/365293/209750869-01517391-bfba-4971-8d19-7f1e2c1c519b.png)


- This is a follow-up of #20049.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20255.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
