### PR TITLE
PR: Require py2app 0.28.4 for the Mac installer

### DIFF
--- a/installers/macOS/req-build.txt
+++ b/installers/macOS/req-build.txt
@@ -1,5 +1,5 @@
 # For building standalone Mac app
 dmgbuild>=1.4.2
-py2app>=0.28
+py2app==0.28.4
 sphinx==5.1.1  # See spyder-ide/spyder#19618 for details.
 black==22.8.0  # See spyder-ide/spyder#19743 for details.

--- a/installers/macOS/req-scientific.txt
+++ b/installers/macOS/req-scientific.txt
@@ -1,7 +1,6 @@
 # Scientific packages (for Same as Spyder)
 cython
 matplotlib
-numpy<1.23
 openpyxl
 pandas
 scipy


### PR DESCRIPTION
## Description of Changes

- The app is failing to build with 0.28.5, released five hours ago.
- Also, remove restriction on Numpy because it's no longer necessary.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
