### PR TITLE
PR: Improve completions for scientific modules (Code completion)

### DIFF
--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/ccordoba12/python-lsp-server.git
-	branch = no-signatures-for-modules
-	commit = 8e51d5bdb7d2fc7d58239b1fee16dc95f712c50a
-	parent = 3ee2af1c0c07e5838777d6dfa06272dbab26217e
+	remote = https://github.com/python-lsp/python-lsp-server.git
+	branch = develop
+	commit = 7e739989627cbb1d75164f5c47593c3cfb29d825
+	parent = 452997ed921a2cf0f072d2b5c7fc28bd3e5bcac1
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/python-lsp/python-lsp-server.git
-	branch = develop
-	commit = a79c171da640edc2f0a0c7025b05fd7c37f733c4
-	parent = ea34d3ab5b1f12a9c19fb3faf20d8d02b94936e5
+	remote = https://github.com/ccordoba12/python-lsp-server.git
+	branch = no-signatures-for-modules
+	commit = 8e51d5bdb7d2fc7d58239b1fee16dc95f712c50a
+	parent = 3ee2af1c0c07e5838777d6dfa06272dbab26217e
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/CONFIGURATION.md
+++ b/external-deps/python-lsp-server/CONFIGURATION.md
@@ -32,6 +32,7 @@ This server can be configured using the `workspace/didChangeConfiguration` metho
 | `pylsp.plugins.jedi_definition.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.jedi_definition.follow_imports` | `boolean` | The goto call will follow imports. | `true` |
 | `pylsp.plugins.jedi_definition.follow_builtin_imports` | `boolean` | If follow_imports is True will decide if it follow builtin imports. | `true` |
+| `pylsp.plugins.jedi_definition.follow_builtin_definitions` | `boolean` | Follow builtin and extension definitions to stubs. | `true` |
 | `pylsp.plugins.jedi_hover.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.jedi_references.enabled` | `boolean` | Enable or disable the plugin. | `true` |
 | `pylsp.plugins.jedi_signature_help.enabled` | `boolean` | Enable or disable the plugin. | `true` |

--- a/external-deps/python-lsp-server/pylsp/config/schema.json
+++ b/external-deps/python-lsp-server/pylsp/config/schema.json
@@ -176,6 +176,11 @@
       "default": true,
       "description": "If follow_imports is True will decide if it follow builtin imports."
     },
+    "pylsp.plugins.jedi_definition.follow_builtin_definitions": {
+      "type": "boolean",
+      "default": true,
+      "description": "Follow builtin and extension definitions to stubs."
+    },
     "pylsp.plugins.jedi_hover.enabled": {
       "type": "boolean",
       "default": true,

--- a/external-deps/python-lsp-server/pylsp/plugins/definition.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/definition.py
@@ -17,6 +17,7 @@ def pylsp_definitions(config, workspace, document, position):
             follow_builtin_imports=settings.get('follow_builtin_imports', True),
             **code_position)
 
+        follow_builtin_defns = settings.get("follow_builtin_definitions", True)
         return [
             {
                 'uri': uris.uri_with(document.uri, path=str(d.module_path)),
@@ -25,7 +26,7 @@ def pylsp_definitions(config, workspace, document, position):
                     'end': {'line': d.line - 1, 'character': d.column + len(d.name)},
                 }
             }
-            for d in definitions if d.is_definition() and _not_internal_definition(d)
+            for d in definitions if d.is_definition() and (follow_builtin_defns or _not_internal_definition(d))
         ]
 
 

--- a/external-deps/python-lsp-server/pylsp/plugins/hover.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/hover.py
@@ -31,8 +31,13 @@ def pylsp_hover(config, document, position):
     preferred_markup_kind = _utils.choose_markup_kind(supported_markup_kinds)
 
     # Find first exact matching signature
-    signature = next((x.to_string() for x in definition.get_signatures()
-                      if x.name == word), '')
+    signature = next(
+        (
+            x.to_string() for x in definition.get_signatures()
+            if (x.name == word and x.type not in ["module"])
+        ),
+        ''
+    )
 
     return {
         'contents': _utils.format_docstring(

--- a/external-deps/python-lsp-server/pylsp/plugins/pylint_lint.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/pylint_lint.py
@@ -10,7 +10,6 @@ import re
 from subprocess import Popen, PIPE
 import os
 
-from pylint.epylint import py_run
 from pylsp import hookimpl, lsp
 
 try:
@@ -85,20 +84,21 @@ class PylintLinter:
             # save.
             return cls.last_diags[document.path]
 
-        # py_run will call shlex.split on its arguments, and shlex.split does
-        # not handle Windows paths (it will try to perform escaping). Turn
-        # backslashes into forward slashes first to avoid this issue.
-        path = document.path
-        if sys.platform.startswith('win'):
-            path = path.replace('\\', '/')
+        cmd = [
+            'python',
+            '-c',
+            'import sys; from pylint.lint import Run; Run(sys.argv[1:])',
+            '-f',
+            'json',
+            document.path
+        ] + (str(flags).split(' ') if flags else [])
+        log.debug("Calling pylint with '%s'", ' '.join(cmd))
 
-        pylint_call = '{} -f json {}'.format(path, flags)
-        log.debug("Calling pylint with '%s'", pylint_call)
-        json_out, err = py_run(pylint_call, return_std=True)
-
-        # Get strings
-        json_out = json_out.getvalue()
-        err = err.getvalue()
+        with Popen(cmd, stdout=PIPE, stderr=PIPE,
+                   cwd=document._workspace.root_path, universal_newlines=True) as process:
+            process.wait()
+            json_out = process.stdout.read()
+            err = process.stderr.read()
 
         if err != '':
             log.error("Error calling pylint: '%s'", err)

--- a/external-deps/python-lsp-server/pylsp/plugins/symbols.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/symbols.py
@@ -91,7 +91,7 @@ def pylsp_document_symbols(config, document):
                 else:
                     continue
 
-        if _include_def(d) and Path(document.path) == d.module_path:
+        if _include_def(d) and Path(document.path) == Path(d.module_path):
             tuple_range = _tuple_range(d)
             if tuple_range in exclude:
                 continue

--- a/external-deps/python-lsp-server/test/plugins/test_definitions.py
+++ b/external-deps/python-lsp-server/test/plugins/test_definitions.py
@@ -42,9 +42,24 @@ def test_builtin_definition(config, workspace):
     # Over 'i' in dict
     cursor_pos = {'line': 8, 'character': 24}
 
-    # No go-to def for builtins
     doc = Document(DOC_URI, workspace, DOC)
-    assert not pylsp_definitions(config, workspace, doc, cursor_pos)
+    orig_settings = config.settings()
+
+    # Check definition for `dict` goes to `builtins.pyi::dict`
+    follow_defns_setting = {'follow_builtin_definitions': True}
+    settings = {'plugins': {'jedi_definition': follow_defns_setting}}
+    config.update(settings)
+    defns = pylsp_definitions(config, workspace, doc, cursor_pos)
+    assert len(defns) == 1
+    assert defns[0]["uri"].endswith("builtins.pyi")
+
+    # Check no definitions for `dict`
+    follow_defns_setting['follow_builtin_definitions'] = False
+    config.update(settings)
+    defns = pylsp_definitions(config, workspace, doc, cursor_pos)
+    assert not defns
+
+    config.update(orig_settings)
 
 
 def test_assignment(config, workspace):

--- a/external-deps/python-lsp-server/test/plugins/test_pylint_lint.py
+++ b/external-deps/python-lsp-server/test/plugins/test_pylint_lint.py
@@ -3,11 +3,12 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import contextlib
+from pathlib import Path
 import os
 import tempfile
 
 from pylsp import lsp, uris
-from pylsp.workspace import Document
+from pylsp.workspace import Document, Workspace
 from pylsp.plugins import pylint_lint
 
 DOC_URI = uris.from_fs_path(__file__)
@@ -90,8 +91,9 @@ def test_lint_free_pylint(config, workspace):
     # Can't use temp_document because it might give us a file that doesn't
     # match pylint's naming requirements. We should be keeping this file clean
     # though, so it works for a test of an empty lint.
+    ws = Workspace(str(Path(__file__).absolute().parents[2]), workspace._endpoint)
     assert not pylint_lint.pylsp_lint(
-        config, workspace, Document(uris.from_fs_path(__file__), workspace), True)
+        config, ws, Document(uris.from_fs_path(__file__), ws), True)
 
 
 def test_lint_caching(workspace):

--- a/spyder/config/lsp.py
+++ b/spyder/config/lsp.py
@@ -77,8 +77,13 @@ PYTHON_CONFIG = {
                 },
                 'jedi': {
                     'environment': None,
-                    'extra_paths': None,
+                    'extra_paths': [],
                     'env_vars': None,
+                    # Until we have a graphical way for users to add modules to
+                    # this option
+                    'auto_import_modules': [
+                        'numpy', 'matplotlib', 'pandas', 'scipy'
+                    ]
                 },
                 'jedi_completion': {
                     'enabled': True,

--- a/spyder/config/lsp.py
+++ b/spyder/config/lsp.py
@@ -128,6 +128,12 @@ PYTHON_CONFIG = {
                     'group_cells': True
                 },
                 'pyls_flake8': {
+                    # This third-party plugin is deprecated now.
+                    'enabled': False,
+                },
+                'ruff': {
+                    # Disable it until we have a graphical option for users to
+                    # enable it.
                     'enabled': False,
                 }
             },


### PR DESCRIPTION
## Description of Changes

- PyLSP has now an option called `auto_import_modules` that makes Jedi directly import modules passed to it to provide completions for them. And that significantly improves completions and help for Numpy, Pandas, Matplotlib and Scipy.
- Disable the new PyLSP plugin for ruff until we have a graphical option for users to enable it.
- Resync latest PyLSP to see if our tests pass before releasing 5.4.1

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of issue #20026 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
