### PR TITLE
PR: Fix pydocstyle linting

### DIFF
--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/python-lsp/python-lsp-server.git
-	branch = develop
-	commit = 2b3ac737aa8fd0e63e44ce21c79e2ecd6f014a9d
-	parent = 0a63a22a671afadc61aece0afe2cf223d65d3526
+	remote = https://github.com/ccordoba12/python-lsp-server.git
+	branch = fix-pydocstyle
+	commit = 67772fa0cf258eb9e0a81052b3b12d7172a2ce10
+	parent = 9c37bf30584f2589fede8028eb7a4ff630c47cea
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/ccordoba12/python-lsp-server.git
-	branch = fix-pydocstyle
-	commit = 67772fa0cf258eb9e0a81052b3b12d7172a2ce10
-	parent = 9c37bf30584f2589fede8028eb7a4ff630c47cea
+	remote = https://github.com/python-lsp/python-lsp-server.git
+	branch = develop
+	commit = ce913f16359f03ffe4a60b6a2fe7ccae4b15bb4a
+	parent = 154269962fba47cd4d2360307e4a25d743e05c30
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/pylsp/plugins/pydocstyle_lint.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/pydocstyle_lint.py
@@ -66,9 +66,9 @@ def pylsp_lint(config, workspace, document):
 
         # Will only yield a single filename, the document path
         diags = []
-        for filename, checked_codes, ignore_decorators in conf.get_files_to_check():
+        for filename, checked_codes, ignore_decorators, property_decorators in conf.get_files_to_check():
             errors = pydocstyle.checker.ConventionChecker().check_source(
-                document.source, filename, ignore_decorators=ignore_decorators
+                document.source, filename, ignore_decorators=ignore_decorators, property_decorators=property_decorators
             )
 
             try:

--- a/external-deps/python-lsp-server/pylsp/plugins/pylint_lint.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/pylint_lint.py
@@ -85,7 +85,7 @@ class PylintLinter:
             return cls.last_diags[document.path]
 
         cmd = [
-            'python',
+            sys.executable,
             '-c',
             'import sys; from pylint.lint import Run; Run(sys.argv[1:])',
             '-f',

--- a/external-deps/python-lsp-server/pyproject.toml
+++ b/external-deps/python-lsp-server/pyproject.toml
@@ -31,7 +31,7 @@ all = [
     "flake8>=5.0.0,<7",
     "mccabe>=0.7.0,<0.8.0",
     "pycodestyle>=2.9.0,<2.11.0",
-    "pydocstyle>=2.0.0",
+    "pydocstyle>=6.2.0,<6.3.0",
     "pyflakes>=2.5.0,<3.1.0",
     "pylint>=2.5.0",
     "rope>1.2.0",
@@ -42,7 +42,7 @@ autopep8 = ["autopep8>=1.6.0,<1.7.0"]
 flake8 = ["flake8>=5.0.0,<7"]
 mccabe = ["mccabe>=0.7.0,<0.8.0"]
 pycodestyle = ["pycodestyle>=2.9.0,<2.11.0"]
-pydocstyle = ["pydocstyle>=2.0.0"]
+pydocstyle = ["pydocstyle>=6.2.0,<6.3.0"]
 pyflakes = ["pyflakes>=2.5.0,<3.1.0"]
 pylint = ["pylint>=2.5.0"]
 rope = ["rope>1.2.0"]


### PR DESCRIPTION
## Description of Changes

- This was broken with the new 6.2.0 release of Pydocstyle.
- Depends on https://github.com/python-lsp/python-lsp-server/pull/329

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
