### PR TITLE
PR: Skip a test that started to fail on Windows

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -116,6 +116,7 @@ def test_single_instance_and_edit_magic(main_window, qtbot, tmpdir):
 
 @pytest.mark.slow
 @pytest.mark.use_introspection
+@pytest.mark.skipif(os.name == 'nt', reason="Fails on Windows")
 def test_leaks(main_window, qtbot):
     """
     Test leaks in mainwindow when closing a file or a console.


### PR DESCRIPTION
## Description of Changes

- This started to happen when we merged support for IPython 8 (don't know why).
- It's not urgent to solve for now, but we should get back to it later.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
