### PR TITLE
PR: Update installer workflows to run as release on push of `pre` tag

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -18,11 +18,18 @@ on:
     types:
       - created
 
+  push:
+    tags:
+      - v*rc*
+
 concurrency:
   group: installer-macos-${{ github.ref }}
   cancel-in-progress: true
 
 name: Create macOS App Bundle and DMG
+
+env:
+  IS_RC: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
 
 jobs:
   matrix_prep:
@@ -33,7 +40,7 @@ jobs:
     steps:
     - id: set-matrix
       run: |
-        if [[ ${GITHUB_EVENT_NAME} == 'release' ]]; then
+        if [[ ${GITHUB_EVENT_NAME} == 'release' || ${IS_RC} == 'true' ]]; then
             build_type=$(echo "['Full', 'Lite']")
         else
             build_type=$(echo "['Full']")
@@ -96,10 +103,10 @@ jobs:
       - name: Build Application Bundle
         run: ${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dist-dir ${DISTDIR}
       - name: Create Keychain
-        if: ${{github.event_name == 'release'}}
+        if: ${{github.event_name == 'release' || env.IS_RC == 'true'}}
         run: ./certkeychain.sh "${MACOS_CERTIFICATE}" "${MACOS_CERTIFICATE_PWD}"
       - name: Code Sign Application
-        if: ${{github.event_name == 'release'}}
+        if: ${{github.event_name == 'release' || env.IS_RC == 'true'}}
         run: |
           pil=$(${pythonLocation}/bin/python -c "import PIL, os; print(os.path.dirname(PIL.__file__))")
           rm -v ${DISTDIR}/Spyder.app/Contents/Frameworks/liblzma.5.dylib
@@ -110,10 +117,10 @@ jobs:
       - name: Build Disk Image
         run: ${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dist-dir ${DISTDIR} --dmg --no-app
       - name: Sign Disk Image
-        if: ${{github.event_name == 'release'}}
+        if: ${{github.event_name == 'release' || env.IS_RC == 'true'}}
         run: ./codesign.sh "${DISTDIR}/${DMGNAME}"
       - name: Notarize Disk Image
-        if: ${{github.event_name == 'release'}}
+        if: ${{github.event_name == 'release' || env.IS_RC == 'true'}}
         run: ./notarize.sh -i 30 -p "${APPLICATION_PWD}" "${DISTDIR}/${DMGNAME}"
       - name: Upload Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -20,7 +20,7 @@ on:
 
   push:
     tags:
-      - v*rc*
+      - v*pre*
 
 concurrency:
   group: installer-macos-${{ github.ref }}
@@ -29,7 +29,7 @@ concurrency:
 name: Create macOS App Bundle and DMG
 
 env:
-  IS_RC: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+  IS_PRE: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
 
 jobs:
   matrix_prep:
@@ -40,7 +40,7 @@ jobs:
     steps:
     - id: set-matrix
       run: |
-        if [[ ${GITHUB_EVENT_NAME} == 'release' || ${IS_RC} == 'true' ]]; then
+        if [[ ${GITHUB_EVENT_NAME} == 'release' || ${IS_PRE} == 'true' ]]; then
             build_type=$(echo "['Full', 'Lite']")
         else
             build_type=$(echo "['Full']")
@@ -103,10 +103,10 @@ jobs:
       - name: Build Application Bundle
         run: ${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dist-dir ${DISTDIR}
       - name: Create Keychain
-        if: ${{github.event_name == 'release' || env.IS_RC == 'true'}}
+        if: ${{github.event_name == 'release' || env.IS_PRE == 'true'}}
         run: ./certkeychain.sh "${MACOS_CERTIFICATE}" "${MACOS_CERTIFICATE_PWD}"
       - name: Code Sign Application
-        if: ${{github.event_name == 'release' || env.IS_RC == 'true'}}
+        if: ${{github.event_name == 'release' || env.IS_PRE == 'true'}}
         run: |
           pil=$(${pythonLocation}/bin/python -c "import PIL, os; print(os.path.dirname(PIL.__file__))")
           rm -v ${DISTDIR}/Spyder.app/Contents/Frameworks/liblzma.5.dylib
@@ -117,10 +117,10 @@ jobs:
       - name: Build Disk Image
         run: ${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dist-dir ${DISTDIR} --dmg --no-app
       - name: Sign Disk Image
-        if: ${{github.event_name == 'release' || env.IS_RC == 'true'}}
+        if: ${{github.event_name == 'release' || env.IS_PRE == 'true'}}
         run: ./codesign.sh "${DISTDIR}/${DMGNAME}"
       - name: Notarize Disk Image
-        if: ${{github.event_name == 'release' || env.IS_RC == 'true'}}
+        if: ${{github.event_name == 'release' || env.IS_PRE == 'true'}}
         run: ./notarize.sh -i 30 -p "${APPLICATION_PWD}" "${DISTDIR}/${DMGNAME}"
       - name: Upload Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/installer-win.yml
+++ b/.github/workflows/installer-win.yml
@@ -21,7 +21,7 @@ on:
 
   push:
     tags:
-      - v*rc*
+      - v*pre*
 
 concurrency:
   group: installer-win-${{ github.ref }}
@@ -30,7 +30,7 @@ concurrency:
 name: Create Windows Installer
 
 env:
-  IS_RC: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+  IS_PRE: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
 
 jobs:
   build:

--- a/.github/workflows/installer-win.yml
+++ b/.github/workflows/installer-win.yml
@@ -19,11 +19,18 @@ on:
     types:
       - created
 
+  push:
+    tags:
+      - v*rc*
+
 concurrency:
   group: installer-win-${{ github.ref }}
   cancel-in-progress: true
 
 name: Create Windows Installer
+
+env:
+  IS_RC: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
 
 jobs:
   build:

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -17,17 +17,24 @@ on:
     types:
       - created
 
+  push:
+    tags:
+      - v*rc*
+
 concurrency:
   group: installers-conda-${{ github.ref }}
   cancel-in-progress: true
 
 name: Create conda-based installers for Windows, macOS, and Linux
 
+env:
+  IS_RC: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+
 jobs:
   build-noarch-pkgs:
     name: Build ${{ matrix.pkg }}
     runs-on: ubuntu-latest
-    if: github.event_name != 'release'
+    if: github.event_name == 'pull_request'
     strategy:
       matrix:
         pkg: ["python-lsp-server", "qdarkstyle", "qtconsole"]
@@ -82,7 +89,7 @@ jobs:
         "
         python_version="'3.9'"
 
-        if [[ ${GITHUB_EVENT_NAME} != 'release' ]]; then
+        if [[ ${GITHUB_EVENT_NAME} == 'pull_request' ]]; then
             target_platform=$target_platform", 'win-64'"
             include=$include",{'os': 'windows-latest', 'target-platform': 'win-64'}"
         fi
@@ -152,7 +159,7 @@ jobs:
           env
 
       - name: Download Local Conda Packages
-        if: github.event_name != 'release'
+        if: github.event_name == 'pull_request'
         uses: actions/download-artifact@v3
         with:
           path: ${{ env.ARTIFACTS_PATH }}
@@ -175,13 +182,13 @@ jobs:
       - name: Build ${{ matrix.target-platform }} conda packages
         run: |
           pkgs=("spyder")
-          if [[ $GITHUB_EVENT_NAME != "release" ]]; then
+          if [[ $GITHUB_EVENT_NAME == "pull_request" ]]; then
               pkgs+=("spyder-kernels")
           fi
           python build_conda_pkgs.py --build ${pkgs[@]}
 
       - name: Create Keychain
-        if: github.event_name == 'release' && runner.os == 'macOS'
+        if: (github.event_name == 'release' || env.IS_RC == 'true') && runner.os == 'macOS'
         run: |
           ./certkeychain.sh "${MACOS_CERTIFICATE_PWD}" "${MACOS_CERTIFICATE}" "${MACOS_INSTALLER_CERTIFICATE}"
           CNAME=$(security find-identity -p codesigning -v | pcregrep -o1 "\(([0-9A-Z]+)\)")
@@ -219,7 +226,7 @@ jobs:
           fi
 
       - name: Notarize package installer
-        if: github.event_name == 'release' && runner.os == 'macOS'
+        if: (github.event_name == 'release' || env.IS_RC == 'true') && runner.os == 'macOS'
         run: ./notarize.sh -p $APPLICATION_PWD $PKG_FILE
 
       - name: Upload Artifact

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -19,7 +19,7 @@ on:
 
   push:
     tags:
-      - v*rc*
+      - v*pre*
 
 concurrency:
   group: installers-conda-${{ github.ref }}
@@ -28,7 +28,7 @@ concurrency:
 name: Create conda-based installers for Windows, macOS, and Linux
 
 env:
-  IS_RC: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+  IS_PRE: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
 
 jobs:
   build-noarch-pkgs:
@@ -188,7 +188,7 @@ jobs:
           python build_conda_pkgs.py --build ${pkgs[@]}
 
       - name: Create Keychain
-        if: (github.event_name == 'release' || env.IS_RC == 'true') && runner.os == 'macOS'
+        if: (github.event_name == 'release' || env.IS_PRE == 'true') && runner.os == 'macOS'
         run: |
           ./certkeychain.sh "${MACOS_CERTIFICATE_PWD}" "${MACOS_CERTIFICATE}" "${MACOS_INSTALLER_CERTIFICATE}"
           CNAME=$(security find-identity -p codesigning -v | pcregrep -o1 "\(([0-9A-Z]+)\)")
@@ -226,7 +226,7 @@ jobs:
           fi
 
       - name: Notarize package installer
-        if: (github.event_name == 'release' || env.IS_RC == 'true') && runner.os == 'macOS'
+        if: (github.event_name == 'release' || env.IS_PRE == 'true') && runner.os == 'macOS'
         run: ./notarize.sh -p $APPLICATION_PWD $PKG_FILE
 
       - name: Upload Artifact

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -128,6 +128,17 @@ To release a new version of Spyder you need to follow these steps:
 
 * Merge this PR following the procedure mentioned on [`MAINTENANCE.md`](MAINTENANCE.md)
 
+### Check release candidate
+
+* Update version in `__init__.py` (set release version, remove 'dev0', add 'preX'), then
+
+      git add .
+      git commit -m "Release X.X.XpreX"
+      git tag vX.X.XpreX
+      git push upstream --tags
+
+* If workflows succeed, proceed to steps to publish the release; otherwise merge a fix PR and repeat previous steps with incremented 'preX'
+
 ## To do the release
 
 * Close the current milestone on Github


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

The installer workflows will now run the same way for both a release event _or_ a push of a release candidate tag.
- Pushing a tag of the form `v*pre*` (e.g. `v5.4.2pre1`) will run these workflows in the same manner as a release
- Artifacts are uploaded, but _not_ uploaded to a release.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary

<!--- Thanks for your help making Spyder better for everyone! --->
