### PR TITLE
replacing formatargspec() per inspect.signature()

### DIFF
--- a/external-deps/spyder-kernels/spyder_kernels/utils/dochelpers.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/dochelpers.py
@@ -110,11 +110,8 @@ def getdoc(obj):
             doc['note'] = 'Function'
         doc['name'] = obj.__name__
         if inspect.isfunction(obj):
-            (args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults,
-             annotations) = inspect.getfullargspec(obj)
-            doc['argspec'] = inspect.formatargspec(
-                args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults,
-                annotations, formatvalue=lambda o: '='+repr(o))
+            sig = inspect.signature(obj)
+            doc['argspec'] = str(sig)
             if name == '<lambda>':
                 doc['name'] = name + ' lambda '
                 doc['argspec'] = doc['argspec'][1:-1] # remove parentheses


### PR DESCRIPTION
The formatargspec() function is deprecated since Python 3.5, and removed in Python-3.11
It would be nice to have a fix in coming Spyder-5.4.2


## Description of Changes

* I replace The formatargspec() function, deprecated since Python 3.5; per [inspect.signature()](https://docs.python.org/3/library/inspect.html#inspect.signature)
* [x] should resolve https://github.com/spyder-ide/spyder/issues/20296
* [x] I did a simple check posted in the issue itself
![image](https://user-images.githubusercontent.com/4312421/211159090-756b2230-6a24-4797-a2d9-01d00dd1fbf1.png)

<!--- Explain what you've done and why --->
I asked ChatGPT, as my first try to see what it can do, on a code I don't understand



### Issue(s) Resolved

to solve https://github.com/spyder-ide/spyder/issues/20296 
 
### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
