### PR TITLE
PR: Fix getting object signature from kernel in Python 3.11 (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/juliangilbey/spyder-kernels.git
-	branch = replace-deprecated-formatargspec
-	commit = 688448601300afb421aaac56ad39be37ba731285
-	parent = 20ffa5c72c9fe2005f062afa236df4cd19d127c0
+	remote = https://github.com/spyder-ide/spyder-kernels.git
+	branch = 2.x
+	commit = ef13337fa6162f396e3dbef3e5ac48131cd38ae5
+	parent = 469ab531b133482ac05d536ec945bd6f99094d1d
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 2.x
-	commit = e00fdd802629f0578364f863c2f3c303bc4a8be9
-	parent = b3a356bafdaa3e357ef8a833a9e3b1f2a0b1ded4
+	remote = https://github.com/juliangilbey/spyder-kernels.git
+	branch = replace-deprecated-formatargspec
+	commit = 688448601300afb421aaac56ad39be37ba731285
+	parent = 20ffa5c72c9fe2005f062afa236df4cd19d127c0
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/utils/dochelpers.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/dochelpers.py
@@ -120,11 +120,8 @@ def getdoc(obj):
                     args, varargs, varkw, defaults,
                     formatvalue=lambda o:'='+repr(o))
             else:
-                (args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults,
-                 annotations) = inspect.getfullargspec(obj)
-                doc['argspec'] = inspect.formatargspec(
-                    args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults,
-                    annotations, formatvalue=lambda o:'='+repr(o))
+                sig = inspect.signature(obj)
+                doc['argspec'] = str(sig)
             if name == '<lambda>':
                 doc['name'] = name + ' lambda '
                 doc['argspec'] = doc['argspec'][1:-1] # remove parentheses

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -260,7 +260,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
         # Check if there is a kernel that can be interrupted before trying to
         # do it.
         # Fixes spyder-ide/spyder#20212
-        if self.kernel_manager.has_kernel:
+        if self.kernel_manager and self.kernel_manager.has_kernel:
             super(ShellWidget, self).interrupt_kernel()
         else:
             self._append_html(


### PR DESCRIPTION
## Description of Changes

- We were using a function to get signatures which is deprecated since Python 3.5 and removed in Python 3.11. So, that's giving an error now in the latter version.
- Depends on spyder-ide/spyder-kernels#435.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20296.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
