### PR TITLE
PR: Introduce completions correctly for autocompletion characters and improve file completions (Editor)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -19,6 +19,9 @@ if [ "$USE_CONDA" = "true" ]; then
 
     # Install dependencies per operating system
     if [ "$OS" = "win" ]; then
+        # This is necessary for our tests related to conda envs to pass since
+        # the release of Mamba 1.1.0
+        mamba init
         mamba env update --file requirements/windows.yml
     elif [ "$OS" = "macos" ]; then
         mamba env update --file requirements/macos.yml

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -110,6 +110,14 @@ jobs:
         run: |
           conda info
           conda list
+      # Notes:
+      # 1. This only works for conda, probably because it has the necessary
+      #    MSYS2 packages to create the connection.
+      # 2. Check https://github.com/marketplace/actions/debugging-with-tmate for
+      #    usage.
+      #- name: Setup remote ssh connection
+      #  if: env.USE_CONDA == 'true'
+      #  uses: mxschmitt/action-tmate@v3
       - name: Run manifest checks
         if: env.RUN_BUILD == 'true'
         shell: bash -l {0}

--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/python-lsp/python-lsp-server.git
-	branch = develop
-	commit = ce913f16359f03ffe4a60b6a2fe7ccae4b15bb4a
-	parent = 154269962fba47cd4d2360307e4a25d743e05c30
+	remote = https://github.com/ccordoba12/python-lsp-server.git
+	branch = improve-file-completions
+	commit = dbf75cf19084ab6dbe5e86aa2770b5ca23555c52
+	parent = 783e244cd5a9a077883c6d7564e71bb9305be57b
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/ccordoba12/python-lsp-server.git
-	branch = improve-file-completions
-	commit = dbf75cf19084ab6dbe5e86aa2770b5ca23555c52
-	parent = 783e244cd5a9a077883c6d7564e71bb9305be57b
+	remote = https://github.com/python-lsp/python-lsp-server.git
+	branch = develop
+	commit = 11b54415d4e1f167c75b19804dfd24b32a325ad1
+	parent = 814cbbb8f7ec60452855e14e57261ed5ee739613
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/pylsp/plugins/jedi_completion.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/jedi_completion.py
@@ -2,7 +2,7 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import logging
-import os.path as osp
+import os
 
 import parso
 
@@ -219,10 +219,20 @@ def _format_completion(d, markup_kind: str, include_params=True, resolve=False, 
     if resolve:
         completion = _resolve_completion(completion, d, markup_kind)
 
+    # Adjustments for file completions
     if d.type == 'path':
-        path = osp.normpath(d.name)
+        path = os.path.normpath(d.name)
         path = path.replace('\\', '\\\\')
         path = path.replace('/', '\\/')
+
+        # If the completion ends with os.sep, it means it's a directory. So we add an escaped os.sep
+        # at the end to ease additional file completions.
+        if d.name.endswith(os.sep):
+            if os.name == 'nt':
+                path = path + '\\\\'
+            else:
+                path = path + '\\/'
+
         completion['insertText'] = path
 
     if include_params and not is_exception_class(d.name):

--- a/external-deps/python-lsp-server/pylsp/plugins/pylint_lint.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/pylint_lint.py
@@ -9,6 +9,7 @@ import sys
 import re
 from subprocess import Popen, PIPE
 import os
+import shlex
 
 from pylsp import hookimpl, lsp
 
@@ -91,7 +92,7 @@ class PylintLinter:
             '-f',
             'json',
             document.path
-        ] + (str(flags).split(' ') if flags else [])
+        ] + (shlex.split(str(flags)) if flags else [])
         log.debug("Calling pylint with '%s'", ' '.join(cmd))
 
         with Popen(cmd, stdout=PIPE, stderr=PIPE,
@@ -126,6 +127,7 @@ class PylintLinter:
         # The type can be any of:
         #
         #  * convention
+        #  * information
         #  * error
         #  * fatal
         #  * refactor
@@ -150,6 +152,8 @@ class PylintLinter:
             }
 
             if diag['type'] == 'convention':
+                severity = lsp.DiagnosticSeverity.Information
+            elif diag['type'] == 'information':
                 severity = lsp.DiagnosticSeverity.Information
             elif diag['type'] == 'error':
                 severity = lsp.DiagnosticSeverity.Error

--- a/external-deps/python-lsp-server/pyproject.toml
+++ b/external-deps/python-lsp-server/pyproject.toml
@@ -33,10 +33,10 @@ all = [
     "pycodestyle>=2.9.0,<2.11.0",
     "pydocstyle>=6.2.0,<6.3.0",
     "pyflakes>=2.5.0,<3.1.0",
-    "pylint>=2.5.0",
+    "pylint>=2.5.0,<3",
     "rope>1.2.0",
     "yapf",
-    "whatthepatch"
+    "whatthepatch>=1.0.2,<2.0.0"
 ]
 autopep8 = ["autopep8>=1.6.0,<1.7.0"]
 flake8 = ["flake8>=5.0.0,<7"]
@@ -44,12 +44,12 @@ mccabe = ["mccabe>=0.7.0,<0.8.0"]
 pycodestyle = ["pycodestyle>=2.9.0,<2.11.0"]
 pydocstyle = ["pydocstyle>=6.2.0,<6.3.0"]
 pyflakes = ["pyflakes>=2.5.0,<3.1.0"]
-pylint = ["pylint>=2.5.0"]
+pylint = ["pylint>=2.5.0,<3"]
 rope = ["rope>1.2.0"]
 yapf = ["yapf", "whatthepatch>=1.0.2,<2.0.0"]
 websockets = ["websockets>=10.3"]
 test = [
-    "pylint>=2.5.0",
+    "pylint>=2.5.0,<3",
     "pytest",
     "pytest-cov",
     "coverage",

--- a/external-deps/python-lsp-server/test/plugins/test_completion.py
+++ b/external-deps/python-lsp-server/test/plugins/test_completion.py
@@ -528,3 +528,26 @@ mymodule.f"""
     com_position = {'line': 1, 'character': 10}
     completions = pylsp_jedi_completions(doc._config, doc, com_position)
     assert completions[0]['label'] == 'foo()'
+
+
+def test_file_completions(workspace, tmpdir):
+    # Create directory and a file to get completions for them.
+    # Note: `tmpdir`` is the root dir of the `workspace` fixture. That's why we use
+    # it here.
+    tmpdir.mkdir('bar')
+    file = tmpdir.join('foo.txt')
+    file.write('baz')
+
+    # Content of doc to test completion
+    doc_content = '"'
+    doc = Document(DOC_URI, workspace, doc_content)
+
+    # Request for completions
+    com_position = {'line': 0, 'character': 1}
+    completions = pylsp_jedi_completions(doc._config, doc, com_position)
+
+    # Check completions
+    assert len(completions) == 2
+    assert [c['kind'] == lsp.CompletionItemKind.File for c in completions]
+    assert completions[0]['insertText'] == ('bar' + '\\\\') if os.name == 'nt' else ('bar' + '\\/')
+    assert completions[1]['insertText'] == 'foo.txt"'

--- a/spyder/plugins/editor/extensions/closequotes.py
+++ b/spyder/plugins/editor/extensions/closequotes.py
@@ -3,7 +3,10 @@
 # Copyright © Spyder Project Contributors
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
+
 """This module contains the close quotes editor extension."""
+
+import re
 
 # Third party imports
 from qtpy.QtGui import QTextCursor
@@ -27,10 +30,14 @@ def unmatched_quotes_in_line(text):
 
     Distributed under the terms of the BSD License.
     """
+    # Remove escaped quotes from counting, but only if they are not to the
+    # right of a backslash because in that case the backslash is the char that
+    # is escaped.
+    text = re.sub(r"(?<!\\)\\'", '', text)
+    text = re.sub(r'(?<!\\)\\"', '', text)
+
     # We check " first, then ', so complex cases with nested quotes will
     # get the " to take precedence.
-    text = text.replace("\\'", "")
-    text = text.replace('\\"', '')
     if text.count('"') % 2:
         return '"'
     elif text.count("'") % 2:

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -938,12 +938,12 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
                 end = self.get_position_line_number(end_line, end_col)
             cursor.setPosition(start)
             cursor.setPosition(end, QTextCursor.KeepAnchor)
-            text = to_text_string(completion['textEdit']['newText'])
+            text = str(completion['textEdit']['newText'])
         else:
             text = completion
             if isinstance(completion, dict):
                 text = completion['insertText']
-            text = to_text_string(text)
+            text = str(text)
 
             # Get word to the left of the cursor.
             result = self.get_current_word_and_position(
@@ -953,13 +953,12 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
                 end_position = start_position + len(current_text)
 
                 # Check if the completion position is in the expected range
-                if not start_position <= completion_position <= end_position:
+                if not (start_position <= completion_position <= end_position):
                     return
                 cursor.setPosition(start_position)
 
                 # Remove the word under the cursor
-                cursor.setPosition(end_position,
-                                   QTextCursor.KeepAnchor)
+                cursor.setPosition(end_position, QTextCursor.KeepAnchor)
             else:
                 # Check if we are in the correct position
                 if cursor.position() != completion_position:

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -971,7 +971,7 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
 
                 # Adjustments for file completions
                 if kind == CompletionItemKind.FILE:
-                    special_chars = ['"', "'", '/']
+                    special_chars = ['"', "'", '/', '\\']
 
                     if any(
                         [current_text.endswith(c) for c in special_chars]

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -952,13 +952,30 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
                 current_text, start_position = result
                 end_position = start_position + len(current_text)
 
-                # Check if the completion position is in the expected range
-                if not (start_position <= completion_position <= end_position):
-                    return
-                cursor.setPosition(start_position)
+                # Remove text under cursor only if it's not an autocompletion
+                # character
+                is_auto_completion_character = False
+                if self.objectName() == 'console':
+                    if current_text == '.':
+                        is_auto_completion_character = True
+                else:
+                    if current_text in self.auto_completion_characters:
+                        is_auto_completion_character = True
 
-                # Remove the word under the cursor
-                cursor.setPosition(end_position, QTextCursor.KeepAnchor)
+                if not is_auto_completion_character:
+                    # Check if the completion position is in the expected range
+                    if not (
+                        start_position <= completion_position <= end_position
+                    ):
+                        return
+                    cursor.setPosition(start_position)
+
+                    # Remove the word under the cursor
+                    cursor.setPosition(end_position, QTextCursor.KeepAnchor)
+                else:
+                    # Check if we are in the correct position
+                    if cursor.position() != completion_position:
+                        return
             else:
                 # Check if we are in the correct position
                 if cursor.position() != completion_position:

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -1193,6 +1193,7 @@ def test_dot_completions(completions_codeeditor, qtbot):
     """
     code_editor, _ = completions_codeeditor
     completion = code_editor.completion_widget
+    code_editor.toggle_code_snippets(False)
 
     # Import module and check completions are shown for it after writing a dot
     # after it
@@ -1207,6 +1208,17 @@ def test_dot_completions(completions_codeeditor, qtbot):
 
     qtbot.wait(500)
     assert completion.isVisible()
+
+    # Select a raondom entry in the completion widget
+    entry_index = random.randint(0, 30)
+    inserted_entry = completion.completion_list[entry_index]['insertText']
+    for _ in range(entry_index):
+        qtbot.keyPress(completion, Qt.Key_Down, delay=50)
+
+    # Insert completion and check that the inserted text is the expected one
+    qtbot.keyPress(completion, Qt.Key_Enter)
+    qtbot.wait(500)
+    assert code_editor.toPlainText() == f'import math\nmath.{inserted_entry}'
 
 
 @pytest.mark.slow

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -1223,34 +1223,37 @@ def test_dot_completions(completions_codeeditor, qtbot):
 
 @pytest.mark.slow
 @pytest.mark.order(1)
-def test_completions_for_files_that_start_with_numbers(
-        mock_completions_codeeditor, qtbot):
+@pytest.mark.parametrize("filename", ['000_test.txt', '.hidden', 'any_file'])
+def test_file_completions(filename, mock_completions_codeeditor, qtbot):
     """
-    Test that completions for files that start with numbers are handled as
-    expected.
+    Test that completions for files are handled as expected.
 
-    This is a regression test for issue spyder-ide/spyder#20156
+    This includes a regression test for issue spyder-ide/spyder#20156
     """
     code_editor, mock_response = mock_completions_codeeditor
     completion = code_editor.completion_widget
-    file_name = '000_testing.txt'
 
     # Set text to complete and move cursor to the position we want to ask for
     # completions.
-    qtbot.keyClicks(code_editor, "'0'")
+    if filename == 'any_file':
+        # This checks if we're able to introduce file completions as expected
+        # for any file when requesting them inside a string.
+        qtbot.keyClicks(code_editor, "''")
+    else:
+        qtbot.keyClicks(code_editor, f"'{filename[0]}'")
     code_editor.moveCursor(QTextCursor.PreviousCharacter)
     qtbot.wait(500)
 
     # Complete '0' -> '000_testing.txt'
     mock_response.side_effect = lambda lang, method, params: {'params': [{
-        'label': f'{file_name}',
+        'label': f'{filename}',
         'kind': CompletionItemKind.FILE,
-        'sortText': (0, f'a{file_name}'),
-        'insertText': f'{file_name}',
+        'sortText': (0, f'a{filename}'),
+        'insertText': f'{filename}',
         'data': {'doc_uri': path_as_uri(__file__)},
         'detail': '',
         'documentation': '',
-        'filterText': f'{file_name}',
+        'filterText': f'{filename}',
         'insertTextFormat': 1,
         'provider': 'LSP',
         'resolve': True
@@ -1261,7 +1264,7 @@ def test_completions_for_files_that_start_with_numbers(
         qtbot.keyPress(code_editor, Qt.Key_Tab, delay=300)
 
     qtbot.wait(500)
-    assert code_editor.get_text_with_eol() == f"'{file_name}'"
+    assert code_editor.get_text_with_eol() == f"'{filename}'"
 
 
 if __name__ == '__main__':

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -1225,7 +1225,7 @@ def test_dot_completions(completions_codeeditor, qtbot):
 @pytest.mark.order(1)
 @pytest.mark.parametrize(
     "filename", ['000_test.txt', '.hidden', 'any_file.txt', 'abc.py',
-                 'part.0.parquet'])
+                 'part.0.parquet', '/home', '/usr/bin'])
 def test_file_completions(filename, mock_completions_codeeditor, qtbot):
     """
     Test that completions for files are handled as expected.
@@ -1249,21 +1249,35 @@ def test_file_completions(filename, mock_completions_codeeditor, qtbot):
         # This checks that we can insert file completions next to a dot when a
         # filename has several dots.
         qtbot.keyClicks(code_editor, "'part.0.'")
+    elif filename == '/home':
+        # This checks that we can insert file completions next to a /
+        qtbot.keyClicks(code_editor, "'/'")
+    elif filename == '/usr/bin':
+        # This checks that we can insert file completions next to a / placed at
+        # second-level
+        qtbot.keyClicks(code_editor, "'/usr/'")
     else:
         qtbot.keyClicks(code_editor, f"'{filename[0]}'")
     code_editor.moveCursor(QTextCursor.PreviousCharacter)
     qtbot.wait(500)
 
-    # Complete '0' -> '000_testing.txt'
+    # Set text that will be completed
+    if filename == '/home':
+        completion_text = 'home'
+    elif filename == '/usr/bin':
+        completion_text = 'bin'
+    else:
+        completion_text = filename
+
     mock_response.side_effect = lambda lang, method, params: {'params': [{
-        'label': f'{filename}',
+        'label': f'{completion_text}',
         'kind': CompletionItemKind.FILE,
-        'sortText': (0, f'a{filename}'),
-        'insertText': f'{filename}',
+        'sortText': (0, f'a{completion_text}'),
+        'insertText': f'{completion_text}',
         'data': {'doc_uri': path_as_uri(__file__)},
         'detail': '',
         'documentation': '',
-        'filterText': f'{filename}',
+        'filterText': f'{completion_text}',
         'insertTextFormat': 1,
         'provider': 'LSP',
         'resolve': True

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -1225,7 +1225,7 @@ def test_dot_completions(completions_codeeditor, qtbot):
 @pytest.mark.order(1)
 @pytest.mark.parametrize(
     "filename", ['000_test.txt', '.hidden', 'any_file.txt', 'abc.py',
-                 'part.0.parquet', '/home', '/usr/bin'])
+                 'part.0.parquet', '/home', '/usr/bin', r'C:\\Users'])
 def test_file_completions(filename, mock_completions_codeeditor, qtbot):
     """
     Test that completions for files are handled as expected.
@@ -1256,6 +1256,9 @@ def test_file_completions(filename, mock_completions_codeeditor, qtbot):
         # This checks that we can insert file completions next to a / placed at
         # second-level
         qtbot.keyClicks(code_editor, "'/usr/'")
+    elif filename == r'C:\\Users':
+        # This checks that we can insert file completions next to a \
+        qtbot.keyClicks(code_editor, r"'C:\\'")
     else:
         qtbot.keyClicks(code_editor, f"'{filename[0]}'")
     code_editor.moveCursor(QTextCursor.PreviousCharacter)
@@ -1266,6 +1269,8 @@ def test_file_completions(filename, mock_completions_codeeditor, qtbot):
         completion_text = 'home'
     elif filename == '/usr/bin':
         completion_text = 'bin'
+    elif filename == r'C:\\Users':
+        completion_text = 'Users'
     else:
         completion_text = filename
 

--- a/spyder/plugins/editor/widgets/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/tests/test_introspection.py
@@ -1223,7 +1223,9 @@ def test_dot_completions(completions_codeeditor, qtbot):
 
 @pytest.mark.slow
 @pytest.mark.order(1)
-@pytest.mark.parametrize("filename", ['000_test.txt', '.hidden', 'any_file'])
+@pytest.mark.parametrize(
+    "filename", ['000_test.txt', '.hidden', 'any_file.txt', 'abc.py',
+                 'part.0.parquet'])
 def test_file_completions(filename, mock_completions_codeeditor, qtbot):
     """
     Test that completions for files are handled as expected.
@@ -1235,10 +1237,18 @@ def test_file_completions(filename, mock_completions_codeeditor, qtbot):
 
     # Set text to complete and move cursor to the position we want to ask for
     # completions.
-    if filename == 'any_file':
+    if filename == 'any_file.txt':
         # This checks if we're able to introduce file completions as expected
         # for any file when requesting them inside a string.
         qtbot.keyClicks(code_editor, "''")
+    elif filename == 'abc.py':
+        # This checks that we can insert file completions correctly after a
+        # dot
+        qtbot.keyClicks(code_editor, "'abc.'")
+    elif filename == 'part.0.parquet':
+        # This checks that we can insert file completions next to a dot when a
+        # filename has several dots.
+        qtbot.keyClicks(code_editor, "'part.0.'")
     else:
         qtbot.keyClicks(code_editor, f"'{filename[0]}'")
     code_editor.moveCursor(QTextCursor.PreviousCharacter)

--- a/spyder/plugins/ipythonconsole/utils/tests/test_spyder_kernel.py
+++ b/spyder/plugins/ipythonconsole/utils/tests/test_spyder_kernel.py
@@ -43,6 +43,7 @@ def test_kernel_pypath(tmpdir, default_interpreter):
     # Restore default values
     CONF.set('main_interpreter', 'default', True)
     CONF.set('pythonpath_manager', 'spyder_pythonpath', [])
+    del os.environ['PYTHONPATH']
 
 
 def test_python_interpreter(tmpdir):

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -232,9 +232,14 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
         self.shellwidget.sig_remote_execute.disconnect(
             self._when_prompt_is_ready)
 
-        # It's necessary to do this at this point to avoid giving
-        # focus to _control at startup.
-        self._connect_control_signals()
+        # Notes:
+        # 1. It's necessary to do this at this point to avoid giving focus to
+        #    _control at startup.
+        # 2. The try except is needed to avoid some errors in our tests.
+        try:
+            self._connect_control_signals()
+        except RuntimeError:
+            pass
 
         if self.give_focus:
             self.shellwidget._control.setFocus()


### PR DESCRIPTION
## Description of Changes

- Completions were not introduced correctly when one was selected in the completion widget after they were triggered automatically next to a dot.
- Fix introducing completions for files and directories that start with a dot (they were not introduced correctly either).
- Fix introducing completions for files and directories in empty strings, i.e. you can hit `Tab` in a empty string (`"<Tab>"`) and Jedi will provide file completions in that case. The problem was the selected entry was not placed correctly in the editor either.
- Fix introducing file and directory completions next to a path separator (i.e. `os.sep`).
- Expand tests to cover all those cases.
- Depends on https://github.com/python-lsp/python-lsp-server/pull/337

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20331 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
