### PR TITLE
PR: Fix patch for conda-based installers

### DIFF
--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -200,8 +200,8 @@ class SpyderCondaPkg(BuildCondaPkg):
     def _patch_source(self):
         self.logger.info("Creating Spyder source patch...")
 
-        patch = self.repo.git.format_patch(
-            "..origin/installers-conda-patch", "--stdout", "-U3"
+        patch = self.repo.git.diff(
+            "...origin/installers-conda-patch"
         )
         # newline keyword is not added to pathlib until Python>=3.10,
         # so we must use open to ensure LF on Windows


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* Use `git diff` instead of `git format-patch`. This is more reliable on Linux and is the correct way to do it.
* ~~Do not normalize the tag name. This prevents `setuptools_scm` from replacing 'pre' with 'rc' in the version string.~~