### PR TITLE
PR: Rely on `jupyter-client` 7.4.9+ because it's compatible with PyZMQ 25 (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.github/workflows/linux-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/linux-tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false 
       matrix:
-        PYTHON_VERSION: ['3.7', '3.8', '3.9']
+        PYTHON_VERSION: ['3.8', '3.9', '3.10']
     timeout-minutes: 20
     steps:
       - name: Checkout branch

--- a/external-deps/spyder-kernels/.github/workflows/macos-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/macos-tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false 
       matrix:
-        PYTHON_VERSION: ['3.7', '3.8', '3.9']
+        PYTHON_VERSION: ['3.8', '3.9', '3.10']
     timeout-minutes: 25
     steps:
       - name: Checkout branch

--- a/external-deps/spyder-kernels/.github/workflows/windows-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/windows-tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false 
       matrix:
-        PYTHON_VERSION: ['3.7', '3.8', '3.9']
+        PYTHON_VERSION: ['3.8', '3.9', '3.10']
     timeout-minutes: 25
     steps:
       - name: Checkout branch

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = 2.x
-	commit = ef13337fa6162f396e3dbef3e5ac48131cd38ae5
-	parent = 469ab531b133482ac05d536ec945bd6f99094d1d
+	commit = 7a85b588eadf0722f913b0982f90ece90c19c279
+	parent = d8db7d6b8d1852e4951800a368852d4f7c956082
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/requirements/posix.txt
+++ b/external-deps/spyder-kernels/requirements/posix.txt
@@ -1,6 +1,6 @@
 cloudpickle
 ipykernel>=6.16.1,<7
 ipython>=7.31.1,<9
-jupyter_client>=7.3.4,<8
+jupyter_client>=7.4.9,<8
 pyzmq>=22.1.0
 wurlitzer>=1.0.3

--- a/external-deps/spyder-kernels/requirements/windows.txt
+++ b/external-deps/spyder-kernels/requirements/windows.txt
@@ -1,5 +1,5 @@
 cloudpickle
 ipykernel>=6.16.1,<7
 ipython>=7.31.1,<9
-jupyter_client>=7.3.4,<8
+jupyter_client>=7.4.9,<8
 pyzmq>=22.1.0

--- a/external-deps/spyder-kernels/setup.py
+++ b/external-deps/spyder-kernels/setup.py
@@ -44,7 +44,7 @@ REQUIREMENTS = [
     'ipython<6; python_version<"3"',
     'ipython>=7.31.1,<9; python_version>="3"',
     'jupyter-client>=5.3.4,<6; python_version<"3"',
-    'jupyter-client>=7.3.4,<8; python_version>="3"',
+    'jupyter-client>=7.4.9,<8; python_version>="3"',
     'pyzmq>=17,<20; python_version<"3"',
     'pyzmq>=22.1.0; python_version>="3"',
     'wurlitzer>=1.0.3;platform_system!="Windows"',


### PR DESCRIPTION
## Description of Changes

- New changes in PyZMQ 25 introduced some errors in jupyter-client, which were already fixed and released in its 7.4.9 version.
- Those errors break our IPython console, which is why we need to rely on that version now.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20359.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
