### PR TITLE
PR: Add workflow triggers for release candidates and fix tag normalization

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -1,5 +1,10 @@
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
       - 'installers/macOS/**'
       - '.github/workflows/installer-macos.yml'
@@ -22,6 +27,8 @@ on:
     tags:
       - v*pre*
 
+  workflow_dispatch:
+
 concurrency:
   group: installer-macos-${{ github.ref }}
   cancel-in-progress: true
@@ -29,12 +36,14 @@ concurrency:
 name: Create macOS App Bundle and DMG
 
 env:
-  IS_PRE: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+  IS_PRE: ${{ contains(fromJSON('["workflow_dispatch", "push"]'), github.event_name) || (github.event.action == 'labeled' && github.event.label.name == 'build-installer-artifacts') }}
+  IS_RELEASE: ${{ github.event_name == 'release' }}
 
 jobs:
   matrix_prep:
     name: Determine Build Matrix
     runs-on: macos-11
+    if: github.event.action != 'labeled' || github.event.label.name == 'build-installer-artifacts'
     outputs:
       build_type: ${{ steps.set-matrix.outputs.build_type }}
     steps:
@@ -89,7 +98,7 @@ jobs:
           ${pythonLocation}/bin/python -m pip install -U pip setuptools
           ${pythonLocation}/bin/python -m pip install -r req-build.txt -r req-extras.txt -r req-plugins.txt "${INSTALL_FLAGS[@]}" -e ${GITHUB_WORKSPACE}
       - name: Install Subrepos
-        if: ${{github.event_name == 'pull_request'}}
+        if: ${{github.event_name == 'pull_request' && github.event.action != 'labeled'}}
         run: ${pythonLocation}/bin/python -bb -X dev -W error ${GITHUB_WORKSPACE}/install_dev_repos.py --not-editable --no-install spyder
       - name: Show Build Environment
         run: |
@@ -103,10 +112,10 @@ jobs:
       - name: Build Application Bundle
         run: ${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dist-dir ${DISTDIR}
       - name: Create Keychain
-        if: ${{github.event_name == 'release' || env.IS_PRE == 'true'}}
+        if: ${{env.IS_RELEASE == 'true' || env.IS_PRE == 'true'}}
         run: ./certkeychain.sh "${MACOS_CERTIFICATE}" "${MACOS_CERTIFICATE_PWD}"
       - name: Code Sign Application
-        if: ${{github.event_name == 'release' || env.IS_PRE == 'true'}}
+        if: ${{env.IS_RELEASE == 'true' || env.IS_PRE == 'true'}}
         run: |
           pil=$(${pythonLocation}/bin/python -c "import PIL, os; print(os.path.dirname(PIL.__file__))")
           rm -v ${DISTDIR}/Spyder.app/Contents/Frameworks/liblzma.5.dylib
@@ -117,10 +126,10 @@ jobs:
       - name: Build Disk Image
         run: ${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dist-dir ${DISTDIR} --dmg --no-app
       - name: Sign Disk Image
-        if: ${{github.event_name == 'release' || env.IS_PRE == 'true'}}
+        if: ${{env.IS_RELEASE == 'true' || env.IS_PRE == 'true'}}
         run: ./codesign.sh "${DISTDIR}/${DMGNAME}"
       - name: Notarize Disk Image
-        if: ${{github.event_name == 'release' || env.IS_PRE == 'true'}}
+        if: ${{env.IS_RELEASE == 'true' || env.IS_PRE == 'true'}}
         run: ./notarize.sh -i 30 -p "${APPLICATION_PWD}" "${DISTDIR}/${DMGNAME}"
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
@@ -128,13 +137,13 @@ jobs:
           path: ${{ env.DISTDIR }}/${{ env.DMGNAME }}
           name: ${{ env.DMGNAME }}
       - name: Get Release
-        if: ${{github.event_name == 'release'}}
+        if: ${{env.IS_RELEASE == 'true'}}
         id: get_release
         env:
           GITHUB_TOKEN: ${{ github.token }}
         uses: bruceadams/get-release@v1.2.0
       - name: Upload Release Asset
-        if: ${{github.event_name == 'release'}}
+        if: ${{env.IS_RELEASE == 'true'}}
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/installer-win.yml
+++ b/.github/workflows/installer-win.yml
@@ -1,6 +1,11 @@
 # Based on https://github.com/tlambert03/napari/blob/master/.github/workflows/make_bundle.yml
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
       - 'installers/Windows/**'
       - '.github/workflows/installer-win.yml'
@@ -23,6 +28,8 @@ on:
     tags:
       - v*pre*
 
+  workflow_dispatch:
+
 concurrency:
   group: installer-win-${{ github.ref }}
   cancel-in-progress: true
@@ -30,24 +37,26 @@ concurrency:
 name: Create Windows Installer
 
 env:
-  IS_PRE: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+  IS_PRE: ${{ contains(fromJSON('["workflow_dispatch", "push"]'), github.event_name) || (github.event.action == 'labeled' && github.event.label.name == 'build-installer-artifacts') }}
+  IS_STANDARD_PR: ${{ github.event_name == 'pull_request' && github.event.action != 'labeled' }}
 
 jobs:
   build:
     name: Windows installer
     runs-on: windows-latest
+    if: github.event.action != 'labeled' || github.event.label.name == 'build-installer-artifacts'
     strategy:
       matrix:
         build_type: ['Lite', 'Full']
     env:
-      UNWANTED_PACKAGES: ${{github.event_name == 'pull_request' && 'pip spyder-kernels python-slugify Rtree QDarkStyle PyNaCl psutil' || 'pip python-slugify Rtree PyNaCl psutil' }}
+      UNWANTED_PACKAGES: ${{github.event_name == 'pull_request' && github.event.action != 'labeled' && 'pip spyder-kernels python-slugify Rtree QDarkStyle PyNaCl psutil' || 'pip python-slugify Rtree PyNaCl psutil' }}
       SKIP_PACKAGES: 'bcrypt slugify'
-      ADD_PACKAGES: ${{github.event_name == 'pull_request' && 'spyder_kernels blib2to3 _black_version blackd rtree qdarkstyle nacl psutil' || 'blib2to3 _black_version blackd rtree nacl psutil' }}
+      ADD_PACKAGES: ${{github.event_name == 'pull_request' && github.event.action != 'labeled' && 'spyder_kernels blib2to3 _black_version blackd rtree qdarkstyle nacl psutil' || 'blib2to3 _black_version blackd rtree nacl psutil' }}
       PYNSIST_REQ: pynsist==2.7
-      EXTRA_FLAG: ${{ matrix.build_type == 'Full' && github.event_name == 'pull_request' && '-ep installers/Windows/req-extras-pull-request.txt' || matrix.build_type == 'Lite' && github.event_name == 'pull_request' && '-ep installers/Windows/req-pull-request.txt' || matrix.build_type == 'Full' && '-ep installers/Windows/req-extras-release.txt' || '-ep installers/Windows/req-release.txt' }}
+      EXTRA_FLAG: ${{ matrix.build_type == 'Full' && github.event_name == 'pull_request' && github.event.action != 'labeled' && '-ep installers/Windows/req-extras-pull-request.txt' || matrix.build_type == 'Lite' && github.event_name == 'pull_request' && github.event.action != 'labeled' && '-ep installers/Windows/req-pull-request.txt' || matrix.build_type == 'Full' && '-ep installers/Windows/req-extras-release.txt' || '-ep installers/Windows/req-release.txt' }}
       SUFFIX_FLAG: ${{ matrix.build_type == 'Lite' && '-s lite' || '-s full' }}
       TEMPLATE_FAG: '-t installers/Windows/assets/nsist/spyder.nsi'
-      EXE_NAME: ${{ matrix.build_type == 'Lite' && github.event_name == 'pull_request' && 'Spyder_64bit_lite.exe' || matrix.build_type == 'Lite' && 'Spyder_64bit_lite.exe' || 'Spyder_64bit_full.exe' }}
+      EXE_NAME: ${{ matrix.build_type == 'Lite' && github.event_name == 'pull_request' && github.event.action != 'labeled' && 'Spyder_64bit_lite.exe' || matrix.build_type == 'Lite' && 'Spyder_64bit_lite.exe' || 'Spyder_64bit_full.exe' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -124,7 +124,7 @@ jobs:
     needs:
       - build-matrix
       - build-noarch-pkgs
-    if: ${{ ! failure() && ! cancelled() }}
+    if: ${{ ! failure() && ! cancelled() && needs.build-matrix.result == 'success' }}
     strategy:
       matrix:
         target-platform: ${{fromJson(needs.build-matrix.outputs.target_platform)}}

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -91,8 +91,10 @@ jobs:
       target_platform: ${{ steps.build-matrix.outputs.target_platform }}
       include: ${{ steps.build-matrix.outputs.include }}
       python_version: ${{ steps.build-matrix.outputs.python_version }}
+
     steps:
-    - id: build-matrix
+    - name: Determine Build Matrix
+      id: build-matrix
       run: |
         target_platform="'osx-64', 'linux-64'"
         include="\
@@ -109,6 +111,12 @@ jobs:
         echo "target_platform=[$target_platform]" >> $GITHUB_OUTPUT
         echo "include=[$include]" >> $GITHUB_OUTPUT
         echo "python_version=[$python_version]" >> $GITHUB_OUTPUT
+
+    - name: Remove Label
+      if: github.event.action == 'labeled'
+      uses: actions-ecosystem/action-remove-labels@v1
+      with:
+        labels: build-installer-artifacts
 
   build-installers:
     name: Build installer for ${{ matrix.target-platform }} Python-${{ matrix.python-version }}
@@ -264,11 +272,3 @@ jobs:
           asset_path: ${{ env.PKG_FILE }}
           asset_name: ${{ env.PKG_NAME }}
           asset_content_type: application/octet-stream
-
-  remove_label:
-    runs-on: ubuntu-latest
-    if: always() && github.event.action == 'labeled' && github.event.label.name == 'build-installer-artifacts'
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: build-installer-artifacts

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -1,5 +1,10 @@
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
     paths:
       - 'installers-conda/**'
       - '.github/workflows/installers-conda.yml'
@@ -21,6 +26,8 @@ on:
     tags:
       - v*pre*
 
+  workflow_dispatch:
+
 concurrency:
   group: installers-conda-${{ github.ref }}
   cancel-in-progress: true
@@ -28,13 +35,17 @@ concurrency:
 name: Create conda-based installers for Windows, macOS, and Linux
 
 env:
-  IS_PRE: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+  IS_STANDARD_PR: ${{ github.event_name == 'pull_request' && github.event.action != 'labeled' }}
+  IS_BUILD: ${{ github.event.action != 'labeled' || github.event.label.name == 'build-installer-artifacts' }}
+  IS_LABELED_PR: ${{ github.event.action == 'labeled' && github.event.label.name == 'build-installer-artifacts' }}
+  IS_RELEASE: ${{ github.event_name == 'release' }}
+  IS_PRE: ${{ contains(fromJSON('["workflow_dispatch", "push"]'), github.event_name) || (github.event.action == 'labeled' && github.event.label.name == 'build-installer-artifacts') }}
 
 jobs:
   build-noarch-pkgs:
     name: Build ${{ matrix.pkg }}
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.action != 'labeled'
     strategy:
       matrix:
         pkg: ["python-lsp-server", "qtconsole"]
@@ -75,6 +86,7 @@ jobs:
   build-matrix:
     name: Determine Build Matrix
     runs-on: ubuntu-latest
+    if: github.event.action != 'labeled' || github.event.label.name == 'build-installer-artifacts'
     outputs:
       target_platform: ${{ steps.build-matrix.outputs.target_platform }}
       include: ${{ steps.build-matrix.outputs.include }}
@@ -89,7 +101,7 @@ jobs:
         "
         python_version="'3.9'"
 
-        if [[ ${GITHUB_EVENT_NAME} == 'pull_request' ]]; then
+        if [[ $IS_STANDARD_PR == 'true' ]]; then
             target_platform=$target_platform", 'win-64'"
             include=$include",{'os': 'windows-latest', 'target-platform': 'win-64'}"
         fi
@@ -121,7 +133,7 @@ jobs:
       MACOS_INSTALLER_CERTIFICATE: ${{ secrets.MACOS_INSTALLER_CERTIFICATE }}
       APPLICATION_PWD: ${{ secrets.APPLICATION_PWD }}
       CONSTRUCTOR_TARGET_PLATFORM: ${{ matrix.target-platform }}
-      STATUS: ${{ needs.build-noarch-pkgs.result }}
+      BNP_STATUS: ${{ needs.build-noarch-pkgs.result }}
       MAT_STATUS: ${{ needs.build-matrix.result }}
 
     steps:
@@ -159,7 +171,7 @@ jobs:
           env
 
       - name: Download Local Conda Packages
-        if: github.event_name == 'pull_request'
+        if: env.IS_STANDARD_PR
         uses: actions/download-artifact@v3
         with:
           path: ${{ env.ARTIFACTS_PATH }}
@@ -182,13 +194,13 @@ jobs:
       - name: Build ${{ matrix.target-platform }} conda packages
         run: |
           pkgs=("spyder")
-          if [[ $GITHUB_EVENT_NAME == "pull_request" ]]; then
+          if [[ $IS_STANDARD_PR == "true" ]]; then
               pkgs+=("spyder-kernels")
           fi
           python build_conda_pkgs.py --build ${pkgs[@]}
 
       - name: Create Keychain
-        if: (github.event_name == 'release' || env.IS_PRE == 'true') && runner.os == 'macOS'
+        if: runner.os == 'macOS' && (env.IS_RELEASE == 'true' || env.IS_PRE == 'true')
         run: |
           ./certkeychain.sh "${MACOS_CERTIFICATE_PWD}" "${MACOS_CERTIFICATE}" "${MACOS_INSTALLER_CERTIFICATE}"
           CNAME=$(security find-identity -p codesigning -v | pcregrep -o1 "\(([0-9A-Z]+)\)")
@@ -226,7 +238,7 @@ jobs:
           fi
 
       - name: Notarize package installer
-        if: (github.event_name == 'release' || env.IS_PRE == 'true') && runner.os == 'macOS'
+        if: runner.os == 'macOS' && (env.IS_RELEASE == 'true' || env.IS_PRE == 'true')
         run: ./notarize.sh -p $APPLICATION_PWD $PKG_FILE
 
       - name: Upload Artifact
@@ -252,3 +264,12 @@ jobs:
           asset_path: ${{ env.PKG_FILE }}
           asset_name: ${{ env.PKG_NAME }}
           asset_content_type: application/octet-stream
+
+  remove_label:
+    runs-on: ubuntu-latest
+    if: always() && github.event.action == 'labeled' && github.event.label.name == 'build-installer-artifacts'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: build-installer-artifacts

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -269,7 +269,6 @@ jobs:
     runs-on: ubuntu-latest
     if: always() && github.event.action == 'labeled' && github.event.label.name == 'build-installer-artifacts'
     steps:
-      - uses: actions/checkout@v3
       - uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: build-installer-artifacts

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -133,11 +133,17 @@ To release a new version of Spyder you need to follow these steps:
 * Update version in `__init__.py` (set release version, remove 'dev0', add 'preX'), then
 
       git add .
-      git commit -m "Release X.X.XpreX"
-      git tag vX.X.XpreX
-      git push upstream --tags
+      git commit -m "Release X.X.XpreX [ci skip]"
+      git push upstream 5.x
 
-* If workflows succeed, proceed to steps to publish the release; otherwise merge a fix PR and repeat previous steps with incremented 'preX'
+* Manually activate the workflows:
+    - Create Windows Installer
+    - Create macOS App Bundle and DMG
+    - Create conda-based installers for Windows, macOS, and Linux
+
+* Download and test the installation of the resulting artifacts.
+
+* If either of the previous two steps fail merge a fix PR and begin again with incremented 'preX'.
 
 ## To do the release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -136,7 +136,7 @@ To release a new version of Spyder you need to follow these steps:
       git commit -m "Release X.X.XpreX [ci skip]"
       git push upstream 5.x
 
-* Manually activate the workflows:
+* Manually activate the following workflows (see [Running a workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow)):
     - Create Windows Installer
     - Create macOS App Bundle and DMG
     - Create conda-based installers for Windows, macOS, and Linux

--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -48,6 +48,7 @@ SPYPATCHFILE = DIST / "installers-conda.patch"
 class BuildCondaPkg:
     """Base class for building a conda package for conda-based installer"""
     name = None
+    norm = True
     source = None
     feedstock = None
     shallow_ver = None
@@ -115,7 +116,8 @@ class BuildCondaPkg:
 
     def _get_version(self):
         """Get source version using setuptools_scm"""
-        self.version = get_version(self._bld_src).split('+')[0]
+        v = get_version(self._bld_src, normalize=self.norm)
+        self.version = v.lstrip('v').split('+')[0]
 
     def _patch_source(self):
         pass
@@ -193,6 +195,7 @@ class BuildCondaPkg:
 
 class SpyderCondaPkg(BuildCondaPkg):
     name = "spyder"
+    norm = False
     source = os.environ.get('SPYDER_SOURCE', HERE.parent)
     feedstock = "https://github.com/conda-forge/spyder-feedstock"
     shallow_ver = "v5.3.2"

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -129,7 +129,7 @@ yaml = YAML()
 yaml.indent(mapping=2, sequence=4, offset=2)
 indent4 = partial(indent, prefix="    ")
 
-SPYVER = get_version(SPYREPO).strip().split("+")[0]
+SPYVER = get_version(SPYREPO, normalize=False).lstrip('v').split("+")[0]
 
 specs = {
     "spyder": "=" + SPYVER,


### PR DESCRIPTION
## Description of Changes

* Added workflow trigger for pull requests labeled `build-installer-artifacts`
* Added workflow trigger for manually running installers
* Fix issue where installer version normalized tag version

### Workflow Triggers

Pull requests will continue to trigger all three installer workflows with limited artifacts (Full versions only) and without code-signing or uploading artifacts.

Labeling a pull request with `build-installer-artifacts` or pushing a tag matching the pattern `v*pre*` will also trigger all three installer workflows, but they will run _as if_ it were a release (Lite and Full versions, code-signing, etc.). However, workflow artifacts will not be uploaded to a release. These two trigger methods will not have any affect on a branch in which the latest commit message contains `[ci skip]` (or [equivalent variations](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs)).

All three installer workflows can be triggered manually from the GitHub web interface or CLI and will execute workflows in the same manner as the aforementioned labeling and tagging mechanisms. This method is not affected by the presence of `[ci skip]` (or variants). However, this workflow trigger mechanism will not be available until this update is propagated to the `master` branch, i.e. after merging to `5.x` and subsequent merge to `master`.

All installer workflows will continue to behave as before upon creating a release.

### Normalized version

`setuptools_scm` by default normalizes our `vX.X.XpreX` release candidate tags to   `vX.X.XrcX`, resulting in an installer named `EXPERIMENTAL-Spyder-5.4.2rc1-macOS-x86_64` instead of `EXPERIMENTAL-Spyder-5.4.2pre1-macOS-x86_64`.

To work around this, we tell `setuptools_scm` not to normalize the version. This results in a version `vX.X.XpreX`, so we further remove the leading `v`, finally arriving at the desired `X.X.XpreX`.

Note that the versions for `external_deps` built locally for the installer must remain normalized; otherwise conda will fail to solve the environment.