### PR TITLE
PR: Pin PyZMQ to version 24 to prevent hangs in our CIs

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -37,6 +37,9 @@ if [ "$USE_CONDA" = "true" ]; then
 
     # Install IPython 8
     mamba install -c conda-forge ipython=8
+
+    # Install PyZMQ 24 to avoid hangs
+    mamba install -c conda-forge pyzmq=24
 else
     # Update pip and setuptools
     python -m pip install -U pip setuptools wheel build
@@ -61,6 +64,9 @@ else
 
     # Install IPython 8
     pip install ipython==8.7.0
+
+    # Install PyZMQ 24 to avoid hangs
+    pip install pyzmq==24.0.1
 fi
 
 # Install subrepos from source


### PR DESCRIPTION
## Description of Changes

- Tests started to hang in `master` since last week and this solves it.
- This probably happens due to issue #20381, which should be fixed in Jupyter-client 8.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
