### PR TITLE
PR: Restore `pickle` import in `py3compat.py` and some fixes to the main window tests

### DIFF
--- a/spyder/app/tests/conftest.py
+++ b/spyder/app/tests/conftest.py
@@ -214,6 +214,28 @@ def create_namespace_project(tmpdir):
     spy_project.set_recent_files(abs_filenames)
 
 
+def preferences_dialog_helper(qtbot, main_window, section):
+    """
+    Open preferences dialog and select page with `section` (CONF_SECTION).
+    """
+    # Wait until the window is fully up
+    shell = main_window.ipyconsole.get_current_shellwidget()
+    qtbot.waitUntil(
+        lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
+
+    main_window.show_preferences()
+    preferences = main_window.preferences
+    container = preferences.get_container()
+
+    qtbot.waitUntil(lambda: container.dialog is not None,
+                    timeout=5000)
+    dlg = container.dialog
+    index = dlg.get_index_by_name(section)
+    page = dlg.get_page(index)
+    dlg.set_current_index(index)
+    return dlg, index, page
+
+
 # =============================================================================
 # ---- Pytest hooks
 # =============================================================================

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -5334,6 +5334,7 @@ def test_outline_namespace_package(main_window, qtbot, tmpdir):
 @pytest.mark.skipif(
     sys.platform == 'darwin',
     reason="Only works on Windows and Linux")
+@pytest.mark.order(before='test_tour_message')
 def test_switch_to_plugin(main_window, qtbot):
     """
     Test that switching between the two most important plugins, the Editor and

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -47,8 +47,9 @@ from spyder.api.widgets.auxiliary_widgets import SpyderWindowWidget
 from spyder.api.plugins import Plugins
 from spyder.app.tests.conftest import (
     COMPILE_AND_EVAL_TIMEOUT, COMPLETION_TIMEOUT, EVAL_TIMEOUT,
-    find_desired_tab_in_window, LOCATION, open_file_in_editor, PY37,
-    read_asset_file, reset_run_code, SHELL_TIMEOUT, start_new_kernel)
+    find_desired_tab_in_window, LOCATION, open_file_in_editor,
+    preferences_dialog_helper, PY37, read_asset_file, reset_run_code,
+    SHELL_TIMEOUT, start_new_kernel)
 from spyder.config.base import (
     get_home_dir, get_conf_path, get_module_path, running_in_ci)
 from spyder.config.manager import CONF
@@ -1004,6 +1005,7 @@ def test_run_cython_code(main_window, qtbot):
     main_window.editor.close_file()
 
 
+@flaky(max_runs=5)
 def test_project_path(main_window, tmpdir, qtbot):
     """Test project path added to spyder_pythonpath and IPython Console."""
     projects = main_window.projects
@@ -2627,30 +2629,7 @@ def test_break_while_running(main_window, qtbot, tmpdir):
     main_window.editor.clear_all_breakpoints()
 
 
-# --- Preferences
-# ----------------------------------------------------------------------------
-def preferences_dialog_helper(qtbot, main_window, section):
-    """
-    Open preferences dialog and select page with `section` (CONF_SECTION).
-    """
-    # Wait until the window is fully up
-    shell = main_window.ipyconsole.get_current_shellwidget()
-    qtbot.waitUntil(
-        lambda: shell._prompt_html is not None, timeout=SHELL_TIMEOUT)
-
-    main_window.show_preferences()
-    preferences = main_window.preferences
-    container = preferences.get_container()
-
-    qtbot.waitUntil(lambda: container.dialog is not None,
-                    timeout=5000)
-    dlg = container.dialog
-    index = dlg.get_index_by_name(section)
-    page = dlg.get_page(index)
-    dlg.set_current_index(index)
-    return dlg, index, page
-
-
+@flaky(max_runs=5)
 def test_preferences_run_section_exists(main_window, qtbot):
     """
     Test for spyder-ide/spyder#13524 regression.
@@ -5105,6 +5084,7 @@ def test_debug_unsaved_function(main_window, qtbot):
     assert "1---> 2     print(1)" in control.toPlainText()
 
 
+@flaky(max_runs=5)
 @pytest.mark.close_main_window
 def test_out_runfile_runcell(main_window, qtbot):
     """
@@ -5207,6 +5187,7 @@ def test_cwd_is_synced_when_switching_consoles(main_window, qtbot, tmpdir):
         assert shell_cwd == workdir.get_workdir() == files.get_current_folder()
 
 
+@flaky(max_runs=5)
 def test_console_initial_cwd_is_synced(main_window, qtbot, tmpdir):
     """
     Test that the initial current working directory for new consoles is synced
@@ -5360,6 +5341,7 @@ def test_switch_to_plugin(main_window, qtbot):
     assert QApplication.focusWidget() is code_editor
 
 
+@flaky(max_runs=5)
 def test_PYTHONPATH_in_consoles(main_window, qtbot, tmp_path):
     """
     Test that PYTHONPATH is passed to IPython consoles under different

--- a/spyder/py3compat.py
+++ b/spyder/py3compat.py
@@ -10,13 +10,10 @@ spyder.py3compat
 
 Transitional module providing compatibility functions intended to help
 migrating from Python 2 to Python 3.
-
-This module should be fully compatible with:
-    * Python >=v2.6
-    * Python 3
 """
 
 import operator
+import pickle  # noqa. For compatibility with spyder-line-profiler
 
 
 #==============================================================================
@@ -66,8 +63,6 @@ def to_binary_string(obj, encoding='utf-8'):
 #==============================================================================
 # Misc.
 #==============================================================================
-# Python 3
-
 def qbytearray_to_str(qba):
     """Convert QByteArray object to str in a way compatible with Python 3"""
     return str(bytes(qba.toHex().data()).decode())


### PR DESCRIPTION
## Description of Changes

This is required to have compatibility with the latest version of `spyder-line-profiler`.

I also made the following fixes to our test suite, which I noticed after merging PR #20425:

- Make `test_switch_to_plugin` run before `test_tour_message`. This makes that test pass the first time is run, instead of requiring a second time.
- Move `preferences_dialog_helper` to the main window `conftest.py` files and mark some of its tests as flaky. This makes the main window tests more reliable.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20430.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
