### PR TITLE
PR: Skip `test_tk_backend` on Windows with IPykernel 6.21.0

### DIFF
--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -20,6 +20,7 @@ import sys
 from textwrap import dedent
 
 # Third party imports
+from ipykernel._version import __version__ as ipykernel_version
 import IPython
 from IPython.core import release as ipy_release
 from IPython.core.application import get_ipython_dir
@@ -141,6 +142,9 @@ def test_auto_backend(ipyconsole, qtbot):
 
 @flaky(max_runs=3)
 @pytest.mark.tk_backend
+@pytest.mark.skipif(
+    os.name == 'nt' and (parse(ipykernel_version) == parse('6.21.0')),
+    reason="Fails on Windows with IPykernel 6.21.0")
 def test_tk_backend(ipyconsole, qtbot):
     """Test that the Tkinter backend was set correctly."""
     # Wait until the window is fully up


### PR DESCRIPTION
## Description of Changes

- That version introduced a regression that broke the Tk backend, so the test can't pass successfully with it.
- I'll make sure that future IPykernel versions fix it.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
