### PR TITLE
PR: Fix failure installing Spyder-kernels from master on Windows and other minor fixes on CIS

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -75,7 +75,14 @@ conda list -n jedi-test-env
 
 # Create environment to test conda env activation before launching a kernel
 conda create -n spytest-ž -q -y -c conda-forge python=3.9
-conda run -n spytest-ž python -m pip install git+https://github.com/spyder-ide/spyder-kernels.git@master
+
+# `conda run` fails on Windows without a clear reason
+if [ "$OS" = "win" ]; then
+    /c/Miniconda/envs/spytest-ž/python -m pip install git+https://github.com/spyder-ide/spyder-kernels.git@master
+else
+    conda run -n spytest-ž python -m pip install git+https://github.com/spyder-ide/spyder-kernels.git@master
+fi
+
 conda list -n spytest-ž
 
 # Install pyenv on Linux systems

--- a/conftest.py
+++ b/conftest.py
@@ -69,7 +69,7 @@ def pytest_collection_modifyitems(config, items):
 
     # Break test suite in CIs according to the following criteria:
     # * Mark all main window tests, and a percentage of the IPython console
-    #   ones on Linux and Mac, as slow.
+    #   ones, as slow.
     # * All other tests will be considered as fast.
     # This provides a more balanced partitioning of our test suite (in terms of
     # necessary time to run it) between the slow and fast slots we have on CIs.
@@ -79,19 +79,20 @@ def pytest_collection_modifyitems(config, items):
             item for item in items if 'test_mainwindow' in item.nodeid
         ]
 
-        if not os.name == 'nt':
-            ipyconsole_items = [
-                item for item in items if 'test_ipythonconsole' in item.nodeid
-            ]
+        ipyconsole_items = [
+            item for item in items if 'test_ipythonconsole' in item.nodeid
+        ]
 
-            if sys.platform == 'darwin':
-                percentage = 0.6
-            else:
-                percentage = 0.5
+        if os.name == 'nt':
+            percentage = 0.6
+        elif sys.platform == 'darwin':
+            percentage = 0.6
+        else:
+            percentage = 0.5
 
-            for i, item in enumerate(ipyconsole_items):
-                if i < len(ipyconsole_items) * percentage:
-                    slow_items.append(item)
+        for i, item in enumerate(ipyconsole_items):
+            if i < len(ipyconsole_items) * percentage:
+                slow_items.append(item)
 
     for item in items:
         if slow_option:

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1254,6 +1254,7 @@ def test_calltip(ipyconsole, qtbot):
 @pytest.mark.test_environment_interpreter
 @pytest.mark.skipif(not is_anaconda(), reason='Only works with Anaconda')
 @pytest.mark.skipif(not running_in_ci(), reason='Only works on CIs')
+@pytest.mark.skipif(not os.name == 'nt', reason='Works reliably on Windows')
 def test_conda_env_activation(ipyconsole, qtbot):
     """
     Test that the conda environment associated with an external interpreter


### PR DESCRIPTION
## Description of Changes

- We were using `conda run` to do that, but strangely that started to fail since some hours ago.
- Run `test_conda_env_activation` only on Windows because it started to fail on Linux and it's flaky on Mac (but this only happens on `master`).
- Run a percentage of IPython console tests on slow slots for Windows so the fast ones finish faster.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
