### PR TITLE
PR: Prevent error when trying to show arrays without an actual `dtype` (Variable Explorer)

### DIFF
--- a/spyder/plugins/editor/widgets/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/tests/test_formatting.py
@@ -12,6 +12,7 @@ import os.path as osp
 import random
 
 # Third party imports
+from flaky import flaky
 import pytest
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QTextCursor
@@ -257,6 +258,7 @@ def test_closing_document_formatting(
     assert code_editor.get_text_with_eol() == expected
 
 
+@flaky(max_runs=5)
 @pytest.mark.order(1)
 @pytest.mark.parametrize('formatter', [autopep8, black])
 def test_formatting_on_save(completions_editor, formatter, qtbot):
@@ -306,7 +308,7 @@ def test_formatting_on_save(completions_editor, formatter, qtbot):
     with qtbot.waitSignal(
             code_editor.completions_response_signal, timeout=30000):
         editorstack.save(force=True)
-    qtbot.wait(500)
+    qtbot.wait(1000)
 
     # Check that auto-formatting was applied on save and that we restored the
     # previous line.

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -180,6 +180,7 @@ class CollectionsDelegate(QItemDelegate):
             from .arrayeditor import ArrayEditor
             editor = ArrayEditor(parent=parent)
             if not editor.setup_and_check(value, title=key, readonly=readonly):
+                self.sig_editor_shown.emit()
                 return
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
                                             key=key, readonly=readonly))
@@ -196,6 +197,7 @@ class CollectionsDelegate(QItemDelegate):
             arr = np.array(value)
             editor = ArrayEditor(parent=parent)
             if not editor.setup_and_check(arr, title=key, readonly=readonly):
+                self.sig_editor_shown.emit()
                 return
             conv_func = lambda arr: PIL.Image.fromarray(arr, mode=value.mode)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,


### PR DESCRIPTION
## Description of Changes

- Users can subclass `ndarray` and set its `dtype` to an object that is not an actual `dtype`. In that case, Spyder was giving an error because it was unable to get some regular `dtype` attributes.
- Stop spinner when failing to show arrays or images. I noticed this error while testing the above problem.
- Mark `test_formatting_on_save` as flaky. I noticed that test requires several runs to pass on CIs.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20462.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
