### PR TITLE
PR: Fix installer triggers

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -1,10 +1,5 @@
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
     paths:
       - 'installers/macOS/**'
       - '.github/workflows/installer-macos.yml'
@@ -23,10 +18,6 @@ on:
     types:
       - created
 
-  push:
-    tags:
-      - v*pre*
-
   workflow_dispatch:
 
 concurrency:
@@ -36,14 +27,13 @@ concurrency:
 name: Create macOS App Bundle and DMG
 
 env:
-  IS_PRE: ${{ contains(fromJSON('["workflow_dispatch", "push"]'), github.event_name) || (github.event.action == 'labeled' && github.event.label.name == 'build-installer-artifacts') }}
+  IS_PRE: ${{ github.event_name == 'workflow_dispatch' }}
   IS_RELEASE: ${{ github.event_name == 'release' }}
 
 jobs:
   matrix_prep:
     name: Determine Build Matrix
     runs-on: macos-11
-    if: github.event.action != 'labeled' || github.event.label.name == 'build-installer-artifacts'
     outputs:
       build_type: ${{ steps.set-matrix.outputs.build_type }}
     steps:
@@ -98,7 +88,7 @@ jobs:
           ${pythonLocation}/bin/python -m pip install -U pip setuptools
           ${pythonLocation}/bin/python -m pip install -r req-build.txt -r req-extras.txt -r req-plugins.txt "${INSTALL_FLAGS[@]}" -e ${GITHUB_WORKSPACE}
       - name: Install Subrepos
-        if: ${{github.event_name == 'pull_request' && github.event.action != 'labeled'}}
+        if: ${{github.event_name == 'pull_request'}}
         run: ${pythonLocation}/bin/python -bb -X dev -W error ${GITHUB_WORKSPACE}/install_dev_repos.py --not-editable --no-install spyder
       - name: Show Build Environment
         run: |

--- a/.github/workflows/installer-win.yml
+++ b/.github/workflows/installer-win.yml
@@ -1,11 +1,6 @@
 # Based on https://github.com/tlambert03/napari/blob/master/.github/workflows/make_bundle.yml
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
     paths:
       - 'installers/Windows/**'
       - '.github/workflows/installer-win.yml'
@@ -24,10 +19,6 @@ on:
     types:
       - created
 
-  push:
-    tags:
-      - v*pre*
-
   workflow_dispatch:
 
 concurrency:
@@ -37,26 +28,25 @@ concurrency:
 name: Create Windows Installer
 
 env:
-  IS_PRE: ${{ contains(fromJSON('["workflow_dispatch", "push"]'), github.event_name) || (github.event.action == 'labeled' && github.event.label.name == 'build-installer-artifacts') }}
-  IS_STANDARD_PR: ${{ github.event_name == 'pull_request' && github.event.action != 'labeled' }}
+  IS_PRE: ${{ github.event_name == 'workflow_dispatch' }}
+  IS_STANDARD_PR: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
     name: Windows installer
     runs-on: windows-latest
-    if: github.event.action != 'labeled' || github.event.label.name == 'build-installer-artifacts'
     strategy:
       matrix:
         build_type: ['Lite', 'Full']
     env:
-      UNWANTED_PACKAGES: ${{github.event_name == 'pull_request' && github.event.action != 'labeled' && 'pip spyder-kernels python-slugify Rtree QDarkStyle PyNaCl psutil' || 'pip python-slugify Rtree PyNaCl psutil' }}
+      UNWANTED_PACKAGES: ${{github.event_name == 'pull_request' && 'pip spyder-kernels python-slugify Rtree QDarkStyle PyNaCl psutil' || 'pip python-slugify Rtree PyNaCl psutil' }}
       SKIP_PACKAGES: 'bcrypt slugify'
-      ADD_PACKAGES: ${{github.event_name == 'pull_request' && github.event.action != 'labeled' && 'spyder_kernels blib2to3 _black_version blackd rtree qdarkstyle nacl psutil' || 'blib2to3 _black_version blackd rtree nacl psutil' }}
+      ADD_PACKAGES: ${{github.event_name == 'pull_request' && 'spyder_kernels blib2to3 _black_version blackd rtree qdarkstyle nacl psutil' || 'blib2to3 _black_version blackd rtree nacl psutil' }}
       PYNSIST_REQ: pynsist==2.7
-      EXTRA_FLAG: ${{ matrix.build_type == 'Full' && github.event_name == 'pull_request' && github.event.action != 'labeled' && '-ep installers/Windows/req-extras-pull-request.txt' || matrix.build_type == 'Lite' && github.event_name == 'pull_request' && github.event.action != 'labeled' && '-ep installers/Windows/req-pull-request.txt' || matrix.build_type == 'Full' && '-ep installers/Windows/req-extras-release.txt' || '-ep installers/Windows/req-release.txt' }}
+      EXTRA_FLAG: ${{ matrix.build_type == 'Full' && github.event_name == 'pull_request' && '-ep installers/Windows/req-extras-pull-request.txt' || matrix.build_type == 'Lite' && github.event_name == 'pull_request' && '-ep installers/Windows/req-pull-request.txt' || matrix.build_type == 'Full' && '-ep installers/Windows/req-extras-release.txt' || '-ep installers/Windows/req-release.txt' }}
       SUFFIX_FLAG: ${{ matrix.build_type == 'Lite' && '-s lite' || '-s full' }}
       TEMPLATE_FAG: '-t installers/Windows/assets/nsist/spyder.nsi'
-      EXE_NAME: ${{ matrix.build_type == 'Lite' && github.event_name == 'pull_request' && github.event.action != 'labeled' && 'Spyder_64bit_lite.exe' || matrix.build_type == 'Lite' && 'Spyder_64bit_lite.exe' || 'Spyder_64bit_full.exe' }}
+      EXE_NAME: ${{ matrix.build_type == 'Lite' && github.event_name == 'pull_request' && 'Spyder_64bit_lite.exe' || matrix.build_type == 'Lite' && 'Spyder_64bit_lite.exe' || 'Spyder_64bit_full.exe' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -190,7 +190,7 @@ jobs:
           env
 
       - name: Download Local Conda Packages
-        if: env.IS_STANDARD_PR
+        if: needs.build-noarch-pkgs.result == 'success'
         uses: actions/download-artifact@v3
         with:
           path: ${{ env.ARTIFACTS_PATH }}
@@ -267,14 +267,14 @@ jobs:
           name: ${{ env.PKG_NAME }}
 
       - name: Get Release
-        if: github.event_name == 'release'
+        if: env.IS_RELEASE == 'true'
         id: get_release
         env:
           GITHUB_TOKEN: ${{ github.token }}
         uses: bruceadams/get-release@v1.2.0
 
       - name: Upload Release Asset
-        if: github.event_name == 'release'
+        if: env.IS_RELEASE == 'true'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -1,10 +1,5 @@
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
     paths:
       - 'installers-conda/**'
       - '.github/workflows/installers-conda.yml'
@@ -22,10 +17,6 @@ on:
     types:
       - created
 
-  push:
-    tags:
-      - v*pre*
-
   workflow_dispatch:
 
 concurrency:
@@ -35,17 +26,15 @@ concurrency:
 name: Create conda-based installers for Windows, macOS, and Linux
 
 env:
-  IS_STANDARD_PR: ${{ github.event_name == 'pull_request' && github.event.action != 'labeled' }}
-  IS_BUILD: ${{ github.event.action != 'labeled' || github.event.label.name == 'build-installer-artifacts' }}
-  IS_LABELED_PR: ${{ github.event.action == 'labeled' && github.event.label.name == 'build-installer-artifacts' }}
+  IS_STANDARD_PR: ${{ github.event_name == 'pull_request' }}
   IS_RELEASE: ${{ github.event_name == 'release' }}
-  IS_PRE: ${{ contains(fromJSON('["workflow_dispatch", "push"]'), github.event_name) || (github.event.action == 'labeled' && github.event.label.name == 'build-installer-artifacts') }}
+  IS_PRE: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   build-noarch-pkgs:
     name: Build ${{ matrix.pkg }}
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action != 'labeled'
+    if: github.event_name == 'pull_request'
     strategy:
       matrix:
         pkg: ["python-lsp-server", "qtconsole"]
@@ -86,7 +75,6 @@ jobs:
   build-matrix:
     name: Determine Build Matrix
     runs-on: ubuntu-latest
-    if: github.event.action != 'labeled' || github.event.label.name == 'build-installer-artifacts'
     outputs:
       target_platform: ${{ steps.build-matrix.outputs.target_platform }}
       include: ${{ steps.build-matrix.outputs.include }}
@@ -112,19 +100,13 @@ jobs:
         echo "include=[$include]" >> $GITHUB_OUTPUT
         echo "python_version=[$python_version]" >> $GITHUB_OUTPUT
 
-    - name: Remove Label
-      if: github.event.action == 'labeled'
-      uses: actions-ecosystem/action-remove-labels@v1
-      with:
-        labels: build-installer-artifacts
-
   build-installers:
     name: Build installer for ${{ matrix.target-platform }} Python-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     needs:
       - build-matrix
       - build-noarch-pkgs
-    if: ${{ ! failure() && ! cancelled() && needs.build-matrix.result == 'success' }}
+    if: ${{ ! failure() && ! cancelled() }}
     strategy:
       matrix:
         target-platform: ${{fromJson(needs.build-matrix.outputs.target_platform)}}

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -18,6 +18,27 @@ on:
       - created
 
   workflow_dispatch:
+    inputs:
+      pre:
+        description: 'Build as release candidate'
+        required: false
+        default: true
+        type: boolean
+      mac:
+        description: 'Build macOS installer'
+        required: false
+        default: true
+        type: boolean
+      linux:
+        description: 'Build Linux installer'
+        required: false
+        default: true
+        type: boolean
+      win:
+        description: 'Build Windows installer'
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: installers-conda-${{ github.ref }}
@@ -26,15 +47,15 @@ concurrency:
 name: Create conda-based installers for Windows, macOS, and Linux
 
 env:
-  IS_STANDARD_PR: ${{ github.event_name == 'pull_request' }}
+  IS_STANDARD_PR: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ! inputs.pre) }}
   IS_RELEASE: ${{ github.event_name == 'release' }}
-  IS_PRE: ${{ github.event_name == 'workflow_dispatch' }}
+  IS_PRE: ${{ github.event_name == 'workflow_dispatch' && inputs.pre }}
 
 jobs:
   build-noarch-pkgs:
     name: Build ${{ matrix.pkg }}
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ! inputs.pre)
     strategy:
       matrix:
         pkg: ["python-lsp-server", "qtconsole"]

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -50,6 +50,9 @@ env:
   IS_STANDARD_PR: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ! inputs.pre) }}
   IS_RELEASE: ${{ github.event_name == 'release' }}
   IS_PRE: ${{ github.event_name == 'workflow_dispatch' && inputs.pre }}
+  BUILD_MAC: ${{ github.event_name != 'workflow_dispatch' || inputs.mac }}
+  BUILD_LNX: ${{ github.event_name != 'workflow_dispatch' || inputs.linux }}
+  BUILD_WIN: ${{ github.event_name != 'workflow_dispatch' || inputs.win }}
 
 jobs:
   build-noarch-pkgs:
@@ -105,17 +108,22 @@ jobs:
     - name: Determine Build Matrix
       id: build-matrix
       run: |
-        target_platform="'osx-64', 'linux-64'"
-        include="\
-        {'os': 'macos-11', 'target-platform': 'osx-64'},\
-        {'os': 'ubuntu-latest', 'target-platform': 'linux-64'}\
-        "
-        python_version="'3.9'"
+        [[ $IS_RELEASE == "true" ]] && BUILD_WIN="false"
 
-        if [[ $IS_STANDARD_PR == 'true' ]]; then
-            target_platform=$target_platform", 'win-64'"
-            include=$include",{'os': 'windows-latest', 'target-platform': 'win-64'}"
+        if [[ $BUILD_MAC == "true" ]]; then
+            target_platform="'osx-64'"
+            include="{'os': 'macos-11', 'target-platform': 'osx-64'}"
         fi
+        if [[ $BUILD_LNX == "true" ]]; then
+            target_platform=${target_platform:+"$target_platform, "}"'linux-64'"
+            include=${include:+"$include, "}"{'os': 'ubuntu-latest', 'target-platform': 'linux-64'}"
+        fi
+        if [[ $BUILD_WIN == "true" ]]; then
+            target_platform=${target_platform:+"$target_platform, "}"'win-64'"
+            include=${include:+"$include, "}"{'os': 'windows-latest', 'target-platform': 'win-64'}"
+        fi
+
+        python_version="'3.9'"
 
         echo "target_platform=[$target_platform]" >> $GITHUB_OUTPUT
         echo "include=[$include]" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-files.yml
+++ b/.github/workflows/test-files.yml
@@ -33,6 +33,8 @@ on:
       - '!installers*/**'
       - '!.github/workflows/installer*.yml'
 
+  workflow_dispatch:
+
 concurrency:
   group: test-files-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -33,6 +33,8 @@ on:
       - '!installers*/**'
       - '!.github/workflows/installer*.yml'
 
+  workflow_dispatch:
+
 concurrency:
   group: test-linux-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -33,6 +33,8 @@ on:
       - '!installers*/**'
       - '!.github/workflows/installer*.yml'
 
+  workflow_dispatch:
+
 concurrency:
   group: test-mac-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -33,6 +33,8 @@ on:
       - '!installers*/**'
       - '!.github/workflows/installer*.yml'
 
+  workflow_dispatch:
+
 concurrency:
   group: test-win-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Opening a PR and labeling it at the same time results in a race condition between the `opened` and `labeled` `pull_request` event triggers which can lead to cancelled installer workflows.

To fix this, we remove the `labeled` event trigger for `pull_requests`.
Since release candidates were the primary motivation for these triggers, but this must rely on the `workflow_dispatch` trigger anyway, the `workflow_dispatch` is now the recommended way to trigger workflows outside of `pull_request` and `release` events.

Additionally, `inputs` for the `workflow_dispatch` were added to the conda-based installer workflow for enhanced flexibility.

* `pull_request.labeled` trigger events are removed for installer workflows
* `push.tag` trigger events are removed for installer workflows
* `workflow_dispatch` trigger is added to unit test workflows. These can now be triggered to run on arbitrary branches, independent of pull_requests.
* `inputs` are added to the `workflow_dispatch` in conda-based installer workflow
  * "Build as release candidate": build the installers using released versions of `qtconsole`, `python-lsp-server`, and `spyder-kernels`; codesign and notarize the resulting installers (macOS only). If deselected, `qtconsole`, `python-lsp-server`, and `spyder-kernels` are built from the upstream remote and commit specified in `external-deps`
  * "Build macOS installer": build the macOS installer
  * "Build Linux installer": build the Linux installer
  * "Build Windows installer": build the Windows installer
