### PR TITLE
PR: Use .format() to format floats in array and dataframe editors

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -41,48 +41,48 @@ from spyder.utils.icon_manager import ima
 from spyder.utils.qthelpers import add_actions, create_action, keybinding
 from spyder.plugins.variableexplorer.widgets.basedialog import BaseDialog
 
-# Note: string and unicode data types will be formatted with '%s' (see below)
+# Note: string and unicode data types will be formatted with 's' (see below)
 SUPPORTED_FORMATS = {
-    'single': '%.6g',
-    'double': '%.6g',
-    'float_': '%.6g',
-    'longfloat': '%.6g',
-    'float16': '%.6g',
-    'float32': '%.6g',
-    'float64': '%.6g',
-    'float96': '%.6g',
-    'float128': '%.6g',
-    'csingle': '%r',
-    'complex_': '%r',
-    'clongfloat': '%r',
-    'complex64': '%r',
-    'complex128': '%r',
-    'complex192': '%r',
-    'complex256': '%r',
-    'byte': '%d',
-    'bytes8': '%s',
-    'short': '%d',
-    'intc': '%d',
-    'int_': '%d',
-    'longlong': '%d',
-    'intp': '%d',
-    'int8': '%d',
-    'int16': '%d',
-    'int32': '%d',
-    'int64': '%d',
-    'ubyte': '%d',
-    'ushort': '%d',
-    'uintc': '%d',
-    'uint': '%d',
-    'ulonglong': '%d',
-    'uintp': '%d',
-    'uint8': '%d',
-    'uint16': '%d',
-    'uint32': '%d',
-    'uint64': '%d',
-    'bool_': '%r',
-    'bool8': '%r',
-    'bool': '%r',
+    'single': '.6g',
+    'double': '.6g',
+    'float_': '.6g',
+    'longfloat': '.6g',
+    'float16': '.6g',
+    'float32': '.6g',
+    'float64': '.6g',
+    'float96': '.6g',
+    'float128': '.6g',
+    'csingle': 'r',
+    'complex_': 'r',
+    'clongfloat': 'r',
+    'complex64': 'r',
+    'complex128': 'r',
+    'complex192': 'r',
+    'complex256': 'r',
+    'byte': 'd',
+    'bytes8': 's',
+    'short': 'd',
+    'intc': 'd',
+    'int_': 'd',
+    'longlong': 'd',
+    'intp': 'd',
+    'int8': 'd',
+    'int16': 'd',
+    'int32': 'd',
+    'int64': 'd',
+    'ubyte': 'd',
+    'ushort': 'd',
+    'uintc': 'd',
+    'uint': 'd',
+    'ulonglong': 'd',
+    'uintp': 'd',
+    'uint8': 'd',
+    'uint16': 'd',
+    'uint32': 'd',
+    'uint64': 'd',
+    'bool_': 'r',
+    'bool8': 'r',
+    'bool': 'r',
 }
 
 
@@ -120,7 +120,7 @@ class ArrayModel(QAbstractTableModel):
     ROWS_TO_LOAD = 500
     COLS_TO_LOAD = 40
 
-    def __init__(self, data, format_spec="%.6g", xlabels=None, ylabels=None,
+    def __init__(self, data, format_spec=".6g", xlabels=None, ylabels=None,
                  readonly=False, parent=None):
         QAbstractTableModel.__init__(self)
 
@@ -288,7 +288,8 @@ class ArrayModel(QAbstractTableModel):
                     return value_to_display(value)
                 else:
                     try:
-                        return to_qvariant(self._format_spec % value)
+                        format_spec = self._format_spec
+                        return to_qvariant(format(value, format_spec))
                     except TypeError:
                         self.readonly = True
                         return repr(value)
@@ -346,7 +347,8 @@ class ArrayModel(QAbstractTableModel):
             return False
 
         # Add change to self.changes
-        self.changes[(i, j)] = val
+        # Use self.test_array to convert to correct dtype
+        self.changes[(i, j)] = self.test_array[0]
         self.dataChanged.emit(index, index)
 
         if not is_string(val):
@@ -559,8 +561,9 @@ class ArrayView(QTableView):
         _data = self.model().get_data()
         output = io.BytesIO()
         try:
+            fmt = '%' + self.model().get_format_spec()
             np.savetxt(output, _data[row_min:row_max+1, col_min:col_max+1],
-                       delimiter='\t', fmt=self.model().get_format_spec())
+                       delimiter='\t', fmt=fmt)
         except:
             QMessageBox.warning(self, _("Warning"),
                                 _("It was not possible to copy values for "
@@ -592,7 +595,7 @@ class ArrayEditorWidget(QWidget):
             self.old_data_shape = self.data.shape
             self.data.shape = (1, 1)
 
-        format_spec = SUPPORTED_FORMATS.get(data.dtype.name, '%s')
+        format_spec = SUPPORTED_FORMATS.get(data.dtype.name, 's')
         self.model = ArrayModel(self.data, format_spec=format_spec, xlabels=xlabels,
                                 ylabels=ylabels, readonly=readonly, parent=self)
         self.view = ArrayView(self, self.model, data.dtype, data.shape)
@@ -622,7 +625,7 @@ class ArrayEditorWidget(QWidget):
         if valid:
             format_spec = str(format_spec)
             try:
-                format_spec % 1.1
+                format(1.1, format_spec)
             except:
                 QMessageBox.critical(self, _("Error"),
                                      _("Format (%s) is incorrect") % format_spec)

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -120,7 +120,7 @@ class ArrayModel(QAbstractTableModel):
     ROWS_TO_LOAD = 500
     COLS_TO_LOAD = 40
 
-    def __init__(self, data, format="%.6g", xlabels=None, ylabels=None,
+    def __init__(self, data, format_spec="%.6g", xlabels=None, ylabels=None,
                  readonly=False, parent=None):
         QAbstractTableModel.__init__(self)
 
@@ -145,7 +145,7 @@ class ArrayModel(QAbstractTableModel):
         self.alp = .6 # Alpha-channel
 
         self._data = data
-        self._format = format
+        self._format_spec = format_spec
 
         self.total_rows = self._data.shape[0]
         self.total_cols = self._data.shape[1]
@@ -192,18 +192,18 @@ class ArrayModel(QAbstractTableModel):
             else:
                 self.cols_loaded = self.total_cols
 
-    def get_format(self):
+    def get_format_spec(self):
         """Return current format"""
-        # Avoid accessing the private attribute _format from outside
-        return self._format
+        # Avoid accessing the private attribute _format_spec from outside
+        return self._format_spec
 
     def get_data(self):
         """Return data"""
         return self._data
 
-    def set_format(self, format):
+    def set_format_spec(self, format_spec):
         """Change display format"""
-        self._format = format
+        self._format_spec = format_spec
         self.reset()
 
     def columnCount(self, qindex=QModelIndex()):
@@ -288,7 +288,7 @@ class ArrayModel(QAbstractTableModel):
                     return value_to_display(value)
                 else:
                     try:
-                        return to_qvariant(self._format % value)
+                        return to_qvariant(self._format_spec % value)
                     except TypeError:
                         self.readonly = True
                         return repr(value)
@@ -560,7 +560,7 @@ class ArrayView(QTableView):
         output = io.BytesIO()
         try:
             np.savetxt(output, _data[row_min:row_max+1, col_min:col_max+1],
-                       delimiter='\t', fmt=self.model().get_format())
+                       delimiter='\t', fmt=self.model().get_format_spec())
         except:
             QMessageBox.warning(self, _("Warning"),
                                 _("It was not possible to copy values for "
@@ -592,8 +592,8 @@ class ArrayEditorWidget(QWidget):
             self.old_data_shape = self.data.shape
             self.data.shape = (1, 1)
 
-        format = SUPPORTED_FORMATS.get(data.dtype.name, '%s')
-        self.model = ArrayModel(self.data, format=format, xlabels=xlabels,
+        format_spec = SUPPORTED_FORMATS.get(data.dtype.name, '%s')
+        self.model = ArrayModel(self.data, format_spec=format_spec, xlabels=xlabels,
                                 ylabels=ylabels, readonly=readonly, parent=self)
         self.view = ArrayView(self, self.model, data.dtype, data.shape)
 
@@ -616,18 +616,18 @@ class ArrayEditorWidget(QWidget):
     @Slot()
     def change_format(self):
         """Change display format"""
-        format, valid = QInputDialog.getText(self, _( 'Format'),
+        format_spec, valid = QInputDialog.getText(self, _( 'Format'),
                                  _( "Float formatting"),
-                                 QLineEdit.Normal, self.model.get_format())
+                                 QLineEdit.Normal, self.model.get_format_spec())
         if valid:
-            format = str(format)
+            format_spec = str(format_spec)
             try:
-                format % 1.1
+                format_spec % 1.1
             except:
                 QMessageBox.critical(self, _("Error"),
-                                     _("Format (%s) is incorrect") % format)
+                                     _("Format (%s) is incorrect") % format_spec)
                 return
-            self.model.set_format(format)
+            self.model.set_format_spec(format_spec)
 
 
 class ArrayEditor(BaseDialog):

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -68,7 +68,7 @@ COMPLEX_NUMBER_TYPES = (complex, np.complex64, np.complex128)
 _bool_false = ['false', 'f', '0', '0.', '0.0', ' ']
 
 # Default format for data frames with floats
-DEFAULT_FORMAT = '%.6g'
+DEFAULT_FORMAT = '.6g'
 
 # Limit at which dataframe is considered so large that it is loaded on demand
 LARGE_SIZE = 5e5
@@ -354,11 +354,11 @@ class DataFrameModel(QAbstractTableModel):
             value = self.get_value(row, column)
             if isinstance(value, float):
                 try:
-                    return to_qvariant(self._format_spec % value)
+                    return to_qvariant(format(value, self._format_spec))
                 except (ValueError, TypeError):
-                    # may happen if format = '%d' and value = NaN;
+                    # may happen if format = 'd' and value = NaN;
                     # see spyder-ide/spyder#4139.
-                    return to_qvariant(DEFAULT_FORMAT % value)
+                    return to_qvariant(format(value, DEFAULT_FORMAT))
             elif is_type_text_string(value):
                 # Don't perform any conversion on strings
                 # because it leads to differences between
@@ -1017,8 +1017,7 @@ class DataFrameEditor(BaseDialog, SpyderConfigurationAccessor):
         self.setModel(self.dataModel)
         self.resizeColumnsToContents()
 
-        format_spec = '%' + self.get_conf('dataframe_format')
-        self.dataModel.set_format_spec(format_spec)
+        self.dataModel.set_format_spec(self.get_conf('dataframe_format'))
 
         return True
 
@@ -1307,18 +1306,12 @@ class DataFrameEditor(BaseDialog, SpyderConfigurationAccessor):
         if valid:
             format_spec = str(format_spec)
             try:
-                format_spec % 1.1
+                format(1.1, format_spec)
             except:
                 msg = _("Format ({}) is incorrect").format(format_spec)
                 QMessageBox.critical(self, _("Error"), msg)
                 return
-            if not format_spec.startswith('%'):
-                msg = _("Format ({}) should start with '%'").format(format_spec)
-                QMessageBox.critical(self, _("Error"), msg)
-                return
             self.dataModel.set_format_spec(format_spec)
-
-            format_spec = format_spec[1:]
             self.set_conf('dataframe_format', format_spec)
 
     def get_value(self):

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -41,10 +41,10 @@ from qtpy.compat import from_qvariant, to_qvariant
 from qtpy.QtCore import (QAbstractTableModel, QModelIndex, Qt, Signal, Slot,
                          QItemSelectionModel, QEvent)
 from qtpy.QtGui import QColor, QCursor
-from qtpy.QtWidgets import (QApplication, QCheckBox, QDialog, QGridLayout,
-                            QHBoxLayout, QInputDialog, QLineEdit, QMenu,
-                            QMessageBox, QPushButton, QTableView, QScrollBar,
-                            QTableWidget, QFrame, QItemDelegate)
+from qtpy.QtWidgets import (QApplication, QCheckBox, QGridLayout, QHBoxLayout,
+                            QInputDialog, QLineEdit, QMenu, QMessageBox,
+                            QPushButton, QTableView, QScrollBar, QTableWidget,
+                            QFrame, QItemDelegate)
 from spyder_kernels.utils.lazymodules import numpy as np, pandas as pd
 
 # Local imports

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -43,9 +43,8 @@ from qtpy.QtCore import (QAbstractTableModel, QModelIndex, Qt, Signal, Slot,
 from qtpy.QtGui import QColor, QCursor
 from qtpy.QtWidgets import (QApplication, QCheckBox, QDialog, QGridLayout,
                             QHBoxLayout, QInputDialog, QLineEdit, QMenu,
-                            QMessageBox, QPushButton, QTableView,
-                            QScrollBar, QTableWidget, QFrame,
-                            QItemDelegate)
+                            QMessageBox, QPushButton, QTableView, QScrollBar,
+                            QTableWidget, QFrame, QItemDelegate)
 from spyder_kernels.utils.lazymodules import numpy as np, pandas as pd
 
 # Local imports

--- a/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
@@ -127,8 +127,8 @@ def test_arrayeditor_format(setup_arrayeditor, qtbot):
     qtbot.keyClick(dlg.arraywidget.view, Qt.Key_Down, modifier=Qt.ShiftModifier)
     contents = dlg.arraywidget.view._sel_to_text(dlg.arraywidget.view.selectedIndexes())
     assert contents == "1\n2\n"
-    dlg.arraywidget.view.model().set_format("%.18e")
-    assert dlg.arraywidget.view.model().get_format() == "%.18e"
+    dlg.arraywidget.view.model().set_format_spec("%.18e")
+    assert dlg.arraywidget.view.model().get_format_spec() == "%.18e"
     qtbot.keyClick(dlg.arraywidget.view, Qt.Key_Down, modifier=Qt.ShiftModifier)
     qtbot.keyClick(dlg.arraywidget.view, Qt.Key_Down, modifier=Qt.ShiftModifier)
     contents = dlg.arraywidget.view._sel_to_text(dlg.arraywidget.view.selectedIndexes())

--- a/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
@@ -127,12 +127,23 @@ def test_arrayeditor_format(setup_arrayeditor, qtbot):
     qtbot.keyClick(dlg.arraywidget.view, Qt.Key_Down, modifier=Qt.ShiftModifier)
     contents = dlg.arraywidget.view._sel_to_text(dlg.arraywidget.view.selectedIndexes())
     assert contents == "1\n2\n"
-    dlg.arraywidget.view.model().set_format_spec("%.18e")
-    assert dlg.arraywidget.view.model().get_format_spec() == "%.18e"
+    dlg.arraywidget.view.model().set_format_spec(".18e")
+    assert dlg.arraywidget.view.model().get_format_spec() == ".18e"
     qtbot.keyClick(dlg.arraywidget.view, Qt.Key_Down, modifier=Qt.ShiftModifier)
     qtbot.keyClick(dlg.arraywidget.view, Qt.Key_Down, modifier=Qt.ShiftModifier)
     contents = dlg.arraywidget.view._sel_to_text(dlg.arraywidget.view.selectedIndexes())
     assert contents == "1.000000000000000000e+00\n2.000000000000000000e+00\n"
+
+
+@pytest.mark.parametrize(
+    'data',
+    [np.array([10000])]
+)
+def test_arrayeditor_format_thousands(setup_arrayeditor):
+    """Check that format can include thousands separator."""
+    model = setup_arrayeditor.arraywidget.model
+    model.set_format_spec(',.2f')
+    assert model.data(model.index(0, 0)) == '10,000.00'
 
 
 def test_arrayeditor_with_inf_array(qtbot, recwarn):

--- a/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
@@ -348,40 +348,39 @@ def test_dataframemodel_get_bgcolor_with_missings():
 
 def test_dataframemodel_with_format_percent_d_and_nan():
     """
-    Test DataFrameModel with format `%d` and dataframe containing NaN
+    Test DataFrameModel with format `d` and dataframe containing NaN
 
     Regression test for spyder-ide/spyder#4139.
     """
     np_array = numpy.zeros(2)
     np_array[1] = numpy.nan
     dataframe = DataFrame(np_array)
-    dfm = DataFrameModel(dataframe, format_spec='%d')
+    dfm = DataFrameModel(dataframe, format_spec='d')
     assert data(dfm, 0, 0) == '0'
     assert data(dfm, 1, 0) == 'nan'
 
 def test_change_format(qtbot, monkeypatch):
     mockQInputDialog = Mock()
-    mockQInputDialog.getText = lambda parent, title, label, mode, text: ('%10.3e', True)
+    mockQInputDialog.getText = lambda parent, title, label, mode, text: ('10.3e', True)
     monkeypatch.setattr('spyder.plugins.variableexplorer.widgets.dataframeeditor.QInputDialog', mockQInputDialog)
     df = DataFrame([[0]])
     editor = DataFrameEditor(None)
     editor.setup_and_check(df)
     editor.change_format()
-    assert editor.dataModel._format_spec == '%10.3e'
+    assert editor.dataModel._format_spec == '10.3e'
     assert editor.get_conf('dataframe_format') == '10.3e'
     editor.set_conf('dataframe_format', '.6g')
 
-def test_change_format_with_format_not_starting_with_percent(qtbot, monkeypatch):
-    mockQInputDialog = Mock()
-    mockQInputDialog.getText = lambda parent, title, label, mode, text: ('xxx%f', True)
-    monkeypatch.setattr('spyder.plugins.variableexplorer.widgets.dataframeeditor'
-                        '.QInputDialog', mockQInputDialog)
-    monkeypatch.setattr('spyder.plugins.variableexplorer.widgets.dataframeeditor'
-                        '.QMessageBox.critical', Mock())
-    df = DataFrame([[0]])
-    editor = DataFrameEditor(None)
-    editor.setup_and_check(df)
-    editor.change_format()
+
+def test_dataframemodel_with_format_thousands():
+    """
+    Check that format can include thousands separator.
+
+    Regression test for spyder-ide/spyder#14518.
+    """
+    dataframe = DataFrame([10000.1])
+    dfm = DataFrameModel(dataframe, format_spec=',.2f')
+    assert data(dfm, 0, 0) == '10,000.10'
 
 
 def test_dataframeeditor_with_various_indexes():

--- a/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
@@ -355,7 +355,7 @@ def test_dataframemodel_with_format_percent_d_and_nan():
     np_array = numpy.zeros(2)
     np_array[1] = numpy.nan
     dataframe = DataFrame(np_array)
-    dfm = DataFrameModel(dataframe, format='%d')
+    dfm = DataFrameModel(dataframe, format_spec='%d')
     assert data(dfm, 0, 0) == '0'
     assert data(dfm, 1, 0) == 'nan'
 
@@ -367,7 +367,7 @@ def test_change_format(qtbot, monkeypatch):
     editor = DataFrameEditor(None)
     editor.setup_and_check(df)
     editor.change_format()
-    assert editor.dataModel._format == '%10.3e'
+    assert editor.dataModel._format_spec == '%10.3e'
     assert editor.get_conf('dataframe_format') == '10.3e'
     editor.set_conf('dataframe_format', '.6g')
 


### PR DESCRIPTION
## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

Use `format()` instead of the `%` operator to format floating-point numbers in the array and dataframe editors, because this has more functionality and it is modern Python style instead of C-style priintf. For example, with `.format()` you can specify a thousands separator with `,` in the format specifier, as shown in the animation below.

A difference with the current version is that there is no initial `%` character in the format specifier: the user should now give the format as `.6g` instead of `%.6g`. However, the config option never had the `%` character in it, so there is no hange in the configuration.

![dataframe-format](https://user-images.githubusercontent.com/7941918/216703965-be37dce8-40cb-47a3-995e-4ef4b8a663c8.gif)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #14518


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
