### PR TITLE
PR: Stop automatic scrolling when a plot is selected (Plots)

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2055,8 +2055,9 @@ def test_plots_scroll(main_window, qtbot):
     figbrowser = main_window.plots.current_widget()
 
     # Wait until the window is fully up.
-    qtbot.waitUntil(lambda: shell._prompt_html is not None,
-                    timeout=SHELL_TIMEOUT)
+    qtbot.waitUntil(
+        lambda: shell.spyder_kernel_ready and shell._prompt_html is not None,
+        timeout=SHELL_TIMEOUT)
 
     # Generate a plot inline.
     with qtbot.waitSignal(shell.executed):
@@ -2068,7 +2069,7 @@ def test_plots_scroll(main_window, qtbot):
     assert len(sb._thumbnails) == 1
     assert sb._thumbnails[-1] == sb.current_thumbnail
 
-    # plot 4 more plots
+    # Generate 4 more plots
     with qtbot.waitSignal(shell.executed):
         shell.execute(
             "for i in range(4):\n"
@@ -2079,7 +2080,7 @@ def test_plots_scroll(main_window, qtbot):
     assert len(sb._thumbnails) == 5
     assert sb._thumbnails[-1] == sb.current_thumbnail
 
-    # plot 20 plots
+    # Generate 20 plots
     with qtbot.waitSignal(shell.executed):
         shell.execute(
             "for i in range(20):\n"
@@ -2092,7 +2093,7 @@ def test_plots_scroll(main_window, qtbot):
     assert sb._thumbnails[-1] == sb.current_thumbnail
     assert scrollbar.value() == scrollbar.maximum()
 
-    # plot 20 plots and select a plot in the middle
+    # Generate 20 plots and select a plot in the middle
     with qtbot.waitSignal(shell.executed, timeout=SHELL_TIMEOUT):
         shell.execute(
             "import time\n"
@@ -2105,7 +2106,7 @@ def test_plots_scroll(main_window, qtbot):
         sb.set_current_index(5)
         scrollbar.setValue(scrollbar.minimum())
 
-    # make sure we didn't scroll to the end and a new thumnail was not selected
+    # make sure we didn't scroll to the end and a new thumbnail was not selected
     assert len(sb._thumbnails) == 45
     assert sb._thumbnails[-1] != sb.current_thumbnail
     assert scrollbar.value() != scrollbar.maximum()

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2051,6 +2051,7 @@ def test_plots_plugin(main_window, qtbot, tmpdir, mocker):
 
 def test_plots_scroll(main_window, qtbot):
     """Test plots plugin scrolling"""
+    CONF.set('plots', 'mute_inline_plotting', True)
     shell = main_window.ipyconsole.get_current_shellwidget()
     figbrowser = main_window.plots.current_widget()
 
@@ -2060,7 +2061,7 @@ def test_plots_scroll(main_window, qtbot):
         timeout=SHELL_TIMEOUT)
 
     # Generate a plot inline.
-    with qtbot.waitSignal(shell.executed):
+    with qtbot.waitSignal(shell.executed, timeout=SHELL_TIMEOUT):
         shell.execute(("import matplotlib.pyplot as plt\n"
                        "fig = plt.plot([1, 2, 3, 4], '.')\n"))
 
@@ -2070,7 +2071,7 @@ def test_plots_scroll(main_window, qtbot):
     assert sb._thumbnails[-1] == sb.current_thumbnail
 
     # Generate 4 more plots
-    with qtbot.waitSignal(shell.executed):
+    with qtbot.waitSignal(shell.executed, timeout=SHELL_TIMEOUT):
         shell.execute(
             "for i in range(4):\n"
             "    plt.figure()\n"
@@ -2081,7 +2082,7 @@ def test_plots_scroll(main_window, qtbot):
     assert sb._thumbnails[-1] == sb.current_thumbnail
 
     # Generate 20 plots
-    with qtbot.waitSignal(shell.executed):
+    with qtbot.waitSignal(shell.executed, timeout=SHELL_TIMEOUT):
         shell.execute(
             "for i in range(20):\n"
             "    plt.figure()\n"
@@ -2102,7 +2103,7 @@ def test_plots_scroll(main_window, qtbot):
             "    plt.plot([1, 2, 3, 4], '.')\n"
             "    plt.show()\n"
             "    time.sleep(.1)")
-        qtbot.wait(500)
+        qtbot.waitUntil(lambda: sb._first_thumbnail_shown, timeout=SHELL_TIMEOUT)
         sb.set_current_index(5)
         scrollbar.setValue(scrollbar.minimum())
 
@@ -2112,13 +2113,14 @@ def test_plots_scroll(main_window, qtbot):
     assert scrollbar.value() != scrollbar.maximum()
 
     # One more plot
-    with qtbot.waitSignal(shell.executed):
+    with qtbot.waitSignal(shell.executed, timeout=SHELL_TIMEOUT):
         shell.execute(("fig = plt.plot([1, 2, 3, 4], '.')\n"))
 
     # Make sure everything scrolled at the end
     assert len(sb._thumbnails) == 46
     assert sb._thumbnails[-1] == sb.current_thumbnail
     assert scrollbar.value() == scrollbar.maximum()
+    CONF.set('plots', 'mute_inline_plotting', False)
 
 
 @flaky(max_runs=3)

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2093,7 +2093,7 @@ def test_plots_scroll(main_window, qtbot):
     assert scrollbar.value() == scrollbar.maximum()
 
     # plot 20 plots and select a plot in the middle
-    with qtbot.waitSignal(shell.executed):
+    with qtbot.waitSignal(shell.executed, timeout=SHELL_TIMEOUT):
         shell.execute(
             "import time\n"
             "for i in range(20):\n"

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2049,6 +2049,77 @@ def test_plots_plugin(main_window, qtbot, tmpdir, mocker):
     assert compare_images(ipython_figname, plots_figname, 0.1) is None
 
 
+def test_plots_scroll(main_window, qtbot):
+    """Test plots plugin scrolling"""
+    shell = main_window.ipyconsole.get_current_shellwidget()
+    figbrowser = main_window.plots.current_widget()
+
+    # Wait until the window is fully up.
+    qtbot.waitUntil(lambda: shell._prompt_html is not None,
+                    timeout=SHELL_TIMEOUT)
+
+    # Generate a plot inline.
+    with qtbot.waitSignal(shell.executed):
+        shell.execute(("import matplotlib.pyplot as plt\n"
+                       "fig = plt.plot([1, 2, 3, 4], '.')\n"))
+
+    # Make sure the plot is selected
+    sb = figbrowser.thumbnails_sb
+    assert len(sb._thumbnails) == 1
+    assert sb._thumbnails[-1] == sb.current_thumbnail
+
+    # plot 4 more plots
+    with qtbot.waitSignal(shell.executed):
+        shell.execute(
+            "for i in range(4):\n"
+            "    plt.figure()\n"
+            "    plt.plot([1, 2, 3, 4], '.')")
+
+    # we now have 5 plots and the last one is selected
+    assert len(sb._thumbnails) == 5
+    assert sb._thumbnails[-1] == sb.current_thumbnail
+
+    # plot 20 plots
+    with qtbot.waitSignal(shell.executed):
+        shell.execute(
+            "for i in range(20):\n"
+            "    plt.figure()\n"
+            "    plt.plot([1, 2, 3, 4], '.')")
+
+    # Make sure we scrolled down
+    scrollbar = sb.scrollarea.verticalScrollBar()
+    assert len(sb._thumbnails) == 25
+    assert sb._thumbnails[-1] == sb.current_thumbnail
+    assert scrollbar.value() == scrollbar.maximum()
+
+    # plot 20 plots and select a plot in the middle
+    with qtbot.waitSignal(shell.executed):
+        shell.execute(
+            "import time\n"
+            "for i in range(20):\n"
+            "    plt.figure()\n"
+            "    plt.plot([1, 2, 3, 4], '.')\n"
+            "    plt.show()\n"
+            "    time.sleep(.1)")
+        qtbot.wait(500)
+        sb.set_current_index(5)
+        scrollbar.setValue(scrollbar.minimum())
+
+    # make sure we didn't scroll to the end and a new thumnail was not selected
+    assert len(sb._thumbnails) == 45
+    assert sb._thumbnails[-1] != sb.current_thumbnail
+    assert scrollbar.value() != scrollbar.maximum()
+
+    # One more plot
+    with qtbot.waitSignal(shell.executed):
+        shell.execute(("fig = plt.plot([1, 2, 3, 4], '.')\n"))
+
+    # Make sure everything scrolled at the end
+    assert len(sb._thumbnails) == 46
+    assert sb._thumbnails[-1] == sb.current_thumbnail
+    assert scrollbar.value() == scrollbar.maximum()
+
+
 @flaky(max_runs=3)
 @pytest.mark.skipif(
     (parse_version(ipy_release.version) >= parse_version('7.23.0') and

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2103,7 +2103,8 @@ def test_plots_scroll(main_window, qtbot):
             "    plt.plot([1, 2, 3, 4], '.')\n"
             "    plt.show()\n"
             "    time.sleep(.1)")
-        qtbot.waitUntil(lambda: sb._first_thumbnail_shown, timeout=SHELL_TIMEOUT)
+        qtbot.waitUntil(lambda: sb._first_thumbnail_shown,
+                        timeout=SHELL_TIMEOUT)
         sb.set_current_index(5)
         scrollbar.setValue(scrollbar.minimum())
 

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -243,7 +243,7 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
         self.shellwidget = shellwidget
         self.shellwidget.set_mute_inline_plotting(self.mute_inline_plotting)
         shellwidget.sig_new_inline_figure.connect(self._handle_new_figure)
-        shellwidget.executing.connect(self._handle_executing)
+        shellwidget.executing.connect(self._handle_new_execution)
 
     def _handle_new_figure(self, fig, fmt):
         """
@@ -252,8 +252,8 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
         """
         self.thumbnails_sb.add_thumbnail(fig, fmt)
 
-    def _handle_executing(self):
-        """A new execution started"""
+    def _handle_new_execution(self):
+        """Handle a new execution in the console."""
         self.thumbnails_sb._first_thumbnail_shown = False
 
     # ---- Toolbar Handlers
@@ -798,11 +798,12 @@ class ThumbnailScrollBar(QFrame):
         self.scene.setRowStretch(self.scene.rowCount() - 1, 0)
         self.scene.addWidget(thumbnail, self.scene.rowCount() - 1, 0)
         self.scene.setRowStretch(self.scene.rowCount(), 100)
-        # Only select the new tumbnail if the last one was selected
+
+        # Only select a new thumbnail if the last one was selected
         select_last = (
-            len(self._thumbnails) < 2 or
-            self.current_thumbnail == self._thumbnails[-2] or
-            is_first
+            len(self._thumbnails) < 2
+            or self.current_thumbnail == self._thumbnails[-2]
+            or is_first
         )
         if select_last:
             self.set_current_thumbnail(thumbnail)

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -775,7 +775,7 @@ class ThumbnailScrollBar(QFrame):
         Add a new thumbnail to that thumbnail scrollbar.
         """
         # Always stick at end for the first thumbnail
-        if_first = not self._first_thumbnail_shown
+        is_first = not self._first_thumbnail_shown
 
         # Stick at end if we are already at the end
         stick_at_end = False
@@ -802,7 +802,7 @@ class ThumbnailScrollBar(QFrame):
         select_last = (
             len(self._thumbnails) < 2 or
             self.current_thumbnail == self._thumbnails[-2] or
-            if_first
+            is_first
         )
         if select_last:
             self.set_current_thumbnail(thumbnail)
@@ -810,7 +810,7 @@ class ThumbnailScrollBar(QFrame):
         thumbnail.show()
         self._setup_thumbnail_size(thumbnail)
 
-        if not if_first and not stick_at_end:
+        if not is_first and not stick_at_end:
             self._scroll_to_last_thumbnail = False
 
     def remove_current_thumbnail(self):

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -243,6 +243,7 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
         self.shellwidget = shellwidget
         self.shellwidget.set_mute_inline_plotting(self.mute_inline_plotting)
         shellwidget.sig_new_inline_figure.connect(self._handle_new_figure)
+        shellwidget.executing.connect(self._handle_executing)
 
     def _handle_new_figure(self, fig, fmt):
         """
@@ -250,6 +251,10 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
         kernel.
         """
         self.thumbnails_sb.add_thumbnail(fig, fmt)
+
+    def _handle_executing(self):
+        """A new execution started"""
+        self.thumbnails_sb._first_thumbnail_shown = False
 
     # ---- Toolbar Handlers
     def zoom_in(self):
@@ -587,7 +592,8 @@ class ThumbnailScrollBar(QFrame):
         # is added to the scrollarea, we need to do it instead in a slot
         # connected to the scrollbar's rangeChanged signal.
         # See spyder-ide/spyder#10914 for more details.
-        self._new_thumbnail_added = False
+        self._scroll_to_last_thumbnail = False
+        self._first_thumbnail_shown = False
         self.scrollarea.verticalScrollBar().rangeChanged.connect(
             self._scroll_to_newest_item)
 
@@ -768,6 +774,15 @@ class ThumbnailScrollBar(QFrame):
         """
         Add a new thumbnail to that thumbnail scrollbar.
         """
+        # Always stick at end for the first thumbnail
+        if_first = not self._first_thumbnail_shown
+
+        # Stick at end if we are already at the end
+        stick_at_end = False
+        sb = self.scrollarea.verticalScrollBar()
+        if sb.value() == sb.maximum():
+            stick_at_end = True
+
         thumbnail = FigureThumbnail(
             parent=self, background_color=self.background_color)
         thumbnail.canvas.load_figure(fig, fmt)
@@ -777,15 +792,26 @@ class ThumbnailScrollBar(QFrame):
         thumbnail.sig_context_menu_requested.connect(
             lambda point: self.show_context_menu(point, thumbnail))
         self._thumbnails.append(thumbnail)
-        self._new_thumbnail_added = True
+        self._scroll_to_last_thumbnail = True
+        self._first_thumbnail_shown = True
 
         self.scene.setRowStretch(self.scene.rowCount() - 1, 0)
         self.scene.addWidget(thumbnail, self.scene.rowCount() - 1, 0)
         self.scene.setRowStretch(self.scene.rowCount(), 100)
-        self.set_current_thumbnail(thumbnail)
+        # Only select the new tumbnail if the last one was selected
+        select_last = (
+            len(self._thumbnails) < 2 or
+            self.current_thumbnail == self._thumbnails[-2] or
+            if_first
+        )
+        if select_last:
+            self.set_current_thumbnail(thumbnail)
 
         thumbnail.show()
         self._setup_thumbnail_size(thumbnail)
+
+        if not if_first and not stick_at_end:
+            self._scroll_to_last_thumbnail = False
 
     def remove_current_thumbnail(self):
         """Remove the currently selected thumbnail."""
@@ -912,8 +938,8 @@ class ThumbnailScrollBar(QFrame):
         Note that this method is called each time the rangeChanged signal
         is emitted by the scrollbar.
         """
-        if self._new_thumbnail_added:
-            self._new_thumbnail_added = False
+        if self._scroll_to_last_thumbnail:
+            self._scroll_to_last_thumbnail = False
             self.scrollarea.verticalScrollBar().setValue(vsb_max)
 
     # ---- ScrollBar Handlers


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Only scroll down in the plots plane if the latest plot is selected or if a new execution started



* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20474


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
