### PR TITLE
PR: Add `--no-sandbox` argument for QtApplication

### DIFF
--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -689,7 +689,7 @@ except Exception:
     # fallback fail.
     # See issue spyder-ide/spyder#17889
     if app is None:
-        app = QApplication(['Spyder'])
+        app = QApplication(['Spyder', '--no-sandbox'])
         app.setApplicationName('Spyder')
 
     reset_reply = QMessageBox.critical(

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -109,7 +109,7 @@ def qapplication(translate=True, test_time=3):
     if app is None:
         # Set Application name for Gnome 3
         # https://groups.google.com/forum/#!topic/pyside/24qxvwfrRDs
-        app = SpyderApplication(['Spyder'])
+        app = SpyderApplication(['Spyder', '--no-sandbox'])
 
         # Set application name for KDE. See spyder-ide/spyder#2207.
         app.setApplicationName('Spyder')


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Add `--no-sandbox` argument when instantiating QtApplication object, in order to avoid a bug linked to Ubuntu 22.04 (see https://discourse.slicer.org/t/extensions-not-showing-anything/23432/5 and https://doc.qt.io/qt-6/qtwebengine-platform-notes.html)

Note sure if this is needed in `manager.py` tho, put it here just for consistency.

### Issue(s) Resolved

Fixes #20358

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: tlunet

<!--- Thanks for your help making Spyder better for everyone! --->
