### PR TITLE
PR: Make pane tabs to be left aligned on macOS again

### DIFF
--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -306,7 +306,7 @@ class PanesTabBarStyleSheet(PanesToolbarStyleSheet):
             )
 
             css['QTabWidget::tab-bar'].setValues(
-                alignment='center',
+                alignment='left',
             )
         else:
             # Remove spurious pixel to the left


### PR DESCRIPTION
## Description of Changes

- This regression was introduced in PR https://github.com/spyder-ide/spyder/pull/20122.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20504.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
