### PR TITLE
PR: Fix error when Python Path Manager is reopened

### DIFF
--- a/spyder/plugins/pythonpath/widgets/pathmanager.py
+++ b/spyder/plugins/pythonpath/widgets/pathmanager.py
@@ -244,6 +244,10 @@ class PathManager(QDialog, SpyderWidgetMixin):
     def setup(self):
         """Populate list widget."""
         self.listwidget.clear()
+        self.headers.clear()
+        self.project_header = None
+        self.user_header = None
+        self.system_header = None
 
         # Project path
         if self.project_path:


### PR DESCRIPTION
## Description of Changes

Reset references to Qt objects deleted by `listwidget.clear()`. This fixes a `RuntimeError` when Python Path Manager is reopened.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20506


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:

rear1019

