### PR TITLE
PR: Fix “Last edit location” for unsaved files

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2717,16 +2717,23 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
 
     @Slot()
     def go_to_last_edit_location(self):
-        if self.last_edit_cursor_pos is not None:
-            filename, position = self.last_edit_cursor_pos
-            if not osp.isfile(filename):
-                self.last_edit_cursor_pos = None
-                return
-            else:
-                self.load(filename)
-                editor = self.get_current_editor()
-                if position < editor.document().characterCount():
-                    editor.set_cursor_position(position)
+        if self.last_edit_cursor_pos is None:
+            return
+
+        filename, position = self.last_edit_cursor_pos
+        editor = None
+        if osp.isfile(filename):
+            self.load(filename)
+            editor = self.get_current_editor()
+        else:
+            editor = self.set_current_filename(filename)
+
+        if editor is None:
+            self.last_edit_cursor_pos = None
+            return
+
+        if position < editor.document().characterCount():
+            editor.set_cursor_position(position)
 
     def _pop_next_cursor_diff(self, history, current_filename, current_cursor):
         """Get the next cursor from history that is different from current."""


### PR DESCRIPTION
Fix “Source → Last edit location” action for new (yet unsaved) files.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

rear1019

<!--- Thanks for your help making Spyder better for everyone! --->
