### PR TITLE
PR: Fix test_shell_execution for macOS

### DIFF
--- a/spyder/app/tests/bash_example.sh
+++ b/spyder/app/tests/bash_example.sh
@@ -1,4 +1,4 @@
-set -exou
+set -exo
 
 TEMP_DIR=$1
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -144,7 +144,7 @@ def test_leaks(main_window, qtbot):
                 and shell._prompt_html is not None
             ),
             timeout=SHELL_TIMEOUT)
-    
+
         # Count initial objects
         # Only one of each should be present, but because of many leaks,
         # this is most likely not the case. Here only closing is tested
@@ -159,7 +159,7 @@ def test_leaks(main_window, qtbot):
         for o in objects:
             if type(o).__name__ == "ShellWidget":
                 n_shell_init += 1
-    
+
         # Open a second file and console
         main_window.editor.new()
         main_window.ipyconsole.create_new_client()
@@ -167,7 +167,7 @@ def test_leaks(main_window, qtbot):
         code_editor = main_window.editor.get_focus_widget()
         # Show an error in the editor
         code_editor.set_text("aaa")
-    
+
         shell = main_window.ipyconsole.get_current_shellwidget()
         qtbot.waitUntil(
             lambda: (
@@ -177,7 +177,7 @@ def test_leaks(main_window, qtbot):
             timeout=SHELL_TIMEOUT)
         with qtbot.waitSignal(shell.executed):
             shell.execute("%debug print()")
-    
+
         # Close all files and consoles
         main_window.editor.close_all_files()
         main_window.ipyconsole.restart()
@@ -863,7 +863,6 @@ def test_dedicated_consoles(main_window, qtbot):
 
 @flaky(max_runs=3)
 @pytest.mark.order(after="test_dedicated_consoles")
-@pytest.mark.skipif(sys.platform == 'darwin', reason='Fails on Mac')
 def test_shell_execution(main_window, qtbot, tmpdir):
     """Test that bash/batch files can be executed."""
     ext = 'sh'


### PR DESCRIPTION
`zsh` does not have the `-u` shell option. macOS can use `bash` instead of `zsh`.

Correct execution (via `bash`) looks like this:
```bash
(spy-dev) >> /bin/bash spyder/app/tests/bash_example.sh $(pwd)
allexport      	off
braceexpand    	on
emacs          	off
errexit        	on
errtrace       	off
functrace      	off
hashall        	on
histexpand     	off
history        	off
ignoreeof      	off
interactive-comments	on
keyword        	off
monitor        	off
noclobber      	off
noexec         	off
noglob         	off
nolog          	off
notify         	off
nounset        	off
onecmd         	off
physical       	off
pipefail       	off
posix          	off
privileged     	off
verbose        	off
vi             	off
xtrace         	on
+ TEMP_DIR=/Users/rclary/Documents/Repos/Spyder-IDE/spyder
++ uname
+ echo 'This is a temporary file created by Darwin'
```

The error from `zsh` is:
```
(spy-dev) >> /bin/zsh spyder/app/tests/bash_example.sh $(pwd)
spyder/app/tests/bash_example.sh:set:1: no such option: u
```

Since `zsh` is the default macOS shell, `-u` is removed from `bash_example.sh`