### PR TITLE
PR: Remove macOS and Windows conda-based installers from 5.x branch

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -24,35 +24,17 @@ on:
         required: false
         default: true
         type: boolean
-      mac:
-        description: 'Build macOS installer'
-        required: false
-        default: true
-        type: boolean
-      linux:
-        description: 'Build Linux installer'
-        required: false
-        default: true
-        type: boolean
-      win:
-        description: 'Build Windows installer'
-        required: false
-        default: true
-        type: boolean
 
 concurrency:
   group: installers-conda-${{ github.ref }}
   cancel-in-progress: true
 
-name: Create conda-based installers for Windows, macOS, and Linux
+name: Create conda-based installers for Linux
 
 env:
   IS_STANDARD_PR: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ! inputs.pre) }}
   IS_RELEASE: ${{ github.event_name == 'release' }}
   IS_PRE: ${{ github.event_name == 'workflow_dispatch' && inputs.pre }}
-  BUILD_MAC: ${{ github.event_name != 'workflow_dispatch' || inputs.mac }}
-  BUILD_LNX: ${{ github.event_name != 'workflow_dispatch' || inputs.linux }}
-  BUILD_WIN: ${{ github.event_name != 'workflow_dispatch' || inputs.win }}
 
 jobs:
   build-noarch-pkgs:
@@ -108,21 +90,8 @@ jobs:
     - name: Determine Build Matrix
       id: build-matrix
       run: |
-        [[ $IS_RELEASE == "true" ]] && BUILD_WIN="false"
-
-        if [[ $BUILD_MAC == "true" ]]; then
-            target_platform="'osx-64'"
-            include="{'os': 'macos-11', 'target-platform': 'osx-64'}"
-        fi
-        if [[ $BUILD_LNX == "true" ]]; then
-            target_platform=${target_platform:+"$target_platform, "}"'linux-64'"
-            include=${include:+"$include, "}"{'os': 'ubuntu-latest', 'target-platform': 'linux-64'}"
-        fi
-        if [[ $BUILD_WIN == "true" ]]; then
-            target_platform=${target_platform:+"$target_platform, "}"'win-64'"
-            include=${include:+"$include, "}"{'os': 'windows-latest', 'target-platform': 'win-64'}"
-        fi
-
+        target_platform="'linux-64'"
+        include="{'os': 'ubuntu-latest', 'target-platform': 'linux-64'}"
         python_version="'3.9'"
 
         echo "target_platform=[$target_platform]" >> $GITHUB_OUTPUT
@@ -147,10 +116,6 @@ jobs:
         working-directory: ${{ github.workspace }}/installers-conda
     env:
       DISTDIR: ${{ github.workspace }}/installers-conda/dist
-      MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-      MACOS_INSTALLER_CERTIFICATE: ${{ secrets.MACOS_INSTALLER_CERTIFICATE }}
-      APPLICATION_PWD: ${{ secrets.APPLICATION_PWD }}
       CONSTRUCTOR_TARGET_PLATFORM: ${{ matrix.target-platform }}
       BNP_STATUS: ${{ needs.build-noarch-pkgs.result }}
       MAT_STATUS: ${{ needs.build-matrix.result }}
@@ -160,15 +125,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Install pcregrep
-        if: runner.os == 'macOS'
-        run: |
-          if [[ -z "$(which pcregrep)" ]]; then
-              brew install pcre
-          else
-              echo "$(which pcregrep) already installed."
-          fi
 
       - name: Setup Build Environment
         uses: mamba-org/provision-with-micromamba@main
@@ -201,9 +157,8 @@ jobs:
           echo ${files[@]}
           cd $(dirname $CONDA_BLD_PATH)
 
-          [[ $RUNNER_OS == "Windows" ]] && opts=("--force-local") || opts=()
           for file in ${files[@]}; do
-              tar -xf $file ${opts[@]}
+              tar -xf $file
           done
 
           mamba index $CONDA_BLD_PATH
@@ -218,47 +173,13 @@ jobs:
           fi
           python build_conda_pkgs.py --build ${pkgs[@]}
 
-      - name: Create Keychain
-        if: runner.os == 'macOS' && (env.IS_RELEASE == 'true' || env.IS_PRE == 'true')
-        run: |
-          ./certkeychain.sh "${MACOS_CERTIFICATE_PWD}" "${MACOS_CERTIFICATE}" "${MACOS_INSTALLER_CERTIFICATE}"
-          CNAME=$(security find-identity -p codesigning -v | pcregrep -o1 "\(([0-9A-Z]+)\)")
-          echo "CNAME=$CNAME" >> $GITHUB_ENV
-
-          _codesign=$(which codesign)
-          if [[ $_codesign =~ ${CONDA_PREFIX}.* ]]; then
-              # Find correct codesign
-              echo "Moving $_codesign..."
-              mv $_codesign ${_codesign}.bak
-          fi
-
       - name: Build Package Installer
         run: |
-          [[ -n $CNAME ]] && args=("--cert-id" "$CNAME") || args=()
-          python build_installers.py ${args[@]}
+          python build_installers.py
           PKG_FILE=$(python build_installers.py --artifact-name)
           PKG_NAME=$(basename $PKG_FILE)
           echo "PKG_FILE=$PKG_FILE" >> $GITHUB_ENV
           echo "PKG_NAME=$PKG_NAME" >> $GITHUB_ENV
-
-      - name: Test Application Bundle
-        if: runner.os == 'macOS'
-        run: |
-          installer -dumplog -pkg $PKG_FILE -target CurrentUserHomeDirectory 2>&1
-          app_path=$HOME/Applications/Spyder.app
-          if [[ -e "$app_path" ]]; then
-              ls -al $app_path/Contents/MacOS
-              cat $app_path/Contents/Info.plist
-              echo ""
-              cat $app_path/Contents/MacOS/spyder-script
-              echo ""
-          else
-              echo "$app_path does not exist"
-          fi
-
-      - name: Notarize package installer
-        if: runner.os == 'macOS' && (env.IS_RELEASE == 'true' || env.IS_PRE == 'true')
-        run: ./notarize.sh -p $APPLICATION_PWD $PKG_FILE
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Remove macOS and Windows conda-based installers from 5.x branch since they have moved to the master branch for 6.0.0alpha and are no longer needed here. The Linux experimental conda-based installer will remain, along with the traditional macOS and Windows standalone installers.