### PR TITLE
PR: Show icon instead of text for small widths and clear found results correctly in Find/Replace widget

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2216,9 +2216,13 @@ class EditorStack(QWidget):
             pass
 
         self.update_plugin_title.emit()
+
         # Make sure that any replace happens in the editor on top
         # See spyder-ide/spyder#9688.
         self.find_widget.set_editor(editor, refresh=False)
+
+        # Update total number of matches when switching files.
+        self.find_widget.update_matches()
 
         if editor is not None:
             # Needed in order to handle the close of files open in a directory

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -89,7 +89,7 @@ def editor_find_replace_bot(base_editor_bot, qtbot):
     layout.addWidget(find_replace)
 
     # Resize widget and show
-    widget.resize(480, 360)
+    widget.resize(900, 360)
     widget.show()
 
     return widget

--- a/spyder/plugins/editor/widgets/tests/test_editor.py
+++ b/spyder/plugins/editor/widgets/tests/test_editor.py
@@ -75,6 +75,7 @@ def editor_find_replace_bot(base_editor_bot, qtbot):
 
     editor_stack = base_editor_bot
     layout.addWidget(editor_stack)
+    widget.editor_stack = editor_stack
 
     text = ('spam bacon\n'
             'spam sausage\n'
@@ -662,6 +663,35 @@ def test_tab_copies_find_to_replace(editor_find_replace_bot, qtbot):
     qtbot.wait(500)
     qtbot.keyClick(finder.search_text, Qt.Key_Tab)
     assert finder.replace_text.currentText() == 'This is some test text!'
+
+
+def test_update_matches_in_find_replace(editor_find_replace_bot, qtbot):
+    """
+    Check that the total number of matches in the FindReplace widget is updated
+    when switching files.
+    """
+    editor_stack = editor_find_replace_bot.editor_stack
+    finder = editor_find_replace_bot.find_replace
+
+    # Search for "spam" in current file
+    finder.show(hide_replace=False)
+    finder.search_text.setFocus()
+    finder.search_text.set_current_text('spam')
+    qtbot.wait(500)
+    qtbot.keyClick(finder.search_text, Qt.Key_Return)
+
+    # Open a new file and only write "spam" on it
+    editor_stack.new('foo.py', 'utf-8', 'spam')
+
+    # Focus new file and check the number of matches was updated
+    editor_stack.set_stack_index(1)
+    assert finder.number_matches_text.text() == '1 matches'
+    qtbot.wait(500)
+
+    # Focus initial file and check the number of matches was updated
+    editor_stack.set_stack_index(0)
+    qtbot.wait(500)
+    assert finder.number_matches_text.text() == '3 matches'
 
 
 def test_autosave_all(editor_bot, mocker):

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -181,6 +181,7 @@ class IconManager():
             'replace_next':            [('mdi6.arrow-right-bottom',), {'color': self.MAIN_FG_COLOR}],
             'replace_all':             [('mdi.file-replace-outline',), {'color': self.MAIN_FG_COLOR}],
             'replace_selection':       [('ph.rectangle-bold',), {'color': self.MAIN_FG_COLOR}],
+            'number_matches':          [('mdi.pound-box-outline',), {'color': self.MAIN_FG_COLOR}],
             'undo':                    [('mdi.undo',), {'color': self.MAIN_FG_COLOR}],
             'redo':                    [('mdi.redo',), {'color': self.MAIN_FG_COLOR}],
             'refresh':                 [('mdi.refresh',), {'color': self.MAIN_FG_COLOR}],

--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -104,9 +104,7 @@ class FindReplace(QWidget):
         self.search_text.sig_resized.connect(self._resize_replace_text)
 
         self.number_matches_text = QLabel(self)
-        self.search_text.clear_action.triggered.connect(
-            self.number_matches_text.hide
-        )
+        self.search_text.clear_action.triggered.connect(self.clear_matches)
         self.hide_number_matches_text = False
         self.number_matches_pixmap = (
             ima.icon('number_matches').pixmap(self.icon_size)
@@ -119,9 +117,6 @@ class FindReplace(QWidget):
         self.messages_action.setVisible(False)
         self.search_text.lineEdit().addAction(
             self.messages_action, QLineEdit.TrailingPosition)
-        self.search_text.clear_action.triggered.connect(
-            lambda: self.messages_action.setVisible(False)
-        )
 
         # Button corresponding to the messages_action above
         self.messages_button = (
@@ -362,15 +357,6 @@ class FindReplace(QWidget):
     def update_replace_combo(self):
         self.replace_text.lineEdit().returnPressed.emit()
 
-    @Slot(bool)
-    def toggle_highlighting(self, state):
-        """Toggle the 'highlight all results' feature"""
-        if self.editor is not None:
-            if state:
-                self.highlight_matches()
-            else:
-                self.clear_matches()
-
     def show(self, hide_replace=True):
         """Overrides Qt Method"""
         QWidget.show(self)
@@ -535,6 +521,8 @@ class FindReplace(QWidget):
     def clear_matches(self):
         """Clear all highlighted matches"""
         self.matches_string = ""
+        self.messages_action.setVisible(False)
+        self.number_matches_text.hide()
         if self.is_code_editor:
             self.editor.clear_found_results()
 
@@ -554,7 +542,6 @@ class FindReplace(QWidget):
                 # Clears the selection for WebEngine
                 self.editor.find_text('')
             self.change_number_matches()
-            self.messages_action.setVisible(False)
             self.clear_matches()
             return None
         else:

--- a/spyder/widgets/tests/test_findreplace.py
+++ b/spyder/widgets/tests/test_findreplace.py
@@ -50,7 +50,7 @@ def findreplace_editor(qtbot, request):
     layout.addWidget(findreplace)
 
     # Resize widget and show
-    widget.resize(480, 360)
+    widget.resize(900, 360)
     widget.show()
 
     return widget


### PR DESCRIPTION
## Description of Changes

- This prevents that the widget buttons change position when users replace text with it and the number of matches start to change. The number is shown in the button's tooltip in that case, as shown below:

    ![number_matches_icon](https://user-images.githubusercontent.com/365293/221366922-c93858b3-7c2b-43fe-a824-250e4482ebe8.gif)

- Clear found results when clicking on the clear action, I noticed this bug while working on Spyder.

    ![clear_matches](https://user-images.githubusercontent.com/365293/221367017-574dfdbf-aa83-4830-bef4-34479d6f6bd8.gif)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20476.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
