### PR TITLE
PR: Set `PYDEVD_DISABLE_FILE_VALIDATION` to prevent errors when searching for numpy docs (Online Help)

### DIFF
--- a/spyder/plugins/onlinehelp/widgets.py
+++ b/spyder/plugins/onlinehelp/widgets.py
@@ -68,6 +68,7 @@ try:
     pydoc.safeimport = spyder_safeimport
 except Exception:
     pass
+
 # Needed to prevent showing a warning message regarding debugging
 # See spyder-ide/spyder#20390
 if is_pynsist():

--- a/spyder/plugins/onlinehelp/widgets.py
+++ b/spyder/plugins/onlinehelp/widgets.py
@@ -9,6 +9,7 @@ PyDoc widget.
 """
 
 # Standard library imports
+import os
 import os.path as osp
 import pydoc
 import sys
@@ -22,6 +23,7 @@ from qtpy.QtWidgets import QApplication, QLabel, QVBoxLayout
 # Local imports
 from spyder.api.translations import _
 from spyder.api.widgets.main_widget import PluginMainWidget
+from spyder.config.base import is_pynsist
 from spyder.plugins.onlinehelp.pydoc_patch import _start_server, _url_handler
 from spyder.widgets.browser import FrameWebView, WebViewActions
 from spyder.widgets.comboboxes import UrlComboBox
@@ -66,6 +68,10 @@ try:
     pydoc.safeimport = spyder_safeimport
 except Exception:
     pass
+# Needed to prevent showing a warning message regarding debugging
+# See spyder-ide/spyder#20390
+if is_pynsist():
+    os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
 
 
 class PydocServer(QThread):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

A warning when trying to show numpy inside Online Help was happening with Spyder from the Windows standalone installer. Setting `PYDEVD_DISABLE_FILE_VALIDATION = 1` prevents the warning message.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20390 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
