### PR TITLE
PR: Remove `PYTHONEXECUTABLE` for process that runs the profiler

### DIFF
--- a/spyder/plugins/profiler/widgets/main_widget.py
+++ b/spyder/plugins/profiler/widgets/main_widget.py
@@ -533,6 +533,7 @@ class ProfilerWidget(PluginMainWidget):
             proc_env.insert(k, v)
         proc_env.insert("PYTHONIOENCODING", "utf8")
         proc_env.remove('PYTHONPATH')
+        proc_env.remove('PYTHONEXECUTABLE') # needed on macOS to set sys.path correctly
         if self.pythonpath is not None:
             logger.debug(f"Pass Pythonpath {self.pythonpath} to process")
             proc_env.insert('PYTHONPATH', os.pathsep.join(self.pythonpath))


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Takes care of profiler bug in #20599 due to incorrectly set PYTHONEXECUTABLE env variable

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Makes sure PYTHONEXECUTABLE is removed from environment prior to starting the profiler


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20599


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Mike

<!--- Thanks for your help making Spyder better for everyone! --->
