### PR TITLE
PR: Fix displaying images that have float width or height (IPython console)

### DIFF
--- a/external-deps/qtconsole/.github/workflows/linux-tests.yml
+++ b/external-deps/qtconsole/.github/workflows/linux-tests.yml
@@ -9,6 +9,10 @@ on:
     - master
   workflow_dispatch:
 
+concurrency:
+  group: linux-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux:
     name: Linux Py${{ matrix.PYTHON_VERSION }} - ${{ matrix.INSTALL_TYPE }} - ${{ matrix.QT_LIB }}
@@ -35,7 +39,7 @@ jobs:
       - name: Install System Packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
+          sudo apt-get install -y --no-install-recommends '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libegl1
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -68,7 +72,7 @@ jobs:
           pip list
       - name: Run tests
         shell: bash -l {0}
-        run: xvfb-run --auto-servernum pytest -x -vv -s --full-trace --color=yes --cov=qtconsole qtconsole
+        run: xvfb-run --auto-servernum pytest -vv -s --full-trace --color=yes --cov=qtconsole qtconsole
         env:
           QT_API: ${{ matrix.QT_LIB }}
           PYTEST_QT_API: ${{ matrix.QT_LIB }}

--- a/external-deps/qtconsole/.github/workflows/macos-tests.yml
+++ b/external-deps/qtconsole/.github/workflows/macos-tests.yml
@@ -8,6 +8,10 @@ on:
     branches:
     - master
 
+concurrency:
+  group: macos-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   macos:
     name: Mac Py${{ matrix.PYTHON_VERSION }}
@@ -45,4 +49,4 @@ jobs:
           conda list
       - name: Run tests
         shell: bash -l {0}
-        run: pytest -x -vv --color=yes --cov=qtconsole qtconsole
+        run: pytest -vv --color=yes --cov=qtconsole qtconsole

--- a/external-deps/qtconsole/.github/workflows/windows-tests.yml
+++ b/external-deps/qtconsole/.github/workflows/windows-tests.yml
@@ -8,6 +8,10 @@ on:
     branches:
     - master
 
+concurrency:
+  group: windows-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   windows:
     name: Windows Py${{ matrix.PYTHON_VERSION }}
@@ -45,4 +49,4 @@ jobs:
           conda list
       - name: Run tests
         shell: bash -l {0}
-        run: pytest -x -vv --color=yes --cov=qtconsole qtconsole
+        run: pytest -vv --color=yes --cov=qtconsole qtconsole

--- a/external-deps/qtconsole/.gitrepo
+++ b/external-deps/qtconsole/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/jupyter/qtconsole.git
 	branch = master
-	commit = 90ffe335cf9c82f7814c9a945553584d6665a62c
-	parent = 8299d8c9776501d5f435bd172d57a480e0bc906f
+	commit = 96604f44cdbca051712b5c51072309cba9518ae7
+	parent = be96be0cfc313a34097505631502e711af94071d
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/qtconsole/qtconsole/rich_jupyter_widget.py
+++ b/external-deps/qtconsole/qtconsole/rich_jupyter_widget.py
@@ -379,13 +379,13 @@ class RichJupyterWidget(RichIPythonWidget):
             image = QtGui.QImage()
             image.loadFromData(img, fmt.upper())
             if width and height:
-                image = image.scaled(width, height,
+                image = image.scaled(int(width), int(height),
                                      QtCore.Qt.IgnoreAspectRatio,
                                      QtCore.Qt.SmoothTransformation)
             elif width and not height:
-                image = image.scaledToWidth(width, QtCore.Qt.SmoothTransformation)
+                image = image.scaledToWidth(int(width), QtCore.Qt.SmoothTransformation)
             elif height and not width:
-                image = image.scaledToHeight(height, QtCore.Qt.SmoothTransformation)
+                image = image.scaledToHeight(int(height), QtCore.Qt.SmoothTransformation)
         except ValueError:
             self._insert_plain_text(cursor, 'Received invalid %s data.'%fmt)
         else:

--- a/external-deps/qtconsole/qtconsole/tests/test_jupyter_widget.py
+++ b/external-deps/qtconsole/qtconsole/tests/test_jupyter_widget.py
@@ -1,13 +1,10 @@
 import unittest
 import sys
-from packaging.version import parse
 
 import pytest
-from qtpy import QT6, QT_VERSION
+from qtpy import QT6
 from qtpy import QtWidgets, QtGui
-from qtpy.QtTest import QTest
 
-from qtconsole.client import QtKernelClient
 from qtconsole.jupyter_widget import JupyterWidget
 
 from . import no_display
@@ -73,35 +70,9 @@ class TestJupyterWidget(unittest.TestCase):
             'In [2]: '
         ))
 
-        # Check proper syntax highlighting
-        if QT6 and parse(QT_VERSION) >= parse('6.3'):
-            html = (
-                '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
-                '<html><head><meta name="qrichtext" content="1" /><meta charset="utf-8" /><style type="text/css">\n'
-                'p, li { white-space: pre-wrap; }\n'
-                'hr { height: 1px; border-width: 0; }\n'
-                '</style></head><body style=\" font-family:\'Monospace\'; font-size:9pt; font-weight:400; font-style:normal;\">\n'
-                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Header</p>\n'
-                '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
-                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">[other] In [</span><span style=" font-weight:700; color:#000080;">1</span><span style=" color:#000080;">]:</span> a = 1 + 1</p>\n'
-                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0...:</span> b = range(10)</p>\n'
-                '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
-                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">In [</span><span style=" font-weight:700; color:#000080;">2</span><span style=" color:#000080;">]:</span> </p></body></html>'
-            )
-        elif QT6 and parse(QT_VERSION) < parse('6.3'):
-            html = (
-                '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
-                '<html><head><meta name="qrichtext" content="1" /><meta charset="utf-8" /><style type="text/css">\n'
-                'p, li { white-space: pre-wrap; }\n'
-                '</style></head><body style=\" font-family:\'Monospace\'; font-size:9pt; font-weight:400; font-style:normal;\">\n'
-                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Header</p>\n'
-                '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
-                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">[other] In [</span><span style=" font-weight:700; color:#000080;">1</span><span style=" color:#000080;">]:</span> a = 1 + 1</p>\n'
-                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0...:</span> b = range(10)</p>\n'
-                '<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /></p>\n'
-                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">In [</span><span style=" font-weight:700; color:#000080;">2</span><span style=" color:#000080;">]:</span> </p></body></html>'
-            )
-        else:
+        # Check proper syntax highlighting.
+        # This changes with every Qt6 release, that's why we don't test it on it.
+        if not QT6:
             html = (
                 '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
                 '<html><head><meta name="qrichtext" content="1" /><style type="text/css">\n'
@@ -115,7 +86,7 @@ class TestJupyterWidget(unittest.TestCase):
                 '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000080;">In [</span><span style=" font-weight:600; color:#000080;">2</span><span style=" color:#000080;">]:</span> </p></body></html>'
             )
         
-        self.assertEqual(document.toHtml(), html)
+            self.assertEqual(document.toHtml(), html)
 
     def test_copy_paste_prompt(self):
         """Test copy/paste removes partial and full prompts."""


### PR DESCRIPTION
## Description of Changes

- This was failing in Python 3.10+ for images generated by Seaborn 0.12
- Depends on https://github.com/jupyter/qtconsole/pull/570.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20597

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
