### PR TITLE
PR: Change usage of `iteritems` for `items` in dataframe editor (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -243,7 +243,7 @@ class DataFrameModel(QAbstractTableModel):
         if self.df.shape[0] == 0: # If no rows to compute max/min then return
             return
         self.max_min_col = []
-        for __, col in self.df.iteritems():
+        for __, col in self.df.items():
             # This is necessary to catch an error in Pandas when computing
             # the maximum of a column.
             # Fixes spyder-ide/spyder#17145


### PR DESCRIPTION
## Description of Changes

Exchange of iteritems() for items() in self.df.iteritems()

<!--- Explain what you've done and why --->


This "iteritems()" is deprecated and will be removed in a future release.

### Issue(s) Resolved

Fixes #20496.



