### PR TITLE
PR: Avoid crash at startup when trying to restore the previous session (Editor)

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2262,17 +2262,25 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                                                        editorwindow,
                                                        focus=focus)
             if current_editor is None:
-                # -- Not a valid filename:
+                # Not a valid filename, we need to continue.
                 if not osp.isfile(filename):
                     continue
-                # --
+
                 current_es = self.get_current_editorstack(editorwindow)
+
                 # Creating the editor widget in the first editorstack
                 # (the one that can't be destroyed), then cloning this
                 # editor widget in all other editorstacks:
                 finfo = self.editorstacks[0].load(
                     filename, set_current=False, add_where=add_where,
                     processevents=processevents)
+
+                # This can happen when it was not possible to load filename
+                # from disk.
+                # Fixes spyder-ide/spyder#20670
+                if finfo is None:
+                    continue
+
                 self._clone_file_everywhere(finfo)
                 current_editor = current_es.set_current_filename(filename,
                                                                  focus=focus)
@@ -2281,6 +2289,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                 self.register_widget_shortcuts(current_editor)
                 current_es.analyze_script()
                 self.__add_recent_file(filename)
+
             if goto is not None:  # 'word' is assumed to be None as well
                 current_editor.go_to_line(goto[index], word=word,
                                           start_column=start_column,
@@ -2288,6 +2297,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             current_editor.clearFocus()
             current_editor.setFocus()
             current_editor.window().raise_()
+
             if processevents:
                 QApplication.processEvents()
             else:

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2756,8 +2756,14 @@ class EditorStack(QWidget):
         if processevents:
             self.starting_long_process.emit(_("Loading %s...") % filename)
 
-        # Read file contents
-        text, enc = encoding.read(filename)
+        # This is necessary to avoid a crash at startup when trying to restore
+        # files from the previous session.
+        # Fixes spyder-ide/spyder#20670
+        try:
+            # Read file contents
+            text, enc = encoding.read(filename)
+        except Exception:
+            return
 
         # Associate hash of file's text with its name for autosave
         self.autosave.file_hashes[filename] = hash(text)


### PR DESCRIPTION
## Description of Changes

This problem happens if there's any error while reading the session files from disk.

### Issue(s) Resolved

Fixes #20670.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
