### PR TITLE
PR: Fix error in `document_did_open` when the LSP failed to start (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1109,16 +1109,6 @@ class CodeEditor(TextEditBaseWidget):
             additional_msg = "cloned editor"
         else:
             additional_msg = ""
-
-            # We need to be sure that this signal is disconnected before
-            # calling document_did_open below because that method creates a
-            # unique connection for it and this method is called every time the
-            # server is restarted.
-            try:
-                self._timer_sync_symbols_and_folding.timeout.disconnect()
-            except (TypeError, RuntimeError):
-                pass
-
             self.document_did_open()
 
         logger.debug(u"Completion services available for {0}: {1}".format(
@@ -1181,6 +1171,16 @@ class CodeEditor(TextEditBaseWidget):
              requires_response=False)
     def document_did_open(self):
         """Send textDocument/didOpen request to the server."""
+
+        # We need to be sure that this signal is disconnected before trying to
+        # connect it below.
+        # Note: It can already be connected when the user requires a server
+        # restart or when the server failed to start.
+        # Fixes spyder-ide/spyder#20679
+        try:
+            self._timer_sync_symbols_and_folding.timeout.disconnect()
+        except (TypeError, RuntimeError):
+            pass
 
         # The connect is performed here instead of in __init__() because
         # notify_close() may have been called (which disconnects the signal).


### PR DESCRIPTION
## Description of Changes

Users can encounter this error when trying to rename a file in that scenario.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20679.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
