### PR TITLE
PR: Fix issue where keyring backends are not found in macOS standalone app

### DIFF
--- a/installers/macOS/packages.py
+++ b/installers/macOS/packages.py
@@ -16,6 +16,13 @@ instead.
 humanfriendly :
     spyder-terminal plugin
     ModuleNotFoundError: No module named 'humanfriendly.tables'
+keyring:
+    ModuleNotFoundError: No module named 'keyring.backends.kwallet'
+    ModuleNotFoundError: No module named 'keyring.backends.SecretService'
+    ModuleNotFoundError: No module named 'keyring.backends.Windows'
+    ModuleNotFoundError: No module named 'keyring.backends.chainer'
+    ModuleNotFoundError: No module named 'keyring.backends.libsecret'
+    ModuleNotFoundError: No module named 'keyring.backends.macOS'
 pkg_resources:
     ImportError: The 'more_itertools' package is required; normally this is
     bundled with this package so if you get this warning, consult the
@@ -42,6 +49,7 @@ spyder_terminal :
 # Packages that cannot be in the zip folder
 PACKAGES = [
     'humanfriendly',
+    'keyring',
     'pkg_resources',
     'pygments',
     'pylint_venv',


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


Add keyring to PACKAGES to resolve "ModuleNotFoundError: No module named 'keyring.backends.macOS'"

<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20681


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
