### PR TITLE
PR: Fix `Source` menu order (Editor)

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1249,22 +1249,6 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                 ApplicationMenus.Source
             )
             source_menu.aboutToShow.connect(self.refresh_formatter_name)
-            for option_item in source_menu_option_actions:
-                mainmenu.add_item_to_application_menu(
-                    option_item,
-                    omit_id=True,
-                    menu_id=ApplicationMenus.Source,
-                    section=SourceMenuSections.Options,
-                    before_section=SourceMenuSections.Linting
-                )
-            for linting_item in source_menu_linting_actions:
-                mainmenu.add_item_to_application_menu(
-                    linting_item,
-                    omit_id=True,
-                    menu_id=ApplicationMenus.Source,
-                    section=SourceMenuSections.Linting,
-                    before_section=SourceMenuSections.Cursor
-                )
             for cursor_item in source_menu_cursor_actions:
                 mainmenu.add_item_to_application_menu(
                     cursor_item,
@@ -1280,6 +1264,22 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                     menu_id=ApplicationMenus.Source,
                     section=SourceMenuSections.Formatting,
                     before_section=SourceMenuSections.CodeAnalysis
+                )
+            for option_item in source_menu_option_actions:
+                mainmenu.add_item_to_application_menu(
+                    option_item,
+                    omit_id=True,
+                    menu_id=ApplicationMenus.Source,
+                    section=SourceMenuSections.Options,
+                    before_section=SourceMenuSections.Linting
+                )
+            for linting_item in source_menu_linting_actions:
+                mainmenu.add_item_to_application_menu(
+                    linting_item,
+                    omit_id=True,
+                    menu_id=ApplicationMenus.Source,
+                    section=SourceMenuSections.Linting,
+                    before_section=SourceMenuSections.Cursor
                 )
 
         # ---- Dock widget and file dependent actions ----


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->

After #20620 the Source menu got an incorrect actions order:

![source_menu_error](https://user-images.githubusercontent.com/16781833/225464697-58dedf59-c722-409d-b5cd-7f55a2c789c7.png)

This fixes the order:

![source_menu_fix](https://user-images.githubusercontent.com/16781833/225464688-b00365b7-54cc-45e3-a475-354a6fd125bd.png)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
