### PR TITLE
PR: Avoid error when updating environments (Main interpreter)

### DIFF
--- a/spyder/plugins/maininterpreter/widgets/status.py
+++ b/spyder/plugins/maininterpreter/widgets/status.py
@@ -16,7 +16,6 @@ import sys
 from qtpy.QtCore import QTimer, Signal
 
 # Local imports
-from spyder.api.translations import _
 from spyder.api.widgets.status import BaseTimerStatus
 from spyder.config.base import is_pynsist, running_in_mac_app
 from spyder.utils.conda import get_list_conda_envs
@@ -123,6 +122,7 @@ class InterpreterStatus(BaseTimerStatus):
     def _get_env_info(self, path):
         """Get environment information."""
         path = path.lower() if os.name == 'nt' else path
+
         try:
             name = self.path_to_env[path]
         except KeyError:
@@ -140,6 +140,7 @@ class InterpreterStatus(BaseTimerStatus):
             version = get_interpreter_info(path)
             self.path_to_env[path] = name
             self.envs[name] = (path, version)
+
         __, version = self.envs[name]
         return f'{name} ({version})'
 
@@ -170,7 +171,12 @@ class InterpreterStatus(BaseTimerStatus):
 
     def update_envs(self, worker, output, error):
         """Update the list of environments in the system."""
-        self.envs.update(**output)
+        # This is necessary to avoid an error when the worker can't return a
+        # proper output.
+        # Fixes spyder-ide/spyder#20539
+        if output is not None:
+            self.envs.update(**output)
+
         for env in list(self.envs.keys()):
             path, version = self.envs[env]
             # Save paths in lowercase on Windows to avoid issues with


### PR DESCRIPTION
## Description of Changes

Although I don't understand how, it seems under certain situations the worker in charge of getting the current pyenv and conda envs can return `None`, which gives the error this PR is fixing.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20539.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
