### PR TITLE
PR: Fix restart mechanism for the Windows standalone installer (Installers)

### DIFF
--- a/spyder/app/restart.py
+++ b/spyder/app/restart.py
@@ -235,7 +235,6 @@ def main():
         pynsist_python = osp.join(pynsist_installation, "Python", "pythonw.exe")
         pynsist_script = osp.join(pynsist_installation, "Spyder.launch.pyw")
         command = [f'"{pynsist_python}"', f'"{pynsist_script}"']
-        print(command)
     else:
         if is_bootstrap:
             script = osp.join(spyder_dir, 'bootstrap.py')

--- a/spyder/app/restart.py
+++ b/spyder/app/restart.py
@@ -27,7 +27,7 @@ from qtpy.QtWidgets import QApplication, QMessageBox, QWidget
 
 # Local imports
 from spyder.app.utils import create_splash_screen
-from spyder.config.base import _, running_in_mac_app
+from spyder.config.base import _, running_in_mac_app, is_pynsist
 from spyder.utils.image_path_manager import get_image_path
 from spyder.utils.encoding import to_unicode
 from spyder.utils.qthelpers import qapplication
@@ -230,6 +230,12 @@ def main():
     if running_in_mac_app(sys.executable):
         exe = env['EXECUTABLEPATH']
         command = [f'"{exe}"']
+    elif is_pynsist():
+        pynsist_installation = osp.dirname(spyder_dir)
+        pynsist_python = osp.join(pynsist_installation, "Python", "pythonw.exe")
+        pynsist_script = osp.join(pynsist_installation, "Spyder.launch.pyw")
+        command = [f'"{pynsist_python}"', f'"{pynsist_script}"']
+        print(command)
     else:
         if is_bootstrap:
             script = osp.join(spyder_dir, 'bootstrap.py')

--- a/spyder/app/start.py
+++ b/spyder/app/start.py
@@ -12,8 +12,10 @@ import os
 import sys
 if os.environ.get('PYTHONPATH'):
     for path in os.environ['PYTHONPATH'].split(os.pathsep):
-        if 'pkgs' not in path:
+        if os.name == 'nt' and 'pkgs' in path:
             # Don't remove pynsist installer entry for 'pkgs' directory
+            continue
+        else:
             try:
                 sys.path.remove(path.rstrip(os.sep))
             except ValueError:

--- a/spyder/app/start.py
+++ b/spyder/app/start.py
@@ -12,10 +12,12 @@ import os
 import sys
 if os.environ.get('PYTHONPATH'):
     for path in os.environ['PYTHONPATH'].split(os.pathsep):
-        try:
-            sys.path.remove(path.rstrip(os.sep))
-        except ValueError:
-            pass
+        if 'pkgs' not in path:
+            # Don't remove pynsist installer entry for 'pkgs' directory
+            try:
+                sys.path.remove(path.rstrip(os.sep))
+            except ValueError:
+                pass
 
 # Standard library imports
 import ctypes


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->

Be sure to use the script the standalone installer uses in the shortcut to start and don't remove installer `pkgs` entry from the `PYTHONPATH` when starting Spyder.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

See https://github.com/spyder-ide/spyder/issues/20658#issuecomment-1468338520


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
