### PR TITLE
PR: Fix copy/paste shortcuts in Files and Projects

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -389,7 +389,7 @@ DEFAULTS = [
               '_/run': "F5",
               '_/configure': "Ctrl+F6",
               '_/re-run last script': "F6",
-              # -- Switch to --
+              # -- Switch to plugin --
               '_/switch to help': "Ctrl+Shift+H",
               '_/switch to outline_explorer': "Ctrl+Shift+O",
               '_/switch to editor': "Ctrl+Shift+E",
@@ -530,13 +530,13 @@ DEFAULTS = [
               # -- Files --
               'explorer/copy file': 'Ctrl+C',
               'explorer/paste file': 'Ctrl+V',
-              'explorer/copy absolute path': 'Ctrl+Alt+C',
-              'explorer/copy relative path': 'Alt+Shift+C',
+              'explorer/copy absolute path': 'Alt+Shift+C',
+              'explorer/copy relative path': 'Alt+Shift+D',
               # -- Projects --
               'project_explorer/copy file': 'Ctrl+C',
               'project_explorer/paste file': 'Ctrl+V',
-              'project_explorer/copy absolute path': 'Ctrl+Alt+C',
-              'project_explorer/copy relative path': 'Alt+Shift+C',
+              'project_explorer/copy absolute path': 'Alt+Shift+C',
+              'project_explorer/copy relative path': 'Alt+Shift+D',
               # -- Find --
               'find_in_files/find in files': 'Alt+Shift+F',
               }),

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -366,8 +366,7 @@ DEFAULTS = [
              }),
             ('shortcuts',
              {
-              # ---- Global ----
-              # -- In app/spyder.py
+              # -- Application --
               '_/close pane': "Shift+Ctrl+F4",
               '_/lock unlock panes': "Shift+Ctrl+F5",
               '_/use next layout': "Shift+Alt+PgDown",
@@ -379,7 +378,6 @@ DEFAULTS = [
               '_/spyder documentation': "F1",
               '_/restart': "Shift+Alt+R",
               '_/quit': "Ctrl+Q",
-              # -- In plugins/editor
               '_/file switcher': 'Ctrl+P',
               '_/symbol finder': 'Ctrl+Alt+P',
               '_/debug': "Ctrl+F5",
@@ -391,7 +389,7 @@ DEFAULTS = [
               '_/run': "F5",
               '_/configure': "Ctrl+F6",
               '_/re-run last script': "F6",
-              # -- In plugins/init
+              # -- Switch to --
               '_/switch to help': "Ctrl+Shift+H",
               '_/switch to outline_explorer': "Ctrl+Shift+O",
               '_/switch to editor': "Ctrl+Shift+E",
@@ -405,15 +403,15 @@ DEFAULTS = [
               '_/switch to plots': "Ctrl+Shift+J" if MAC else "Ctrl+Shift+G",
               '_/switch to pylint': "Ctrl+Shift+C",
               '_/switch to profiler': "Ctrl+Shift+R",
-              # -- In widgets/findreplace.py
+              '_/switch to breakpoints': "Ctrl+Shift+B",
+              # -- Find/replace --
               'find_replace/find text': "Ctrl+F",
               'find_replace/find next': "Ctrl+G" if MAC else "F3",
               'find_replace/find previous': (
                   "Ctrl+Shift+G" if MAC else "Shift+F3"),
               'find_replace/replace text': "Ctrl+R",
               'find_replace/hide find and replace': "Escape",
-              # ---- Editor ----
-              # -- In widgets/sourcecode/codeeditor.py
+              # -- Editor --
               'editor/code completion': CTRL+'+Space',
               'editor/duplicate line up': (
                   "Ctrl+Alt+Up" if WIN else "Shift+Alt+Up"),
@@ -454,7 +452,6 @@ DEFAULTS = [
               'editor/paste': 'Ctrl+V',
               'editor/delete': 'Del',
               'editor/select all': "Ctrl+A",
-              # -- In widgets/editor.py
               'editor/inspect current object': 'Ctrl+I',
               'editor/breakpoint': 'F12',
               'editor/conditional breakpoint': 'Shift+F12',
@@ -496,17 +493,15 @@ DEFAULTS = [
               'editor/docstring': "Ctrl+Alt+D",
               'editor/autoformatting': "Ctrl+Alt+I",
               'editor/show in external file explorer': '',
-              # -- In Breakpoints
-              '_/switch to breakpoints': "Ctrl+Shift+B",
-              # ---- Consoles (in widgets/shell) ----
+              # -- Internal console --
               'console/inspect current object': "Ctrl+I",
               'console/clear shell': "Ctrl+L",
               'console/clear line': "Shift+Escape",
-              # ---- In Pylint ----
+              # -- Pylint --
               'pylint/run analysis': "F8",
-              # ---- In Profiler ----
+              # -- Profiler --
               'profiler/run profiler': "F10",
-              # ---- In widgets/ipythonconsole/shell.py ----
+              # -- IPython console --
               'ipython_console/new tab': "Ctrl+T",
               'ipython_console/reset namespace': "Ctrl+Alt+R",
               'ipython_console/restart kernel': "Ctrl+.",
@@ -515,15 +510,14 @@ DEFAULTS = [
               'ipython_console/clear line': "Shift+Escape",
               'ipython_console/enter array inline': "Ctrl+Alt+M",
               'ipython_console/enter array table': "Ctrl+M",
-              # ---- In widgets/arraybuider.py ----
+              # -- Array buider --
               'array_builder/enter array inline': "Ctrl+Alt+M",
               'array_builder/enter array table': "Ctrl+M",
-              # ---- In widgets/variableexplorer/arrayeditor.py ----
+              # -- Variable explorer --
               'variable_explorer/copy': 'Ctrl+C',
-              # ---- In widgets/variableexplorer/namespacebrowser.py ----
               'variable_explorer/search': 'Ctrl+F',
               'variable_explorer/refresh': 'Ctrl+R',
-              # ---- In widgets/plots/figurebrowser.py ----
+              # -- Plots --
               'plots/copy': 'Ctrl+C',
               'plots/previous figure': 'Ctrl+PgUp',
               'plots/next figure': 'Ctrl+PgDown',
@@ -533,12 +527,17 @@ DEFAULTS = [
               'plots/close all': 'Ctrl+Shift+W',
               'plots/zoom in': "Ctrl++",
               'plots/zoom out': "Ctrl+-",
-              # ---- In widgets/explorer ----
+              # -- Files --
               'explorer/copy file': 'Ctrl+C',
               'explorer/paste file': 'Ctrl+V',
               'explorer/copy absolute path': 'Ctrl+Alt+C',
-              'explorer/copy relative path': 'Ctrl+Alt+Shift+C',
-              # ---- In plugins/findinfiles/plugin ----
+              'explorer/copy relative path': 'Alt+Shift+C',
+              # -- Projects --
+              'project_explorer/copy file': 'Ctrl+C',
+              'project_explorer/paste file': 'Ctrl+V',
+              'project_explorer/copy absolute path': 'Ctrl+Alt+C',
+              'project_explorer/copy relative path': 'Alt+Shift+C',
+              # -- Find --
               'find_in_files/find in files': 'Alt+Shift+F',
               }),
             ('appearance', APPEARANCE),
@@ -642,4 +641,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '73.0.0'
+CONF_VERSION = '74.0.0'

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -20,7 +20,7 @@ from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.utils.icon_manager import ima
 from spyder.plugins.completion.api import CompletionItemKind
 from spyder.py3compat import to_text_string
-from spyder.utils.qthelpers import keyevent_to_keysequence
+from spyder.utils.qthelpers import keyevent_to_keysequence_str
 from spyder.widgets.helperwidgets import HTMLDelegate
 
 
@@ -367,7 +367,7 @@ class CompletionWidget(QListWidget, SpyderConfigurationAccessor):
             # take effect in textedit.
             # Fixes spyder-ide/spyder#19372
             if modifier:
-                key_sequence = keyevent_to_keysequence(event)
+                key_sequence = keyevent_to_keysequence_str(event)
 
                 # Ask to save file if the user pressed the sequence for that.
                 # Fixes spyder-ide/spyder#14806

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -12,7 +12,7 @@ import sys
 
 # Third psrty imports
 from qtpy.QtCore import QPoint, Qt, Signal, Slot
-from qtpy.QtGui import QFontMetrics, QFocusEvent, QKeySequence
+from qtpy.QtGui import QFontMetrics, QFocusEvent
 from qtpy.QtWidgets import QListWidget, QListWidgetItem, QToolTip
 
 # Local imports
@@ -20,6 +20,7 @@ from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.utils.icon_manager import ima
 from spyder.plugins.completion.api import CompletionItemKind
 from spyder.py3compat import to_text_string
+from spyder.utils.qthelpers import keyevent_to_keysequence
 from spyder.widgets.helperwidgets import HTMLDelegate
 
 
@@ -366,23 +367,13 @@ class CompletionWidget(QListWidget, SpyderConfigurationAccessor):
             # take effect in textedit.
             # Fixes spyder-ide/spyder#19372
             if modifier:
-                # Build the sequence as an int.
-                # See https://stackoverflow.com/a/23919177/438386 for context.
-                # Note: We only accept Ctrl, Shift and Alt as modifiers for
-                # keyboard shortcuts in Preferences.
-                key_sequence = key
-                if ctrl:
-                    key_sequence += Qt.CTRL
-                if shift:
-                    key_sequence += Qt.SHIFT
-                if alt:
-                    key_sequence += Qt.ALT
+                key_sequence = keyevent_to_keysequence(event)
 
                 # Ask to save file if the user pressed the sequence for that.
                 # Fixes spyder-ide/spyder#14806
                 save_shortcut = self.get_conf(
                     'editor/save file', section='shortcuts')
-                if QKeySequence(key_sequence) == QKeySequence(save_shortcut):
+                if key_sequence == save_shortcut:
                     self.textedit.sig_save_requested.emit()
 
                     # Hiding the widget reassures users that the save operation

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -42,7 +42,7 @@ from spyder.utils.icon_manager import ima
 from spyder.utils import misc, programs, vcs
 from spyder.utils.misc import getcwd_or_home
 from spyder.utils.qthelpers import (
-    file_uri, keyevent_to_keysequence, start_file)
+    file_uri, keyevent_to_keysequence_str, start_file)
 
 try:
     from nbconvert import PythonExporter as nbexporter
@@ -776,7 +776,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
 
     def keyPressEvent(self, event):
         """Handle keyboard shortcuts and special keys."""
-        key_seq = keyevent_to_keysequence(event)
+        key_seq = keyevent_to_keysequence_str(event)
 
         if event.key() in (Qt.Key_Enter, Qt.Key_Return):
             self.clicked()

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -22,7 +22,7 @@ import sys
 from qtpy import PYQT5
 from qtpy.compat import getexistingdirectory, getsavefilename
 from qtpy.QtCore import QDir, QMimeData, Qt, QTimer, QUrl, Signal, Slot
-from qtpy.QtGui import QDrag, QKeySequence
+from qtpy.QtGui import QDrag
 from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
                             QFileSystemModel, QInputDialog, QLabel, QLineEdit,
                             QMessageBox, QProxyStyle, QStyle, QTextEdit,
@@ -41,7 +41,8 @@ from spyder.utils import encoding
 from spyder.utils.icon_manager import ima
 from spyder.utils import misc, programs, vcs
 from spyder.utils.misc import getcwd_or_home
-from spyder.utils.qthelpers import file_uri, start_file
+from spyder.utils.qthelpers import (
+    file_uri, keyevent_to_keysequence, start_file)
 
 try:
     from nbconvert import PythonExporter as nbexporter
@@ -775,9 +776,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
 
     def keyPressEvent(self, event):
         """Handle keyboard shortcuts and special keys."""
-        # Get keyboard sequence introduced by the user as a string.
-        # From https://stackoverflow.com/a/20656496/438386
-        key_seq = QKeySequence(event.modifiers() | event.key()).toString()
+        key_seq = keyevent_to_keysequence(event)
 
         if event.key() in (Qt.Key_Enter, Qt.Key_Return):
             self.clicked()

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -166,6 +166,35 @@ def keybinding(attr):
     return from_qvariant(QKeySequence.keyBindings(ks)[0], str)
 
 
+def keyevent_to_keysequence(event):
+    """Get key sequence corresponding to a key event as a string."""
+    try:
+        # See https://stackoverflow.com/a/20656496/438386 for context
+        return QKeySequence(event.modifiers() | event.key()).toString()
+    except TypeError:
+        # This error appears in old PyQt versions (e.g. 5.12) which are
+        # running under Python 3.10+. In that case, we need to build the
+        # key sequence as an int.
+        # See https://stackoverflow.com/a/23919177/438386 for context.
+        key = event.key()
+        alt = event.modifiers() & Qt.AltModifier
+        shift = event.modifiers() & Qt.ShiftModifier
+        ctrl = event.modifiers() & Qt.ControlModifier
+        meta = event.modifiers() & Qt.MetaModifier
+
+        key_sequence = key
+        if ctrl:
+            key_sequence += Qt.CTRL
+        if shift:
+            key_sequence += Qt.SHIFT
+        if alt:
+            key_sequence += Qt.ALT
+        if meta:
+            key_sequence += Qt.META
+
+        return QKeySequence(key_sequence).toString()
+
+
 def _process_mime_path(path, extlist):
     if path.startswith(r"file://"):
         if os.name == 'nt':

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -166,7 +166,7 @@ def keybinding(attr):
     return from_qvariant(QKeySequence.keyBindings(ks)[0], str)
 
 
-def keyevent_to_keysequence(event):
+def keyevent_to_keysequence_str(event):
     """Get key sequence corresponding to a key event as a string."""
     try:
         # See https://stackoverflow.com/a/20656496/438386 for context


### PR DESCRIPTION
## Description of Changes

- I think those shortcuts were broken since the migration of Files and Projects to the new API.
- Add default shortcuts for copy/paste actions present in Projects.
- Change shortcut to copy relative paths to `Alt+Shift+C` because it's easier to introduce.
- Add `keyevent_to_keysequence` utility function and use it to simplify some code in the editor's completion widget.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20068.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
