### PR TITLE
PR: Fix clicking on file names in tracebacks for IPython 8 and minor fixes for messages shown in the console

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -4721,8 +4721,7 @@ def test_copy_paste(main_window, qtbot, tmpdir):
     # Test copy
     cursor = code_editor.textCursor()
     cursor.setPosition(69)
-    cursor.movePosition(QTextCursor.End,
-                        QTextCursor.KeepAnchor)
+    cursor.movePosition(QTextCursor.End, QTextCursor.KeepAnchor)
     code_editor.setTextCursor(cursor)
     qtbot.keyClick(code_editor, "c", modifier=Qt.ControlModifier)
     assert QApplication.clipboard().text() == (
@@ -5383,6 +5382,68 @@ def test_PYTHONPATH_in_consoles(main_window, qtbot, tmp_path,
         shell.execute("import sys; sys_path = sys.path")
 
     assert str(new_dir) in shell.get_value("sys_path")
+
+
+@flaky(max_runs=3)
+def test_clickable_ipython_tracebacks(main_window, qtbot, tmpdir):
+    """
+    Test that file names in IPython console tracebacks are clickable.
+
+    This is a regression test for issue spyder-ide/spyder#20407.
+    """
+    shell = main_window.ipyconsole.get_current_shellwidget()
+    control = shell._control
+    qtbot.waitUntil(lambda: shell._prompt_html is not None,
+                    timeout=SHELL_TIMEOUT)
+
+    # Open test file
+    test_file = osp.join(LOCATION, 'script.py')
+    main_window.editor.load(test_file)
+    code_editor = main_window.editor.get_focus_widget()
+
+    # Introduce an error at the end of the file. This only works if the last
+    # line is empty.
+    text = code_editor.toPlainText()
+    assert text.splitlines(keepends=True)[-1].endswith('\n')
+
+    cursor = code_editor.textCursor()
+    cursor.movePosition(QTextCursor.End, QTextCursor.MoveAnchor)
+    code_editor.setTextCursor(cursor)
+    qtbot.keyClicks(code_editor, '1/0')
+
+    # Run test file
+    qtbot.keyClick(code_editor, Qt.Key_F5)
+    qtbot.wait(500)
+
+    # Find last 'File' line in traceback, which corresponds to the file we
+    # opened.
+    control.setFocus()
+    find_widget = main_window.ipyconsole.get_widget().find_widget
+    find_widget.show()
+    find_widget.search_text.lineEdit().setText('  File')
+    find_widget.find_previous()
+
+    # Position mouse on top of that line
+    cursor_point = control.cursorRect(control.textCursor()).center()
+    qtbot.mouseMove(control, cursor_point)
+    qtbot.wait(500)
+
+    # Check cursor shape is the right one
+    assert QApplication.overrideCursor().shape() == Qt.PointingHandCursor
+
+    # Click on the line and check that that sends us to the editor
+    qtbot.mouseClick(control.viewport(), Qt.LeftButton, pos=cursor_point,
+                     delay=300)
+    assert QApplication.focusWidget() is code_editor
+
+    # Check we are in the right line
+    cursor = code_editor.textCursor()
+    assert cursor.blockNumber() == code_editor.blockCount() - 1
+
+    # Remove error and save file
+    code_editor.delete_line()
+    code_editor.sig_save_requested.emit()
+    qtbot.wait(500)
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/ipythonconsole/widgets/control.py
+++ b/spyder/plugins/ipythonconsole/widgets/control.py
@@ -7,9 +7,9 @@
 """Control widgets used by ShellWidget"""
 
 # Third-party imports
-from qtpy.QtCore import Qt, QUrl, Signal
-from qtpy.QtGui import QColor, QDesktopServices, QTextFrameFormat
-from qtpy.QtWidgets import QApplication, QTextEdit
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import QColor, QTextFrameFormat
+from qtpy.QtWidgets import QTextEdit
 
 # Local imports
 from spyder.utils.palette import QStylePalette
@@ -49,9 +49,6 @@ class ControlWidget(TracebackLinksMixin, GetHelpMixin,
 
         # To not use Spyder calltips obtained through the monitor
         self.calltips = False
-
-        # To detect anchors and make them clickable
-        self.anchor = None
 
     # ---- Public methods ----------------------------------------------------
     def insert_horizontal_ruler(self):
@@ -105,24 +102,6 @@ class ControlWidget(TracebackLinksMixin, GetHelpMixin,
         """Reimplement Qt method to send focus change notification"""
         self.sig_focus_changed.emit()
         return super(ControlWidget, self).focusOutEvent(event)
-
-    def mouseMoveEvent(self, event):
-        """Detect anchors and change cursor shape accordingly."""
-        self.anchor = self.anchorAt(event.pos())
-        if self.anchor:
-            QApplication.setOverrideCursor(Qt.PointingHandCursor)
-        else:
-            QApplication.restoreOverrideCursor()
-        super(ControlWidget, self).mouseMoveEvent(event)
-
-    def mouseReleaseEvent(self, event):
-        """Ooen anchors when clicked."""
-        if self.anchor:
-            QDesktopServices.openUrl(QUrl(self.anchor))
-            QApplication.setOverrideCursor(Qt.ArrowCursor)
-            self.anchor = None
-        else:
-            super(ControlWidget, self).mouseReleaseEvent(event)
 
 
 class PageControlWidget(QTextEdit, BaseEditMixin):

--- a/spyder/plugins/ipythonconsole/widgets/figurebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/figurebrowser.py
@@ -57,15 +57,17 @@ class FigureBrowserWidget(RichJupyterWidget):
 
         if img is not None:
             self.sig_new_inline_figure.emit(img, fmt)
-            if (self.figurebrowser is not None and
-                    self.figurebrowser.mute_inline_plotting):
+            if (
+                self.figurebrowser is not None
+                and self.figurebrowser.mute_inline_plotting
+            ):
                 if not self.sended_render_message:
                     self._append_html("<br>", before_prompt=True)
                     self.append_html_message(
-                        _('Figures now render in the Plots pane by default. '
-                          'To make them also appear inline in the Console, '
-                          'uncheck "Mute Inline Plotting" under the Plots '
-                          'pane options menu.'),
+                        _('Figures are displayed in the Plots pane by '
+                          'default. To make them also appear inline in the '
+                          'console, you need to uncheck "Mute inline '
+                          'plotting" under the options menu of Plots.'),
                         before_prompt=True
                     )
                     self.sended_render_message = True

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -2516,9 +2516,17 @@ class IPythonConsoleWidget(PluginMainWidget):
         match = get_error_match(str(text))
         if match:
             fname, lnb = match.groups()
-            if ("<ipython-input-" in fname and
-                    self.run_cell_filename is not None):
+            if (
+                "<ipython-input-" in fname
+                and self.run_cell_filename is not None
+            ):
                 fname = self.run_cell_filename
+
+            # For IPython 8+ tracebacks.
+            # Fixes spyder-ide/spyder#20407
+            if '~' in fname:
+                fname = osp.expanduser(fname)
+
             # This is needed to fix issue spyder-ide/spyder#9217.
             try:
                 self.sig_edit_goto_requested.emit(

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -24,9 +24,9 @@ from traitlets import observe
 # Local imports
 from spyder.config.base import (
     _, is_pynsist, running_in_mac_app, running_under_pytest)
-from spyder.config.gui import get_color_scheme
+from spyder.config.gui import get_color_scheme, is_dark_interface
 from spyder.py3compat import to_text_string
-from spyder.utils.palette import SpyderPalette
+from spyder.utils.palette import QStylePalette, SpyderPalette
 from spyder.utils.clipboard_helper import CLIPBOARD_HELPER
 from spyder.utils import syntaxhighlighters as sh
 from spyder.plugins.ipythonconsole.utils.style import (
@@ -819,7 +819,7 @@ the sympy module (e.g. plot)
             Type of message to be showm. Possible values are
             'warning' and 'error'.
         """
-        # The message is displayed in a table with a single cell.
+        # The message is displayed in a table with a header and a single cell.
         table_properties = (
             "border='0.5'" +
             "width='90%'" +
@@ -831,14 +831,27 @@ the sympy module (e.g. plot)
             header = _("Error")
             bgcolor = SpyderPalette.COLOR_ERROR_2
         else:
-            header = _("Warning")
+            header = _("Important")
             bgcolor = SpyderPalette.COLOR_WARN_1
 
+        # This makes the header text have good contrast against its background
+        # for the light theme.
+        if is_dark_interface():
+            font_color = QStylePalette.COLOR_TEXT_1
+        else:
+            font_color = 'white'
+
         self._append_html(
-            f"<div align='center'><table {table_properties}>" +
-            f"<tr><th bgcolor='{bgcolor}'>{header}</th></tr>" +
-            "<tr><td>" + html + "</td></tr>" +
-            "</table></div>",
+            f"<div align='center'>"
+            f"<table {table_properties}>"
+            # Header
+            f"<tr><th bgcolor='{bgcolor}'><font color='{font_color}'>"
+            f"{header}"
+            f"</th></tr>"
+            # Cell with html message
+            f"<tr><td>{html}</td></tr>"
+            f"</table>"
+            f"</div>",
             before_prompt=before_prompt
         )
 

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -154,18 +154,16 @@ def remove_backslashes(path):
 
 def get_error_match(text):
     """Check if text contains a Python error."""
-    # For IPython 8+ tracebacks. We check for this first because we assume most
-    # users need to click on file names present on tracebacks in the IPython
-    # console.
-    # Fixes spyder-ide/spyder#20407
-    ipython8_match = re.match(r'  File (.*):(\d*)', text)
-    if ipython8_match is not None:
-        return ipython8_match
-
     # For regular Python tracebacks and IPython 7 or less.
     match_python = re.match(r'  File "(.*)", line (\d*)', text)
     if match_python is not None:
         return match_python
+
+    # For IPython 8+ tracebacks.
+    # Fixes spyder-ide/spyder#20407
+    ipython8_match = re.match(r'  File (.*):(\d*)', text)
+    if ipython8_match is not None:
+        return ipython8_match
 
     return False
 

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -153,9 +153,21 @@ def remove_backslashes(path):
 
 
 def get_error_match(text):
-    """Return error match"""
-    import re
-    return re.match(r'  File "(.*)", line (\d*)', text)
+    """Check if text contains a Python error."""
+    # For IPython 8+ tracebacks. We check for this first because we assume most
+    # users need to click on file names present on tracebacks in the IPython
+    # console.
+    # Fixes spyder-ide/spyder#20407
+    ipython8_match = re.match(r'  File (.*):(\d*)', text)
+    if ipython8_match is not None:
+        return ipython8_match
+
+    # For regular Python tracebacks and IPython 7 or less.
+    match_python = re.match(r'  File "(.*)", line (\d*)', text)
+    if match_python is not None:
+        return match_python
+
+    return False
 
 
 def get_python_executable():


### PR DESCRIPTION
## Description of Changes

- The format for tracebacks changed in IPython 8. That's why our previous code to detect filenames inside them failed.
- Add a test for this functionality so we notice when it breaks in the future.
- Restore showing the pointing hand cursor when hovering over file names on tracebacks. This was broken in #15809.
- Change header for non-error messages from `Warning` to `Important` to better convey the meaning of those messages to users (not all of them are warnings). Also, use white color for it so that it's more readable in the light theme.

    **Before**

    ![image](https://user-images.githubusercontent.com/365293/227258619-11e86c6c-d083-4c73-8bd1-13b37101b8d1.png)

    **After**

    ![image](https://user-images.githubusercontent.com/365293/227258124-2f207059-4651-435c-92ee-2248df630f22.png)

- Change message shown the first time a plot is generated with the Inline backend. That message was written for Spyder 3 users so they understood where their plots went in Spyder 4. But it makes little sense now for new users.

    **Before**

    ![image](https://user-images.githubusercontent.com/365293/227260301-f060e397-cdee-4888-8308-3e3cdb28ecaa.png)

    **After**

    ![image](https://user-images.githubusercontent.com/365293/227260715-bb91f3d5-d3d3-4824-b9ed-d00430a44754.png)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20407.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
