### PR TITLE
PR: Various Fixes to improve compatibility with PySide2. 

### DIFF
--- a/spyder/config/gui.py
+++ b/spyder/config/gui.py
@@ -105,7 +105,8 @@ def _config_shortcut(action, context, name, keystr, parent):
     The data contained in this tuple will be registered in our shortcuts
     preferences page.
     """
-    qsc = QShortcut(QKeySequence(keystr), parent, action)
+    qsc = QShortcut(QKeySequence(keystr), parent)
+    qsc.activated.connect(action)
     qsc.setContext(Qt.WidgetWithChildrenShortcut)
     sc = Shortcut(data=(qsc, context, name))
     return sc

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -374,7 +374,6 @@ class LanguageServerProvider(SpyderCompletionProvider):
                     self.start_completion_services_for_language(language)
 
 
-    @Slot(str)
     def report_server_error(self, error):
         """Report server errors in our error report dialog."""
         error_data = dict(

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -19,6 +19,7 @@ import sys
 # Third-party imports
 from qtpy.QtCore import Signal, Slot, QTimer
 from qtpy.QtWidgets import QMessageBox
+from qtpy import PYSIDE2
 
 # Local imports
 from spyder.api.config.decorators import on_conf_change
@@ -188,7 +189,10 @@ class LanguageServerProvider(SpyderCompletionProvider):
                     self.clients_hearbeat[language].stop()
                     self.clients_hearbeat[language].setParent(None)
                     del self.clients_hearbeat[language]
-                    client['instance'].disconnect()
+                    if PYSIDE2:
+                        client['instance'].disconnect(None, None, None)
+                    else:
+                        client['instance'].disconnect()
                     client['instance'].stop()
                 except (TypeError, KeyError, RuntimeError):
                     pass
@@ -663,7 +667,10 @@ class LanguageServerProvider(SpyderCompletionProvider):
             if language_client['status'] == self.RUNNING:
                 logger.info("Stopping LSP client for {}...".format(language))
                 try:
-                    language_client['instance'].disconnect()
+                    if PYSIDE2:
+                        language_client['instance'].disconnect(None, None, None)
+                    else:
+                        language_client['instance'].disconnect()
                 except TypeError:
                     pass
                 try:

--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -23,6 +23,7 @@ import sys
 from qtpy.compat import getopenfilename
 from qtpy.QtCore import Qt, Signal, Slot
 from qtpy.QtWidgets import QAction, QInputDialog, QLineEdit, QVBoxLayout
+from qtpy import PYSIDE2
 
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
@@ -465,7 +466,10 @@ class ConsoleWidget(PluginMainWidget):
         if self.error_dlg.dismiss_box.isChecked():
             self.dismiss_error = True
 
-        self.error_dlg.disconnect()
+        if PYSIDE2:
+            self.error_dlg.disconnect(None, None, None)
+        else:
+            self.error_dlg.disconnect()
         self.error_dlg = None
 
     @Slot()

--- a/spyder/plugins/explorer/widgets/fileassociations.py
+++ b/spyder/plugins/explorer/widgets/fileassociations.py
@@ -443,7 +443,7 @@ class FileAssociationsWidget(QWidget):
     @Slot()
     def add_association(self, value=None):
         """Add extension file association."""
-        if value is None:
+        if value is None or isinstance(value, bool):
             text, ok_pressed = '', False
             self._dlg_input.set_text('')
 

--- a/spyder/plugins/preferences/widgets/container.py
+++ b/spyder/plugins/preferences/widgets/container.py
@@ -7,6 +7,7 @@
 # Third party imports
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QAction
+from qtpy import PYSIDE2
 
 # Local imports
 from spyder.api.translations import _
@@ -36,7 +37,10 @@ class PreferencesContainer(PluginMainContainer):
 
         def _dialog_finished(result_code):
             """Restore preferences dialog instance variable."""
-            self.dialog.disconnect()
+            if PYSIDE2:
+                self.dialog.disconnect(None, None, None)
+            else:
+                self.dialog.disconnect()
             self.dialog = None
 
         if self.dialog is None:

--- a/spyder/plugins/pylint/plugin.py
+++ b/spyder/plugins/pylint/plugin.py
@@ -212,7 +212,7 @@ class Pylint(SpyderDockablePlugin):
             if self.get_conf("save_before", True) and not editor.save():
                 return
 
-        if filename is None:
+        if filename is None or isinstance(filename, bool):
             filename = self.get_widget().get_filename()
 
         self.switch_to_plugin(force_focus=True)

--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -192,7 +192,7 @@ class FindReplace(QWidget):
         search_layout.addSpacerItem(QSpacerItem(10, 0))
         search_layout.addWidget(self.number_matches_text)
         search_layout.addSpacerItem(
-            QSpacerItem(6, 0, hPolicy=QSizePolicy.Expanding)
+            QSpacerItem(6, 0, QSizePolicy.Expanding)
         )
 
         glayout.addLayout(search_layout, 0, 1)

--- a/spyder/widgets/github/gh_login.py
+++ b/spyder/widgets/github/gh_login.py
@@ -87,10 +87,10 @@ class DlgGitHubLogin(QDialog):
         token_layout.addSpacerItem(QSpacerItem(0, 8))
         token_layout.addWidget(token_lbl_msg)
         token_layout.addSpacerItem(
-            QSpacerItem(0, 50, vPolicy=QSizePolicy.Expanding))
+            QSpacerItem(0, 50, QSizePolicy.Minimum, QSizePolicy.Expanding))
         token_layout.addLayout(token_form_layout)
         token_layout.addSpacerItem(
-            QSpacerItem(0, 50, vPolicy=QSizePolicy.Expanding))
+            QSpacerItem(0, 50, QSizePolicy.Minimum, QSizePolicy.Expanding))
         token_auth.setLayout(token_layout)
         self.tabs.addTab(token_auth, _("Access Token"))
 


### PR DESCRIPTION
## Description of Changes

Various fixes to improve compatibility with PySide2. Notes
* `pyside2: Fix usage of keyword argument in QSpacerItem`: It should be possible to fix this globally via monkey patching in `qtpy`, similar to spyder-ide/qtpy#341. Please let me know if this is desired.
* `pyside2: Fix QObject.disconnect() calls`: Unfortunately, this cannot be fixed globally via monkey patching in `qtpy`.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:

rear1019
