### PR TITLE
PR: Remove some unused methods from MainWindow and fix Code Analysis and Profiler actions in menus position

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1054,66 +1054,6 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         """Free memory after event."""
         gc.collect()
 
-    def show_shortcuts(self, menu):
-        """Show action shortcuts in menu."""
-        menu_actions = menu.actions()
-        for action in menu_actions:
-            if getattr(action, '_shown_shortcut', False):
-                # This is a SpyderAction
-                if action._shown_shortcut is not None:
-                    action.setShortcut(action._shown_shortcut)
-            elif action.menu() is not None:
-                # This is submenu, so we need to call this again
-                self.show_shortcuts(action.menu())
-            else:
-                # We don't need to do anything for other elements
-                continue
-
-    def hide_shortcuts(self, menu):
-        """Hide action shortcuts in menu."""
-        menu_actions = menu.actions()
-        for action in menu_actions:
-            if getattr(action, '_shown_shortcut', False):
-                # This is a SpyderAction
-                if action._shown_shortcut is not None:
-                    action.setShortcut(QKeySequence())
-            elif action.menu() is not None:
-                # This is submenu, so we need to call this again
-                self.hide_shortcuts(action.menu())
-            else:
-                # We don't need to do anything for other elements
-                continue
-
-    def hide_options_menus(self):
-        """Hide options menu when menubar is pressed in macOS."""
-        for plugin in self.widgetlist + self.thirdparty_plugins:
-            if plugin.CONF_SECTION == 'editor':
-                editorstack = self.editor.get_current_editorstack()
-                editorstack.menu.hide()
-            else:
-                try:
-                    # New API
-                    plugin.options_menu.hide()
-                except AttributeError:
-                    # Old API
-                    plugin._options_menu.hide()
-
-    def get_focus_widget_properties(self):
-        """Get properties of focus widget
-        Returns tuple (widget, properties) where properties is a tuple of
-        booleans: (is_console, not_readonly, readwrite_editor)"""
-        from spyder.plugins.editor.widgets.base import TextEditBaseWidget
-        from spyder.plugins.ipythonconsole.widgets import ControlWidget
-        widget = QApplication.focusWidget()
-
-        textedit_properties = None
-        if isinstance(widget, (TextEditBaseWidget, ControlWidget)):
-            console = isinstance(widget, ControlWidget)
-            not_readonly = not widget.isReadOnly()
-            readwrite_editor = not_readonly and not console
-            textedit_properties = (console, not_readonly, readwrite_editor)
-        return widget, textedit_properties
-
     def set_splash(self, message):
         """Set splash message"""
         if self.splash is None:

--- a/spyder/plugins/profiler/plugin.py
+++ b/spyder/plugins/profiler/plugin.py
@@ -20,6 +20,7 @@ from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
 from spyder.api.translations import _
 from spyder.plugins.editor.api.run import FileRun
+from spyder.plugins.mainmenu.api import ApplicationMenus, RunMenuSections
 from spyder.plugins.profiler.api import ProfilerPyConfiguration
 from spyder.plugins.profiler.confpage import ProfilerConfigPage
 from spyder.plugins.profiler.widgets.main_widget import (
@@ -29,7 +30,6 @@ from spyder.plugins.profiler.widgets.run_conf import (
 from spyder.plugins.run.api import (
     RunExecutor, run_execute, RunContext, RunConfiguration,
     ExtendedRunExecutionParameters, PossibleRunResult)
-
 
 
 class Profiler(SpyderDockablePlugin, RunExecutor):
@@ -109,7 +109,10 @@ class Profiler(SpyderDockablePlugin, RunExecutor):
                 icon=self.create_icon('profiler'),
                 shortcut_context='profiler',
                 register_shortcut=True,
-                add_to_menu=True
+                add_to_menu={
+                    "menu": ApplicationMenus.Run,
+                    "section": RunMenuSections.RunInExecutors
+                }
             )
 
     @on_plugin_teardown(plugin=Plugins.Editor)

--- a/spyder/plugins/pylint/plugin.py
+++ b/spyder/plugins/pylint/plugin.py
@@ -132,16 +132,11 @@ class Pylint(SpyderDockablePlugin, RunExecutor):
             icon=self.create_icon("pylint"),
             shortcut_context='pylint',
             register_shortcut=True,
-            add_to_menu=True
+            add_to_menu={
+                "menu": ApplicationMenus.Source,
+                "section": SourceMenuSections.CodeAnalysis
+            }
         )
-
-        mainmenu = self.get_plugin(Plugins.MainMenu)
-        if mainmenu:
-            mainmenu.add_item_to_application_menu(
-                self.run_action,
-                menu_id=ApplicationMenus.Source,
-                section=SourceMenuSections.CodeAnalysis
-            )
 
     @on_plugin_teardown(plugin=Plugins.Editor)
     def on_editor_teardown(self):
@@ -163,16 +158,6 @@ class Pylint(SpyderDockablePlugin, RunExecutor):
         projects = self.get_plugin(Plugins.Projects)
         projects.sig_project_loaded.disconnect(self._set_project_dir)
         projects.sig_project_closed.disconnect(self._unset_project_dir)
-
-    @on_plugin_teardown(plugin=Plugins.MainMenu)
-    def on_main_menu_teardown(self):
-        mainmenu = self.get_plugin(Plugins.MainMenu)
-
-        if self.run_action is not None:
-            mainmenu.remove_item_from_application_menu(
-                self.run_action.name,
-                menu_id=ApplicationMenus.Source
-            )
 
     @on_plugin_teardown(plugin=Plugins.Run)
     def on_run_teardown(self):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

* Remove some methods from the mainwindow that seem unused:
    * `show_shortcuts`
    * `hide_shortcuts`
    * `hide_options_menus`
    * `get_focus_widget_properties`

* Fix position of code analysis and profiler actions in menus:
    * Before:
    ![menus_before](https://user-images.githubusercontent.com/16781833/231314595-2c814a03-dccc-47dc-b9a5-04d211761f98.gif)

    * After:
    ![menus_after](https://user-images.githubusercontent.com/16781833/231314493-e9a23a47-726a-42c5-b703-1b3adbd26f55.gif)


Not totally sure if the actions should remain in the position where you find them when using 5.x but if not at least no action should be repeated in different menus I think

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
