### PR TITLE
PR: Keep `PYTHONHOME` in `get_user_environment_variables` for macOS standalone app

### DIFF
--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -22,7 +22,7 @@ except Exception:
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports
-from spyder.config.base import _, running_in_ci
+from spyder.config.base import _, running_in_ci, running_in_mac_app
 from spyder.widgets.collectionseditor import CollectionsEditor
 from spyder.utils.icon_manager import ima
 from spyder.utils.programs import run_shell_command
@@ -67,7 +67,11 @@ def get_user_environment_variables():
                 f"{shell} -l -c"
                 f""" "{sys.executable} -c 'import os; print(dict(os.environ))'" """
             )
-            proc = run_shell_command(cmd, env={}, text=True)
+            if running_in_mac_app():
+                env = {"PYTHONHOME": os.environ["PYTHONHOME"]}
+            else:
+                env = {}
+            proc = run_shell_command(cmd, env=env, text=True)
             stdout, stderr = proc.communicate()
             env_var = eval(stdout, None)
     except Exception:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


For the standalone macOS app, `PYTHONHOME` is required to correctly execute the Python subprocess for retrieving the user's system environment variables.

Note: after merging into 5.x, these changes should _not_ be merged into master.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Partially addresses #20808


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary

<!--- Thanks for your help making Spyder better for everyone! --->
