### PR TITLE
PR: Ensure Pythonpath Manager widget is in front and has focus after adding path on macOS

### DIFF
--- a/spyder/plugins/pythonpath/container.py
+++ b/spyder/plugins/pythonpath/container.py
@@ -105,6 +105,8 @@ class PythonpathContainer(PluginMainContainer):
 
     def show_path_manager(self):
         """Show path manager dialog."""
+        # Do not update paths or run setup if widget is already open,
+        # see spyder-ide/spyder#20808
         if not self.path_manager_dialog.isVisible():
             # Set main attributes saved here
             self.path_manager_dialog.update_paths(

--- a/spyder/plugins/pythonpath/widgets/pathmanager.py
+++ b/spyder/plugins/pythonpath/widgets/pathmanager.py
@@ -482,9 +482,13 @@ class PathManager(QDialog, SpyderWidgetMixin):
                       "."),
                     QMessageBox.Ok)
 
-        self.activateWindow()
-        self.raise_()
-        self.setFocus()
+        # Widget moves to back and loses focus on macOS,
+        # see spyder-ide/spyder#20808
+        if sys.platform == 'darwin':
+            self.activateWindow()
+            self.raise_()
+            self.setFocus()
+
         self.refresh()
 
     @Slot()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* Ensure that PYTHONPATH Manager widget is the front window and has focus after adding a path.
* Do not update paths upon the `path_manager_action` _if_ the widget is already visible

These changes should be rebased _after_ merging #20811.
After merging into 5.x, these changes may be merged into master.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20808


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @mrclary 

<!--- Thanks for your help making Spyder better for everyone! --->
