### PR TITLE
PR: Change reporting of macOS system from Darwin to macOS and include machine type

### DIFF
--- a/spyder/__init__.py
+++ b/spyder/__init__.py
@@ -95,6 +95,7 @@ def get_versions(reporev=True):
         'revision': revision,  # '9fdf926eccce',
         'branch': branch,  # '4.x' or master,
         'machine': platform.machine(),  # 'arm64', 'x86_64', 'AMD64', ...
+        'platform': platform.platform(aliased=True),
     }
     if sys.platform == 'darwin':
         versions.update(system='macOS', release=platform.mac_ver()[0])
@@ -114,5 +115,5 @@ def get_versions_text(reporev=True):
 * Python version: {versions['python']} {versions['bitness']}-bit
 * Qt version: {versions['qt']}
 * {versions['qt_api']} version: {versions['qt_api_ver']}
-* Operating System: {versions['system']} {versions['release']} ({versions['machine']})
+* Operating System: {versions['platform']}
 """

--- a/spyder/__init__.py
+++ b/spyder/__init__.py
@@ -81,7 +81,7 @@ def get_versions(reporev=True):
     else:
         installer = 'pip'
 
-    return {
+    versions = {
         'spyder': __version__,
         'installer': installer,
         'python': platform.python_version(),  # "2.7.3"
@@ -93,8 +93,13 @@ def get_versions(reporev=True):
         'system': platform.system(),   # Linux, Windows, ...
         'release': platform.release(),  # XP, 10.6, 2.2.0, etc.
         'revision': revision,  # '9fdf926eccce',
-        'branch': branch,  # '4.x' or master
+        'branch': branch,  # '4.x' or master,
+        'machine': platform.machine(),  # 'arm64', 'x86_64', 'AMD64', ...
     }
+    if sys.platform == 'darwin':
+        versions.update(system='macOS', release=platform.mac_ver()[0])
+
+    return versions
 
 
 def get_versions_text(reporev=True):
@@ -109,5 +114,5 @@ def get_versions_text(reporev=True):
 * Python version: {versions['python']} {versions['bitness']}-bit
 * Qt version: {versions['qt']}
 * {versions['qt_api']} version: {versions['qt_api_ver']}
-* Operating System: {versions['system']} {versions['release']}
+* Operating System: {versions['system']} {versions['release']} ({versions['machine']})
 """

--- a/spyder/widgets/about.py
+++ b/spyder/widgets/about.py
@@ -75,7 +75,7 @@ class AboutDialog(QDialog):
             Python {versions['python']} {versions['bitness']}-bit |
             Qt {versions['qt']} |
             {versions['qt_api']} {versions['qt_api_ver']} |
-            {versions['system']} {versions['release']}
+            {versions['system']} {versions['release']} ({versions['machine']})
             </p>
             <br> <br>
             <a href="{project_url}">GitHub</a> | <a href="{twitter_url}">


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

In About widget, changed system info reporting for macOS from "Darwin" to "macOS" with appropriately changed release designation.
Also added machine type ('arm64', 'x86_64', 'AMD64', etc) to the system info for all platforms.

In the system info for issue reporting (and "Copy version info" of About widget), operating system value is replaced with the value of `platform.platform`.

"macOS 13.3" is more meaningful than "Darwin 22.4.0" to users, issue reporters, and developers. Additionally, inclusion of machine type may eliminate the need for developers to ask issue reporters "Is your machine Intel or M1?".

# New "About" widget text
<img width="662" alt="Screenshot 2023-04-17 at 8 40 32 AM" src="https://user-images.githubusercontent.com/9618975/232538901-297ddd28-882b-4a59-bf4b-ae0de22b3b96.png">

# New Issue text
* Spyder version: 6.0.0.dev0 47a906db (standalone)
* Python version: 3.9.16 64-bit
* Qt version: 5.15.6
* PyQt5 version: 5.15.7
* Operating System: macOS-13.3-x86_64-i386-64bit
