### PR TITLE
PR: Move CONF usage for bookmarks logic and use `SpyderConfiguratorAccessor` class in Editor widgets (Editor)

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -38,7 +38,6 @@ from spyder.api.panel import Panel
 from spyder.api.plugins import Plugins, SpyderPluginWidget
 from spyder.api.widgets.menus import SpyderMenu
 from spyder.config.base import _, get_conf_path, running_under_pytest
-from spyder.config.manager import CONF
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
                                  get_filter)
 from spyder.py3compat import qbytearray_to_str, to_text_string
@@ -476,10 +475,10 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
 
     def register_file_run_metadata(self, filename, filename_ext):
         """Register opened files with the Run plugin."""
-        all_uuids = CONF.get('editor', 'file_uuids', default={})
+        all_uuids = self.get_conf('file_uuids', default={})
         file_id = all_uuids.get(filename, str(uuid.uuid4()))
         all_uuids[filename] = file_id
-        CONF.set('editor', 'file_uuids', all_uuids)
+        self.set_conf('file_uuids', all_uuids)
 
         metadata: RunConfigurationMetadata = {
             'name': filename,
@@ -948,15 +947,16 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             _("Remove trailing spaces"),
             triggered=self.remove_trailing_spaces)
 
-        formatter = CONF.get(
-            'completions',
+        formatter = self.get_conf(
             ('provider_configuration', 'lsp', 'values', 'formatting'),
-            '')
+            default='',
+            section='completions'
+        )
         self.formatting_action = create_action(
             self,
             _('Format file or selection with {0}').format(
                 formatter.capitalize()),
-            shortcut=CONF.get_shortcut('editor', 'autoformatting'),
+            shortcut=self.get_shortcut('autoformatting'),
             context=Qt.WidgetShortcut,
             triggered=self.format_document_or_selection)
         self.formatting_action.setEnabled(False)
@@ -1033,13 +1033,13 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             self.go_to_next_file_action = create_action(
                 self,
                 _("Go to next file"),
-                shortcut=CONF.get_shortcut('editor', 'go to previous file'),
+                shortcut=self.get_shortcut('go to previous file'),
                 triggered=self.go_to_next_file,
             )
             self.go_to_previous_file_action = create_action(
                 self,
                 _("Go to previous file"),
-                shortcut=CONF.get_shortcut('editor', 'go to next file'),
+                shortcut=self.get_shortcut('go to next file'),
                 triggered=self.go_to_previous_file,
             )
             self.register_shortcut(
@@ -1479,7 +1479,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         color_scheme = self.get_color_scheme()
         for editorstack in self.editorstacks:
             editorstack.set_default_font(font, color_scheme)
-            completion_size = CONF.get('main', 'completion/size')
+            completion_size = self.get_conf('completion/size', section='main')
             for finfo in editorstack.data:
                 comp_widget = finfo.editor.completion_widget
                 comp_widget.setup_appearance(completion_size, font)
@@ -1526,10 +1526,10 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         if conf_name not in ['pycodestyle', 'pydocstyle']:
             action.setChecked(self.get_option(conf_name))
         else:
-            opt = CONF.get(
-                'completions',
+            opt = self.get_conf(
                 ('provider_configuration', 'lsp', 'values', conf_name),
-                False
+                default=False,
+                section='completions'
             )
             action.setChecked(opt)
 
@@ -1562,10 +1562,11 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             self.set_option(conf_name, checked)
         else:
             if conf_name in ('pycodestyle', 'pydocstyle'):
-                CONF.set(
-                    'completions',
+                self.set_conf(
                     ('provider_configuration', 'lsp', 'values', conf_name),
-                    checked)
+                    checked,
+                    section='completions'
+                )
             if self.main.get_plugin(Plugins.Completions, error=False):
                 completions = self.main.completions
                 completions.after_configuration_update([])
@@ -1679,26 +1680,25 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         for method, setting in settings:
             getattr(editorstack, method)(self.get_option(setting))
 
-        editorstack.set_help_enabled(CONF.get('help', 'connect/editor'))
+        editorstack.set_help_enabled(self.get_conf('help', 'connect/editor'))
 
-        hover_hints = CONF.get(
-            'completions',
-            ('provider_configuration', 'lsp', 'values',
-                'enable_hover_hints'),
-            True
+        hover_hints = self.get_conf(
+            ('provider_configuration', 'lsp', 'values', 'enable_hover_hints'),
+            default=True,
+            section='completions'
         )
 
-        format_on_save = CONF.get(
-            'completions',
+        format_on_save = self.get_conf(
             ('provider_configuration', 'lsp', 'values', 'format_on_save'),
-            False
+            default=False,
+            section='completions'
         )
 
-        edge_line_columns = CONF.get(
-            'completions',
+        edge_line_columns = self.get_conf(
             ('provider_configuration', 'lsp', 'values',
              'pycodestyle/max_line_length'),
-            79
+            default=79,
+            section='completions'
         )
 
         editorstack.set_hover_hints_enabled(hover_hints)
@@ -2041,10 +2041,11 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         self.formatting_action.setEnabled(status)
 
     def refresh_formatter_name(self):
-        formatter = CONF.get(
-            'completions',
+        formatter = self.get_conf(
             ('provider_configuration', 'lsp', 'values', 'formatting'),
-            '')
+            default='',
+            section='completions'
+        )
         self.formatting_action.setText(
             _('Format file or selection with {0}').format(
                 formatter.capitalize()))
@@ -2102,7 +2103,9 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         bookmarks = to_text_string(bookmarks)
         filename = osp.normpath(osp.abspath(filename))
         bookmarks = eval(bookmarks)
-        save_bookmarks(filename, bookmarks)
+        old_slots = self.get_conf('bookmarks', default={})
+        new_slots = save_bookmarks(filename, bookmarks, old_slots)
+        self.set_conf('bookmarks', new_slots)
 
     #------ File I/O
     def __load_temp_file(self):
@@ -2454,7 +2457,8 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                 self._clone_file_everywhere(finfo)
                 current_editor = current_es.set_current_filename(filename,
                                                                  focus=focus)
-                current_editor.set_bookmarks(load_bookmarks(filename))
+                slots = self.get_conf('bookmarks', default={})
+                current_editor.set_bookmarks(load_bookmarks(filename, slots))
                 self.register_widget_shortcuts(current_editor)
                 current_es.analyze_script()
                 self.__add_recent_file(filename)
@@ -3256,7 +3260,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
     @Slot(int)
     def save_bookmark(self, slot_num):
         """Save current line and position as bookmark."""
-        bookmarks = CONF.get('editor', 'bookmarks')
+        bookmarks = self.get_conf('bookmarks')
         editorstack = self.get_current_editorstack()
         if slot_num in bookmarks:
             filename, line_num, column = bookmarks[slot_num]
@@ -3273,7 +3277,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
     @Slot(int)
     def load_bookmark(self, slot_num):
         """Set cursor to bookmarked file and position."""
-        bookmarks = CONF.get('editor', 'bookmarks')
+        bookmarks = self.get_conf('bookmarks')
         if slot_num in bookmarks:
             filename, line_num, column = bookmarks[slot_num]
         else:
@@ -3380,7 +3384,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
             tab_stop_width_spaces_n = 'tab_stop_width_spaces'
             tab_stop_width_spaces_o = self.get_option(tab_stop_width_spaces_n)
             help_n = 'connect_to_oi'
-            help_o = CONF.get('help', 'connect/editor')
+            help_o = self.get_conf('connect/editor', section='help')
             todo_n = 'todo_list'
             todo_o = self.get_option(todo_n)
 

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -59,7 +59,7 @@ from spyder.plugins.editor.widgets.editor import (EditorMainWindow,
 from spyder.plugins.editor.widgets.printer import (
     SpyderPrinter, SpyderPrintPreviewDialog)
 from spyder.plugins.editor.utils.bookmarks import (load_bookmarks,
-                                                   save_bookmarks)
+                                                   update_bookmarks)
 from spyder.plugins.editor.widgets.status import (CursorPositionStatus,
                                                   EncodingStatus, EOLStatus,
                                                   ReadWriteStatus, VCSStatus)
@@ -2104,7 +2104,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         filename = osp.normpath(osp.abspath(filename))
         bookmarks = eval(bookmarks)
         old_slots = self.get_conf('bookmarks', default={})
-        new_slots = save_bookmarks(filename, bookmarks, old_slots)
+        new_slots = update_bookmarks(filename, bookmarks, old_slots)
         self.set_conf('bookmarks', new_slots)
 
     #------ File I/O

--- a/spyder/plugins/editor/utils/bookmarks.py
+++ b/spyder/plugins/editor/utils/bookmarks.py
@@ -31,8 +31,25 @@ def load_bookmarks_without_file(filename, slots):
     return {k: v for k, v in bookmarks.items() if v[0] != filename}
 
 
-def save_bookmarks(filename, bookmarks, old_slots):
-    """Save all bookmarks from specific file to config."""
+def update_bookmarks(filename, bookmarks, old_slots):
+    """
+    Compute an updated version of all the bookmarks from a specific file.
+
+    Parameters
+    ----------
+    filename : str
+        File path that the bookmarks are related too.
+    bookmarks : dict
+        New or changed bookmarks for the file.
+    old_slots : dict
+        Base general bookmarks entries available before any changes where done.
+
+    Returns
+    -------
+    updated_slots : dict
+        Updated general bookmarks.
+
+    """
     if not osp.isfile(filename):
         return
     updated_slots = load_bookmarks_without_file(filename, old_slots)

--- a/spyder/plugins/editor/utils/bookmarks.py
+++ b/spyder/plugins/editor/utils/bookmarks.py
@@ -10,36 +10,32 @@ Contains the bookmarsks utilities.
 # Standard imports
 import os.path as osp
 
-# Local imports
-from spyder.config.manager import CONF
 
-
-def _load_all_bookmarks():
+def _load_all_bookmarks(slots):
     """Load all bookmarks from config."""
-    slots = CONF.get('editor', 'bookmarks', {})
     for slot_num in list(slots.keys()):
         if not osp.isfile(slots[slot_num][0]):
             slots.pop(slot_num)
     return slots
 
 
-def load_bookmarks(filename):
+def load_bookmarks(filename, slots):
     """Load all bookmarks for a specific file from config."""
-    bookmarks = _load_all_bookmarks()
+    bookmarks = _load_all_bookmarks(slots)
     return {k: v for k, v in bookmarks.items() if v[0] == filename}
 
 
-def load_bookmarks_without_file(filename):
+def load_bookmarks_without_file(filename, slots):
     """Load all bookmarks but those from a specific file."""
-    bookmarks = _load_all_bookmarks()
+    bookmarks = _load_all_bookmarks(slots)
     return {k: v for k, v in bookmarks.items() if v[0] != filename}
 
 
-def save_bookmarks(filename, bookmarks):
+def save_bookmarks(filename, bookmarks, old_slots):
     """Save all bookmarks from specific file to config."""
     if not osp.isfile(filename):
         return
-    slots = load_bookmarks_without_file(filename)
+    updated_slots = load_bookmarks_without_file(filename, old_slots)
     for slot_num, content in bookmarks.items():
-        slots[slot_num] = [filename, content[0], content[1]]
-    CONF.set('editor', 'bookmarks', slots)
+        updated_slots[slot_num] = [filename, content[0], content[1]]
+    return updated_slots

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -23,8 +23,8 @@ from qtpy.QtGui import (QClipboard, QColor, QMouseEvent, QTextFormat,
 from qtpy.QtWidgets import QApplication, QMainWindow, QPlainTextEdit, QToolTip
 
 # Local imports
+from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.config.gui import get_font
-from spyder.config.manager import CONF
 from spyder.plugins.editor.api.decoration import TextDecoration, DRAW_ORDERS
 from spyder.plugins.editor.utils.decoration import TextDecorationsManager
 from spyder.plugins.editor.widgets.completion import CompletionWidget
@@ -36,7 +36,9 @@ from spyder.widgets.calltip import CallTipWidget, ToolTipWidget
 from spyder.widgets.mixins import BaseEditMixin
 
 
-class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
+class TextEditBaseWidget(
+        QPlainTextEdit, BaseEditMixin, SpyderConfigurationAccessor
+        ):
     """Text edit base widget"""
     BRACE_MATCHING_SCOPE = ('sof', 'eof')
     focus_in = Signal()
@@ -121,7 +123,7 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
         self._current_line_block = None
 
     def setup_completion(self):
-        size = CONF.get('main', 'completion/size')
+        size = self.get_conf('completion/size', section='main')
         font = get_font()
         self.completion_widget.setup_appearance(size, font)
 

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -49,7 +49,6 @@ from three_merge import merge
 # Local imports
 from spyder.api.panel import Panel
 from spyder.config.base import _, get_debug_level, running_under_pytest
-from spyder.config.manager import CONF
 from spyder.plugins.editor.api.decoration import TextDecoration
 from spyder.plugins.editor.extensions import (CloseBracketsExtension,
                                               CloseQuotesExtension,
@@ -121,6 +120,8 @@ def schedule_request(req=None, method=None, requires_response=True):
 @class_register
 class CodeEditor(TextEditBaseWidget):
     """Source Code Editor Widget based exclusively on Qt"""
+
+    CONF_SECTION = 'editor'
 
     LANGUAGES = {
         'Python': (sh.PythonSH, '#'),
@@ -288,7 +289,7 @@ class CodeEditor(TextEditBaseWidget):
         self.current_project_path = None
 
         # Caret (text cursor)
-        self.setCursorWidth(CONF.get('main', 'cursor/width'))
+        self.setCursorWidth(self.get_conf('cursor/width', section='main'))
 
         self.text_helper = TextHelper(self)
 
@@ -743,7 +744,7 @@ class CodeEditor(TextEditBaseWidget):
         shortcuts = []
         for context, name, callback in shortcut_context_name_callbacks:
             shortcuts.append(
-                CONF.config_shortcut(
+                self.config_shortcut(
                     callback, context=context, name=name, parent=self))
         return shortcuts
 
@@ -4517,27 +4518,27 @@ class CodeEditor(TextEditBaseWidget):
         """Setup context menu"""
         self.undo_action = create_action(
             self, _("Undo"), icon=ima.icon('undo'),
-            shortcut=CONF.get_shortcut('editor', 'undo'), triggered=self.undo)
+            shortcut=self.get_shortcut('undo'), triggered=self.undo)
         self.redo_action = create_action(
             self, _("Redo"), icon=ima.icon('redo'),
-            shortcut=CONF.get_shortcut('editor', 'redo'), triggered=self.redo)
+            shortcut=self.get_shortcut('redo'), triggered=self.redo)
         self.cut_action = create_action(
             self, _("Cut"), icon=ima.icon('editcut'),
-            shortcut=CONF.get_shortcut('editor', 'cut'), triggered=self.cut)
+            shortcut=self.get_shortcut('cut'), triggered=self.cut)
         self.copy_action = create_action(
             self, _("Copy"), icon=ima.icon('editcopy'),
-            shortcut=CONF.get_shortcut('editor', 'copy'), triggered=self.copy)
+            shortcut=self.get_shortcut('copy'), triggered=self.copy)
         self.paste_action = create_action(
             self, _("Paste"), icon=ima.icon('editpaste'),
-            shortcut=CONF.get_shortcut('editor', 'paste'),
+            shortcut=self.get_shortcut('paste'),
             triggered=self.paste)
         selectall_action = create_action(
             self, _("Select All"), icon=ima.icon('selectall'),
-            shortcut=CONF.get_shortcut('editor', 'select all'),
+            shortcut=self.get_shortcut('select all'),
             triggered=self.selectAll)
         toggle_comment_action = create_action(
             self, _("Comment")+"/"+_("Uncomment"), icon=ima.icon('comment'),
-            shortcut=CONF.get_shortcut('editor', 'toggle comment'),
+            shortcut=self.get_shortcut('toggle comment'),
             triggered=self.toggle_comment)
         self.clear_all_output_action = create_action(
             self, _("Clear all ouput"), icon=ima.icon('ipython_console'),
@@ -4547,13 +4548,13 @@ class CodeEditor(TextEditBaseWidget):
             triggered=self.convert_notebook)
         self.gotodef_action = create_action(
             self, _("Go to definition"),
-            shortcut=CONF.get_shortcut('editor', 'go to definition'),
+            shortcut=self.get_shortcut('go to definition'),
             triggered=self.go_to_definition_from_cursor)
 
         self.inspect_current_object_action = create_action(
             self, _("Inspect current object"),
             icon=ima.icon('MessageBoxInformation'),
-            shortcut=CONF.get_shortcut('editor', 'inspect current object'),
+            shortcut=self.get_shortcut('inspect current object'),
             triggered=self.sig_show_object_info)
 
         # Run actions
@@ -4575,20 +4576,20 @@ class CodeEditor(TextEditBaseWidget):
         writer = self.writer_docstring
         self.docstring_action = create_action(
             self, _("Generate docstring"),
-            shortcut=CONF.get_shortcut('editor', 'docstring'),
+            shortcut=self.get_shortcut('docstring'),
             triggered=writer.write_docstring_at_first_line_of_function)
 
         # Document formatting
-        formatter = CONF.get(
-            'completions',
+        formatter = self.get_conf(
             ('provider_configuration', 'lsp', 'values', 'formatting'),
-            ''
+            default='',
+            section='completions',
         )
         self.format_action = create_action(
             self,
             _('Format file or selection with {0}').format(
                 formatter.capitalize()),
-            shortcut=CONF.get_shortcut('editor', 'autoformatting'),
+            shortcut=self.get_shortcut('autoformatting'),
             triggered=self.format_document_or_range)
 
         self.format_action.setEnabled(False)
@@ -5435,10 +5436,10 @@ class CodeEditor(TextEditBaseWidget):
                                              nbformat is not None)
         self.gotodef_action.setVisible(self.go_to_definition_enabled)
 
-        formatter = CONF.get(
-            'completions',
+        formatter = self.get_conf(
             ('provider_configuration', 'lsp', 'values', 'formatting'),
-            ''
+            default='',
+            section='completions'
         )
         self.format_action.setText(_(
             'Format file or selection with {0}').format(

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -33,7 +33,7 @@ from qtpy.QtWidgets import (QAction, QApplication, QFileDialog, QHBoxLayout,
 from spyder.api.panel import Panel
 from spyder.config.base import _, running_under_pytest
 from spyder.config.gui import is_dark_interface
-from spyder.config.manager import CONF
+from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
                                  get_filter, is_kde_desktop, is_anaconda)
 from spyder.plugins.editor.utils.autosave import AutosaveForStack
@@ -68,8 +68,10 @@ from spyder.widgets.tabs import BaseTabs
 logger = logging.getLogger(__name__)
 
 
-class TabSwitcherWidget(QListWidget):
+class TabSwitcherWidget(QListWidget, SpyderConfigurationAccessor):
     """Show tabs in mru order and change between them."""
+
+    CONF_SECTION = "editor"
 
     def __init__(self, parent, stack_history, tabs):
         QListWidget.__init__(self, parent)
@@ -84,15 +86,22 @@ class TabSwitcherWidget(QListWidget):
 
         self.id_list = []
         self.load_data()
-        size = CONF.get('main', 'completion/size')
+        size = self.get_conf('completion/size', section='main')
         self.resize(*size)
         self.set_dialog_position()
         self.setCurrentRow(0)
 
-        CONF.config_shortcut(lambda: self.select_row(-1), context='Editor',
-                             name='Go to previous file', parent=self)
-        CONF.config_shortcut(lambda: self.select_row(1), context='Editor',
-                             name='Go to next file', parent=self)
+        self.config_shortcut(
+            lambda: self.select_row(-1),
+            context='Editor',
+            name='Go to previous file',
+            parent=self
+        )
+        self.config_shortcut(
+            lambda: self.select_row(1),
+            context='Editor',
+            name='Go to next file', parent=self
+        )
 
     def load_data(self):
         """Fill ListWidget with the tabs texts.
@@ -143,7 +152,7 @@ class TabSwitcherWidget(QListWidget):
         When ctrl is released and tab_switcher is visible, tab will be changed.
         """
         if self.isVisible():
-            qsc = CONF.get_shortcut(context='Editor', name='Go to next file')
+            qsc = self.get_shortcut(context='Editor', name='Go to next file')
 
             for key in qsc.split('+'):
                 key = key.lower()
@@ -169,7 +178,7 @@ class TabSwitcherWidget(QListWidget):
             self.close()
 
 
-class EditorStack(QWidget):
+class EditorStack(QWidget, SpyderConfigurationAccessor):
     reset_statusbar = Signal()
     readonly_changed = Signal(bool)
     encoding_changed = Signal(str)
@@ -332,7 +341,7 @@ class EditorStack(QWidget):
         external_fileexp_action = create_action(
             self, text,
             triggered=self.show_in_external_file_explorer,
-            shortcut=CONF.get_shortcut(context="Editor",
+            shortcut=self.get_shortcut(context="Editor",
                                        name="show in external file explorer"),
             context=Qt.WidgetShortcut)
 
@@ -452,175 +461,175 @@ class EditorStack(QWidget):
     def create_shortcuts(self):
         """Create local shortcuts"""
         # --- Configurable shortcuts
-        inspect = CONF.config_shortcut(
+        inspect = self.config_shortcut(
             self.inspect_current_object,
             context='Editor',
             name='Inspect current object',
             parent=self)
 
-        gotoline = CONF.config_shortcut(
+        gotoline = self.config_shortcut(
             self.go_to_line,
             context='Editor',
             name='Go to line',
             parent=self)
 
-        tab = CONF.config_shortcut(
+        tab = self.config_shortcut(
             lambda: self.tab_navigation_mru(forward=False),
             context='Editor',
             name='Go to previous file',
             parent=self)
 
-        tabshift = CONF.config_shortcut(
+        tabshift = self.config_shortcut(
             self.tab_navigation_mru,
             context='Editor',
             name='Go to next file',
             parent=self)
 
-        prevtab = CONF.config_shortcut(
+        prevtab = self.config_shortcut(
             lambda: self.tabs.tab_navigate(-1),
             context='Editor',
             name='Cycle to previous file',
             parent=self)
 
-        nexttab = CONF.config_shortcut(
+        nexttab = self.config_shortcut(
             lambda: self.tabs.tab_navigate(1),
             context='Editor',
             name='Cycle to next file',
             parent=self)
 
-        new_file = CONF.config_shortcut(
+        new_file = self.config_shortcut(
             self.sig_new_file[()],
             context='Editor',
             name='New file',
             parent=self)
 
-        open_file = CONF.config_shortcut(
+        open_file = self.config_shortcut(
             self.plugin_load[()],
             context='Editor',
             name='Open file',
             parent=self)
 
-        save_file = CONF.config_shortcut(
+        save_file = self.config_shortcut(
             self.save,
             context='Editor',
             name='Save file',
             parent=self)
 
-        save_all = CONF.config_shortcut(
+        save_all = self.config_shortcut(
             self.save_all,
             context='Editor',
             name='Save all',
             parent=self)
 
-        save_as = CONF.config_shortcut(
+        save_as = self.config_shortcut(
             self.sig_save_as,
             context='Editor',
             name='Save As',
             parent=self)
 
-        close_all = CONF.config_shortcut(
+        close_all = self.config_shortcut(
             self.close_all_files,
             context='Editor',
             name='Close all',
             parent=self)
 
-        prev_edit_pos = CONF.config_shortcut(
+        prev_edit_pos = self.config_shortcut(
             self.sig_prev_edit_pos,
             context="Editor",
             name="Last edit location",
             parent=self)
 
-        prev_cursor = CONF.config_shortcut(
+        prev_cursor = self.config_shortcut(
             self.sig_prev_cursor,
             context="Editor",
             name="Previous cursor position",
             parent=self)
 
-        next_cursor = CONF.config_shortcut(
+        next_cursor = self.config_shortcut(
             self.sig_next_cursor,
             context="Editor",
             name="Next cursor position",
             parent=self)
 
-        zoom_in_1 = CONF.config_shortcut(
+        zoom_in_1 = self.config_shortcut(
             self.zoom_in,
             context="Editor",
             name="zoom in 1",
             parent=self)
 
-        zoom_in_2 = CONF.config_shortcut(
+        zoom_in_2 = self.config_shortcut(
             self.zoom_in,
             context="Editor",
             name="zoom in 2",
             parent=self)
 
-        zoom_out = CONF.config_shortcut(
+        zoom_out = self.config_shortcut(
             self.zoom_out,
             context="Editor",
             name="zoom out",
             parent=self)
 
-        zoom_reset = CONF.config_shortcut(
+        zoom_reset = self.config_shortcut(
             self.zoom_reset,
             context="Editor",
             name="zoom reset",
             parent=self)
 
-        close_file_1 = CONF.config_shortcut(
+        close_file_1 = self.config_shortcut(
             self.close_file,
             context="Editor",
             name="close file 1",
             parent=self)
 
-        close_file_2 = CONF.config_shortcut(
+        close_file_2 = self.config_shortcut(
             self.close_file,
             context="Editor",
             name="close file 2",
             parent=self)
 
-        go_to_next_cell = CONF.config_shortcut(
+        go_to_next_cell = self.config_shortcut(
             self.advance_cell,
             context="Editor",
             name="go to next cell",
             parent=self)
 
-        go_to_previous_cell = CONF.config_shortcut(
+        go_to_previous_cell = self.config_shortcut(
             lambda: self.advance_cell(reverse=True),
             context="Editor",
             name="go to previous cell",
             parent=self)
 
-        prev_warning = CONF.config_shortcut(
+        prev_warning = self.config_shortcut(
             self.sig_prev_warning,
             context="Editor",
             name="Previous warning",
             parent=self)
 
-        next_warning = CONF.config_shortcut(
+        next_warning = self.config_shortcut(
             self.sig_next_warning,
             context="Editor",
             name="Next warning",
             parent=self)
 
-        split_vertically = CONF.config_shortcut(
+        split_vertically = self.config_shortcut(
             self.sig_split_vertically,
             context="Editor",
             name="split vertically",
             parent=self)
 
-        split_horizontally = CONF.config_shortcut(
+        split_horizontally = self.config_shortcut(
             self.sig_split_horizontally,
             context="Editor",
             name="split horizontally",
             parent=self)
 
-        close_split = CONF.config_shortcut(
+        close_split = self.config_shortcut(
             self.close_split,
             context="Editor",
             name="close split panel",
             parent=self)
 
-        external_fileexp = CONF.config_shortcut(
+        external_fileexp = self.config_shortcut(
             self.show_in_external_file_explorer,
             context="Editor",
             name="show in external file explorer",
@@ -922,7 +931,6 @@ class EditorStack(QWidget):
         return self.todolist_enabled
 
     def set_todolist_enabled(self, state, current_finfo=None):
-        # CONF.get(self.CONF_SECTION, 'todo_list')
         self.todolist_enabled = state
         if self.data:
             for finfo in self.data:
@@ -933,7 +941,6 @@ class EditorStack(QWidget):
                         finfo.run_todo_finder()
 
     def set_linenumbers_enabled(self, state, current_finfo=None):
-        # CONF.get(self.CONF_SECTION, 'line_numbers')
         self.linenumbers_enabled = state
         if self.data:
             for finfo in self.data:
@@ -952,14 +959,12 @@ class EditorStack(QWidget):
                 finfo.editor.set_scrollpastend_enabled(state)
 
     def set_edgeline_enabled(self, state):
-        # CONF.get(self.CONF_SECTION, 'edge_line')
         self.edgeline_enabled = state
         if self.data:
             for finfo in self.data:
                 finfo.editor.edge_line.set_enabled(state)
 
     def set_edgeline_columns(self, columns):
-        # CONF.get(self.CONF_SECTION, 'edge_line_column')
         self.edgeline_columns = columns
         if self.data:
             for finfo in self.data:
@@ -972,35 +977,30 @@ class EditorStack(QWidget):
                 finfo.editor.toggle_identation_guides(state)
 
     def set_close_parentheses_enabled(self, state):
-        # CONF.get(self.CONF_SECTION, 'close_parentheses')
         self.close_parentheses_enabled = state
         if self.data:
             for finfo in self.data:
                 finfo.editor.set_close_parentheses_enabled(state)
 
     def set_close_quotes_enabled(self, state):
-        # CONF.get(self.CONF_SECTION, 'close_quotes')
         self.close_quotes_enabled = state
         if self.data:
             for finfo in self.data:
                 finfo.editor.set_close_quotes_enabled(state)
 
     def set_add_colons_enabled(self, state):
-        # CONF.get(self.CONF_SECTION, 'add_colons')
         self.add_colons_enabled = state
         if self.data:
             for finfo in self.data:
                 finfo.editor.set_add_colons_enabled(state)
 
     def set_auto_unindent_enabled(self, state):
-        # CONF.get(self.CONF_SECTION, 'auto_unindent')
         self.auto_unindent_enabled = state
         if self.data:
             for finfo in self.data:
                 finfo.editor.set_auto_unindent_enabled(state)
 
     def set_indent_chars(self, indent_chars):
-        # CONF.get(self.CONF_SECTION, 'indent_chars')
         indent_chars = indent_chars[1:-1]  # removing the leading/ending '*'
         self.indent_chars = indent_chars
         if self.data:
@@ -1008,7 +1008,6 @@ class EditorStack(QWidget):
                 finfo.editor.set_indent_chars(indent_chars)
 
     def set_tab_stop_width_spaces(self, tab_stop_width_spaces):
-        # CONF.get(self.CONF_SECTION, 'tab_stop_width')
         self.tab_stop_width_spaces = tab_stop_width_spaces
         if self.data:
             for finfo in self.data:
@@ -1046,28 +1045,24 @@ class EditorStack(QWidget):
                     finfo.editor.mark_occurrences()
 
     def set_wrap_enabled(self, state):
-        # CONF.get(self.CONF_SECTION, 'wrap')
         self.wrap_enabled = state
         if self.data:
             for finfo in self.data:
                 finfo.editor.toggle_wrap_mode(state)
 
     def set_tabmode_enabled(self, state):
-        # CONF.get(self.CONF_SECTION, 'tab_always_indent')
         self.tabmode_enabled = state
         if self.data:
             for finfo in self.data:
                 finfo.editor.set_tab_mode(state)
 
     def set_stripmode_enabled(self, state):
-        # CONF.get(self.CONF_SECTION, 'strip_trailing_spaces_on_modify')
         self.stripmode_enabled = state
         if self.data:
             for finfo in self.data:
                 finfo.editor.set_strip_mode(state)
 
     def set_intelligent_backspace_enabled(self, state):
-        # CONF.get(self.CONF_SECTION, 'intelligent_backspace')
         self.intelligent_backspace_enabled = state
         if self.data:
             for finfo in self.data:
@@ -1122,14 +1117,12 @@ class EditorStack(QWidget):
                 finfo.editor.toggle_format_on_save(state)
 
     def set_occurrence_highlighting_enabled(self, state):
-        # CONF.get(self.CONF_SECTION, 'occurrence_highlighting')
         self.occurrence_highlighting_enabled = state
         if self.data:
             for finfo in self.data:
                 finfo.editor.set_occurrence_highlighting(state)
 
     def set_occurrence_highlighting_timeout(self, timeout):
-        # CONF.get(self.CONF_SECTION, 'occurrence_highlighting/timeout')
         self.occurrence_highlighting_timeout = timeout
         if self.data:
             for finfo in self.data:
@@ -1154,11 +1147,9 @@ class EditorStack(QWidget):
                 finfo.editor.set_highlight_current_cell(state)
 
     def set_checkeolchars_enabled(self, state):
-        # CONF.get(self.CONF_SECTION, 'check_eol_chars')
         self.checkeolchars_enabled = state
 
     def set_always_remove_trailing_spaces(self, state):
-        # CONF.get(self.CONF_SECTION, 'always_remove_trailing_spaces')
         self.always_remove_trailing_spaces = state
         if self.data:
             for finfo in self.data:
@@ -1178,12 +1169,10 @@ class EditorStack(QWidget):
 
     def set_convert_eol_on_save(self, state):
         """If `state` is `True`, saving files will convert line endings."""
-        # CONF.get(self.CONF_SECTION, 'convert_eol_on_save')
         self.convert_eol_on_save = state
 
     def set_convert_eol_on_save_to(self, state):
         """`state` can be one of ('LF', 'CRLF', 'CR')"""
-        # CONF.get(self.CONF_SECTION, 'convert_eol_on_save_to')
         self.convert_eol_on_save_to = state
 
     def set_current_project_path(self, root_path=None):
@@ -1388,7 +1377,7 @@ class EditorStack(QWidget):
             icon=ima.icon('versplit'),
             tip=_("Split vertically this editor window"),
             triggered=self.sig_split_vertically,
-            shortcut=CONF.get_shortcut(context='Editor',
+            shortcut=self.get_shortcut(context='Editor',
                                        name='split vertically'),
             context=Qt.WidgetShortcut)
 
@@ -1398,7 +1387,7 @@ class EditorStack(QWidget):
             icon=ima.icon('horsplit'),
             tip=_("Split horizontally this editor window"),
             triggered=self.sig_split_horizontally,
-            shortcut=CONF.get_shortcut(context='Editor',
+            shortcut=self.get_shortcut(context='Editor',
                                        name='split horizontally'),
             context=Qt.WidgetShortcut)
 
@@ -1407,7 +1396,7 @@ class EditorStack(QWidget):
             _("Close this panel"),
             icon=ima.icon('close_panel'),
             triggered=self.close_split,
-            shortcut=CONF.get_shortcut(context='Editor',
+            shortcut=self.get_shortcut(context='Editor',
                                        name='close split panel'),
             context=Qt.WidgetShortcut)
 
@@ -3407,7 +3396,7 @@ class EditorWidget(QSplitter):
             self.outlineexplorer.change_tree_visibility(True)
 
 
-class EditorMainWindow(QMainWindow):
+class EditorMainWindow(QMainWindow, SpyderConfigurationAccessor):
     sig_window_state_changed = Signal(object)
 
     def __init__(self, plugin, menu_actions, toolbar_list, menu_list,
@@ -3483,7 +3472,9 @@ class EditorMainWindow(QMainWindow):
 
     def load_toolbars(self):
         """Loads the last visible toolbars from the .ini file."""
-        toolbars_names = CONF.get('main', 'last_visible_toolbars', default=[])
+        toolbars_names = self.get_conf(
+            'last_visible_toolbars', section='main', default=[]
+        )
         if toolbars_names:
             dic = {}
             for toolbar in self.toolbars:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
<!--- Explain what you've done and why --->

Replace direct `CONF` usage in the Editor related widgets for methods inherited from the `SpyderConfiguratorAccessor` class

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
