### PR TITLE
PR: Don't treat warnings as errors when installing Spyder and subrepos (CI)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -51,7 +51,7 @@ else
 fi
 
 # Install subrepos from source
-python -bb -X dev -W error install_dev_repos.py --not-editable --no-install spyder
+python -bb -X dev install_dev_repos.py --not-editable --no-install spyder
 
 # Install boilerplate plugin
 pushd spyder/app/tests/spyder-boilerplate
@@ -59,8 +59,8 @@ pip install --no-deps -q -e .
 popd
 
 # Install Spyder to test it as if it was properly installed.
-python -bb -X dev -W error -m build
-python -bb -X dev -W error -m pip install --no-deps dist/spyder*.whl
+python -bb -X dev -m build
+python -bb -X dev -m pip install --no-deps dist/spyder*.whl
 
 # Adjust PATH on Windows so that we can use conda below. This needs to be done
 # at this point or the pip slots fail.


### PR DESCRIPTION
## Description of Changes

This was making our tests failed due to an internal warning issued by `pip`.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
