### PR TITLE
PR: Fix errors with OnlineHelp plugin regarding readonly properties and ModuleScanner errors

### DIFF
--- a/spyder/plugins/onlinehelp/pydoc_patch.py
+++ b/spyder/plugins/onlinehelp/pydoc_patch.py
@@ -719,7 +719,9 @@ def _url_handler(url, content_type="text/html"):
 
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore')  # ignore problems during import
-            ModuleScanner().run(callback, key)
+            def onerror(modname):
+                pass
+            ModuleScanner().run(callback, key, onerror=onerror)
 
         # format page
         def bltinlink(name):

--- a/spyder/plugins/onlinehelp/pydoc_patch.py
+++ b/spyder/plugins/onlinehelp/pydoc_patch.py
@@ -473,6 +473,8 @@ class CustomHTMLDoc(Doc):
                           lambda t: t[1] == 'class method')
             attrs = spill('Static methods %s' % tag, attrs,
                           lambda t: t[1] == 'static method')
+            attrs = spilldescriptors("Readonly properties %s" % tag, attrs,
+                                     lambda t: t[1] == 'readonly property')
             attrs = spilldescriptors('Data descriptors %s' % tag, attrs,
                                      lambda t: t[1] == 'data descriptor')
             attrs = spilldata('Data and other attributes %s' % tag, attrs,

--- a/spyder/plugins/onlinehelp/tests/test_pydocgui.py
+++ b/spyder/plugins/onlinehelp/tests/test_pydocgui.py
@@ -43,16 +43,9 @@ def pydocbrowser(qtbot):
 @pytest.mark.order(1)
 @pytest.mark.parametrize(
     "lib",
-    [('str', 'class str', [0, 1]), ('numpy.testing', 'numpy.testing', [5, 10])]
-)
-@pytest.mark.skipif(
-    (sys.platform == 'darwin' or
-     NumpyVersion(np.__version__) < NumpyVersion('1.21.0')),
-    reason="Fails on Mac and older versions of Numpy"
-)
-@pytest.mark.skipif(
-    sys.platform.startswith('linux') or os.name == 'nt' and running_in_ci(),
-    reason="Stalls CI frequenly on Linux and Windows"
+    [('str', 'class str', [1, 2]),
+     ('numpy.testing', 'numpy.testing', [5, 10]),
+     ('numpy.finfo', 'numpy.finfo', [1, 5])]
 )
 def test_get_pydoc(pydocbrowser, qtbot, lib):
     """


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes



<!--- Explain what you've done and why --->

* Added handling of attributes that are classified as "readonly property", consistent with mechanisms in `pydoc.HTMLDoc`. This was the cause for `numpy` and `pandas` errors.
* Added error handling for `ModuleScanner`, consistent with mechanisms existing in `pydoc._url_handler`. This was the cause for keyword search errors.
* Updated unit tests. I believe that the root cause that motivated the skip filters may be the same issues that are remedied here and therefore the filters can be discarded.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20866


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
