### PR TITLE
PR: Migrate the Spyder update mechanism to the conda-based standalone application

### DIFF
--- a/spyder/__init__.py
+++ b/spyder/__init__.py
@@ -29,7 +29,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 """
 
-version_info = (6, 0, 0, "dev0")
+version_info = (5, 4, 4, "dev0")
 
 __version__ = '.'.join(map(str, version_info))
 __installer_version__ = __version__

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -80,6 +80,7 @@ DEFAULTS = [
               'use_custom_cursor_blinking': False,
               'show_internal_errors': True,
               'check_updates_on_startup': True,
+              'check_stable_only': True,
               'cursor/width': 2,
               'completion/size': (300, 180),
               'report_error/remember_token': False,

--- a/spyder/plugins/application/confpage.py
+++ b/spyder/plugins/application/confpage.py
@@ -67,6 +67,8 @@ class ApplicationConfigPage(PluginConfigPage):
                                     "them to Github"), 'show_internal_errors')
         check_updates = newcb(_("Check for updates on startup"),
                               'check_updates_on_startup')
+        stable_only = newcb(_("Check for stable releases only"),
+                            'check_stable_only')
 
         # Decide if it's possible to activate or not single instance mode
         # ??? Should we allow multiple instances for macOS?
@@ -89,6 +91,7 @@ class ApplicationConfigPage(PluginConfigPage):
         advanced_layout.addWidget(prompt_box)
         advanced_layout.addWidget(popup_console_box)
         advanced_layout.addWidget(check_updates)
+        advanced_layout.addWidget(stable_only)
 
         advanced_widget = QWidget()
         advanced_widget.setLayout(advanced_layout)

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -13,7 +13,6 @@ Holds references for base actions in the Application of Spyder.
 # Standard library imports
 import logging
 import os
-import subprocess
 import sys
 import glob
 
@@ -239,9 +238,9 @@ class ApplicationContainer(PluginMainContainer):
             self.dependencies_thread.wait()
 
         # Run installer after Spyder is closed
-        cmd = ('start' if os.name == 'nt' else 'open')
         if self.installer_path:
-            subprocess.Popen(' '.join([cmd, self.installer_path]), shell=True)
+            self.application_update_status.installer.install(
+                self.installer_path)
 
     @Slot()
     def show_about(self):
@@ -268,6 +267,7 @@ class ApplicationContainer(PluginMainContainer):
         # Get results from worker
         update_available = self.worker_updates.update_available
         latest_release = self.worker_updates.latest_release
+        update_from_github = self.worker_updates.update_from_github
         error_msg = self.worker_updates.error
 
         url_i = 'https://docs.spyder-ide.org/current/installation.html'

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -11,6 +11,7 @@ Holds references for base actions in the Application of Spyder.
 """
 
 # Standard library imports
+import logging
 import os
 import subprocess
 import sys
@@ -39,6 +40,9 @@ from spyder.widgets.about import AboutDialog
 from spyder.widgets.dependencies import DependenciesDialog
 from spyder.widgets.helperwidgets import MessageCheckBox
 from spyder.workers.updates import WorkerUpdates
+
+# Logger setup
+logger = logging.getLogger(__name__)
 
 
 class ApplicationPluginMenus:
@@ -380,6 +384,7 @@ class ApplicationContainer(PluginMainContainer):
     @Slot()
     def check_updates(self, startup=False):
         """Check for spyder updates on github releases using a QThread."""
+        logger.debug(f"Checking for updates. startup = {startup}.")
         # Disable check_updates_action while the thread is working
         self.check_updates_action.setDisabled(True)
         if self.application_update_status:

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -305,6 +305,7 @@ class ApplicationContainer(PluginMainContainer):
             box.setText(error_msg)
             box.set_check_visible(False)
             box.exec_()
+            self.application_update_status.set_no_status()
         elif update_available:
             self.application_update_status.save_latest_release(
                 latest_release, update_from_github)

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -116,6 +116,8 @@ class ApplicationContainer(PluginMainContainer):
              .connect(self.check_updates))
             (self.application_update_status.sig_install_on_close_requested
                  .connect(self.set_install_on_close))
+            self.application_update_status.sig_quit_requested.connect(
+                self.sig_quit_requested)
             self.application_update_status.set_no_status()
         self.give_updates_feedback = False
         self.thread_updates = None

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -293,10 +293,10 @@ class ApplicationContainer(PluginMainContainer):
         # given. self.startup = False is used after startup when using the menu
         # action, and gives feeback if updates are, or are not found.
         if (
-            self.startup and                       # startup and...
-            ('dev' in self.worker_updates.version  # current version is dev
-             or error_msg is not None              # or there is an error
-             or not update_available)              # or no updates available
+            self.startup and           # startup and...
+            ('dev' in __version__      # current version is dev
+             or error_msg is not None  # or there is an error
+             or not update_available)  # or no updates available
         ):
             # Do not show QMessageBox
             pass

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -315,11 +315,7 @@ class ApplicationContainer(PluginMainContainer):
                 box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
                 box.setDefaultButton(QMessageBox.Yes)
 
-                msg = (
-                    header +
-                    _("Would you like to automatically download "
-                      "and install it?")
-                )
+                msg = header + _("Would you like to automatically download it?")
 
                 box.setText(msg)
                 box.exec_()

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -108,17 +108,14 @@ class ApplicationContainer(PluginMainContainer):
 
         # Attributes
         self.dialog_manager = DialogManager()
-        self.application_update_status = None
-        if is_conda_based_app():
-            self.application_update_status = ApplicationUpdateStatus(
-                parent=self)
-            (self.application_update_status.sig_check_for_updates_requested
+        self.application_update_status = ApplicationUpdateStatus(parent=self)
+        (self.application_update_status.sig_check_for_updates_requested
              .connect(self.check_updates))
-            (self.application_update_status.sig_install_on_close_requested
-                 .connect(self.set_install_on_close))
-            self.application_update_status.sig_quit_requested.connect(
-                self.sig_quit_requested)
-            self.application_update_status.set_no_status()
+        (self.application_update_status.sig_install_on_close_requested
+             .connect(self.set_install_on_close))
+        self.application_update_status.sig_quit_requested.connect(
+            self.sig_quit_requested)
+        self.application_update_status.set_no_status()
         self.give_updates_feedback = False
         self.thread_updates = None
         self.worker_updates = None
@@ -276,8 +273,7 @@ class ApplicationContainer(PluginMainContainer):
              or not update_available)             # or no updates available
         ):
             # Just set status and return
-            if self.application_update_status:
-                self.application_update_status.set_no_status()
+            self.application_update_status.set_no_status()
             self.check_updates_action.setDisabled(False)
             self.give_updates_feedback = True
             return
@@ -386,8 +382,7 @@ class ApplicationContainer(PluginMainContainer):
         else:
             box.setText(_("Spyder is up to date."))
             box.exec_()
-            if self.application_update_status:
-                self.application_update_status.set_no_status()
+            self.application_update_status.set_no_status()
 
         self.set_conf(option, box.is_checked())
 
@@ -400,8 +395,7 @@ class ApplicationContainer(PluginMainContainer):
         logger.debug(f"Checking for updates. startup = {startup}.")
         # Disable check_updates_action while the thread is working
         self.check_updates_action.setDisabled(True)
-        if self.application_update_status:
-            self.application_update_status.set_status_checking()
+        self.application_update_status.set_status_checking()
 
         if self.thread_updates is not None:
             self.thread_updates.quit()
@@ -412,9 +406,8 @@ class ApplicationContainer(PluginMainContainer):
         self.worker_updates.sig_ready.connect(self._check_updates_ready)
         self.worker_updates.sig_ready.connect(self.thread_updates.quit)
         self.worker_updates.moveToThread(self.thread_updates)
-        if self.application_update_status:
-            self.thread_updates.started.connect(
-                self.application_update_status.set_status_checking)
+        self.thread_updates.started.connect(
+            self.application_update_status.set_status_checking)
         self.thread_updates.started.connect(self.worker_updates.start)
 
         # Delay starting this check to avoid blocking the main window
@@ -424,10 +417,9 @@ class ApplicationContainer(PluginMainContainer):
             self.updates_timer = QTimer(self)
             self.updates_timer.setInterval(60000)
             self.updates_timer.setSingleShot(True)
-            if self.application_update_status:
-                self.application_update_status.blockSignals(True)
-                self.updates_timer.timeout.connect(
-                    lambda: self.application_update_status.blockSignals(False))
+            self.application_update_status.blockSignals(True)
+            self.updates_timer.timeout.connect(
+                lambda: self.application_update_status.blockSignals(False))
             self.updates_timer.timeout.connect(self.thread_updates.start)
             self.updates_timer.start()
         else:

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -238,7 +238,7 @@ class ApplicationContainer(PluginMainContainer):
 
         # Run installer after Spyder is closed
         if self.install_on_close:
-            self.application_update_status.install()
+            self.application_update_status.start_installation()
 
     @Slot()
     def show_about(self):

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -318,8 +318,10 @@ class ApplicationContainer(PluginMainContainer):
             self.thread_updates.quit()
             self.thread_updates.wait()
 
+        stable_only = self.get_conf('check_stable_only')
+
         self.thread_updates = QThread(None)
-        self.worker_updates = WorkerUpdates(self)
+        self.worker_updates = WorkerUpdates(self, stable_only)
         self.worker_updates.sig_ready.connect(self._check_updates_ready)
         self.worker_updates.sig_ready.connect(self.thread_updates.quit)
         self.worker_updates.sig_ready.connect(
@@ -334,7 +336,7 @@ class ApplicationContainer(PluginMainContainer):
         # Fixes spyder-ide/spyder#15839
         if self.startup:
             self.updates_timer = QTimer(self)
-            self.updates_timer.setInterval(60000)
+            self.updates_timer.setInterval(10000)
             self.updates_timer.setSingleShot(True)
             self.application_update_status.blockSignals(True)
             self.updates_timer.timeout.connect(

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -338,7 +338,7 @@ class ApplicationContainer(PluginMainContainer):
             if box.result() == QMessageBox.Yes:
                 if update_from_github:
                     # Start download
-                    self.application_update_status.start_installation()
+                    self.application_update_status.start_download()
                 else:
                     # Confirm installation
                     self.application_update_status.confirm_installation()

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -17,7 +17,6 @@ import sys
 import glob
 
 # Third party imports
-from packaging.version import parse
 from qtpy.QtCore import Qt, QThread, QTimer, Signal, Slot
 from qtpy.QtGui import QGuiApplication
 from qtpy.QtWidgets import QAction, QMessageBox, QPushButton
@@ -294,46 +293,36 @@ class ApplicationContainer(PluginMainContainer):
             box.exec_()
         elif update_available:
             # Update using our installers
-            if parse(latest_release) >= parse("6.0.0"):
-                box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
-                box.setDefaultButton(QMessageBox.Yes)
+            box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+            box.setDefaultButton(QMessageBox.Yes)
 
-                if not is_conda_based_app():
-                    installers_url = url_i + "#standalone-installers"
-                    msg = (
-                        header +
-                        _("Would you like to automatically download and "
-                          "install it using Spyder's installer?"
-                          "<br><br>"
-                          "We <a href='{}'>recommend our own installer</a> "
-                          "because it's more stable and makes updating easy. "
-                          "This will leave your existing Spyder installation "
-                          "untouched.").format(installers_url)
-                    )
-                else:
-                    msg = (
-                        header +
-                        _("Would you like to automatically download "
-                          "and install it?")
-                    )
+            if not is_conda_based_app():
+                installers_url = url_i + "#standalone-installers"
+                msg = (
+                    header +
+                    _("Would you like to automatically download and "
+                      "install it using Spyder's installer?"
+                      "<br><br>"
+                      "We <a href='{}'>recommend our own installer</a> "
+                      "because it's more stable and makes updating easy. "
+                      "This will leave your existing Spyder installation "
+                      "untouched.").format(installers_url)
+                )
+            else:
+                msg = (
+                    header +
+                    _("Would you like to automatically download "
+                      "and install it?")
+                )
 
-                box.setText(msg)
-                box.exec_()
-                if box.result() == QMessageBox.Yes:
-                    self.application_update_status.start_installation(
-                        latest_release=latest_release)
+            box.setText(msg)
+            box.exec_()
+            if box.result() == QMessageBox.Yes:
+                self.application_update_status.start_installation(
+                    latest_release=latest_release)
 
             # Manual update
-            if (
-                not box.result()  # The installer dialog was skipped
-                or (
-                    box.result() == QMessageBox.No
-                    and not is_conda_based_app()
-                )
-            ):
-                # Update-at-startup checkbox visible only if manual update
-                # is first message box
-                box.set_check_visible(not box.result())
+            if box.result() == QMessageBox.No and not is_conda_based_app():
                 box.setStandardButtons(QMessageBox.Ok)
                 box.setDefaultButton(QMessageBox.Ok)
 
@@ -370,6 +359,7 @@ class ApplicationContainer(PluginMainContainer):
 
                 box.setText(msg)
                 box.exec_()
+
         elif feedback:
             box.setText(_("Spyder is up to date."))
             box.exec_()

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -392,11 +392,6 @@ class ApplicationContainer(PluginMainContainer):
         """Check for spyder updates on github releases using a QThread."""
         # Disable check_updates_action while the thread is working
         self.check_updates_action.setDisabled(True)
-        # !!! >>> Disable signals until alpha1
-        if is_conda_based_app():
-            self.application_update_status.blockSignals(True)
-            return
-        # !!! <<< Disable signals until alpha1
         if self.application_update_status:
             self.application_update_status.set_status_checking()
 

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -101,19 +101,17 @@ class Application(SpyderPluginV2):
 
     @on_plugin_available(plugin=Plugins.StatusBar)
     def on_statusbar_available(self):
-        # Add status widget if created
-        if self.application_update_status:
-            statusbar = self.get_plugin(Plugins.StatusBar)
-            statusbar.add_status_widget(self.application_update_status)
+        # Add status widget
+        statusbar = self.get_plugin(Plugins.StatusBar)
+        statusbar.add_status_widget(self.application_update_status)
 
     # -------------------------- PLUGIN TEARDOWN ------------------------------
 
     @on_plugin_teardown(plugin=Plugins.StatusBar)
     def on_statusbar_teardown(self):
         # Remove status widget if created
-        if self.application_update_status:
-            statusbar = self.get_plugin(Plugins.StatusBar)
-            statusbar.remove_status_widget(self.application_update_status.ID)
+        statusbar = self.get_plugin(Plugins.StatusBar)
+        statusbar.remove_status_widget(self.application_update_status.ID)
 
     @on_plugin_teardown(plugin=Plugins.Preferences)
     def on_preferences_teardown(self):

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -149,8 +149,8 @@ class Application(SpyderPluginV2):
 
         # Check for updates
         if DEV is None and self.get_conf('check_updates_on_startup'):
-            container.give_updates_feedback = False
-            container.check_updates(startup=True)
+            container.startup = True
+            container.check_updates()
 
         # Handle DPI scale and window changes to show a restart message.
         # Don't activate this functionality on macOS because it's being

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -138,7 +138,8 @@ class Application(SpyderPluginV2):
         self.report_action.setVisible(False)
 
     def on_close(self, _unused=True):
-        self.get_container().on_close()
+        # The container is closed directly in the plugin registry
+        pass
 
     def on_mainwindow_visible(self):
         """Actions after the mainwindow in visible."""

--- a/spyder/plugins/application/scripts/install.bat
+++ b/spyder/plugins/application/scripts/install.bat
@@ -1,0 +1,88 @@
+:: This script updates or installs a new version of Spyder
+@echo off
+
+:: Create variables from arguments
+:parse
+IF "%~1"=="" GOTO endparse
+IF "%~1"=="-p" set prefix=%2 & SHIFT
+IF "%~1"=="-i" set install_exe=%2 & SHIFT
+IF "%~1"=="-c" set conda=%2 & SHIFT
+IF "%~1"=="-v" set spy_ver=%2 & SHIFT
+SHIFT
+GOTO parse
+:endparse
+
+:: Enforce encoding
+chcp 65001>nul
+
+IF not "%conda%"=="" IF not "%spy_ver%"=="" (
+    call :update_subroutine
+    call :launch_spyder
+    goto exit
+)
+
+IF not "%install_exe%"=="" (
+    call :install_subroutine
+    goto exit
+)
+
+:exit
+exit %ERRORLEVEL%
+
+:install_subroutine
+    echo Installing Spyder from: %install_exe%
+
+    call :wait_for_spyder_quit
+
+    :: Uninstall Spyder
+    for %%I in ("%prefix%\..\..") do set "conda_root=%%~fI"
+
+    echo Install will proceed after the current Spyder version is uninstalled.
+    start %conda_root%\Uninstall-Spyder.exe
+
+    :: Must wait for uninstaller to appear on tasklist
+    :wait_for_uninstall_start
+    tasklist /fi "ImageName eq Un_A.exe" /fo csv 2>NUL | find /i "Un_A.exe">NUL
+    IF "%ERRORLEVEL%"=="1" (
+        timeout /t 1 /nobreak > nul
+        goto wait_for_uninstall_start
+    )
+    echo Uninstall in progress...
+
+    :wait_for_uninstall
+    timeout /t 1 /nobreak > nul
+    tasklist /fi "ImageName eq Un_A.exe" /fo csv 2>NUL | find /i "Un_A.exe">NUL
+    IF "%ERRORLEVEL%"=="0" goto wait_for_uninstall
+    echo Uninstall complete.
+
+    start %install_exe%
+    goto :EOF
+
+:update_subroutine
+    echo Updating Spyder
+
+    call :wait_for_spyder_quit
+
+    %conda% install -p %prefix% -y spyder=%spy_ver%
+    set /P CONT=Press any key to exit...
+    goto :EOF
+
+:wait_for_spyder_quit
+    echo Waiting for Spyder to quit...
+    :loop
+    tasklist /fi "ImageName eq spyder.exe" /fo csv 2>NUL | find /i "spyder.exe">NUL
+    IF "%ERRORLEVEL%"=="0" (
+        timeout /t 1 /nobreak > nul
+        goto loop
+    )
+    echo Spyder is quit.
+    goto :EOF
+
+:launch_spyder
+    echo %prefix% | findstr /b "%USERPROFILE%" > nul && (
+        set shortcut_root=%APPDATA%
+    ) || (
+        set shortcut_root=%ALLUSERSPROFILE%
+    )
+    start "" /B "%shortcut_root%\Microsoft\Windows\Start Menu\Programs\spyder\Spyder.lnk"
+    goto :EOF

--- a/spyder/plugins/application/scripts/install.bat
+++ b/spyder/plugins/application/scripts/install.bat
@@ -63,7 +63,7 @@ exit %ERRORLEVEL%
 
     call :wait_for_spyder_quit
 
-    %conda% install -p %prefix% -y spyder=%spy_ver%
+    %conda% install -p %prefix% -c conda-forge --override-channels -y spyder=%spy_ver%
     set /P CONT=Press any key to exit...
     goto :EOF
 

--- a/spyder/plugins/application/scripts/install.bat
+++ b/spyder/plugins/application/scripts/install.bat
@@ -63,7 +63,7 @@ exit %ERRORLEVEL%
 
     call :wait_for_spyder_quit
 
-    %conda% install -p %prefix% -c conda-forge --override-channels -y spyder=%spy_ver%
+    %conda% install -p %prefix% -c conda-forge --override-channels spyder=%spy_ver%
     set /P CONT=Press any key to exit...
     goto :EOF
 

--- a/spyder/plugins/application/scripts/install.sh
+++ b/spyder/plugins/application/scripts/install.sh
@@ -13,7 +13,7 @@ done
 shift $(($OPTIND - 1))
 
 update_spyder(){
-    $conda install -p $prefix -c conda-forge --override-channels -y spyder=$spy_ver
+    $conda install -p $prefix -c conda-forge --override-channels spyder=$spy_ver
     read -p "Press any key to exit..."
 }
 
@@ -33,7 +33,7 @@ install_spyder(){
     uninstall_script="$prefix/../../uninstall-spyder.sh"
     if [[ -f "$uninstall_script" ]]; then
         echo "Uninstalling Spyder..."
-        $uninstall_script
+        $uninstall_script || true
     fi
 
     # Run installer

--- a/spyder/plugins/application/scripts/install.sh
+++ b/spyder/plugins/application/scripts/install.sh
@@ -13,7 +13,7 @@ done
 shift $(($OPTIND - 1))
 
 update_spyder(){
-    $conda install -p $prefix -y spyder=$spy_ver
+    $conda install -p $prefix -c conda-forge --override-channels -y spyder=$spy_ver
     read -p "Press any key to exit..."
 }
 

--- a/spyder/plugins/application/scripts/install.sh
+++ b/spyder/plugins/application/scripts/install.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -i
+set -e
+unset HISTFILE  # Do not write to history with interactive shell
+
+while getopts "i:c:p:v:" option; do
+    case "$option" in
+        (i) install_exe=$OPTARG ;;
+        (c) conda=$OPTARG ;;
+        (p) prefix=$OPTARG ;;
+        (v) spy_ver=$OPTARG ;;
+    esac
+done
+shift $(($OPTIND - 1))
+
+update_spyder(){
+    $conda install -p $prefix -y spyder=$spy_ver
+    read -p "Press any key to exit..."
+}
+
+launch_spyder(){
+    if [[ "$OSTYPE" = "darwin"* ]]; then
+        shortcut=/Applications/Spyder.app
+        [[ "$prefix" = "$HOME"* ]] && open -a $HOME$shortcut || open -a $shortcut
+    elif [[ -n "$(which gtk-launch)" ]]; then
+        gtk-launch spyder_spyder
+    else
+        nohup $prefix/bin/spyder &>/dev/null &
+    fi
+}
+
+install_spyder(){
+    # First uninstall Spyder
+    uninstall_script="$prefix/../../uninstall-spyder.sh"
+    if [[ -f "$uninstall_script" ]]; then
+        echo "Uninstalling Spyder..."
+        $uninstall_script
+    fi
+
+    # Run installer
+    [[ "$OSTYPE" = "darwin"* ]] && open $install_exe || sh $install_exe
+}
+
+while [[ $(pgrep spyder 2> /dev/null) ]]; do
+    echo "Waiting for Spyder to quit..."
+    sleep 1
+done
+
+echo "Spyder quit."
+
+if [[ -e "$conda" && -d "$prefix" && -n "$spy_ver" ]]; then
+    update_spyder
+    launch_spyder
+elif [[ -e "$install_exe" ]]; then
+    install_spyder
+fi
+
+if [[ "$OSTYPE" = "darwin"* ]]; then
+    # Close the Terminal window that was opened for this process
+    osascript -e 'tell application "Terminal" to close first window' &
+fi

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -226,7 +226,7 @@ class UpdateInstallerDialog(QDialog):
         """Cancel the installation in progress."""
         reply = QMessageBox.critical(
             self._parent, 'Spyder',
-            _('Do you really want to cancel the Spyder update installation?'),
+            _('Do you really want to cancel the download?'),
             QMessageBox.Yes, QMessageBox.No)
         if reply == QMessageBox.Yes:
             self.cancelled = True

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -266,9 +266,8 @@ class UpdateInstallerDialog(QDialog):
         )
         msg_box.setWindowTitle(_("Spyder update"))
         msg_box.setAttribute(Qt.WA_ShowWithoutActivating)
-        if os.name == 'nt' and is_conda_based_app():
-            # Only add yes button for Windows installer
-            # since it has the logic to restart Spyder
+        if is_conda_based_app():
+            # Only add yes button for conda-based installers
             yes_button = msg_box.addButton(QMessageBox.Yes)
         else:
             yes_button = None

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -50,7 +50,7 @@ INSTALL_INFO_MESSAGES = {
 }
 
 
-class UpdateInstallation(QWidget):
+class UpdateDownload(QWidget):
     """Update progress installation widget."""
 
     def __init__(self, parent):
@@ -159,22 +159,22 @@ class UpdateInstallerDialog(QDialog):
         super().__init__(parent)
         self.setWindowFlags(Qt.Dialog | Qt.MSWindowsFixedSizeDialogHint)
         self._parent = parent
-        self._installation_widget = UpdateInstallation(self)
+        self._download_widget = UpdateDownload(self)
 
         # Layout
         installer_layout = QVBoxLayout()
-        installer_layout.addWidget(self._installation_widget)
+        installer_layout.addWidget(self._download_widget)
         self.setLayout(installer_layout)
 
         # Signals
         self.sig_download_progress.connect(
-            self._installation_widget.update_installation_progress)
+            self._download_widget.update_installation_progress)
         self.sig_installation_status.connect(
-            self._installation_widget.update_installation_status)
+            self._download_widget.update_installation_status)
 
-        self._installation_widget.ok_button.clicked.connect(
+        self._download_widget.ok_button.clicked.connect(
             self.close_installer)
-        self._installation_widget.cancel_button.clicked.connect(
+        self._download_widget.cancel_button.clicked.connect(
             self.cancel_download)
 
         # Show installation widget
@@ -182,15 +182,14 @@ class UpdateInstallerDialog(QDialog):
 
     def reject(self):
         """Reimplemented Qt method."""
-        on_installation_widget = self._installation_widget.isVisible()
-        if on_installation_widget:
+        if self._download_widget.isVisible():
             self.close_installer()
         else:
             super().reject()
 
     def setup(self):
         """Setup visibility of widgets."""
-        self._installation_widget.setVisible(True)
+        self._download_widget.setVisible(True)
         self.adjustSize()
 
     def save_latest_release(self, latest_release, update_from_github):

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -260,15 +260,6 @@ class UpdateInstallerDialog(QDialog):
         if self.cancelled:
             return
 
-        self.installer_path = None
-        # Get data from WorkerDownload
-        if self.download_worker:
-            if self.download_worker.error:
-                # If download error, do not proceed with install
-                self._change_update_download_status(NO_STATUS)
-                return
-            self.installer_path = self.download_worker.installer_path
-
         msg_box = QMessageBox(
             icon=QMessageBox.Question,
             text=_("Would you like to proceed with the installation?<br><br>"),
@@ -276,6 +267,20 @@ class UpdateInstallerDialog(QDialog):
         )
         msg_box.setWindowTitle(_("Spyder update"))
         msg_box.setAttribute(Qt.WA_ShowWithoutActivating)
+
+        self.installer_path = None
+        # Get data from WorkerDownload
+        if self.download_worker:
+            if self.download_worker.error:
+                # If download error, do not proceed with install
+                msg_box.setIcon(QMessageBox.Warning)
+                msg_box.setText(self.download_worker.error)
+                msg_box.addButton(QMessageBox.Ok)
+                msg_box.exec_()
+                self._change_update_download_status(status=PENDING)
+                return
+            self.installer_path = self.download_worker.installer_path
+
         if is_conda_based_app():
             # Only add yes button for conda-based installers
             yes_button = msg_box.addButton(QMessageBox.Yes)

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -257,6 +257,9 @@ class UpdateInstallerDialog(QDialog):
         self.installer_path = None
         # Get data from WorkerDownload
         if self.download_worker:
+            if self.download_worker.error:
+                # If download error, do not proceed with install
+                return
             self.installer_path = self.download_worker.installer_path
 
         msg_box = QMessageBox(

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -199,13 +199,13 @@ class UpdateInstallerDialog(QDialog):
     def start_download(self):
         """Start downloading the update and set downloading status."""
         self.cancelled = False
-        self._change_update_installation_status(
+        self._change_update_download_status(
             status=DOWNLOADING_INSTALLER)
         self.download_thread = QThread(None)
         self.download_worker = WorkerDownloadInstaller(
             self, self.latest_release)
         self.download_worker.sig_ready.connect(
-            lambda: self._change_update_installation_status(DOWNLOAD_FINISHED))
+            lambda: self._change_update_download_status(DOWNLOAD_FINISHED))
         self.download_worker.sig_ready.connect(self.confirm_installation)
         self.download_worker.sig_ready.connect(self.download_thread.quit)
         self.download_worker.sig_download_progress.connect(
@@ -245,7 +245,7 @@ class UpdateInstallerDialog(QDialog):
         if reply.result() == QMessageBox.Yes:
             self.start_download()
         else:
-            self._change_update_installation_status(status=PENDING)
+            self._change_update_download_status(status=PENDING)
 
     def confirm_installation(self):
         """
@@ -259,7 +259,7 @@ class UpdateInstallerDialog(QDialog):
         if self.download_worker:
             if self.download_worker.error:
                 # If download error, do not proceed with install
-                self._change_update_installation_status(NO_STATUS)
+                self._change_update_download_status(NO_STATUS)
                 return
             self.installer_path = self.download_worker.installer_path
 
@@ -281,14 +281,14 @@ class UpdateInstallerDialog(QDialog):
         msg_box.exec_()
 
         if msg_box.clickedButton() == yes_button:
-            self._change_update_installation_status(status=INSTALLING)
+            self._change_update_download_status(status=INSTALLING)
             self.start_installation()
-            self._change_update_installation_status(status=PENDING)
+            self._change_update_download_status(status=PENDING)
         elif msg_box.clickedButton() == after_closing_button:
             self.sig_install_on_close_requested.emit(True)
-            self._change_update_installation_status(status=PENDING)
+            self._change_update_download_status(status=PENDING)
         else:
-            self._change_update_installation_status(status=PENDING)
+            self._change_update_download_status(status=PENDING)
 
     def start_installation(self):
         """Install from downloaded installer or update through conda."""
@@ -332,7 +332,7 @@ class UpdateInstallerDialog(QDialog):
         else:
             self.hide()
 
-    def _change_update_installation_status(self, status=NO_STATUS):
+    def _change_update_download_status(self, status=NO_STATUS):
         """Set the installation status."""
         logger.debug(f"Installation status: {status}")
         self.status = status
@@ -344,8 +344,8 @@ class UpdateInstallerDialog(QDialog):
             self.status, self.latest_release)
 
     def _cancel_download(self):
-        self._change_update_installation_status(status=CANCELLED)
+        self._change_update_download_status(status=CANCELLED)
         self.download_worker.cancelled = True
         self.download_thread.quit()
         self.download_thread.wait()
-        self._change_update_installation_status(status=PENDING)
+        self._change_update_download_status(status=PENDING)

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -271,23 +271,27 @@ class UpdateInstallerDialog(QDialog):
 
         if msg_box.clickedButton() == yes_button:
             self._change_update_installation_status(status=INSTALLING)
-            if os.name == 'nt':
-                cmd = 'start'
-            elif sys.platform == 'darwin':
-                cmd = 'open'
-            else:
-                cmd = 'gnome-terminal -- sh'
-            if self.installer_path:
-                subprocess.Popen(
-                    ' '.join([cmd, self.installer_path]),
-                    shell=True
-                )
+            self.install(installer_path)
             self._change_update_installation_status(status=PENDING)
         elif msg_box.clickedButton() == after_closing_button:
             self.sig_install_on_close_requested.emit(self.installer_path)
             self._change_update_installation_status(status=PENDING)
         else:
             self._change_update_installation_status(status=PENDING)
+
+    def install(self, installer_path):
+        """Install from downloaded installer."""
+        if os.name == 'nt':
+            cmd = 'start'
+        elif sys.platform == 'darwin':
+            cmd = 'open'
+        else:
+            cmd = 'gnome-terminal --window -- sh'
+        if os.path.exists(installer_path):
+            subprocess.Popen(
+                ' '.join([cmd, installer_path]),
+                shell=True
+            )
 
     def finish_installation(self):
         """Handle finished installation."""

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -283,7 +283,7 @@ class UpdateInstallerDialog(QDialog):
 
         if msg_box.clickedButton() == yes_button:
             self._change_update_installation_status(status=INSTALLING)
-            self.install()
+            self.start_installation()
             self._change_update_installation_status(status=PENDING)
         elif msg_box.clickedButton() == after_closing_button:
             self.sig_install_on_close_requested.emit(True)
@@ -291,7 +291,7 @@ class UpdateInstallerDialog(QDialog):
         else:
             self._change_update_installation_status(status=PENDING)
 
-    def install(self):
+    def start_installation(self):
         """Install from downloaded installer or update through conda."""
         if (
             self.update_from_github

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -175,7 +175,7 @@ class UpdateInstallerDialog(QDialog):
         self._installation_widget.ok_button.clicked.connect(
             self.close_installer)
         self._installation_widget.cancel_button.clicked.connect(
-            self.cancel_installation)
+            self.cancel_download)
 
         # Show installation widget
         self.setup()
@@ -215,7 +215,7 @@ class UpdateInstallerDialog(QDialog):
         self.download_thread.started.connect(self.download_worker.start)
         self.download_thread.start()
 
-    def cancel_installation(self):
+    def cancel_download(self):
         """Cancel the installation in progress."""
         reply = QMessageBox.critical(
             self._parent, 'Spyder',

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -96,9 +96,10 @@ class UpdateInstallation(QWidget):
 
     def update_installation_status(self, status, latest_version):
         """Update installation status (downloading, installing, finished)."""
-        self._progress_label.setText(status)
-        self.install_info.setText(INSTALL_INFO_MESSAGES[status].format(
-            version=latest_version))
+        if status in INSTALL_INFO_MESSAGES:
+            self._progress_label.setText(status)
+            self.install_info.setText(INSTALL_INFO_MESSAGES[status].format(
+                version=latest_version))
         if status == INSTALLING:
             self._progress_bar.setRange(0, 0)
             self.cancel_button.setEnabled(False)
@@ -259,6 +260,7 @@ class UpdateInstallerDialog(QDialog):
         if self.download_worker:
             if self.download_worker.error:
                 # If download error, do not proceed with install
+                self._change_update_installation_status(NO_STATUS)
                 return
             self.installer_path = self.download_worker.installer_path
 

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -197,7 +197,7 @@ class UpdateInstallerDialog(QDialog):
         self.latest_release = latest_release
         self.update_from_github = update_from_github
 
-    def start_installation(self):
+    def start_download(self):
         """Start downloading the update and set downloading status."""
         self.cancelled = False
         self._change_update_installation_status(
@@ -244,7 +244,7 @@ class UpdateInstallerDialog(QDialog):
         reply.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
         reply.exec_()
         if reply.result() == QMessageBox.Yes:
-            self.start_installation()
+            self.start_download()
         else:
             self._change_update_installation_status(status=PENDING)
 

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -161,7 +161,6 @@ class UpdateInstallerDialog(QDialog):
         self.download_thread = None
         self.download_worker = None
         self.latest_release = None
-        self.update_from_github = None
         self.installer_path = None
 
         super().__init__(parent)
@@ -200,9 +199,14 @@ class UpdateInstallerDialog(QDialog):
         self._download_widget.setVisible(True)
         self.adjustSize()
 
-    def save_latest_release(self, latest_release, update_from_github):
+    def start_update(self, latest_release, download=False):
         self.latest_release = latest_release
-        self.update_from_github = update_from_github
+        if download:
+            # Start download
+            self.start_download()
+        else:
+            # Confirm installation
+            self.confirm_installation()
 
     def start_download(self):
         """Start downloading the update and set downloading status."""
@@ -320,17 +324,10 @@ class UpdateInstallerDialog(QDialog):
 
         # Sub command
         sub_cmd = [script, '-p', sys.prefix]
-        if (
-            self.update_from_github
-            and self.installer_path is not None
-            and os.path.exists(self.installer_path)
-        ):
+        if self.installer_path and os.path.exists(self.installer_path):
             # Run downloaded installer
             sub_cmd.extend(['-i', self.installer_path])
-        elif (
-            not self.update_from_github
-            and self.latest_release is not None
-        ):
+        elif self.latest_release is not None:
             # Update with conda
             sub_cmd.extend(['-c', find_conda(), '-v', self.latest_release])
 

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -147,6 +147,11 @@ class UpdateInstallerDialog(QDialog):
         Whether to install on close.
     """
 
+    sig_quit_requested = Signal()
+    """
+    This signal can be emitted to request the main application to quit.
+    """
+
     def __init__(self, parent):
         self.cancelled = False
         self.status = NO_STATUS
@@ -281,9 +286,8 @@ class UpdateInstallerDialog(QDialog):
         msg_box.exec_()
 
         if msg_box.clickedButton() == yes_button:
-            self._change_update_download_status(status=INSTALLING)
-            self.start_installation()
-            self._change_update_download_status(status=PENDING)
+            self.sig_install_on_close_requested.emit(True)
+            self.sig_quit_requested.emit()
         elif msg_box.clickedButton() == after_closing_button:
             self.sig_install_on_close_requested.emit(True)
             self._change_update_download_status(status=PENDING)

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -50,6 +50,8 @@ INSTALL_INFO_MESSAGES = {
     CANCELLED: _("Spyder update cancelled")
 }
 
+header = _("<b>Spyder {} is available!</b> "
+           "<i>(you&nbsp;have&nbsp;{})</i><br><br>")
 
 class UpdateDownload(QWidget):
     """Update progress installation widget."""
@@ -239,11 +241,15 @@ class UpdateInstallerDialog(QDialog):
 
         Download the installer if needed or prompt to install.
         """
-        reply = QMessageBox(icon=QMessageBox.Question,
-                            text=_("Would you like to update Spyder to "
-                                   "the latest version?"
-                                   "<br><br>"),
-                            parent=self._parent)
+        msg = (
+            header.format(self.latest_release, __version__) +
+            _("Would you like to update Spyder to the latest version?<br><br>")
+        )
+        reply = QMessageBox(
+            icon=QMessageBox.Question,
+            text=msg,
+            parent=self._parent
+        )
         reply.setWindowTitle("Spyder")
         reply.setAttribute(Qt.WA_ShowWithoutActivating)
         reply.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
@@ -260,9 +266,14 @@ class UpdateInstallerDialog(QDialog):
         if self.cancelled:
             return
 
+        msg = (
+            header.format(self.latest_release, __version__) +
+            _("Would you like to proceed with the installation?<br><br>")
+        )
+
         msg_box = QMessageBox(
             icon=QMessageBox.Question,
-            text=_("Would you like to proceed with the installation?<br><br>"),
+            text=msg,
             parent=self._parent
         )
         msg_box.setWindowTitle(_("Spyder update"))

--- a/spyder/plugins/application/widgets/install.py
+++ b/spyder/plugins/application/widgets/install.py
@@ -9,6 +9,7 @@
 # Standard library imports
 import logging
 import os
+import sys
 import subprocess
 
 # Third-party imports
@@ -270,7 +271,12 @@ class UpdateInstallerDialog(QDialog):
 
         if msg_box.clickedButton() == yes_button:
             self._change_update_installation_status(status=INSTALLING)
-            cmd = ('start' if os.name == 'nt' else 'open')
+            if os.name == 'nt':
+                cmd = 'start'
+            elif sys.platform == 'darwin':
+                cmd = 'open'
+            else:
+                cmd = 'gnome-terminal -- sh'
             if self.installer_path:
                 subprocess.Popen(
                     ' '.join([cmd, self.installer_path]),

--- a/spyder/plugins/application/widgets/status.py
+++ b/spyder/plugins/application/widgets/status.py
@@ -144,7 +144,7 @@ class ApplicationUpdateStatus(StatusBarWidget):
             percentage_progress = round((current_value/total) * 100)
         self.custom_widget.setText(f"{percentage_progress}%")
 
-    def set_status_pending(self, latest_release):
+    def set_status_pending(self):
         self.set_value(PENDING)
 
     def set_status_checking(self):

--- a/spyder/plugins/application/widgets/status.py
+++ b/spyder/plugins/application/widgets/status.py
@@ -51,6 +51,11 @@ class ApplicationUpdateStatus(StatusBarWidget):
         Whether to install on close.
     """
 
+    sig_quit_requested = Signal()
+    """
+    This signal can be emitted to request the main application to quit.
+    """
+
     CUSTOM_WIDGET_CLASS = QLabel
 
     def __init__(self, parent):
@@ -78,6 +83,7 @@ class ApplicationUpdateStatus(StatusBarWidget):
             self.set_value)
         self.installer.sig_install_on_close_requested.connect(
             self.sig_install_on_close_requested)
+        self.installer.sig_quit_requested.connect(self.sig_quit_requested)
 
     def set_value(self, value):
         """Return update installation state."""

--- a/spyder/plugins/application/widgets/status.py
+++ b/spyder/plugins/application/widgets/status.py
@@ -168,7 +168,10 @@ class ApplicationUpdateStatus(StatusBarWidget):
         ):
             self.installer.show()
         elif value == PENDING and is_conda_based_app():
-            self.installer.continue_installation()
+            if self.installer.update_from_github:
+                self.installer.continue_installation()
+            else:
+                self.installer.confirm_installation()
         elif value == NO_STATUS:
             self.menu.clear()
             check_for_updates_action = create_action(

--- a/spyder/plugins/application/widgets/status.py
+++ b/spyder/plugins/application/widgets/status.py
@@ -123,8 +123,8 @@ class ApplicationUpdateStatus(StatusBarWidget):
     def save_latest_release(self, latest_release, update_from_github):
         self.installer.save_latest_release(latest_release, update_from_github)
 
-    def start_installation(self):
-        self.installer.start_installation()
+    def start_download(self):
+        self.installer.start_download()
 
     def confirm_installation(self):
         self.installer.confirm_installation()

--- a/spyder/plugins/application/widgets/status.py
+++ b/spyder/plugins/application/widgets/status.py
@@ -141,7 +141,7 @@ class ApplicationUpdateStatus(StatusBarWidget):
     def set_download_progress(self, current_value, total):
         percentage_progress = 0
         if total > 0:
-            percentage_progress = round((current_value/total) * 100)
+            percentage_progress = round((current_value / total) * 100)
         self.custom_widget.setText(f"{percentage_progress}%")
 
     def set_status_pending(self):

--- a/spyder/plugins/application/widgets/status.py
+++ b/spyder/plugins/application/widgets/status.py
@@ -41,14 +41,14 @@ class ApplicationUpdateStatus(StatusBarWidget):
     Signal to request checking for updates.
     """
 
-    sig_install_on_close_requested = Signal(str)
+    sig_install_on_close_requested = Signal(bool)
     """
     Signal to request running the downloaded installer on close.
 
     Parameters
     ----------
-    installer_path: str
-        Path to instal
+    install_on_close: bool
+        Whether to install on close.
     """
 
     CUSTOM_WIDGET_CLASS = QLabel
@@ -120,8 +120,17 @@ class ApplicationUpdateStatus(StatusBarWidget):
     def get_icon(self):
         return ima.icon('spyder_about')
 
-    def start_installation(self, latest_release):
-        self.installer.start_installation(latest_release)
+    def save_latest_release(self, latest_release, update_from_github):
+        self.installer.save_latest_release(latest_release, update_from_github)
+
+    def start_installation(self):
+        self.installer.start_installation()
+
+    def confirm_installation(self):
+        self.installer.confirm_installation()
+
+    def install(self):
+        self.installer.install()
 
     def set_download_progress(self, current_value, total):
         percentage_progress = 0
@@ -131,7 +140,6 @@ class ApplicationUpdateStatus(StatusBarWidget):
 
     def set_status_pending(self, latest_release):
         self.set_value(PENDING)
-        self.installer.save_latest_release(latest_release)
 
     def set_status_checking(self):
         self.set_value(CHECKING)

--- a/spyder/plugins/application/widgets/status.py
+++ b/spyder/plugins/application/widgets/status.py
@@ -129,8 +129,8 @@ class ApplicationUpdateStatus(StatusBarWidget):
     def confirm_installation(self):
         self.installer.confirm_installation()
 
-    def install(self):
-        self.installer.install()
+    def start_installation(self):
+        self.installer.start_installation()
 
     def set_download_progress(self, current_value, total):
         percentage_progress = 0

--- a/spyder/plugins/application/widgets/status.py
+++ b/spyder/plugins/application/widgets/status.py
@@ -129,6 +129,14 @@ class ApplicationUpdateStatus(StatusBarWidget):
     def save_latest_release(self, latest_release, update_from_github):
         self.installer.save_latest_release(latest_release, update_from_github)
 
+    def start_update(self):
+        if self.installer.update_from_github:
+            # Start download
+            self.installer.start_download()
+        else:
+            # Confirm installation
+            self.installer.confirm_installation()
+
     def start_download(self):
         self.installer.start_download()
 

--- a/spyder/plugins/application/widgets/status.py
+++ b/spyder/plugins/application/widgets/status.py
@@ -126,16 +126,8 @@ class ApplicationUpdateStatus(StatusBarWidget):
     def get_icon(self):
         return ima.icon('spyder_about')
 
-    def save_latest_release(self, latest_release, update_from_github):
-        self.installer.save_latest_release(latest_release, update_from_github)
-
-    def start_update(self):
-        if self.installer.update_from_github:
-            # Start download
-            self.installer.start_download()
-        else:
-            # Confirm installation
-            self.installer.confirm_installation()
+    def start_update(self, *args, **kwargs):
+        self.installer.start_update(*args, **kwargs)
 
     def start_download(self):
         self.installer.start_download()

--- a/spyder/utils/conda.py
+++ b/spyder/utils/conda.py
@@ -35,7 +35,8 @@ def is_conda_env(prefix=None, pyexec=None):
         raise ValueError('Only `prefix` or `pyexec` should be provided!')
 
     if pyexec and prefix is None:
-        prefix = get_conda_env_path(pyexec).replace('\\', '/')
+        real_pyexec = osp.realpath(pyexec)  # May be symlink
+        prefix = get_conda_env_path(real_pyexec).replace('\\', '/')
 
     return os.path.exists(os.path.join(prefix, 'conda-meta'))
 

--- a/spyder/workers/tests/test_update.py
+++ b/spyder/workers/tests/test_update.py
@@ -10,49 +10,46 @@ from spyder.config.utils import is_anaconda
 from spyder.workers.updates import WorkerUpdates
 
 
-def test_update(qtbot):
+@pytest.fixture
+def worker():
+    return WorkerUpdates(None)
+
+
+def test_update(qtbot, worker):
     """Test we offer updates for lower versions."""
-    worker = WorkerUpdates(None, False, version="1.0.0")
+    worker.version = "1.0.0"
     worker.start()
     assert worker.update_available
 
 
-def test_no_update(qtbot):
+def test_no_update(qtbot, worker):
     """Test we don't offer updates for very high versions."""
-    worker = WorkerUpdates(None, False, version="1000.0.0")
+    worker.version = "1000.0.0"
     worker.start()
     assert not worker.update_available
 
 
-def test_no_update_development(qtbot):
-    """Test we don't offer updates for development versions."""
-    worker = WorkerUpdates(None, False, version="3.3.2.dev0",
-                           releases=['3.3.1'])
-    worker.start()
-    assert not worker.update_available
-
-
-def test_update_pre_to_pre(qtbot):
+def test_update_pre_to_pre(qtbot, worker):
     """Test we offer updates between prereleases."""
-    worker = WorkerUpdates(None, False, version="4.0.0a1",
-                           releases=['4.0.0b5'])
+    worker.version = "4.0.0a1"
+    worker.releases = ['4.0.0b5']
     worker.start()
     assert worker.update_available
 
 
-def test_update_pre_to_final(qtbot):
+def test_update_pre_to_final(qtbot, worker):
     """Test we offer updates from prereleases to the final versions."""
-    worker = WorkerUpdates(None, False, version="4.0.0b3",
-                           releases=['4.0.0'])
+    worker.version = "4.0.0b3"
+    worker.releases = ['4.0.0']
     worker.start()
     assert worker.update_available
 
 
 @pytest.mark.skipif(not is_anaconda(),
                     reason='It only makes sense for Anaconda.')
-def test_releases_anaconda(qtbot):
+def test_releases_anaconda(qtbot, worker):
     """Test we don't include spyder-kernels releases in detected releases."""
-    worker = WorkerUpdates(None, False, version="3.3.1")
+    worker.version = "3.3.1"
     worker.start()
     assert '0.2.4' not in worker.releases
 

--- a/spyder/workers/tests/test_update.py
+++ b/spyder/workers/tests/test_update.py
@@ -12,7 +12,7 @@ from spyder.workers.updates import WorkerUpdates
 
 @pytest.fixture
 def worker():
-    return WorkerUpdates(None)
+    return WorkerUpdates(None, stable_only=False)
 
 
 def test_update(qtbot, worker):

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -75,6 +75,7 @@ class WorkerUpdates(QObject):
         if is_stable_version(self.version):
             # If current version is stable, only use stable releases
             releases = [r for r in releases if is_stable_version(r)]
+        logger.debug(f"Available versions: {releases}")
 
         # If releases is empty, default to current version
         self.latest_release = releases[-1] if releases else self.version

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -21,7 +21,6 @@ from urllib.error import URLError, HTTPError
 # Third party imports
 from packaging.version import parse
 from qtpy.QtCore import QObject, Signal
-from qtpy.QtWidgets import QMessageBox
 
 # Local imports
 from spyder import __version__
@@ -259,16 +258,6 @@ class WorkerDownloadInstaller(QObject):
             logger.debug(exc, stack_info=True)
             error_msg = _('Unable to download the installer.')
         self.error = error_msg
-
-        if error_msg:
-            msg_box = QMessageBox(
-                icon=QMessageBox.Warning,
-                text=error_msg,
-                parent=self._parent
-            )
-            msg_box.setWindowTitle(_("Spyder update"))
-            msg_box.addButton(QMessageBox.Ok)
-            msg_box.exec_()
 
         try:
             self.sig_ready.emit()

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -11,6 +11,7 @@ import os
 import os.path as osp
 import platform
 import re
+import shutil
 import ssl
 import sys
 import tempfile
@@ -223,8 +224,7 @@ class WorkerDownloadInstaller(QObject):
         os.makedirs(installer_dir_path, exist_ok=True)
         for file in os.listdir(dir_path):
             if file not in [__version__, self.latest_release_version]:
-                remove = osp.join(dir_path, file)
-                os.remove(remove)
+                shutil.rmtree(osp.join(dir_path, file))
 
         installer_path = osp.join(installer_dir_path, fname)
         self.installer_path = installer_path

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -172,15 +172,8 @@ class WorkerDownloadInstaller(QObject):
     and Linux without blocking the Spyder user interface.
     """
 
-    sig_ready = Signal(str)
-    """
-    Signal to inform that the worker has finished successfully.
-
-    Parameters
-    ----------
-    installer_path: str
-        Path where the downloaded installer is located.
-    """
+    sig_ready = Signal()
+    """Signal to inform that the worker has finished successfully."""
 
     sig_download_progress = Signal(int, int)
     """
@@ -265,6 +258,6 @@ class WorkerDownloadInstaller(QObject):
             error_msg = _('Unable to download the installer.')
         self.error = error_msg
         try:
-            self.sig_ready.emit(self.installer_path)
+            self.sig_ready.emit()
         except RuntimeError:
             pass

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -52,11 +52,10 @@ class WorkerUpdates(QObject):
     """
     sig_ready = Signal()
 
-    def __init__(self, parent, startup, version=""):
+    def __init__(self, parent, version=""):
         QObject.__init__(self)
         self._parent = parent
         self.error = None
-        self.startup = startup
         self.releases = []
 
         if not version:
@@ -70,7 +69,6 @@ class WorkerUpdates(QObject):
 
     def check_update_available(self):
         """Checks if there is an update available from releases."""
-        # Don't perform any check for development versions
         logger.debug("Checking releases for available updates.")
 
         # Filter releases
@@ -87,8 +85,6 @@ class WorkerUpdates(QObject):
 
         self.update_available = check_version(self.version,
                                               self.latest_release, '<')
-        if 'dev' in self.version:
-            self.update_available = False
 
         logger.debug(f"Update available: {self.update_available}")
         logger.debug(f"Latest release: {self.latest_release}")
@@ -163,11 +159,10 @@ class WorkerUpdates(QObject):
         if self.error:
             logger.info(self.error)
 
-        if not self.startup or self.error is None:
-            try:
-                self.sig_ready.emit()
-            except RuntimeError:
-                pass
+        try:
+            self.sig_ready.emit()
+        except RuntimeError:
+            pass
 
 
 class WorkerDownloadInstaller(QObject):

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -213,7 +213,7 @@ class WorkerDownloadInstaller(QObject):
             plat, ext = 'macOS', 'pkg'
         if sys.platform.startswith('linux'):
             plat, ext = 'Linux', 'sh'
-        mach = platform.machine()
+        mach = platform.machine().lower().replace("amd64", "x86_64")
         fname = f'Spyder-{self.latest_release_version}-{plat}-{mach}.{ext}'
 
         url = ('https://github.com/spyder-ide/spyder/releases/latest/'

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -69,6 +69,8 @@ class WorkerUpdates(QObject):
         """Checks if there is an update available from releases."""
         logger.debug("Checking releases for available updates.")
 
+        self.update_available = False
+
         # Filter releases
         releases = self.releases
         if is_stable_version(self.version):
@@ -86,6 +88,9 @@ class WorkerUpdates(QObject):
         logger.debug(f"Latest release: {self.latest_release}")
 
     def get_releases(self):
+        releases = []
+        self.error = None
+
         if self.update_from_github:
             # Get releases from GitHub
             url = 'https://api.github.com/repos/spyder-ide/spyder/releases'
@@ -124,17 +129,15 @@ class WorkerUpdates(QObject):
                                for item in data)
             else:
                 releases = set(v['version'] for v in data['spyder'])
-            self.releases = sorted(releases)
         except Exception:
             self.error = _('Unable to retrieve Spyder version information.')
+        finally:
+            # Always reset self.releases
+            self.releases = sorted(releases)
 
     def start(self):
         """Main method of the WorkerUpdates worker"""
         logger.debug("Starting WorkerUpdates.")
-
-        self.update_available = False
-        self.latest_release = self.version
-        self.error = None
 
         try:
             # First check major version update for conda-based app

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -18,13 +18,11 @@ from urllib.request import urlopen, urlretrieve
 from urllib.error import URLError, HTTPError
 
 # Third party imports
-from packaging.version import parse
 from qtpy.QtCore import QObject, Signal
 
 # Local imports
 from spyder import __version__
-from spyder.config.base import (_, is_stable_version, is_conda_based_app,
-                                running_under_pytest)
+from spyder.config.base import _, is_stable_version, running_under_pytest
 from spyder.py3compat import is_text_string
 from spyder.utils.conda import is_conda_env
 from spyder.utils.programs import check_version
@@ -63,7 +61,6 @@ class WorkerUpdates(QObject):
 
         self.update_available = None
         self.latest_release = None
-        self.update_from_github = True
 
     def check_update_available(self):
         """Checks if there is an update available from releases."""
@@ -131,23 +128,10 @@ class WorkerUpdates(QObject):
         """Main method of the WorkerUpdates worker"""
         logger.debug("Starting WorkerUpdates.")
 
-        # First check major version update for conda-based app
-        self.update_from_github = True
         self.get_releases()
         self.check_update_available()
-        current_major = parse(self.version).major
-        latest_major = parse(self.latest_release).major
-        download = is_conda_based_app() and current_major < latest_major
-        if self.update_available and not download:
-            # Check for available update from conda
-            self.update_from_github = False
-            self.get_releases()
-            self.check_update_available()
 
-        try:
-            self.sig_ready.emit()
-        except RuntimeError:
-            pass
+        self.sig_ready.emit()
 
 
 class WorkerDownloadInstaller(QObject):

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -52,12 +52,13 @@ class WorkerUpdates(QObject):
     """
     sig_ready = Signal()
 
-    def __init__(self, parent):
+    def __init__(self, parent, stable_only):
         QObject.__init__(self)
         self._parent = parent
         self.error = None
         self.releases = []
         self.version = __version__
+        self.stable_only = stable_only
 
         self.update_available = None
         self.latest_release = None
@@ -70,8 +71,8 @@ class WorkerUpdates(QObject):
 
         # Filter releases
         releases = self.releases
-        if is_stable_version(self.version):
-            # If current version is stable, only use stable releases
+        if self.stable_only:
+            # Only use stable releases
             releases = [r for r in releases if is_stable_version(r)]
         logger.debug(f"Available versions: {releases}")
 
@@ -88,7 +89,7 @@ class WorkerUpdates(QObject):
         releases = []
         self.error = None
 
-        if is_conda_env(pyexec=sys.executable):
+        if False:  # is_conda_env(pyexec=sys.executable):
             # Any conda env, including conda-based installer, use conda-forge
             url = 'https://conda.anaconda.org/conda-forge/channeldata.json'
         else:

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -21,6 +21,7 @@ from urllib.error import URLError, HTTPError
 # Third party imports
 from packaging.version import parse
 from qtpy.QtCore import QObject, Signal
+from qtpy.QtWidgets import QMessageBox
 
 # Local imports
 from spyder import __version__
@@ -254,6 +255,17 @@ class WorkerDownloadInstaller(QObject):
         except Exception:
             error_msg = _('Unable to download the installer.')
         self.error = error_msg
+
+        if error_msg:
+            msg_box = QMessageBox(
+                icon=QMessageBox.Warning,
+                text=error_msg,
+                parent=self._parent
+            )
+            msg_box.setWindowTitle(_("Spyder update"))
+            msg_box.addButton(QMessageBox.Ok)
+            msg_box.exec_()
+
         try:
             self.sig_ready.emit()
         except RuntimeError:

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -148,16 +148,16 @@ class WorkerUpdates(QObject):
                 self.update_from_github = False
                 self.get_releases()
                 self.check_update_available()
-        except HTTPError:
+        except HTTPError as exc:
+            logger.debug(exc, stack_info=True)
             self.error = _('Unable to retrieve information.')
-        except URLError:
+        except URLError as exc:
+            logger.debug(exc, stack_info=True)
             self.error = _('Unable to connect to the internet. <br><br>Make '
                            'sure the connection is working properly.')
-        except Exception:
+        except Exception as exc:
+            logger.debug(exc, stack_info=True)
             self.error = _('Unable to check for updates.')
-
-        if self.error:
-            logger.info(self.error)
 
         try:
             self.sig_ready.emit()
@@ -247,12 +247,15 @@ class WorkerDownloadInstaller(QObject):
             if self.installer_path:
                 os.remove(self.installer_path)
             return
-        except HTTPError:
+        except HTTPError as exc:
+            logger.debug(exc, stack_info=True)
             error_msg = _('Unable to retrieve installer information.')
-        except URLError:
+        except URLError as exc:
+            logger.debug(exc, stack_info=True)
             error_msg = _('Unable to connect to the internet. <br><br>'
                           'Make sure the connection is working properly.')
-        except Exception:
+        except Exception as exc:
+            logger.debug(exc, stack_info=True)
             error_msg = _('Unable to download the installer.')
         self.error = error_msg
 

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -66,6 +66,7 @@ class WorkerUpdates(QObject):
         Example: ['2.3.2', '2.3.3' ...] or with github ['2.3.4', '2.3.3' ...]
         """
         # Don't perform any check for development versions
+        logger.debug("Checking releases for available updates.")
         if 'dev' in self.version:
             return (False, self.latest_release)
 
@@ -77,9 +78,12 @@ class WorkerUpdates(QObject):
                         if not is_stable_version(r) or r in self.version]
 
         latest_release = releases[-1]
+        update_available = check_version(self.version, latest_release, '<')
 
-        return (check_version(self.version, latest_release, '<'),
-                latest_release)
+        logger.debug(f"Update available: {update_available}")
+        logger.debug(f"Latest release: {latest_release}")
+
+        return update_available, latest_release
 
     def start(self):
         """Main method of the WorkerUpdates worker"""
@@ -99,6 +103,7 @@ class WorkerUpdates(QObject):
 
         error_msg = None
 
+        logger.debug(f"Starting WorkerUpdates. Getting releases from {self.url}.")
         try:
             if hasattr(ssl, '_create_unverified_context'):
                 # Fix for spyder-ide/spyder#2685.
@@ -233,6 +238,7 @@ class WorkerDownloadInstaller(QObject):
 
     def start(self):
         """Main method of the WorkerDownloadInstaller worker."""
+        logger.debug("Starting WorkerDownloadInstaller.")
         error_msg = None
         try:
             self._download_installer()

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -216,8 +216,8 @@ class WorkerDownloadInstaller(QObject):
         mach = platform.machine().lower().replace("amd64", "x86_64")
         fname = f'Spyder-{self.latest_release_version}-{plat}-{mach}.{ext}'
 
-        url = ('https://github.com/spyder-ide/spyder/releases/latest/'
-               f'download/{fname}')
+        url = ('https://github.com/spyder-ide/spyder/releases/download/'
+               f'v{self.latest_release_version}/{fname}')
         dir_path = osp.join(tmpdir, 'spyder', 'updates')
         os.makedirs(dir_path, exist_ok=True)
         installer_dir_path = osp.join(

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -72,12 +72,15 @@ class WorkerUpdates(QObject):
 
         # Filter releases
         if is_stable_version(self.version):
+            # If current version is stable, only use stable releases
             releases = [r for r in self.releases if is_stable_version(r)]
         else:
+            # If current version is not stable, only use non-stable releases
             releases = [r for r in self.releases
                         if not is_stable_version(r) or r in self.version]
 
-        latest_release = releases[-1]
+        # If releases is empty, default to current version
+        latest_release = releases[-1] if releases else self.version
         update_available = check_version(self.version, latest_release, '<')
 
         logger.debug(f"Update available: {update_available}")

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -235,7 +235,7 @@ class WorkerDownloadInstaller(QObject):
             urlretrieve(
                 url, installer_path, reporthook=self._progress_reporter)
         else:
-            self._progress_reporter(1, 1)
+            self._progress_reporter(1, 1, 1)
 
     def start(self):
         """Main method of the WorkerDownloadInstaller worker."""

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -69,13 +69,10 @@ class WorkerUpdates(QObject):
         logger.debug("Checking releases for available updates.")
 
         # Filter releases
+        releases = self.releases
         if is_stable_version(self.version):
             # If current version is stable, only use stable releases
-            releases = [r for r in self.releases if is_stable_version(r)]
-        else:
-            # If current version is not stable, only use non-stable releases
-            releases = [r for r in self.releases
-                        if not is_stable_version(r) or r in self.version]
+            releases = [r for r in releases if is_stable_version(r)]
 
         # If releases is empty, default to current version
         self.latest_release = releases[-1] if releases else self.version


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* All conda installations (Anaconda, conda-forge, our conda-based installers) will use conda-forge to check for available updates. Any other installations will use PyPi to check for updates.
  The reasons for this are as follows. Users of our conda-based installers, conda-forge installs, and PyPi installs will only be alerted to updates when its actually available to be installed. This may not be the case if checking against GitHub. Anaconda main channel installs will almost certainly be notified before the version is actually available on this channel, however, our install instructions should allow them safely install from the conda-forge channel without breaking their environment. Since anaconda main updates have extremely long lead times, users likely will not be alerted to our new conda-based installer until 6.1.0 is released. I think there is a large advantage to alerting these users sooner and makes this is an acceptable tradeoff.
* For current versions that are not conda-base installs, or there is a major version update for a conda-based install, the user is prompted to download and install the update.
* For all release types, upon commencing install Spyder will quit and the installation/update process will proceed.
* If the update downloaded a conda-based installer, an interactive GUI uninstaller will launch (Windows) or an interactive uninstaller is executed at a shell terminal (macOS, Linux). For all platforms, the interactive GUI installer is launched upon successful completion of the uninstall process.
* If the update did not require downloading a conda-based installer, a shell terminal will inform the user that Spyder is being updated via conda, and conda's standard output is displayed.
* In all scenarios, Spyder will start/restart upon successful install/update.
* For current versions that are not conda-based installs, only downloading the conda-based installer will result in installing an update. If the user rejects this option, the user is only instructed how to perform the update, _but no automatica update will be peformed_.
* A new preference is added to Application->Advanced settings that permits the user to consider unstable releases when checking for updates. The default is to consider only stable releases.

## Questions

<details>
* Is it possible to use Spyder's restart mechanism for installations?
  * I suspect that it is not possible.
  * For the downloaded installer, an entirely new environment will be created and the restart subprocess will attempt to execute code that no longer exists (if uninstalled), or not execute the code from the new environment.
  * For the downloaded installer, an attempt to uninstall the existing environment may fail because the restart subprocess may have a lock on files in that environment.
  * For conda updates, an attempt to overwrite code in the existing environment may fail because the restart subprocess may have a lock on files in the environment.
* Should Spyder quit before any new update proceeds (and possibly restart afterward)?
  * I think this is the safest thing to do for the same reasons mentioned in the previous question.
* Do we want interactive installers to automatically open Spyder upon successful completion? Or provide the option to open Spyder upon successful completion? Or not open Spyder at all?
* Do we want Spyder's update dialog to provide the user with the option to restart Spyder after updating?
  * close now and update
  * close now and update and restart
  * close later and update
  * close later and update and restart
  * Any other possibilities?
* When the user proceeds to update from Spyder's dialog, do we want to run the downloaded installers in batch mode (non-interactive)?
</details>

## Proposed path forward

<details>
* When the user proceeds with the install, the user will have the option to install on close (same as currently implemented).
* If proceeding with the install immediately, emit sig_install_on_close_requested and automatically close Spyder. I.e. Spyder will always close before updating; the user just determines when this will occur.
* The install procedure (interactive installer or conda update) will occur in a subshell and so should not block any file operations in the environment.
* If the install procedure runs the downloaded installer, then the install script will first uninstall an existing conda-based installation before launching the interactive downloaded installer.
* The downloaded interactive installer will automatically start Spyder upon successful installation. This is accomplished via a post-install script and is _not_ presented as an option, e.g. "Do you want to start Spyder?".
* If the install procedure is a conda update, then part of the subshell command will start Spyder after the conda update successfully completes.

Note that the downloaded installer will always be run interactively. The primary reason for this is that the user will be able to see the progress of the install. If the macOS installer is run in batch mode, then the only way to view the progress (several minutes!) will be to have the installer batch script launched in a terminal and tail stream the `install.log` file (similar to our GitHub workflow). I don't know if this is possible on Windows. In either case, the interactive installer will be more aesthetically pleasing to the user rather than a mysterious terminal window popping up and spitting out a bunch of seemingly random garbage. Unfortunately, this is unavoidable for the case where we update through conda.
</details>

## Interactive Testing

1. Install latest 6.0.0a2: Uninstall or rename your existing Spyder installation. If you already have a conda-based installation, you won't be able to install over it; it must be uninstalled first. For installations other than conda-based, the conda-based installer may not over-write an existing application shortcut, so the shortcut will need to be renamed or deleted. Then download and install 6.0.0a2.
1. Update conda-based installation.
   1. Checkout the [`mrclary:issue-20831-cbi-updater`](https://github.com/mrclary/spyder/tree/issue-20831-cbi-updater) branch in your local Spyder repository.
   1. Modify the following files in your Spyder repository:
      - `spyder/__init__.py`. Change the version on line 32 to `(5, 4, 4, "dev0")`.
      - `spyder/plugins/application/container.py`. Change the delay interval on line 339 from `60000` ms to `10000` ms. This is not strictly necessary, but it is easier to test when only waiting 10s instead of 60s to trigger the updater at Spyder startup.
      - `spyder/plugins/application/scripts/install.[sh|bat]`. Remove `-y` from the conda install command on line 16 (`.sh`) and line 66 (`.bat`) to allow you to cancel a conda update without clobbering your existing install.
      - `spyder/plugins/application/scripts/install.sh`. Add ` || true` to the end of line 36 to allow you to cancel an uninstall without aborting the call to the installer.
      - `spyder/workers/updates.py`. Change line 92 to read
        ```
        if False:  # is_conda_env(pyexec=sys.executable):
        ```
        This will ensure that PyPi is used to check for updates. This is only needed for testing in order to see both stable and unstable releases (conda-forge doesn't list 6.0.0a2).
   1. Run the following command in a terminal/cmd window to update the conda-based Spyder.
      ```
      conda run --live-stream -p path/to/spyder-6/envs/spyder-runtime python path/to/spyder/install_dev_repos.py --not-editable
      ```
      Be sure to substitute the correct paths to your conda-based installation and your local Spyder git repo, respectively.
1. Start or restart Spyder.
1. The updater should run at Spyder launch.
   1. Testing for a minor update, Spyder will be updated in-place using `conda` mechanisms. 
      - You should be alerted that Spyder 5.4.5 is available and whether you want to proceed to install it. Click "Yes".
      - Spyder will quit.
      - A terminal/cmd window appears and displays the progress of the conda update. After the environment solve, do _not_ confirm the changes: type "n" and hit return. You do not want to proceed with the conda update.
      - After the terminal/cmd window closes, Spyder will launch.
   1. Testing for a major update, a conda-based installer will be downloaded and launched.
      - You should be alerted to Spyder 5.4.5 being available and whether you want to proceed to install it. Click "No".
      - Open *Preferences->Application->Advanced settings* and uncheck "Check for stable releases only".
      - Click "Check for updates..." in the Help menu.
      - You should be alerted that version Spyder 6.0.0a2 is available and whether you want to download and install it. Click "Yes". This will initiate downloading the conda-based installer.
      - After the download is complete, a message box will appear asking if you want to proceed with the installation. Click "Yes".
      - Spyder will quit.
      - Spyder's uninstall script will launch interactively in a terminal asking if you wish to uninstall Spyder (macOS or Linux), or a Windows Uninstaller will launch (Windows). Cancel the uninstall operation.
      - After the uninstall terminal/window is closed, the installer should launch. Cancel the installer.

## GIFs

<details>
For the following demonstrations, I modify Spyder's `__init__.py` to spoof the version in order to trigger updates.

* Setting the version to non-stable and prior to 6.0.0a1 will trigger a major version upgrade (download installer). For the purposes of the demonstration, I disable exiting on error in order to cancel the uninstaller and still show the installer. I also cancel the installer. Upon successful install Spyder will start.
* Setting the version to stable and prior to 5.4.3 will trigger a minor version upgrade (conda install). For the purposes of the demonstration, I removed the `--yes` flag in order to be able to cancel the conda install (this is destructive). Spyder starts up after the install is complete.

### Windows GIF
![updater-win](https://github.com/spyder-ide/spyder/assets/9618975/5b63454c-7714-4bde-9a6e-4ffae2540a0b)

### Linux GIF
![Peek 2023-06-27 14-26](https://github.com/spyder-ide/spyder/assets/9618975/bacec54c-a1e1-4feb-b4e0-f8fab10375d9)

### macOS GIF
![updater-mac](https://github.com/spyder-ide/spyder/assets/9618975/41ff74ae-07db-4481-a500-e1f864b4aad0)
</details>
