### PR TITLE
PR: Reverse paint order of scrollflags (Editor)

### DIFF
--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -215,7 +215,7 @@ class ScrollFlagArea(Panel):
         }
         dict_flag_lists.update(self._dict_flag_list)
 
-        for flag_type in dict_flag_lists:
+        for flag_type in reversed(dict_flag_lists):
             painter.setBrush(self._facecolors[flag_type])
             painter.setPen(self._edgecolors[flag_type])
             if editor.verticalScrollBar().maximum() == 0:


### PR DESCRIPTION
Draw occurrences and found results after errors and warnings to make them more visible when working with a file that has many errors

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Remember that an image/animation is worth a thousand words! --->

<!--- Explain what you've done and why --->
Working with files that have many current errors or warnings makes it impossible to see the occurrences or found results flags in the scrollflag pane of the editor. Maybe others have a different opinion of this, but I think the occurrence flag should be higher viewing priority. Reversing the paint order is very simple and achieves my desired result:




![Untitled](https://github.com/spyder-ide/spyder/assets/25141140/96b76c44-9b37-4396-a989-dadb2beb6782)




### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: athompson673

<!--- Thanks for your help making Spyder better for everyone! --->
