### PR TITLE
PR: Catch `PermissionsError` when trying to get applications executables (Files)

### DIFF
--- a/spyder/plugins/explorer/widgets/fileassociations.py
+++ b/spyder/plugins/explorer/widgets/fileassociations.py
@@ -147,7 +147,10 @@ class ApplicationsDialog(QDialog):
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
         self.list.clear()
         if applications is None:
-            apps = get_installed_applications()
+            try:
+                apps = get_installed_applications()
+            except PermissionError:
+                apps = []
         else:
             apps = applications
 

--- a/spyder/plugins/explorer/widgets/fileassociations.py
+++ b/spyder/plugins/explorer/widgets/fileassociations.py
@@ -147,6 +147,9 @@ class ApplicationsDialog(QDialog):
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
         self.list.clear()
         if applications is None:
+            # This is necessary to avoid an error on Windows for non-admin
+            # accounts.
+            # Fixes spyder-ide/spyder#20907
             try:
                 apps = get_installed_applications()
             except PermissionError:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

When running from a non-admin account on Windows the applications executables discovery can fail with a `PermissionsError`. Catch the error an fallback to an empty applications list.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20907 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
