### PR TITLE
PR: Fix class/function selector for split editors (Editor)

### DIFF
--- a/spyder/app/tests/conftest.py
+++ b/spyder/app/tests/conftest.py
@@ -297,6 +297,8 @@ def main_window(request, tmpdir, qtbot):
     # Set exclamation mark to True
     CONF.set('ipython_console', 'pdb_use_exclamation_mark', True)
 
+    CONF.set('editor', 'show_class_func_dropdown', True)
+
     # Check if we need to use introspection in a given test
     # (it's faster and less memory consuming not to use it!)
     use_introspection = request.node.get_closest_marker('use_introspection')

--- a/spyder/app/tests/conftest.py
+++ b/spyder/app/tests/conftest.py
@@ -297,8 +297,6 @@ def main_window(request, tmpdir, qtbot):
     # Set exclamation mark to True
     CONF.set('ipython_console', 'pdb_use_exclamation_mark', True)
 
-    CONF.set('editor', 'show_class_func_dropdown', True)
-
     # Check if we need to use introspection in a given test
     # (it's faster and less memory consuming not to use it!)
     use_introspection = request.node.get_closest_marker('use_introspection')
@@ -330,8 +328,10 @@ def main_window(request, tmpdir, qtbot):
     preload_complex_project = request.node.get_closest_marker(
         'preload_complex_project')
     if preload_complex_project:
+        CONF.set('editor', 'show_class_func_dropdown', True)
         create_complex_project(tmpdir)
     else:
+        CONF.set('editor', 'show_class_func_dropdown', False)
         if not preload_project:
             CONF.set('project_explorer', 'current_project_path', None)
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -4227,6 +4227,36 @@ def test_update_outline(main_window, qtbot, tmpdir):
     root_1 = treewidget.editor_items[treewidget.current_editor.get_id()]
     assert root_1.node.childCount() == 2
 
+    # Check that class/function selector of cloned editor is populated
+    editorstack_1.set_stack_index(idx)
+    editor_1 = editorstack_1.get_current_editor()
+    editor_2 = editorstack_2.get_current_editor()
+    assert editor_2.is_cloned
+    # one class + "<None>" entry
+    assert editor_2.classfuncdropdown.class_cb.count() == 2
+    # one function + two methods + "<None>" entry
+    assert editor_2.classfuncdropdown.method_cb.count() == 4
+    assert editor_1.classfuncdropdown._data == editor_2.classfuncdropdown._data
+    def get_cb_list(cb):
+        return [cb.itemText(i) for i in range(cb.count())]
+    assert get_cb_list(editor_1.classfuncdropdown.class_cb) == get_cb_list(editor_2.classfuncdropdown.class_cb)
+    assert get_cb_list(editor_1.classfuncdropdown.method_cb) == get_cb_list(editor_2.classfuncdropdown.method_cb)
+
+    # Check that class/function selector of cloned editor is updated
+    with qtbot.waitSignal(editor_2.oe_proxy.sig_outline_explorer_data_changed,
+                          timeout=5000):
+        editor_2.set_text('def baz(x):\n    return x')
+    assert editor_2.is_cloned
+    # "<None>" entry
+    assert editor_2.classfuncdropdown.class_cb.count() == 1
+    # one function + "<None>" entry
+    assert editor_2.classfuncdropdown.method_cb.count() == 2
+    assert editor_1.classfuncdropdown._data == editor_2.classfuncdropdown._data
+    def get_cb_list(cb):
+        return [cb.itemText(i) for i in range(cb.count())]
+    assert get_cb_list(editor_1.classfuncdropdown.class_cb) == get_cb_list(editor_2.classfuncdropdown.class_cb)
+    assert get_cb_list(editor_1.classfuncdropdown.method_cb) == get_cb_list(editor_2.classfuncdropdown.method_cb)
+
     # Hide outline from view
     outline_explorer.toggle_view_action.setChecked(False)
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -4237,10 +4237,13 @@ def test_update_outline(main_window, qtbot, tmpdir):
     # one function + two methods + "<None>" entry
     assert editor_2.classfuncdropdown.method_cb.count() == 4
     assert editor_1.classfuncdropdown._data == editor_2.classfuncdropdown._data
+
     def get_cb_list(cb):
         return [cb.itemText(i) for i in range(cb.count())]
-    assert get_cb_list(editor_1.classfuncdropdown.class_cb) == get_cb_list(editor_2.classfuncdropdown.class_cb)
-    assert get_cb_list(editor_1.classfuncdropdown.method_cb) == get_cb_list(editor_2.classfuncdropdown.method_cb)
+    assert get_cb_list(editor_1.classfuncdropdown.class_cb) == \
+           get_cb_list(editor_2.classfuncdropdown.class_cb)
+    assert get_cb_list(editor_1.classfuncdropdown.method_cb) == \
+           get_cb_list(editor_2.classfuncdropdown.method_cb)
 
     # Check that class/function selector of cloned editor is updated
     with qtbot.waitSignal(editor_2.oe_proxy.sig_outline_explorer_data_changed,
@@ -4252,10 +4255,10 @@ def test_update_outline(main_window, qtbot, tmpdir):
     # one function + "<None>" entry
     assert editor_2.classfuncdropdown.method_cb.count() == 2
     assert editor_1.classfuncdropdown._data == editor_2.classfuncdropdown._data
-    def get_cb_list(cb):
-        return [cb.itemText(i) for i in range(cb.count())]
-    assert get_cb_list(editor_1.classfuncdropdown.class_cb) == get_cb_list(editor_2.classfuncdropdown.class_cb)
-    assert get_cb_list(editor_1.classfuncdropdown.method_cb) == get_cb_list(editor_2.classfuncdropdown.method_cb)
+    assert get_cb_list(editor_1.classfuncdropdown.class_cb) == \
+           get_cb_list(editor_2.classfuncdropdown.class_cb)
+    assert get_cb_list(editor_1.classfuncdropdown.method_cb) == \
+           get_cb_list(editor_2.classfuncdropdown.method_cb)
 
     # Hide outline from view
     outline_explorer.toggle_view_action.setChecked(False)

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1063,14 +1063,6 @@ class CodeEditor(TextEditBaseWidget):
 
         self.set_strip_mode(strip_mode)
 
-    def update_classfuncdropdown(self, symbols):
-        symbols = [] if symbols is None else symbols
-
-        if self.classfuncdropdown.isVisible():
-            self.classfuncdropdown.update_data(symbols)
-        else:
-            self.classfuncdropdown.set_data(symbols)
-
     # ---- LSP: Basic methods
     # -------------------------------------------------------------------------
     @Slot(str, dict)
@@ -1236,8 +1228,7 @@ class CodeEditor(TextEditBaseWidget):
         """Handle symbols response."""
         try:
             symbols = params['params']
-
-            self.update_classfuncdropdown(symbols)
+            self._update_classfuncdropdown(symbols)
 
             if self.oe_proxy is not None:
                 self.oe_proxy.update_outline_info(symbols)
@@ -1249,6 +1240,15 @@ class CodeEditor(TextEditBaseWidget):
             self.log_lsp_handle_errors("Error when processing symbols")
         finally:
             self.symbols_in_sync = True
+
+    def _update_classfuncdropdown(self, symbols):
+        """Update class/function dropdown."""
+        symbols = [] if symbols is None else symbols
+
+        if self.classfuncdropdown.isVisible():
+            self.classfuncdropdown.update_data(symbols)
+        else:
+            self.classfuncdropdown.set_data(symbols)
 
     # ---- LSP: Linting and didChange
     # -------------------------------------------------------------------------

--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1063,6 +1063,14 @@ class CodeEditor(TextEditBaseWidget):
 
         self.set_strip_mode(strip_mode)
 
+    def update_classfuncdropdown(self, symbols):
+        symbols = [] if symbols is None else symbols
+
+        if self.classfuncdropdown.isVisible():
+            self.classfuncdropdown.update_data(symbols)
+        else:
+            self.classfuncdropdown.set_data(symbols)
+
     # ---- LSP: Basic methods
     # -------------------------------------------------------------------------
     @Slot(str, dict)
@@ -1228,12 +1236,8 @@ class CodeEditor(TextEditBaseWidget):
         """Handle symbols response."""
         try:
             symbols = params['params']
-            symbols = [] if symbols is None else symbols
 
-            if self.classfuncdropdown.isVisible():
-                self.classfuncdropdown.update_data(symbols)
-            else:
-                self.classfuncdropdown.set_data(symbols)
+            self.update_classfuncdropdown(symbols)
 
             if self.oe_proxy is not None:
                 self.oe_proxy.update_outline_info(symbols)

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2682,7 +2682,7 @@ class EditorStack(QWidget):
             cloned_from.oe_proxy.sig_outline_explorer_data_changed.connect(
                 editor.oe_proxy.update_outline_info)
             cloned_from.oe_proxy.sig_outline_explorer_data_changed.connect(
-                editor.update_classfuncdropdown)
+                editor._update_classfuncdropdown)
             cloned_from.oe_proxy.sig_start_outline_spinner.connect(
                 editor.oe_proxy.emit_request_in_progress)
 

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2681,6 +2681,8 @@ class EditorStack(QWidget):
             # symbols for the clon are updated as expected.
             cloned_from.oe_proxy.sig_outline_explorer_data_changed.connect(
                 editor.oe_proxy.update_outline_info)
+            cloned_from.oe_proxy.sig_outline_explorer_data_changed.connect(
+                editor.update_classfuncdropdown)
             cloned_from.oe_proxy.sig_start_outline_spinner.connect(
                 editor.oe_proxy.emit_request_in_progress)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->

This PR fixes missing updates of the class and function selector of vertically/horizontally split (cloned) editors. See commit message for details.

Note: Update of indent guides and code folding in cloned editors is broken as well (similar root cause). I have looked into fixing that as well, however, have not succeeded so far.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

rear1019

<!--- Thanks for your help making Spyder better for everyone! --->
