### PR TITLE
PR: Fix searching in a single file (Find)

### DIFF
--- a/spyder/plugins/findinfiles/widgets/results_browser.py
+++ b/spyder/plugins/findinfiles/widgets/results_browser.py
@@ -79,9 +79,17 @@ class FileMatchItem(QTreeWidgetItem):
 
         # Get relative dirname according to the path we're searching in.
         dirname = osp.dirname(filename)
-        rel_dirname = dirname.split(path)[1]
-        if rel_dirname.startswith(osp.sep):
-            rel_dirname = rel_dirname[1:]
+
+        # Catch errors when it's not possible to get the relative directory
+        # name. This happens when the user is searching in a single file.
+        # Fixes spyder-ide/spyder#17443 and spyder-ide/spyder#20964
+        try:
+            rel_dirname = dirname.split(path)[1]
+            if rel_dirname.startswith(osp.sep):
+                rel_dirname = rel_dirname[1:]
+        except IndexError:
+            rel_dirname = dirname
+
         self.rel_dirname = rel_dirname
 
         title = (
@@ -257,18 +265,13 @@ class ResultsBrowser(OneColumnTree):
     def append_file_result(self, filename):
         """Real-time update of file items."""
         if len(self.data) < self.max_results:
-            # Catch any error while creating file items.
-            # Fixes spyder-ide/spyder#17443
-            try:
-                item = FileMatchItem(
-                    self,
-                    self.path,
-                    filename,
-                    self.sorting,
-                    self.text_color
-                )
-            except Exception:
-                return
+            item = FileMatchItem(
+                self,
+                self.path,
+                filename,
+                self.sorting,
+                self.text_color
+            )
 
             self.files[filename] = item
 

--- a/spyder/plugins/findinfiles/widgets/search_thread.py
+++ b/spyder/plugins/findinfiles/widgets/search_thread.py
@@ -263,10 +263,13 @@ class SearchThread(QThread):
                             found = line.find(text, found + 1)
                             if found > -1:
                                 break
-
         except IOError as xxx_todo_changeme:
             (_errno, _strerror) = xxx_todo_changeme.args
             self.error_flag = _("permission denied errors were encountered")
+
+        # Process any pending results
+        if self.is_file and self.partial_results:
+            self.process_results()
 
         self.completed = True
 

--- a/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
+++ b/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
@@ -649,5 +649,25 @@ def test_max_results(findinfiles, qtbot):
     findinfiles.set_max_results(1000)
 
 
+@flaky(max_runs=5)
+def test_find_in_single_file(findinfiles, qtbot):
+    """
+    Test that find in files works for a single file.
+
+    This a regression test for issues spyder-ide/spyder#17443 and
+    spyder-ide/spyder#20964.
+    """
+    findinfiles.set_search_text("spam")
+    findinfiles.set_file_path(osp.join(LOCATION, "data", 'spam.txt'))
+    findinfiles.path_selection_combo.setCurrentIndex(FILE_PATH)
+
+    with qtbot.waitSignal(findinfiles.sig_finished):
+        findinfiles.find()
+
+    matches = process_search_results(findinfiles.result_browser.data)
+    assert list(matches.keys()) == ['spam.txt']
+    assert expected_results()['spam.txt'] == matches['spam.txt']
+
+
 if __name__ == "__main__":
     pytest.main(['-x', osp.basename(__file__), '-v', '-rw'])


### PR DESCRIPTION
## Description of Changes

- This replaces one of the fixes done in PR #19124, which was incorrect because it didn't alow to show the results found for a single file.
- Add a test to check that functionality.

### Issue(s) Resolved

Fixes #20964.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
