### PR TITLE
PR: Prevent error when removing several unsaved files from Projects or Files (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -1816,7 +1816,15 @@ class EditorStack(QWidget):
         yes_all = no_all = False
         for index in indexes:
             self.set_stack_index(index)
-            finfo = self.data[index]
+
+            # Prevent error when trying to remove several unsaved files from
+            # Projects or Files.
+            # Fixes spyder-ide/spyder#20998
+            try:
+                finfo = self.data[index]
+            except IndexError:
+                return False
+
             if finfo.filename == self.tempfile_path or yes_all:
                 if not self.save(index):
                     return False


### PR DESCRIPTION
## Description of Changes

The problem was that if users decide to close a file (through the dialog shown in `__check_file_status`) before Spyder runs the method that suggests them to save it, then an error was raised because Spyder can't find the index corresponding to the closed file to check its save status.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20998.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
