### PR TITLE
PR: Catch error when a file is pointed by too many levels of symlinks (Find)

### DIFF
--- a/spyder/plugins/findinfiles/widgets/main_widget.py
+++ b/spyder/plugins/findinfiles/widgets/main_widget.py
@@ -462,7 +462,7 @@ class FindInFilesWidget(PluginMainWidget):
             if self.search_thread.isRunning():
                 if ignore_results:
                     self.search_thread.sig_finished.disconnect(
-                        self.search_complete)
+                        self._handle_search_complete)
                 self.search_thread.stop()
                 self.search_thread.wait()
 

--- a/spyder/plugins/findinfiles/widgets/search_thread.py
+++ b/spyder/plugins/findinfiles/widgets/search_thread.py
@@ -151,9 +151,16 @@ class SearchThread(QThread):
                     filename = os.path.join(path, f)
                     ext = osp.splitext(filename)[1]
 
-                    # Only search in regular files (i.e. not pipes)
-                    st_file_mode = os.stat(filename).st_mode
-                    if not stat.S_ISREG(st_file_mode):
+                    # Only search in regular files (i.e. not pipes).
+                    # The try/except is necessary to catch an error when
+                    # Python can't get the file status due to too many levels
+                    # of symbolic links.
+                    # Fixes spyder-ide/spyder#20798
+                    try:
+                        st_file_mode = os.stat(filename).st_mode
+                        if not stat.S_ISREG(st_file_mode):
+                            continue
+                    except OSError:
                         continue
 
                     # Exclude patterns defined by the user


### PR DESCRIPTION
## Description of Changes

Also, fix error on close because we were trying to disconnect a Qt signal from a slot that doesn't exist.

### Issue(s) Resolved

Fixes #20798.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
