### PR TITLE
PR: Catch an error when trying to kill the kernel children processes (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/manager.py
+++ b/spyder/plugins/ipythonconsole/utils/manager.py
@@ -60,12 +60,16 @@ class SpyderKernelManager(QtKernelManager):
             children.append(parent)
 
         for child_process in children:
-            # This is necessary to avoid an error when restarting the
-            # kernel that started a PyQt5 application in the background.
+            # This is necessary to avoid an error when restarting the kernel
+            # that started a PyQt5 application in the background. It also fixes
+            # a problem when some of the kernel children are not available
+            # anymore, probably because they were removed by the OS before this
+            # method is able to run.
+            # Fixes spyder-ide/spyder#21012
             # Fixes spyder-ide/spyder#13999
             try:
                 child_process.send_signal(sig)
-            except psutil.AccessDenied:
+            except (psutil.AccessDenied, psutil.NoSuchProcess):
                 return ([], [])
 
         gone, alive = psutil.wait_procs(


### PR DESCRIPTION
## Description of Changes

This can happen because `kill_proc_tree` is now async and the OS may have removed the kernel's children before that method was able to run.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21012.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
