### PR TITLE
PR: Prevent setting cursor in a negative position (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -4960,10 +4960,10 @@ class CodeEditor(TextEditBaseWidget):
         # Correctly handle completions when Backspace key is pressed.
         # We should not show the widget if deleting a space before a word.
         if key == Qt.Key_Backspace:
-            cursor.setPosition(pos - 1, QTextCursor.MoveAnchor)
+            cursor.setPosition(max(0, pos - 1), QTextCursor.MoveAnchor)
             cursor.select(QTextCursor.WordUnderCursor)
             prev_text = to_text_string(cursor.selectedText())
-            cursor.setPosition(pos - 1, QTextCursor.MoveAnchor)
+            cursor.setPosition(max(0, pos - 1), QTextCursor.MoveAnchor)
             cursor.setPosition(pos, QTextCursor.KeepAnchor)
             prev_char = cursor.selectedText()
             if prev_text == '' or prev_char in (u'\u2029', ' ', '\t'):
@@ -4971,7 +4971,7 @@ class CodeEditor(TextEditBaseWidget):
 
         # Text might be after a dot '.'
         if text == '':
-            cursor.setPosition(pos - 1, QTextCursor.MoveAnchor)
+            cursor.setPosition(max(0, pos - 1), QTextCursor.MoveAnchor)
             cursor.select(QTextCursor.WordUnderCursor)
             text = to_text_string(cursor.selectedText())
             if text != '.':


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

When doing autocompletions there is some logic related with setting the cursor position to -1 which causes a warning when the cursor is already at position 0 (so the cursor position was being set to -1).

Preventing setting the position to negative values while handling the autocompletions prevents the warning message.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21028 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
