### PR TITLE
PR: Add `spyder_kernels_rc` conda-forge label (Installers)

### DIFF
--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -223,6 +223,7 @@ def _definitions():
         "version": SPYVER,
         "channels": [
             "napari/label/bundle_tools_2",
+            "conda-forge/label/spyder_kernels_rc",
             "conda-forge",
         ],
         "conda_default_channels": ["conda-forge"],


### PR DESCRIPTION
To accommodate possible pre-release candidates of `spyder-kernels`, added `conda-forge/label/spyder_kernels_rc` to the channel list for building the installed environment.