### PR TITLE
PR: Use cursor `position` instead of `blockNumber` when restoring cursor after format (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/tests/test_formatting.py
@@ -302,6 +302,7 @@ def test_formatting_on_save(completions_editor, formatter, qtbot):
     # Make a simple change to the file
     code_editor.moveCursor(QTextCursor.EndOfLine)
     qtbot.keyPress(code_editor, Qt.Key_Space)
+    current_position = cursor.position()
     qtbot.wait(500)
 
     # Save the file
@@ -313,4 +314,4 @@ def test_formatting_on_save(completions_editor, formatter, qtbot):
     # Check that auto-formatting was applied on save and that we restored the
     # previous line.
     assert code_editor.get_text_with_eol() == expected
-    assert code_editor.textCursor().blockNumber() == current_line
+    assert code_editor.textCursor().position() == current_position


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->
When `Wrap lines` is enabled is possible for the `blockNumber` to not match the actual position expected for the cursor to be after formatting. Seems like using the actual cursor position overcomes this.

### Preview

#### Before

![before_format](https://github.com/spyder-ide/spyder/assets/16781833/4193f1d5-6bcc-4085-9a83-4a67575baa0a)

#### After

![after_format](https://github.com/spyder-ide/spyder/assets/16781833/5886e666-f026-444e-96e9-c77adbddf0b1)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20852


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
