### PR TITLE
PR: Fix issues for all-user install in post-install script (Installers)

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -82,10 +82,12 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Build Environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: installers-conda/build-environment.yml
-          extra-specs: python=${{ matrix.python-version }}
+          create-args: python=${{ matrix.python-version }}
+          cache-downloads: true
+          cache-environment: true
 
       - name: Build Conda Packages
         run: python build_conda_pkgs.py --build $pkg
@@ -163,12 +165,12 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Build Environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: installers-conda/build-environment.yml
-          extra-specs: python=${{ matrix.python-version }}
+          create-args: python=${{ matrix.python-version }}
           cache-downloads: true
-          cache-env: true
+          cache-environment: true
 
       - name: Env Variables
         run: |

--- a/installers-conda/resources/post-install.sh
+++ b/installers-conda/resources/post-install.sh
@@ -33,7 +33,7 @@ m1="# >>> Added by Spyder >>>"
 m2="# <<< Added by Spyder <<<"
 
 add_alias() (
-    if [[ ! -e $shell_init || ! -s $shell_init ]]; then
+    if [[ ! -f "$shell_init" || ! -s "$shell_init" ]]; then
         echo -e "$m1\n$1\n$m2" > $shell_init
         exit 0
     fi
@@ -84,24 +84,26 @@ if [[ \$OSTYPE = "darwin"* ]]; then
     osascript -e 'quit app "Spyder.app"' 2> /dev/null
 fi
 
+# Remove aliases from shell startup
+if [[ -f "$shell_init" ]]; then
+    echo "Removing shell commands..."
+    sed ${sed_opts[@]} "/$m1/,/$m2/d" $shell_init
+fi
+
 # Remove shortcut and environment
 echo "Removing Spyder and environment..."
 rm -rf ${shortcut_path}
 rm -rf ${PREFIX}
 
-# Remove aliases from shell startup
-if [[ -e ${shell_init} ]]; then
-    echo "Removing shell commands..."
-    sed ${sed_opts[@]} "/$m1/,/$m2/d" ${shell_init}
-fi
-
 echo "Spyder successfully uninstalled."
 EOF
-chmod +x ${u_spy_exe}
+chmod u+x ${u_spy_exe}
 
 # ----
-echo "Creating aliases in $shell_init ..."
-add_alias "${alias_text}"
+if [[ -n "$shell_init" ]]; then
+    echo "Creating aliases in $shell_init ..."
+    add_alias "$alias_text"
+fi
 
 # ----
 if [[ $OSTYPE = "linux"* ]]; then

--- a/installers-conda/resources/spyder-menu.json
+++ b/installers-conda/resources/spyder-menu.json
@@ -27,7 +27,7 @@
                 "osx": {
                     "precommand": "eval \"$($SHELL -l -c \"declare -x\")\"",
                     "command": [
-                        "{{ MENU_ITEM_LOCATION }}/Contents/MacOS/python",
+                        "$(dirname $0)/python",
                         "{{ PREFIX }}/bin/spyder",
                         "$@"
                     ],


### PR DESCRIPTION
* Quote variable interpolation in conditional statements and check for file not just exists.
* Remove aliases before removing environment in uninstall.
* Set executable permission for user only for `uninstall-spyder.sh`.
* Only add aliases if `shell_init` is not null.
* Use relative path in shortcut command for macOS to allow Spyder.app to be moved. `menuinst` currently puts shortcut in `~/Applications` instead of `/Applications` for all-user install.
