### PR TITLE
PR: Save fonts with delta in our font cache (Config)

### DIFF
--- a/spyder/config/gui.py
+++ b/spyder/config/gui.py
@@ -64,7 +64,7 @@ FONT_CACHE = {}
 
 def get_font(section='appearance', option='font', font_size_delta=0):
     """Get console font properties depending on OS and user options"""
-    font = FONT_CACHE.get((section, option))
+    font = FONT_CACHE.get((section, option, font_size_delta))
 
     if font is None:
         families = CONF.get(section, option+"/family", None)
@@ -82,7 +82,7 @@ def get_font(section='appearance', option='font', font_size_delta=0):
         size = CONF.get(section, option+'/size', 9) + font_size_delta
         font = QFont(family, size, weight)
         font.setItalic(italic)
-        FONT_CACHE[(section, option)] = font
+        FONT_CACHE[(section, option, font_size_delta)] = font
 
     size = CONF.get(section, option+'/size', 9) + font_size_delta
     font.setPointSize(size)
@@ -90,12 +90,17 @@ def get_font(section='appearance', option='font', font_size_delta=0):
 
 
 def set_font(font, section='appearance', option='font'):
-    """Set font"""
+    """Set font properties in our config system."""
     CONF.set(section, option+'/family', to_text_string(font.family()))
     CONF.set(section, option+'/size', float(font.pointSize()))
     CONF.set(section, option+'/italic', int(font.italic()))
     CONF.set(section, option+'/bold', int(font.bold()))
-    FONT_CACHE[(section, option)] = font
+
+    # This function is only used to set fonts that were changed through
+    # Preferences. And in that case it's not possible to set a delta.
+    font_size_delta = 0
+
+    FONT_CACHE[(section, option, font_size_delta)] = font
 
 
 def _config_shortcut(action, context, name, keystr, parent):


### PR DESCRIPTION
## Description of Changes

This prevents altering the same font with different deltas, which was applied incorrectly to plugins that didn't require a delta.

The most visible effect of this bug was seen in the interaction between the Variable Explorer and the IPython console. The Variable Explorer uses the `Plain text` font with a small delta, which was changing the font size used by the IPython console as a side effect.

**Before**

![wrong-font-size-after-restart](https://github.com/spyder-ide/spyder/assets/365293/e9a28585-a0ae-421e-9e33-296606fce767)

**After**

![right-font-size-after-restart](https://github.com/spyder-ide/spyder/assets/365293/624d0e23-3125-4f5f-af08-0a99841d8931)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20716.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
