### PR TITLE
PR: Fix issue where cmd.exe window flashes on Spyder startup on Windows (installer)

### DIFF
--- a/installers-conda/build-environment.yml
+++ b/installers-conda/build-environment.yml
@@ -7,5 +7,6 @@ dependencies:
   - conda-standalone
   - constructor
   - gitpython
+  - menuinst
   - ruamel.yaml.jinja2
   - setuptools_scm

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -132,8 +132,6 @@ SPYVER = get_version(SPYREPO, normalize=False).lstrip('v').split("+")[0]
 specs = {
     "python": "=" + PY_VER,
     "spyder": "=" + SPYVER,
-    "paramiko": "",
-    "pyxdg": "",
 }
 specs.update(scientific_packages)
 

--- a/installers-conda/resources/spyder-menu.json
+++ b/installers-conda/resources/spyder-menu.json
@@ -7,13 +7,12 @@
             "name": "Spyder",
             "description": "Scientific PYthon Development EnviRonment",
             "icon": "{{ MENU_DIR }}/spyder.{{ ICON_EXT }}",
-            "activate": true,
+            "activate": false,
             "terminal": false,
             "platforms": {
                 "win": {
                     "desktop": true,
-                    "precommand": "set SPY_BRANCH=__SPY_BRANCH__\nset SPY_COMMIT=__SPY_COMMIT__",
-                    "command": ["spyder", "%*"]
+                    "command": ["{{ PREFIX }}/pythonw.exe", "{{ PREFIX }}/Scripts/spyder-script.py"]
                 },
                 "linux": {
                     "Categories": [

--- a/installers-conda/resources/spyder-menu.json
+++ b/installers-conda/resources/spyder-menu.json
@@ -19,7 +19,7 @@
                         "Graphics",
                         "Science"
                     ],
-                    "command": ["spyder", "$@"],
+                    "command": ["{{ PREFIX }}/bin/spyder", "$@"],
                     "StartupWMClass": "Spyder"
                 },
                 "osx": {

--- a/installers-conda/resources/spyder-menu.json
+++ b/installers-conda/resources/spyder-menu.json
@@ -19,7 +19,6 @@
                         "Graphics",
                         "Science"
                     ],
-                    "precommand": "export SPY_BRANCH=__SPY_BRANCH__ && export SPY_COMMIT=__SPY_COMMIT__",
                     "command": ["spyder", "$@"],
                     "StartupWMClass": "Spyder"
                 },
@@ -36,11 +35,7 @@
                     "CFBundleName": "Spyder",
                     "CFBundleDisplayName": "Spyder",
                     "CFBundleIdentifier": "org.spyder-ide.Spyder",
-                    "CFBundleVersion": "__PKG_VERSION__",
-                    "LSEnvironment": {
-                        "SPY_BRANCH": "__SPY_BRANCH__",
-                        "SPY_COMMIT": "__SPY_COMMIT__"
-                    }
+                    "CFBundleVersion": "__PKG_VERSION__"
                 }
             }
         }

--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,7 @@ def get_data_files():
                       ('share/metainfo',
                        ['scripts/org.spyder_ide.spyder.appdata.xml'])]
     elif os.name == 'nt':
-        data_files = [('scripts', ['img_src/spyder.ico',
-                                   'img_src/spyder_reset.ico'])]
+        data_files = [('scripts', ['img_src/spyder.ico'])]
     else:
         data_files = []
 


### PR DESCRIPTION
`menuinst` still presents a temporary `cmd.exe` window on Spyder startup. See conda/menuinst#128.
This can be eliminated by restricting the Windows shortcut link target to use `pythonw.exe`.
However, this comes with the tradeoff that the environment cannot be activated and additional pre-activation commands cannot be provided.

The pre-commands are not required by Spyder. Since Spyder application does not require intrinsic conda environment manipulation, then activating the runtime environment in the runtime shell environment is also not strictly required.
