### PR TITLE
PR: Fix issue getting user environment variables on Posix systems and pass them to the IPython console

### DIFF
--- a/installers-conda/resources/spyder-menu.json
+++ b/installers-conda/resources/spyder-menu.json
@@ -23,7 +23,6 @@
                     "StartupWMClass": "Spyder"
                 },
                 "osx": {
-                    "precommand": "eval \"$($SHELL -l -c \"declare -x\")\"",
                     "command": [
                         "$(dirname $0)/python",
                         "{{ PREFIX }}/bin/spyder",

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -171,11 +171,11 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
         """Env vars for kernels"""
         default_interpreter = self.get_conf(
             'default', section='main_interpreter')
-        env_vars = os.environ.copy()
 
-        # Ensure that user environment variables are included for posix
-        if sys.name == 'posix':
-            env_vars.update(get_user_environment_variables())
+        # Ensure that user environment variables are included, but don't
+        # override existing environ values
+        env_vars = get_user_environment_variables()
+        env_vars.update(os.environ)
 
         # Avoid IPython adding the virtualenv on which Spyder is running
         # to the kernel sys.path

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -27,7 +27,7 @@ from spyder.plugins.ipythonconsole import (
     SpyderKernelError)
 from spyder.utils.conda import (add_quotes, get_conda_env_path, is_conda_env,
                                 find_conda)
-from spyder.utils.environ import clean_env
+from spyder.utils.environ import clean_env, get_user_environment_variables
 from spyder.utils.misc import get_python_executable
 from spyder.utils.programs import is_python_interpreter, is_module_installed
 
@@ -173,6 +173,10 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
             'default', section='main_interpreter')
         env_vars = os.environ.copy()
 
+        # Ensure that user environment variables are included for posix
+        if sys.name == 'posix':
+            env_vars.update(get_user_environment_variables())
+
         # Avoid IPython adding the virtualenv on which Spyder is running
         # to the kernel sys.path
         env_vars.pop('VIRTUAL_ENV', None)
@@ -193,7 +197,7 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
         # Environment variables that we need to pass to the kernel
         env_vars.update({
             'SPY_EXTERNAL_INTERPRETER': (not default_interpreter
-                or self.path_to_custom_interpreter),
+                                         or self.path_to_custom_interpreter),
             'SPY_UMR_ENABLED': self.get_conf(
                 'umr/enabled', section='main_interpreter'),
             'SPY_UMR_VERBOSE': self.get_conf(

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -63,21 +63,17 @@ def get_user_environment_variables():
         )
     else:
         shell = os.environ.get("SHELL", "/bin/bash")
-        # -l and -i flags are mutually exclusive. To source both interactive
-        # and login startup files, run each flag in sequence.
-        for flag in ['-l', '-i']:
-            cmd = (
-                f"{shell} {flag} -c "
-                f"\"{sys.executable} -c "
-                "'import os; print(dict(os.environ))'\""
-            )
-            proc = run_shell_command(cmd, env=env_var, text=True)
-            try:
-                # In case of hangs, use a timeout
-                stdout, stderr = proc.communicate(timeout=1)
-                env_var = eval(stdout, None)
-            except TimeoutError:
-                pass
+        # -i flag causes Spyder to hang, so ~/.bashrc cannot be sourced
+        cmd = (
+            f"{shell} -l -c \"{sys.executable} -c "
+            "'import os; print(dict(os.environ))'\""
+        )
+        proc = run_shell_command(cmd, env={}, text=True)
+        try:
+            stdout, stderr = proc.communicate()
+            env_var = eval(stdout, None)
+        except Exception:
+            pass
 
     return env_var
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* Use a shell script in Spyder's config directory to retriev user environment variables on posix systems.
* The shell script is created on Spyder startup and only for posix systems.

To get user environment variables from login and interactive startup files on posix, both `-l` and `-i` flags must be used. Parsing the environment list is problematic if the variable has a newline character, but Python's `os.environ` can do this for us. However, executing Python in an interactive shell in a subprocess causes Spyder to hang on Linux. Using a shell script resolves the issue. Note that `-i` must be in the sha-bang line; if `-i` and `-l` are swapped, Spyder will hang.

Also note that for environment variables for `KernelSpec` objects are first set to the user's environment variables, then _updated_ with `os.environ`. Thus user login and interactive variables are ensured to be present, but values in `os.environ` may override user variable values.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #3891


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
