### PR TITLE
PR: Fix crash at startup when plugins fail their compatibility checks

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -382,17 +382,32 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         if status_bar.isVisible():
             status_bar.showMessage(message, timeout)
 
-    def show_plugin_compatibility_message(self, message):
+    def show_plugin_compatibility_message(self, plugin_name, message):
         """
         Show a compatibility message.
         """
         messageBox = QMessageBox(self)
+
+        # Set attributes
         messageBox.setWindowModality(Qt.NonModal)
         messageBox.setAttribute(Qt.WA_DeleteOnClose)
-        messageBox.setWindowTitle(_('Compatibility Check'))
-        messageBox.setText(message)
+        messageBox.setWindowTitle(_('Spyder compatibility check'))
+        messageBox.setText(
+            _("It was not possible to load the {} plugin. The problem "
+              "was:<br><br>{}").format(plugin_name, message)
+        )
         messageBox.setStandardButtons(QMessageBox.Ok)
+
+        # Show message.
+        # Note: All adjustments that require graphical properties of the widget
+        # need to be done after this point.
         messageBox.show()
+
+        # Center message
+        screen_geometry = QApplication.desktop().screenGeometry()
+        x = (screen_geometry.width() - messageBox.width()) / 2
+        y = (screen_geometry.height() - messageBox.height()) / 2
+        messageBox.move(x, y)
 
     def register_plugin(self, plugin_name, external=False, omit_conf=False):
         """
@@ -409,7 +424,7 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         plugin.get_description()
 
         if not is_compatible:
-            self.show_plugin_compatibility_message(message)
+            self.show_plugin_compatibility_message(plugin.get_name(), message)
             return
 
         # Connect plugin signals to main window methods

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -905,7 +905,13 @@ class Layout(SpyderPluginV2):
                 action.action_id = f'switch to {plugin.CONF_SECTION}'
 
             if action:
-                action.setChecked(plugin.dockwidget.isVisible())
+                # Plugins that fail their compatibility checks don't have a
+                # dockwidget. So, we need to skip them from the plugins menu.
+                # Fixes spyder-ide/spyder#21074
+                if plugin.dockwidget is None:
+                    continue
+                else:
+                    action.setChecked(plugin.dockwidget.isVisible())
 
             try:
                 name = plugin.CONF_SECTION
@@ -935,6 +941,12 @@ class Layout(SpyderPluginV2):
         self._update_lock_interface_action()
         # Apply lock to panes
         for plugin in self.get_dockable_plugins():
+            # Plugins that fail their compatibility checks don't have a
+            # dockwidget. So, we need to skip them from the code below.
+            # Fixes spyder-ide/spyder#21074
+            if plugin.dockwidget is None:
+                continue
+
             if self._interface_locked:
                 if plugin.dockwidget.isFloating():
                     plugin.dockwidget.setFloating(False)
@@ -965,7 +977,12 @@ class Layout(SpyderPluginV2):
         # Restore visible plugins
         for plugin in visible_plugins:
             plugin_class = self.get_plugin(plugin, error=False)
-            if plugin_class and plugin_class.dockwidget.isVisible():
+            if (
+                plugin_class
+                # This check is necessary for spyder-ide/spyder#21074
+                and plugin_class.dockwidget is not None
+                and plugin_class.dockwidget.isVisible()
+            ):
                 plugin_class.dockwidget.raise_()
 
     def save_visible_plugins(self):


### PR DESCRIPTION
## Description of Changes

Also, improve the `QMessageBox` we use to display those messages by centering it and adding the plugin name to the message:

**Before**

![image](https://github.com/spyder-ide/spyder/assets/365293/675a94f9-31dc-4ce5-a7db-3574ce9fa1e2)

**After**

![image](https://github.com/spyder-ide/spyder/assets/365293/6c0c7611-74c4-4454-9d26-aa87b88f02d2)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21074.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
