### PR TITLE
PR: Fix issue where bootstrap incorrectly determines git branch

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -86,7 +86,7 @@ if not args.no_install:
         prev_branch = boot_branch_file.read_text()
 
     result = subprocess.run(
-        ["git", "merge-base", "--fork-point", "master"],
+        ["git", "-C", DEVPATH, "merge-base", "--fork-point", "master"],
         capture_output=True
     )
     branch = "master" if result.stdout else "not master"


### PR DESCRIPTION
Calling `python .../spyder/bootstrap.py` when the current working directory is not the Spyder repo results in incorrectly determining the git branch. This PR fixes that.