### PR TITLE
PR: Fix error when running main window tests and failing tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -84,11 +84,11 @@ def pytest_collection_modifyitems(config, items):
         ]
 
         if os.name == 'nt':
-            percentage = 0.6
-        elif sys.platform == 'darwin':
-            percentage = 0.6
-        else:
             percentage = 0.5
+        elif sys.platform == 'darwin':
+            percentage = 0.5
+        else:
+            percentage = 0.4
 
         for i, item in enumerate(ipyconsole_items):
             if i < len(ipyconsole_items) * percentage:

--- a/spyder/app/tests/conftest.py
+++ b/spyder/app/tests/conftest.py
@@ -462,12 +462,13 @@ def main_window(request, tmpdir, qtbot):
                 CONF.reset_to_defaults(notification=False)
             else:
                 try:
-                    # Close everything we can think of
-                    window.switcher.close()
+                    # Close or hide everything we can think of
+                    window.switcher.hide()
 
                     # Close editor related elements
                     window.editor.close_all_files()
-                    # force close all files
+
+                    # Force close all files
                     while window.editor.editorstacks[0].close_file(force=True):
                         pass
                     for editorwindow in window.editor.editorwindows:
@@ -498,7 +499,6 @@ def main_window(request, tmpdir, qtbot):
                     (window.ipyconsole.get_widget()
                         .create_new_client_if_empty) = False
                     window.ipyconsole.restart()
-
                 except Exception:
                     main_window.window = None
                     window.close()

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2580,6 +2580,7 @@ def example_def_2():
 
 
 @flaky(max_runs=3)
+@pytest.mark.skipif(running_in_ci(), reason="Can't run on CI")
 def test_switcher_projects_integration(main_window, pytestconfig, qtbot,
                                        tmp_path):
     """Test integration between the Switcher and Projects plugins."""

--- a/spyder/plugins/switcher/tests/test_switcher.py
+++ b/spyder/plugins/switcher/tests/test_switcher.py
@@ -14,6 +14,8 @@ from qtpy.QtCore import Qt
 from spyder.config.base import _
 
 
+# --- Fixtures
+# -----------------------------------------------------------------------------
 @pytest.fixture
 def dlg_switcher(qtbot):
     """Set up switcher widget."""
@@ -45,12 +47,19 @@ def dlg_switcher(qtbot):
 
     dlg_switcher.sig_mode_selected.connect(handle_modes)
     dlg_switcher.sig_item_selected.connect(item_selected)
+    dlg_switcher.sig_search_text_available.connect(
+        lambda text: dlg_switcher.setup()
+    )
 
     qtbot.addWidget(dlg_switcher)
+    dlg_switcher.show()
     create_vcs_example_switcher(dlg_switcher)
+
     return dlg_switcher
 
 
+# --- Tests
+# -----------------------------------------------------------------------------
 def test_switcher(dlg_switcher, qtbot):
     """Test that shortcut summary is visible and is not empty"""
     # Test that the dialog exists and is shown
@@ -115,9 +124,9 @@ def test_switcher_filter_unicode(dlg_switcher, qtbot):
     qtbot.wait(1000)
     assert dlg_switcher.count() == 2
 
-# Helper functions for tests
 
-
+# --- Helper functions for tests
+# -----------------------------------------------------------------------------
 def create_vcs_example_switcher(sw):
     """Add example data for vcs."""
     from spyder.utils.icon_manager import ima

--- a/spyder/tests/test_dependencies_in_sync.py
+++ b/spyder/tests/test_dependencies_in_sync.py
@@ -204,7 +204,7 @@ def test_dependencies_for_spyder_dialog_in_sync():
     full_reqs.update(linux_reqs)
 
     # These packages are not declared in our dependencies dialog
-    for dep in ['pyqt', 'pyqtwebengine', 'python.app']:
+    for dep in ['pyqt', 'pyqtwebengine', 'python.app', 'fzf', 'fcitx-qt5']:
         full_reqs.pop(dep)
 
     assert spyder_deps == full_reqs
@@ -226,8 +226,9 @@ def test_dependencies_for_spyder_setup_install_requires_in_sync():
     full_reqs.update(mac_reqs)
     full_reqs.update(linux_reqs)
 
-    # We don't declare python.app as a dependency in other places
-    full_reqs.pop('python.app')
+    # We can't declare these as dependencies in setup.py
+    for dep in ['python.app', 'fzf', 'fcitx-qt5']:
+        full_reqs.pop(dep)
 
     assert spyder_setup == full_reqs
 

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -104,7 +104,9 @@ def get_user_environment_variables():
             proc = run_shell_command(user_env_script, env={}, text=True)
 
             # Use timeout to fix spyder-ide/spyder#21172
-            stdout, stderr = proc.communicate(timeout=0.5)
+            stdout, stderr = proc.communicate(
+                timeout=3 if running_in_ci() else 0.5
+            )
 
             if stderr:
                 logger.info(stderr.strip())


### PR DESCRIPTION
## Description of Changes

- That error was preventing to reuse the window between tests, which significantly increased its running time on CIs.
- Decrease percentage of IPython tests run on slow slots a bit.
- Fix some tests related to the switcher, dependencies and getting environment variables on Mac.

### Issue(s) Resolved

Fixes #21322.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
