### PR TITLE
PR: Add better shortcuts to switch edit tabs for macOS

### DIFF
--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -389,13 +389,13 @@ class BaseTabs(QTabWidget):
         handled = False
         if ctrl and self.count() > 0:
             index = self.currentIndex()
-            if key == Qt.Key_PageUp:
+            if key == Qt.Key_PageUp or key == Qt.Key_8:
                 if index > 0:
                     self.setCurrentIndex(index - 1)
                 else:
                     self.setCurrentIndex(self.count() - 1)
                 handled = True
-            elif key == Qt.Key_PageDown:
+            elif key == Qt.Key_PageDown or key == Qt.Key_9:
                 if index < self.count() - 1:
                     self.setCurrentIndex(index + 1)
                 else:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Because macOS keyboards don't have PgUp/Down, I added shortcuts to switch edit tabs for macOS. The shortcuts are listed below.

- `command + 8` -> switch to the left tab
- `command + 9` -> switch to the right tab


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1741


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ryohei22