### PR TITLE
PR: Fix LSP status widget logic when it is `None` using early return

### DIFF
--- a/spyder/plugins/completion/providers/languageserver/widgets/status.py
+++ b/spyder/plugins/completion/providers/languageserver/widgets/status.py
@@ -66,25 +66,27 @@ class LSPStatusWidget(StatusBarWidget):
 
     def show_menu(self):
         """Display a menu when clicking on the widget."""
+        
+        if self.current_language is None:
+            return
+
         menu = self.menu
         language = self.current_language.lower()
-
-        if language is not None:
-            menu.clear()
-            text = _(
-                "Restart {} Language Server").format(language.capitalize())
-            restart_action = create_action(
-                self,
-                text=text,
-                triggered=lambda: self.provider.restart_lsp(language,
-                                                            force=True),
-            )
-            add_actions(menu, [restart_action])
-            rect = self.contentsRect()
-            os_height = 7 if os.name == 'nt' else 12
-            pos = self.mapToGlobal(
-                rect.topLeft() + QPoint(-40, -rect.height() - os_height))
-            menu.popup(pos)
+        menu.clear()
+        text = _(
+            "Restart {} Language Server").format(language.capitalize())
+        restart_action = create_action(
+            self,
+            text=text,
+            triggered=lambda: self.provider.restart_lsp(language,
+                                                        force=True),
+        )
+        add_actions(menu, [restart_action])
+        rect = self.contentsRect()
+        os_height = 7 if os.name == 'nt' else 12
+        pos = self.mapToGlobal(
+            rect.topLeft() + QPoint(-40, -rect.height() - os_height))
+        menu.popup(pos)
 
     def set_status(self, lsp_language=None, status=None):
         """Set LSP status."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21127


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
