### PR TITLE
PR: Reinstate notarization of conda-based macOS installer

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -303,8 +303,7 @@ jobs:
       - name: Notarize or Compute Checksum
         if: env.IS_RELEASE == 'true' || env.IS_PRE == 'true'
         run: |
-          # Skip notarization for now because our Apple ID is expired.
-          if [[ $RUNNER_OS == "skip" ]]; then
+          if [[ $RUNNER_OS == "macOS" ]]; then
               ./notarize.sh -p $APPLICATION_PWD $PKG_PATH
           else
               cd $(dirname $PKG_PATH)


### PR DESCRIPTION
This reverts commit e829688cc43d6bb47ed2c908fb994682ace404bc.

With the replacement of our GitHub secrets with new Developer ID certificates, we can reinstate notariztion.