### PR TITLE
PR: Improve UI of `PaneEmptyWidget`, show message on panes connected to dead consoles and improve About dialog UI

### DIFF
--- a/spyder/api/shellconnect/main_widget.py
+++ b/spyder/api/shellconnect/main_widget.py
@@ -118,15 +118,10 @@ class ShellConnectMainWidget(PluginMainWidget):
         widget = self.get_widget_for_shellwidget(shellwidget)
         if widget is None:
             return
-        self._stack.setCurrentWidget(widget)
 
-        # This prevents errors when the widget we're switching to is a
-        # PaneEmptyWidget
-        try:
-            self.switch_widget(widget, old_widget)
-            self.update_actions()
-        except AttributeError:
-            pass
+        self._stack.setCurrentWidget(widget)
+        self.switch_widget(widget, old_widget)
+        self.update_actions()
 
     def add_errored_shellwidget(self, shellwidget):
         """

--- a/spyder/api/shellconnect/main_widget.py
+++ b/spyder/api/shellconnect/main_widget.py
@@ -137,8 +137,8 @@ class ShellConnectMainWidget(PluginMainWidget):
                 self,
                 "variable-explorer",  # TODO: Use custom icon here
                 _("No connected console"),
-                _("The associated console failed to start, so it is not "
-                  "possible to show any content here.")
+                _("The current console failed to start, so there is no "
+                  "content to show here.")
             )
 
             self._stack.addWidget(widget)

--- a/spyder/api/shellconnect/main_widget.py
+++ b/spyder/api/shellconnect/main_widget.py
@@ -43,6 +43,24 @@ class ShellConnectMainWidget(PluginMainWidget):
         layout.addWidget(self._stack)
         self.setLayout(layout)
 
+    # ---- PluginMainWidget API
+    # ------------------------------------------------------------------------
+    def current_widget(self):
+        """
+        Return the current widget in the stack.
+
+        Returns
+        -------
+        QWidget
+            The current widget.
+        """
+        return self._stack.currentWidget()
+
+    def get_focus_widget(self):
+        return self.current_widget()
+
+    # ---- SpyderWidgetMixin API
+    # ------------------------------------------------------------------------
     def update_style(self):
         self._stack.setStyleSheet("QStackedWidget {padding: 0px; border: 0px}")
 
@@ -58,20 +76,6 @@ class ShellConnectMainWidget(PluginMainWidget):
             The number of widgets in the stack.
         """
         return self._stack.count()
-
-    def current_widget(self):
-        """
-        Return the current figure browser widget in the stack.
-
-        Returns
-        -------
-        QWidget
-            The current widget.
-        """
-        return self._stack.currentWidget()
-
-    def get_focus_widget(self):
-        return self.current_widget()
 
     def get_widget_for_shellwidget(self, shellwidget):
         """return widget corresponding to shellwidget."""
@@ -163,3 +167,7 @@ class ShellConnectMainWidget(PluginMainWidget):
         if self.count():
             widget = self.current_widget()
             widget.refresh()
+
+    def is_current_widget_empty(self):
+        """Check if the current widget is a PaneEmptyWidget."""
+        return isinstance(self.current_widget(), PaneEmptyWidget)

--- a/spyder/api/shellconnect/mixins.py
+++ b/spyder/api/shellconnect/mixins.py
@@ -35,6 +35,8 @@ class ShellConnectMixin:
         ipyconsole.sig_shellwidget_changed.connect(self.set_shellwidget)
         ipyconsole.sig_shellwidget_created.connect(self.add_shellwidget)
         ipyconsole.sig_shellwidget_deleted.connect(self.remove_shellwidget)
+        ipyconsole.sig_shellwidget_errored.connect(
+            self.add_errored_shellwidget)
 
     @on_plugin_teardown(plugin=Plugins.IPythonConsole)
     def on_ipython_console_teardown(self):
@@ -44,10 +46,11 @@ class ShellConnectMixin:
 
     def unregister_ipythonconsole(self, ipyconsole):
         """Unregister the console."""
-
         ipyconsole.sig_shellwidget_changed.disconnect(self.set_shellwidget)
         ipyconsole.sig_shellwidget_created.disconnect(self.add_shellwidget)
         ipyconsole.sig_shellwidget_deleted.disconnect(self.remove_shellwidget)
+        ipyconsole.sig_shellwidget_errored.disconnect(
+            self.add_errored_shellwidget)
 
     # ---- Public API
     # -------------------------------------------------------------------------
@@ -86,6 +89,17 @@ class ShellConnectMixin:
             The shell widget.
         """
         self.get_widget().remove_shellwidget(shellwidget)
+
+    def add_errored_shellwidget(self, shellwidget):
+        """
+        Add a new shellwidget whose kernel failed to start.
+
+        Parameters
+        ----------
+        shellwidget: spyder.plugins.ipyconsole.widgets.shell.ShellWidget
+            The shell widget.
+        """
+        self.get_widget().add_errored_shellwidget(shellwidget)
 
     def current_widget(self):
         """

--- a/spyder/api/utils.py
+++ b/spyder/api/utils.py
@@ -12,11 +12,9 @@ API utilities.
 
 def get_class_values(cls):
     """
-    Get the attribute values for the class enumerations used in our
-    API.
+    Get the attribute values for the class enumerations used in our API.
 
-    Idea from:
-    https://stackoverflow.com/a/17249228/438386
+    Idea from: https://stackoverflow.com/a/17249228/438386
     """
     return [v for (k, v) in cls.__dict__.items() if k[:1] != '_']
 
@@ -54,3 +52,15 @@ class PrefixedTuple(PrefixNode):
             child = self.children[key]
             for prefix in child:
                 yield prefix
+
+
+class classproperty(property):
+    """
+    Decorator to declare class constants as properties that require additional
+    computation.
+
+    Taken from: https://stackoverflow.com/a/7864317/438386
+    """
+
+    def __get__(self, cls, owner):
+        return classmethod(self.fget).__get__(None, owner)()

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -666,11 +666,11 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         logger.info("Applying theme configuration...")
         ui_theme = self.get_conf('ui_theme', section='appearance')
         color_scheme = self.get_conf('selected', section='appearance')
+        qapp = QApplication.instance()
 
         if ui_theme == 'dark':
             if not running_under_pytest():
                 # Set style proxy to fix combobox popup on mac and qdark
-                qapp = QApplication.instance()
                 qapp.setStyle(self._proxy_style)
             dark_qss = str(APP_STYLESHEET)
             self.setStyleSheet(dark_qss)
@@ -680,7 +680,6 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         elif ui_theme == 'light':
             if not running_under_pytest():
                 # Set style proxy to fix combobox popup on mac and qdark
-                qapp = QApplication.instance()
                 qapp.setStyle(self._proxy_style)
             light_qss = str(APP_STYLESHEET)
             self.setStyleSheet(light_qss)
@@ -691,7 +690,6 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
             if not is_dark_font_color(color_scheme):
                 if not running_under_pytest():
                     # Set style proxy to fix combobox popup on mac and qdark
-                    qapp = QApplication.instance()
                     qapp.setStyle(self._proxy_style)
                 dark_qss = str(APP_STYLESHEET)
                 self.setStyleSheet(dark_qss)
@@ -702,6 +700,10 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
                 self.setStyleSheet(light_qss)
                 self.statusBar().setStyleSheet(light_qss)
                 css_path = CSS_PATH
+
+        # This needs to done after applying the stylesheet to the window
+        logger.info("Set color for links in Qt widgets")
+        set_links_color(qapp)
 
         # Set css_path as a configuration to be used by the plugins
         self.set_conf('css_path', css_path, section='appearance')
@@ -1440,9 +1442,6 @@ def main(options, args):
         except Exception:
             pass
     CONF.set('main', 'previous_crash', previous_crash)
-
-    # **** Set color for links ****
-    set_links_color(app)
 
     # **** Create main window ****
     mainwindow = None

--- a/spyder/plugins/debugger/plugin.py
+++ b/spyder/plugins/debugger/plugin.py
@@ -17,7 +17,7 @@ from qtpy.QtCore import Slot
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
-from spyder.api.shellconnect.mixins import ShellConnectMixin
+from spyder.api.shellconnect.mixins import ShellConnectPluginMixin
 from spyder.api.translations import _
 from spyder.config.manager import CONF
 from spyder.plugins.debugger.confpage import DebuggerConfigPage
@@ -37,7 +37,7 @@ from spyder.plugins.ipythonconsole.widgets.config import IPythonConfigOptions
 from spyder.plugins.editor.api.run import CellRun, SelectionRun
 
 
-class Debugger(SpyderDockablePlugin, ShellConnectMixin, RunExecutor):
+class Debugger(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
     """Debugger plugin."""
 
     NAME = 'debugger'

--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -341,6 +341,9 @@ class DebuggerWidget(ShellConnectMainWidget):
     def update_actions(self):
         """Update actions."""
         widget = self.current_widget()
+        if self.is_current_widget_empty():
+            return
+
         search_action = self.get_action(DebuggerWidgetActions.Search)
         enter_debug_action = self.get_action(
             DebuggerWidgetActions.EnterDebug)
@@ -361,6 +364,7 @@ class DebuggerWidget(ShellConnectMainWidget):
             show_enter_debugger = post_mortem or executing
             is_inspecting = widget.state == FramesBrowserState.Inspect
             pdb_prompt = sw.is_waiting_pdb_input()
+
         search_action.setChecked(search)
         enter_debug_action.setEnabled(show_enter_debugger)
         inspect_action.setEnabled(executing)
@@ -372,8 +376,7 @@ class DebuggerWidget(ShellConnectMainWidget):
                 DebuggerWidgetActions.Step,
                 DebuggerWidgetActions.Return,
                 DebuggerWidgetActions.Stop,
-                DebuggerWidgetActions.GotoCursor,
-                ]:
+                DebuggerWidgetActions.GotoCursor]:
             action = self.get_action(action_name)
             action.setEnabled(pdb_prompt)
 
@@ -490,7 +493,7 @@ class DebuggerWidget(ShellConnectMainWidget):
         next call.
         """
         widget = self.current_widget()
-        if widget is None:
+        if widget is None or self.is_current_widget_empty():
             return False
         widget.shellwidget._pdb_take_focus = take_focus
 
@@ -498,14 +501,14 @@ class DebuggerWidget(ShellConnectMainWidget):
     def toggle_finder(self, checked):
         """Show or hide finder."""
         widget = self.current_widget()
-        if widget is None:
+        if widget is None or self.is_current_widget_empty():
             return
         widget.toggle_finder(checked)
 
     def get_pdb_state(self):
         """Get debugging state of the current console."""
         widget = self.current_widget()
-        if widget is None or not hasattr(widget, 'shellwidget'):
+        if widget is None or self.is_current_widget_empty():
             return False
         sw = widget.shellwidget
         if sw is not None:
@@ -515,7 +518,7 @@ class DebuggerWidget(ShellConnectMainWidget):
     def get_pdb_last_step(self):
         """Get last pdb step of the current console."""
         widget = self.current_widget()
-        if widget is None or not hasattr(widget, 'shellwidget'):
+        if widget is None or self.is_current_widget_empty():
             return None, None
         sw = widget.shellwidget
         if sw is not None:

--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -505,7 +505,7 @@ class DebuggerWidget(ShellConnectMainWidget):
     def get_pdb_state(self):
         """Get debugging state of the current console."""
         widget = self.current_widget()
-        if widget is None:
+        if widget is None or not hasattr(widget, 'shellwidget'):
             return False
         sw = widget.shellwidget
         if sw is not None:
@@ -515,7 +515,7 @@ class DebuggerWidget(ShellConnectMainWidget):
     def get_pdb_last_step(self):
         """Get last pdb step of the current console."""
         widget = self.current_widget()
-        if widget is None:
+        if widget is None or not hasattr(widget, 'shellwidget'):
             return None, None
         sw = widget.shellwidget
         if sw is not None:

--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -340,24 +340,22 @@ class DebuggerWidget(ShellConnectMainWidget):
 
     def update_actions(self):
         """Update actions."""
-        widget = self.current_widget()
-        if self.is_current_widget_empty():
-            return
-
         search_action = self.get_action(DebuggerWidgetActions.Search)
         enter_debug_action = self.get_action(
             DebuggerWidgetActions.EnterDebug)
         inspect_action = self.get_action(
             DebuggerWidgetActions.Inspect)
 
-        if widget is None:
-            search = False
+        widget = self.current_widget()
+        if self.is_current_widget_empty() or widget is None:
+            search_action.setEnabled(False)
             show_enter_debugger = False
             executing = False
             is_inspecting = False
             pdb_prompt = False
         else:
-            search = widget.finder_is_visible()
+            search_action.setEnabled(True)
+            search_action.setChecked(widget.finder_is_visible())
             post_mortem = widget.state == FramesBrowserState.Error
             sw = widget.shellwidget
             executing = sw._executing
@@ -365,7 +363,6 @@ class DebuggerWidget(ShellConnectMainWidget):
             is_inspecting = widget.state == FramesBrowserState.Inspect
             pdb_prompt = sw.is_waiting_pdb_input()
 
-        search_action.setChecked(search)
         enter_debug_action.setEnabled(show_enter_debugger)
         inspect_action.setEnabled(executing)
         self.context_menu.setEnabled(is_inspecting)
@@ -428,9 +425,10 @@ class DebuggerWidget(ShellConnectMainWidget):
 
     def switch_widget(self, widget, old_widget):
         """Set the current FramesBrowser."""
-        sw = widget.shellwidget
-        state = sw.is_waiting_pdb_input()
-        self.sig_pdb_state_changed.emit(state)
+        if not self.is_current_widget_empty():
+            sw = widget.shellwidget
+            state = sw.is_waiting_pdb_input()
+            self.sig_pdb_state_changed.emit(state)
 
     def close_widget(self, widget):
         """Close widget."""

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -141,6 +141,16 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
         The shellwigdet.
     """
 
+    sig_shellwidget_errored = Signal(object)
+    """
+    This signal is emitted when the current shellwidget failed to start.
+
+    Parameters
+    ----------
+    shellwidget: spyder.plugins.ipyconsole.widgets.shell.ShellWidget
+        The shellwigdet.
+    """
+
     sig_render_plain_text_requested = Signal(str)
     """
     This signal is emitted to request a plain text help render.
@@ -208,6 +218,7 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
         widget.sig_shellwidget_created.connect(self.sig_shellwidget_created)
         widget.sig_shellwidget_deleted.connect(self.sig_shellwidget_deleted)
         widget.sig_shellwidget_changed.connect(self.sig_shellwidget_changed)
+        widget.sig_shellwidget_errored.connect(self.sig_shellwidget_errored)
         widget.sig_render_plain_text_requested.connect(
             self.sig_render_plain_text_requested)
         widget.sig_render_rich_text_requested.connect(

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -22,7 +22,7 @@ import time
 import traceback
 
 # Third party imports (qtpy)
-from qtpy.QtCore import QUrl, QTimer, Signal, Slot, QThread
+from qtpy.QtCore import QUrl, QTimer, Signal, Slot
 from qtpy.QtWidgets import QVBoxLayout, QWidget
 
 # Local imports
@@ -478,6 +478,9 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
             self.set_info_page()
             self.shellwidget.hide()
             self.infowidget.show()
+
+        # Inform other plugins that the shell failed to start
+        self.shellwidget.sig_shellwidget_errored.emit(self.shellwidget)
 
         # Stop shellwidget
         self.shellwidget.shutdown()

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -214,6 +214,16 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
         The shellwigdet.
     """
 
+    sig_shellwidget_errored = Signal(object)
+    """
+    This signal is emitted when the current shellwidget failed to start.
+
+    Parameters
+    ----------
+    shellwidget: spyder.plugins.ipyconsole.widgets.shell.ShellWidget
+        The shellwigdet.
+    """
+
     sig_render_plain_text_requested = Signal(str)
     """
     This signal is emitted to request a plain text help render.
@@ -1648,11 +1658,13 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
         shellwidget.sig_exception_occurred.connect(
             self.sig_exception_occurred)
 
-        # Closing Shellwidget
+        # Signals
         shellwidget.sig_shellwidget_deleted.connect(
             self.sig_shellwidget_deleted)
         shellwidget.sig_shellwidget_created.connect(
             self.sig_shellwidget_created)
+        shellwidget.sig_shellwidget_errored.connect(
+            self.sig_shellwidget_errored)
         shellwidget.sig_restart_kernel.connect(self.restart_kernel)
 
     def close_client(self, index=None, client=None, ask_recursive=True):

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -9,7 +9,6 @@ Shell Widget for the IPython Console
 """
 
 # Standard library imports
-import ast
 import os
 import os.path as osp
 import time
@@ -118,9 +117,10 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
     # Request plugins to send additional configuration to the Spyder kernel
     sig_config_spyder_kernel = Signal()
 
-    # To notify of kernel connection / disconnection
+    # To notify of kernel connection, disconnection and kernel errors
     sig_shellwidget_created = Signal(object)
     sig_shellwidget_deleted = Signal(object)
+    sig_shellwidget_errored = Signal(object)
 
     # To request restart
     sig_restart_kernel = Signal()

--- a/spyder/plugins/ipythonconsole/widgets/status.py
+++ b/spyder/plugins/ipythonconsole/widgets/status.py
@@ -34,7 +34,7 @@ class MatplotlibStatus(StatusBarWidget, ShellConnectMixin):
 
     def toggle_matplotlib(self):
         """Toggle matplotlib interactive backend."""
-        if self._current_id is None:
+        if self._current_id is None or self._gui == 'failed':
             return
         backend = "inline" if self._gui != "inline" else "auto"
         sw = self._shellwidget_dict[self._current_id]["widget"]
@@ -61,6 +61,8 @@ class MatplotlibStatus(StatusBarWidget, ShellConnectMixin):
         self._gui = gui
         if gui == "inline":
             text = _("Inline")
+        elif gui == 'failed':
+            text = _('No backend')
         else:
             text = _("Interactive")
         self.set_value(text)
@@ -103,6 +105,15 @@ class MatplotlibStatus(StatusBarWidget, ShellConnectMixin):
         shellwidget_id = id(shellwidget)
         if shellwidget_id in self._shellwidget_dict:
             del self._shellwidget_dict[shellwidget_id]
-    
+
+    def add_errored_shellwidget(self, shellwidget):
+        """Add errored shellwidget."""
+        swid = id(shellwidget)
+        self._shellwidget_dict[swid] = {
+            "gui": 'failed',
+            "widget": shellwidget,
+        }
+        self.set_shellwidget(shellwidget)
+
     def get_icon(self):
         return self.create_icon('plot')

--- a/spyder/plugins/ipythonconsole/widgets/status.py
+++ b/spyder/plugins/ipythonconsole/widgets/status.py
@@ -19,8 +19,7 @@ class MatplotlibStatus(StatusBarWidget, ShellConnectMixin):
     CONF_SECTION = 'ipython_console'
 
     def __init__(self, parent):
-        super(MatplotlibStatus, self).__init__(
-            parent)
+        super().__init__(parent)
         self._gui = None
         self._shellwidget_dict = {}
         self._current_id = None

--- a/spyder/plugins/plots/plugin.py
+++ b/spyder/plugins/plots/plugin.py
@@ -10,12 +10,12 @@ Plots Plugin.
 
 # Local imports
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
-from spyder.api.shellconnect.mixins import ShellConnectMixin
+from spyder.api.shellconnect.mixins import ShellConnectPluginMixin
 from spyder.api.translations import _
 from spyder.plugins.plots.widgets.main_widget import PlotsWidget
 
 
-class Plots(SpyderDockablePlugin, ShellConnectMixin):
+class Plots(SpyderDockablePlugin, ShellConnectPluginMixin):
     """
     Plots plugin.
     """

--- a/spyder/plugins/plots/widgets/main_widget.py
+++ b/spyder/plugins/plots/widgets/main_widget.py
@@ -216,7 +216,7 @@ class PlotsWidget(ShellConnectMainWidget):
         value = False
         widget = self.current_widget()
         figviewer = None
-        if widget:
+        if widget and hasattr(widget, 'figviewer'):
             figviewer = widget.figviewer
             thumbnails_sb = widget.thumbnails_sb
             value = figviewer.figcanvas.fig is not None

--- a/spyder/plugins/plots/widgets/main_widget.py
+++ b/spyder/plugins/plots/widgets/main_widget.py
@@ -216,7 +216,7 @@ class PlotsWidget(ShellConnectMainWidget):
         value = False
         widget = self.current_widget()
         figviewer = None
-        if widget and hasattr(widget, 'figviewer'):
+        if widget and not self.is_current_widget_empty():
             figviewer = widget.figviewer
             thumbnails_sb = widget.thumbnails_sb
             value = figviewer.figcanvas.fig is not None

--- a/spyder/plugins/variableexplorer/plugin.py
+++ b/spyder/plugins/variableexplorer/plugin.py
@@ -12,7 +12,7 @@ Variable Explorer Plugin.
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
-from spyder.api.shellconnect.mixins import ShellConnectMixin
+from spyder.api.shellconnect.mixins import ShellConnectPluginMixin
 from spyder.api.translations import _
 from spyder.plugins.variableexplorer.confpage import (
     VariableExplorerConfigPage)
@@ -20,7 +20,7 @@ from spyder.plugins.variableexplorer.widgets.main_widget import (
     VariableExplorerWidget)
 
 
-class VariableExplorer(SpyderDockablePlugin, ShellConnectMixin):
+class VariableExplorer(SpyderDockablePlugin, ShellConnectPluginMixin):
     """
     Variable explorer plugin.
     """

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -420,24 +420,26 @@ class VariableExplorerWidget(ShellConnectMainWidget):
 
     def update_actions(self):
         """Update the actions."""
-        nsb = self.current_widget()
         if self.is_current_widget_empty():
+            self._set_main_toolbar_state(False)
             return
+        else:
+            self._set_main_toolbar_state(True)
 
         action = self.get_action(VariableExplorerWidgetActions.ToggleMinMax)
         action.setEnabled(is_module_installed('numpy'))
 
+        nsb = self.current_widget()
         if nsb:
             save_data_action = self.get_action(
                 VariableExplorerWidgetActions.SaveData)
             save_data_action.setEnabled(nsb.filename is not None)
-        search_action = self.get_action(VariableExplorerWidgetActions.Search)
 
+        search_action = self.get_action(VariableExplorerWidgetActions.Search)
         if nsb is None:
             checked = False
         else:
             checked = nsb.finder_is_visible()
-
         search_action.setChecked(checked)
 
     @on_conf_change
@@ -455,7 +457,6 @@ class VariableExplorerWidget(ShellConnectMainWidget):
 
     # ---- Public API
     # ------------------------------------------------------------------------
-
     def create_new_widget(self, shellwidget):
         """Create new NamespaceBrowser."""
         nsb = NamespaceBrowser(self)
@@ -630,3 +631,9 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         self.exclude_capitalized_action.setEnabled(value)
         self.exclude_unsupported_action.setEnabled(value)
         self.exclude_callables_and_modules_action.setEnabled(value)
+
+    def _set_main_toolbar_state(self, enabled):
+        """Set main toolbar enabled state."""
+        main_toolbar = self.get_main_toolbar()
+        for action in main_toolbar.actions():
+            action.setEnabled(enabled)

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -420,18 +420,24 @@ class VariableExplorerWidget(ShellConnectMainWidget):
 
     def update_actions(self):
         """Update the actions."""
+        nsb = self.current_widget()
+        if self.is_current_widget_empty():
+            return
+
         action = self.get_action(VariableExplorerWidgetActions.ToggleMinMax)
         action.setEnabled(is_module_installed('numpy'))
-        nsb = self.current_widget()
+
         if nsb:
             save_data_action = self.get_action(
                 VariableExplorerWidgetActions.SaveData)
             save_data_action.setEnabled(nsb.filename is not None)
         search_action = self.get_action(VariableExplorerWidgetActions.Search)
+
         if nsb is None:
             checked = False
         else:
             checked = nsb.finder_is_visible()
+
         search_action.setChecked(checked)
 
     @on_conf_change
@@ -483,19 +489,19 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         """
         Import data in current namespace.
         """
-        if self.count():
+        if not self.is_current_widget_empty():
             nsb = self.current_widget()
             nsb.refresh_table()
             nsb.import_data(filenames=filenames)
 
     def save_data(self):
-        if self.count():
+        if not self.is_current_widget_empty():
             nsb = self.current_widget()
             nsb.save_data()
             self.update_actions()
 
     def reset_namespace(self):
-        if self.count():
+        if not self.is_current_widget_empty():
             nsb = self.current_widget()
             nsb.reset_namespace()
 
@@ -503,7 +509,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
     def toggle_finder(self, checked):
         """Hide or show the finder."""
         widget = self.current_widget()
-        if widget is None:
+        if widget is None or self.is_current_widget_empty():
             return
         widget.toggle_finder(checked)
 
@@ -514,7 +520,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         action.setChecked(False)
 
     def refresh_table(self):
-        if self.count():
+        if not self.is_current_widget_empty():
             nsb = self.current_widget()
             nsb.refresh_table()
 
@@ -530,10 +536,12 @@ class VariableExplorerWidget(ShellConnectMainWidget):
                           self.sig_free_memory_requested)
 
     def resize_rows(self):
-        self._current_editor.resizeRowsToContents()
+        if self._current_editor is not None:
+            self._current_editor.resizeRowsToContents()
 
     def resize_columns(self):
-        self._current_editor.resize_column_contents()
+        if self._current_editor is not None:
+            self._current_editor.resize_column_contents()
 
     def paste(self):
         self._current_editor.paste()
@@ -576,7 +584,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
     @property
     def _current_editor(self):
         editor = None
-        if self.count():
+        if not self.is_current_widget_empty():
             nsb = self.current_widget()
             editor = nsb.editor
         return editor

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -108,12 +108,13 @@ class VariableExplorerWidget(ShellConnectMainWidget):
     def __init__(self, name=None, plugin=None, parent=None):
         super().__init__(name, plugin, parent)
 
-
         # Widgets
         self.context_menu = None
         self.empty_context_menu = None
-
         self.filter_button = None
+
+        # Attributes
+        self._is_filter_button_checked = True
 
     # ---- PluginMainWidget API
     # ------------------------------------------------------------------------
@@ -227,6 +228,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
             tip=_("Filter variables")
             )
         self.filter_button.setCheckable(True)
+        self.filter_button.toggled.connect(self._set_filter_button_state)
 
         # ---- Context menu actions
         resize_rows_action = self.create_action(
@@ -637,3 +639,18 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         main_toolbar = self.get_main_toolbar()
         for action in main_toolbar.actions():
             action.setEnabled(enabled)
+
+        # Adjustments for the filter button
+        if enabled:
+            # Restore state for active consoles
+            self.filter_button.setChecked(self._is_filter_button_checked)
+        else:
+            # Uncheck button for dead consoles if it's checked so that the
+            # toolbar looks good
+            if self.filter_button.isChecked():
+                self.filter_button.setChecked(False)
+                self._is_filter_button_checked = True
+
+    def _set_filter_button_state(self, checked):
+        """Keep track of the filter button checked state."""
+        self._is_filter_button_checked = checked

--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -417,12 +417,27 @@ class DialogStyle(SpyderFontsMixin):
 
     @classproperty
     def TitleFontSize(cls):
-        return f"{cls._fs + 9}pt" if MAC else f"{cls._fs + 4}pt"
+        if WIN:
+            return f"{cls._fs + 6}pt"
+        elif MAC:
+            return f"{cls._fs + 6}pt"
+        else:
+            return f"{cls._fs + 4}pt"
 
     @classproperty
     def ContentFontSize(cls):
-        return f"{cls._fs + 5}pt" if MAC else f"{cls._fs + 2}pt"
+        if WIN:
+            return f"{cls._fs + 4}pt"
+        elif MAC:
+            return f"{cls._fs + 2}pt"
+        else:
+            return f"{cls._fs + 2}pt"
 
     @classproperty
     def ButtonsFontSize(cls):
-        return f"{cls._fs + 5}pt" if MAC else f"{cls._fs + 3}pt"
+        if WIN:
+            return f"{cls._fs + 5}pt"
+        elif MAC:
+            return f"{cls._fs + 2}pt"
+        else:
+            return f"{cls._fs + 3}pt"

--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -18,6 +18,8 @@ import qstylizer.style
 
 # Local imports
 from spyder.api.config.mixins import SpyderConfigurationAccessor
+from spyder.api.config.fonts import SpyderFontType, SpyderFontsMixin
+from spyder.api.utils import classproperty
 from spyder.config.gui import OLD_PYQT
 from spyder.utils.palette import QStylePalette
 
@@ -403,11 +405,24 @@ PANES_TABBAR_STYLESHEET = PanesTabBarStyleSheet()
 # =============================================================================
 # ---- Style for special dialogs
 # =============================================================================
-class DialogStyle:
-    """Style constants for tour, about and kite dialogs."""
+class DialogStyle(SpyderFontsMixin):
+    """Style constants for tour and about dialogs."""
 
     IconScaleFactor = 0.5
-    TitleFontSize = '19pt' if MAC else '14pt'
-    ContentFontSize = '15pt' if MAC else '12pt'
-    ButtonsFontSize = '15pt' if MAC else '13pt'
     ButtonsPadding = '6px' if MAC else '4px 10px'
+
+    @classproperty
+    def _fs(cls):
+        return cls.get_font(SpyderFontType.Interface).pointSize()
+
+    @classproperty
+    def TitleFontSize(cls):
+        return f"{cls._fs + 9}pt" if MAC else f"{cls._fs + 4}pt"
+
+    @classproperty
+    def ContentFontSize(cls):
+        return f"{cls._fs + 5}pt" if MAC else f"{cls._fs + 2}pt"
+
+    @classproperty
+    def ButtonsFontSize(cls):
+        return f"{cls._fs + 5}pt" if MAC else f"{cls._fs + 3}pt"

--- a/spyder/widgets/about.py
+++ b/spyder/widgets/about.py
@@ -62,31 +62,42 @@ class AboutDialog(QDialog):
         instagram_url = "https://www.instagram.com/spyderide/",
         self.label_overview = QLabel(
             f"""
+            <style>
+                p, h1 {{margin-bottom: 2em}}
+                h1 {{margin-top: 0}}
+            </style>
+
             <div style='font-family: "{font_family}";
                         font-size: {font_size};
                         font-weight: normal;
                         '>
             <br>
+            <h1>Spyder IDE</h1>
+
             <p>
-            <b> Spyder IDE</b>
-            <br> <br>
-            The Scientific Python Development Environment |
-            <a href="{website_url}">Spyder-IDE.org</a>
+            The Scientific Python Development Environment
             <br>
+            <a href="{website_url}">Spyder-IDE.org</a>
+            </p>
+
             <p>
             Python {versions['python']} {versions['bitness']}-bit |
             Qt {versions['qt']} |
-            {versions['qt_api']} {versions['qt_api_ver']} |
+            {versions['qt_api']} {versions['qt_api_ver']}
+            <br>
             {versions['system']} {versions['release']} ({versions['machine']})
             </p>
-            <br> <br>
+
+            <p>
             <a href="{project_url}">GitHub</a> | <a href="{twitter_url}">
             Twitter</a> |
             <a href="{facebook_url}">Facebook</a> | <a href="{youtube_url}">
             YouTube</a> |
             <a href="{instagram_url}">Instagram</a>
+            </p>
 
-            </div>""")
+            </div>"""
+        )
 
         self.label_community = QLabel(
             f"""
@@ -178,7 +189,6 @@ class AboutDialog(QDialog):
                 font-weight: normal;
                 '>
             <p>
-            <b>Spyder IDE</b>
             <br>{spyder_ver}
             <br>{revision}
             <br>({installer})
@@ -251,7 +261,7 @@ class AboutDialog(QDialog):
         bbox.accepted.connect(self.accept)
 
         # Size
-        self.resize(550, 430)
+        self.resize(720, 480)
 
         # Style
         css = qstylizer.style.StyleSheet()

--- a/spyder/widgets/about.py
+++ b/spyder/widgets/about.py
@@ -10,6 +10,7 @@
 import sys
 
 # Third party imports
+import qstylizer.style
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QPixmap
 from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
@@ -28,7 +29,7 @@ from spyder.config.base import _
 from spyder.utils.icon_manager import ima
 from spyder.utils.image_path_manager import get_image_path
 from spyder.utils.palette import QStylePalette
-from spyder.utils.stylesheet import APP_STYLESHEET, DialogStyle
+from spyder.utils.stylesheet import DialogStyle
 
 
 class AboutDialog(QDialog):
@@ -39,6 +40,7 @@ class AboutDialog(QDialog):
         self.setWindowFlags(
             self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         versions = get_versions()
+
         # Show Git revision for development version
         revlink = ''
         if versions['revision']:
@@ -229,9 +231,10 @@ class AboutDialog(QDialog):
         tabslayout.setContentsMargins(0, 15, 15, 0)
 
         btmhlayout = QHBoxLayout()
+        btmhlayout.addStretch(1)
         btmhlayout.addWidget(btn)
         btmhlayout.addWidget(bbox)
-        btmhlayout.setContentsMargins(100, 20, 0, 20)
+        btmhlayout.setContentsMargins(0, 20, 15, 20)
         btmhlayout.addStretch()
 
         vlayout = QVBoxLayout()
@@ -251,11 +254,13 @@ class AboutDialog(QDialog):
         self.resize(550, 430)
 
         # Style
-        css = APP_STYLESHEET.get_copy()
-        css = css.get_stylesheet()
+        css = qstylizer.style.StyleSheet()
         css.QDialog.setValues(backgroundColor=dialog_background_color)
         css.QLabel.setValues(backgroundColor=dialog_background_color)
-        self.setStyleSheet(str(css))
+        css.QTabBar.setValues(fontSize=font_size)
+        css['QTabBar::tab!selected'].setValues(
+            borderBottomColor=dialog_background_color)
+        self.setStyleSheet(css.toString())
 
     def copy_to_clipboard(self):
         QApplication.clipboard().setText(get_versions_text())

--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -25,12 +25,12 @@ from qtpy.QtWidgets import (QApplication, QCheckBox, QLineEdit, QMessageBox,
                             QWidget, QHBoxLayout, QLabel, QFrame)
 
 # Local imports
+from spyder.api.config.fonts import SpyderFontType, SpyderFontsMixin
 from spyder.config.base import _
 from spyder.utils.icon_manager import ima
 from spyder.utils.stringmatching import get_search_regex
 from spyder.utils.palette import QStylePalette, SpyderPalette
 from spyder.utils.image_path_manager import get_image_path
-from spyder.utils.stylesheet import DialogStyle
 
 # Valid finder chars. To be improved
 VALID_ACCENT_CHARS = "ÁÉÍOÚáéíúóàèìòùÀÈÌÒÙâêîôûÂÊÎÔÛäëïöüÄËÏÖÜñÑ"
@@ -445,11 +445,15 @@ class CustomSortFilterProxy(QSortFilterProxyModel):
             return True
 
 
-class PaneEmptyWidget(QFrame):
+class PaneEmptyWidget(QFrame, SpyderFontsMixin):
     """Widget to show a pane/plugin functionality description."""
 
     def __init__(self, parent, icon_filename, text, description):
         super().__init__(parent)
+
+        interface_font_size = self.get_font(
+            SpyderFontType.Interface).pointSize()
+
         # Image
         image_path = get_image_path(icon_filename)
         image = QPixmap(image_path)
@@ -472,7 +476,7 @@ class PaneEmptyWidget(QFrame):
         text_label.setWordWrap(True)
         text_label_qss = qstylizer.style.StyleSheet()
         text_label_qss.QLabel.setValues(
-            fontSize=DialogStyle.ContentFontSize,
+            fontSize=f'{interface_font_size + 5}pt',
             border="0px"
         )
         text_label.setStyleSheet(text_label_qss.toString())
@@ -483,7 +487,7 @@ class PaneEmptyWidget(QFrame):
         description_label.setWordWrap(True)
         description_label_qss = qstylizer.style.StyleSheet()
         description_label_qss.QLabel.setValues(
-            fontSize="10pt",
+            fontSize=f"{interface_font_size}pt",
             backgroundColor=SpyderPalette.COLOR_OCCURRENCE_3,
             border="0px",
             padding="20px"
@@ -495,9 +499,9 @@ class PaneEmptyWidget(QFrame):
         pane_empty_layout.addStretch(1)
         pane_empty_layout.addWidget(image_label)
         pane_empty_layout.addWidget(text_label)
-        pane_empty_layout.addWidget(description_label)
         pane_empty_layout.addStretch(2)
-        pane_empty_layout.setContentsMargins(10, 0, 10, 8)
+        pane_empty_layout.addWidget(description_label)
+        pane_empty_layout.setContentsMargins(10, 0, 10, 10)
         self.setLayout(pane_empty_layout)
 
         # Setup border style

--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -508,6 +508,13 @@ class PaneEmptyWidget(QFrame, SpyderFontsMixin):
         self.setFocusPolicy(Qt.StrongFocus)
         self._apply_stylesheet(False)
 
+    def setup(self, *args, **kwargs):
+        """
+        This method is needed when using this widget to show a "no connected
+        console" message in plugins that inherit from ShellConnectMainWidget.
+        """
+        pass
+
     def focusInEvent(self, event):
         self._apply_stylesheet(True)
         super().focusOutEvent(event)


### PR DESCRIPTION
## Description of Changes

* For `PaneEmptyWidgets`: show description at the bottom and increase size of main text (these changes were suggested by @conradolandia); and load their icons in a way that doesn't make them appear pixelated at scale factors greater than one.

    ![imagen](https://github.com/spyder-ide/spyder/assets/365293/1dd4d6e6-ca19-4422-8d9b-6957d29e355c)

* For dead consoles: show an appropriate message using a `PaneEmptyWidget` on panes that depend on the console to work. This needs an additional icon that @conradolandia is going to design and add in a follow-up PR.

    ![imagen](https://github.com/spyder-ide/spyder/assets/365293/e1202e05-1162-4f69-977d-2ce070ecb73f)

* This also includes some improvements to the About dialog: use font sizes relative to the interface one, correctly align buttons to the right, increase font size for its tabs, remove white pixels below tabs and make it bigger.

    **Before**

    ![imagen](https://github.com/spyder-ide/spyder/assets/365293/822dfee7-f2d8-4f8c-ad6f-f83e060b1c5c)

    **After**

   ![imagen](https://github.com/spyder-ide/spyder/assets/365293/f45f21a4-3f81-4377-9f20-e65753d93f46)

* Fix color of links in Qt widgets, which was broken in #20933.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
