### PR TITLE
PR: Prevent failures when Codecov action fails and switch to `setup-micromamba` (CI)

### DIFF
--- a/.github/workflows/test-files.yml
+++ b/.github/workflows/test-files.yml
@@ -84,13 +84,12 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-cachepip-installconda-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
       - name: Create conda test environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: requirements/main.yml
           environment-name: test
           cache-downloads: true
-          extra-specs: |
-            python=${{ matrix.PYTHON_VERSION }}
+          create-args: python=${{ matrix.PYTHON_VERSION }}
       - name: Install additional dependencies
         shell: bash -l {0}
         run: bash -l .github/scripts/install.sh

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -145,5 +145,5 @@ jobs:
       - name: Coverage
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -90,23 +90,22 @@ jobs:
           key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
       - name: Create conda test environment
         if: env.USE_CONDA == 'true'
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: requirements/main.yml
           environment-name: test
           cache-downloads: true
-          extra-specs: |
-            python=${{ matrix.PYTHON_VERSION }}
+          create-args: python=${{ matrix.PYTHON_VERSION }}
       - name: Create pip test environment
         if: env.USE_CONDA != 'true'
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: false
           environment-name: test
           cache-downloads: true
-          channels: conda-forge
-          extra-specs: |
-            python=${{ matrix.PYTHON_VERSION }}
+          create-args: python=${{ matrix.PYTHON_VERSION }}
+          condarc: |
+            channels:
+              - conda-forge
       - name: Install additional dependencies
         shell: bash -l {0}
         run: bash -l .github/scripts/install.sh

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -116,5 +116,5 @@ jobs:
       - name: Coverage
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -83,13 +83,12 @@ jobs:
           path: ~/Library/Caches/pip
           key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
       - name: Create conda test environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: requirements/main.yml
           environment-name: test
           cache-downloads: true
-          extra-specs: |
-            python=${{ matrix.PYTHON_VERSION }}
+          create-args: python=${{ matrix.PYTHON_VERSION }}
       - name: Install additional dependencies
         shell: bash -l {0}
         run: bash -l .github/scripts/install.sh

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -84,23 +84,22 @@ jobs:
           key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
       - name: Create conda test environment
         if: env.USE_CONDA == 'true'
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: requirements/main.yml
           environment-name: test
           cache-downloads: true
-          extra-specs: |
-            python=${{ matrix.PYTHON_VERSION }}
+          create-args: python=${{ matrix.PYTHON_VERSION }}
       - name: Create pip test environment
         if: env.USE_CONDA != 'true'
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: false
           environment-name: test
           cache-downloads: true
-          channels: conda-forge
-          extra-specs: |
-            python=${{ matrix.PYTHON_VERSION }}
+          create-args: python=${{ matrix.PYTHON_VERSION }}
+          condarc: |
+            channels:
+              - conda-forge
       - name: Install additional dependencies
         shell: bash -l {0}
         run: bash -l .github/scripts/install.sh

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -140,5 +140,5 @@ jobs:
       - name: Coverage
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true

--- a/spyder/plugins/editor/widgets/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/tests/test_formatting.py
@@ -258,7 +258,7 @@ def test_closing_document_formatting(
     assert code_editor.get_text_with_eol() == expected
 
 
-@flaky(max_runs=5)
+@flaky(max_runs=20)
 @pytest.mark.order(1)
 @pytest.mark.parametrize('formatter', [autopep8, black])
 def test_formatting_on_save(completions_editor, formatter, qtbot):


### PR DESCRIPTION
## Description of Changes

- Codecov is quite flaky lately, which causes a full restart to make our test suite pass.
- We need to switch to `setup-micromamba` because `provision-with-micromamba` is now obsolete.
- Also, make `test_formatting_on_save` run more times because it's quite flaky.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
