### PR TITLE
PR: Some fixes for the report error dialog (UI)

### DIFF
--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -212,13 +212,12 @@ class SpyderErrorDialog(QDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
         # Checkbox to dismiss future errors
         self.dismiss_box = QCheckBox(_("Hide all future errors during this "
                                        "session"))
+        self.dismiss_box.setStyleSheet('margin-left: 2px')
 
         # Checkbox to include IPython console environment
         self.include_env = QCheckBox(_("Include IPython console environment"))
+        self.include_env.setStyleSheet('margin-left: 2px')
         self.include_env.hide()
-        include_env_layout = QHBoxLayout()
-        include_env_layout.addWidget(self.include_env)
-        include_env_layout.setContentsMargins(2, 0, 0, 0)
 
         # Dialog buttons
         gh_icon = ima.icon('github')
@@ -257,6 +256,7 @@ class SpyderErrorDialog(QDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
         layout.addWidget(self.desc_chars_label)
 
         if not self.is_report:
+            layout.addSpacing(15)
             layout.addWidget(self.dismiss_box)
 
         # Only provide checkbox if not an installer default interpreter
@@ -265,8 +265,9 @@ class SpyderErrorDialog(QDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
             or not self.get_conf('default', section='main_interpreter')
         ):
             self.include_env.show()
-            layout.addSpacing(15)
-            layout.addLayout(include_env_layout)
+            if self.is_report:
+                layout.addSpacing(15)
+            layout.addWidget(self.include_env)
             layout.addSpacing(5)
         else:
             layout.addSpacing(5)

--- a/spyder/widgets/reporterror.py
+++ b/spyder/widgets/reporterror.py
@@ -50,7 +50,9 @@ class DescriptionWidget(SimpleCodeEditor, SpyderFontsMixin):
         # Editor options
         self.setup_editor(
             language='md',
-            font=self.get_font(SpyderFontType.MonospaceInterface),
+            font=self.get_font(
+                SpyderFontType.MonospaceInterface, font_size_delta=1
+            ),
             wrap=True,
             linenumbers=False,
             highlight_current_line=False,
@@ -112,7 +114,8 @@ class DescriptionWidget(SimpleCodeEditor, SpyderFontsMixin):
         pass
 
 
-class ShowErrorWidget(TracebackLinksMixin, ConsoleBaseWidget, BaseEditMixin):
+class ShowErrorWidget(TracebackLinksMixin, ConsoleBaseWidget, BaseEditMixin,
+                      SpyderFontsMixin):
     """Widget to show errors as they appear in the Internal console."""
     QT_CLASS = QPlainTextEdit
     sig_go_to_error_requested = Signal(str)
@@ -121,10 +124,14 @@ class ShowErrorWidget(TracebackLinksMixin, ConsoleBaseWidget, BaseEditMixin):
         ConsoleBaseWidget.__init__(self, parent)
         BaseEditMixin.__init__(self)
         TracebackLinksMixin.__init__(self)
+
         self.setReadOnly(True)
+        self.set_pythonshell_font(
+            self.get_font(SpyderFontType.MonospaceInterface, font_size_delta=1)
+        )
 
 
-class SpyderErrorDialog(QDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
+class SpyderErrorDialog(QDialog, SpyderConfigurationAccessor):
     """Custom error dialog for error reporting."""
 
     def __init__(self, parent=None, is_report=False):
@@ -195,9 +202,7 @@ class SpyderErrorDialog(QDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
 
         # Widget to show errors
         self.details = ShowErrorWidget(self)
-        self.details.set_pythonshell_font(
-            self.get_font(SpyderFontType.MonospaceInterface)
-        )
+        self.details.setStyleSheet('margin-left: 4px')
         self.details.hide()
 
         self.description_minimum_length = DESC_MIN_CHARS


### PR DESCRIPTION
## Description of Changes

- Fix spacing and alignment of dismiss checkbox.
- Increase monospace font size by one point because the current size is too small.
- Fix left alignment of the details widget.

**Before**

![imagen](https://github.com/spyder-ide/spyder/assets/365293/c909d372-716f-4846-b473-0e3806d4566e)

**After**

![imagen](https://github.com/spyder-ide/spyder/assets/365293/63080287-099b-4635-ac46-8da87bee63ac)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
