### PR TITLE
PR: Cache subrepo conda builds for installers

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -106,7 +106,7 @@ jobs:
     env:
       DISTDIR: ${{ github.workspace }}/installers-conda/dist
       pkg: ${{ matrix.pkg }}
-      artifact_name: ${{ matrix.pkg }}_${{ matrix.python-version }}
+      cache_base: ${{ matrix.pkg }}_${{ matrix.python-version }}
 
     steps:
       - name: Checkout Code
@@ -122,17 +122,25 @@ jobs:
           cache-downloads: true
           cache-environment: true
 
-      - name: Build Conda Packages
-        run: python build_conda_pkgs.py --build $pkg
+      - name: Env Variables
+        run: |
+          # conda build path should be in the workspace for caching
+          CONDA_BLD_PATH=$PWD/build/conda-bld
+          echo "CONDA_BLD_PATH=$CONDA_BLD_PATH" >> $GITHUB_ENV
+          env | sort
 
-      - name: Build Artifact
-        run: tar -a -C $CONDA_PREFIX -cf $PWD/${artifact_name}.tar.bz2 conda-bld
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+      - name: Cache ${{ matrix.pkg }} Conda Build
+        id: cache
+        uses: actions/cache@v3
         with:
-          path: ${{ github.workspace }}/installers-conda/${{ env.artifact_name }}.tar.bz2
-          name: ${{ env.artifact_name }}
+          path: installers-conda/build/conda-bld/**/*.tar.bz2
+          key: ${{ env.cache_base }}_${{ hashFiles(format('external-deps/{0}/.gitrepo', env.pkg)) }}
+          lookup-only: true
+          enableCrossOsArchive: true
+
+      - name: Build ${{ matrix.pkg }} Conda Package
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: python build_conda_pkgs.py --build $pkg
 
   build-installers:
     name: Build installer for ${{ matrix.target-platform }} Python-${{ matrix.python-version }}
@@ -176,33 +184,34 @@ jobs:
 
       - name: Env Variables
         run: |
-          ARTIFACTS_PATH=$RUNNER_TEMP/artifacts
           CONDA_BLD_PATH=$RUNNER_TEMP/conda-bld
 
-          echo "ARTIFACTS_PATH=$ARTIFACTS_PATH" >> $GITHUB_ENV
           echo "CONDA_BLD_PATH=$CONDA_BLD_PATH" >> $GITHUB_ENV
 
-          [[ -d $ARTIFACTS_PATH ]] || mkdir $ARTIFACTS_PATH
           [[ -d $CONDA_BLD_PATH ]] || mkdir $CONDA_BLD_PATH
 
           env | sort
 
-      - name: Download Local Conda Packages
-        if: needs.build-noarch-pkgs.result == 'success'
-        uses: actions/download-artifact@v3
+      - name: Restore python-lsp-server Cache
+        if: env.IS_STANDARD_PR == 'true'
+        uses: actions/cache/restore@v3
         with:
-          path: ${{ env.ARTIFACTS_PATH }}
+          path: installers-conda/build/conda-bld/**/*.tar.bz2
+          key: python-lsp-server_${{ matrix.python-version }}_${{ hashFiles('external-deps/python-lsp-server/.gitrepo') }}
+          enableCrossOsArchive: true
+
+      - name: Restore qtconsole Cache
+        if: env.IS_STANDARD_PR == 'true'
+        uses: actions/cache/restore@v3
+        with:
+          path: installers-conda/build/conda-bld/**/*.tar.bz2
+          key: qtconsole_${{ matrix.python-version }}_${{ hashFiles('external-deps/qtconsole/.gitrepo') }}
+          enableCrossOsArchive: true
 
       - name: Create Local Conda Channel
         run: |
-          files=($(find $ARTIFACTS_PATH -name *.tar.bz2))
-          echo ${files[@]}
-          cd $(dirname $CONDA_BLD_PATH)
-
-          [[ $RUNNER_OS == "Windows" ]] && opts=("--force-local") || opts=()
-          for file in ${files[@]}; do
-              tar -xf $file ${opts[@]}
-          done
+          # Copy cached packages to build location outside workspace
+          [[ -d build/conda-bld ]] && cp -Rv build/conda-bld $CONDA_BLD_PATH
 
           mamba index $CONDA_BLD_PATH
 

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -114,21 +114,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Build Environment
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: installers-conda/build-environment.yml
-          create-args: python=${{ matrix.python-version }}
-          cache-downloads: true
-          cache-environment: true
-
-      - name: Env Variables
-        run: |
-          # conda build path should be in the workspace for caching
-          CONDA_BLD_PATH=$PWD/build/conda-bld
-          echo "CONDA_BLD_PATH=$CONDA_BLD_PATH" >> $GITHUB_ENV
-          env | sort
-
       - name: Cache ${{ matrix.pkg }} Conda Build
         id: cache
         uses: actions/cache@v3
@@ -138,8 +123,19 @@ jobs:
           lookup-only: true
           enableCrossOsArchive: true
 
-      - name: Build ${{ matrix.pkg }} Conda Package
+      - name: Setup Build Environment
         if: steps.cache.outputs.cache-hit != 'true'
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: installers-conda/build-environment.yml
+          create-args: python=${{ matrix.python-version }}
+          cache-downloads: true
+          cache-environment: true
+
+      - name: Build & Cache ${{ matrix.pkg }} Conda Package
+        if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          CONDA_BLD_PATH: ${{ github.workspace }}/installers-conda/build/conda-bld
         run: python build_conda_pkgs.py --build $pkg
 
   build-installers:
@@ -175,17 +171,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Build Environment
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: installers-conda/build-environment.yml
-          create-args: python=${{ matrix.python-version }}
-          cache-downloads: true
-          cache-environment: true
-
-      - name: Env Variables
-        run: env | sort
-
       - name: Restore python-lsp-server Cache
         if: env.IS_STANDARD_PR == 'true'
         uses: actions/cache/restore@v3
@@ -217,7 +202,18 @@ jobs:
           path: installers-conda/build/conda-bld/**/spyder-kernels-*.tar.bz2
           key: spyder-kernels_${{ matrix.target-platform }}_${{ matrix.python-version }}_${{ hashFiles('external-deps/spyder-kernels/.gitrepo') }}
 
-      - name: Build Windows spyder-kernels Conda Package
+      - name: Setup Build Environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: installers-conda/build-environment.yml
+          create-args: python=${{ matrix.python-version }}
+          cache-downloads: true
+          cache-environment: true
+
+      - name: Env Variables
+        run: env | sort
+
+      - name: Build & Cache Windows spyder-kernels Conda Package
         if: env.IS_STANDARD_PR == 'true' && runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
         env:
           CONDA_BLD_PATH: ${{ github.workspace }}/installers-conda/build/conda-bld
@@ -228,7 +224,8 @@ jobs:
         env:
           CONDA_BLD_PATH: ${{ runner.temp }}/conda-bld
         run: |
-          # Copy built packages to new build location
+          # Copy built packages to new build location because spyder cannot be
+          # built in workspace
           [[ -d build/conda-bld ]] && cp -Rv build/conda-bld $CONDA_BLD_PATH
 
           python build_conda_pkgs.py --build spyder

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -235,8 +235,9 @@ jobs:
         env:
           CONDA_BLD_PATH: ${{ runner.temp }}/conda-bld
         run: |
+          conda config --set bld_path $CONDA_BLD_PATH
           mamba index $CONDA_BLD_PATH
-          mamba search -c $CONDA_BLD_PATH --override-channels || true
+          mamba search -c local --override-channels || true
 
       - name: Create Keychain
         if: runner.os == 'macOS' && (env.IS_RELEASE == 'true' || env.IS_PRE == 'true')

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -153,7 +153,7 @@ jobs:
         include: ${{fromJson(needs.build-matrix.outputs.include)}}
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -le {0}
         working-directory: ${{ github.workspace }}/installers-conda
     env:
       DISTDIR: ${{ github.workspace }}/installers-conda/dist

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -150,6 +150,7 @@ jobs:
       - build-noarch-pkgs
     if: ${{ ! failure() && ! cancelled() }}
     strategy:
+      fail-fast: false
       matrix:
         target-platform: ${{fromJson(needs.build-matrix.outputs.target_platform)}}
         python-version: ${{fromJson(needs.build-matrix.outputs.python_version)}}

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -97,7 +97,7 @@ jobs:
     if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ! inputs.pre)
     strategy:
       matrix:
-        pkg: ["python-lsp-server", "qtconsole"]
+        pkg: ["python-lsp-server", "qtconsole", "spyder-kernels"]
         python-version: ${{fromJson(needs.build-matrix.outputs.python_version)}}
     defaults:
       run:
@@ -183,14 +183,7 @@ jobs:
           cache-environment: true
 
       - name: Env Variables
-        run: |
-          CONDA_BLD_PATH=$RUNNER_TEMP/conda-bld
-
-          echo "CONDA_BLD_PATH=$CONDA_BLD_PATH" >> $GITHUB_ENV
-
-          [[ -d $CONDA_BLD_PATH ]] || mkdir $CONDA_BLD_PATH
-
-          env | sort
+        run: env | sort
 
       - name: Restore python-lsp-server Cache
         if: env.IS_STANDARD_PR == 'true'
@@ -208,29 +201,44 @@ jobs:
           key: qtconsole_${{ matrix.python-version }}_${{ hashFiles('external-deps/qtconsole/.gitrepo') }}
           enableCrossOsArchive: true
 
-      - name: Create Local Conda Channel
-        run: |
-          # Copy cached packages to build location outside workspace
-          [[ -d build/conda-bld ]] && cp -Rv build/conda-bld $CONDA_BLD_PATH
+      - name: Restore Unix spyder-kernels Cache
+        if: env.IS_STANDARD_PR == 'true' && runner.os != 'Windows'
+        uses: actions/cache/restore@v3
+        with:
+          path: installers-conda/build/conda-bld/**/*.tar.bz2
+          key: spyder-kernels_${{ matrix.python-version }}_${{ hashFiles('external-deps/spyder-kernels/.gitrepo') }}
 
-          mamba index $CONDA_BLD_PATH
-
-          mamba search -c $CONDA_BLD_PATH --override-channels || true
-
-      - name: Cache spyder-kernels Conda Build
-        if: env.IS_STANDARD_PR == 'true'
+      - name: Restore Windows spyder-kernels Cache
         id: cache
+        if: env.IS_STANDARD_PR == 'true' && runner.os == 'Windows'
         uses: actions/cache@v3
         with:
-          path: ${{ env.CONDA_BLD_PATH }}/**/spyder-kernels-*.tar.bz2
+          path: installers-conda/build/conda-bld/**/spyder-kernels-*.tar.bz2
+          key: spyder-kernels_${{ matrix.target-platform }}_${{ matrix.python-version }}_${{ hashFiles('external-deps/spyder-kernels/.gitrepo') }}
 
-      - name: Build spyder-kernels Conda Package
-        if: env.IS_STANDARD_PR == 'true' && steps.cache.outputs.cache-hit != 'true'
+      - name: Build Windows spyder-kernels Conda Package
+        if: env.IS_STANDARD_PR == 'true' && runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
+        env:
+          CONDA_BLD_PATH: ${{ github.workspace }}/installers-conda/build/conda-bld
         run: python build_conda_pkgs.py --build spyder-kernels
 
       - name: Build ${{ matrix.target-platform }} spyder Conda Package
         if: env.IS_STANDARD_PR == 'true'
-        run: python build_conda_pkgs.py --build spyder
+        env:
+          CONDA_BLD_PATH: ${{ runner.temp }}/conda-bld
+        run: |
+          # Copy built packages to new build location
+          [[ -d build/conda-bld ]] && cp -Rv build/conda-bld $CONDA_BLD_PATH
+
+          python build_conda_pkgs.py --build spyder
+
+      - name: Create Local Conda Channel
+        if: env.IS_STANDARD_PR == 'true'
+        env:
+          CONDA_BLD_PATH: ${{ runner.temp }}/conda-bld
+        run: |
+          mamba index $CONDA_BLD_PATH
+          mamba search -c $CONDA_BLD_PATH --override-channels || true
 
       - name: Create Keychain
         if: runner.os == 'macOS' && (env.IS_RELEASE == 'true' || env.IS_PRE == 'true')

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -217,13 +217,20 @@ jobs:
 
           mamba search -c $CONDA_BLD_PATH --override-channels || true
 
-      - name: Build ${{ matrix.target-platform }} conda packages
-        run: |
-          pkgs=("spyder")
-          if [[ $IS_STANDARD_PR == "true" ]]; then
-              pkgs+=("spyder-kernels")
-          fi
-          python build_conda_pkgs.py --build ${pkgs[@]}
+      - name: Cache spyder-kernels Conda Build
+        if: env.IS_STANDARD_PR == 'true'
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CONDA_BLD_PATH }}/**/spyder-kernels-*.tar.bz2
+
+      - name: Build spyder-kernels Conda Package
+        if: env.IS_STANDARD_PR == 'true' && steps.cache.outputs.cache-hit != 'true'
+        run: python build_conda_pkgs.py --build spyder-kernels
+
+      - name: Build ${{ matrix.target-platform }} spyder Conda Package
+        if: env.IS_STANDARD_PR == 'true'
+        run: python build_conda_pkgs.py --build spyder
 
       - name: Create Keychain
         if: runner.os == 'macOS' && (env.IS_RELEASE == 'true' || env.IS_PRE == 'true')

--- a/installers-conda/resources/post-install.sh
+++ b/installers-conda/resources/post-install.sh
@@ -15,8 +15,10 @@ spy_exe=${PREFIX}/envs/spyder-runtime/bin/spyder
 u_spy_exe=${PREFIX}/uninstall-spyder.sh
 all_user=$([[ -e ${PREFIX}/.nonadmin ]] && echo false || echo true)
 
+sed_opts=("-i")
 alias_text="alias uninstall-spyder=${u_spy_exe}"
 if [[ "$OSTYPE" = "darwin"* ]]; then
+    sed_opts+=("", "-e")
     shortcut_path="/Applications/${INSTALLER_NAME}.app"
     if [[ "$all_user" = "false" ]]; then
         shortcut_path="${HOME}${shortcut_path}"
@@ -45,11 +47,11 @@ add_alias() {
 
     # Remove old-style markers, if present; discard after EXPERIMENTAL
     # installer attrition.
-    sed -i "" -e "/# <<<< Added by Spyder <<<</,/# >>>> Added by Spyder >>>>/d" $shell_init
+    sed ${sed_opts[@]} "/# <<<< Added by Spyder <<<</,/# >>>> Added by Spyder >>>>/d" $shell_init
 
     # Posix compliant sed does not like semicolons.
     # Must use newlines to work on macOS
-    sed -i "" -e "
+    sed ${sed_opts[@]} "
     /$m1/,/$m2/{
         h
         /$m2/ s|.*|$m1\n$alias_text\n$m2|
@@ -133,7 +135,7 @@ done
 for x in ${shell_init_list[@]}; do
     [[ ! -f "\$x" ]] && continue
     echo "Removing Spyder shell commands from \$x..."
-    sed -i "" -e "/$m1/,/$m2/d" \$x
+    sed ${sed_opts[@]} "/$m1/,/$m2/d" \$x
 done
 
 # Remove shortcut and environment


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

A significant amount of time is spent building conda packages of the subrepos `python-lsp-server`, `qtconsole`, and `spyder-kernels` during standard PRs. These package versions are not necessarily stable release versions or release candidate versions and must be built from the commit states specified in their respective `.gitrepo` files. Nevertheless, they do not change very often and therefore are excellent candidates for caching.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21157