### PR TITLE
PR: Fix config page radiobutton reference (Main interpreter)

### DIFF
--- a/spyder/plugins/maininterpreter/confpage.py
+++ b/spyder/plugins/maininterpreter/confpage.py
@@ -243,7 +243,7 @@ class MainInterpreterConfigPage(PluginConfigPage):
 
     def perform_adjustments(self):
         """Perform some adjustments to the page after applying preferences."""
-        if not self.def_exec_radio.isChecked():
+        if not self.def_exec_radio.radiobutton.isChecked():
             # Get current executable
             executable = self.pyexec_edit.text()
             executable = osp.normpath(executable)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->

Prevent an error when changing the Python interpreter config from the preferences:

```python-traceback
Traceback (most recent call last):
  File "e:\acer\documentos\spyder\spyder\spyder\plugins\preferences\widgets\configdialog.py", line 142, in button_clicked
    configpage.apply_changes()
  File "e:\acer\documentos\spyder\spyder\spyder\plugins\preferences\api.py", line 119, in apply_changes
    self.apply_callback()
  File "e:\acer\documentos\spyder\spyder\spyder\plugins\maininterpreter\confpage.py", line 246, in perform_adjustments
    if not self.def_exec_radio.isChecked():
AttributeError: 'QWidget' object has no attribute 'isChecked'
```

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
