### PR TITLE
PR: Do not overwrite test script to allow tests to be rerun

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -5417,8 +5417,8 @@ def test_PYTHONPATH_in_consoles(main_window, qtbot, tmp_path,
     assert str(new_dir) in shell.get_value("sys_path")
 
 
-@flaky(max_runs=3)
-def test_clickable_ipython_tracebacks(main_window, qtbot, tmpdir):
+@flaky(max_runs=10)
+def test_clickable_ipython_tracebacks(main_window, qtbot, tmp_path):
     """
     Test that file names in IPython console tracebacks are clickable.
 
@@ -5429,8 +5429,11 @@ def test_clickable_ipython_tracebacks(main_window, qtbot, tmpdir):
     qtbot.waitUntil(lambda: shell._prompt_html is not None,
                     timeout=SHELL_TIMEOUT)
 
-    # Open test file
-    test_file = osp.join(LOCATION, 'script.py')
+    # Copy test file to a temporary location to avoid modifying it.
+    # See spyder-ide/spyder#21186 for the details
+    test_file_orig = osp.join(LOCATION, 'script.py')
+    test_file = str(tmp_path / 'script.py')
+    shutil.copyfile(test_file_orig, test_file)
     main_window.editor.load(test_file)
     code_editor = main_window.editor.get_focus_widget()
 
@@ -5472,11 +5475,6 @@ def test_clickable_ipython_tracebacks(main_window, qtbot, tmpdir):
     # Check we are in the right line
     cursor = code_editor.textCursor()
     assert cursor.blockNumber() == code_editor.blockCount() - 1
-
-    # Remove error and save file
-    code_editor.delete_line()
-    code_editor.sig_save_requested.emit()
-    qtbot.wait(500)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->

The new test in 5.4.3 or 5.4.4 `spyder/app/tests/test_mainwindow.py::test_clickable_ipython_tracebacks` modifies the sample script `script.py` used by other tests.  This means that those other tests will fail if they are run after this test.

This PR fixes this by copying `script.py` and editing the copy instead.  It also means that this test itself can be rerun.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @juliangilbey 

<!--- Thanks for your help making Spyder better for everyone! --->
