### PR TITLE
PR: Fix `ReadOnlyCollectionsModel` tooltip logic (Widgets/Variable Explorer)

### DIFF
--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -406,10 +406,6 @@ class ReadOnlyCollectionsModel(QAbstractTableModel, SpyderFontsMixin):
         if not index.isValid():
             return to_qvariant()
         value = self.get_value(index)
-        if role == Qt.ToolTipRole and index.column() == 3:
-            return value['view']
-        elif role == Qt.ToolTipRole:
-            return value
         if index.column() == 4 and role == Qt.DisplayRole:
             # TODO: Check the effect of not hiding the column
             # Treating search scores as a table column simplifies the
@@ -428,6 +424,8 @@ class ReadOnlyCollectionsModel(QAbstractTableModel, SpyderFontsMixin):
                 display = to_text_string(value)
             else:
                 display = value
+        if role == Qt.ToolTipRole:
+            return display
         if role == Qt.UserRole:
             if isinstance(value, NUMERIC_TYPES):
                 return to_qvariant(value)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Prevents an error when trying to get a tooltip for variables inside a collections editor instance shown from clicking a variable in the Variable Explorer

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21191 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
