### PR TITLE
Build subrepo caches on master

### DIFF
--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -1,0 +1,70 @@
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - '**.gitrepo'
+
+  workflow_dispatch:
+
+concurrency:
+  group: build-subrepos-${{ github.ref }}
+  cancel-in-progress: true
+
+name: Create Subrepo Conda Packages
+
+jobs:
+  build-pkgs:
+    name: Build ${{ matrix.pkg }} ${{ matrix.cache-arch }} Python-${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        pkg: [python-lsp-server, qtconsole, spyder-kernels]
+        include:
+          - python-version: '3.10'
+          - cache-arch: noarch
+          - os: ubuntu-latest
+            pkg: spyder-kernels
+            cache-arch: unix
+          - os: windows-latest
+            pkg: spyder-kernels
+            python-version: '3.10'
+            cache-arch: win-64
+    defaults:
+      run:
+        shell: bash -l {0}
+        working-directory: ${{ github.workspace }}/installers-conda
+    env:
+      pkg: ${{ matrix.pkg }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Cache ${{ matrix.pkg }} ${{ matrix.cache-arch }} Conda Build
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: installers-conda/build/conda-bld/**/*.tar.bz2
+          key: ${{ matrix.pkg }}_${{ matrix.cache-arch }}_${{ matrix.python-version }}_${{ hashFiles(format('external-deps/{0}/.gitrepo', env.pkg)) }}
+          lookup-only: true
+          enableCrossOsArchive: true
+
+      - name: Setup Build Environment
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: installers-conda/build-environment.yml
+          create-args: python=${{ matrix.python-version }}
+          cache-downloads: true
+          cache-environment: true
+
+      - name: Build ${{ matrix.pkg }} Conda Package
+        if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          CONDA_BLD_PATH: ${{ github.workspace }}/installers-conda/build/conda-bld
+        run: python build_conda_pkgs.py --build $pkg


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

PR #21182 implemented caching conda builds of Spyder's subrepositories (qtconsole, python-lsp-server, and spyder-kernels). While this reduced workflow time, the caching is limited in scope to the branch the PR is intending to merge, i.e. the subrepos must be built at least once per PR.

This PR will create caches of the subrepos on the master branch, thus increasing the scope of the caches to any branch based off of master. This means that new PRs or new branches will not need to build the subrepos conda packages unless `.gitrepo` changes.

This PR introduces a new workflow that builds and caches the conda packages for Spyder's subrepos. It is triggered only when a `.gitrepo` file is changed on a push to master branch, or by workflow-dispatch (manual trigger).

The existing installer workflow will no longer build the subrepo conda packages, but only restore the caches.