### PR TITLE
PR: Update installer workflow to only restore cache of subrepo builds (Installers)

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -73,84 +73,30 @@ jobs:
       run: |
         if [[ $BUILD_MAC == "true" ]]; then
             target_platform="'osx-64'"
-            include="{'os': 'macos-11', 'target-platform': 'osx-64'}"
+            include="{'os': 'macos-11', 'target-platform': 'osx-64', 'spyk-arch': 'unix'}"
         fi
         if [[ $BUILD_LNX == "true" ]]; then
             target_platform=${target_platform:+"$target_platform, "}"'linux-64'"
-            include=${include:+"$include, "}"{'os': 'ubuntu-latest', 'target-platform': 'linux-64'}"
+            include=${include:+"$include, "}"{'os': 'ubuntu-latest', 'target-platform': 'linux-64', 'spyk-arch': 'unix'}"
         fi
         if [[ $BUILD_WIN == "true" ]]; then
             target_platform=${target_platform:+"$target_platform, "}"'win-64'"
-            include=${include:+"$include, "}"{'os': 'windows-latest', 'target-platform': 'win-64'}"
+            include=${include:+"$include, "}"{'os': 'windows-latest', 'target-platform': 'win-64', 'spyk-arch': 'win-64'}"
         fi
-
-        python_version="'3.10'"
 
         echo "target_platform=[$target_platform]" >> $GITHUB_OUTPUT
         echo "include=[$include]" >> $GITHUB_OUTPUT
-        echo "python_version=[$python_version]" >> $GITHUB_OUTPUT
-
-  build-noarch-pkgs:
-    name: Build ${{ matrix.pkg }} Python-${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    needs:
-      - build-matrix
-    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ! inputs.pre)
-    strategy:
-      matrix:
-        pkg: ["python-lsp-server", "qtconsole", "spyder-kernels"]
-        python-version: ${{fromJson(needs.build-matrix.outputs.python_version)}}
-    defaults:
-      run:
-        shell: bash -l {0}
-        working-directory: ${{ github.workspace }}/installers-conda
-    env:
-      DISTDIR: ${{ github.workspace }}/installers-conda/dist
-      pkg: ${{ matrix.pkg }}
-      cache_base: ${{ matrix.pkg }}_${{ matrix.python-version }}
-
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Cache ${{ matrix.pkg }} Conda Build
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: installers-conda/build/conda-bld/**/*.tar.bz2
-          key: ${{ env.cache_base }}_${{ hashFiles(format('external-deps/{0}/.gitrepo', env.pkg)) }}
-          lookup-only: true
-          enableCrossOsArchive: true
-
-      - name: Setup Build Environment
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: installers-conda/build-environment.yml
-          create-args: python=${{ matrix.python-version }}
-          cache-downloads: true
-          cache-environment: true
-
-      - name: Build & Cache ${{ matrix.pkg }} Conda Package
-        if: steps.cache.outputs.cache-hit != 'true'
-        env:
-          CONDA_BLD_PATH: ${{ github.workspace }}/installers-conda/build/conda-bld
-        run: python build_conda_pkgs.py --build $pkg
 
   build-installers:
     name: Build installer for ${{ matrix.target-platform }} Python-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     needs:
       - build-matrix
-      - build-noarch-pkgs
-    if: ${{ ! failure() && ! cancelled() }}
     strategy:
       fail-fast: false
       matrix:
         target-platform: ${{fromJson(needs.build-matrix.outputs.target_platform)}}
-        python-version: ${{fromJson(needs.build-matrix.outputs.python_version)}}
+        python-version: ['3.10']
         include: ${{fromJson(needs.build-matrix.outputs.include)}}
     defaults:
       run:
@@ -163,8 +109,6 @@ jobs:
       MACOS_INSTALLER_CERTIFICATE: ${{ secrets.MACOS_INSTALLER_CERTIFICATE }}
       APPLICATION_PWD: ${{ secrets.APPLICATION_PWD }}
       CONSTRUCTOR_TARGET_PLATFORM: ${{ matrix.target-platform }}
-      BNP_STATUS: ${{ needs.build-noarch-pkgs.result }}
-      MAT_STATUS: ${{ needs.build-matrix.result }}
 
     steps:
       - name: Checkout Code
@@ -177,31 +121,27 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: installers-conda/build/conda-bld/**/*.tar.bz2
-          key: python-lsp-server_${{ matrix.python-version }}_${{ hashFiles('external-deps/python-lsp-server/.gitrepo') }}
+          key: python-lsp-server_noarch_${{ matrix.python-version }}_${{ hashFiles('external-deps/python-lsp-server/.gitrepo') }}
           enableCrossOsArchive: true
+          fail-on-cache-miss: true
 
       - name: Restore qtconsole Cache
         if: env.IS_STANDARD_PR == 'true'
         uses: actions/cache/restore@v3
         with:
           path: installers-conda/build/conda-bld/**/*.tar.bz2
-          key: qtconsole_${{ matrix.python-version }}_${{ hashFiles('external-deps/qtconsole/.gitrepo') }}
+          key: qtconsole_noarch_${{ matrix.python-version }}_${{ hashFiles('external-deps/qtconsole/.gitrepo') }}
           enableCrossOsArchive: true
+          fail-on-cache-miss: true
 
-      - name: Restore Unix spyder-kernels Cache
-        if: env.IS_STANDARD_PR == 'true' && runner.os != 'Windows'
+      - name: Restore ${{ matrix.spyk-arch }} spyder-kernels Cache
+        if: env.IS_STANDARD_PR == 'true'
         uses: actions/cache/restore@v3
         with:
           path: installers-conda/build/conda-bld/**/*.tar.bz2
-          key: spyder-kernels_${{ matrix.python-version }}_${{ hashFiles('external-deps/spyder-kernels/.gitrepo') }}
-
-      - name: Restore Windows spyder-kernels Cache
-        id: cache
-        if: env.IS_STANDARD_PR == 'true' && runner.os == 'Windows'
-        uses: actions/cache@v3
-        with:
-          path: installers-conda/build/conda-bld/**/spyder-kernels-*.tar.bz2
-          key: spyder-kernels_${{ matrix.target-platform }}_${{ matrix.python-version }}_${{ hashFiles('external-deps/spyder-kernels/.gitrepo') }}
+          key: spyder-kernels_${{ matrix.spyk-arch }}_${{ matrix.python-version }}_${{ hashFiles('external-deps/spyder-kernels/.gitrepo') }}
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
 
       - name: Setup Build Environment
         uses: mamba-org/setup-micromamba@v1
@@ -213,12 +153,6 @@ jobs:
 
       - name: Env Variables
         run: env | sort
-
-      - name: Build & Cache Windows spyder-kernels Conda Package
-        if: env.IS_STANDARD_PR == 'true' && runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
-        env:
-          CONDA_BLD_PATH: ${{ github.workspace }}/installers-conda/build/conda-bld
-        run: python build_conda_pkgs.py --build spyder-kernels
 
       - name: Build ${{ matrix.target-platform }} spyder Conda Package
         if: env.IS_STANDARD_PR == 'true'


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Follow-up PR to #21212 

This PR revises the existing installer workflow to only restore caches of the subrepo conda packages. These packages will now be built and cached by the workflow introduced in #21212.