### PR TITLE
PR: Fix showing text in the dark theme for keyboard sequences in the Shortcurts page (Preferences)

### DIFF
--- a/spyder/plugins/completion/providers/languageserver/conftabs/otherlanguages.py
+++ b/spyder/plugins/completion/providers/languageserver/conftabs/otherlanguages.py
@@ -19,7 +19,7 @@ from spyder.config.base import _
 from spyder.plugins.completion.api import SUPPORTED_LANGUAGES
 from spyder.plugins.completion.providers.languageserver.widgets import (
     LSPServerTable)
-from spyder.utils.icon_manager import ima
+
 
 LSP_URL = "https://microsoft.github.io/language-server-protocol"
 
@@ -45,7 +45,7 @@ class OtherLanguagesConfigTab(SpyderPreferencesTab):
 
         # Servers table
         table_group = QGroupBox(_('Available servers:'))
-        self.table = LSPServerTable(self, text_color=ima.MAIN_FG_COLOR)
+        self.table = LSPServerTable(self)
         self.table.setMaximumHeight(150)
         table_layout = QVBoxLayout()
         table_layout.addWidget(self.table)

--- a/spyder/plugins/completion/providers/languageserver/widgets/serversconfig.py
+++ b/spyder/plugins/completion/providers/languageserver/widgets/serversconfig.py
@@ -26,6 +26,7 @@ from spyder.api.config.fonts import SpyderFontsMixin, SpyderFontType
 from spyder.config.base import _
 from spyder.plugins.completion.api import SUPPORTED_LANGUAGES
 from spyder.utils.misc import check_connection_port
+from spyder.utils.palette import QStylePalette
 from spyder.utils.programs import find_program
 from spyder.widgets.helperwidgets import ItemDelegate
 from spyder.widgets.simplecodeeditor import SimpleCodeEditor
@@ -484,7 +485,7 @@ LANGUAGE, ADDR, CMD = [0, 1, 2]
 
 
 class LSPServersModel(QAbstractTableModel):
-    def __init__(self, parent, text_color=None, text_color_highlight=None):
+    def __init__(self, parent):
         QAbstractTableModel.__init__(self)
         self._parent = parent
 
@@ -498,17 +499,7 @@ class LSPServersModel(QAbstractTableModel):
         self.widths = []
 
         # Needed to compensate for the HTMLDelegate color selection unawareness
-        palette = parent.palette()
-        if text_color is None:
-            self.text_color = palette.text().color().name()
-        else:
-            self.text_color = text_color
-
-        if text_color_highlight is None:
-            self.text_color_highlight = \
-                palette.highlightedText().color().name()
-        else:
-            self.text_color_highlight = text_color_highlight
+        self.text_color = QStylePalette.COLOR_TEXT_1
 
     def sortByName(self):
         """Qt Override."""
@@ -582,11 +573,11 @@ class LSPServersModel(QAbstractTableModel):
 
 
 class LSPServerTable(QTableView):
-    def __init__(self, parent, text_color=None):
+    def __init__(self, parent):
         QTableView.__init__(self, parent)
         self._parent = parent
         self.delete_queue = []
-        self.source_model = LSPServersModel(self, text_color=text_color)
+        self.source_model = LSPServersModel(self)
         self.setModel(self.source_model)
         self.setItemDelegateForColumn(CMD, ItemDelegate(self))
         self.setSelectionBehavior(QAbstractItemView.SelectRows)

--- a/spyder/plugins/completion/providers/snippets/widgets/snippetsconfig.py
+++ b/spyder/plugins/completion/providers/snippets/widgets/snippetsconfig.py
@@ -405,7 +405,7 @@ class SnippetsModel(QAbstractTableModel):
     TRIGGER = 0
     DESCRIPTION = 1
 
-    def __init__(self, parent, text_color=None, text_color_highlight=None):
+    def __init__(self, parent):
         QAbstractTableModel.__init__(self)
         self.parent = parent
 
@@ -417,19 +417,6 @@ class SnippetsModel(QAbstractTableModel):
         self.letters = ''
         self.label = QLabel()
         self.widths = []
-
-        # Needed to compensate for the HTMLDelegate color selection unawareness
-        palette = parent.palette()
-        if text_color is None:
-            self.text_color = palette.text().color().name()
-        else:
-            self.text_color = text_color
-
-        if text_color_highlight is None:
-            self.text_color_highlight = \
-                palette.highlightedText().color().name()
-        else:
-            self.text_color_highlight = text_color_highlight
 
     def sortByName(self):
         self.snippets = sorted(self.snippets, key=lambda x: x.trigger_text)
@@ -493,9 +480,9 @@ class SnippetModelsProxy:
         self.awaiting_queue = {}
         self.parent = parent
 
-    def get_model(self, table, language, text_color=None):
+    def get_model(self, table, language):
         if language not in self.models:
-            language_model = SnippetsModel(table, text_color=text_color)
+            language_model = SnippetsModel(table)
             to_add = self.awaiting_queue.pop(language, [])
             self.load_snippets(language, language_model, to_add=to_add)
             self.models[language] = language_model
@@ -660,13 +647,12 @@ class SnippetModelsProxy:
 
 
 class SnippetTable(QTableView):
-    def __init__(self, parent, proxy, language=None, text_color=None):
+    def __init__(self, parent, proxy, language=None):
         super(SnippetTable, self).__init__()
         self._parent = parent
         self.language = language
         self.proxy = proxy
-        self.source_model = proxy.get_model(
-            self, language.lower(), text_color=text_color)
+        self.source_model = proxy.get_model(self, language.lower())
         self.setModel(self.source_model)
         self.setItemDelegateForColumn(CMD, ItemDelegate(self))
         self.setSelectionBehavior(QAbstractItemView.SelectRows)

--- a/spyder/plugins/shortcuts/confpage.py
+++ b/spyder/plugins/shortcuts/confpage.py
@@ -6,20 +6,15 @@
 
 """Shortcut configuration page."""
 
-# Standard library imports
-import re
-
 # Third party imports
-from qtpy import PYQT5
 from qtpy.QtWidgets import (QHBoxLayout, QLabel, QMessageBox, QPushButton,
                             QVBoxLayout)
 
 # Local imports
 from spyder.api.preferences import PluginConfigPage
 from spyder.api.translations import _
-from spyder.plugins.shortcuts.widgets.table import (ShortcutFinder,
-                                                    ShortcutsTable)
-from spyder.utils.icon_manager import ima
+from spyder.plugins.shortcuts.widgets.table import (
+    ShortcutFinder, ShortcutsTable)
 
 
 class ShortcutsConfigPage(PluginConfigPage):
@@ -27,7 +22,7 @@ class ShortcutsConfigPage(PluginConfigPage):
 
     def setup_page(self):
         # Widgets
-        self.table = ShortcutsTable(self, text_color=ima.MAIN_FG_COLOR)
+        self.table = ShortcutsTable(self)
         self.finder = ShortcutFinder(self.table, self.table.set_regex)
         self.label_finder = QLabel(_('Search: '))
         self.reset_btn = QPushButton(_("Reset to default values"))

--- a/spyder/plugins/shortcuts/widgets/table.py
+++ b/spyder/plugins/shortcuts/widgets/table.py
@@ -23,6 +23,7 @@ from qtpy.QtWidgets import (QAbstractItemView, QApplication, QDialog,
 from spyder.api.translations import _
 from spyder.config.manager import CONF
 from spyder.utils.icon_manager import ima
+from spyder.utils.palette import QStylePalette
 from spyder.utils.qthelpers import create_toolbutton
 from spyder.utils.stringmatching import get_search_regex, get_search_scores
 from spyder.widgets.helperwidgets import (
@@ -500,7 +501,7 @@ CONTEXT, NAME, SEQUENCE, SEARCH_SCORE = [0, 1, 2, 3]
 
 
 class ShortcutsModel(QAbstractTableModel):
-    def __init__(self, parent, text_color=None, text_color_highlight=None):
+    def __init__(self, parent):
         QAbstractTableModel.__init__(self)
         self._parent = parent
 
@@ -514,17 +515,8 @@ class ShortcutsModel(QAbstractTableModel):
         self.widths = []
 
         # Needed to compensate for the HTMLDelegate color selection unawarness
-        palette = parent.palette()
-        if text_color is None:
-            self.text_color = palette.text().color().name()
-        else:
-            self.text_color = text_color
-
-        if text_color_highlight is None:
-            self.text_color_highlight = \
-                palette.highlightedText().color().name()
-        else:
-            self.text_color_highlight = text_color_highlight
+        self.text_color = QStylePalette.COLOR_TEXT_1
+        self.text_color_highlight = QStylePalette.COLOR_TEXT_1
 
     def current_index(self):
         """Get the currently selected index in the parent table view."""
@@ -652,16 +644,12 @@ class ShortcutsModel(QAbstractTableModel):
 
 
 class ShortcutsTable(HoverRowsTableView):
-    def __init__(self, parent=None, text_color=None,
-                 text_color_highlight=None):
+    def __init__(self, parent=None):
         HoverRowsTableView.__init__(self, parent)
         self._parent = parent
         self.finder = None
         self.shortcut_data = None
-        self.source_model = ShortcutsModel(
-                                    self,
-                                    text_color=text_color,
-                                    text_color_highlight=text_color_highlight)
+        self.source_model = ShortcutsModel(self)
         self.proxy_model = ShortcutsSortFilterProxy(self)
         self.last_regex = ''
 

--- a/spyder/plugins/shortcuts/widgets/table.py
+++ b/spyder/plugins/shortcuts/widgets/table.py
@@ -565,6 +565,7 @@ class ShortcutsModel(QAbstractTableModel):
                 return to_qvariant(text)
             elif column == SEQUENCE:
                 text = QKeySequence(key).toString(QKeySequence.NativeText)
+                text = '<p style="color:{0}">{1}</p>'.format(color, text)
                 return to_qvariant(text)
             elif column == SEARCH_SCORE:
                 # Treating search scores as a table column simplifies the


### PR DESCRIPTION
## Description of Changes

- This was a regression introduced in PR #21101.
- I also took the opportunity to remove hard-coded colors from the Shortcuts table and other tables as well.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21206.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
