### PR TITLE
Initial fixes to make Spyder work with Qt 6

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -159,8 +159,10 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
             # None is needed, see: https://bugreports.qt.io/browse/PYSIDE-922
             self._proxy_style = SpyderProxyStyle(None)
 
-        # Enabling scaling for high dpi
-        qapp.setAttribute(Qt.AA_UseHighDpiPixmaps)
+        # Enabling scaling for high dpi (not required with Qt 6 where it is
+        # always enabled, see https://doc.qt.io/qt-6/portingguide.html#high-dpi)
+        if hasattr(Qt, "AA_UseHighDpiPixmaps"):
+            qapp.setAttribute(Qt.AA_UseHighDpiPixmaps)
 
         # Set Windows app icon to use .ico file
         if os.name == "nt":
@@ -378,7 +380,7 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         messageBox.show()
 
         # Center message
-        screen_geometry = QApplication.desktop().screenGeometry()
+        screen_geometry = self.screen().geometry()
         x = (screen_geometry.width() - messageBox.width()) / 2
         y = (screen_geometry.height() - messageBox.height()) / 2
         messageBox.move(x, y)

--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -92,18 +92,22 @@ def set_opengl_implementation(option):
 
     See spyder-ide/spyder#7447 for the details.
     """
+    if hasattr(QQuickWindow, "setGraphicsApi"):
+        set_api = QQuickWindow.setGraphicsApi  # Qt 6
+    else:
+        set_api = QQuickWindow.setSceneGraphBackend  # Qt 5
     if option == 'software':
         QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
         if QQuickWindow is not None:
-            QQuickWindow.setSceneGraphBackend(QSGRendererInterface.Software)
+            set_api(QSGRendererInterface.GraphicsApi.Software)
     elif option == 'desktop':
         QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
         if QQuickWindow is not None:
-            QQuickWindow.setSceneGraphBackend(QSGRendererInterface.OpenGL)
+            set_api(QSGRendererInterface.GraphicsApi.OpenGL)
     elif option == 'gles':
         QCoreApplication.setAttribute(Qt.AA_UseOpenGLES)
         if QQuickWindow is not None:
-            QQuickWindow.setSceneGraphBackend(QSGRendererInterface.OpenGL)
+            set_api(QSGRendererInterface.GraphicsApi.OpenGL)
 
 
 def setup_logging(cli_options):

--- a/spyder/config/gui.py
+++ b/spyder/config/gui.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 
 # Third party imports
 from qtconsole.styles import dark_color
-from qtpy import PYQT_VERSION
+from qtpy import PYQT_VERSION, QT_VERSION
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QFont, QFontDatabase, QKeySequence
 from qtpy.QtWidgets import QShortcut
@@ -44,7 +44,8 @@ OLD_PYQT = programs.check_version(PYQT_VERSION, "5.12", "<")
 
 def font_is_installed(font):
     """Check if font is installed"""
-    return [fam for fam in QFontDatabase().families()
+    db = QFontDatabase() if QT_VERSION.startswith("5") else QFontDatabase
+    return [fam for fam in db.families()
             if to_text_string(fam)==font]
 
 

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -22,7 +22,7 @@ import weakref
 # Third-party imports
 from packaging.version import parse
 from pkg_resources import iter_entry_points
-from qtpy.QtCore import QMutex, QMutexLocker, QTimer, Slot, Signal
+from qtpy.QtCore import QRecursiveMutex, QMutexLocker, QTimer, Slot, Signal
 
 # Local imports
 from spyder.config.manager import CONF
@@ -214,7 +214,7 @@ class CompletionPlugin(SpyderPluginV2):
         self.req_id = 0
 
         # Lock to prevent concurrent access to requests mapping
-        self.collection_mutex = QMutex(QMutex.Recursive)
+        self.collection_mutex = QRecursiveMutex()
 
         # Completion request priority
         self.source_priority = {}

--- a/spyder/plugins/editor/extensions/tests/test_docstring.py
+++ b/spyder/plugins/editor/extensions/tests/test_docstring.py
@@ -340,7 +340,7 @@ def test_editor_docstring_below_def_by_shortcut(qtbot, editor_auto_docstring,
 
     cursor = editor.textCursor()
     cursor.movePosition(QTextCursor.NextBlock)
-    cursor.setPosition(QTextCursor.End, QTextCursor.MoveAnchor)
+    cursor.movePosition(QTextCursor.End, QTextCursor.MoveAnchor)
     editor.setTextCursor(cursor)
 
     editor.writer_docstring.write_docstring_for_shortcut()
@@ -376,7 +376,7 @@ def test_editor_docstring_delayed_popup(qtbot, editor_auto_docstring,
 
     cursor = editor.textCursor()
     cursor.movePosition(QTextCursor.NextBlock)
-    cursor.setPosition(QTextCursor.EndOfLine, QTextCursor.MoveAnchor)
+    cursor.movePosition(QTextCursor.EndOfLine, QTextCursor.MoveAnchor)
     editor.setTextCursor(cursor)
 
     qtbot.keyPress(editor, Qt.Key_Space)
@@ -618,7 +618,7 @@ def test_docstring_annotated_call(editor_auto_docstring, text, expected):
 
     cursor = editor.textCursor()
     cursor.movePosition(QTextCursor.NextBlock)
-    cursor.setPosition(QTextCursor.End, QTextCursor.MoveAnchor)
+    cursor.movePosition(QTextCursor.End, QTextCursor.MoveAnchor)
     editor.setTextCursor(cursor)
 
     editor.writer_docstring.write_docstring_for_shortcut()
@@ -659,7 +659,7 @@ def test_docstring_line_break(editor_auto_docstring, text, expected):
 
     cursor = editor.textCursor()
     cursor.movePosition(QTextCursor.NextBlock)
-    cursor.setPosition(QTextCursor.End, QTextCursor.MoveAnchor)
+    cursor.movePosition(QTextCursor.End, QTextCursor.MoveAnchor)
     editor.setTextCursor(cursor)
 
     editor.writer_docstring.write_docstring_for_shortcut()

--- a/spyder/plugins/editor/utils/editor.py
+++ b/spyder/plugins/editor/utils/editor.py
@@ -594,7 +594,7 @@ class TextHelper(object):
             pos = cursor_or_block.position() - b.position()
             layout = b.layout()
         if layout is not None:
-            additional_formats = layout.additionalFormats()
+            additional_formats = layout.formats()
             sh = self._editor.syntax_highlighter
             if sh:
                 ref_formats = sh.color_scheme.formats

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -1193,8 +1193,7 @@ class TextEditBaseWidget(
 
     def position_widget_at_cursor(self, widget):
         # Retrieve current screen height
-        desktop = QApplication.desktop()
-        srect = desktop.availableGeometry(desktop.screenNumber(widget))
+        srect = self.screen().availableGeometry()
 
         left, top, right, bottom = (srect.left(), srect.top(),
                                     srect.right(), srect.bottom())

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -31,7 +31,7 @@ from IPython.core.inputtransformer2 import TransformerManager
 from packaging.version import parse
 from qtpy import QT_VERSION
 from qtpy.compat import to_qvariant
-from qtpy.QtCore import QEvent, QRegExp, Qt, QTimer, QUrl, Signal, Slot
+from qtpy.QtCore import QEvent, QRegularExpression, Qt, QTimer, QUrl, Signal, Slot
 from qtpy.QtGui import (QColor, QCursor, QFont, QKeySequence, QPaintEvent,
                         QPainter, QMouseEvent, QTextCursor, QDesktopServices,
                         QKeyEvent, QTextDocument, QTextFormat, QTextOption,
@@ -1291,7 +1291,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
         cursor = self.textCursor()
         # Scanning whole document
         cursor.movePosition(QTextCursor.Start)
-        regexp = QRegExp(r"\b%s\b" % QRegExp.escape(text), Qt.CaseSensitive)
+        regexp = QRegularExpression(r"\b%s\b" % QRegularExpression.escape(text))
         cursor = self.document().find(regexp, cursor, flags)
         self.__find_first_pos = cursor.position()
         return cursor
@@ -1299,7 +1299,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
     def __find_next(self, text, cursor):
         """Find next occurrence"""
         flags = QTextDocument.FindCaseSensitively|QTextDocument.FindWholeWords
-        regexp = QRegExp(r"\b%s\b" % QRegExp.escape(text), Qt.CaseSensitive)
+        regexp = QRegularExpression(r"\b%s\b" % QRegularExpression.escape(text))
         cursor = self.document().find(regexp, cursor, flags)
         if cursor.position() != self.__find_first_pos:
             return cursor
@@ -3105,7 +3105,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
         block = cursor.block()
         pos = cursor.position() - block.position()  # relative pos within block
         layout = block.layout()
-        block_formats = layout.additionalFormats()
+        block_formats = layout.formats()
 
         if block_formats:
             # To easily grab current format for autoinsert_colons

--- a/spyder/plugins/editor/widgets/printer.py
+++ b/spyder/plugins/editor/widgets/printer.py
@@ -18,7 +18,7 @@ from spyder.utils.stylesheet import PANES_TOOLBAR_STYLESHEET
 
 # TODO: Implement header and footer support
 class SpyderPrinter(QPrinter):
-    def __init__(self, mode=QPrinter.ScreenResolution, header_font=None):
+    def __init__(self, mode=QPrinter.PrinterMode.ScreenResolution, header_font=None):
         QPrinter.__init__(self, mode)
         self.setColorMode(QPrinter.Color)
         self.setPageOrder(QPrinter.FirstPageFirst)

--- a/spyder/plugins/editor/widgets/recover.py
+++ b/spyder/plugins/editor/widgets/recover.py
@@ -223,7 +223,7 @@ class RecoveryDialog(QDialog):
 
     def center(self):
         """Center the dialog."""
-        screen = QApplication.desktop().screenGeometry(0)
+        screen = self.screen().geometry()
         x = int(screen.center().x() - self.width() / 2)
         y = int(screen.center().y() - self.height() / 2)
         self.move(x, y)

--- a/spyder/plugins/explorer/widgets/fileassociations.py
+++ b/spyder/plugins/explorer/widgets/fileassociations.py
@@ -15,8 +15,8 @@ import sys
 
 # Third party imports
 from qtpy.compat import getopenfilename
-from qtpy.QtCore import QRegExp, QSize, Qt, Signal, Slot
-from qtpy.QtGui import QCursor, QRegExpValidator
+from qtpy.QtCore import QRegularExpression, QSize, Qt, Signal, Slot
+from qtpy.QtGui import QCursor, QRegularExpressionValidator
 from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
                             QHBoxLayout, QLabel, QLineEdit,
                             QListWidget, QListWidgetItem, QPushButton,
@@ -83,7 +83,7 @@ class InputTextDialog(QDialog):
         """Set the regular expression to validate content."""
         self._regex = regex
         self._reg = re.compile(regex, re.IGNORECASE)
-        validator = QRegExpValidator(QRegExp(regex))
+        validator = QRegularExpressionValidator(QRegularExpression(regex))
         self.lineedit.setValidator(validator)
 
     def text(self):

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -15,7 +15,7 @@ import os
 # Third party imports
 from qtpy.QtCore import Qt, QByteArray, QSize, QPoint, Slot
 from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QApplication, QDesktopWidget
+from qtpy.QtWidgets import QApplication
 
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
@@ -491,7 +491,7 @@ class Layout(SpyderPluginV2):
         # with the current screen. See spyder-ide/spyder#3748.
         width = pos[0]
         height = pos[1]
-        screen_shape = QApplication.desktop().geometry()
+        screen_shape = self.main.screen().geometry()
         current_width = screen_shape.width()
         current_height = screen_shape.height()
         if current_width < width or current_height < height:
@@ -871,11 +871,7 @@ class Layout(SpyderPluginV2):
                                     | Qt.FramelessWindowHint
                                     | Qt.WindowStaysOnTopHint)
 
-                screen_number = QDesktopWidget().screenNumber(main)
-                if screen_number < 0:
-                    screen_number = 0
-
-                r = QApplication.desktop().screenGeometry(screen_number)
+                r = main.screen().geometry()
                 main.setGeometry(
                     r.left() - 1, r.top() - 1, r.width() + 2, r.height() + 2)
                 main.showNormal()

--- a/spyder/plugins/layout/widgets/dialog.py
+++ b/spyder/plugins/layout/widgets/dialog.py
@@ -58,16 +58,16 @@ class LayoutModel(QAbstractTableModel):
         ui_name, name, state = self.row(row)
 
         if name in self.read_only:
-            return Qt.NoItemFlags
+            return Qt.ItemFlag(0)
         if not index.isValid():
-            return Qt.ItemIsEnabled
+            return Qt.ItemFlag.ItemIsEnabled
         column = index.column()
         if column in [0]:
-            return Qt.ItemFlags(int(Qt.ItemIsEnabled | Qt.ItemIsSelectable |
-                                    Qt.ItemIsUserCheckable |
-                                    Qt.ItemIsEditable))
+            return (Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable |
+                    Qt.ItemFlag.ItemIsUserCheckable |
+                    Qt.ItemFlag.ItemIsEditable)
         else:
-            return Qt.ItemFlags(Qt.ItemIsEnabled)
+            return Qt.ItemFlag.ItemIsEnabled
 
     def data(self, index, role=Qt.DisplayRole):
         """Override Qt method"""

--- a/spyder/plugins/preferences/api.py
+++ b/spyder/plugins/preferences/api.py
@@ -16,8 +16,8 @@ import os.path as osp
 from qtpy import API
 from qtpy.compat import (getexistingdirectory, getopenfilename, from_qvariant,
                          to_qvariant)
-from qtpy.QtCore import Qt, Signal, Slot, QRegExp, QSize
-from qtpy.QtGui import QColor, QRegExpValidator, QTextOption, QPixmap
+from qtpy.QtCore import Qt, Signal, Slot, QRegularExpression, QSize
+from qtpy.QtGui import QColor, QRegularExpressionValidator, QTextOption, QPixmap
 from qtpy.QtWidgets import (QButtonGroup, QCheckBox, QComboBox, QDoubleSpinBox,
                             QFileDialog, QFontComboBox, QGridLayout, QGroupBox,
                             QHBoxLayout, QLabel, QLineEdit, QMessageBox,
@@ -537,7 +537,7 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
         layout.addWidget(edit)
         layout.setContentsMargins(0, 0, 0, 0)
         if regex:
-            edit.setValidator(QRegExpValidator(QRegExp(regex)))
+            edit.setValidator(QRegularExpressionValidator(QRegularExpression(regex)))
         if placeholder:
             edit.setPlaceholderText(placeholder)
         self.lineedits[edit] = (section, option, default)

--- a/spyder/plugins/shortcuts/widgets/summary.py
+++ b/spyder/plugins/shortcuts/widgets/summary.py
@@ -15,8 +15,8 @@ from itertools import groupby
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QFont, QKeySequence
 from qtpy.QtWidgets import (QDialog, QLabel, QGridLayout, QGroupBox,
-                            QVBoxLayout, QHBoxLayout, QDesktopWidget,
-                            QScrollArea, QWidget)
+                            QVBoxLayout, QHBoxLayout, QScrollArea,
+                            QWidget)
 
 # Local imports
 from spyder.config.base import _
@@ -148,8 +148,7 @@ class ShortcutsSummaryDialog(QDialog):
 
     def get_screen_resolution(self):
         """Return the screen resolution of the primary screen."""
-        widget = QDesktopWidget()
-        geometry = widget.availableGeometry(widget.primaryScreen())
+        geometry = self.screen().availableGeometry()
         return geometry.width(), geometry.height()
 
 

--- a/spyder/plugins/shortcuts/widgets/table.py
+++ b/spyder/plugins/shortcuts/widgets/table.py
@@ -12,8 +12,8 @@ import re
 # Third party imports
 from qtpy.compat import from_qvariant, to_qvariant
 from qtpy.QtCore import (QAbstractTableModel, QEvent, QModelIndex,
-                         QSortFilterProxyModel, Qt, Slot, QRegExp)
-from qtpy.QtGui import QIcon, QKeySequence, QRegExpValidator
+                         QSortFilterProxyModel, Qt, Slot, QRegularExpression)
+from qtpy.QtGui import QIcon, QKeySequence, QRegularExpressionValidator
 from qtpy.QtWidgets import (QAbstractItemView, QApplication, QDialog,
                             QGridLayout, QHBoxLayout, QKeySequenceEdit,
                             QLabel, QLineEdit, QMessageBox, QPushButton,
@@ -119,8 +119,8 @@ class ShortcutFinder(QLineEdit):
         self.main = main
 
         # Widget setup
-        regex = QRegExp(regex_base + "{100}")
-        self.setValidator(QRegExpValidator(regex))
+        regex = QRegularExpression(regex_base + "{100}")
+        self.setValidator(QRegularExpressionValidator(regex))
 
         # Signals
         if callback:
@@ -532,8 +532,8 @@ class ShortcutsModel(QAbstractTableModel):
     def flags(self, index):
         """Qt Override."""
         if not index.isValid():
-            return Qt.ItemIsEnabled
-        return Qt.ItemFlags(int(QAbstractTableModel.flags(self, index)))
+            return Qt.ItemFlag.ItemIsEnabled
+        return QAbstractTableModel.flags(self, index)
 
     def data(self, index, role=Qt.DisplayRole):
         """Qt Override."""

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -364,9 +364,8 @@ class ArrayModel(QAbstractTableModel, SpyderFontsMixin):
     def flags(self, index):
         """Set editable flag"""
         if not index.isValid():
-            return Qt.ItemIsEnabled
-        return Qt.ItemFlags(int(QAbstractTableModel.flags(self, index) |
-                                Qt.ItemIsEditable))
+            return Qt.ItemFlag.ItemIsEnabled
+        return QAbstractTableModel.flags(self, index) | Qt.ItemFlag.ItemIsEditable
 
     def headerData(self, section, orientation, role=Qt.DisplayRole):
         """Set header data"""

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -432,8 +432,7 @@ class DataFrameModel(QAbstractTableModel, SpyderFontsMixin):
 
     def flags(self, index):
         """Set flags"""
-        return Qt.ItemFlags(int(QAbstractTableModel.flags(self, index) |
-                                Qt.ItemIsEditable))
+        return QAbstractTableModel.flags(self, index) | Qt.ItemFlag.ItemIsEditable
 
     def setData(self, index, value, role=Qt.EditRole, change_type=None):
         """Cell content change"""

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -272,7 +272,7 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
             radio_layout.addWidget(radio_button)
             self.button_group.addButton(radio_button, button_id)
 
-        self.button_group.buttonClicked[int].connect(
+        self.button_group.idClicked.connect(
             self._change_details_field)
         self.button_group.button(0).setChecked(True)
 

--- a/spyder/plugins/workingdirectory/container.py
+++ b/spyder/plugins/workingdirectory/container.py
@@ -201,7 +201,7 @@ class WorkingDirectoryContainer(PluginMainContainer):
         # Signals
         self.pathedit.open_dir.connect(self.chdir)
         self.pathedit.edit_goto.connect(self.edit_goto)
-        self.pathedit.activated[str].connect(self.chdir)
+        self.pathedit.textActivated.connect(self.chdir)
 
         # Actions
         self.previous_action = self.create_action(

--- a/spyder/requirements.py
+++ b/spyder/requirements.py
@@ -31,7 +31,8 @@ def show_warning(message):
 
 def check_qt():
     """Check Qt binding requirements"""
-    qt_infos = dict(pyqt5=("PyQt5", "5.9"), pyside2=("PySide2", "5.12"))
+    qt_infos = dict(pyqt5=("PyQt5", "5.9"), pyside2=("PySide2", "5.12"),
+                    pyqt6=("PyQt6", "6.5"), pyside6=("PySide6", "6.5"))
     try:
         import qtpy
         package_name, required_ver = qt_infos[qtpy.API]

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -168,7 +168,11 @@ def keyevent_to_keysequence_str(event):
     """Get key sequence corresponding to a key event as a string."""
     try:
         # See https://stackoverflow.com/a/20656496/438386 for context
-        return QKeySequence(event.modifiers() | event.key()).toString()
+        if hasattr(event, "keyCombination"):
+            key_combination = event.keyCombination()  # Qt 6
+        else:
+            key_combination = event.modifiers() | event.key()  # Qt 5
+        return QKeySequence(key_combination).toString()
     except TypeError:
         # This error appears in old PyQt versions (e.g. 5.12) which are
         # running under Python 3.10+. In that case, we need to build the

--- a/spyder/utils/tests/test_syntaxhighlighters.py
+++ b/spyder/utils/tests/test_syntaxhighlighters.py
@@ -36,7 +36,7 @@ def test_HtmlSH_basic():
            (26, 14, 'comment'),  # |<!--comment-->|
            (40, 5, 'normal'),    # | bar.|
            (45, 4, 'builtin')]   # |</p>|
-    compare_formats(doc.firstBlock().layout().additionalFormats(), res, sh)
+    compare_formats(doc.firstBlock().layout().formats(), res, sh)
 
 def test_HtmlSH_unclosed_commend():
     txt = '-->'
@@ -44,7 +44,7 @@ def test_HtmlSH_unclosed_commend():
     sh = HtmlSH(doc, color_scheme='Spyder')
     sh.rehighlightBlock(doc.firstBlock())
     res = [(0, 3, 'normal')]
-    compare_formats(doc.firstBlock().layout().additionalFormats(), res, sh)
+    compare_formats(doc.firstBlock().layout().formats(), res, sh)
 
 
 def test_PythonSH_UTF16_number():
@@ -54,7 +54,7 @@ def test_PythonSH_UTF16_number():
     sh = PythonSH(doc, color_scheme='Spyder')
     sh.rehighlightBlock(doc.firstBlock())
     res = [(0, 11, 'normal'), (11, 9, 'number')]
-    compare_formats(doc.firstBlock().layout().additionalFormats(), res, sh)
+    compare_formats(doc.firstBlock().layout().formats(), res, sh)
 
 
 def test_PythonSH_UTF16_string():
@@ -64,7 +64,7 @@ def test_PythonSH_UTF16_string():
     sh = PythonSH(doc, color_scheme='Spyder')
     sh.rehighlightBlock(doc.firstBlock())
     res = [(0, 11, 'normal'), (11, 10, 'string')]
-    compare_formats(doc.firstBlock().layout().additionalFormats(), res, sh)
+    compare_formats(doc.firstBlock().layout().formats(), res, sh)
 
 
 def test_python_string_prefix():
@@ -85,7 +85,7 @@ def test_python_string_prefix():
                (9 + offset, 10 + offset, 'string'),  # |{prefix}'''test'''|
                (19 + 2*offset, 1, 'normal')]         # | |
 
-        compare_formats(doc.firstBlock().layout().additionalFormats(), res, sh)
+        compare_formats(doc.firstBlock().layout().formats(), res, sh)
 
 
 def test_Markdown_basic():
@@ -108,7 +108,7 @@ def test_Markdown_basic():
            (61, 1, 'normal'),  # ||
            ]
 
-    compare_formats(doc.firstBlock().layout().additionalFormats(), res, sh)
+    compare_formats(doc.firstBlock().layout().formats(), res, sh)
 
 
 @pytest.mark.parametrize('line', ['# --- First variant',

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -75,7 +75,7 @@ class WebPage(QWebEnginePage):
         """
         Overloaded method to handle links ourselves
         """
-        if navigation_type == QWebEnginePage.NavigationTypeLinkClicked:
+        if navigation_type == QWebEnginePage.NavigationType.NavigationTypeLinkClicked:
             self.linkClicked.emit(url)
             return False
 
@@ -119,7 +119,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
 
     def setup(self, options={}):
         # Actions
-        original_back_action = self.pageAction(QWebEnginePage.Back)
+        original_back_action = self.pageAction(QWebEnginePage.WebAction.Back)
         back_action = self.create_action(
             name=WebViewActions.Back,
             text=_("Back"),
@@ -128,7 +128,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
             context=Qt.WidgetWithChildrenShortcut,
         )
 
-        original_forward_action = self.pageAction(QWebEnginePage.Forward)
+        original_forward_action = self.pageAction(QWebEnginePage.WebAction.Forward)
         forward_action = self.create_action(
             name=WebViewActions.Forward,
             text=_("Forward"),
@@ -137,7 +137,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
             context=Qt.WidgetWithChildrenShortcut,
         )
 
-        original_select_action = self.pageAction(QWebEnginePage.SelectAll)
+        original_select_action = self.pageAction(QWebEnginePage.WebAction.SelectAll)
         select_all_action = self.create_action(
             name=WebViewActions.SelectAll,
             text=_("Select all"),
@@ -145,7 +145,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
             context=Qt.WidgetWithChildrenShortcut,
         )
 
-        original_copy_action = self.pageAction(QWebEnginePage.Copy)
+        original_copy_action = self.pageAction(QWebEnginePage.WebAction.Copy)
         copy_action = self.create_action(
             name=WebViewActions.Copy,
             text=_("Copy"),
@@ -170,7 +170,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
         )
 
         original_inspect_action = self.pageAction(
-            QWebEnginePage.InspectElement)
+            QWebEnginePage.WebAction.InspectElement)
         inspect_action = self.create_action(
             name=WebViewActions.Inspect,
             text=_("Inspect"),
@@ -178,7 +178,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
             context=Qt.WidgetWithChildrenShortcut,
         )
 
-        original_refresh_action = self.pageAction(QWebEnginePage.Reload)
+        original_refresh_action = self.pageAction(QWebEnginePage.WebAction.Reload)
         self.create_action(
             name=WebViewActions.Refresh,
             text=_("Refresh"),
@@ -187,7 +187,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
             context=Qt.WidgetWithChildrenShortcut,
         )
 
-        original_stop_action = self.pageAction(QWebEnginePage.Stop)
+        original_stop_action = self.pageAction(QWebEnginePage.WebAction.Stop)
         self.create_action(
             name=WebViewActions.Stop,
             text=_("Stop"),
@@ -239,14 +239,14 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
         if not WEBENGINE:
             findflag = QWebEnginePage.FindWrapsAroundDocument
         else:
-            findflag = 0
+            findflag = QWebEnginePage.FindFlag(0)
 
         if not forward:
             findflag = findflag | QWebEnginePage.FindBackward
         if case:
             findflag = findflag | QWebEnginePage.FindCaseSensitively
 
-        return self.findText(text, QWebEnginePage.FindFlags(findflag))
+        return self.findText(text, findflag)
 
     def get_selected_text(self):
         """Return text selected by current text cursor"""
@@ -292,15 +292,17 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
     def set_font(self, font, fixed_font=None):
         font = QFontInfo(font)
         settings = self.page().settings()
-        for fontfamily in (settings.StandardFont, settings.SerifFont,
-                           settings.SansSerifFont, settings.CursiveFont,
-                           settings.FantasyFont):
+        for fontfamily in (QWebEngineSettings.FontFamily.StandardFont,
+                           QWebEngineSettings.FontFamily.SerifFont,
+                           QWebEngineSettings.FontFamily.SansSerifFont,
+                           QWebEngineSettings.FontFamily.CursiveFont,
+                           QWebEngineSettings.FontFamily.FantasyFont):
             settings.setFontFamily(fontfamily, font.family())
         if fixed_font is not None:
-            settings.setFontFamily(settings.FixedFont, fixed_font.family())
+            settings.setFontFamily(QWebEngineSettings.FontFamily.FixedFont, fixed_font.family())
         size = font.pixelSize()
-        settings.setFontSize(settings.DefaultFontSize, size)
-        settings.setFontSize(settings.DefaultFixedFontSize, size)
+        settings.setFontSize(QWebEngineSettings.FontSize.DefaultFontSize, size)
+        settings.setFontSize(QWebEngineSettings.FontSize.DefaultFixedFontSize, size)
 
     def apply_zoom_factor(self):
         """Apply zoom factor."""

--- a/spyder/widgets/calltip.py
+++ b/spyder/widgets/calltip.py
@@ -45,7 +45,7 @@ class ToolTipWidget(QLabel):
         """
         Shows tooltips that can be styled with the different themes.
         """
-        super(ToolTipWidget, self).__init__(None, Qt.ToolTip)
+        super().__init__(parent, Qt.ToolTip)
 
         # Variables
         self.completion_doc = None
@@ -147,7 +147,7 @@ class ToolTipWidget(QLabel):
         else:
             cursor_rect = text_edit.cursorRect(cursor)
 
-        screen_rect = self.app.desktop().screenGeometry(text_edit)
+        screen_rect = self.screen().geometry()
         point.setY(point.y() + padding)
         tip_height = self.size().height()
         tip_width = self.size().width()
@@ -255,7 +255,7 @@ class CallTipWidget(QLabel):
             text edit widget.
         """
         assert isinstance(text_edit, (QTextEdit, QPlainTextEdit))
-        super(CallTipWidget, self).__init__(None, Qt.ToolTip)
+        super().__init__(text_edit, Qt.ToolTip)
         self.app = QCoreApplication.instance()
         self.as_tooltip = as_tooltip
 
@@ -462,7 +462,7 @@ class CallTipWidget(QLabel):
         # location based trying to minimize the  area that goes off-screen.
         padding = 0  # Distance in pixels between cursor bounds and tip box.
         cursor_rect = text_edit.cursorRect(cursor)
-        screen_rect = self.app.desktop().screenGeometry(text_edit)
+        screen_rect = self.screen().geometry()
         point.setY(point.y() + padding)
         tip_height = self.size().height()
         tip_width = self.size().width()

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -468,9 +468,8 @@ class ReadOnlyCollectionsModel(QAbstractTableModel, SpyderFontsMixin):
         # This method was implemented in CollectionsModel only, but to enable
         # tuple exploration (even without editing), this method was moved here
         if not index.isValid():
-            return Qt.ItemIsEnabled
-        return Qt.ItemFlags(int(QAbstractTableModel.flags(self, index) |
-                                Qt.ItemIsEditable))
+            return Qt.ItemFlag.ItemIsEnabled
+        return QAbstractTableModel.flags(self, index) | Qt.ItemFlag.ItemIsEditable
 
     def reset(self):
         self.beginResetModel()

--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -155,7 +155,7 @@ class PatternComboBox(BaseComboBox):
         BaseComboBox.__init__(self, parent)
 
         if adjust_to_minimum:
-            self.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLength)
+            self.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLengthWithIcon)
 
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
@@ -221,7 +221,7 @@ class EditableComboBox(BaseComboBox):
         self.selected_text = self.currentText()
 
         # Widget setup
-        self.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLength)
+        self.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLengthWithIcon)
 
         # Signals
         self.editTextChanged.connect(self.validate)
@@ -270,7 +270,7 @@ class PathComboBox(EditableComboBox):
         if adjust_to_contents:
             self.setSizeAdjustPolicy(QComboBox.AdjustToContents)
         else:
-            self.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLength)
+            self.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLengthWithIcon)
             self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.tips = {True: _("Press enter to validate this path"),
                      False: ''}

--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -15,9 +15,9 @@ import re
 import qstylizer.style
 from qtpy import PYQT5
 from qtpy.QtCore import (
-    QPoint, QRegExp, QSize, QSortFilterProxyModel, Qt, Signal)
+    QPoint, QRegularExpression, QSize, QSortFilterProxyModel, Qt, Signal)
 from qtpy.QtGui import (QAbstractTextDocumentLayout, QColor, QFontMetrics,
-                        QImage, QPainter, QRegExpValidator, QTextDocument,
+                        QImage, QPainter, QRegularExpressionValidator, QTextDocument,
                         QPixmap)
 from qtpy.QtSvg import QSvgRenderer
 from qtpy.QtWidgets import (QApplication, QCheckBox, QLineEdit, QMessageBox,
@@ -382,8 +382,8 @@ class FinderLineEdit(QLineEdit):
 
         if regex_base is not None:
             # Widget setup
-            regex = QRegExp(regex_base + "{100}")
-            self.setValidator(QRegExpValidator(regex))
+            regex = QRegularExpression(regex_base + "{100}")
+            self.setValidator(QRegularExpressionValidator(regex))
 
     def keyPressEvent(self, event):
         """Qt and FilterLineEdit Override."""

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -1286,7 +1286,7 @@ class BaseEditMixin(object):
                   word=False, regexp=False):
         """Find text."""
         cursor = self.textCursor()
-        findflag = QTextDocument.FindFlag()
+        findflag = QTextDocument.FindFlag(0)
 
         # Get visible region to center cursor in case it's necessary.
         if getattr(self, 'get_visible_block_numbers', False):


### PR DESCRIPTION
## Description of Changes

- Spyder GUI shows up with PyQt6, PySide6 is broken (once again, MRO issues when using `super()`)
- Test suite mostly passes with PyQt6, PySide6 not tried yet
- The changes are backward compatible with Qt 5
- Concerning PySide6 support: We will definitely look into it and provide patches. Question for Spyder devs: Which minimum Qt 6 version do you intend to support? This might affect PySide6 patches (PySide6 >= 6.5 claims to fix MRO issues when using `super()`).

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

rear1019

<!--- Thanks for your help making Spyder better for everyone! --->
