### PR TITLE
PR: Display plots from collections editor in the Plots pane

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -2409,7 +2409,7 @@ def test_plot_from_collectioneditor(main_window, qtbot):
 
     # Create variable
     with qtbot.waitSignal(shell.executed):
-        shell.execute(('nested_list = [[1, 2, 3], [4, 5, 6]]'))
+        shell.execute('nested_list = [[1, 2, 3], [4, 5, 6]]')
 
     # Edit `nested_list` in Variable Explorer
     main_window.variableexplorer.change_visibility(True)

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -535,8 +535,8 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
         return self.get_widget().get_current_shellwidget()
 
     def set_current_shellwidget(self, shellwidget):
-        """Activate client associated to given shellwidget"""
-        return self.get_widget().select_tab(shellwidget)
+        """Activate client associated to given shellwidget."""
+        self.get_widget().select_tab(shellwidget)
 
     def rename_client_tab(self, client, given_name):
         """

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -534,6 +534,10 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
         """Return the shellwidget of the current client"""
         return self.get_widget().get_current_shellwidget()
 
+    def set_current_shellwidget(self, shellwidget):
+        """Activate client associated to given shellwidget"""
+        return self.get_widget().select_tab(shellwidget)
+
     def rename_client_tab(self, client, given_name):
         """
         Rename a client's tab.

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1233,6 +1233,15 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
         # Register client
         self.register_client(client)
 
+    def select_tab(self, shellwidget):
+        """
+        Select tab with given shellwidget.
+        """
+        for client in self.clients:
+            if client.shellwidget == shellwidget:
+                self.tabwidget.setCurrentWidget(client)
+                return
+
     def move_tab(self, index_from, index_to):
         """
         Move tab (tabs themselves have already been moved by the tabwidget).

--- a/spyder/plugins/plots/plugin.py
+++ b/spyder/plugins/plots/plugin.py
@@ -46,6 +46,23 @@ class Plots(SpyderDockablePlugin, ShellConnectPluginMixin):
         # a plot is generated.
         self.get_widget().sig_figure_loaded.connect(self._on_first_plot)
 
+    # ---- Public API
+    # ------------------------------------------------------------------------
+    def add_plot(self, fig, fmt, shellwidget):
+        """
+        Add a plot to the specified figure browser.
+
+        Add the plot to the figure browser with the given shellwidget. Also,
+        bring the plugin to the front and raise the window that it is in so
+        that the plot is shown.
+
+        If no figure browser with the given shellwidget exists, then nothing
+        happens.
+        """
+        self.switch_to_plugin(force_focus=False)
+        self.get_widget().window().raise_()
+        self.get_widget().add_plot(fig, fmt, shellwidget)
+
     # ---- Private API
     # ------------------------------------------------------------------------
     def _on_first_plot(self):

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -259,13 +259,15 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
         """Bind the shellwidget instance to the figure browser"""
         self.shellwidget = shellwidget
         self.shellwidget.set_mute_inline_plotting(self.mute_inline_plotting)
-        shellwidget.sig_new_inline_figure.connect(self._handle_new_figure)
+        shellwidget.sig_new_inline_figure.connect(self.add_figure)
         shellwidget.executing.connect(self._handle_new_execution)
 
-    def _handle_new_figure(self, fig, fmt):
+    def add_figure(self, fig, fmt):
         """
-        Handle when a new figure is sent to the IPython console by the
-        kernel.
+        Add a figure to the figure browser.
+
+        This is called when a new figure is sent to the IPython console by the
+        kernel, but can also be called directly.
         """
         self.thumbnails_sb.add_thumbnail(fig, fmt)
 

--- a/spyder/plugins/plots/widgets/main_widget.py
+++ b/spyder/plugins/plots/widgets/main_widget.py
@@ -20,6 +20,7 @@ from spyder.api.shellconnect.main_widget import ShellConnectMainWidget
 from spyder.plugins.plots.widgets.figurebrowser import FigureBrowser
 from spyder.utils.misc import getcwd_or_home
 from spyder.utils.palette import QStylePalette
+from spyder.widgets.helperwidgets import PaneEmptyWidget
 
 
 MAIN_BG_COLOR = QStylePalette.COLOR_BACKGROUND_1
@@ -374,6 +375,14 @@ class PlotsWidget(ShellConnectMainWidget):
                 # Reset the toolbar buttons to use the figviewer and not the thumbnail
                 # selection
                 self._right_clicked_thumbnail = None
+
+    def add_plot(self, fig, fmt, shellwidget):
+        """
+        Add a plot to the figure browser with the given shellwidget, if any.
+        """
+        fig_browser = self.get_widget_for_shellwidget(shellwidget)
+        if fig_browser and not isinstance(fig_browser, PaneEmptyWidget):
+            fig_browser.add_figure(fig, fmt)
 
     def remove_plot(self):
         """

--- a/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
+++ b/spyder/plugins/plots/widgets/tests/test_plots_widgets.py
@@ -79,7 +79,7 @@ def add_figures_to_browser(figbrowser, nfig, tmpdir, fmt='image/png'):
     for i in range(nfig):
         figname = osp.join(str(tmpdir), 'mplfig' + str(i) + fext)
         figs.append(create_figure(figname))
-        figbrowser._handle_new_figure(figs[-1], fmt)
+        figbrowser.add_figure(figs[-1], fmt)
 
     assert len(figbrowser.thumbnails_sb._thumbnails) == nfig
     assert figbrowser.thumbnails_sb.get_current_index() == nfig - 1
@@ -102,7 +102,7 @@ def png_to_qimage(png):
 @pytest.mark.order(1)
 @pytest.mark.parametrize("fmt, fext",
                          [('image/png', '.png'), ('image/svg+xml', '.svg')])
-def test_handle_new_figures(figbrowser, tmpdir, fmt, fext):
+def test_add_figures(figbrowser, tmpdir, fmt, fext):
     """
     Test that the figure browser widget display correctly new figures in
     its viewer and thumbnails scrollbar.
@@ -114,7 +114,7 @@ def test_handle_new_figures(figbrowser, tmpdir, fmt, fext):
     for i in range(3):
         figname = osp.join(str(tmpdir), 'mplfig' + str(i) + fext)
         fig = create_figure(figname)
-        figbrowser._handle_new_figure(fig, fmt)
+        figbrowser.add_figure(fig, fmt)
         assert len(figbrowser.thumbnails_sb._thumbnails) == i + 1
         assert figbrowser.thumbnails_sb.get_current_index() == i
         assert figbrowser.thumbnails_sb.current_thumbnail.canvas.fig == fig
@@ -323,7 +323,7 @@ def test_scroll_down_to_newest_plot(figbrowser, tmpdir, qtbot):
     for i in range(8):
         newfig = create_figure(
             osp.join(str(tmpdir), 'new_mplfig{}.png'.format(i)))
-        figbrowser._handle_new_figure(newfig, 'image/png')
+        figbrowser.add_figure(newfig, 'image/png')
         qtbot.wait(500)
 
     # Assert that the scrollbar range was updated correctly and that it's

--- a/spyder/plugins/variableexplorer/plugin.py
+++ b/spyder/plugins/variableexplorer/plugin.py
@@ -54,6 +54,14 @@ class VariableExplorer(SpyderDockablePlugin, ShellConnectPluginMixin):
         widget.sig_open_preferences_requested.connect(self._open_preferences)
         widget.sig_show_figure_requested.connect(self._show_figure)
 
+    @on_plugin_available(plugin=Plugins.Plots)
+    def on_plots_available(self):
+        self.get_widget().set_plots_plugin_enabled(True)
+
+    @on_plugin_teardown(plugin=Plugins.Plots)
+    def on_plots_teardown(self):
+        self.get_widget().set_plots_plugin_enabled(False)
+
     @on_plugin_available(plugin=Plugins.Preferences)
     def on_preferences_available(self):
         preferences = self.get_plugin(Plugins.Preferences)

--- a/spyder/plugins/variableexplorer/plugin.py
+++ b/spyder/plugins/variableexplorer/plugin.py
@@ -88,7 +88,8 @@ class VariableExplorer(SpyderDockablePlugin, ShellConnectPluginMixin):
         Parameters
         ----------
         image: bytes
-            The image to show.
+            The image to show. SVG images should be encoded so that the type
+            of this parameter is `bytes`, not `str`.
         mime_type: str
             The image's mime type.
         shellwidget: ShellWidget
@@ -100,4 +101,6 @@ class VariableExplorer(SpyderDockablePlugin, ShellConnectPluginMixin):
 
         plots = self.get_plugin(Plugins.Plots)
         if plots:
+            if mime_type == 'image/svg+xml':
+                image = image.decode()
             plots.add_plot(image, mime_type, shellwidget)

--- a/spyder/plugins/variableexplorer/plugin.py
+++ b/spyder/plugins/variableexplorer/plugin.py
@@ -81,8 +81,9 @@ class VariableExplorer(SpyderDockablePlugin, ShellConnectPluginMixin):
         Show figure in Plots plugin.
 
         This shows the figure in the figure browser associated with the given
-        shellwidget. The Plots plugin and the window containing the Plots
-        plugin are both raised so that the user will see the figure.
+        shellwidget. The shellwidget is activated and the Plots plugin and the
+        window containing the Plots plugin are both raised so that the user
+        will see the figure.
 
         Parameters
         ----------
@@ -93,6 +94,10 @@ class VariableExplorer(SpyderDockablePlugin, ShellConnectPluginMixin):
         shellwidget: ShellWidget
             The shellwidget associated with the figure.
         """
+        ipython_console = self.get_plugin(Plugins.IPythonConsole)
+        if ipython_console:
+            ipython_console.set_current_shellwidget(shellwidget)
+
         plots = self.get_plugin(Plugins.Plots)
         if plots:
             plots.add_plot(image, mime_type, shellwidget)

--- a/spyder/plugins/variableexplorer/plugin.py
+++ b/spyder/plugins/variableexplorer/plugin.py
@@ -26,6 +26,7 @@ class VariableExplorer(SpyderDockablePlugin, ShellConnectPluginMixin):
     """
     NAME = 'variable_explorer'
     REQUIRES = [Plugins.IPythonConsole, Plugins.Preferences]
+    OPTIONAL = [Plugins.Plots]
     TABIFY = None
     WIDGET_CLASS = VariableExplorerWidget
     CONF_SECTION = NAME
@@ -50,9 +51,8 @@ class VariableExplorer(SpyderDockablePlugin, ShellConnectPluginMixin):
 
     def on_initialize(self):
         widget = self.get_widget()
-        widget.sig_open_preferences_requested.connect(
-            self._open_preferences
-        )
+        widget.sig_open_preferences_requested.connect(self._open_preferences)
+        widget.sig_show_figure_requested.connect(self._show_figure)
 
     @on_plugin_available(plugin=Plugins.Preferences)
     def on_preferences_available(self):
@@ -75,3 +75,24 @@ class VariableExplorer(SpyderDockablePlugin, ShellConnectPluginMixin):
             dlg = container.dialog
             index = dlg.get_index_by_name(self.NAME)
             dlg.set_current_index(index)
+
+    def _show_figure(self, image, mime_type, shellwidget):
+        """
+        Show figure in Plots plugin.
+
+        This shows the figure in the figure browser associated with the given
+        shellwidget. The Plots plugin and the window containing the Plots
+        plugin are both raised so that the user will see the figure.
+
+        Parameters
+        ----------
+        image: bytes
+            The image to show.
+        mime_type: str
+            The image's mime type.
+        shellwidget: ShellWidget
+            The shellwidget associated with the figure.
+        """
+        plots = self.get_plugin(Plugins.Plots)
+        if plots:
+            plots.add_plot(image, mime_type, shellwidget)

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -43,8 +43,9 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
     sig_editor_creation_started = Signal()
     sig_editor_shown = Signal()
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, namespacebrowser=None):
         QItemDelegate.__init__(self, parent)
+        self.namespacebrowser = namespacebrowser
         self._editors = {}  # keep references on opened editors
 
     def get_value(self, index):
@@ -161,7 +162,8 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
         # CollectionsEditor for a list, tuple, dict, etc.
         elif isinstance(value, (list, set, tuple, dict)) and not object_explorer:
             from spyder.widgets.collectionseditor import CollectionsEditor
-            editor = CollectionsEditor(parent=parent)
+            editor = CollectionsEditor(
+                parent=parent, namespacebrowser=self.namespacebrowser)
             editor.setup(value, key, icon=self.parent().windowIcon(),
                          readonly=readonly)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
@@ -269,6 +271,7 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
                 value,
                 name=key,
                 parent=parent,
+                namespacebrowser=self.namespacebrowser,
                 readonly=readonly)
             self.create_dialog(editor, dict(model=index.model(),
                                             editor=editor,
@@ -411,8 +414,8 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
 
 class ToggleColumnDelegate(CollectionsDelegate):
     """ToggleColumn Item Delegate"""
-    def __init__(self, parent=None):
-        CollectionsDelegate.__init__(self, parent)
+    def __init__(self, parent=None, namespacebrowser=None):
+        CollectionsDelegate.__init__(self, parent, namespacebrowser)
         self.current_index = None
         self.old_obj = None
 
@@ -467,7 +470,8 @@ class ToggleColumnDelegate(CollectionsDelegate):
         # CollectionsEditor for a list, tuple, dict, etc.
         if isinstance(value, (list, set, tuple, dict)):
             from spyder.widgets.collectionseditor import CollectionsEditor
-            editor = CollectionsEditor(parent=parent)
+            editor = CollectionsEditor(
+                parent=parent, namespacebrowser=self.namespacebrowser)
             editor.setup(value, key, icon=self.parent().windowIcon(),
                          readonly=readonly)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -129,6 +129,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
 
         # Attributes
         self._is_filter_button_checked = True
+        self.plots_plugin_enabled = False
 
     # ---- PluginMainWidget API
     # ------------------------------------------------------------------------
@@ -465,6 +466,19 @@ class VariableExplorerWidget(ShellConnectMainWidget):
             if widget:
                 widget.setup()
 
+    def set_plots_plugin_enabled(self, value: bool):
+        """
+        Change whether the Plots plugin is enabled.
+
+        This stores the information in this widget and propagates it to every
+        NamespaceBrowser.
+        """
+        self.plots_plugin_enabled = value
+        for index in range(self.count()):
+            nsb = self._stack.widget(index)
+            if nsb:
+                nsb.plots_plugin_enabled = value
+
     # ---- Stack accesors
     # ------------------------------------------------------------------------
     def switch_widget(self, nsb, old_nsb):
@@ -482,6 +496,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         nsb.sig_stop_spinner_requested.connect(self.stop_spinner)
         nsb.sig_show_figure_requested.connect(self.sig_show_figure_requested)
         nsb.set_shellwidget(shellwidget)
+        nsb.plots_plugin_enabled = self.plots_plugin_enabled
         nsb.setup()
         self._set_actions_and_menus(nsb)
 

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -51,7 +51,7 @@ class VariableExplorerWidgetActions:
 
 class VariableExplorerWidgetOptionsMenuSections:
     Display = 'excludes_section'
-    Highlight = 'highlight_section'    
+    Highlight = 'highlight_section'
     Resize = 'resize_section'
 
 
@@ -103,6 +103,20 @@ class VariableExplorerWidget(ShellConnectMainWidget):
     sig_open_preferences_requested = Signal()
     """
     Signal to open the variable explorer preferences.
+    """
+
+    sig_show_figure_requested = Signal(bytes, str, object)
+    """
+    This is emitted to request that a figure be shown in the Plots plugin.
+
+    Parameters
+    ----------
+    image: bytes
+        The image to show.
+    mime_type: str
+        The image's mime type.
+    shellwidget: ShellWidget
+        The shellwidget associated with the figure.
     """
 
     def __init__(self, name=None, plugin=None, parent=None):
@@ -401,7 +415,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
                 menu=self.context_menu,
                 section=VariableExplorerContextMenuSections.Filter,
             )
-        
+
         for item in [self.view_action, self.plot_action, self.hist_action,
                      self.imshow_action]:
             self.add_item_to_menu(
@@ -466,6 +480,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         nsb.sig_free_memory_requested.connect(self.free_memory)
         nsb.sig_start_spinner_requested.connect(self.start_spinner)
         nsb.sig_stop_spinner_requested.connect(self.stop_spinner)
+        nsb.sig_show_figure_requested.connect(self.sig_show_figure_requested)
         nsb.set_shellwidget(shellwidget)
         nsb.setup()
         self._set_actions_and_menus(nsb)
@@ -481,6 +496,8 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         nsb.sig_free_memory_requested.disconnect(self.free_memory)
         nsb.sig_start_spinner_requested.disconnect(self.start_spinner)
         nsb.sig_stop_spinner_requested.disconnect(self.stop_spinner)
+        nsb.sig_show_figure_requested.disconnect(
+            self.sig_show_figure_requested)
         nsb.shellwidget.sig_kernel_state_arrived.disconnect(nsb.update_view)
         nsb.shellwidget.sig_config_spyder_kernel.disconnect(
             nsb.setup_kernel)

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -460,10 +460,11 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
           to "inline",
         then call `plot_in_plots_plugin`, else call `plot_in_window`.
         """
-        if (self.plots_plugin_enabled
-                and self.get_conf('mute_inline_plotting', section='plots')
-                and self.get_conf('pylab/backend',
-                                  section='ipython_console') == 0):
+        if (
+            self.plots_plugin_enabled
+            and self.get_conf('mute_inline_plotting', section='plots')
+            and self.get_conf('pylab/backend', section='ipython_console') == 0
+        ):
             self.plot_in_plots_plugin(data, funcname)
         else:
             self.plot_in_window(data, funcname)
@@ -472,8 +473,8 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
         """
         Plot data in Plots plugin.
 
-        Plot the given data to a PNG image and show the plot in the Plots
-        plugin.
+        Plot the given data to a PNG or SVG image and show the plot in the
+        Plots plugin.
         """
         import spyder.pyplot as plt
         from IPython.core.pylabtools import print_figure

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -83,6 +83,7 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
 
         # Attributes
         self.filename = None
+        self.plots_plugin_enabled = False
 
         # Widgets
         self.editor = None
@@ -459,10 +460,7 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
           to "inline",
         then call `plot_in_plots_plugin`, else call `plot_in_window`.
         """
-        stacked_widget = self.parent()
-        variable_explorer_widget = stacked_widget.parent()
-        variable_explorer_plugin = variable_explorer_widget.get_plugin()
-        if (variable_explorer_plugin.is_plugin_enabled(Plugins.Plots)
+        if (self.plots_plugin_enabled
                 and self.get_conf('mute_inline_plotting', section='plots')
                 and self.get_conf('pylab/backend',
                                   section='ipython_console') == 0):

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -432,3 +432,10 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
             return msg
         except (UnpicklingError, RuntimeError, CommError):
             return None
+
+    def plot(self, data, funcname):
+        """Plot data"""
+        import spyder.pyplot as plt
+        plt.figure()
+        getattr(plt, funcname)(data)
+        plt.show()

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -480,10 +480,32 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
         import spyder.pyplot as plt
         from IPython.core.pylabtools import print_figure
 
-        fig, ax = plt.subplots()
+        if self.get_conf('pylab/inline/figure_format',
+                         section='ipython_console') == 1:
+            figure_format = 'svg'
+            mime_type = 'image/svg+xml'
+        else:
+            figure_format = 'png'
+            mime_type = 'image/png'
+        resolution = self.get_conf('pylab/inline/resolution',
+                                   section='ipython_console')
+        width = self.get_conf('pylab/inline/width',
+                              section='ipython_console')
+        height = self.get_conf('pylab/inline/height',
+                               section='ipython_console')
+        if self.get_conf('pylab/inline/bbox_inches',
+                         section='ipython_console'):
+            bbox_inches = 'tight'
+        else:
+            bbox_inches = None
+
+        fig, ax = plt.subplots(figsize=(width, height))
         getattr(ax, funcname)(data)
-        png = print_figure(fig)
-        self.sig_show_figure_requested.emit(png, 'image/png', self.shellwidget)
+        image = print_figure(fig, fmt=figure_format, bbox_inches=bbox_inches,
+                             dpi=resolution)
+        if figure_format == 'svg':
+            image = image.encode()
+        self.sig_show_figure_requested.emit(image, mime_type, self.shellwidget)
 
     def plot_in_window(self, data, funcname):
         """

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -52,6 +52,7 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
                  expanded=False,
                  resize_to_contents=True,
                  parent=None,
+                 namespacebrowser=None,
                  attribute_columns=DEFAULT_ATTR_COLS,
                  attribute_details=DEFAULT_ATTR_DETAILS,
                  readonly=None,
@@ -59,11 +60,13 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
         """
         Constructor
 
+        :param obj: any Python object or variable
         :param name: name of the object as it will appear in the root node
         :param expanded: show the first visible root element expanded
         :param resize_to_contents: resize columns to contents ignoring width
             of the attributes
-        :param obj: any Python object or variable
+        :param namespacebrowser: the NamespaceBrowser that the object
+            originates from, if any
         :param attribute_columns: list of AttributeColumn objects that
             define which columns are present in the table and their defaults
         :param attribute_details: list of AttributeDetails objects that define
@@ -100,7 +103,7 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
         # self._proxy_tree_model.setSortCaseSensitivity(Qt.CaseInsensitive)
 
         # Tree widget
-        self.obj_tree = ToggleColumnTreeView()
+        self.obj_tree = ToggleColumnTreeView(namespacebrowser)
         self.obj_tree.setAlternatingRowColors(True)
         self.obj_tree.setModel(self._proxy_tree_model)
         self.obj_tree.setSelectionBehavior(QAbstractItemView.SelectRows)

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -13,7 +13,7 @@ import logging
 import traceback
 
 # Third-party imports
-from qtpy.QtCore import Slot, QModelIndex, QPoint, QSize, Qt
+from qtpy.QtCore import Signal, Slot, QModelIndex, QPoint, QSize, Qt
 from qtpy.QtGui import QKeySequence, QTextOption
 from qtpy.QtWidgets import (QAbstractItemView, QAction, QButtonGroup,
                             QGroupBox, QHBoxLayout, QHeaderView,

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
@@ -155,12 +155,13 @@ class ToggleColumnTreeView(QTreeView, ToggleColumnMixIn):
     show/hide columns.
     """
 
-    def __init__(self, readonly=False):
+    def __init__(self, namespacebrowser=None, readonly=False):
         QTreeView.__init__(self)
         self.readonly = readonly
         from spyder.plugins.variableexplorer.widgets.collectionsdelegate \
             import ToggleColumnDelegate
-        self.setItemDelegate(ToggleColumnDelegate(self))
+        self.delegate = ToggleColumnDelegate(self, namespacebrowser)
+        self.setItemDelegate(self.delegate)
         self.setEditTriggers(QAbstractItemView.DoubleClicked)
         self.expanded.connect(self.resize_columns_to_contents)
         self.collapsed.connect(self.resize_columns_to_contents)

--- a/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
@@ -228,7 +228,8 @@ def test_namespacebrowser_plot_with_mute_inline_plotting_true(
         namespacebrowser.plot(my_list, 'plot')
 
     mock_axis.plot.assert_called_once_with(my_list)
-    mock_print_figure.assert_called_once_with(mock_figure)
+    mock_print_figure.assert_called_once_with(
+        mock_figure, fmt='png', bbox_inches='tight', dpi=72)
     expected_args = [mock_png, 'image/png', namespacebrowser.shellwidget]
     assert blocker.args == expected_args
 

--- a/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
@@ -17,7 +17,6 @@ import pytest
 from qtpy.QtCore import Qt, QPoint, QModelIndex
 
 # Local imports
-from spyder.config.manager import CONF
 from spyder.plugins.variableexplorer.widgets.namespacebrowser import (
     NamespaceBrowser)
 from spyder.widgets.collectionseditor import ROWS_TO_LOAD
@@ -210,7 +209,7 @@ def test_namespacebrowser_plot_with_mute_inline_plotting_true(
     Test that plotting a list from the namespace browser sends a signal
     with the plot if `mute_inline_plotting` is set to `True`.
     """
-    CONF.set('plots', 'mute_inline_plotting', True)
+    namespacebrowser.set_conf('mute_inline_plotting', True, section='plots')
     namespacebrowser.plots_plugin_enabled = True
     my_list = [4, 2]
     mock_figure = Mock()
@@ -237,7 +236,7 @@ def test_namespacebrowser_plot_with_mute_inline_plotting_false(namespacebrowser)
     Test that plotting a list from the namespace browser shows a plot if
     `mute_inline_plotting` is set to `False`.
     """
-    CONF.set('plots', 'mute_inline_plotting', False)
+    namespacebrowser.set_conf('mute_inline_plotting', False, section='plots')
     my_list = [4, 2]
 
     with (patch('spyder.pyplot.figure') as mock_figure,

--- a/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
@@ -211,15 +211,13 @@ def test_namespacebrowser_plot_with_mute_inline_plotting_true(
     with the plot if `mute_inline_plotting` is set to `True`.
     """
     CONF.set('plots', 'mute_inline_plotting', True)
+    namespacebrowser.plots_plugin_enabled = True
     my_list = [4, 2]
     mock_figure = Mock()
     mock_axis = Mock()
     mock_png = b'fake png'
-    mock_stacked_widget = Mock()
 
-    with (patch.object(namespacebrowser, 'parent',
-                       return_value=mock_stacked_widget),
-          patch('spyder.pyplot.subplots',
+    with (patch('spyder.pyplot.subplots',
                 return_value=(mock_figure, mock_axis)),
           patch('IPython.core.pylabtools.print_figure',
                 return_value=mock_png) as mock_print_figure,
@@ -241,11 +239,8 @@ def test_namespacebrowser_plot_with_mute_inline_plotting_false(namespacebrowser)
     """
     CONF.set('plots', 'mute_inline_plotting', False)
     my_list = [4, 2]
-    mock_stacked_widget = Mock()
 
-    with (patch.object(namespacebrowser, 'parent',
-                       return_value=mock_stacked_widget),
-          patch('spyder.pyplot.figure') as mock_figure,
+    with (patch('spyder.pyplot.figure') as mock_figure,
           patch('spyder.pyplot.plot') as mock_plot,
           patch('spyder.pyplot.show') as mock_show):
         namespacebrowser.plot(my_list, 'plot')

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -1315,7 +1315,7 @@ class BaseTableView(QTableView, SpyderConfigurationAccessor):
 class CollectionsEditorTableView(BaseTableView):
     """CollectionsEditor table view"""
 
-    def __init__(self, parent, data, namespacebrowser=None,  readonly=False,
+    def __init__(self, parent, data, namespacebrowser=None, readonly=False,
                  title="", names=False):
         BaseTableView.__init__(self, parent)
         self.dictfilter = None

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -1420,10 +1420,7 @@ class CollectionsEditorTableView(BaseTableView):
     def plot(self, key, funcname):
         """Plot item"""
         data = self.source_model.get_data()
-        import spyder.pyplot as plt
-        plt.figure()
-        getattr(plt, funcname)(data[key])
-        plt.show()
+        self.namespacebrowser.plot(data[key], funcname)
 
     def imshow(self, key):
         """Show item's image"""

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -29,8 +29,9 @@ from qtpy.QtWidgets import QWidget, QDateEdit
 # Local imports
 from spyder.config.manager import CONF
 from spyder.widgets.collectionseditor import (
-    RemoteCollectionsEditorTableView, CollectionsEditorTableView,
-    CollectionsModel, CollectionsEditor, LARGE_NROWS, ROWS_TO_LOAD, natsort)
+    CollectionsEditor, CollectionsEditorTableView, CollectionsEditorWidget,
+    CollectionsModel, LARGE_NROWS, natsort, RemoteCollectionsEditorTableView,
+    ROWS_TO_LOAD)
 from spyder.plugins.variableexplorer.widgets.tests.test_dataframeeditor import (
     generate_pandas_indexes)
 from spyder_kernels.utils.nsview import get_size
@@ -920,6 +921,22 @@ def test_dicts_natural_sorting_mixed_types():
     assert data_table(cm, 4, 3) == [['DSeries', 'kDict', 'List', 'aStr'],
                                     ['Series', 'dict', 'list', 'str'],
                                     ['(0,)', 2, 3, str_size]]
+
+
+def test_collectioneditor_plot(qtbot):
+    """
+    Test that plotting a list from the collection editor calls the .plot()
+    function in the associated namespace browser.
+    """
+    my_list = [4, 2]
+    mock_namespacebrowser = Mock()
+    cew = CollectionsEditorWidget(
+        None, {'list': my_list}, namespacebrowser=mock_namespacebrowser)
+    qtbot.addWidget(cew)
+
+    cew.editor.plot('list', 'plot')
+
+    mock_namespacebrowser.plot.assert_called_once_with(my_list, 'plot')
 
 
 if __name__ == "__main__":

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -935,7 +935,6 @@ def test_collectioneditor_plot(qtbot):
     qtbot.addWidget(cew)
 
     cew.editor.plot('list', 'plot')
-
     mock_namespacebrowser.plot.assert_called_once_with(my_list, 'plot')
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->

The collection editor is opened when the user edits a list, set, dict or tuple in the Variable Explorer. At the moment, plotting in the collection editor opens a new window with the plot. This PR changes this so that the plot is displayed in the Plots pane, for consistency with the namespace browser. The Plots pane is brought to the front so that users notice the new plot. However, if the user unticks the setting "Mute inline plots" in the Plots pane, then the old behaviour is restored and plots are shown in a separate window.

The collection editor is also used in several places outside the Variable Explorer:
* The IPython Console uses it to show environment variables and sys.path contents. Neither of these can be plotted as far as I can see.
* The `oedit()` function can create a collection editor. I am not sure about this function. I don't think it is used anywhere in Spyder but perhaps it is meant to be run from the Internal Console. Plotting from a collection editor created by `oedit()` will not work, because the signal is not connected to anything.

One niggle is that plots from the collection editor will be shown in the currently active figure browser in the Plots pane, which is associated to the currently active console. However, the variable shown in the collection editor may originate from a different console.

![collection-plot](https://github.com/spyder-ide/spyder/assets/7941918/0f3cd8a6-9071-48a0-bd5d-d0b33471cd1c)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21145


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
