### PR TITLE
Use timeout when getting user environment variables.

### DIFF
--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -72,7 +72,8 @@ def get_user_environment_variables():
             else:
                 env = {}
             proc = run_shell_command(cmd, env=env, text=True)
-            stdout, stderr = proc.communicate()
+            # Use timeout: https://github.com/spyder-ide/spyder/issues/21172
+            stdout, stderr = proc.communicate(timeout=0.5)
             env_var = eval(stdout, None)
     except Exception:
         return {}


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


Added timeout to subprocess when getting user environment variables to prevent hanging at startup.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21172
