### PR TITLE
PR: Expand patterns to detect possible `site-packages` directories (Pythonpath manager)

### DIFF
--- a/spyder/plugins/pythonpath/tests/__init__.py
+++ b/spyder/plugins/pythonpath/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Pythonpath manager tests.
+"""

--- a/spyder/plugins/pythonpath/tests/test_utils.py
+++ b/spyder/plugins/pythonpath/tests/test_utils.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+import os
+
+from spyder.plugins.pythonpath.utils import check_path
+
+
+def test_check_path(tmp_path):
+    """
+    Test for the check_path utlity function.
+
+    Test cases taken from
+    https://discuss.python.org/t/understanding-site-packages-directories/12959
+    """
+
+    # A regular path must pass the test
+    assert check_path(str(tmp_path / 'foo'))
+
+    # One digit Python versions
+    assert not check_path('lib/python3.9/site-packages')
+
+    # Two digit Python versions
+    assert not check_path('lib/python3.11/site-packages')
+
+    # Global Python in Redhat and derivatives
+    assert not check_path('lib64/python3.10/site-packages')
+
+    # Global Python in Debian and derivatives
+    assert not check_path('lib/python3/dist-packages')
+
+    # Framework installations on Mac
+    assert not check_path('Library/Python/3.9/lib/python/site-packages')
+
+    # Python installations on Windows
+    if os.name == 'nt':
+        assert not check_path(
+            'C:\\Users\\User\\Anaconda3\\envs\\foo\\Lib\\site-packages')
+
+        assert not check_path('lib\\site-packages')
+
+    # Paths that don't have digits must pass
+    assert check_path('lib/pythonX.Y/site-packages')

--- a/spyder/plugins/pythonpath/tests/test_utils.py
+++ b/spyder/plugins/pythonpath/tests/test_utils.py
@@ -41,6 +41,7 @@ def test_check_path(tmp_path):
             'C:\\Users\\User\\Anaconda3\\envs\\foo\\Lib\\site-packages')
 
         assert not check_path('lib\\site-packages')
+        assert not check_path('lib\\dist-packages')
 
     # Paths that don't have digits must pass
     assert check_path('lib/pythonX.Y/site-packages')

--- a/spyder/plugins/pythonpath/utils.py
+++ b/spyder/plugins/pythonpath/utils.py
@@ -18,12 +18,12 @@ from spyder.utils.environ import get_user_env
 def check_path(path):
     """Check that `path` is not a [site|dist]-packages folder."""
     if os.name == 'nt':
-        pattern = re.compile(r'.*(?:l|L)ib/(?:site|dist)-packages.*')
+        pattern = re.compile(r'.*(l|L)ib/(site|dist)-packages.*')
     else:
         pattern = re.compile(
-            r'.*(:?lib|lib64)/'
-            '(?:python|python(\d+)|python(\d+)\.(\d+)|python(\d+)\.(\d+)(\d+))'
-            '/(?:site|dist)-packages.*'
+            r'.*(lib|lib64)/'
+            '(python|python\d+|python\d+\.\d+)/'
+            '(site|dist)-packages.*'
         )
 
     path_norm = path.replace('\\', '/')

--- a/spyder/plugins/pythonpath/utils.py
+++ b/spyder/plugins/pythonpath/utils.py
@@ -18,12 +18,16 @@ from spyder.utils.environ import get_user_env
 def check_path(path):
     """Check that `path` is not a [site|dist]-packages folder."""
     if os.name == 'nt':
-        pat = re.compile(r'.*lib/(?:site|dist)-packages.*')
+        pattern = re.compile(r'.*(?:l|L)ib/(?:site|dist)-packages.*')
     else:
-        pat = re.compile(r'.*lib/python.../(?:site|dist)-packages.*')
+        pattern = re.compile(
+            r'.*(:?lib|lib64)/'
+            '(?:python|python(\d+)|python(\d+)\.(\d+)|python(\d+)\.(\d+)(\d+))'
+            '/(?:site|dist)-packages.*'
+        )
 
     path_norm = path.replace('\\', '/')
-    return pat.match(path_norm) is None
+    return pattern.match(path_norm) is None
 
 
 def get_system_pythonpath():


### PR DESCRIPTION
## Description of Changes

* We were not detecting `site-packages` directories in Mac framework installations and two digit Python environments (e.g. Python 3.10).
* Add tests for the small utility function that does that job.

### Issue(s) Resolved

Fixes #21228.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
