### PR TITLE
PR: Catch errors when trying to reload a file (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2401,26 +2401,44 @@ class EditorStack(QWidget):
             # Else, testing if it has been modified elsewhere:
             lastm = QFileInfo(finfo.filename).lastModified()
             if str(lastm.toString()) != str(finfo.lastmodified.toString()):
-                if finfo.editor.document().isModified():
+                # Catch any error when trying to reload a file and close it if
+                # that's the case to prevent users from destroying external
+                # changes in Spyder.
+                # Fixes spyder-ide/spyder#21248
+                try:
+                    if finfo.editor.document().isModified():
+                        self.msgbox = QMessageBox(
+                            QMessageBox.Question,
+                            self.title,
+                            _("The file <b>{}</b> has been modified outside "
+                              "Spyder."
+                              "<br><br>"
+                              "Do you want to reload it and lose all your "
+                              "changes?").format(name),
+                            QMessageBox.Yes | QMessageBox.No,
+                            self
+                        )
+
+                        answer = self.msgbox.exec_()
+                        if answer == QMessageBox.Yes:
+                            self.reload(index)
+                        else:
+                            finfo.lastmodified = lastm
+                    else:
+                        self.reload(index)
+                except Exception:
                     self.msgbox = QMessageBox(
-                        QMessageBox.Question,
+                        QMessageBox.Warning,
                         self.title,
-                        _("The file <b>%s</b> has been modified outside "
-                          "Spyder."
+                        _("The file <b>{}</b> has been modified outside "
+                          "Spyder but it was not possible to reload it."
                           "<br><br>"
-                          "Do you want to reload it and lose all your "
-                          "changes?") % name,
-                        QMessageBox.Yes | QMessageBox.No,
+                          "Therefore, it will be closed.").format(name),
+                        QMessageBox.Ok,
                         self
                     )
-
-                    answer = self.msgbox.exec_()
-                    if answer == QMessageBox.Yes:
-                        self.reload(index)
-                    else:
-                        finfo.lastmodified = lastm
-                else:
-                    self.reload(index)
+                    self.msgbox.exec_()
+                    self.close_file(index, force=True)
 
         # Finally, resetting temporary flag:
         self.__file_status_flag = False


### PR DESCRIPTION
## Description of Changes

If errors appear while doing it, we close the file to prevent users from destroying external changes in Spyder.

### Issue(s) Resolved

Fixes #21248.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
