### PR TITLE
PR: Do not include spyder-terminal in standalone applications

### DIFF
--- a/installers/Windows/req-extras-pull-request.txt
+++ b/installers/Windows/req-extras-pull-request.txt
@@ -20,7 +20,7 @@ cython
 sympy
 
 # Spyder external plugins
-spyder-terminal>=1.2.2
+# spyder-terminal>=1.2.2
 
 # Spyder external dependencies (spyder-kernels)
 ./external-deps/spyder-kernels

--- a/installers/Windows/req-extras-release.txt
+++ b/installers/Windows/req-extras-release.txt
@@ -20,4 +20,4 @@ cython
 sympy
 
 # Spyder external plugins
-spyder-terminal>=1.2.2
+# spyder-terminal>=1.2.2

--- a/installers/Windows/req-pull-request.txt
+++ b/installers/Windows/req-pull-request.txt
@@ -1,5 +1,5 @@
 # Spyder external plugins
-spyder-terminal>=1.2.2
+# spyder-terminal>=1.2.2
 
 # Spyder external dependencies (spyder-kernels)
 ./external-deps/spyder-kernels

--- a/installers/Windows/req-release.txt
+++ b/installers/Windows/req-release.txt
@@ -1,2 +1,2 @@
 # Spyder external plugins
-spyder-terminal>=1.2.2
+# spyder-terminal>=1.2.2

--- a/installers/macOS/packages.py
+++ b/installers/macOS/packages.py
@@ -13,9 +13,6 @@ The following packages are included in py2app's PACKAGES option so that
 they will be placed in Spyder.app/Contents/Resources/lib/python<ver>
 instead.
 
-humanfriendly :
-    spyder-terminal plugin
-    ModuleNotFoundError: No module named 'humanfriendly.tables'
 keyring:
     ModuleNotFoundError: No module named 'keyring.backends.kwallet'
     ModuleNotFoundError: No module named 'keyring.backends.SecretService'
@@ -42,13 +39,10 @@ spyder :
     python38.zip/spyder/app/mac_stylesheet.qss'
 spyder_kernels :
     No module named spyder_kernels.console.__main__
-spyder_terminal :
-    No module named spyder_terminal.server
 """
 
 # Packages that cannot be in the zip folder
 PACKAGES = [
-    'humanfriendly',
     'keyring',
     'pkg_resources',
     'pygments',
@@ -58,7 +52,6 @@ PACKAGES = [
     'setuptools',
     'spyder',
     'spyder_kernels',
-    'spyder_terminal',
 ]
 
 # Packages to exclude

--- a/installers/macOS/req-plugins.txt
+++ b/installers/macOS/req-plugins.txt
@@ -1,2 +1,2 @@
 # Spyder plugins
-spyder-terminal
+# spyder-terminal


### PR DESCRIPTION
## Description of Changes

Removed `spyder-terminal` plugin from the standalone applications

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21258

