### PR TITLE
PR: Compute Projects switcher results in a worker to avoid freezes

### DIFF
--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -275,8 +275,20 @@ def create_application():
     # The try/except is necessary to run the main window tests on their own.
     try:
         app.set_font()
-    except AttributeError:
-        pass
+    except AttributeError as error:
+        if running_under_pytest():
+            # Set font options to avoid a ton of Qt warnings when running tests
+            app_family = app.font().family()
+            app_size = app.font().pointSize()
+            CONF.set('appearance', 'app_font/family', app_family)
+            CONF.set('appearance', 'app_font/size', app_size)
+
+            from spyder.config.fonts import MEDIUM, MONOSPACE
+            CONF.set('appearance', 'monospace_app_font/family', MONOSPACE[0])
+            CONF.set('appearance', 'monospace_app_font/size', MEDIUM)
+        else:
+            # Raise in case the error is valid
+            raise error
 
     # Required for correct icon on GNOME/Wayland:
     if hasattr(app, 'setDesktopFileName'):

--- a/spyder/config/utils.py
+++ b/spyder/config/utils.py
@@ -116,11 +116,11 @@ def get_filter(filetypes, ext):
         return ''
 
 
-def get_edit_filetypes():
+def get_edit_filetypes(ignore_pygments_extensions=True):
     """Get all file types supported by the Editor"""
-    # The filter details are not hidden on Windows, so we can't use
-    # all Pygments extensions on that platform
-    if os.name == 'nt':
+    # The filter details are not hidden on Windows, so we can't use all
+    # Pygments extensions on that platform.
+    if os.name == 'nt' and ignore_pygments_extensions:
         supported_exts = []
     else:
         try:
@@ -154,8 +154,8 @@ def get_edit_extensions():
     Return extensions associated with the file types
     supported by the Editor
     """
-    edit_filetypes = get_edit_filetypes()
-    return _get_extensions(edit_filetypes)+['']
+    edit_filetypes = get_edit_filetypes(ignore_pygments_extensions=False)
+    return _get_extensions(edit_filetypes) + ['']
 
 
 #==============================================================================

--- a/spyder/plugins/editor/utils/switcher_manager.py
+++ b/spyder/plugins/editor/utils/switcher_manager.py
@@ -84,10 +84,8 @@ class EditorSwitcherManager(object):
         editor_list = editorstack.data.copy()
         editor_list.reverse()
 
-        paths = [data.filename.lower()
-                 for data in editor_list]
-        save_statuses = [data.newly_created
-                         for data in editor_list]
+        paths = [data.filename for data in editor_list]
+        save_statuses = [data.newly_created for data in editor_list]
         short_paths = shorten_paths(paths, save_statuses)
 
         for idx, data in enumerate(editor_list):
@@ -99,14 +97,17 @@ class EditorSwitcherManager(object):
             if len(paths[idx]) > 75:
                 path = short_paths[idx]
             else:
-                path = osp.dirname(data.filename.lower())
+                path = osp.dirname(data.filename)
             last_item = (idx + 1 == len(editor_list))
-            self._switcher.add_item(title=title,
-                                    description=path,
-                                    icon=icon,
-                                    section=self._section,
-                                    data=data,
-                                    last_item=last_item)
+            self._switcher.add_item(
+                title=title,
+                description=path,
+                icon=icon,
+                section=self._section,
+                data=data,
+                last_item=last_item
+            )
+
         self._switcher.set_current_row(0)
 
     def create_line_switcher(self):

--- a/spyder/plugins/editor/utils/switcher_manager.py
+++ b/spyder/plugins/editor/utils/switcher_manager.py
@@ -78,12 +78,7 @@ class EditorSwitcherManager(object):
             _('Start typing the name of an open file'))
 
         editorstack = self._editorstack()
-
-        # Since editor open files are inserted at position 0, the
-        # list needs to be reversed so they're shown in order.
         editor_list = editorstack.data.copy()
-        editor_list.reverse()
-
         paths = [data.filename for data in editor_list]
         save_statuses = [data.newly_created for data in editor_list]
         short_paths = shorten_paths(paths, save_statuses)
@@ -99,16 +94,16 @@ class EditorSwitcherManager(object):
             else:
                 path = osp.dirname(data.filename)
             last_item = (idx + 1 == len(editor_list))
+
             self._switcher.add_item(
                 title=title,
                 description=path,
                 icon=icon,
                 section=self._section,
                 data=data,
-                last_item=last_item
+                last_item=last_item,
+                score=0  # To make these items appear above those from Projects
             )
-
-        self._switcher.set_current_row(0)
 
     def create_line_switcher(self):
         """Populate switcher with line info."""

--- a/spyder/plugins/editor/utils/switcher_manager.py
+++ b/spyder/plugins/editor/utils/switcher_manager.py
@@ -61,6 +61,9 @@ class EditorSwitcherManager(object):
         self._switcher.sig_rejected.connect(self.handle_switcher_rejection)
         self._switcher.sig_item_changed.connect(
             self.handle_switcher_item_change)
+        self._switcher.sig_search_text_available.connect(
+            lambda text: self._switcher.setup()
+        )
 
     def handle_switcher_modes(self, mode):
         """Handle switcher for registered modes."""

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -508,17 +508,11 @@ class Projects(SpyderDockablePlugin):
         mode: str
             The selected mode (open files "", symbol "@" or line ":").
         """
-        items = self.get_widget().handle_switcher_modes()
-        for (title, description, icon, section, path, is_last_item) in items:
-            self._switcher.add_item(
-                title=title,
-                description=description,
-                icon=icon,
-                section=section,
-                data=path,
-                last_item=is_last_item
-            )
+        # Don't compute anything if we're not in files mode
+        if mode != "":
+            return
 
+        self.get_widget().display_default_switcher_items()
         self._switcher.set_current_row(0)
 
     def _handle_switcher_selection(self, item, mode, search_text):
@@ -555,7 +549,7 @@ class Projects(SpyderDockablePlugin):
         """
         self.get_widget().handle_switcher_filtering(search_text, items_data)
 
-    def _display_items_in_switcher(self, items):
+    def _display_items_in_switcher(self, items, setup=True):
         """Display a list of items in the switcher."""
         for (title, description, icon, section, path, is_last_item) in items:
             self._switcher.add_item(
@@ -568,4 +562,5 @@ class Projects(SpyderDockablePlugin):
                 score=1e10  # To make the editor results appear first
             )
 
-        self._switcher.setup()
+        if setup:
+            self._switcher.setup()

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -545,8 +545,22 @@ class Projects(SpyderDockablePlugin):
         """
         self.get_widget().handle_switcher_search(search_text)
 
-    def _display_items_in_switcher(self, items, setup=True):
-        """Display a list of items in the switcher."""
+    def _display_items_in_switcher(self, items, setup, clear_section):
+        """
+        Display a list of items in the switcher.
+
+        Parameters
+        ----------
+        items: list
+            Items to display.
+        setup: bool
+            Call the switcher's setup after adding the items.
+        clear_section: bool
+            Clear Projects section before adding the items.
+        """
+        if clear_section:
+            self._switcher.remove_section(self.get_widget().get_title())
+
         for (title, description, icon, section, path, is_last_item) in items:
             self._switcher.add_item(
                 title=title,

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -513,7 +513,6 @@ class Projects(SpyderDockablePlugin):
             return
 
         self.get_widget().display_default_switcher_items()
-        self._switcher.set_current_row(0)
 
     def _handle_switcher_selection(self, item, mode, search_text):
         """

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -518,6 +518,7 @@ class Projects(SpyderDockablePlugin):
                 data=path,
                 last_item=is_last_item
             )
+
         self._switcher.set_current_row(0)
 
     def _handle_switcher_selection(self, item, mode, search_text):
@@ -564,5 +565,7 @@ class Projects(SpyderDockablePlugin):
                 section=section,
                 data=path,
                 last_item=is_last_item,
-                score=100
+                score=1e10  # To make the editor results appear first
             )
+
+        self._switcher.setup()

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -216,7 +216,7 @@ class Projects(SpyderDockablePlugin):
         self._switcher.sig_item_selected.connect(
             self._handle_switcher_selection)
         self._switcher.sig_search_text_available.connect(
-            self._handle_switcher_results)
+            self._handle_switcher_filtering)
 
     @on_plugin_teardown(plugin=Plugins.Editor)
     def on_editor_teardown(self):
@@ -281,7 +281,7 @@ class Projects(SpyderDockablePlugin):
         self._switcher.sig_item_selected.disconnect(
             self._handle_switcher_selection)
         self._switcher.sig_search_text_available.disconnect(
-            self._handle_switcher_results)
+            self._handle_switcher_filtering)
         self._switcher = None
 
     def on_close(self, cancelable=False):
@@ -540,7 +540,7 @@ class Projects(SpyderDockablePlugin):
         self.get_widget().handle_switcher_selection(item, mode, search_text)
         self._switcher.hide()
 
-    def _handle_switcher_results(self, search_text, items_data):
+    def _handle_switcher_filtering(self, search_text, items_data):
         """
         Handle user typing in switcher to filter results.
 
@@ -552,8 +552,10 @@ class Projects(SpyderDockablePlugin):
         items_data: list
             List of items shown in the switcher.
         """
-        items = self.get_widget().handle_switcher_results(search_text,
-                                                          items_data)
+        self.get_widget().handle_switcher_filtering(search_text, items_data)
+
+    def _display_items_in_switcher(self, items):
+        """Display a list of items in the switcher."""
         for (title, description, icon, section, path, is_last_item) in items:
             self._switcher.add_item(
                 title=title,

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -216,7 +216,7 @@ class Projects(SpyderDockablePlugin):
         self._switcher.sig_item_selected.connect(
             self._handle_switcher_selection)
         self._switcher.sig_search_text_available.connect(
-            self._handle_switcher_filtering)
+            self._handle_switcher_search)
 
     @on_plugin_teardown(plugin=Plugins.Editor)
     def on_editor_teardown(self):
@@ -281,7 +281,7 @@ class Projects(SpyderDockablePlugin):
         self._switcher.sig_item_selected.disconnect(
             self._handle_switcher_selection)
         self._switcher.sig_search_text_available.disconnect(
-            self._handle_switcher_filtering)
+            self._handle_switcher_search)
         self._switcher = None
 
     def on_close(self, cancelable=False):
@@ -535,19 +535,16 @@ class Projects(SpyderDockablePlugin):
         self.get_widget().handle_switcher_selection(item, mode, search_text)
         self._switcher.hide()
 
-    def _handle_switcher_filtering(self, search_text, items_data):
+    def _handle_switcher_search(self, search_text):
         """
         Handle user typing in switcher to filter results.
 
-        Load switcher results when a search text is typed for projects.
         Parameters
         ----------
         text: str
             The current search text in the switcher dialog box.
-        items_data: list
-            List of items shown in the switcher.
         """
-        self.get_widget().handle_switcher_filtering(search_text, items_data)
+        self.get_widget().handle_switcher_search(search_text)
 
     def _display_items_in_switcher(self, items, setup=True):
         """Display a list of items in the switcher."""

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -569,7 +569,8 @@ class Projects(SpyderDockablePlugin):
                 section=section,
                 data=path,
                 last_item=is_last_item,
-                score=1e10  # To make the editor results appear first
+                score=1e10,  # To make the editor results appear first
+                use_score=False  # Results come from fzf in the right order
             )
 
         if setup:

--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -351,7 +351,7 @@ def test_project_explorer_tree_root(projects, tmpdir, qtbot):
     # Open the projects.
     for ppath in [ppath1, ppath2]:
         projects.open_project(path=ppath)
-        projects.get_widget()._update_explorer(None)
+        projects.get_widget()._setup_project(ppath)
 
         # Check that the root path of the project explorer tree widget is
         # set correctly.

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -27,6 +27,7 @@ from spyder.api.translations import _
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.config.base import (
     get_home_dir, get_project_config_folder, running_under_pytest)
+from spyder.config.utils import get_edit_extensions
 from spyder.plugins.completion.api import (
     CompletionRequestTypes, FileChangeType)
 from spyder.plugins.completion.decorators import (
@@ -191,8 +192,11 @@ class ProjectExplorerWidget(PluginMainWidget):
         self.watcher = WorkspaceWatcher(self)
         self.watcher.connect_signals(self)
 
-        # To manage the worker that calls fzf
+        # -- Worker manager for calls to fzf
         self._worker_manager = WorkerManager(self)
+
+        # -- List of possible file extensions that can be opened in the Editor
+        self._edit_extensions = get_edit_extensions()
 
         # -- Signals
         self.sig_project_loaded.connect(self._setup_project)
@@ -1032,9 +1036,10 @@ class ProjectExplorerWidget(PluginMainWidget):
             for path in relative_path_list
         ]
 
-        # Remove binary files
+        # Filter files that can be opened in the editor
         result_list = [
-            path for path in result_list if encoding.is_text_file(path)
+            path for path in result_list
+            if osp.splitext(path)[1] in self._edit_extensions
         ]
 
         # Limit the number of results to not introduce lags when displaying

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -1020,7 +1020,7 @@ class ProjectExplorerWidget(PluginMainWidget):
 
         # List of tuples with the absolute path
         result_list = [
-            osp.normpath(os.path.join(project_path, path)).lower()
+            osp.normpath(os.path.join(project_path, path))
             for path in relative_path_list
         ]
 
@@ -1039,10 +1039,10 @@ class ProjectExplorerWidget(PluginMainWidget):
         Convert a list of paths to items that can be shown in the switcher.
         """
         # The paths that are opened in the editor need to be excluded because
-        # they are shown already in the switcher in the "editor" section.
+        # they are shown already in the Editor section of the switcher.
         open_files = self.get_plugin()._get_open_filenames()
         for file in open_files:
-            normalized_path = osp.normpath(file).lower()
+            normalized_path = osp.normpath(file)
             if normalized_path in paths:
                 paths.remove(normalized_path)
 

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -183,7 +183,7 @@ class ProjectExplorerWidget(PluginMainWidget):
         self.watcher.connect_signals(self)
 
         # Signals
-        self.sig_project_loaded.connect(self._update_explorer)
+        self.sig_project_loaded.connect(self._setup_project)
 
         # Layout
         layout = QVBoxLayout()
@@ -995,10 +995,6 @@ class ProjectExplorerWidget(PluginMainWidget):
             expanded_state = None
         if expanded_state is not None:
             self.treewidget.set_expanded_state(expanded_state)
-
-    def _update_explorer(self, _unused):
-        """Update explorer tree"""
-        self._setup_project(self.get_active_project_path())
 
     def _get_valid_recent_projects(self, recent_projects):
         """

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -1027,16 +1027,18 @@ class ProjectExplorerWidget(PluginMainWidget):
         if output is None or error:
             return
 
+        # Get list of paths from fzf output
         relative_path_list = output.decode('utf-8').strip().split("\n")
-        if relative_path_list == ['']:
-            return
 
-        # List of tuples with the absolute path
-        project_path = self.get_active_project_path()
-        result_list = [
-            osp.normpath(os.path.join(project_path, path))
-            for path in relative_path_list
-        ]
+        # List of results with absolute path
+        if relative_path_list != ['']:
+            project_path = self.get_active_project_path()
+            result_list = [
+                osp.normpath(os.path.join(project_path, path))
+                for path in relative_path_list
+            ]
+        else:
+            result_list = []
 
         # Filter files that can be opened in the editor
         result_list = [

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -14,7 +14,6 @@ import os
 import os.path as osp
 import pathlib
 import shutil
-import subprocess
 
 # Third party imports
 from qtpy.compat import getexistingdirectory
@@ -43,6 +42,7 @@ from spyder.plugins.switcher.utils import get_file_icon, shorten_paths
 from spyder.widgets.helperwidgets import PaneEmptyWidget
 from spyder.utils import encoding
 from spyder.utils.misc import getcwd_or_home
+from spyder.utils.workers import WorkerManager
 
 
 # For logging
@@ -77,8 +77,14 @@ class RecentProjectsMenuSections:
 # -----------------------------------------------------------------------------
 @class_register
 class ProjectExplorerWidget(PluginMainWidget):
-    """Project Explorer"""
+    """Project explorer main widget."""
 
+    # ---- Constants
+    # -------------------------------------------------------------------------
+    MAX_SWITCHER_RESULTS = 50
+
+    # ---- Signals
+    # -------------------------------------------------------------------------
     sig_open_file_requested = Signal(str)
     """
     This signal is emitted when a file is requested to be opened.
@@ -150,11 +156,11 @@ class ProjectExplorerWidget(PluginMainWidget):
     def __init__(self, name, plugin, parent=None):
         super().__init__(name, plugin=plugin, parent=parent)
 
-        # Attributes from conf
+        # -- Attributes from conf
         self.name_filters = self.get_conf('name_filters')
         self.show_hscrollbar = self.get_conf('show_hscrollbar')
 
-        # Main attributes
+        # -- Main attributes
         self.recent_projects = self._get_valid_recent_projects(
             self.get_conf('recent_projects', [])
         )
@@ -162,8 +168,10 @@ class ProjectExplorerWidget(PluginMainWidget):
         self.current_active_project = None
         self.latest_project = None
         self.completions_available = False
+        self._default_switcher_paths = []
+        self._switcher_items_data = []
 
-        # Tree widget
+        # -- Tree widget
         self.treewidget = ProjectExplorerTreeWidget(self, self.show_hscrollbar)
         self.treewidget.setup()
         self.treewidget.setup_view()
@@ -178,14 +186,24 @@ class ProjectExplorerWidget(PluginMainWidget):
             _("Create one using the menu entry Projects > New project.")
         )
 
-        # Watcher
+        # -- Watcher
         self.watcher = WorkspaceWatcher(self)
         self.watcher.connect_signals(self)
 
-        # Signals
+        # To manage the worker that calls fzf
+        self._worker_manager = WorkerManager(self)
+
+        # -- Signals
         self.sig_project_loaded.connect(self._setup_project)
 
-        # Layout
+        # This is necessary to populate the switcher with some default list of
+        # paths instead of computing it every open is shown.
+        self.sig_project_loaded.connect(lambda p: self._call_fzf())
+
+        # Clear saved paths for the switcher when closing the project.
+        self.sig_project_closed.connect(lambda p: self._clear_switcher_paths())
+
+        # -- Layout
         layout = QVBoxLayout()
         layout.addWidget(self.pane_empty)
         layout.addWidget(self.treewidget)
@@ -254,10 +272,12 @@ class ProjectExplorerWidget(PluginMainWidget):
     def set_pane_empty(self):
         self.treewidget.hide()
         self.pane_empty.show()
-        
 
     def update_actions(self):
         pass
+
+    def on_close(self):
+        self._worker_manager.terminate_all()
 
     # ---- Public API
     # -------------------------------------------------------------------------
@@ -610,6 +630,8 @@ class ProjectExplorerWidget(PluginMainWidget):
         self.raise_()
         self.update()
 
+    # ---- Public API for the Switcher
+    # -------------------------------------------------------------------------
     def handle_switcher_modes(self):
         """
         Populate switcher with files in active project.
@@ -617,10 +639,11 @@ class ProjectExplorerWidget(PluginMainWidget):
         List the file names of the current active project with their
         directories in the switcher.
         """
-        paths = self._execute_fzf_subprocess()
+        paths = self._default_switcher_paths
         if paths == []:
             return []
-        # the paths that are opened in the editor need to be excluded because
+
+        # The paths that are opened in the editor need to be excluded because
         # they are shown already in the switcher in the "editor" section.
         open_files = self.get_plugin()._get_open_filenames()
         for file in open_files:
@@ -670,7 +693,7 @@ class ProjectExplorerWidget(PluginMainWidget):
         # Open file in editor
         self.sig_open_file_requested.emit(item.get_data())
 
-    def handle_switcher_results(self, search_text, items_data):
+    def handle_switcher_filtering(self, search_text, items_data):
         """
         Handle user typing in switcher to filter results.
 
@@ -682,28 +705,8 @@ class ProjectExplorerWidget(PluginMainWidget):
         items_data: list
             List of items shown in the switcher.
         """
-        paths = self._execute_fzf_subprocess(search_text)
-        for sw_path in items_data:
-            if (sw_path in paths):
-                paths.remove(sw_path)
-
-        is_unsaved = [False] * len(paths)
-        short_paths = shorten_paths(paths, is_unsaved)
-        section = self.get_title()
-
-        items = []
-        for i, (path, short_path) in enumerate(zip(paths, short_paths)):
-            title = osp.basename(path)
-            icon = get_file_icon(path)
-            description = osp.dirname(path).lower()
-            if len(path) > 75:
-                description = short_path
-            is_last_item = (i+1 == len(paths))
-
-            item_tuple = (title, description, icon,
-                          section, path, is_last_item)
-            items.append(item_tuple)
-        return items
+        self._call_fzf(search_text)
+        self._switcher_items_data = items_data
 
     # ---- Public API for the LSP
     # -------------------------------------------------------------------------
@@ -1011,55 +1014,88 @@ class ProjectExplorerWidget(PluginMainWidget):
 
         return valid_projects
 
-    def _execute_fzf_subprocess(self, search_text=""):
+    # ---- Private API for the Switcher
+    # -------------------------------------------------------------------------
+    def _call_fzf(self, search_text=""):
         """
-        Execute fzf subprocess to get the list of files in the current
-        project filtered by `search_text`.
+        Call fzf in a worker to get the list of files in the current project
+        that match with `search_text`.
 
         Parameters
         ----------
-        search_text: str
-            The current search text in the switcher dialog box.
+        search_text: str, optional
+            The search text to pass to fzf.
         """
         project_path = self.get_active_project_path()
         if project_path is None:
             return []
 
-        # command = fzf --filter <search_str>
-        cmd_list = ["fzf", "--filter", search_text]
-        shell = False
-        env = os.environ.copy()
+        self._worker_manager.terminate_all()
 
-        # This is only available on Windows
-        if os.name == 'nt':
-            startupinfo = subprocess.STARTUPINFO()
+        worker = self._worker_manager.create_process_worker(
+            ["fzf", "--filter", search_text],
+            os.environ.copy()
+        )
+
+        worker.set_cwd(project_path)
+        worker.sig_finished.connect(self._process_fzf_output)
+        worker.start()
+
+    def _process_fzf_output(self, worker, output, error):
+        """Process output that comes from the fzf worker."""
+        if output is None or error:
+            return
+
+        relative_path_list = output.decode('utf-8').strip().split("\n")
+        project_path = self.get_active_project_path()
+
+        # List of tuples with the absolute path
+        result_list = [
+            osp.normpath(os.path.join(project_path, path)).lower()
+            for path in relative_path_list
+        ]
+
+        # Limit the number of results to not introduce lags when displaying
+        # them in the switcher.
+        if len(result_list) > self.MAX_SWITCHER_RESULTS:
+            result_list = result_list[:self.MAX_SWITCHER_RESULTS]
+
+        if not self._default_switcher_paths:
+            self._default_switcher_paths = result_list
         else:
-            startupinfo = None
+            self._display_paths_in_switcher(result_list)
 
-        try:
-            out = subprocess.check_output(
-                cmd_list,
-                cwd=project_path,
-                shell=shell,
-                env=env,
-                startupinfo=startupinfo,
-                stderr=subprocess.STDOUT
-            )
+    def _display_paths_in_switcher(self, paths):
+        """Display a list of paths in the switcher."""
+        for sw_path in self._switcher_items_data:
+            if (sw_path in paths):
+                paths.remove(sw_path)
 
-            relative_path_list = out.decode('UTF-8').strip().split("\n")
+        is_unsaved = [False] * len(paths)
+        short_paths = shorten_paths(paths, is_unsaved)
+        section = self.get_title()
 
-            # List of tuples with the absolute path
-            result_list = [
-                osp.normpath(os.path.join(project_path, path)).lower()
-                for path in relative_path_list]
+        items = []
+        for i, (path, short_path) in enumerate(zip(paths, short_paths)):
+            title = osp.basename(path)
+            icon = get_file_icon(path)
+            description = osp.dirname(path).lower()
+            if len(path) > 75:
+                description = short_path
+            is_last_item = (i+1 == len(paths))
 
-            # Limit the number of results to 500
-            if (len(result_list) > 500):
-                result_list = result_list[:500]
-            return result_list
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            return []
+            item_tuple = (title, description, icon,
+                          section, path, is_last_item)
+            items.append(item_tuple)
 
+        # Call directly the plugin's method instead of emitting a signal
+        # because it's faster
+        self._plugin._display_items_in_switcher(items)
+
+    def _clear_switcher_paths(self):
+        """Clear saved switcher results."""
+        self._default_switcher_paths = []
+        self._switcher_items_data = []
 
 # =============================================================================
 # Tests

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -217,7 +217,7 @@ class ProjectExplorerWidget(PluginMainWidget):
     # ---- PluginMainWidget API
     # -------------------------------------------------------------------------
     def get_title(self):
-        return _("Projects")
+        return _("Project")
 
     def setup(self):
         """Setup the widget."""

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -1024,6 +1024,11 @@ class ProjectExplorerWidget(PluginMainWidget):
             for path in relative_path_list
         ]
 
+        # Remove binary files
+        result_list = [
+            path for path in result_list if encoding.is_text_file(path)
+        ]
+
         # Limit the number of results to not introduce lags when displaying
         # them in the switcher.
         if len(result_list) > self.MAX_SWITCHER_RESULTS:

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -39,10 +39,11 @@ from spyder.plugins.projects.widgets.projectdialog import ProjectDialog
 from spyder.plugins.projects.widgets.projectexplorer import (
     ProjectExplorerTreeWidget)
 from spyder.plugins.switcher.utils import get_file_icon, shorten_paths
-from spyder.widgets.helperwidgets import PaneEmptyWidget
 from spyder.utils import encoding
 from spyder.utils.misc import getcwd_or_home
+from spyder.utils.programs import find_program
 from spyder.utils.workers import WorkerManager
+from spyder.widgets.helperwidgets import PaneEmptyWidget
 
 
 # For logging
@@ -168,6 +169,7 @@ class ProjectExplorerWidget(PluginMainWidget):
         self.current_active_project = None
         self.latest_project = None
         self.completions_available = False
+        self._fzf = find_program('fzf')
         self._default_switcher_paths = []
         self._switcher_items_data = []
 
@@ -1027,13 +1029,13 @@ class ProjectExplorerWidget(PluginMainWidget):
             The search text to pass to fzf.
         """
         project_path = self.get_active_project_path()
-        if project_path is None:
-            return []
+        if self._fzf is None or project_path is None:
+            return
 
         self._worker_manager.terminate_all()
 
         worker = self._worker_manager.create_process_worker(
-            ["fzf", "--filter", search_text],
+            [self._fzf, "--filter", search_text],
             os.environ.copy()
         )
 

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -645,7 +645,7 @@ class ProjectExplorerWidget(PluginMainWidget):
             return
 
         self._display_paths_in_switcher(
-            self._default_switcher_paths, setup=False
+            self._default_switcher_paths, setup=False, clear_section=False
         )
 
     def handle_switcher_selection(self, item, mode, search_text):
@@ -1052,7 +1052,9 @@ class ProjectExplorerWidget(PluginMainWidget):
         if not self._default_switcher_paths:
             self._default_switcher_paths = result_list
         else:
-            self._display_paths_in_switcher(result_list)
+            self._display_paths_in_switcher(
+                result_list, setup=True, clear_section=True
+            )
 
     def _convert_paths_to_switcher_items(self, paths):
         """
@@ -1086,13 +1088,13 @@ class ProjectExplorerWidget(PluginMainWidget):
 
         return items
 
-    def _display_paths_in_switcher(self, paths, setup=True):
+    def _display_paths_in_switcher(self, paths, setup, clear_section):
         """Display a list of paths in the switcher."""
         items = self._convert_paths_to_switcher_items(paths)
 
         # Call directly the plugin's method instead of emitting a signal
-        # because it's faster
-        self._plugin._display_items_in_switcher(items, setup=setup)
+        # because it's faster.
+        self._plugin._display_items_in_switcher(items, setup, clear_section)
 
     def _clear_switcher_paths(self):
         """Clear saved switcher results."""

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -171,7 +171,6 @@ class ProjectExplorerWidget(PluginMainWidget):
         self.completions_available = False
         self._fzf = find_program('fzf')
         self._default_switcher_paths = []
-        self._switcher_items_data = []
 
         # -- Tree widget
         self.treewidget = ProjectExplorerTreeWidget(self, self.show_hscrollbar)
@@ -666,7 +665,7 @@ class ProjectExplorerWidget(PluginMainWidget):
         # Open file in editor
         self.sig_open_file_requested.emit(item.get_data())
 
-    def handle_switcher_filtering(self, search_text, items_data):
+    def handle_switcher_search(self, search_text):
         """
         Handle user typing in switcher to filter results.
 
@@ -675,11 +674,8 @@ class ProjectExplorerWidget(PluginMainWidget):
         ----------
         text: str
             The current search text in the switcher dialog box.
-        items_data: list
-            List of items shown in the switcher.
         """
         self._call_fzf(search_text)
-        self._switcher_items_data = items_data
 
     # ---- Public API for the LSP
     # -------------------------------------------------------------------------
@@ -1081,7 +1077,6 @@ class ProjectExplorerWidget(PluginMainWidget):
     def _clear_switcher_paths(self):
         """Clear saved switcher results."""
         self._default_switcher_paths = []
-        self._switcher_items_data = []
 
 # =============================================================================
 # Tests

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -1028,9 +1028,11 @@ class ProjectExplorerWidget(PluginMainWidget):
             return
 
         relative_path_list = output.decode('utf-8').strip().split("\n")
-        project_path = self.get_active_project_path()
+        if relative_path_list == ['']:
+            return
 
         # List of tuples with the absolute path
+        project_path = self.get_active_project_path()
         result_list = [
             osp.normpath(os.path.join(project_path, path))
             for path in relative_path_list
@@ -1057,7 +1059,7 @@ class ProjectExplorerWidget(PluginMainWidget):
         Convert a list of paths to items that can be shown in the switcher.
         """
         # The paths that are opened in the editor need to be excluded because
-        # they are shown already in the Editor section of the switcher.
+        # they are already shown in the Editor section of the switcher.
         open_files = self.get_plugin()._get_open_filenames()
         for file in open_files:
             normalized_path = osp.normpath(file)

--- a/spyder/plugins/switcher/container.py
+++ b/spyder/plugins/switcher/container.py
@@ -58,11 +58,14 @@ class SwitcherContainer(PluginMainContainer):
             switcher.hide()
             return
 
+        # Set mode and setup
         if symbol:
             switcher.set_search_text('@')
         else:
             switcher.set_search_text('')
-            switcher.setup()
+
+        # Setup
+        switcher.setup()
 
         # Set position
         mainwindow = self._plugin.get_main()

--- a/spyder/plugins/switcher/plugin.py
+++ b/spyder/plugins/switcher/plugin.py
@@ -90,7 +90,7 @@ class Switcher(SpyderPluginV2):
         The selected mode (open files "", symbol "@" or line ":").
     """
 
-    sig_search_text_available = Signal(str, list)
+    sig_search_text_available = Signal(str)
     """
     This signal is emitted when the user stops typing the search/filter text.
 
@@ -98,8 +98,6 @@ class Switcher(SpyderPluginV2):
     ----------
     search_text: str
         The current search/filter text.
-    items_data: list
-        List of items shown in the switcher.
     """
 
     # --- SpyderPluginV2 API

--- a/spyder/plugins/switcher/plugin.py
+++ b/spyder/plugins/switcher/plugin.py
@@ -39,7 +39,7 @@ class Switcher(SpyderPluginV2):
     """
 
     NAME = "switcher"
-    OPTIONAL = [Plugins.MainMenu, Plugins.Projects]
+    OPTIONAL = [Plugins.MainMenu]
     CONTAINER_CLASS = SwitcherContainer
     CONF_SECTION = NAME
     CONF_FILE = False
@@ -159,15 +159,6 @@ class Switcher(SpyderPluginV2):
                 action,
                 menu_id=ApplicationMenus.File
             )
-
-    @on_plugin_available(plugin=Plugins.Projects)
-    def on_projects_available(self):
-        projects = self.get_plugin(Plugins.Projects)
-        self._switcher.projects_section = projects.get_widget().get_title()
-
-    @on_plugin_teardown(plugin=Plugins.Projects)
-    def on_projects_teardown(self):
-        self._switcher.projects_section = None
 
     # ---- Public API
     # -------------------------------------------------------------------------

--- a/spyder/plugins/switcher/plugin.py
+++ b/spyder/plugins/switcher/plugin.py
@@ -163,8 +163,11 @@ class Switcher(SpyderPluginV2):
     @on_plugin_available(plugin=Plugins.Projects)
     def on_projects_available(self):
         projects = self.get_plugin(Plugins.Projects)
+
         projects.sig_project_loaded.connect(self._set_project_dir)
         projects.sig_project_closed.connect(self._unset_project_dir)
+
+        self._switcher.projects_section = projects.get_widget().get_title()
 
     @on_plugin_teardown(plugin=Plugins.Projects)
     def on_projects_teardown(self):

--- a/spyder/plugins/switcher/plugin.py
+++ b/spyder/plugins/switcher/plugin.py
@@ -212,11 +212,11 @@ class Switcher(SpyderPluginV2):
 
     def add_item(self, icon=None, title=None, description=None, shortcut=None,
                  section=None, data=None, tool_tip=None, action_item=False,
-                 last_item=True, score=None):
+                 last_item=True, score=None, use_score=True):
         """Add a switcher list item."""
         self._switcher.add_item(icon, title, description, shortcut,
                                 section, data, tool_tip, action_item,
-                                last_item, score)
+                                last_item, score, use_score)
 
     def set_current_row(self, row):
         """Set the current selected row in the switcher."""

--- a/spyder/plugins/switcher/plugin.py
+++ b/spyder/plugins/switcher/plugin.py
@@ -163,17 +163,11 @@ class Switcher(SpyderPluginV2):
     @on_plugin_available(plugin=Plugins.Projects)
     def on_projects_available(self):
         projects = self.get_plugin(Plugins.Projects)
-
-        projects.sig_project_loaded.connect(self._set_project_dir)
-        projects.sig_project_closed.connect(self._unset_project_dir)
-
         self._switcher.projects_section = projects.get_widget().get_title()
 
     @on_plugin_teardown(plugin=Plugins.Projects)
     def on_projects_teardown(self):
-        projects = self.get_plugin(Plugins.Projects)
-        projects.sig_project_loaded.disconnect(self._set_project_dir)
-        projects.sig_project_closed.connect(self._unset_project_dir)
+        self._switcher.projects_section = None
 
     # ---- Public API
     # -------------------------------------------------------------------------
@@ -240,6 +234,10 @@ class Switcher(SpyderPluginV2):
         """Get the item count in the list widget."""
         return self._switcher.count()
 
+    def remove_section(self, section):
+        """Remove all items in a section of the switcher."""
+        self._switcher.remove_section(section)
+
     # Mode methods
     def add_mode(self, token, description):
         """Add mode by token key and description."""
@@ -261,11 +259,3 @@ class Switcher(SpyderPluginV2):
     def set_search_text(self, string):
         """Set the content of the search text."""
         self._switcher.set_search_text(string)
-
-    # ---- Private API
-    # -------------------------------------------------------------------------
-    def _set_project_dir(self, path):
-        self._switcher.current_project = path
-
-    def _unset_project_dir(self, path):
-        self._switcher.current_project = None

--- a/spyder/plugins/switcher/widgets/item.py
+++ b/spyder/plugins/switcher/widgets/item.py
@@ -232,7 +232,9 @@ class SwitcherItem(SwitcherBaseItem):
         self._score = -1
         self._action_item = action_item
 
-        self._section_visible = True
+        # Section visibility is computed by the setup_sections method of the
+        # switcher.
+        self._section_visible = False
 
         # Setup
         self.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)

--- a/spyder/plugins/switcher/widgets/item.py
+++ b/spyder/plugins/switcher/widgets/item.py
@@ -28,9 +28,9 @@ class SwitcherBaseItem(QStandardItem):
     _STYLES = None
     _TEMPLATE = None
 
-    def __init__(self, parent=None, styles=_STYLES):
+    def __init__(self, parent=None, styles=_STYLES, use_score=True):
         """Create basic List Item."""
-        super(SwitcherBaseItem, self).__init__()
+        super().__init__()
 
         # Style
         self._width = self._WIDTH
@@ -39,6 +39,7 @@ class SwitcherBaseItem(QStandardItem):
         self._action_item = False
         self._score = -1
         self._height = self._get_height()
+        self._use_score = use_score
 
         # Setup
         # self._height is a float from QSizeF but
@@ -84,8 +85,9 @@ class SwitcherBaseItem(QStandardItem):
 
     def set_score(self, value):
         """Set the search text fuzzy match score."""
-        self._score = value
-        self._set_rendered_text()
+        if self._use_score:
+            self._score = value
+            self._set_rendered_text()
 
     def is_action_item(self):
         """Return whether the item is of action type."""
@@ -122,8 +124,7 @@ class SwitcherSeparatorItem(SwitcherBaseItem):
 
     def __init__(self, parent=None, styles=_STYLES):
         """Separator Item represented as <hr>."""
-        super(SwitcherSeparatorItem, self).__init__(parent=parent,
-                                                    styles=styles)
+        super().__init__(parent=parent, styles=styles)
         self.setFlags(Qt.NoItemFlags)
         self._set_rendered_text()
 
@@ -218,9 +219,9 @@ class SwitcherItem(SwitcherBaseItem):
 
     def __init__(self, parent=None, icon=None, title=None, description=None,
                  shortcut=None, section=None, data=None, tool_tip=None,
-                 action_item=False, styles=_STYLES):
+                 action_item=False, styles=_STYLES, score=-1, use_score=True):
         """Switcher item with title, description, shortcut and section."""
-        super(SwitcherItem, self).__init__(parent=parent, styles=styles)
+        super().__init__(parent=parent, styles=styles, use_score=use_score)
 
         self._title = title if title else ''
         self._rich_title = ''
@@ -229,7 +230,7 @@ class SwitcherItem(SwitcherBaseItem):
         self._section = section if section else ''
         self._icon = icon
         self._data = data
-        self._score = -1
+        self._score = score
         self._action_item = action_item
 
         # Section visibility is computed by the setup_sections method of the

--- a/spyder/plugins/switcher/widgets/switcher.py
+++ b/spyder/plugins/switcher/widgets/switcher.py
@@ -165,7 +165,6 @@ class Switcher(QDialog):
         self._mode_on = ''
         self._item_styles = item_styles
         self._item_separator_styles = item_separator_styles
-        self.current_project = None
         self.projects_section = None
 
         # Widgets
@@ -411,6 +410,17 @@ class Switcher(QDialog):
                 if not mode:
                     item.set_section_visible(True)
 
+    def remove_section(self, section):
+        """Remove all items in a section of the switcher."""
+        # As we are removing items from the model, we need to iterate backwards
+        # so that the indexes are not affected.
+        for row in range(self.model.rowCount() - 1, -1, -1):
+            item = self.model.item(row)
+            if isinstance(item, SwitcherItem):
+                if item._section == section:
+                    self.model.removeRow(row)
+                    continue
+
     def set_height(self):
         """Set height taking into account the number of items."""
         if self.count() >= self._MAX_NUM_ITEMS:
@@ -491,19 +501,8 @@ class Switcher(QDialog):
 
     def _on_search_text_changed(self):
         """Actions to take when the search text has changed."""
-        if self.search_text() != "" and self.current_project is not None:
+        if self.search_text() != "":
             search_text = clean_string(self.search_text())
-
-            # Remove project rows and get data of editor items
-            for row in range(self.model.rowCount() - 1, -1, -1):
-                # As we are removing items from the model, we need to iterate
-                # backwards so that the indexes are not affected
-                item = self.model.item(row)
-                if isinstance(item, SwitcherItem):
-                    if item._section == self.projects_section:
-                        self.model.removeRow(row)
-                        continue
-
             self.sig_search_text_available.emit(search_text)
         else:
             self.setup()

--- a/spyder/plugins/switcher/widgets/switcher.py
+++ b/spyder/plugins/switcher/widgets/switcher.py
@@ -222,11 +222,8 @@ class Switcher(QDialog):
         self.edit.setFocus()
 
     # ---- Helper methods
-    def _add_item(self, item, last_item=True, score=None):
+    def _add_item(self, item, last_item=True):
         """Perform common actions when adding items."""
-        if score is not None:
-            item.set_score(score)
-
         item.set_width(self._ITEM_WIDTH)
         self.model.appendRow(item)
 
@@ -273,7 +270,7 @@ class Switcher(QDialog):
 
     def add_item(self, icon=None, title=None, description=None, shortcut=None,
                  section=None, data=None, tool_tip=None, action_item=False,
-                 last_item=True, score=None):
+                 last_item=True, score=-1, use_score=True):
         """Add switcher list item."""
         item = SwitcherItem(
             parent=self.list,
@@ -285,14 +282,17 @@ class Switcher(QDialog):
             section=section,
             action_item=action_item,
             tool_tip=tool_tip,
-            styles=self._item_styles
+            styles=self._item_styles,
+            score=score,
+            use_score=use_score
         )
-        self._add_item(item, last_item=last_item, score=score)
+        self._add_item(item, last_item=last_item)
 
     def add_separator(self):
         """Add separator item."""
-        item = SwitcherSeparatorItem(parent=self.list,
-                                     styles=self._item_separator_styles)
+        item = SwitcherSeparatorItem(
+            parent=self.list, styles=self._item_separator_styles
+        )
         self._add_item(item)
 
     def setup(self):

--- a/spyder/plugins/switcher/widgets/switcher.py
+++ b/spyder/plugins/switcher/widgets/switcher.py
@@ -165,7 +165,6 @@ class Switcher(QDialog):
         self._mode_on = ''
         self._item_styles = item_styles
         self._item_separator_styles = item_separator_styles
-        self.projects_section = None
 
         # Widgets
         self.edit = QLineEdit(self)
@@ -350,10 +349,7 @@ class Switcher(QDialog):
                 rich_title = rich_title.replace(" ", "&nbsp;")
                 item.set_rich_title(rich_title)
 
-            # Results come from Projects in the right order, so we don't need
-            # to sort them here.
-            if item._section != self.projects_section:
-                item.set_score(score_value)
+            item.set_score(score_value)
 
         self.proxy.set_filter_by_score(True)
         self.proxy.sortBy('_score')

--- a/spyder/plugins/switcher/widgets/switcher.py
+++ b/spyder/plugins/switcher/widgets/switcher.py
@@ -407,7 +407,7 @@ class Switcher(QDialog):
                 if not self._is_separator(item):
                     item.set_section_visible(visible)
             else:
-                # We need to remove this if when a mode has several sections
+                # We need to remove this when a mode has several sections
                 if not mode:
                     item.set_section_visible(True)
 
@@ -471,13 +471,14 @@ class Switcher(QDialog):
 
     def reject(self):
         """Override Qt method."""
+        # This prevents calling _on_search_text_changed, which unnecessarily
+        # tries to populate the switcher when we're closing it.
+        self.edit.blockSignals(True)
         self.set_search_text('')
+        self.edit.blockSignals(False)
+
         self.sig_rejected.emit()
         super(Switcher, self).reject()
-
-    def resizeEvent(self, event):
-        """Override Qt method."""
-        super(Switcher, self).resizeEvent(event)
 
     # ---- Helper methods: Lineedit widget
     def search_text(self):

--- a/spyder/plugins/switcher/widgets/switcher.py
+++ b/spyder/plugins/switcher/widgets/switcher.py
@@ -475,7 +475,7 @@ class Switcher(QDialog):
 
     def _on_search_text_changed(self):
         """Actions to take when the search text has changed."""
-        if not self._mode_on:
+        if self.search_text() != "" and self.current_project is not None:
             search_text = clean_string(self.search_text())
 
             # Remove project rows and get data of editor items

--- a/spyder/plugins/switcher/widgets/switcher.py
+++ b/spyder/plugins/switcher/widgets/switcher.py
@@ -165,6 +165,7 @@ class Switcher(QDialog):
         self._mode_on = ''
         self._item_styles = item_styles
         self._item_separator_styles = item_separator_styles
+        self.current_project = None
 
         # Widgets
         self.edit = QLineEdit(self)

--- a/spyder/plugins/switcher/widgets/switcher.py
+++ b/spyder/plugins/switcher/widgets/switcher.py
@@ -139,7 +139,7 @@ class Switcher(QDialog):
         The selected mode (open files "", symbol "@" or line ":").
     """
 
-    sig_search_text_available = Signal(str, list)
+    sig_search_text_available = Signal(str)
     """
     This signal is emitted when the user stops typing in the filter line edit.
 
@@ -147,8 +147,6 @@ class Switcher(QDialog):
     ----------
     search_text: str
         The current search text.
-    items_data: list
-        List of items shown in the switcher.
     """
 
     _MAX_NUM_ITEMS = 15
@@ -478,7 +476,6 @@ class Switcher(QDialog):
         """Actions to take when the search text has changed."""
         if not self._mode_on:
             search_text = clean_string(self.search_text())
-            items_data = []
 
             # Remove project rows and get data of editor items
             for row in range(self.model.rowCount() - 1, -1, -1):
@@ -489,11 +486,8 @@ class Switcher(QDialog):
                     if item._section == "Projects":
                         self.model.removeRow(row)
                         continue
-                    else:
-                        if item._data is not None:
-                            items_data.append(item._data._filename.lower())
 
-            self.sig_search_text_available.emit(search_text, items_data)
+            self.sig_search_text_available.emit(search_text)
         else:
             self.setup()
 

--- a/spyder/plugins/switcher/widgets/switcher.py
+++ b/spyder/plugins/switcher/widgets/switcher.py
@@ -166,6 +166,7 @@ class Switcher(QDialog):
         self._item_styles = item_styles
         self._item_separator_styles = item_separator_styles
         self.current_project = None
+        self.projects_section = None
 
         # Widgets
         self.edit = QLineEdit(self)
@@ -352,7 +353,7 @@ class Switcher(QDialog):
 
             # Results come from Projects in the right order, so we don't need
             # to sort them here.
-            if item._section != "Projects":
+            if item._section != self.projects_section:
                 item.set_score(score_value)
 
         self.proxy.set_filter_by_score(True)
@@ -498,7 +499,7 @@ class Switcher(QDialog):
                 # backwards so that the indexes are not affected
                 item = self.model.item(row)
                 if isinstance(item, SwitcherItem):
-                    if item._section == "Projects":
+                    if item._section == self.projects_section:
                         self.model.removeRow(row)
                         continue
 

--- a/spyder/utils/workers.py
+++ b/spyder/utils/workers.py
@@ -12,6 +12,7 @@ blocking threads.
 
 # Standard library imports
 from collections import deque
+import logging
 import os
 import sys
 
@@ -23,7 +24,7 @@ from qtpy.QtCore import (QByteArray, QObject, QProcess, QThread, QTimer,
 from spyder.py3compat import to_text_string
 
 
-WIN = os.name == 'nt'
+logger = logging.getLogger(__name__)
 
 
 def handle_qbytearray(obj, encoding):
@@ -123,7 +124,7 @@ class ProcessWorker(QObject):
         enco = 'utf-8'
 
         #  Currently only cp1252 is allowed?
-        if WIN:
+        if os.name == 'nt':
             import ctypes
             codepage = to_text_string(ctypes.cdll.kernel32.GetACP())
             # import locale
@@ -226,11 +227,12 @@ class ProcessWorker(QObject):
 
 
 class WorkerManager(QObject):
-    """Spyder Worker Manager for Generic Workers."""
+    """Manager for generic workers."""
 
-    def __init__(self, max_threads=10):
-        """Spyder Worker Manager for Generic Workers."""
-        super().__init__()
+    def __init__(self, parent=None, max_threads=10):
+        super().__init__(parent=parent)
+        self.parent = parent
+
         self._queue = deque()
         self._queue_workers = deque()
         self._threads = []
@@ -261,13 +263,16 @@ class WorkerManager(QObject):
             self._queue_workers.append(worker)
 
         if self._queue_workers and self._running_threads < self._max_threads:
-            #print('Queue: {0} Running: {1} Workers: {2} '
-            #       'Threads: {3}'.format(len(self._queue_workers),
-            #                                 self._running_threads,
-            #                                 len(self._workers),
-            #                                 len(self._threads)))
-            worker = self._queue_workers.popleft()
+            if self.parent is not None:
+                logger.debug(
+                    f"Workers managed in {self.parent} -- "
+                    f"In queue: {len(self._queue_workers)} -- "
+                    f"Running threads: {self._running_threads} -- "
+                    f"Workers: {len(self._workers)} -- "
+                    f"Threads: {len(self._threads)}"
+                )
 
+            worker = self._queue_workers.popleft()
             if isinstance(worker, PythonWorker):
                 self._running_threads += 1
                 thread = QThread(None)

--- a/spyder/utils/workers.py
+++ b/spyder/utils/workers.py
@@ -220,6 +220,10 @@ class ProcessWorker(QObject):
             self.sig_started.emit(self)
             self._started = True
 
+    def set_cwd(self, cwd):
+        """Set the process current working directory."""
+        self._process.setWorkingDirectory(cwd)
+
 
 class WorkerManager(QObject):
     """Spyder Worker Manager for Generic Workers."""
@@ -262,19 +266,19 @@ class WorkerManager(QObject):
             #                                 self._running_threads,
             #                                 len(self._workers),
             #                                 len(self._threads)))
-            self._running_threads += 1
             worker = self._queue_workers.popleft()
-            thread = QThread(None)
+
             if isinstance(worker, PythonWorker):
+                self._running_threads += 1
+                thread = QThread(None)
+                self._threads.append(thread)
+
                 worker.moveToThread(thread)
                 worker.sig_finished.connect(thread.quit)
                 thread.started.connect(worker._start)
                 thread.start()
             elif isinstance(worker, ProcessWorker):
-                thread.quit()
-                thread.wait()
                 worker._start()
-            self._threads.append(thread)
         else:
             self._timer.start()
 

--- a/spyder/utils/workers.py
+++ b/spyder/utils/workers.py
@@ -115,6 +115,10 @@ class ProcessWorker(QObject):
         self._process = QProcess(self)
         self._set_environment(environ)
 
+        # This is necessary to pass text input to the process as part of
+        # cmd_list
+        self._process.setInputChannelMode(QProcess.ForwardedInputChannel)
+
         self._timer.setInterval(150)
         self._timer.timeout.connect(self._communicate)
         self._process.readyReadStandardOutput.connect(self._partial)


### PR DESCRIPTION
## Description of Changes

- Since the initial implementation was synchronous, the interface was freezing when using the Switcher with large projects (i.e. projects that have more than 1000 files).
- Highlight matched characters of Projects switcher results that match the searched text.
- Remove binary files from the results computed by `fzf` because they can't be opened in the editor.
- Fix process workers because they were not working as expected.
- Simplify the way sections are shown in the Switcher, which was not very efficient and hard to understand.
- Improve test that checks the integration between Projects and the Switcher.
- Set app and monospace interface fonts when running single main window tests. That avoids a ton of Qt warnings to be displayed.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20940.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
