### PR TITLE
PR: Don't try to reverse the dict of scroll flags in Python 3.7 (Editor)

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -391,7 +391,7 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         # Set attributes
         messageBox.setWindowModality(Qt.NonModal)
         messageBox.setAttribute(Qt.WA_DeleteOnClose)
-        messageBox.setWindowTitle(_('Spyder compatibility check'))
+        messageBox.setWindowTitle(_('Plugin compatibility check'))
         messageBox.setText(
             _("It was not possible to load the {} plugin. The problem "
               "was:<br><br>{}").format(plugin_name, message)

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -215,7 +215,17 @@ class ScrollFlagArea(Panel):
         }
         dict_flag_lists.update(self._dict_flag_list)
 
-        for flag_type in reversed(dict_flag_lists):
+        # The ability to reverse dictionaries was added in Python 3.8.
+        # Fixes spyder-ide/spyder#21286
+        if sys.version_info[:2] > (3, 7):
+            # This is necessary to paint find matches above errors and
+            # warnings.
+            # See spyder-ide/spyder#20970
+            dict_flag_lists_iter = reversed(dict_flag_lists)
+        else:
+            dict_flag_lists_iter = dict_flag_lists
+
+        for flag_type in dict_flag_lists_iter:
             painter.setBrush(self._facecolors[flag_type])
             painter.setPen(self._edgecolors[flag_type])
             if editor.verticalScrollBar().maximum() == 0:


### PR DESCRIPTION
## Description of Changes

- Unfortunately, PR #20970 broke compatibility with Python 3.7, which is generating a ton of errors in the Editor.
- This PR restores that compatibility.

### Issue(s) Resolved

Fixes #21286.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
