### PR TITLE
PR: Support all real number dtypes in dataframe editor

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -63,7 +63,7 @@ from spyder.plugins.variableexplorer.widgets.basedialog import BaseDialog
 from spyder.utils.palette import QStylePalette
 
 
-# Supported Numbers and complex numbers
+# Supported real and complex number types
 REAL_NUMBER_TYPES = (float, int, np.int64, np.int32)
 COMPLEX_NUMBER_TYPES = (complex, np.complex64, np.complex128)
 
@@ -89,6 +89,18 @@ BACKGROUND_NUMBER_ALPHA = 0.6
 BACKGROUND_NONNUMBER_COLOR = QStylePalette.COLOR_BACKGROUND_2
 BACKGROUND_STRING_ALPHA = 0.05
 BACKGROUND_MISC_ALPHA = 0.3
+
+
+def is_any_real_numeric_dtype(dtype) -> bool:
+    """
+    Test whether a Pandas dtype is a real numeric type.
+    """
+    try:
+        import pandas.api.types
+        return pandas.api.types.is_any_real_numeric_dtype(dtype)
+    except AttributeError:
+        # Pandas version 1
+        return dtype in REAL_NUMBER_TYPES
 
 
 def bool_false_check(value):
@@ -250,8 +262,9 @@ class DataFrameModel(QAbstractTableModel, SpyderFontsMixin):
             # the maximum of a column.
             # Fixes spyder-ide/spyder#17145
             try:
-                if col.dtype in REAL_NUMBER_TYPES + COMPLEX_NUMBER_TYPES:
-                    if col.dtype in REAL_NUMBER_TYPES:
+                if (is_any_real_numeric_dtype(col.dtype)
+                        or col.dtype in COMPLEX_NUMBER_TYPES):
+                    if is_any_real_numeric_dtype(col.dtype):
                         vmax = col.max(skipna=True)
                         vmin = col.min(skipna=True)
                     else:

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -98,7 +98,7 @@ def is_any_real_numeric_dtype(dtype) -> bool:
     try:
         import pandas.api.types
         return pandas.api.types.is_any_real_numeric_dtype(dtype)
-    except AttributeError:
+    except Exception:
         # Pandas version 1
         return dtype in REAL_NUMBER_TYPES
 
@@ -262,8 +262,10 @@ class DataFrameModel(QAbstractTableModel, SpyderFontsMixin):
             # the maximum of a column.
             # Fixes spyder-ide/spyder#17145
             try:
-                if (is_any_real_numeric_dtype(col.dtype)
-                        or col.dtype in COMPLEX_NUMBER_TYPES):
+                if (
+                    is_any_real_numeric_dtype(col.dtype)
+                    or col.dtype in COMPLEX_NUMBER_TYPES
+                ):
                     if is_any_real_numeric_dtype(col.dtype):
                         vmax = col.max(skipna=True)
                         vmin = col.min(skipna=True)

--- a/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
@@ -358,6 +358,41 @@ def test_dataframemodel_get_bgcolor_with_missings():
             'Wrong bg color for missing of type ' + column
 
 
+def test_dataframemodel_get_bgcolor_with_nullable_numbers():
+    """
+    Test background colors for nullable integer data types
+
+    Regression test for spyder-ide/spyder#21222.
+    """
+    vals = [1, 2, 3, 4, 5]
+    vals_na = [1, 2, 3, None, 5]
+    df = DataFrame({
+        'old': Series(vals),
+        'old_na': Series(vals_na),
+        'new': Series(vals, dtype='Int64'),
+        'new_na': Series(vals_na, dtype='Int64')
+    })
+    dfm = DataFrameModel(df)
+    dfm.colum_avg(0)
+
+    # Test numbers
+    h0 = dataframeeditor.BACKGROUND_NUMBER_MINHUE
+    dh = dataframeeditor.BACKGROUND_NUMBER_HUERANGE
+    s = dataframeeditor.BACKGROUND_NUMBER_SATURATION
+    v = dataframeeditor.BACKGROUND_NUMBER_VALUE
+    a = dataframeeditor.BACKGROUND_NUMBER_ALPHA
+    for col_index in range(4):
+        assert colorclose(bgcolor(dfm, 0, col_index), (h0 + dh, s, v, a))
+    assert colorclose(bgcolor(dfm, 3, 0), (h0 + 1 / 4 * dh, s, v, a))
+    assert colorclose(bgcolor(dfm, 3, 2), (h0 + 1 / 4 * dh, s, v, a))
+
+    # Test null values
+    h, s, v, __ = QColor(dataframeeditor.BACKGROUND_NONNUMBER_COLOR).getHsvF()
+    alpha = dataframeeditor.BACKGROUND_MISC_ALPHA
+    assert colorclose(bgcolor(dfm, 3, 1), (h, s, v, alpha))
+    assert colorclose(bgcolor(dfm, 3, 3), (h, s, v, alpha))
+
+
 def test_dataframemodel_with_format_percent_d_and_nan():
     """
     Test DataFrameModel with format `d` and dataframe containing NaN


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

This is a small PR which uses the new function `pandas.api.types.is_any_real_numeric_dtype()` to decide whether a Pandas dtype is a real number and thus gets the background colouring of numbers in the Dataframe editor. This allows us to supports the nullable integer types and also numeric types that were previously not supported like `numpy.int16`. A test is also included.

This PR imports `pandas` inside a function. As far as I can see, no part of Spyder explicitly imports `pandas` but I think that `pandas` is always imported when a Dataframe editor is opened, so this should not be a problem.

Screenshot after:

![df-new](https://github.com/spyder-ide/spyder/assets/7941918/096aacc5-df63-4d4e-b0bc-96efc98312fa)

Screenshot before:

![df-old](https://github.com/spyder-ide/spyder/assets/7941918/876ff3b9-2a06-41cd-8771-db1f8cbd25fe)

These are produced using the following code, from issue #21022:

```python
import pandas as pd

vals = [1, 2, 3, 4, 5]
vals_na = [1, 2, 3, None, 5]

df = pd.DataFrame({
    'old': pd.Series(vals),
    'old_na': pd.Series(vals_na),
    'new': pd.Series(vals, dtype='Int64'),
    'new_na': pd.Series(vals_na, dtype='Int64')
})
```

### Issue(s) Resolved

Fixes #21222


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
