### PR TITLE
PR: Remove installers workflow step validation for spyder conda package build to be done only on PRs (CI)

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -155,7 +155,6 @@ jobs:
         run: env | sort
 
       - name: Build ${{ matrix.target-platform }} spyder Conda Package
-        if: env.IS_STANDARD_PR == 'true'
         env:
           CONDA_BLD_PATH: ${{ runner.temp }}/conda-bld
         run: |
@@ -166,7 +165,6 @@ jobs:
           python build_conda_pkgs.py --build spyder
 
       - name: Create Local Conda Channel
-        if: env.IS_STANDARD_PR == 'true'
         env:
           CONDA_BLD_PATH: ${{ runner.temp }}/conda-bld
         run: |


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

As part of the Spyder 6alpha2 release I did the release candidate step and tried to generate the installers, but seems like the manual worflow dispatch fails due to the spyder conda package build step being skipped (seems like it was skipped if the workflow is not being run from a PR). Not totally sure if this is the correct approach but opening a PR just in case and to discuss if something else needs to be done @ccordoba12 @mrclary 

* Workflow run that failed: https://github.com/spyder-ide/spyder/actions/runs/6053595167

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
