### PR TITLE
PR: Add Refresh button to editors from Variable Explorer

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -45,7 +45,8 @@ from spyder.plugins.variableexplorer.widgets.basedialog import BaseDialog
 from spyder.py3compat import (is_binary_string, is_string, is_text_string,
                               to_binary_string, to_text_string)
 from spyder.utils.icon_manager import ima
-from spyder.utils.qthelpers import add_actions, create_action, keybinding
+from spyder.utils.qthelpers import (
+    add_actions, create_action, keybinding, safe_disconnect)
 from spyder.utils.stylesheet import PANES_TOOLBAR_STYLESHEET
 
 
@@ -127,14 +128,6 @@ def get_idx_rect(index_list):
     rows, cols = list(zip(*[(i.row(), i.column()) for i in index_list]))
     return ( min(rows), max(rows), min(cols), max(cols) )
 
-
-def safe_disconnect(signal):
-    """Disconnect a QtSignal, ignoring TypeError"""
-    try:
-        signal.disconnect()
-    except TypeError:
-        # Raised when no slots are connected to the signal
-        pass
 
 #==============================================================================
 # Main classes

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -1092,8 +1092,25 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
         """
         assert self.data_function is not None
 
+        if self.btn_save_and_close.isEnabled():
+            if not self.ask_for_refresh_confirmation():
+                return
         data = self.data_function()
         self.set_data_and_check(data)
+
+    def ask_for_refresh_confirmation(self) -> bool:
+        """
+        Ask user to confirm refreshing the editor.
+
+        This function is to be called if refreshing the editor would overwrite
+        changes that the user made previously. The function returns True if
+        the user confirms that they want to refresh and False otherwise.
+        """
+        message = _('Refreshing the editor will overwrite the changes that '
+                    'you made. Do you want to proceed?')
+        result = QMessageBox.question(
+            self, _('Refresh array editor?'), message)
+        return result == QMessageBox.Yes
 
     @Slot()
     def accept(self):

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -1098,7 +1098,13 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
         if self.btn_save_and_close.isEnabled():
             if not self.ask_for_refresh_confirmation():
                 return
-        data = self.data_function()
+
+        try:
+            data = self.data_function()
+        except KeyError:
+            self.error(_('The variable no longer exists.'))
+            return
+
         if not self.set_data_and_check(data):
             self.error(
                 _('The new value cannot be displayed in the array editor.'))

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -1101,7 +1101,7 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
 
         try:
             data = self.data_function()
-        except KeyError:
+        except (IndexError, KeyError):
             self.error(_('The variable no longer exists.'))
             return
 

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -857,6 +857,9 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
         Setup ArrayEditor:
         return False if data is not supported, True otherwise
         """
+        if not isinstance(data, (np.ndarray, np.ma.MaskedArray)):
+            return False
+
         self.data = data
         readonly = readonly or not self.data.flags.writeable
         is_masked_array = isinstance(data, np.ma.MaskedArray)
@@ -1096,7 +1099,9 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
             if not self.ask_for_refresh_confirmation():
                 return
         data = self.data_function()
-        self.set_data_and_check(data)
+        if not self.set_data_and_check(data):
+            self.error(
+                _('The new value cannot be displayed in the array editor.'))
 
     def ask_for_refresh_confirmation(self) -> bool:
         """

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -8,14 +8,13 @@
 NumPy Array Editor Dialog based on Qt
 """
 
-from __future__ import annotations
-
 # pylint: disable=C0103
 # pylint: disable=R0903
 # pylint: disable=R0911
 # pylint: disable=R0201
 
 # Standard library imports
+from __future__ import annotations
 import io
 from typing import Callable, Optional, TYPE_CHECKING
 
@@ -656,8 +655,11 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
 
     CONF_SECTION = 'variable_explorer'
 
-    def __init__(self, parent: Optional[QWidget] = None,
-                 data_function: Optional[Callable[[], ArrayLike]] = None):
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        data_function: Optional[Callable[[], ArrayLike]] = None
+    ):
         """
         Constructor.
 
@@ -692,15 +694,16 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
 
     def setup_and_check(self, data, title='', readonly=False):
         """
-        Setup ArrayEditor:
-        return False if data is not supported, True otherwise
+        Setup the editor.
+
+        It returns False if data is not supported, True otherwise.
         """
         self.setup_ui(title, readonly)
         return self.set_data_and_check(data, readonly)
 
     def setup_ui(self, title='', readonly=False):
         """
-        Create user interface
+        Create the user interface.
 
         This creates the necessary widgets and layouts that make up the user
         interface of the array editor. Some elements need to be hidden
@@ -716,8 +719,8 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
 
         def do_nothing():
             # .create_action() needs a toggled= parameter, but we can only
-            # set it later in .set_data_and_check(), so we use this function
-            # as a placeholder here.
+            # set it later in the set_data_and_check method, so we use this
+            # function as a placeholder here.
             pass
 
         self.copy_action = self.create_action(
@@ -778,7 +781,8 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
         # ---- Widgets in bottom left for special arrays
         #
         # These are normally hidden. When editing masked, record or 3d arrays,
-        # the relevant elements are made visible in `.set_data_and_check()`.
+        # the relevant elements are made visible in the set_data_and_check
+        # method.
 
         self.btn_layout = QHBoxLayout()
 
@@ -803,15 +807,17 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
         self.btn_layout.addWidget(self.slicing_label)
 
         self.masked_label = QLabel(
-            _('<u>Warning</u>: Changes are applied separately'))
+            _('<u>Warning</u>: Changes are applied separately')
+        )
         self.masked_label.setToolTip(
             _("For performance reasons, changes applied to masked arrays won't"
-              "be reflected in array's data (and vice-versa)."))
+              "be reflected in array's data (and vice-versa).")
+          )
         self.btn_layout.addWidget(self.masked_label)
 
         self.btn_layout.addStretch()
 
-        # ---- Push buttons on bottom right
+        # ---- Push buttons on the bottom right
 
         self.btn_save_and_close = QPushButton(_('Save and Close'))
         self.btn_save_and_close.setDisabled(True)
@@ -1024,9 +1030,11 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
         self.arraywidget = self.stack.widget(index)
         if self.arraywidget:
             self.arraywidget.model.dataChanged.connect(
-                self.save_and_close_enable)
+                self.save_and_close_enable
+            )
             self.toggle_bgcolor_action.setChecked(
-                self.arraywidget.model.bgcolor_enabled)
+                self.arraywidget.model.bgcolor_enabled
+            )
 
     def change_active_widget(self, index):
         """
@@ -1100,7 +1108,8 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
 
         if not self.set_data_and_check(data):
             self.error(
-                _('The new value cannot be displayed in the array editor.'))
+                _('The new value cannot be displayed in the array editor.')
+            )
 
     def ask_for_refresh_confirmation(self) -> bool:
         """
@@ -1113,7 +1122,10 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
         message = _('Refreshing the editor will overwrite the changes that '
                     'you made. Do you want to proceed?')
         result = QMessageBox.question(
-            self, _('Refresh array editor?'), message)
+            self,
+            _('Refresh array editor?'),
+            message
+        )
         return result == QMessageBox.Yes
 
     @Slot()

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -121,6 +121,14 @@ def get_idx_rect(index_list):
     return ( min(rows), max(rows), min(cols), max(cols) )
 
 
+def safe_disconnect(signal):
+    """Disconnect a QtSignal, ignoring TypeError"""
+    try:
+        signal.disconnect()
+    except TypeError:
+        # Raised when no slots are connected to the signal
+        pass
+
 #==============================================================================
 # Main classes
 #==============================================================================
@@ -672,9 +680,159 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
         Setup ArrayEditor:
         return False if data is not supported, True otherwise
         """
+        self.setup_ui(title, readonly)
+        return self.set_data_and_check(data, readonly)
+
+    def setup_ui(self, title='', readonly=False):
+        """
+        Create user interface
+
+        This creates the necessary widgets and layouts that make up the user
+        interface of the array editor. Some elements need to be hidden
+        depending on the data; this will be done when the data is set.
+        """
+        self.layout = QGridLayout()
+        self.setLayout(self.layout)
+
+        # ---- Toolbar and actions
+
+        toolbar = SpyderToolbar(parent=self, title='Editor toolbar')
+        toolbar.setStyleSheet(str(PANES_TOOLBAR_STYLESHEET))
+
+        def do_nothing():
+            # .create_action() needs a toggled= parameter, but we can only
+            # set it later in .set_data_and_check(), so we use this function
+            # as a placeholder here.
+            pass
+
+        self.copy_action = self.create_action(
+            ArrayEditorActions.Copy,
+            text=_('Copy'),
+            icon=self.create_icon('editcopy'),
+            triggered=do_nothing)
+        toolbar.add_item(self.copy_action)
+
+        self.edit_action = self.create_action(
+            ArrayEditorActions.Edit,
+            text=_('Edit'),
+            icon=self.create_icon('edit'),
+            triggered=do_nothing)
+        toolbar.add_item(self.edit_action)
+
+        self.format_action = self.create_action(
+            ArrayEditorActions.Format,
+            text=_('Format'),
+            icon=self.create_icon('format_float'),
+            tip=_('Set format of floating-point numbers'),
+            triggered=do_nothing)
+        toolbar.add_item(self.format_action)
+
+        self.resize_action = self.create_action(
+            ArrayEditorActions.Resize,
+            text=_('Resize'),
+            icon=self.create_icon('collapse_column'),
+            tip=_('Resize columns to contents'),
+            triggered=do_nothing)
+        toolbar.add_item(self.resize_action)
+
+        self.toggle_bgcolor_action = self.create_action(
+            ArrayEditorActions.ToggleBackgroundColor,
+            text=_('Background color'),
+            icon=self.create_icon('background_color'),
+            toggled=do_nothing)
+        toolbar.add_item(self.toggle_bgcolor_action)
+
+        toolbar._render()
+        self.layout.addWidget(toolbar, 0, 0)
+
+        # ---- Stack widget (empty)
+
+        self.stack = QStackedWidget(self)
+        self.stack.currentChanged.connect(self.current_widget_changed)
+        self.layout.addWidget(self.stack, 1, 0)
+
+        # ---- Widgets in bottom left for special arrays
+        #
+        # These are normally hidden. When editing masked, record or 3d arrays,
+        # the relevant elements are made visible in `.set_data_and_check()`.
+
+        self.btn_layout = QHBoxLayout()
+
+        self.combo_label = QLabel()
+        self.btn_layout.addWidget(self.combo_label)
+
+        self.combo_box = QComboBox(self)
+        self.combo_box.currentIndexChanged.connect(self.combo_box_changed)
+        self.btn_layout.addWidget(self.combo_box)
+
+        self.shape_label = QLabel()
+        self.btn_layout.addWidget(self.shape_label)
+
+        self.index_label = QLabel(_('Index:'))
+        self.btn_layout.addWidget(self.index_label)
+
+        self.index_spin = QSpinBox(self, keyboardTracking=False)
+        self.index_spin.valueChanged.connect(self.change_active_widget)
+        self.btn_layout.addWidget(self.index_spin)
+
+        self.slicing_label = QLabel()
+        self.btn_layout.addWidget(self.slicing_label)
+
+        self.masked_label = QLabel(
+            _('<u>Warning</u>: Changes are applied separately'))
+        self.masked_label.setToolTip(
+            _("For performance reasons, changes applied to masked arrays won't"
+              "be reflected in array's data (and vice-versa)."))
+        self.btn_layout.addWidget(self.masked_label)
+
+        self.btn_layout.addStretch()
+
+        # ---- Push buttons on bottom right
+
+        self.btn_save_and_close = QPushButton(_('Save and Close'))
+        self.btn_save_and_close.setDisabled(True)
+        self.btn_save_and_close.clicked.connect(self.accept)
+        self.btn_layout.addWidget(self.btn_save_and_close)
+
+        self.btn_close = QPushButton(_('Close'))
+        self.btn_close.setAutoDefault(True)
+        self.btn_close.setDefault(True)
+        self.btn_close.clicked.connect(self.reject)
+        self.btn_layout.addWidget(self.btn_close)
+
+        # ---- Final layout
+
+        # Add bottom row of widgets
+        self.btn_layout.setContentsMargins(4, 4, 4, 4)
+        self.layout.addLayout(self.btn_layout, 2, 0)
+
+        # Set title
+        if title:
+            title = to_text_string(title) + " - " + _("NumPy object array")
+        else:
+            title = _("Array editor")
+        if readonly:
+            title += ' (' + _('read only') + ')'
+        self.setWindowTitle(title)
+
+        # Set minimum size
+        self.setMinimumSize(500, 300)
+
+        # Make the dialog act as a window
+        self.setWindowFlags(Qt.Window)
+
+    def set_data_and_check(self, data, readonly=False):
+        """
+        Setup ArrayEditor:
+        return False if data is not supported, True otherwise
+        """
         self.data = data
         readonly = readonly or not self.data.flags.writeable
         is_masked_array = isinstance(data, np.ma.MaskedArray)
+
+        # Reset data for 3d arrays
+        self.dim_indexes = [{}, {}, {}]
+        self.last_dim = 0
 
         # This is necessary in case users subclass ndarray and set the dtype
         # to an object that is not an actual dtype.
@@ -712,18 +870,16 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
                 self.error(_("%s are currently not supported") % arr)
                 return False
 
-        self.layout = QGridLayout()
-        self.setLayout(self.layout)
-        if title:
-            title = to_text_string(title) + " - " + _("NumPy object array")
-        else:
-            title = _("Array editor")
-        if readonly:
-            title += ' (' + _('read only') + ')'
-        self.setWindowTitle(title)
-
         # ---- Stack widget
-        self.stack = QStackedWidget(self)
+
+        # Remove old widgets, if any
+        while self.stack.count() > 0:
+            # Note: widgets get renumbered after removeWidget()
+            widget = self.stack.widget(0)
+            self.stack.removeWidget(widget)
+            widget.deleteLater()
+
+        # Add widgets to the stack
         if is_record_array:
             for name in data.dtype.names:
                 self.stack.addWidget(ArrayEditorWidget(self, data[name],
@@ -733,157 +889,106 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
             self.stack.addWidget(ArrayEditorWidget(self, data.data, readonly))
             self.stack.addWidget(ArrayEditorWidget(self, data.mask, readonly))
         elif data.ndim == 3:
-            # We create here the necessary widgets for current_dim_changed to
-            # work. The rest are created below.
-            # QSpinBox
-            self.index_spin = QSpinBox(self, keyboardTracking=False)
-            self.index_spin.valueChanged.connect(self.change_active_widget)
-
-            # Labels
-            self.shape_label = QLabel()
-            self.slicing_label = QLabel()
-
             # Set the widget to display when launched
-            self.current_dim_changed(self.last_dim)
+            self.combo_box_changed(self.last_dim)
         else:
             self.stack.addWidget(ArrayEditorWidget(self, data, readonly))
 
         self.arraywidget = self.stack.currentWidget()
         self.arraywidget.model.dataChanged.connect(self.save_and_close_enable)
-        self.stack.currentChanged.connect(self.current_widget_changed)
-        self.layout.addWidget(self.stack, 1, 0)
 
-        # ---- Toolbar and actions
-        toolbar = SpyderToolbar(parent=self, title='Editor toolbar')
-        toolbar.setStyleSheet(str(PANES_TOOLBAR_STYLESHEET))
+        # ---- Actions
 
-        self.copy_action = self.create_action(
-            ArrayEditorActions.Copy,
-            text=_('Copy'),
-            icon=self.create_icon('editcopy'),
-            triggered=self.arraywidget.view.copy)
-        toolbar.add_item(self.copy_action)
+        safe_disconnect(self.copy_action.triggered)
+        self.copy_action.triggered.connect(self.arraywidget.view.copy)
 
-        self.edit_action = self.create_action(
-            ArrayEditorActions.Edit,
-            text=_('Edit'),
-            icon=self.create_icon('edit'),
-            triggered=self.arraywidget.view.edit_item)
-        toolbar.add_item(self.edit_action)
+        safe_disconnect(self.edit_action.triggered)
+        self.edit_action.triggered.connect(self.arraywidget.view.edit_item)
 
-        self.format_action = self.create_action(
-            ArrayEditorActions.Format,
-            text=_('Format'),
-            icon=self.create_icon('format_float'),
-            tip=_('Set format of floating-point numbers'),
-            triggered=self.arraywidget.change_format)
+        safe_disconnect(self.format_action.triggered)
+        self.format_action.triggered.connect(self.arraywidget.change_format)
         self.format_action.setEnabled(is_float(self.arraywidget.data.dtype))
-        toolbar.add_item(self.format_action)
 
-        self.resize_action = self.create_action(
-            ArrayEditorActions.Resize,
-            text=_('Resize'),
-            icon=self.create_icon('collapse_column'),
-            tip=_('Resize columns to contents'),
-            triggered=self.arraywidget.view.resize_to_contents)
-        toolbar.add_item(self.resize_action)
+        safe_disconnect(self.resize_action.triggered)
+        self.resize_action.triggered.connect(
+            self.arraywidget.view.resize_to_contents)
 
-        self.toggle_bgcolor_action = self.create_action(
-            ArrayEditorActions.ToggleBackgroundColor,
-            text=_('Background color'),
-            icon=self.create_icon('background_color'),
-            toggled=lambda state: self.arraywidget.model.bgcolor(state),
-            initial=self.arraywidget.model.bgcolor_enabled)
+        safe_disconnect(self.toggle_bgcolor_action.toggled)
+        self.toggle_bgcolor_action.toggled.connect(
+            lambda state: self.arraywidget.model.bgcolor(state))
         self.toggle_bgcolor_action.setEnabled(
             self.arraywidget.model.bgcolor_enabled)
-        toolbar.add_item(self.toggle_bgcolor_action)
+        self.toggle_bgcolor_action.setChecked(
+            self.arraywidget.model.bgcolor_enabled)
 
-        toolbar._render()
-        self.layout.addWidget(toolbar, 0, 0)
+        # ---- Widgets in bottom left
 
-        # ---- Buttons in bottom left, if any
-        btn_layout = QHBoxLayout()
-        if is_record_array or is_masked_array or data.ndim == 3:
+        # By default, all these widgets are hidden
+        self.combo_label.hide()
+        self.combo_box.hide()
+        self.shape_label.hide()
+        self.index_label.hide()
+        self.index_spin.hide()
+        self.slicing_label.hide()
+        self.masked_label.hide()
 
-            if is_record_array:
-                btn_layout.addWidget(QLabel(_("Record array fields:")))
-                names = []
-                for name in data.dtype.names:
-                    field = data.dtype.fields[name]
-                    text = name
-                    if len(field) >= 3:
-                        title = field[2]
-                        if not is_text_string(title):
-                            title = repr(title)
-                        text += ' - '+title
-                    names.append(text)
-            else:
-                names = [_('Masked data'), _('Data'), _('Mask')]
+        # Empty combo box
+        while self.combo_box.count() > 0:
+            self.combo_box.removeItem(0)
 
-            if data.ndim == 3:
-                # QComboBox
-                names = [str(i) for i in range(3)]
-                ra_combo = QComboBox(self)
-                ra_combo.addItems(names)
-                ra_combo.currentIndexChanged.connect(self.current_dim_changed)
+        # Handle cases
+        if is_record_array:
 
-                # Adding the widgets to layout
-                label = QLabel(_("Axis:"))
-                btn_layout.addWidget(label)
-                btn_layout.addWidget(ra_combo)
-                btn_layout.addWidget(self.shape_label)
+            self.combo_label.setText(_('Record array fields:'))
+            self.combo_label.show()
 
-                label = QLabel(_("Index:"))
-                btn_layout.addWidget(label)
-                btn_layout.addWidget(self.index_spin)
+            names = []
+            for name in data.dtype.names:
+                field = data.dtype.fields[name]
+                text = name
+                if len(field) >= 3:
+                    title = field[2]
+                    if not is_text_string(title):
+                        title = repr(title)
+                    text += ' - '+title
+                names.append(text)
+            self.combo_box.addItems(names)
+            self.combo_box.show()
 
-                btn_layout.addWidget(self.slicing_label)
-            else:
-                ra_combo = QComboBox(self)
-                ra_combo.currentIndexChanged.connect(self.stack.setCurrentIndex)
-                ra_combo.addItems(names)
-                btn_layout.addWidget(ra_combo)
+        elif is_masked_array:
 
-            if is_masked_array:
-                label = QLabel(
-                    _("<u>Warning</u>: Changes are applied separately")
-                )
-                label.setToolTip(_("For performance reasons, changes applied "
-                                   "to masked arrays won't be reflected in "
-                                   "array's data (and vice-versa)."))
-                btn_layout.addWidget(label)
+            names = [_('Masked data'), _('Data'), _('Mask')]
+            self.combo_box.addItems(names)
+            self.combo_box.show()
 
-        # ---- Buttons on bottom right
-        btn_layout.addStretch()
+            self.masked_label.show()
 
-        if not readonly:
-            self.btn_save_and_close = QPushButton(_('Save and Close'))
-            self.btn_save_and_close.setDisabled(True)
-            self.btn_save_and_close.clicked.connect(self.accept)
-            btn_layout.addWidget(self.btn_save_and_close)
+        elif data.ndim == 3:
 
-        self.btn_close = QPushButton(_('Close'))
-        self.btn_close.setAutoDefault(True)
-        self.btn_close.setDefault(True)
-        self.btn_close.clicked.connect(self.reject)
-        btn_layout.addWidget(self.btn_close)
+            self.combo_label.setText(_('Axis:'))
+            self.combo_label.show()
 
-        # ---- Final layout
-        btn_layout.setContentsMargins(4, 4, 4, 4)
-        self.layout.addLayout(btn_layout, 2, 0)
+            names = [str(i) for i in range(3)]
+            self.combo_box.addItems(names)
+            self.combo_box.show()
 
-        # Set minimum size
-        self.setMinimumSize(500, 300)
+            self.shape_label.show()
+            self.index_label.show()
+            self.index_spin.show()
+            self.slicing_label.show()
 
-        # Make the dialog act as a window
-        self.setWindowFlags(Qt.Window)
+        # ---- Bottom row of buttons
+
+        self.btn_save_and_close.setDisabled(True)
+        if readonly:
+            self.btn_save_and_close.hide()
 
         return True
 
     @Slot(QModelIndex, QModelIndex)
     def save_and_close_enable(self, left_top, bottom_right):
         """Handle the data change event to enable the save and close button."""
-        if self.btn_save_and_close:
+        if self.btn_save_and_close.isVisible():
             self.btn_save_and_close.setEnabled(True)
             self.btn_save_and_close.setAutoDefault(True)
             self.btn_save_and_close.setDefault(True)
@@ -922,11 +1027,18 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
             self.stack.update()
         self.stack.setCurrentIndex(stack_index)
 
-    def current_dim_changed(self, index):
+    def combo_box_changed(self, index):
         """
-        This change the active axis the array editor is plotting over
-        in 3D
+        Handle changes in the combo box
+
+        For masked and record arrays, this changes the visible widget in the
+        stack. For 3d arrays, this changes the active axis the array editor is
+        plotting over.
         """
+        if self.data.ndim != 3:
+            self.stack.setCurrentIndex(index)
+            return
+
         self.last_dim = index
         string_size = ['%i']*3
         string_size[index] = '<font color=red>%i</font>'

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -251,7 +251,8 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
                 and pd.DataFrame is not FakeObject and not object_explorer):
             # We need to leave this import here for tests to pass.
             from .dataframeeditor import DataFrameEditor
-            editor = DataFrameEditor(parent=parent)
+            editor = DataFrameEditor(
+                parent=parent, data_function=self.make_data_function(index))
             if not editor.setup_and_check(value, title=key):
                 self.sig_editor_shown.emit()
                 return

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -45,8 +45,12 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
     sig_editor_creation_started = Signal()
     sig_editor_shown = Signal()
 
-    def __init__(self, parent=None, namespacebrowser=None,
-                 data_function: Optional[Callable[[], Any]] = None):
+    def __init__(
+        self,
+        parent=None,
+        namespacebrowser=None,
+        data_function: Optional[Callable[[], Any]] = None
+    ):
         QItemDelegate.__init__(self, parent)
         self.namespacebrowser = namespacebrowser
         self.data_function = data_function
@@ -60,8 +64,10 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
         if index.isValid():
             index.model().set_value(index, value)
 
-    def make_data_function(self, index: QModelIndex
-                           ) -> Optional[Callable[[], Any]]:
+    def make_data_function(
+        self,
+        index: QModelIndex
+    ) -> Optional[Callable[[], Any]]:
         """
         Construct function which returns current value of data.
 
@@ -92,6 +98,7 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
             data = self.data_function()
             if isinstance(data, (tuple, list, dict, set)):
                 return data[key]
+
             try:
                 return getattr(data, key)
             except (NotImplementedError, AttributeError,
@@ -207,8 +214,10 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
         elif isinstance(value, (list, set, tuple, dict)) and not object_explorer:
             from spyder.widgets.collectionseditor import CollectionsEditor
             editor = CollectionsEditor(
-                parent=parent, namespacebrowser=self.namespacebrowser,
-                data_function=self.make_data_function(index))
+                parent=parent,
+                namespacebrowser=self.namespacebrowser,
+                data_function=self.make_data_function(index)
+            )
             editor.setup(value, key, icon=self.parent().windowIcon(),
                          readonly=readonly)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
@@ -220,7 +229,9 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
             # We need to leave this import here for tests to pass.
             from .arrayeditor import ArrayEditor
             editor = ArrayEditor(
-                parent=parent, data_function=self.make_data_function(index))
+                parent=parent,
+                data_function=self.make_data_function(index)
+            )
             if not editor.setup_and_check(value, title=key, readonly=readonly):
                 self.sig_editor_shown.emit()
                 return
@@ -252,7 +263,9 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
             # We need to leave this import here for tests to pass.
             from .dataframeeditor import DataFrameEditor
             editor = DataFrameEditor(
-                parent=parent, data_function=self.make_data_function(index))
+                parent=parent,
+                data_function=self.make_data_function(index)
+            )
             if not editor.setup_and_check(value, title=key):
                 self.sig_editor_shown.emit()
                 return
@@ -466,7 +479,8 @@ class ToggleColumnDelegate(CollectionsDelegate):
     def __init__(self, parent=None, namespacebrowser=None,
                  data_function: Optional[Callable[[], Any]] = None):
         CollectionsDelegate.__init__(
-            self, parent, namespacebrowser, data_function)
+            self, parent, namespacebrowser, data_function
+        )
         self.current_index = None
         self.old_obj = None
 
@@ -486,8 +500,10 @@ class ToggleColumnDelegate(CollectionsDelegate):
         if index.isValid():
             index.model().set_value(index, value)
 
-    def make_data_function(self, index: QModelIndex
-                           ) -> Optional[Callable[[], Any]]:
+    def make_data_function(
+        self,
+        index: QModelIndex
+    ) -> Optional[Callable[[], Any]]:
         """
         Construct function which returns current value of data.
 
@@ -565,8 +581,10 @@ class ToggleColumnDelegate(CollectionsDelegate):
         if isinstance(value, (list, set, tuple, dict)):
             from spyder.widgets.collectionseditor import CollectionsEditor
             editor = CollectionsEditor(
-                parent=parent, namespacebrowser=self.namespacebrowser,
-                data_function=self.make_data_function(index))
+                parent=parent,
+                namespacebrowser=self.namespacebrowser,
+                data_function=self.make_data_function(index)
+            )
             editor.setup(value, key, icon=self.parent().windowIcon(),
                          readonly=readonly)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
@@ -576,7 +594,9 @@ class ToggleColumnDelegate(CollectionsDelegate):
         elif (isinstance(value, (np.ndarray, np.ma.MaskedArray)) and
                 np.ndarray is not FakeObject):
             editor = ArrayEditor(
-                parent=parent, data_function=self.make_data_function(index))
+                parent=parent,
+                data_function=self.make_data_function(index)
+            )
             if not editor.setup_and_check(value, title=key, readonly=readonly):
                 return
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
@@ -598,7 +618,9 @@ class ToggleColumnDelegate(CollectionsDelegate):
         elif (isinstance(value, (pd.DataFrame, pd.Index, pd.Series))
                 and pd.DataFrame is not FakeObject):
             editor = DataFrameEditor(
-                parent=parent, data_function=self.make_data_function(index))
+                parent=parent,
+                data_function=self.make_data_function(index)
+            )
             if not editor.setup_and_check(value, title=key):
                 return
             self.create_dialog(editor, dict(model=index.model(), editor=editor,

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -319,6 +319,7 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
                 name=key,
                 parent=parent,
                 namespacebrowser=self.namespacebrowser,
+                data_function=self.make_data_function(index),
                 readonly=readonly)
             self.create_dialog(editor, dict(model=index.model(),
                                             editor=editor,

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -188,7 +188,8 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
         elif isinstance(value, (list, set, tuple, dict)) and not object_explorer:
             from spyder.widgets.collectionseditor import CollectionsEditor
             editor = CollectionsEditor(
-                parent=parent, namespacebrowser=self.namespacebrowser)
+                parent=parent, namespacebrowser=self.namespacebrowser,
+                data_function=self.make_data_function(index))
             editor.setup(value, key, icon=self.parent().windowIcon(),
                          readonly=readonly)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -788,7 +788,8 @@ class DataFrameView(QTableView, SpyderConfigurationAccessor):
             self, _('Refresh'),
             icon=ima.icon('refresh'),
             tip=_('Refresh editor with current value of variable in console'),
-            triggered=lambda: self.sig_refresh_requested.emit())
+            triggered=lambda: self.sig_refresh_requested.emit()
+        )
         self.refresh_action.setEnabled(self.data_function is not None)
 
         self.convert_to_action = create_action(self, _('Convert to'))
@@ -1612,8 +1613,11 @@ class DataFrameEditor(BaseDialog, SpyderConfigurationAccessor):
     """
     CONF_SECTION = 'variable_explorer'
 
-    def __init__(self, parent: QWidget = None,
-                 data_function: Optional[Callable[[], Any]] = None):
+    def __init__(
+        self,
+        parent: QWidget = None,
+        data_function: Optional[Callable[[], Any]] = None
+    ):
         super().__init__(parent)
         self.data_function = data_function
 
@@ -1630,20 +1634,22 @@ class DataFrameEditor(BaseDialog, SpyderConfigurationAccessor):
 
     def setup_and_check(self, data, title='') -> bool:
         """
-        Setup DataFrameEditor:
-        return False if data is not supported, True otherwise.
-        Supported types for data are DataFrame, Series and Index.
+        Setup editor.
+        
+        It returns False if data is not supported, True otherwise. Supported
+        types for data are DataFrame, Series and Index.
         """
         if title:
             title = to_text_string(title) + " - %s" % data.__class__.__name__
         else:
             title = _("%s editor") % data.__class__.__name__
+
         self.setup_ui(title)
         return self.set_data_and_check(data)
 
     def setup_ui(self, title: str) -> None:
         """
-        Create user interface
+        Create user interface.
         """
         self.layout = QVBoxLayout()
         self.layout.setSpacing(0)
@@ -1718,9 +1724,9 @@ class DataFrameEditor(BaseDialog, SpyderConfigurationAccessor):
 
     def set_data_and_check(self, data) -> bool:
         """
-        Checks whether data is suitable and display it in the editor
+        Checks whether data is suitable and display it in the editor.
 
-        This function returns False if data is not supported.
+        This method returns False if data is not supported.
         """
         if not isinstance(data, (pd.DataFrame, pd.Series, pd.Index)):
             return False
@@ -2111,7 +2117,8 @@ class DataFrameEditor(BaseDialog, SpyderConfigurationAccessor):
         if not self.set_data_and_check(data):
             self.error(
                 _('The new value cannot be displayed in the dataframe '
-                  'editor.'))
+                  'editor.')
+            )
 
     def ask_for_refresh_confirmation(self) -> bool:
         """
@@ -2124,7 +2131,10 @@ class DataFrameEditor(BaseDialog, SpyderConfigurationAccessor):
         message = _('Refreshing the editor will overwrite the changes that '
                     'you made. Do you want to proceed?')
         result = QMessageBox.question(
-            self, _('Refresh dataframe editor?'), message)
+            self,
+            _('Refresh dataframe editor?'),
+            message
+        )
         return result == QMessageBox.Yes
 
     def error(self, message):

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -58,9 +58,9 @@ from spyder.config.base import _
 from spyder.py3compat import (is_text_string, is_type_text_string,
                               to_text_string)
 from spyder.utils.icon_manager import ima
-from spyder.utils.qthelpers import (add_actions, create_action,
-                                    MENU_SEPARATOR, keybinding,
-                                    qapplication)
+from spyder.utils.qthelpers import (
+    add_actions, create_action, keybinding, MENU_SEPARATOR, qapplication,
+    safe_disconnect)
 from spyder.plugins.variableexplorer.widgets.arrayeditor import get_idx_rect
 from spyder.plugins.variableexplorer.widgets.basedialog import BaseDialog
 from spyder.utils.palette import QStylePalette
@@ -1753,12 +1753,7 @@ class DataFrameEditor(BaseDialog, SpyderConfigurationAccessor):
         self.bgcolor.setChecked(self.dataModel.bgcolor_enabled)
         self.bgcolor.setEnabled(self.dataModel.bgcolor_enabled)
 
-        try:
-            self.bgcolor_global.stateChanged.disconnect()
-        except TypeError:
-            # Raised when no slots are connected to the signal
-            pass
-
+        safe_disconnect(self.bgcolor_global.stateChanged)
         self.bgcolor_global.stateChanged.connect(self.dataModel.colum_avg)
         self.bgcolor_global.setChecked(self.dataModel.colum_avg_enabled)
         self.bgcolor_global.setEnabled(not self.is_series and

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -150,7 +150,8 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
 
         # Tree widget
         old_obj_tree = self.obj_tree
-        self.obj_tree = ToggleColumnTreeView(self.namespacebrowser)
+        self.obj_tree = ToggleColumnTreeView(
+            self.namespacebrowser, self.data_function)
         self.obj_tree.setAlternatingRowColors(True)
         self.obj_tree.setModel(self._proxy_tree_model)
         self.obj_tree.setSelectionBehavior(QAbstractItemView.SelectRows)

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -143,7 +143,9 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
         # Tree widget
         old_obj_tree = self.obj_tree
         self.obj_tree = ToggleColumnTreeView(
-            self.namespacebrowser, self.data_function)
+            self.namespacebrowser,
+            self.data_function
+        )
         self.obj_tree.setAlternatingRowColors(True)
         self.obj_tree.setModel(self._proxy_tree_model)
         self.obj_tree.setSelectionBehavior(QAbstractItemView.SelectRows)
@@ -257,8 +259,10 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
         self.refresh_button = create_toolbutton(
             self, icon=ima.icon('refresh'),
             tip=_('Refresh editor with current value of variable in console'),
-            triggered=self.refresh_editor)
+            triggered=self.refresh_editor
+        )
         self.refresh_button.setEnabled(self.data_function is not None)
+        self.refresh_button.setStyleSheet(str(PANES_TOOLBAR_STYLESHEET))
         self.tools_layout.addSpacing(5)
         self.tools_layout.addWidget(self.refresh_button)
 
@@ -419,8 +423,11 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
         try:
             data = self.data_function()
         except (IndexError, KeyError):
-            QMessageBox.critical(self, _('Collection editor'),
-                                 _('The variable no longer exists.'))
+            QMessageBox.critical(
+                self,
+                _('Object explorer'),
+                _('The variable no longer exists.')
+            )
             self.reject()
             return
 

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -31,7 +31,8 @@ from spyder.plugins.variableexplorer.widgets.objectexplorer import (
     DEFAULT_ATTR_COLS, DEFAULT_ATTR_DETAILS, ToggleColumnTreeView,
     TreeItem, TreeModel, TreeProxyModel)
 from spyder.utils.icon_manager import ima
-from spyder.utils.qthelpers import add_actions, create_toolbutton, qapplication
+from spyder.utils.qthelpers import (
+    add_actions, create_toolbutton, qapplication, safe_disconnect)
 from spyder.utils.stylesheet import PANES_TOOLBAR_STYLESHEET
 from spyder.widgets.simplecodeeditor import SimpleCodeEditor
 
@@ -41,15 +42,6 @@ logger = logging.getLogger(__name__)
 
 # About message
 EDITOR_NAME = 'Object'
-
-
-def safe_disconnect(signal):
-    """Disconnect a QtSignal, ignoring TypeError"""
-    try:
-        signal.disconnect()
-    except TypeError:
-        # Raised when no slots are connected to the signal
-        pass
 
 
 class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -13,7 +13,7 @@ import logging
 import traceback
 
 # Third-party imports
-from qtpy.QtCore import Signal, Slot, QModelIndex, QPoint, QSize, Qt
+from qtpy.QtCore import Slot, QModelIndex, QPoint, QSize, Qt
 from qtpy.QtGui import QKeySequence, QTextOption
 from qtpy.QtWidgets import (QAbstractItemView, QAction, QButtonGroup,
                             QGroupBox, QHBoxLayout, QHeaderView,
@@ -40,6 +40,15 @@ logger = logging.getLogger(__name__)
 
 # About message
 EDITOR_NAME = 'Object'
+
+
+def safe_disconnect(signal):
+    """Disconnect a QtSignal, ignoring TypeError"""
+    try:
+        signal.disconnect()
+    except TypeError:
+        # Raised when no slots are connected to the signal
+        pass
 
 
 class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
@@ -82,16 +91,50 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
         show_special_attributes = self.get_conf('show_special_attributes')
 
         # Model
+        self.name = name
+        self.expanded = expanded
+        self.namespacebrowser = namespacebrowser
         self._attr_cols = attribute_columns
         self._attr_details = attribute_details
         self.readonly = readonly
 
+        self.obj_tree = None
         self.btn_save_and_close = None
         self.btn_close = None
 
-        self._tree_model = TreeModel(obj, obj_name=name,
+        # Views
+        self._setup_actions()
+        self._setup_menu(show_callable_attributes=show_callable_attributes,
+                         show_special_attributes=show_special_attributes)
+        self._setup_views()
+        if self.name:
+            self.setWindowTitle(f'{self.name} - {EDITOR_NAME}')
+        else:
+            self.setWindowTitle(EDITOR_NAME)
+        self.setWindowFlags(Qt.Window)
+
+        # Load object into editor
+        self.set_value(obj)
+
+        self._resize_to_contents = resize_to_contents
+        self._readViewSettings(reset=reset)
+
+        # Update views with model
+        self.toggle_show_special_attribute_action.setChecked(
+            show_special_attributes)
+        self.toggle_show_callable_action.setChecked(show_callable_attributes)
+
+    def get_value(self):
+        """Get editor current object state."""
+        return self._tree_model.inspectedItem.obj
+
+    def set_value(self, obj):
+        """Set object displayed in the editor."""
+        self._tree_model = TreeModel(obj, obj_name=self.name,
                                      attr_cols=self._attr_cols)
 
+        show_callable_attributes = self.get_conf('show_callable_attributes')
+        show_special_attributes = self.get_conf('show_special_attributes')
         self._proxy_tree_model = TreeProxyModel(
             show_callable_attributes=show_callable_attributes,
             show_special_attributes=show_special_attributes
@@ -103,40 +146,67 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
         # self._proxy_tree_model.setSortCaseSensitivity(Qt.CaseInsensitive)
 
         # Tree widget
-        self.obj_tree = ToggleColumnTreeView(namespacebrowser)
+        old_obj_tree = self.obj_tree
+        self.obj_tree = ToggleColumnTreeView(self.namespacebrowser)
         self.obj_tree.setAlternatingRowColors(True)
         self.obj_tree.setModel(self._proxy_tree_model)
         self.obj_tree.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.obj_tree.setUniformRowHeights(True)
         self.obj_tree.add_header_context_menu()
 
-        # Views
-        self._setup_actions()
-        self._setup_menu(show_callable_attributes=show_callable_attributes,
-                         show_special_attributes=show_special_attributes)
-        self._setup_views()
-        if name:
-            name = "{} -".format(name)
-        self.setWindowTitle("{} {}".format(name, EDITOR_NAME))
-        self.setWindowFlags(Qt.Window)
+        # Connect signals
+        safe_disconnect(self.toggle_show_callable_action.toggled)
+        self.toggle_show_callable_action.toggled.connect(
+            self._proxy_tree_model.setShowCallables)
+        self.toggle_show_callable_action.toggled.connect(
+            self.obj_tree.resize_columns_to_contents)
 
-        self._resize_to_contents = resize_to_contents
-        self._readViewSettings(reset=reset)
+        safe_disconnect(self.toggle_show_special_attribute_action.toggled)
+        self.toggle_show_special_attribute_action.toggled.connect(
+            self._proxy_tree_model.setShowSpecialAttributes)
+        self.toggle_show_special_attribute_action.toggled.connect(
+            self.obj_tree.resize_columns_to_contents)
 
-        # Update views with model
-        self.toggle_show_special_attribute_action.setChecked(
-            show_special_attributes)
-        self.toggle_show_callable_action.setChecked(show_callable_attributes)
+        # Keep a temporary reference of the selection_model to prevent
+        # segfault in PySide.
+        # See http://permalink.gmane.org/gmane.comp.lib.qt.pyside.devel/222
+        selection_model = self.obj_tree.selectionModel()
+        selection_model.currentChanged.connect(self._update_details)
+
+        # Check if the values of the model have been changed
+        self._proxy_tree_model.sig_setting_data.connect(
+            self.save_and_close_enable)
+
+        self._proxy_tree_model.sig_update_details.connect(
+            self._update_details_for_item)
 
         # Select first row so that a hidden root node will not be selected.
         first_row_index = self._proxy_tree_model.firstItemIndex()
         self.obj_tree.setCurrentIndex(first_row_index)
-        if self._tree_model.inspectedNodeIsVisible or expanded:
+        if self._tree_model.inspectedNodeIsVisible or self.expanded:
             self.obj_tree.expand(first_row_index)
 
-    def get_value(self):
-        """Get editor current object state."""
-        return self._tree_model.inspectedItem.obj
+        # Stretch last column?
+        # It doesn't play nice when columns are hidden and then shown again.
+        obj_tree_header = self.obj_tree.header()
+        obj_tree_header.setSectionsMovable(True)
+        obj_tree_header.setStretchLastSection(False)
+
+        # Add menu item for toggling columns to the Options menu
+        add_actions(self.show_cols_submenu,
+                    self.obj_tree.toggle_column_actions_group.actions())
+        column_visible = [col.col_visible for col in self._attr_cols]
+        for idx, visible in enumerate(column_visible):
+            elem = self.obj_tree.toggle_column_actions_group.actions()[idx]
+            elem.setChecked(visible)
+
+        # Place tree widget in editor
+        if old_obj_tree:
+            self.central_splitter.replaceWidget(0, self.obj_tree)
+            old_obj_tree.deleteLater()
+        else:
+            self.central_splitter.insertWidget(0, self.obj_tree)
+
 
     def _make_show_column_function(self, column_idx):
         """Creates a function that shows or hides a column."""
@@ -155,11 +225,6 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
             statusTip=_("Shows/hides attributes that are callable "
                         "(functions, methods, etc)")
         )
-        self.toggle_show_callable_action.toggled.connect(
-            self._proxy_tree_model.setShowCallables)
-        self.toggle_show_callable_action.toggled.connect(
-            self.obj_tree.resize_columns_to_contents)
-
         # Show/hide special attributes
         self.toggle_show_special_attribute_action = QAction(
             _("Show __special__ attributes"),
@@ -168,10 +233,6 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
             shortcut=QKeySequence("Alt+S"),
             statusTip=_("Shows or hides __special__ attributes")
         )
-        self.toggle_show_special_attribute_action.toggled.connect(
-            self._proxy_tree_model.setShowSpecialAttributes)
-        self.toggle_show_special_attribute_action.toggled.connect(
-            self.obj_tree.resize_columns_to_contents)
 
     def _setup_menu(self, show_callable_attributes=False,
                     show_special_attributes=False):
@@ -235,16 +296,6 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
         self.central_splitter = QSplitter(self, orientation=Qt.Vertical)
         layout.addWidget(self.central_splitter)
         self.setLayout(layout)
-
-        # Stretch last column?
-        # It doesn't play nice when columns are hidden and then shown again.
-        obj_tree_header = self.obj_tree.header()
-        obj_tree_header.setSectionsMovable(True)
-        obj_tree_header.setStretchLastSection(False)
-        add_actions(self.show_cols_submenu,
-                    self.obj_tree.toggle_column_actions_group.actions())
-
-        self.central_splitter.addWidget(self.obj_tree)
 
         # Bottom pane
         bottom_pane_widget = QWidget()
@@ -311,20 +362,6 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
         self.central_splitter.setCollapsible(1, True)
         self.central_splitter.setSizes([500, 320])
 
-        # Connect signals
-        # Keep a temporary reference of the selection_model to prevent
-        # segfault in PySide.
-        # See http://permalink.gmane.org/gmane.comp.lib.qt.pyside.devel/222
-        selection_model = self.obj_tree.selectionModel()
-        selection_model.currentChanged.connect(self._update_details)
-
-        # Check if the values of the model have been changed
-        self._proxy_tree_model.sig_setting_data.connect(
-            self.save_and_close_enable)
-
-        self._proxy_tree_model.sig_update_details.connect(
-            self._update_details_for_item)
-
     # End of setup_methods
     def _readViewSettings(self, reset=False):
         """
@@ -356,18 +393,12 @@ class ObjectExplorer(BaseDialog, SpyderConfigurationAccessor, SpyderFontsMixin):
 
         if not header_restored:
             column_sizes = [col.width for col in self._attr_cols]
-            column_visible = [col.col_visible for col in self._attr_cols]
-
             for idx, size in enumerate(column_sizes):
                 if not self._resize_to_contents and size > 0:  # Just in case
                     header.resizeSection(idx, size)
                 else:
                     header.resizeSections(QHeaderView.ResizeToContents)
                     break
-
-            for idx, visible in enumerate(column_visible):
-                elem = self.obj_tree.toggle_column_actions_group.actions()[idx]
-                elem.setChecked(visible)
 
         self.resize(window_size)
 

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/test_objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/test_objectexplorer.py
@@ -184,7 +184,7 @@ class DataclassForTesting:
 
 def test_objectexplorer_refreshbutton_disabled():
     """
-    Test that the Refresh button is disabled by default.
+    Test that the refresh button is disabled by default.
     """
     data = DataclassForTesting('lemon', 0.15, 5)
     editor = ObjectExplorer(data, name='data')
@@ -193,8 +193,8 @@ def test_objectexplorer_refreshbutton_disabled():
 
 def test_objectexplorer_refresh():
     """
-    Test that after pressing the refresh button, the value of the Array Editor
-    is replaced by the return value of the data_function.
+    Test that after pressing the refresh button, the value of the editor is
+    replaced by the return value of the data_function.
     """
     data_old = DataclassForTesting('lemon', 0.15, 5)
     data_new = range(1, 42, 3)
@@ -237,7 +237,7 @@ class Box:
 
 def test_objectexplorer_refresh_nested():
     """
-    Open an editor for an `Box` object containing a list, and then open another
+    Open an editor for a `Box` object containing a list, and then open another
     editor for the nested list. Test that refreshing the second editor works.
     """
     old_data = Box([1, 2, 3])
@@ -257,7 +257,7 @@ def test_objectexplorer_refresh_nested():
 
 def test_objectexplorer_refresh_doubly_nested():
     """
-    Open an editor for an `Box` object containing another `Box` object which
+    Open an editor for a `Box` object containing another `Box` object which
     in turn contains a list. Then open a second editor for the nested list.
     Test that refreshing the second editor works.
     """

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
@@ -10,9 +10,10 @@
 
 # Standard library imports
 import logging
+from typing import Any, Callable, Optional
 
 # Third-party imports
-from qtpy.QtCore import Qt, Signal, Slot
+from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import (QAbstractItemView, QAction, QActionGroup,
                             QHeaderView, QTableWidget, QTreeView, QTreeWidget)
 
@@ -155,12 +156,15 @@ class ToggleColumnTreeView(QTreeView, ToggleColumnMixIn):
     show/hide columns.
     """
 
-    def __init__(self, namespacebrowser=None, readonly=False):
+    def __init__(self, namespacebrowser=None,
+                 data_function: Optional[Callable[[], Any]] = None,
+                 readonly=False):
         QTreeView.__init__(self)
         self.readonly = readonly
         from spyder.plugins.variableexplorer.widgets.collectionsdelegate \
             import ToggleColumnDelegate
-        self.delegate = ToggleColumnDelegate(self, namespacebrowser)
+        self.delegate = ToggleColumnDelegate(
+            self, namespacebrowser, data_function)
         self.setItemDelegate(self.delegate)
         self.setEditTriggers(QAbstractItemView.DoubleClicked)
         self.expanded.connect(self.resize_columns_to_contents)

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
@@ -156,15 +156,19 @@ class ToggleColumnTreeView(QTreeView, ToggleColumnMixIn):
     show/hide columns.
     """
 
-    def __init__(self, namespacebrowser=None,
-                 data_function: Optional[Callable[[], Any]] = None,
-                 readonly=False):
+    def __init__(
+        self,
+        namespacebrowser=None,
+        data_function: Optional[Callable[[], Any]] = None,
+        readonly=False
+    ):
         QTreeView.__init__(self)
         self.readonly = readonly
         from spyder.plugins.variableexplorer.widgets.collectionsdelegate \
             import ToggleColumnDelegate
         self.delegate = ToggleColumnDelegate(
-            self, namespacebrowser, data_function)
+            self, namespacebrowser, data_function
+        )
         self.setItemDelegate(self.delegate)
         self.setEditTriggers(QAbstractItemView.DoubleClicked)
         self.expanded.connect(self.resize_columns_to_contents)

--- a/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
@@ -280,6 +280,22 @@ def test_arrayeditor_refresh_after_edit(result):
         assert_array_equal(dlg.get_value(), arr_edited)
 
 
+def test_arrayeditor_refresh_into_int(qtbot):
+    """
+    Test that if the value after refreshing is not an array but an integer,
+    a critical dialog box is displayed and that the array editor is closed.
+    """
+    arr_ones = np.ones((3, 3))
+    datafunc = lambda: 1
+    dlg = ArrayEditor(data_function=datafunc)
+    dlg.setup_and_check(arr_ones, '2D array')
+    with patch('spyder.plugins.variableexplorer.widgets.arrayeditor'
+               '.QMessageBox.critical') as mock_critical, \
+         qtbot.waitSignal(dlg.rejected, timeout=0):
+        dlg.refresh_action.trigger()
+    mock_critical.assert_called_once()
+
+
 def test_arrayeditor_edit_1d_array(qtbot):
     exp_arr = np.array([1, 0, 2, 3, 4])
     arr = np.arange(0, 5)

--- a/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
@@ -224,6 +224,32 @@ def test_arrayeditor_with_empty_3d_array(qtbot):
     assert_array_equal(arr, launch_arrayeditor(arr, "3D array"))
 
 
+def test_arrayeditor_refreshaction_disabled():
+    """
+    Test that the Refresh action is disabled by default.
+    """
+    arr_ones = np.ones((3, 3))
+    dlg = ArrayEditor()
+    dlg.setup_and_check(arr_ones, '2D array')
+    assert not dlg.refresh_action.isEnabled()
+
+
+def test_arrayeditor_refresh():
+    """
+    Test that after pressing the refresh button, the value of the Array Editor
+    is replaced by the return value of the data_function.
+    """
+    arr_ones = np.ones((3, 3))
+    arr_zeros = np.zeros((4, 4))
+    datafunc = lambda: arr_zeros
+    dlg = ArrayEditor(data_function=datafunc)
+    assert dlg.setup_and_check(arr_ones, '2D array')
+    assert_array_equal(dlg.get_value(), arr_ones)
+    assert dlg.refresh_action.isEnabled()
+    dlg.refresh_action.trigger()
+    assert_array_equal(dlg.get_value(), arr_zeros)
+
+
 def test_arrayeditor_edit_1d_array(qtbot):
     exp_arr = np.array([1, 0, 2, 3, 4])
     arr = np.arange(0, 5)

--- a/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
@@ -37,10 +37,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 # =============================================================================
 # Utility functions
 # =============================================================================
-def launch_arrayeditor(data, title="", xlabels=None, ylabels=None):
+def launch_arrayeditor(data, title=""):
     """Helper routine to launch an arrayeditor and return its result."""
     dlg = ArrayEditor()
-    assert dlg.setup_and_check(data, title, xlabels=xlabels, ylabels=ylabels)
+    assert dlg.setup_and_check(data, title)
     dlg.show()
     dlg.accept()  # trigger slot connected to OK button
     return dlg.get_value()
@@ -185,16 +185,13 @@ def test_arrayeditor_with_record_array_with_titles(qtbot):
 
 def test_arrayeditor_with_float_array(qtbot):
     arr = np.random.rand(5, 5)
-    assert_array_equal(arr, launch_arrayeditor(arr, "float array",
-                                      xlabels=['a', 'b', 'c', 'd', 'e']))
+    assert_array_equal(arr, launch_arrayeditor(arr, "float array"))
 
 
 def test_arrayeditor_with_complex_array(qtbot):
     arr = np.round(np.random.rand(5, 5)*10)+\
                    np.round(np.random.rand(5, 5)*10)*1j
-    assert_array_equal(arr, launch_arrayeditor(arr, "complex array",
-                                      xlabels=np.linspace(-12, 12, 5),
-                                      ylabels=np.linspace(-12, 12, 5)))
+    assert_array_equal(arr, launch_arrayeditor(arr, "complex array"))
 
 
 def test_arrayeditor_with_bool_array(qtbot):
@@ -231,7 +228,7 @@ def test_arrayeditor_edit_1d_array(qtbot):
     exp_arr = np.array([1, 0, 2, 3, 4])
     arr = np.arange(0, 5)
     dlg = ArrayEditor()
-    assert dlg.setup_and_check(arr, '1D array', xlabels=None, ylabels=None)
+    assert dlg.setup_and_check(arr, '1D array')
     with qtbot.waitExposed(dlg):
         dlg.show()
     view = dlg.arraywidget.view
@@ -251,7 +248,7 @@ def test_arrayeditor_edit_2d_array(qtbot):
     arr = np.ones((3, 3))
     diff_arr = arr.copy()
     dlg = ArrayEditor()
-    assert dlg.setup_and_check(arr, '2D array', xlabels=None, ylabels=None)
+    assert dlg.setup_and_check(arr, '2D array')
     with qtbot.waitExposed(dlg):
         dlg.show()
     view = dlg.arraywidget.view
@@ -276,8 +273,7 @@ def test_arrayeditor_edit_complex_array(qtbot):
     cnum = -1+0.5j
     arr = (np.random.random((10, 10)) - 0.50) * cnum
     dlg = ArrayEditor()
-    assert dlg.setup_and_check(arr, '2D complex array', xlabels=None,
-                               ylabels=None)
+    assert dlg.setup_and_check(arr, '2D complex array')
     with qtbot.waitExposed(dlg):
         dlg.show()
     view = dlg.arraywidget.view
@@ -343,8 +339,7 @@ def test_arrayeditor_edit_overflow(qtbot, monkeypatch):
     for idx, int_type, bit_exponent in test_parameters:
         test_array = np.arange(0, 5).astype(int_type)
         dialog = ArrayEditor()
-        assert dialog.setup_and_check(test_array, '1D array',
-                                      xlabels=None, ylabels=None)
+        assert dialog.setup_and_check(test_array, '1D array')
         with qtbot.waitExposed(dialog):
             dialog.show()
         view = dialog.arraywidget.view

--- a/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
@@ -296,6 +296,24 @@ def test_arrayeditor_refresh_into_int(qtbot):
     mock_critical.assert_called_once()
 
 
+def test_arrayeditor_refresh_when_variable_deleted(qtbot):
+    """
+    Test that if the variable is deleted and then the editor is refreshed
+    (resulting in data_function raising a KeyError), a critical dialog box
+    is displayed and that the array editor is closed.
+    """
+    def datafunc():
+        raise KeyError
+    arr_ones = np.ones((3, 3))
+    dlg = ArrayEditor(data_function=datafunc)
+    dlg.setup_and_check(arr_ones, '2D array')
+    with patch('spyder.plugins.variableexplorer.widgets.arrayeditor'
+               '.QMessageBox.critical') as mock_critical, \
+         qtbot.waitSignal(dlg.rejected, timeout=0):
+        dlg.refresh_action.trigger()
+    mock_critical.assert_called_once()
+
+
 def test_arrayeditor_edit_1d_array(qtbot):
     exp_arr = np.array([1, 0, 2, 3, 4])
     arr = np.arange(0, 5)

--- a/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
@@ -237,8 +237,8 @@ def test_arrayeditor_refreshaction_disabled():
 
 def test_arrayeditor_refresh():
     """
-    Test that after pressing the refresh button, the value of the Array Editor
-    is replaced by the return value of the data_function.
+    Test that after pressing the refresh button, the value of the editor is
+    replaced by the return value of the data_function.
     """
     arr_ones = np.ones((3, 3))
     arr_zeros = np.zeros((4, 4))

--- a/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
@@ -446,8 +446,8 @@ def test_dataframeeditor_refreshaction_disabled():
 
 def test_dataframeeditor_refresh():
     """
-    Test that after pressing the refresh button, the value of the Array Editor
-    is replaced by the return value of the data_function.
+    Test that after pressing the refresh button, the value of the editor is
+    replaced by the return value of the data_function.
     """
     df_zero = DataFrame([[0]])
     df_new = DataFrame([[0, 10], [1, 20], [2, 40]])

--- a/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
@@ -129,13 +129,19 @@ def test_dataframe_to_type(qtbot):
     view = editor.dataTable
     view.setCurrentIndex(view.model().index(0, 0))
 
-    # Show context menu and select option `To bool`
+    # Show context menu, go down until `Convert to`, and open submenu
     view.menu.show()
-    qtbot.keyPress(view.menu, Qt.Key_Up)
-    qtbot.keyPress(view.menu, Qt.Key_Up)
-    qtbot.keyPress(view.menu, Qt.Key_Up)
-    qtbot.keyPress(view.menu, Qt.Key_Return)
-    submenu = view.menu.activeAction().menu()
+    for _ in range(100):
+        activeAction = view.menu.activeAction()
+        if activeAction and activeAction.text() == 'Convert to':
+            qtbot.keyPress(view.menu, Qt.Key_Return)
+            break
+        qtbot.keyPress(view.menu, Qt.Key_Down)
+    else:
+        raise RuntimeError('Item "Convert to" not found')
+
+    # Select first option, which is `To bool`
+    submenu = activeAction.menu()
     qtbot.keyPress(submenu, Qt.Key_Return)
     qtbot.wait(1000)
 

--- a/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
@@ -14,7 +14,7 @@ Tests for the dataframe editor.
 import os
 import sys
 from datetime import datetime
-from unittest.mock import Mock, ANY
+from unittest.mock import Mock, patch, ANY
 
 # Third party imports
 from flaky import flaky
@@ -23,6 +23,7 @@ from packaging.version import parse
 from pandas import (
     __version__ as pandas_version, DataFrame, date_range, read_csv, concat,
     Index, RangeIndex, MultiIndex, CategoricalIndex, Series)
+from pandas.testing import assert_frame_equal
 import pytest
 from qtpy.QtGui import QColor
 from qtpy.QtCore import Qt, QTimer
@@ -425,6 +426,90 @@ def test_dataframemodel_with_format_percent_d_and_nan():
     dfm = DataFrameModel(dataframe, format_spec='d')
     assert data(dfm, 0, 0) == '0'
     assert data(dfm, 1, 0) == 'nan'
+
+
+def test_dataframeeditor_refreshaction_disabled():
+    """
+    Test that the Refresh action is disabled by default.
+    """
+    df = DataFrame([[0]])
+    editor = DataFrameEditor(None)
+    editor.setup_and_check(df)
+    assert not editor.dataTable.refresh_action.isEnabled()
+
+
+def test_dataframeeditor_refresh():
+    """
+    Test that after pressing the refresh button, the value of the Array Editor
+    is replaced by the return value of the data_function.
+    """
+    df_zero = DataFrame([[0]])
+    df_new = DataFrame([[0, 10], [1, 20], [2, 40]])
+    editor = DataFrameEditor(data_function=lambda: df_new)
+    editor.setup_and_check(df_zero)
+    assert_frame_equal(editor.get_value(), df_zero)
+    assert editor.dataTable.refresh_action.isEnabled()
+    editor.dataTable.refresh_action.trigger()
+    assert_frame_equal(editor.get_value(), df_new)
+
+
+@pytest.mark.parametrize('result', [QMessageBox.Yes, QMessageBox.No])
+def test_dataframeeditor_refresh_after_edit(result):
+    """
+    Test that after changing a value in the editor, pressing the Refresh
+    button opens a dialog box (which asks for confirmation), and that the
+    editor is only refreshed if the user clicks Yes.
+    """
+    df_zero = DataFrame([[0]])
+    df_edited = DataFrame([[2]])
+    df_new = DataFrame([[0, 10], [1, 20], [2, 40]])
+    editor = DataFrameEditor(data_function=lambda: df_new)
+    editor.setup_and_check(df_zero)
+    model = editor.dataModel
+    model.setData(model.index(0, 0), '2')
+    with patch('spyder.plugins.variableexplorer.widgets.dataframeeditor'
+               '.QMessageBox.question',
+               return_value=result) as mock_question:
+        editor.dataTable.refresh_action.trigger()
+    mock_question.assert_called_once()
+    editor.accept()
+    if result == QMessageBox.Yes:
+        assert_frame_equal(editor.get_value(), df_new)
+    else:
+        assert_frame_equal(editor.get_value(), df_edited)
+
+
+def test_dataframeeditor_refresh_into_int(qtbot):
+    """
+    Test that if the value after refreshing is not a DataFrame but an integer,
+    a critical dialog box is displayed and that the editor is closed.
+    """
+    df_zero = DataFrame([[0]])
+    editor = DataFrameEditor(data_function=lambda: 1)
+    editor.setup_and_check(df_zero)
+    with patch('spyder.plugins.variableexplorer.widgets.dataframeeditor'
+               '.QMessageBox.critical') as mock_critical, \
+         qtbot.waitSignal(editor.rejected, timeout=0):
+        editor.dataTable.refresh_action.trigger()
+    mock_critical.assert_called_once()
+
+
+def test_dataframeeditor_refresh_when_variable_deleted(qtbot):
+    """
+    Test that if the variable is deleted and then the editor is refreshed
+    (resulting in data_function raising a KeyError), a critical dialog box
+    is displayed and that the dataframe editor is closed.
+    """
+    def datafunc():
+        raise KeyError
+    df_zero = DataFrame([[0]])
+    editor = DataFrameEditor(data_function=datafunc)
+    editor.setup_and_check(df_zero)
+    with patch('spyder.plugins.variableexplorer.widgets.dataframeeditor'
+               '.QMessageBox.critical') as mock_critical, \
+         qtbot.waitSignal(editor.rejected, timeout=0):
+        editor.dataTable.refresh_action.trigger()
+    mock_critical.assert_called_once()
 
 
 def test_change_format(qtbot, monkeypatch):

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -886,5 +886,14 @@ def register_app_launchservices(
     app.applicationStateChanged.connect(handle_applicationStateChanged)
 
 
+def safe_disconnect(signal):
+    """Disconnect a QtSignal, ignoring TypeError"""
+    try:
+        signal.disconnect()
+    except TypeError:
+        # Raised when no slots are connected to the signal
+        pass
+
+
 if __name__ == "__main__":
     show_std_icons()

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -887,7 +887,7 @@ def register_app_launchservices(
 
 
 def safe_disconnect(signal):
-    """Disconnect a QtSignal, ignoring TypeError"""
+    """Disconnect a Qt signal, ignoring TypeError."""
     try:
         signal.disconnect()
     except TypeError:

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -1335,7 +1335,8 @@ class CollectionsEditorTableView(BaseTableView):
         self.model = self.source_model
         self.setModel(self.source_model)
         self.delegate = CollectionsDelegate(
-            self, namespacebrowser, data_function)
+            self, namespacebrowser, data_function
+        )
         self.setItemDelegate(self.delegate)
 
         self.setup_table()
@@ -1458,7 +1459,8 @@ class CollectionsEditorWidget(QWidget):
                 self, data, readonly)
         else:
             self.editor = CollectionsEditorTableView(
-                self, data, namespacebrowser, data_function, readonly, title)
+                self, data, namespacebrowser, data_function, readonly, title
+            )
 
         toolbar = SpyderToolbar(parent=None, title='Editor toolbar')
         toolbar.setStyleSheet(str(PANES_TOOLBAR_STYLESHEET))
@@ -1472,7 +1474,8 @@ class CollectionsEditorWidget(QWidget):
             text=_('Refresh'),
             icon=ima.icon('refresh'),
             tip=_('Refresh editor with current value of variable in console'),
-            triggered=lambda: self.sig_refresh_requested.emit())
+            triggered=lambda: self.sig_refresh_requested.emit()
+        )
         toolbar.addAction(self.refresh_action)
 
         # Update the toolbar actions state
@@ -1540,7 +1543,8 @@ class CollectionsEditor(BaseDialog):
 
         self.widget = CollectionsEditorWidget(
             self, self.data_copy, self.namespacebrowser, self.data_function,
-            title=title, readonly=readonly, remote=remote)
+            title=title, readonly=readonly, remote=remote
+        )
         self.widget.sig_refresh_requested.connect(self.refresh_editor)
         self.widget.editor.source_model.sig_setting_data.connect(
             self.save_and_close_enable)
@@ -1605,8 +1609,11 @@ class CollectionsEditor(BaseDialog):
         try:
             new_value = self.data_function()
         except (IndexError, KeyError):
-            QMessageBox.critical(self, _('Collection editor'),
-                                 _('The variable no longer exists.'))
+            QMessageBox.critical(
+                self,
+                _('Collection editor'),
+                _('The variable no longer exists.')
+            )
             self.reject()
             return
 
@@ -1628,7 +1635,10 @@ class CollectionsEditor(BaseDialog):
         message = _('Refreshing the editor will overwrite the changes that '
                     'you made. Do you want to proceed?')
         result = QMessageBox.question(
-            self, _('Refresh collection editor?'), message)
+            self,
+            _('Refresh collections editor?'),
+            message
+        )
         return result == QMessageBox.Yes
 
 
@@ -1653,8 +1663,10 @@ class RemoteCollectionsDelegate(CollectionsDelegate):
             name = source_index.model().keys[source_index.row()]
             self.parent().new_value(name, value)
 
-    def make_data_function(self, index: QModelIndex
-                           ) -> Optional[Callable[[], Any]]:
+    def make_data_function(
+        self,
+        index: QModelIndex
+    ) -> Optional[Callable[[], Any]]:
         """
         Construct function which returns current value of data.
 

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -24,6 +24,7 @@ import io
 import re
 import sys
 import warnings
+from typing import Any, Callable, Optional
 
 # Third party imports
 from qtpy.compat import getsavefilename, to_qvariant
@@ -1594,6 +1595,36 @@ class RemoteCollectionsDelegate(CollectionsDelegate):
             source_index = index.model().mapToSource(index)
             name = source_index.model().keys[source_index.row()]
             self.parent().new_value(name, value)
+
+    def make_data_function(self, index: QModelIndex
+                           ) -> Optional[Callable[[], Any]]:
+        """
+        Construct function which returns current value of data.
+
+        The returned function uses the associated console to retrieve the
+        current value of the variable. This is used to refresh editors created
+        from that variable.
+
+        Parameters
+        ----------
+        index : QModelIndex
+            Index of item whose current value is to be returned by the
+            function constructed here.
+
+        Returns
+        -------
+        Optional[Callable[[], Any]]
+            Function which returns the current value of the data, or None if
+            such a function cannot be constructed.
+        """
+        source_index = index.model().mapToSource(index)
+        name = source_index.model().keys[source_index.row()]
+        parent = self.parent()
+
+        def get_data():
+            return parent.get_value(name)
+
+        return get_data
 
 
 class RemoteCollectionsEditorTableView(BaseTableView):

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -1317,6 +1317,7 @@ class CollectionsEditorTableView(BaseTableView):
     """CollectionsEditor table view"""
 
     def __init__(self, parent, data, namespacebrowser=None,
+                 data_function: Optional[Callable[[], Any]] = None,
                  readonly=False, title="", names=False):
         BaseTableView.__init__(self, parent)
         self.dictfilter = None
@@ -1333,7 +1334,8 @@ class CollectionsEditorTableView(BaseTableView):
         )
         self.model = self.source_model
         self.setModel(self.source_model)
-        self.delegate = CollectionsDelegate(self, namespacebrowser)
+        self.delegate = CollectionsDelegate(
+            self, namespacebrowser, data_function)
         self.setItemDelegate(self.delegate)
 
         self.setup_table()
@@ -1456,7 +1458,7 @@ class CollectionsEditorWidget(QWidget):
                 self, data, readonly)
         else:
             self.editor = CollectionsEditorTableView(
-                self, data, namespacebrowser, readonly, title)
+                self, data, namespacebrowser, data_function, readonly, title)
 
         toolbar = SpyderToolbar(parent=None, title='Editor toolbar')
         toolbar.setStyleSheet(str(PANES_TOOLBAR_STYLESHEET))
@@ -1602,7 +1604,7 @@ class CollectionsEditor(BaseDialog):
 
         try:
             new_value = self.data_function()
-        except KeyError:
+        except (IndexError, KeyError):
             QMessageBox.critical(self, _('Collection editor'),
                                  _('The variable no longer exists.'))
             self.reject()
@@ -1610,7 +1612,8 @@ class CollectionsEditor(BaseDialog):
 
         self.widget.set_data(new_value)
         self.data_copy = new_value
-        self.btn_save_and_close.setEnabled(False)
+        if self.btn_save_and_close:
+            self.btn_save_and_close.setEnabled(False)
         self.btn_close.setAutoDefault(True)
         self.btn_close.setDefault(True)
 

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -565,6 +565,23 @@ def test_collectioneditor_refresh_when_variable_deleted(qtbot):
     mock_critical.assert_called_once()
 
 
+def test_collectioneditor_refresh_nested():
+    """
+    Open an editor for a list with a tuple nested inside, and then open another
+    editor for the nested tuple. Test that refreshing the second editor works.
+    """
+    old_list = [1, 2, 3, (4, 5)]
+    new_list = [1, 2, 3, (4,)]
+    editor = CollectionsEditor(None, data_function=lambda: new_list)
+    editor.setup(old_list)
+    view = editor.widget.editor
+    view.edit(view.model.index(3, 3))
+    nested_editor = list(view.delegate._editors.values())[0]['editor']
+    assert nested_editor.get_value() == (4, 5)
+    nested_editor.widget.refresh_action.trigger()
+    assert nested_editor.get_value() == (4,)
+
+
 def test_edit_datetime(monkeypatch):
     """
     Test datetimes are editable and NaT values are correctly handled.

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -265,6 +265,25 @@ def test_filter_rows(qtbot):
     assert editor.model.rowCount() == 0
 
 
+def test_remote_make_data_function():
+    """
+    Test that the function returned by make_data_function() ...
+    """
+    variables = {'a': {'type': 'int',
+                       'size': 1,
+                       'view': '1',
+                       'python_type': 'int',
+                       'numpy_type': 'Unknown'}}
+    mock_shellwidget = Mock()
+    editor = RemoteCollectionsEditorTableView(
+        None, variables, mock_shellwidget)
+    index = editor.model.index(0, 0)
+    data_function = editor.delegate.make_data_function(index)
+    value = data_function()
+    mock_shellwidget.get_value.assert_called_once_with('a')
+    assert value == mock_shellwidget.get_value.return_value
+
+
 def test_create_dataframeeditor_with_correct_format(qtbot):
     df = pandas.DataFrame(['foo', 'bar'])
     editor = CollectionsEditorTableView(None, {'df': df})

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -267,7 +267,8 @@ def test_filter_rows(qtbot):
 
 def test_remote_make_data_function():
     """
-    Test that the function returned by make_data_function() ...
+    Test that the function returned by make_data_function() is the expected
+    one.
     """
     variables = {'a': {'type': 'int',
                        'size': 1,
@@ -276,7 +277,8 @@ def test_remote_make_data_function():
                        'numpy_type': 'Unknown'}}
     mock_shellwidget = Mock()
     editor = RemoteCollectionsEditorTableView(
-        None, variables, mock_shellwidget)
+        None, variables, mock_shellwidget
+    )
     index = editor.model.index(0, 0)
     data_function = editor.delegate.make_data_function(index)
     value = data_function()
@@ -508,8 +510,8 @@ def test_collectioneditorwidget_refresh_action_disabled():
 
 def test_collectioneditor_refresh():
     """
-    Test that after pressing the refresh button, the value of the Array Editor
-    is replaced by the return value of the data_function.
+    Test that after pressing the refresh button, the value of the editor is
+    replaced by the return value of the data_function.
     """
     old_list = [1, 2, 3, 4]
     new_list = [3, 1, 4, 1, 5]
@@ -524,7 +526,7 @@ def test_collectioneditor_refresh():
 @pytest.mark.parametrize('result', [QMessageBox.Yes, QMessageBox.No])
 def test_collectioneditor_refresh_after_edit(result):
     """
-    Test that after changing a value in the collection editor, refreshing the
+    Test that after changing a value in the collections editor, refreshing the
     editor opens a dialog box (which asks for confirmation), and that the
     editor is only refreshed if the user clicks Yes.
     """
@@ -551,15 +553,15 @@ def test_collectioneditor_refresh_when_variable_deleted(qtbot):
     """
     Test that if the variable is deleted and then the editor is refreshed
     (resulting in data_function raising a KeyError), a critical dialog box
-    is displayed and that the array editor is closed.
+    is displayed and that the editor is closed.
     """
     def datafunc():
         raise KeyError
     lst = [1, 2, 3, 4]
     editor = CollectionsEditor(None, data_function=datafunc)
     editor.setup(lst)
-    with patch('spyder.plugins.variableexplorer.widgets.arrayeditor'
-               '.QMessageBox.critical') as mock_critical, \
+    with patch('spyder.widgets.collectionseditor.QMessageBox'
+               '.critical') as mock_critical, \
          qtbot.waitSignal(editor.rejected, timeout=0):
         editor.widget.refresh_action.trigger()
     mock_critical.assert_called_once()


### PR DESCRIPTION
## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

This adds a Refresh button to the array editor, the dataframe editor, the collection editor and the object explorer. 

Clicking the Refresh button in the array editor refreshes the editor with the current value of the array variable:

https://github.com/spyder-ide/spyder/assets/7941918/a481ba3b-544b-4b93-8cc6-a6c43d4cd13b

The same for the dataframe editor:

https://github.com/spyder-ide/spyder/assets/7941918/ff8ba761-909b-407d-9fde-c45b03e59f70

The same for the collection editor:

https://github.com/spyder-ide/spyder/assets/7941918/15c51175-185e-454d-a0e0-5865196157e6

The same of the object explorer:

https://github.com/spyder-ide/spyder/assets/7941918/41e88831-63a9-4566-87c9-05832548b0a5

It is possible to refresh editors opened from the Variable Explorer or editors opened from other editors, so the user can for instance refresh an array nested inside a dictionary inside an object inside another object inside a list:

https://github.com/spyder-ide/spyder/assets/7941918/cbcf73d8-9488-48dc-8401-a164aa19b5d0

However, you can only refresh editors which ultimately originate from the Variable Explorer. For instance, you can open a collection editor from the IPython Console to display the contents of `sys.path`, but the Refresh button on that editor is disabled:

https://github.com/spyder-ide/spyder/assets/7941918/fe01b1bf-18bc-45e6-9a96-276c5e6b52d6

If the user changes a value in the editor and then refreshes, Spyder asks for confirmation:

https://github.com/spyder-ide/spyder/assets/7941918/ff0e2126-0ae2-4335-bca9-1640ae632ba1

If the new value can't be displayed in the array editor, for instance because the variable now contains an integer, then Spyder shows an error message and closes the array editor:

https://github.com/spyder-ide/spyder/assets/7941918/fc1c9947-be55-496e-a77c-5ab472f7ec82

The same happens if the variable no longer exists:

https://github.com/spyder-ide/spyder/assets/7941918/1d2b4d16-7ce0-46df-8a38-c818351e8f81

Note that in this case, the console displays an exception generated inside spyder-kernels. This is existing behaviour, the same happens in the current master if you open a variable in the Variable Explorer that no longer exists.

In the array editor, the UI changes depending on whether the array is a standard 2d array, a record array, a masked array or a 3d array. Refreshing the editor changes the UI if necessary:

https://github.com/spyder-ide/spyder/assets/7941918/7eeb33dc-d1dc-459e-9b70-f9aed79663cf

However, if the variable changes from an array to a dataframe, for instance, then the array editor will not transform into a dataframe editor. Instead, an informative message is displayed and the editor is closed, just as above where the array variable changed to an integer.

As part of this PR, I split the function which sets up the editors in two: one function for setting up the UI and one function for setting the value to be displayed. The first function is called only one, the second function is called when the editor is opened and when it is refreshed. I implemented the refresh functionality by passing another parameter, `data_function`, to the editors. Calling this function should return the current value of the variable; if `data_function` is `None` then the editor can't be refreshed.

The four editors (array, dataframe, collection and object) are all implemented differently, so the details of how to implement the refresh is also different in each case.

This PR removes the options `xlabels` and `ylabels` in the Array Editor. These can be used to change the column and row labels in the editor, but they are not currently used in Spyder. These options were added by Pierre in 2011. I could not find where they were used in the past, if they ever were, so I don't know their intended use. I don't know what to do when refreshing means that the size of the array changes, because then the number of labels also needs to change, so I chose to remove the options.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #6325 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
