### PR TITLE
Fix syntax in test_namespacebrowser.py for Python 3.8 and 3.9

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
@@ -216,12 +216,12 @@ def test_namespacebrowser_plot_with_mute_inline_plotting_true(
     mock_axis = Mock()
     mock_png = b'fake png'
 
-    with (patch('spyder.pyplot.subplots',
-                return_value=(mock_figure, mock_axis)),
-          patch('IPython.core.pylabtools.print_figure',
-                return_value=mock_png) as mock_print_figure,
-          qtbot.waitSignal(namespacebrowser.sig_show_figure_requested)
-          as blocker):
+    with patch('spyder.pyplot.subplots',
+               return_value=(mock_figure, mock_axis)), \
+         patch('IPython.core.pylabtools.print_figure',
+               return_value=mock_png) as mock_print_figure, \
+         qtbot.waitSignal(namespacebrowser.sig_show_figure_requested) \
+             as blocker:
         namespacebrowser.plot(my_list, 'plot')
 
     mock_axis.plot.assert_called_once_with(my_list)
@@ -239,9 +239,9 @@ def test_namespacebrowser_plot_with_mute_inline_plotting_false(namespacebrowser)
     namespacebrowser.set_conf('mute_inline_plotting', False, section='plots')
     my_list = [4, 2]
 
-    with (patch('spyder.pyplot.figure') as mock_figure,
-          patch('spyder.pyplot.plot') as mock_plot,
-          patch('spyder.pyplot.show') as mock_show):
+    with patch('spyder.pyplot.figure') as mock_figure, \
+         patch('spyder.pyplot.plot') as mock_plot, \
+         patch('spyder.pyplot.show') as mock_show:
         namespacebrowser.plot(my_list, 'plot')
 
     mock_figure.assert_called_once_with()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions) **N/A**
* [ ] Added unit test(s) covering the changes (if testable) **N/A**
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/)) **N/A**


This is a follow-up for PR #21235 which included a test that does not work under Python 3.8, as noted in https://github.com/spyder-ide/spyder/pull/21235#issuecomment-1712706071. This was not picked up by the automatic tests because of #21322.

Specifically, the `with (..., ...)` syntax was introduced in Python 3.10. Before, multiple context managers were possible but it had to be written without parentheses. Thus, this PR replace the parentheses with backslashes so that the test code works in Python 3.8 and 3.9.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
