### PR TITLE
PR: Fix Codesigning for the Installers and Run Workflow on Schedule

### DIFF
--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -6,10 +6,7 @@ on:
       - '**.gitrepo'
       - '.github/workflows/build-subrepos.yml'
 
-  pull_request:
-    paths:
-      - '**.gitrepo'
-      - '.github/workflows/build-subrepos.yml'
+  workflow_call:
 
   workflow_dispatch:
 

--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -4,9 +4,12 @@ on:
       - 'master'
     paths:
       - '**.gitrepo'
+      - '.github/workflows/build-subrepos.yml'
+
   pull_request:
     paths:
       - '**.gitrepo'
+      - '.github/workflows/build-subrepos.yml'
 
   workflow_dispatch:
 

--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -62,7 +62,10 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: installers-conda/build-environment.yml
-          create-args: python=${{ matrix.python-version }}
+          environment-name: spy-inst
+          create-args: >-
+            --channel-priority=strict
+            python=${{ matrix.python-version }}
           cache-downloads: true
           cache-environment: true
 

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -173,7 +173,7 @@ jobs:
           mamba search -c local --override-channels || true
 
       - name: Create Keychain
-        if: 'false'
+        if: runner.os == 'macOS' && (env.IS_RELEASE == 'true' || env.IS_PRE == 'true')
         run: |
           ./certkeychain.sh "${MACOS_CERTIFICATE_PWD}" "${MACOS_CERTIFICATE}" "${MACOS_INSTALLER_CERTIFICATE}"
           CNAME=$(security find-identity -p codesigning -v | pcre2grep -o1 "\(([0-9A-Z]+)\)")
@@ -271,7 +271,7 @@ jobs:
           EXIT /B %ERRORLEVEL%
 
       - name: Notarize or Compute Checksum
-        if: 'false'
+        if: env.IS_RELEASE == 'true' || env.IS_PRE == 'true'
         run: |
           if [[ $RUNNER_OS == "macOS" ]]; then
               ./notarize.sh -p $APPLICATION_PWD $PKG_PATH

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'installers-conda/**'
       - '.github/workflows/installers-conda.yml'
-      - '.github/workflows/build-subrepos.yml'
       - 'requirements/*.yml'
       - 'MANIFEST.in'
 
@@ -86,11 +85,18 @@ jobs:
         echo "target_platform=[$target_platform]" >> $GITHUB_OUTPUT
         echo "include=[$include]" >> $GITHUB_OUTPUT
 
+  build-subrepos:
+    name: Build Subrepos
+    if: github.event_name == 'pull_request' || github.event == 'schedule' || (github.event_name == 'workflow_dispatch' && ! inputs.pre)
+    uses: ./.github/workflows/build-subrepos.yml
+
   build-installers:
     name: Build installer for ${{ matrix.target-platform }} Python-${{ matrix.python-version }}
+    if: ${{ ! failure() && ! cancelled() }}
     runs-on: ${{ matrix.os }}
     needs:
       - build-matrix
+      - build-subrepos
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -154,7 +154,10 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: installers-conda/build-environment.yml
-          create-args: python=${{ matrix.python-version }}
+          environment-name: spy-inst
+          create-args: >-
+            --channel-priority=strict
+            python=${{ matrix.python-version }}
           cache-downloads: true
           cache-environment: true
 

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -116,6 +116,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Remote SSH Connection
+        if: env.ENABLE_SSH == 'true'
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 10
+        with:
+          detached: true
+
       - name: Restore python-lsp-server Cache
         if: env.IS_STANDARD_PR == 'true'
         uses: actions/cache/restore@v3
@@ -279,16 +286,6 @@ jobs:
               cd $(dirname $PKG_PATH)
               echo $(sha256sum $PKG_NAME) > "${PKG_GLOB}-sha256sum.txt"
           fi
-
-      - name: Setup Remote SSH Connection
-        # Notes:
-        # 1. This only works for conda, probably because it has the necessary
-        #    MSYS2 packages to create the connection.
-        # 2. Check https://github.com/marketplace/actions/debugging-with-tmate for
-        #    usage.
-        if: failure() && env.ENABLE_SSH == 'true'
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 45
 
       - name: Upload Artifact
         if: env.IS_RELEASE == 'false'

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -1,4 +1,7 @@
 on:
+  schedule:
+    - cron: '30 6 * * *'
+
   pull_request:
     paths:
       - 'installers-conda/**'
@@ -6,10 +9,6 @@ on:
       - '.github/workflows/build-subrepos.yml'
       - 'requirements/*.yml'
       - 'MANIFEST.in'
-      - '**.bat'
-      - '**.py'
-      - '**.sh'
-      - '!**.md'
 
   release:
     types:
@@ -50,7 +49,7 @@ concurrency:
 name: Create conda-based installers for Windows, macOS, and Linux
 
 env:
-  IS_STANDARD_PR: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ! inputs.pre) }}
+  USE_SUBREPOS: ${{ github.event_name == 'pull_request' || github.event == 'schedule' || (github.event_name == 'workflow_dispatch' && ! inputs.pre) }}
   IS_RELEASE: ${{ github.event_name == 'release' }}
   IS_PRE: ${{ github.event_name == 'workflow_dispatch' && inputs.pre }}
   BUILD_MAC: ${{ github.event_name != 'workflow_dispatch' || inputs.mac }}
@@ -124,7 +123,7 @@ jobs:
           detached: true
 
       - name: Restore python-lsp-server Cache
-        if: env.IS_STANDARD_PR == 'true'
+        if: env.USE_SUBREPOS == 'true'
         uses: actions/cache/restore@v3
         with:
           path: installers-conda/build/conda-bld/**/*.tar.bz2
@@ -133,7 +132,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Restore qtconsole Cache
-        if: env.IS_STANDARD_PR == 'true'
+        if: env.USE_SUBREPOS == 'true'
         uses: actions/cache/restore@v3
         with:
           path: installers-conda/build/conda-bld/**/*.tar.bz2
@@ -142,7 +141,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Restore ${{ matrix.spyk-arch }} spyder-kernels Cache
-        if: env.IS_STANDARD_PR == 'true'
+        if: env.USE_SUBREPOS == 'true'
         uses: actions/cache/restore@v3
         with:
           path: installers-conda/build/conda-bld/**/*.tar.bz2

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -185,16 +185,16 @@ jobs:
       - name: Create Keychain
         if: runner.os == 'macOS' && (env.IS_RELEASE == 'true' || env.IS_PRE == 'true')
         run: |
-          ./certkeychain.sh "${MACOS_CERTIFICATE_PWD}" "${MACOS_CERTIFICATE}" "${MACOS_INSTALLER_CERTIFICATE}"
-          CNAME=$(security find-identity -p codesigning -v | pcre2grep -o1 "\(([0-9A-Z]+)\)")
-          echo "CNAME=$CNAME" >> $GITHUB_ENV
-
           _codesign=$(which codesign)
           if [[ $_codesign =~ ${CONDA_PREFIX}.* ]]; then
               # Find correct codesign
               echo "Moving $_codesign..."
               mv $_codesign ${_codesign}.bak
           fi
+
+          ./certkeychain.sh "${MACOS_CERTIFICATE_PWD}" "${MACOS_CERTIFICATE}" "${MACOS_INSTALLER_CERTIFICATE}"
+          CNAME=$(security find-identity -p codesigning -v | pcre2grep -o1 "\(([0-9A-Z]+)\)")
+          echo "CNAME=$CNAME" >> $GITHUB_ENV
 
       - name: Build Package Installer
         run: |

--- a/installers-conda/build-environment.yml
+++ b/installers-conda/build-environment.yml
@@ -4,10 +4,10 @@ channels:
   - conda-forge
 dependencies:
   - boa
-  - napari/label/bundle_tools_3::conda
-  - napari/label/bundle_tools_3::conda-standalone
-  - napari/label/bundle_tools_3::constructor
+  - conda
+  - conda-standalone
+  - constructor
   - gitpython
-  - napari/label/bundle_tools_3::menuinst
+  - menuinst
   - ruamel.yaml.jinja2
   - setuptools_scm

--- a/installers-conda/certkeychain.sh
+++ b/installers-conda/certkeychain.sh
@@ -61,6 +61,7 @@ fi
 log "Creating keychain $KEYCHAINFILE..."
 security create-keychain -p $KEY_PASS $KEYCHAIN
 security list-keychains -s $KEYCHAIN
+security set-keychain-settings -lut 21600 $KEYCHAIN
 security unlock-keychain -p $KEY_PASS $KEYCHAIN
 
 log "Importing certificate(s)..."


### PR DESCRIPTION
## Description of Changes

* Call `set-key-partition-list` after correcting the `codesign` executable path
* Set the keychain timeout
* Run the installer workflow daily at 06:30UTC
* Run the installer workflow for PRs only if relevant workflow files have changed
* Run the subrepo build workflow only on push to master or called from within the installer workflow.

The first two changes listed above seem to correct the issue where `codesign` would hang while replacing the signature for `conda.exe`, independently.

I suspect that a gui prompt is launched, waiting for user input and giving the appearance of hanging.
I think this may occur under two conditions:
* `set-key-partition-list` may have registered `.../spy-inst/bin/codesign` instead of `/usr/bin/codesign`, resulting in a gui prompt requesting user input (password).
* If the keychain locks, then a gui may be lauched requesting user input (password).

The fact that both the keychain timeout and the location of `set-key-partition-list` appear to resolve the issue _independently_ is strange (I tried each commit in isolation).
I would think that they each should be necessary but insufficient. 🤷🏼 

Also, I still don't understand how napari/packaging avoids this issue.
They do not use `set-key-partition-list` at all, just the timeout. In my investigations, the absence of `set-key-partition-list` does not work.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21302 
