### PR TITLE
PR: Fix Installer workflow on schedule and add badge to Readme

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -48,13 +48,13 @@ concurrency:
 name: Create conda-based installers for Windows, macOS, and Linux
 
 env:
-  USE_SUBREPOS: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && ! inputs.pre) }}
   IS_RELEASE: ${{ github.event_name == 'release' }}
-  IS_PRE: ${{ github.event_name == 'workflow_dispatch' && inputs.pre }}
+  ENABLE_SSH: ${{ github.event_name == 'workflow_dispatch' && inputs.ssh }}
   BUILD_MAC: ${{ github.event_name != 'workflow_dispatch' || inputs.mac }}
   BUILD_LNX: ${{ github.event_name != 'workflow_dispatch' || inputs.linux }}
   BUILD_WIN: ${{ github.event_name != 'workflow_dispatch' || inputs.win }}
-  ENABLE_SSH: ${{ github.event_name == 'workflow_dispatch' && inputs.ssh }}
+  USE_SUBREPOS: ${{ github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ! inputs.pre) }}
+  NOTARIZE: ${{ github.event_name == 'schedule' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.pre) }}
 
 jobs:
   build-matrix:
@@ -87,7 +87,8 @@ jobs:
 
   build-subrepos:
     name: Build Subrepos
-    if: github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && ! inputs.pre)
+    # env.USE_SUBREPOS is not available at job level; must copy-paste here
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ! inputs.pre)
     uses: ./.github/workflows/build-subrepos.yml
 
   build-installers:
@@ -188,7 +189,7 @@ jobs:
           mamba search -c local --override-channels || true
 
       - name: Create Keychain
-        if: runner.os == 'macOS' && (env.IS_RELEASE == 'true' || env.IS_PRE == 'true')
+        if: runner.os == 'macOS' && env.NOTARIZE == 'true'
         run: |
           _codesign=$(which codesign)
           if [[ $_codesign =~ ${CONDA_PREFIX}.* ]]; then
@@ -286,7 +287,7 @@ jobs:
           EXIT /B %ERRORLEVEL%
 
       - name: Notarize or Compute Checksum
-        if: env.IS_RELEASE == 'true' || env.IS_PRE == 'true'
+        if: env.NOTARIZE == 'true'
         run: |
           if [[ $RUNNER_OS == "macOS" ]]; then
               ./notarize.sh -p $APPLICATION_PWD $PKG_PATH

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -48,7 +48,7 @@ concurrency:
 name: Create conda-based installers for Windows, macOS, and Linux
 
 env:
-  USE_SUBREPOS: ${{ github.event_name == 'pull_request' || github.event == 'schedule' || (github.event_name == 'workflow_dispatch' && ! inputs.pre) }}
+  USE_SUBREPOS: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && ! inputs.pre) }}
   IS_RELEASE: ${{ github.event_name == 'release' }}
   IS_PRE: ${{ github.event_name == 'workflow_dispatch' && inputs.pre }}
   BUILD_MAC: ${{ github.event_name != 'workflow_dispatch' || inputs.mac }}
@@ -87,7 +87,7 @@ jobs:
 
   build-subrepos:
     name: Build Subrepos
-    if: github.event_name == 'pull_request' || github.event == 'schedule' || (github.event_name == 'workflow_dispatch' && ! inputs.pre)
+    if: github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && ! inputs.pre)
     uses: ./.github/workflows/build-subrepos.yml
 
   build-installers:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/spyder-ide/spyder/badge.svg?branch=master)](https://coveralls.io/github/spyder-ide/spyder?branch=master)
 [![codecov](https://codecov.io/gh/spyder-ide/spyder/branch/master/graph/badge.svg)](https://codecov.io/gh/spyder-ide/spyder)
 [![Crowdin](https://badges.crowdin.net/spyder/localized.svg)](https://crowdin.com/project/spyder)
-[![Nightly Installer](https://github.com/mrclary/spyder/actions/workflows/installers-conda.yml/badge.svg?branch=master&event=schedule)](https://github.com/mrclary/spyder/actions/workflows/installers-conda.yml)
+[![Nightly Installers](https://github.com/mrclary/spyder/actions/workflows/installers-conda.yml/badge.svg?branch=master&event=schedule)](https://github.com/mrclary/spyder/actions/workflows/installers-conda.yml)
 
 ## Try Spyder online
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@
 [![PyPI status](https://img.shields.io/pypi/status/spyder.svg)](https://github.com/spyder-ide/spyder)
 
 ## Build status
+
 [![Win](https://github.com/spyder-ide/spyder/workflows/Win%20tests/badge.svg)](https://github.com/spyder-ide/spyder/actions?query=workflow%3A%22Win+tests%22)
 [![Mac](https://github.com/spyder-ide/spyder/workflows/Mac%20tests/badge.svg)](https://github.com/spyder-ide/spyder/actions?query=workflow%3A%22Mac+tests%22)
 [![Linux](https://github.com/spyder-ide/spyder/workflows/Linux%20tests/badge.svg)](https://github.com/spyder-ide/spyder/actions?query=workflow%3A%Linux+tests%22)
 [![Coverage Status](https://coveralls.io/repos/github/spyder-ide/spyder/badge.svg?branch=master)](https://coveralls.io/github/spyder-ide/spyder?branch=master)
 [![codecov](https://codecov.io/gh/spyder-ide/spyder/branch/master/graph/badge.svg)](https://codecov.io/gh/spyder-ide/spyder)
 [![Crowdin](https://badges.crowdin.net/spyder/localized.svg)](https://crowdin.com/project/spyder)
+[![Nightly Installer](https://github.com/mrclary/spyder/actions/workflows/installers-conda.yml/badge.svg?branch=master&event=schedule)](https://github.com/mrclary/spyder/actions/workflows/installers-conda.yml)
 
 ## Try Spyder online
 


### PR DESCRIPTION
* Fixed typo that prevented using subrepos on schedule trigger.
* Fixed logic to notarize on schedule trigger.
* Added status badge to repo landing page.

In addition to the status badge, scheduled workflow failures will trigger notifications to the last person to enable the workflow or set the cron schedule (currently @mrclary). This is set in the user's notification setttings of his/her GitHub profile.