### PR TITLE
Add an empty message to the Debugger pane

### DIFF
--- a/spyder/plugins/debugger/widgets/framesbrowser.py
+++ b/spyder/plugins/debugger/widgets/framesbrowser.py
@@ -131,7 +131,7 @@ class FramesBrowser(QWidget, SpyderWidgetMixin):
         if self.finder is None:
             return False
         return self.finder.isVisible()
-    
+
     def set_pane_empty(self, empty):
         if empty:
             self.stack_layout.setCurrentWidget(self.pane_empty)
@@ -154,7 +154,7 @@ class FramesBrowser(QWidget, SpyderWidgetMixin):
         self.finder.sig_find_text.connect(self.do_find)
         self.finder.sig_hide_finder_requested.connect(
             self.sig_hide_finder_requested)
-        
+
         # Widget empty pane
         self.pane_empty = PaneEmptyWidget(
             self,

--- a/spyder/plugins/debugger/widgets/framesbrowser.py
+++ b/spyder/plugins/debugger/widgets/framesbrowser.py
@@ -28,7 +28,7 @@ from spyder.api.config.fonts import SpyderFontsMixin, SpyderFontType
 from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.api.translations import _
-from spyder.widgets.helperwidgets import FinderWidget
+from spyder.widgets.helperwidgets import FinderWidget, PaneEmptyWidget
 
 
 class FramesBrowserState:
@@ -148,6 +148,17 @@ class FramesBrowser(QWidget, SpyderWidgetMixin):
         self.finder.sig_find_text.connect(self.do_find)
         self.finder.sig_hide_finder_requested.connect(
             self.sig_hide_finder_requested)
+        
+        # Widget empty pane
+        self.pane_empty = PaneEmptyWidget(
+            self,
+            "plots",
+            _("No plots to show"),
+            _("Run plot-generating code in the Editor or IPython console to "
+              "see your figures appear here. This pane only supports "
+              "static images, so it can't display interactive plots "
+              "like Bokeh, Plotly or Altair.")
+        )
 
         # Setup layout.
         layout = QVBoxLayout()

--- a/spyder/plugins/debugger/widgets/framesbrowser.py
+++ b/spyder/plugins/debugger/widgets/framesbrowser.py
@@ -159,9 +159,9 @@ class FramesBrowser(QWidget, SpyderWidgetMixin):
         self.pane_empty = PaneEmptyWidget(
             self,
             "debugger",
-            _("Not debugging right now"),
+            _("Debugging is not active"),
             _("Start a debugging session with the ⏯ button, allowing you to "
-              "step through your code and see the functions that "
+              "step through your code and see the functions here that "
               "Python has run.")
         )
 

--- a/spyder/plugins/debugger/widgets/framesbrowser.py
+++ b/spyder/plugins/debugger/widgets/framesbrowser.py
@@ -160,7 +160,9 @@ class FramesBrowser(QWidget, SpyderWidgetMixin):
             self,
             "debugger",
             _("Not debugging right now"),
-            _("Please come back later when we're actually debugging")
+            _("Start a debugging session with the ⏯ button, allowing you to "
+              "step through your code and see the functions that "
+              "Python has run.")
         )
 
         # Setup layout.


### PR DESCRIPTION
## Description of Changes
* [x] Added icons for panes: console-off, console-remote-off, debugger and dependencies.
* [x] Added widget to show empty pane in debugger while no debugging sessions are active.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:
@conradolandia 

![image](https://github.com/spyder-ide/spyder/assets/5027583/ffc2a0b5-348e-4416-ab88-0d87a3a7d4bd)


