### PR TITLE
PR: Move main and plugin windows to the primary screen if not in a visible location at startup

### DIFF
--- a/spyder/api/widgets/auxiliary_widgets.py
+++ b/spyder/api/widgets/auxiliary_widgets.py
@@ -40,6 +40,9 @@ class SpyderWindowWidget(QMainWindow):
         super().__init__()
         self.widget = widget
 
+        # To distinguish these windows from the main Spyder one
+        self.is_window_widget = True
+
         # Setting interface theme
         self.setStyleSheet(str(APP_STYLESHEET))
 

--- a/spyder/api/widgets/auxiliary_widgets.py
+++ b/spyder/api/widgets/auxiliary_widgets.py
@@ -14,10 +14,11 @@ from qtpy.QtWidgets import QMainWindow, QSizePolicy, QToolBar, QWidget
 
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
+from spyder.api.widgets.mixins import SpyderMainWindowMixin
 from spyder.utils.stylesheet import APP_STYLESHEET
 
 
-class SpyderWindowWidget(QMainWindow):
+class SpyderWindowWidget(QMainWindow, SpyderMainWindowMixin):
     """MainWindow subclass that contains a SpyderDockablePlugin."""
 
     # ---- Signals

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -773,6 +773,10 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
                 window.restoreGeometry(
                     QByteArray().fromHex(str(geometry).encode('utf-8'))
                 )
+
+                # Move to the primary screen if the window is not placed in a
+                # visible location.
+                window.move_to_primary_screen()
             except Exception:
                 pass
 

--- a/spyder/api/widgets/mixins.py
+++ b/spyder/api/widgets/mixins.py
@@ -15,8 +15,10 @@ Spyder API Mixins.
 from typing import Any, Optional, Dict
 
 # Third party imports
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QSizePolicy, QToolBar, QWidget, QToolButton
+from qtpy.QtCore import QPoint, Qt
+from qtpy.QtWidgets import (
+    QApplication, QMainWindow, QSizePolicy, QToolBar, QWidget, QToolButton
+)
 
 # Local imports
 from spyder.api.config.mixins import SpyderConfigurationObserver
@@ -608,3 +610,39 @@ class SpyderWidgetMixin(SpyderActionMixin, SpyderMenuMixin,
         change.
         """
         pass
+
+
+class SpyderMainWindowMixin:
+    """
+    Mixin with additional functionality for the QMainWindow's used in Spyder.
+    """
+
+    def _is_on_visible_screen(self: QMainWindow):
+        """Detect if the window is placed on a visible screen."""
+        x, y = self.geometry().x(), self.geometry().y()
+        qapp = QApplication.instance()
+        current_screen = qapp.screenAt(QPoint(x, y))
+
+        if current_screen is None:
+            return False
+        else:
+            return True
+
+    def move_to_primary_screen(self: QMainWindow):
+        """Move the window to the primary screen if necessary."""
+        if self._is_on_visible_screen():
+            return
+
+        qapp = QApplication.instance()
+        primary_screen_geometry = qapp.primaryScreen().availableGeometry()
+        x, y = primary_screen_geometry.x(), primary_screen_geometry.y()
+
+        if self.isMaximized():
+            self.showNormal()
+
+        self.move(QPoint(x, y))
+
+        # With this we want to maximize only the Spyder main window and not the
+        # plugin ones, which usually are not maximized.
+        if not hasattr(self, 'is_window_widget'):
+            self.showMaximized()

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -74,6 +74,7 @@ from spyder.app.utils import (
     set_opengl_implementation)
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
 from spyder.api.config.mixins import SpyderConfigurationAccessor
+from spyder.api.widgets.mixins import SpyderMainWindowMixin
 from spyder.config.base import (_, DEV, get_conf_path, get_debug_level,
                                 get_home_dir, is_pynsist, running_in_mac_app,
                                 running_under_pytest, STDERR)
@@ -123,7 +124,11 @@ qInstallMessageHandler(qt_message_handler)
 #==============================================================================
 # Main Window
 #==============================================================================
-class MainWindow(QMainWindow, SpyderConfigurationAccessor):
+class MainWindow(
+    QMainWindow,
+    SpyderMainWindowMixin,
+    SpyderConfigurationAccessor
+):
     """Spyder main window"""
     CONF_SECTION = 'main'
 
@@ -1031,6 +1036,10 @@ class MainWindow(QMainWindow, SpyderConfigurationAccessor):
         QApplication.processEvents()
         if self.splash is not None:
             self.splash.hide()
+
+        # Move the window to the primary screen if the previous location is not
+        # visible to the user.
+        self.move_to_primary_screen()
 
         # Call on_mainwindow_visible for all plugins, except Layout because it
         # needs to be called first (see above).


### PR DESCRIPTION
## Description of Changes

* This happened when:
    -  Spyder was closed in a screen which was not the primary one.
    - The location of that screen was changed by the user (e.g. from left to right of the primary one) before Spyder was opened again.
    - That caused Spyder to be placed in a non-visible region at startup.
* This PR detects if that's the case and moves Spyder automatically to the primary screen.
* It also does the same for undocked plugin windows.

### Issue(s) Resolved

Fixes #20344.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
