### PR TITLE
PR: Temporarily use Apple Developer ID Application Certificate for signing Windows installer

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -202,6 +202,16 @@ jobs:
           CNAME=$(security find-identity -p codesigning -v | pcre2grep -o1 "\(([0-9A-Z]+)\)")
           echo "CNAME=$CNAME" >> $GITHUB_ENV
 
+      - name: Load signing certificate (Windows)
+        if: runner.os == 'Windows' && env.NOTARIZE == 'true'
+        run: |
+          echo "${MACOS_CERTIFICATE}" > "${{ runner.temp }}/certificate.b64.txt"
+          certutil.exe -decode "${{ runner.temp }}/certificate.b64.txt" "${{ runner.temp }}/certificate.pfx"
+
+          echo "CONSTRUCTOR_SIGNING_CERTIFICATE=${{ runner.temp }}/certificate.pfx" >> $GITHUB_ENV
+          echo "CONSTRUCTOR_PFX_CERTIFICATE_PASSWORD=${MACOS_CERTIFICATE_PWD}" >> $GITHUB_ENV
+          echo "CONSTRUCTOR_SIGNTOOL_PATH=C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe" >> $GITHUB_ENV
+
       - name: Build Package Installer
         run: |
           [[ -n $CNAME ]] && args=("--cert-id" "$CNAME") || args=()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Use Apple Developer ID Application Certificate for signing Windows installer.
Eventually, a different certificate will be required for full Windows security compliance.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Partially addresses #21389 

