### PR TITLE
PR: Fix compatibility with Python 2 environments (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = 2.x
-	commit = 9687928c3733936301987c6b98d9182b032c6c7e
-	parent = d208136f8926d9ff968b5a6c8b7e516b378b29c2
+	commit = 53c95fe072d5f62e2a7b56906d3780cc3792b863
+	parent = 0639f5600cd9f2759040582b6b35ba32fb357591
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/comms/frontendcomm.py
+++ b/external-deps/spyder-kernels/spyder_kernels/comms/frontendcomm.py
@@ -24,6 +24,10 @@ from spyder_kernels.comms.commbase import CommBase, CommError
 from spyder_kernels.py3compat import TimeoutError, PY2
 
 
+if PY2:
+    import thread
+
+
 def get_free_port():
     """Find a free port on the local machine."""
     sock = socket.socket()
@@ -264,7 +268,7 @@ class FrontendComm(CommBase):
             current_stderr = sys.stderr
             saved_stdout_write = current_stdout.write
             saved_stderr_write = current_stderr.write
-            thread_id = threading.get_ident()
+            thread_id = thread.get_ident() if PY2 else threading.get_ident()
             current_stdout.write = WriteWrapper(
                 saved_stdout_write, call_name, thread_id)
             current_stderr.write = WriteWrapper(
@@ -300,7 +304,8 @@ class WriteWrapper(object):
 
     def __call__(self, string):
         """Print warning once."""
-        if self._thread_id != threading.get_ident():
+        thread_id = thread.get_ident() if PY2 else threading.get_ident()
+        if self._thread_id != thread_id:
             return self._write(string)
 
         if not self.is_benign_message(string):

--- a/external-deps/spyder-kernels/spyder_kernels/console/start.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/start.py
@@ -239,7 +239,8 @@ def kernel_config():
 
     # Disable the new mechanism to capture and forward low-level output
     # in IPykernel 6. For that we have Wurlitzer.
-    spy_cfg.IPKernelApp.capture_fd_output = False
+    if not PY2:
+        spy_cfg.IPKernelApp.capture_fd_output = False
 
     # Merge IPython and Spyder configs. Spyder prefs will have prevalence
     # over IPython ones


### PR DESCRIPTION
## Description of Changes

- This was broken in Spyder-kernels 2.4.0
- I tested with a Python 2 env and things are working as expected again (including plots with Matplotlib).
- Depends on spyder-ide/spyder-kernels#469

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21310.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
