### PR TITLE
PR: Fix calling the `%debug` magic after an error (IPython console)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -26,10 +26,6 @@ if [ "$USE_CONDA" = "true" ]; then
     # Remove pylsp before installing its subrepo below
     micromamba remove --force python-lsp-server python-lsp-server-base -y
 
-    # IPython 8.15 broke the %debug magic, which is used in some of our tests.
-    # So, pinning it to 8.14 for now.
-    micromamba install ipython=8.14
-
 else
     # Update pip and setuptools
     python -m pip install -U pip setuptools wheel build
@@ -51,10 +47,6 @@ else
         pip uninstall pyqt5 pyqt5-qt5 pyqt5-sip pyqtwebengine pyqtwebengine-qt5 -q -y
         pip install pyqt5==5.12.* pyqtwebengine==5.12.*
     fi
-
-    # IPython 8.15 broke the %debug magic, which is used in some of our tests.
-    # So, pinning it to 8.14 for now.
-    pip install ipython==8.14.0
 
 fi
 

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = 2.x
-	commit = 3d3791284093015f1ad09dd8f959f67bd11a356b
-	parent = 324cf7eab940e8681bcf4deb250772fc35ae192e
+	commit = 072c6cf31a0f438ee4122bfdd14a9cfcec37b69c
+	parent = 7628e5add6ead8ef3dcbfa3e5794363962ebc968
 	method = merge
 	cmdver = 0.4.3


### PR DESCRIPTION
## Description of Changes

This was broken in IPython 8.15+ due to the new support for chained exceptions in the debugger, which was introduced in that version.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21377

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
