### PR TITLE
PR: Catch error when trying to get mime type to set icon for files (Icon Manager)

### DIFF
--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -454,7 +454,14 @@ class IconManager():
 
         basename = osp.basename(fname)
         __, extension = osp.splitext(basename.lower())
-        mime_type, __ = mime.guess_type(basename)
+
+        # Catch error when it's not possible to access the Windows registry to
+        # check for this.
+        # Fixes spyder-ide/spyder#21304
+        try:
+            mime_type, __ = mime.guess_type(basename)
+        except PermissionError:
+            mime_type = None
 
         if osp.isdir(fname):
             extension = "Folder"


### PR DESCRIPTION
## Description of Changes

This happens when it's forbidden to access the Windows registry in the system to do that.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21304.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
