### PR TITLE
PR: Use `requests` instead of `urllib` for updates

### DIFF
--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -14,7 +14,7 @@ import traceback
 # Third party imports
 from qtpy.QtCore import QObject, Signal
 import requests
-from requests.adapters import SSLError, ConnectionError
+from requests.adapters import ConnectionError, SSLError
 
 # Local imports
 from spyder import __version__
@@ -27,13 +27,14 @@ from spyder.utils.programs import check_version, is_module_installed
 # Logger setup
 logger = logging.getLogger(__name__)
 
-ssl_error_msg = _(
-   'SSL certificate verification failed while checking for Spyder updates.<br><br>'
-    'Please contact your network administrator for assistance.'
+SSL_ERROR_MSG = _(
+    'SSL certificate verification failed while checking for Spyder updates.'
+    '<br><br>Please contact your network administrator for assistance.'
 )
-connect_error_msg = _(
-    'Unable to connect to the internet while checking for Spyder updates. <br><br>'
-    'Make sure the connection is working properly.'
+
+CONNECT_ERROR_MSG = _(
+    'Unable to connect to the internet while checking for Spyder updates.'
+    '<br><br>Make sure the connection is working properly.'
 )
 
 
@@ -140,10 +141,10 @@ class WorkerUpdates(QObject):
             result = self.check_update_available()
             self.update_available, self.latest_release = result
         except SSLError as err:
-            error_msg = ssl_error_msg
+            error_msg = SSL_ERROR_MSG
             logger.debug(err, stack_info=True)
         except ConnectionError as err:
-            error_msg = connect_error_msg
+            error_msg = CONNECT_ERROR_MSG
             logger.debug(err, stack_info=True)
         except Exception as err:
             error = traceback.format_exc()
@@ -278,10 +279,10 @@ class WorkerDownloadInstaller(QObject):
                 os.remove(self.installer_path)
             return
         except SSLError as err:
-            error_msg = ssl_error_msg
+            error_msg = SSL_ERROR_MSG
             logger.debug(err, stack_info=True)
         except ConnectionError as err:
-            error_msg = connect_error_msg
+            error_msg = CONNECT_ERROR_MSG
             logger.debug(err, stack_info=True)
         except Exception as err:
             error = traceback.format_exc()

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -28,11 +28,11 @@ from spyder.utils.programs import check_version, is_module_installed
 logger = logging.getLogger(__name__)
 
 ssl_error_msg = _(
-    'SSL certificate verification failed.<br><br>'
+   'SSL certificate verification failed while checking for Spyder updates.<br><br>'
     'Please contact your network administrator for assistance.'
 )
 connect_error_msg = _(
-    'Unable to connect to the internet. <br><br>'
+    'Unable to connect to the internet while checking for Spyder updates. <br><br>'
     'Make sure the connection is working properly.'
 )
 

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -244,31 +244,29 @@ class WorkerDownloadInstaller(QObject):
             return
 
         logger.debug(f"Downloading installer from {url} to {installer_path}")
-        with (
-            requests.get(url, stream=True) as r,
-            open(installer_path, 'wb') as f
-        ):
-            chunk_size = 8 * 1024
-            size = -1
-            size_read = 0
-            chunk_num = 0
+        with requests.get(url, stream=True) as r:
+            with open(installer_path, 'wb') as f:
+                chunk_size = 8 * 1024
+                size = -1
+                size_read = 0
+                chunk_num = 0
 
-            if "content-length" in r.headers:
-                size = int(r.headers["content-length"])
+                if "content-length" in r.headers:
+                    size = int(r.headers["content-length"])
 
-            self._progress_reporter(chunk_num, chunk_size, size)
-
-            for chunk in r.iter_content(chunk_size=chunk_size):
-                size_read += len(chunk)
-                f.write(chunk)
-                chunk_num += 1
                 self._progress_reporter(chunk_num, chunk_size, size)
 
-            if size >= 0 and size_read < size:
-                raise UpdateDownloadIncompleteError(
-                    "Download incomplete: retrieved only "
-                    f"{size_read} out of {size} bytes."
-                )
+                for chunk in r.iter_content(chunk_size=chunk_size):
+                    size_read += len(chunk)
+                    f.write(chunk)
+                    chunk_num += 1
+                    self._progress_reporter(chunk_num, chunk_size, size)
+
+                if size >= 0 and size_read < size:
+                    raise UpdateDownloadIncompleteError(
+                        "Download incomplete: retrieved only "
+                        f"{size_read} out of {size} bytes."
+                    )
 
     def start(self):
         """Main method of the WorkerDownloadInstaller worker."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->

* Replaced the use of `urllib.urlopen` and `urllib.urlrequest` with `requests.get` when checking and downloading updates.
* SSL certificates are now verified by default when checking for updates. This was already the default for downloading updates.
* Some error messaging was updated to reflect possible SSL certificate verification errors.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21398
