### PR TITLE
PR: Change name of workflow for conda-based installers

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -29,7 +29,7 @@ concurrency:
   group: installers-conda-${{ github.ref }}
   cancel-in-progress: true
 
-name: Conda-based installers
+name: Nightly conda-based installers
 
 env:
   IS_STANDARD_PR: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ! inputs.pre) }}

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -29,7 +29,7 @@ concurrency:
   group: installers-conda-${{ github.ref }}
   cancel-in-progress: true
 
-name: Create conda-based installers for Linux
+name: Conda-based installers
 
 env:
   IS_STANDARD_PR: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ! inputs.pre) }}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/spyder-ide/spyder/badge.svg?branch=master)](https://coveralls.io/github/spyder-ide/spyder?branch=master)
 [![codecov](https://codecov.io/gh/spyder-ide/spyder/branch/master/graph/badge.svg)](https://codecov.io/gh/spyder-ide/spyder)
 [![Crowdin](https://badges.crowdin.net/spyder/localized.svg)](https://crowdin.com/project/spyder)
+[![Conda-based installers](https://github.com/spyder-ide/spyder/actions/workflows/installers-conda.yml/badge.svg)](https://github.com/spyder-ide/spyder/actions/workflows/installers-conda.yml)
 
 ## Try Spyder online
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
 [![Coverage Status](https://coveralls.io/repos/github/spyder-ide/spyder/badge.svg?branch=master)](https://coveralls.io/github/spyder-ide/spyder?branch=master)
 [![codecov](https://codecov.io/gh/spyder-ide/spyder/branch/master/graph/badge.svg)](https://codecov.io/gh/spyder-ide/spyder)
 [![Crowdin](https://badges.crowdin.net/spyder/localized.svg)](https://crowdin.com/project/spyder)
-[![Conda-based installers](https://github.com/spyder-ide/spyder/actions/workflows/installers-conda.yml/badge.svg)](https://github.com/spyder-ide/spyder/actions/workflows/installers-conda.yml)
 
 ## Try Spyder online
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Change the name of the workflow for conda-based installers to be more generic. When merging into master, the name of the workflow should be adopted in master as well so that the workflow in both branches has the same `name` parameter.