### PR TITLE
PR: Improve how we get signatures and catch error when trying to do it for certain objects (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/ccordoba12/spyder-kernels.git
-	branch = sig-improvements
-	commit = cd347998c82e98ed68b47b71c34849d7fb090dc7
-	parent = bb2fc9a025927245ce00f2f5f2296bfa76585505
+	remote = https://github.com/spyder-ide/spyder-kernels.git
+	branch = 2.x
+	commit = 82eea9f77ac3cd3b7c6bdbd782de3dfb03a71d94
+	parent = efdd32e8f4534384b27c271b927b3e083e25f3d3
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = 2.x
-	commit = 70cb79e68a7e585fd4f97de78b57ba06f892a08e
-	parent = 3c59ce50ab7487b9559e160cf45c000b5f7a8fa2
+	remote = https://github.com/ccordoba12/spyder-kernels.git
+	branch = sig-improvements
+	commit = cd347998c82e98ed68b47b71c34849d7fb090dc7
+	parent = bb2fc9a025927245ce00f2f5f2296bfa76585505
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = 2.x
-	commit = 072c6cf31a0f438ee4122bfdd14a9cfcec37b69c
-	parent = 7628e5add6ead8ef3dcbfa3e5794363962ebc968
+	commit = 70cb79e68a7e585fd4f97de78b57ba06f892a08e
+	parent = 3c59ce50ab7487b9559e160cf45c000b5f7a8fa2
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_dochelpers.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_dochelpers.py
@@ -139,5 +139,22 @@ def test_multisignature():
     assert signature == "(x, y)"
 
 
+def test_multiline_signature():
+    """
+    Test that we can get signatures splitted into multiple lines in a
+    docstring.
+    """
+    def foo():
+        """
+        foo(x,
+            y)
+
+        This is a docstring.
+        """
+
+    signature = getargspecfromtext(foo.__doc__)
+    assert signature.startswith("(x, ")
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -345,14 +345,19 @@ class ApplicationContainer(PluginMainContainer):
 
                 if os.name == "nt":
                     if is_anaconda():
-                        msg += _("Run the following commands in the Anaconda "
-                                 "prompt to update manually:<br><br>")
+                        msg += _("Run the following command or commands in "
+                                 "the Anaconda prompt to update manually:"
+                                 "<br><br>")
                     else:
-                        msg += _("Run the following commands in a cmd prompt "
+                        msg += _("Run the following command in a cmd prompt "
                                  "to update manually:<br><br>")
                 else:
-                    msg += _("Run the following commands in a terminal to "
-                             "update manually:<br><br>")
+                    if is_anaconda():
+                        msg += _("Run the following command or commands in a "
+                                 "terminal to update manually:<br><br>")
+                    else:
+                        msg += _("Run the following command in a terminal to "
+                                 "update manually:<br><br>")
 
                 if is_anaconda():
                     channel, __ = get_spyder_conda_channel()

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -93,6 +93,12 @@ def test_banners(ipyconsole, qtbot):
      ("np.where",  # Python gives an error when getting its signature
       ["condition", "/"],
       ["Return elements chosen from `x`"]),
+     ("np.array",  # Signature is splitted into several lines
+      ["object", "dtype=None"],
+      ["Create an array.<br><br>", "Parameters"]),
+     ("np.linalg.norm",  # Includes IPython default signature in inspect reply
+      ["x", "ord=None"],
+      ["Matrix or vector norm"]),
      ("range",  # Check we display the first signature among several
       ["stop"],
       ["range(stop) -> range object"]),

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -77,21 +77,34 @@ def test_banners(ipyconsole, qtbot):
 
 @flaky(max_runs=3)
 @pytest.mark.parametrize(
-    "function,signature,documentation",
-    [("arange",
+    "function, signature, documentation",
+    [("np.arange",  # Check we get the signature from the object's docstring
       ["start", "stop"],
       ["Return evenly spaced values within a given interval.<br>",
        "open interval ..."]),
-     ("vectorize",
+     ("np.vectorize",  # Numpy function with a proper signature
       ["pyfunc", "otype", "signature"],
       ["Returns an object that acts like pyfunc, but takes arrays as<br>input."
        "<br>",
        "Define a vectorized function which takes a nested sequence ..."]),
-     ("absolute",
+     ("np.abs",  # np.abs has the same signature as np.absolute
       ["x", "/", "out"],
-      ["Parameters<br>", "x : array_like ..."])]
-    )
-@pytest.mark.skipif(not os.name == 'nt',
+      ["Calculate the absolute value"]),
+     ("np.where",  # Python gives an error when getting its signature
+      ["condition", "/"],
+      ["Return elements chosen from `x`"]),
+     ("range",  # Check we display the first signature among several
+      ["stop"],
+      ["range(stop) -> range object"]),
+     ("dict",  # Check we skip an empty signature
+      ["mapping"],
+      ["dict() -> new empty dictionary"]),
+     ("foo",  # Check we display the right tooltip for interactive objects
+      ["x", "y"],
+      ["My function"])
+    ]
+)
+@pytest.mark.skipif(running_in_ci() and not os.name == 'nt',
                     reason="Times out on macOS and fails on Linux")
 @pytest.mark.skipif(parse(np.__version__) < parse('1.25.0'),
                     reason="Documentation for np.vectorize is different")
@@ -104,10 +117,22 @@ def test_get_calltips(ipyconsole, qtbot, function, signature, documentation):
     with qtbot.waitSignal(shell.executed):
         shell.execute('import numpy as np')
 
+    if function == "foo":
+        with qtbot.waitSignal(shell.executed):
+            code = dedent('''
+            def foo(x, y):
+                """
+                My function
+                """
+                return x + y
+            ''')
+
+            shell.execute(code)
+
     # Write an object in the console that should generate a calltip
     # and wait for the kernel to send its response.
     with qtbot.waitSignal(shell.kernel_client.shell_channel.message_received):
-        qtbot.keyClicks(control, 'np.' + function + '(')
+        qtbot.keyClicks(control, function + '(')
 
     # Wait a little bit for the calltip to appear
     qtbot.waitUntil(lambda: control.calltip_widget.isVisible())

--- a/spyder/plugins/ipythonconsole/widgets/help.py
+++ b/spyder/plugins/ipythonconsole/widgets/help.py
@@ -16,7 +16,6 @@ import re
 from pickle import UnpicklingError
 from qtconsole.ansi_code_processor import ANSI_OR_SPECIAL_PATTERN, ANSI_PATTERN
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
-from qtpy.QtCore import QEventLoop
 
 # Local imports
 from spyder_kernels.utils.dochelpers import (getargspecfromtext,
@@ -42,23 +41,29 @@ class HelpWidget(RichJupyterWidget):
         """Get documentation from inspect reply content."""
         data = content.get('data', {})
         text = data.get('text/plain', '')
+
         if text:
-            if (self.language_name is not None
-                    and self.language_name == 'python'):
+            if (
+                self.language_name is not None
+                and self.language_name == 'python'
+            ):
                 text = re.compile(ANSI_PATTERN).sub('', text)
                 signature = self.get_signature(content).split('(')[-1]
 
                 # Base value for the documentation
-                documentation = (text.split('Docstring:')[-1].
-                                 split('Type:')[0].split('File:')[0])
+                documentation = (
+                    text.split('Docstring:')[-1].split('Type:')[0].
+                    split('File:')[0]
+                )
 
                 if signature:
                     # Check if the signature is in the Docstring
                     doc_from_signature = documentation.split(signature)
                     if len(doc_from_signature) > 1:
-                        return (doc_from_signature[-1].split('Docstring:')[-1].
-                                split('Type:')[0].
-                                split('File:')[0]).strip('\r\n')
+                        return (
+                            doc_from_signature[-1].split('Docstring:')[-1].
+                            split('Type:')[0].split('File:')[0]
+                        ).strip('\r\n')
 
                 return documentation.strip('\r\n')
             else:
@@ -71,6 +76,7 @@ class HelpWidget(RichJupyterWidget):
         """Get signature from text using a given function name."""
         signature = ''
         argspec = getargspecfromtext(text)
+
         if argspec:
             # This covers cases like np.abs, whose docstring is
             # the same as np.absolute and because of that a proper
@@ -78,15 +84,19 @@ class HelpWidget(RichJupyterWidget):
             signature = name + argspec
         else:
             signature = getsignaturefromtext(text, name)
+
         return signature
 
     def get_signature(self, content):
         """Get signature from inspect reply content"""
         data = content.get('data', {})
         text = data.get('text/plain', '')
+
         if text:
-            if (self.language_name is not None
-                    and self.language_name == 'python'):
+            if (
+                self.language_name is not None
+                and self.language_name == 'python'
+            ):
                 self._control.current_prompt_pos = self._prompt_pos
                 line = self._control.get_current_line_to_cursor()
                 name = line[:-1].split('(')[-1]   # Take last token after a (
@@ -156,14 +166,19 @@ class HelpWidget(RichJupyterWidget):
         """
         cursor = self._get_cursor()
         info = self._request_info.get('call_tip')
-        if (info and info.id == rep['parent_header']['msg_id'] and
-                info.pos == cursor.position()):
+
+        if (
+            info
+            and info.id == rep['parent_header']['msg_id']
+            and info.pos == cursor.position()
+        ):
             content = rep['content']
             if content.get('status') == 'ok' and content.get('found', False):
                 signature = self.get_signature(content)
                 documentation = self.get_documentation(content)
                 new_line = (self.language_name is not None
                             and self.language_name == 'python')
+
                 self._control.show_calltip(
                     signature,
                     documentation=documentation,

--- a/spyder/workers/tests/test_update.py
+++ b/spyder/workers/tests/test_update.py
@@ -4,6 +4,8 @@
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
 
+import sys
+
 import pytest
 
 from spyder.workers.updates import WorkerUpdates
@@ -48,6 +50,7 @@ def test_updates(qtbot, mocker, is_anaconda, is_pypi, version,
     assert len(worker.releases) == 1
 
 
+@pytest.mark.skipif(sys.platform == 'darwin', reason="Fails frequently on Mac")
 @pytest.mark.parametrize("version", ["1.0.0", "1000.0.0"])
 def test_updates_for_installers(qtbot, mocker, version):
     """


### PR DESCRIPTION
## Description of Changes

- Improve how we get signatures from the kernel inspect replies (the previous code was not working as expected).
- Fix error for objects (e.g. `numpy.where`) for which Python gives an error when trying to get their signature with `inspect.signature`.
- Make some small followup improvements after #21402.
- Depends on spyder-ide/spyder-kernels#473.
- Depends on spyder-ide/spyder-kernels#474.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21148

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
