### PR TITLE
PR: Fix issue where statusbar status was not updated properly after checking for updates

### DIFF
--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -290,7 +290,14 @@ class ApplicationContainer(PluginMainContainer):
             box.setText(error_msg)
             box.set_check_visible(False)
             box.show()
+            if self.application_update_status:
+                self.application_update_status.set_no_status()
+
         elif update_available:
+            if self.application_update_status:
+                self.application_update_status.set_status_pending(
+                    latest_release)
+
             # Update using our installers
             if (
                 not sys.platform.startswith("linux")

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -292,7 +292,6 @@ class ApplicationContainer(PluginMainContainer):
             box.show()
             if self.application_update_status:
                 self.application_update_status.set_no_status()
-
         elif update_available:
             if self.application_update_status:
                 self.application_update_status.set_status_pending(


### PR DESCRIPTION
Fix an issue where the statusbar status "Checking for updates..." would persist after `WorkerUpdates` completed. See: https://github.com/spyder-ide/spyder/pull/21423#issuecomment-1762232364
