### PR TITLE
PR: Avoid pydev warning under all circumstances (Online help)

### DIFF
--- a/spyder/plugins/onlinehelp/widgets.py
+++ b/spyder/plugins/onlinehelp/widgets.py
@@ -23,7 +23,6 @@ from qtpy.QtWidgets import QApplication, QLabel, QVBoxLayout
 # Local imports
 from spyder.api.translations import _
 from spyder.api.widgets.main_widget import PluginMainWidget
-from spyder.config.base import is_pynsist
 from spyder.plugins.onlinehelp.pydoc_patch import _start_server, _url_handler
 from spyder.widgets.browser import FrameWebView, WebViewActions
 from spyder.widgets.comboboxes import UrlComboBox
@@ -69,10 +68,9 @@ try:
 except Exception:
     pass
 
-# Needed to prevent showing a warning message regarding debugging
-# See spyder-ide/spyder#20390
-if is_pynsist():
-    os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
+# Needed to prevent showing a warning message regarding debugging.
+# Fixes spyder-ide/spyder#20390 and spyder-ide/spyder#21171
+os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
 
 
 class PydocServer(QThread):


### PR DESCRIPTION
## Description of Changes

This can also happen when Spyder is installed in a Python 3.11 environment besides our installer.

### Issue(s) Resolved

Fixes #21171.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
