### PR TITLE
PR: Avoid error when restarting external kernel (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -806,9 +806,13 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
                 # Aborting!
                 return
 
-            # Start autorestart mechanism
-            sw.kernel_manager.autorestart = True
-            sw.kernel_manager.start_restarter()
+            # Start autorestart mechanism.
+            # Note: We need to check for kernel_manager in case the kernel is
+            # not managed by us.
+            # Fixes spyder-ide/spyder#21165
+            if sw.kernel_manager:
+                sw.kernel_manager.autorestart = True
+                sw.kernel_manager.start_restarter()
 
             # For spyder-ide/spyder#6235, IPython was changing the
             # setting of %colors on windows by assuming it was using a


### PR DESCRIPTION
## Description of Changes

This happened when Spyder is connected to a kernel in JupyterLab and the user restart it there.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21165.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
