### PR TITLE
PR: Fix interface language auto-configuration

### DIFF
--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -385,14 +385,18 @@ def get_available_translations():
 
     # Check that there is a language code available in case a new translation
     # is added, to ensure LANGUAGE_CODES is updated.
+    retlangs = []
     for lang in langs:
         if lang not in LANGUAGE_CODES:
             if DEV:
                 error = ('Update LANGUAGE_CODES (inside config/base.py) if a '
-                         'new translation has been added to Spyder')
+                         'new translation has been added to Spyder. '
+                         'Currently missing ' + lang)
                 print(error)  # spyder: test-skip
-            return ['en']
-    return langs
+                return ['en']
+        else:
+            retlangs.append(lang)
+    return retlangs
 
 
 def get_interface_language():

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -360,11 +360,15 @@ LANGUAGE_CODES = {
     'zh_CN': u'简体中文',
     'ja': u'日本語',
     'de': u'Deutsch',
-    'pl': u'Polski'
+    'pl': u'Polski',
+    'fa': u'Persian',
+    'hr': u'Croatian',
+    'te': u'Telugu',
+    'uk': u'Ukrainian',
 }
 
 # Disabled languages because their translations are outdated or incomplete
-DISABLED_LANGUAGES = ['hu', 'pl']
+DISABLED_LANGUAGES = ['fa', 'hr', 'hu', 'pl', 'te', 'uk']
 
 
 def get_available_translations():


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [N/A] Wrote at least one-line docstrings (for any new functions)
* [N/A] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [N/A] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

The autoconfiguration of the language is currently completely broken: when starting spyder on a e.g. french-installed OS, spyder still displays english by default.

This is because `spyder/config/base.py`'s `get_available_translations()` currently always return `['en']`, because `LANGUAGE_CODES` is currently missing a few cases of `spyder/locale/`. One can of course just add the missing cases, but better just at least support autoconfiguring the cases which are in `LANGUAGE_CODES` rather than breaking them all (Except for developers, which do need to take notice of this).

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:

Samuel Thibault


