### PR TITLE
PR: Escape backslashes when replacing all occurrences of some text by another with them (Find/Replace)

### DIFF
--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -671,12 +671,19 @@ class FindReplace(QWidget):
         """Replace and find all matching occurrences"""
         if self.editor is None:
             return
-        replace_text = to_text_string(self.replace_text.currentText())
-        search_text = to_text_string(self.search_text.currentText())
+
+        replace_text = str(self.replace_text.currentText())
+        search_text = str(self.search_text.currentText())
         re_pattern = None
         case = self.case_button.isChecked()
         re_flags = re.MULTILINE if case else re.IGNORECASE | re.MULTILINE
         re_enabled = self.re_button.isChecked()
+
+        # Escape backslashes present in replace_text to avoid an error when
+        # using the regexp pattern below to perform the substitution.
+        # Fixes spyder-ide/spyder#21007.
+        replace_text = replace_text.replace('\\', r'\\')
+
         # Check regexp before proceeding
         if re_enabled:
             try:

--- a/spyder/widgets/tests/test_findreplace.py
+++ b/spyder/widgets/tests/test_findreplace.py
@@ -247,5 +247,43 @@ def test_clear_action(findreplace_editor, qtbot):
     assert not findreplace.messages_action.isVisible()
 
 
+def test_replace_all_backslash(findreplace_editor, qtbot):
+    """
+    Test that we can replace all occurrences of a certain text with an
+    expression that contains backslashes.
+
+    This is a regression test for issue spyder-ide/spyder#21007
+    """
+    editor = findreplace_editor.editor
+    findreplace = findreplace_editor.findreplace
+
+    # Replace all instances of | by \
+    editor.set_text("a | b | c")
+    edit = findreplace.search_text.lineEdit()
+    edit.setFocus()
+    qtbot.keyClicks(edit, '|')
+
+    findreplace.replace_text_button.setChecked(True)
+    findreplace.replace_text.setCurrentText('\\')
+    qtbot.wait(100)
+    findreplace.replace_find_all()
+    assert editor.toPlainText() == "a \\ b \\ c"
+
+    # Clear editor and edit
+    editor.selectAll()
+    qtbot.keyClick(edit, Qt.Key_Delete)
+    edit.clear()
+
+    # Replace all instances of \alpha by \beta
+    editor.set_text("\\Psi\n\\alpha\n\\beta\n\\alpha")
+    edit.setFocus()
+    qtbot.keyClicks(edit, "\\alpha")
+
+    findreplace.replace_text.setCurrentText('\\beta')
+    qtbot.wait(100)
+    findreplace.replace_find_all()
+    assert editor.toPlainText() == "\\Psi\n\\beta\n\\beta\n\\beta"
+
+
 if __name__ == "__main__":
     pytest.main([os.path.basename(__file__)])


### PR DESCRIPTION
## Description of Changes

- This problem happens when users try to replace all occurrences of some text by an expression that contains backslashes.
- Also, add a regression test for this case.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21007 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
