### PR TITLE
PR: Fix enabling/disabling individual providers (Completions)

### DIFF
--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -948,7 +948,15 @@ class CompletionPlugin(SpyderPluginV2):
         """Start a given provider."""
         provider_info = self.providers[provider_name]
         if provider_info['status'] == self.STOPPED:
-            provider_info['instance'].start()
+            provider_instance = provider_info['instance']
+            provider_instance.start()
+            for language in self.language_status:
+                language_providers = self.language_status[language]
+                language_providers[provider_name] = (
+                    provider_instance.start_completion_services_for_language(
+                        language
+                    )
+                )
 
     def shutdown_provider_instance(self, provider_name: str):
         """Shutdown a given provider."""
@@ -956,6 +964,10 @@ class CompletionPlugin(SpyderPluginV2):
         if provider_info['status'] == self.RUNNING:
             provider_info['instance'].shutdown()
             provider_info['status'] = self.STOPPED
+            for language in self.language_status:
+                language_providers = self.language_status[language]
+                if provider_name in language_providers:
+                    language_providers[provider_name] = False
 
     # ---------- Methods to create/access graphical elements -----------
     def create_action(self, *args, **kwargs):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->
The start and shutdown providers logic was missing updating the `language_status` attribute which is used to determine the providers that are available for a certain language. In the case of a completion request all responses for the available providers need to be aggregated, so all providers need to be waited before a response is made available. This caused that by disabling one of the providers no reponse was able to be retrieved but still that provider was expected to give a reponse

Also, there is some logic to handle a timeout but only the LSP provider is marked as slow and at least 3 providers need to be marked as slow to trigger the logic. For more details about that see:

https://github.com/spyder-ide/spyder/blob/6d531015aaf0a91cc88a8fab945832206b2d93ab/spyder/plugins/completion/plugin.py#L1038-L1044


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21462


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
