### PR TITLE
PR: Fix unchecking `Display variables and attributes` not updating tree (Outline explorer)

### DIFF
--- a/spyder/plugins/outlineexplorer/tests/test_widgets.py
+++ b/spyder/plugins/outlineexplorer/tests/test_widgets.py
@@ -217,6 +217,48 @@ def test_go_to_last_item(create_outlineexplorer, qtbot):
     assert outlineexplorer.treewidget.currentItem().text(0) == 'method1'
 
 
+@flaky(max_runs=10)
+def test_display_variables(create_outlineexplorer, qtbot):
+    """
+    Test that clicking on the 'Display variables and attributes' button located in the
+    toolbar of the outline explorer is working as expected by updating the tree widget.
+
+    Regression test for spyder-ide/spyder#21456.
+    """
+    outlineexplorer, _ = create_outlineexplorer('text')
+
+    editor = outlineexplorer.treewidget.current_editor
+    state = outlineexplorer.treewidget.display_variables
+
+    editor_id = editor.get_id()
+
+    initial_tree = outlineexplorer.treewidget.editor_tree_cache[editor_id]
+
+    # Click on the 'Display variables and attributes' button of the outline explorer's
+    # toolbar :
+    # qtbot.mouseClick(
+    #     TODO,
+    #     Qt.LeftButton)
+
+    outlineexplorer.treewidget.toggle_variables(not state)
+
+    first_toggle_tree = outlineexplorer.treewidget.editor_tree_cache[editor_id]
+
+    assert first_toggle_tree != initial_tree
+
+    # Click on the 'Display variables and attributes' button of the outline explorer's
+    # toolbar :
+    # qtbot.mouseClick(
+    #     TODO,
+    #     Qt.LeftButton)
+    outlineexplorer.treewidget.toggle_variables(state)
+
+    second_toggle_tree = outlineexplorer.treewidget.editor_tree_cache[editor_id]
+
+    assert (second_toggle_tree != first_toggle_tree) and (
+        second_toggle_tree == initial_tree)
+
+
 if __name__ == "__main__":
     import os
     pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])

--- a/spyder/plugins/outlineexplorer/tests/test_widgets.py
+++ b/spyder/plugins/outlineexplorer/tests/test_widgets.py
@@ -234,23 +234,12 @@ def test_display_variables(create_outlineexplorer, qtbot):
 
     initial_tree = outlineexplorer.treewidget.editor_tree_cache[editor_id]
 
-    # Click on the 'Display variables and attributes' button of the outline explorer's
-    # toolbar :
-    # qtbot.mouseClick(
-    #     TODO,
-    #     Qt.LeftButton)
-
     outlineexplorer.treewidget.toggle_variables(not state)
 
     first_toggle_tree = outlineexplorer.treewidget.editor_tree_cache[editor_id]
 
     assert first_toggle_tree != initial_tree
 
-    # Click on the 'Display variables and attributes' button of the outline explorer's
-    # toolbar :
-    # qtbot.mouseClick(
-    #     TODO,
-    #     Qt.LeftButton)
     outlineexplorer.treewidget.toggle_variables(state)
 
     second_toggle_tree = outlineexplorer.treewidget.editor_tree_cache[editor_id]

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -608,8 +608,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         if not must_update:
             # Compare with current tree to check if it's necessary to update
             # it.
-            changes = tree - current_tree
-            if tree and len(changes) == 0:
+            if tree and tree == current_tree:
                 logger.debug(
                     f"Current and new trees for file {editor.fname} are the "
                     f"same, so no update is necessary"

--- a/spyder/plugins/outlineexplorer/widgets.py
+++ b/spyder/plugins/outlineexplorer/widgets.py
@@ -608,7 +608,7 @@ class OutlineExplorerTreeWidget(OneColumnTree):
         if not must_update:
             # Compare with current tree to check if it's necessary to update
             # it.
-            if tree and tree == current_tree:
+            if tree == current_tree:
                 logger.debug(
                     f"Current and new trees for file {editor.fname} are the "
                     f"same, so no update is necessary"


### PR DESCRIPTION
## Description of Changes

This fixes https://github.com/spyder-ide/spyder/issues/21456 where unchecking "Display variables and attributes" in the outline does not work.

Issue debug log:
```
2023-10-31 11:28:00,930 [DEBUG] [spyder.plugins.editor.widgets.editor] -> Refresh EditorStack
2023-10-31 11:28:00,931 [DEBUG] [spyder.plugins.outlineexplorer.widgets] -> Set current editor to file /Users/remisalmon/test.py
2023-10-31 11:28:00,940 [DEBUG] [spyder.config.manager] -> Sending notification to observers of display_variables option in configuration section outline_explorer
2023-10-31 11:28:00,940 [DEBUG] [spyder.plugins.outlineexplorer.widgets] -> Current and new trees for file /Users/remisalmon/test.py are the same, so no update is necessary
```

I believe this uses the wrong operator from the `intervaltree` package where the difference operator does work as expected in this case:

with a file like:
```python
def function():
    return

x = 0
```
we get, after unchecking Display variables and attributes:
```
current_tree=IntervalTree([Interval(0, 3, ((0, 2), function, 0b7cc8e0-5ff3-4535-b9e9-aa01e97ba571, False)), Interval(3, 4, ((3, 3), x, deb51838-ac1c-457a-b0ab-ce8449fd1e14, False))])
tree=IntervalTree([Interval(0, 3, ((0, 2), function, bbd41a82-41b7-460f-b56f-d5fca0f1e6f8, False))])
tree - current_tree = IntervalTree()
tree == current_tree = False
```
(the difference returns an empty tree object but the trees are different)

Another fix would be to look at `changes = current_tree - tree` but we do not need the actual difference tree object `changes` so this makes the code simpler.

This also fixes an issue where the tree would not update when "Display variables and attributes" is checked and a variable or attribute is removed from the code.

Tested locally.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21456

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: remisamon

<!--- Thanks for your help making Spyder better for everyone! --->
