### PR TITLE
PR: Install QDarkstyle 3.2.0 on Linux pip slots (CI)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -26,10 +26,6 @@ if [ "$USE_CONDA" = "true" ]; then
     # Remove pylsp before installing its subrepo below
     micromamba remove --force python-lsp-server python-lsp-server-base -y
 
-    # IPython 8.15 broke the %debug magic, which is used in some of our tests.
-    # So, pinning it to 8.14 for now.
-    micromamba install ipython=8.14
-
 else
     # Update pip and setuptools
     python -m pip install -U pip setuptools wheel build
@@ -46,15 +42,14 @@ else
     # To check our manifest
     pip install -q check-manifest
 
-    # This allows the test suite to run more reliably on Linux
     if [ "$OS" = "linux" ]; then
+        # This allows the test suite to run more reliably on Linux
         pip uninstall pyqt5 pyqt5-qt5 pyqt5-sip pyqtwebengine pyqtwebengine-qt5 -q -y
         pip install pyqt5==5.12.* pyqtwebengine==5.12.*
-    fi
 
-    # IPython 8.15 broke the %debug magic, which is used in some of our tests.
-    # So, pinning it to 8.14 for now.
-    pip install ipython==8.14.0
+        # QDarkstyle 3.2.1 doesn't work with PyQt 5.12
+        pip install qdarkstyle==3.2
+    fi
 
 fi
 


### PR DESCRIPTION
## Description of Changes

That's because that version is compatible with PyQt 5.12, which is what we're using for testing on Linux.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
