### PR TITLE
PR: Fix syntax error over the completion plugin API (`SpyderCompletionProvider` class) (Completion)

### DIFF
--- a/spyder/plugins/completion/api.py
+++ b/spyder/plugins/completion/api.py
@@ -1347,7 +1347,7 @@ class SpyderCompletionProvider(QObject, CompletionConfigurationObserver):
         """
         self.main.create_menu(name, text=text, icon=icon)
 
-    def get_menu(name, context: Optional[str] = None,
+    def get_menu(self, name, context: Optional[str] = None,
                  plugin: Optional[str] = None):
         """Retrieve a menu by its id."""
         if context is None and plugin is None:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->

Missing `self` on the `get_menu` method of the `SpyderCompletionProvider`. Discovered while checking ways to generated an API reference to add to a new wiki page for an initial explanation of the Completion plugin API (https://github.com/spyder-ide/spyder/wiki/Dev:-SpyderCompletionProvider-API)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dathviz

<!--- Thanks for your help making Spyder better for everyone! --->
