### PR TITLE
PR: Remove comments from the function definition lines before generating docstrings

### DIFF
--- a/spyder/plugins/editor/extensions/docstring.py
+++ b/spyder/plugins/editor/extensions/docstring.py
@@ -120,6 +120,14 @@ def is_in_scope_backward(text):
         text.replace(r"\"", "").replace(r"\'", "")[::-1])
 
 
+def remove_comments(text):
+    """
+    Remove code comments from text while ignoring hash symbols (#) inside
+    quotes, which can be part of function arguments.
+    """
+    return re.sub(pattern=r"""(?<!['"])(#.*)""", repl="", string=text)
+
+
 class DocstringWriterExtension(object):
     """Class for insert docstring template automatically."""
 
@@ -194,6 +202,7 @@ class DocstringWriterExtension(object):
 
         for __ in range(min(remain_lines, 20)):
             cur_text = to_text_string(cursor.block().text()).rstrip()
+            cur_text = remove_comments(cur_text)
 
             if is_first_line:
                 if not is_start_of_function(cur_text):
@@ -239,6 +248,7 @@ class DocstringWriterExtension(object):
 
             cursor.movePosition(QTextCursor.PreviousBlock)
             prev_text = to_text_string(cursor.block().text()).rstrip()
+            prev_text = remove_comments(prev_text)
 
             if is_first_line:
                 if not self.is_end_of_function_definition(

--- a/spyder/plugins/editor/extensions/tests/test_docstring.py
+++ b/spyder/plugins/editor/extensions/tests/test_docstring.py
@@ -665,3 +665,60 @@ def test_docstring_line_break(editor_auto_docstring, text, expected):
     editor.writer_docstring.write_docstring_for_shortcut()
 
     assert editor.toPlainText() == expected
+
+
+@pytest.mark.parametrize(
+    'text, expected',
+    [
+        ('''  def test(v: str = "#"):  # comment, with '#' and "#"
+      ''',
+         '''  def test(v: str = "#"):  # comment, with '#' and "#"
+      """\n      \n
+      Parameters
+      ----------
+      v : str, optional
+          DESCRIPTION. The default is "#".
+
+      Returns
+      -------
+      None.
+
+      """
+      '''),
+        ('''  def test(v1: str = "#", # comment, with '#' and "#"
+         v2: str = '#') -> str:
+      ''',
+         '''  def test(v1: str = "#", # comment, with '#' and "#"
+         v2: str = '#') -> str:
+      """\n      \n
+      Parameters
+      ----------
+      v1 : str, optional
+          DESCRIPTION. The default is "#".
+      v2 : str, optional
+          DESCRIPTION. The default is '#'.
+
+      Returns
+      -------
+      str
+          DESCRIPTION.
+
+      """
+      '''),
+    ])
+def test_docstring_comments(editor_auto_docstring, text, expected):
+    """
+    Test auto docstring with comments on lines of function definition.
+    """
+    CONF.set('editor', 'docstring_type', 'Numpydoc')
+    editor = editor_auto_docstring
+    editor.set_text(text)
+
+    cursor = editor.textCursor()
+    cursor.movePosition(QTextCursor.NextBlock)
+    cursor.setPosition(QTextCursor.End, QTextCursor.MoveAnchor)
+    editor.setTextCursor(cursor)
+
+    editor.writer_docstring.write_docstring_for_shortcut()
+
+    assert editor.toPlainText() == expected


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Remove comments from the function definition lines before generating docstrings. Comments are removed, but # symbols inside quotes are kept as these might be default function arguments.

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Before:
![issue_before_fix](https://github.com/spyder-ide/spyder/assets/2330659/da0702c5-6e97-49b4-8e29-9939f5293f79)

With this PR:
![issue_after_fix](https://github.com/spyder-ide/spyder/assets/2330659/95406269-1bda-4265-8f08-d0165e31b21b)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21527


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @rhkarls 

<!--- Thanks for your help making Spyder better for everyone! --->
