### PR TITLE
PR: Fix KeyError issue with format in update worker

### DIFF
--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -154,7 +154,7 @@ class WorkerUpdates(QObject):
             error_msg = CONNECT_ERROR_MSG
             logger.debug(err, stack_info=True)
         except HTTPError as err:
-            error_msg = HTTP_ERROR_MSG.format(page.status_code)
+            error_msg = HTTP_ERROR_MSG.format(status_code=page.status_code)
             logger.debug(err, stack_info=True)
         except Exception as err:
             error = traceback.format_exc()


### PR DESCRIPTION
Added keyword argument to string format method in order to resolve `KeyError`.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21546
