### PR TITLE
PR: Pin IPykernel to 6.26.0, QDarkstyle to 3.2.0 and fix building the Linux installer (CI)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -26,6 +26,9 @@ if [ "$USE_CONDA" = "true" ]; then
     # Remove pylsp before installing its subrepo below
     micromamba remove --force python-lsp-server python-lsp-server-base -y
 
+    # Prevent error in a test for the %edit magic
+    micromamba install ipykernel=6.26.0 -q -y
+
 else
     # Update pip and setuptools
     python -m pip install -U pip setuptools wheel build
@@ -42,11 +45,17 @@ else
     # To check our manifest
     pip install -q check-manifest
 
-    # This allows the test suite to run more reliably on Linux
     if [ "$OS" = "linux" ]; then
+        # This allows the test suite to run more reliably on Linux
         pip uninstall pyqt5 pyqt5-qt5 pyqt5-sip pyqtwebengine pyqtwebengine-qt5 -q -y
         pip install pyqt5==5.12.* pyqtwebengine==5.12.*
+
+        # QDarkstyle 3.2.1 doesn't work with PyQt 5.12
+        pip install qdarkstyle==3.2
     fi
+
+    # Prevent error in a test for the %edit magic
+    pip install ipykernel==6.26.0
 
 fi
 

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -61,10 +61,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Build Environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: installers-conda/build-environment.yml
-          extra-specs: python=${{ matrix.python-version }}
+          create-args: python=${{ matrix.python-version }}
 
       - name: Build Conda Packages
         run: python build_conda_pkgs.py --build $pkg
@@ -127,10 +127,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Build Environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: installers-conda/build-environment.yml
-          extra-specs: python=${{ matrix.python-version }}
+          create-args: python=${{ matrix.python-version }}
 
       - name: Env Variables
         run: |

--- a/installers-conda/build-environment.yml
+++ b/installers-conda/build-environment.yml
@@ -7,5 +7,6 @@ dependencies:
   - conda-standalone
   - constructor
   - gitpython
+  - mamba
   - ruamel.yaml.jinja2
   - setuptools_scm


### PR DESCRIPTION
## Description of Changes

- This avoids IPykernel 6.27.0, which broke the `%edit` magic, and QDarkstyle 3.2.1, which doesn't work with PyQt 5.12.
- Also, fix failures with the Conda-based Linux installer.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
