### PR TITLE
PR: Add new options for font size and bottom edge for inline plot

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = master
-	commit = a24faa7ae3083f4247709481627aa97bf2a6efc0
-	parent = 3a083a611f2aa96cf3d7975d5af8a228948abc9a
+	commit = 66576a716f1dc0282ff3dc26ba5ce7c43ede852c
+	parent = 5fca910e11f69b1dc83f8d249c3a28b1b99ca3d6
 	method = merge
-	cmdver = 0.4.3
+	cmdver = 0.4.6

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -557,6 +557,8 @@ class SpyderKernel(IPythonKernel):
         resolution_n = 'pylab/inline/resolution'
         width_n = 'pylab/inline/width'
         height_n = 'pylab/inline/height'
+        fontsize_n = 'pylab/inline/fontsize'
+        bottom_n = 'pylab/inline/bottom'
         bbox_inches_n = 'pylab/inline/bbox_inches'
         inline_backend = 'inline'
 
@@ -579,6 +581,15 @@ class SpyderKernel(IPythonKernel):
             self._set_mpl_inline_rc_config(
                 'figure.figsize',
                 (conf[width_n], conf[height_n])
+            )
+
+        if fontsize_n in conf:
+            self._set_mpl_inline_rc_config('font.size', conf[fontsize_n])
+
+        if bottom_n in conf:
+            self._set_mpl_inline_rc_config(
+                'figure.subplot.bottom',
+                conf[bottom_n]
             )
 
         if bbox_inches_n in conf:

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 #
 # Copyright © Spyder Project Contributors
 # Licensed under the terms of the MIT License
@@ -151,6 +152,8 @@ DEFAULTS = [
               'pylab/inline/resolution': 72,
               'pylab/inline/width': 6,
               'pylab/inline/height': 4,
+              'pylab/inline/fontsize': 10.0,
+              'pylab/inline/bottom': 0.11,
               'pylab/inline/bbox_inches': True,
               'startup/run_lines': '',
               'startup/use_run_file': False,

--- a/spyder/plugins/ipythonconsole/confpage.py
+++ b/spyder/plugins/ipythonconsole/confpage.py
@@ -185,16 +185,15 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         inline_layout = QGridLayout()
         inline_layout.addWidget(format_box.label, 1, 0)
         inline_layout.addWidget(format_box.combobox, 1, 1)
-        inline_layout.addWidget(resolution_spin.plabel, 2, 0)
-        inline_layout.addWidget(resolution_spin.spinbox, 2, 1)
-        inline_layout.addWidget(resolution_spin.slabel, 2, 2)
-        inline_layout.addWidget(width_spin.plabel, 3, 0)
-        inline_layout.addWidget(width_spin.spinbox, 3, 1)
-        inline_layout.addWidget(width_spin.slabel, 3, 2)
-        inline_layout.addWidget(height_spin.plabel, 4, 0)
-        inline_layout.addWidget(height_spin.spinbox, 4, 1)
-        inline_layout.addWidget(height_spin.slabel, 4, 2)
-        inline_layout.addWidget(bbox_inches_box, 5, 0, 1, 4)
+
+        spinboxes = [resolution_spin, width_spin, height_spin]
+        for counter, spinbox in enumerate(spinboxes):
+            inline_layout.addWidget(spinbox.plabel, counter + 2, 0)
+            inline_layout.addWidget(spinbox.spinbox, counter + 2, 1)
+            inline_layout.addWidget(spinbox.slabel, counter + 2, 2)
+            inline_layout.addWidget(spinbox.help_label, counter + 2, 3)
+
+        inline_layout.addWidget(bbox_inches_box, len(spinboxes) + 2, 0, 1, 4)
 
         inline_h_layout = QHBoxLayout()
         inline_h_layout.addLayout(inline_layout)

--- a/spyder/plugins/ipythonconsole/confpage.py
+++ b/spyder/plugins/ipythonconsole/confpage.py
@@ -171,6 +171,18 @@ class IPythonConsoleConfigPage(PluginConfigPage):
                           _("Height:")+"  ", " "+_("inches"),
                           'pylab/inline/height', min_=1, max_=20, step=1,
                           tip=_("Default is 4"))
+        fontsize_spin = self.create_spinbox(
+                          _("Font size:")+"  ", " "+_("points"),
+                          'pylab/inline/fontsize', min_=5, max_=48, step=1.0,
+                          tip=_("Default is 10"))
+        bottom_spin = self.create_spinbox(
+                          _("Bottom edge:")+"  ",
+                          " "+_("of figure height"),
+                          'pylab/inline/bottom', min_=0, max_=0.3, step=0.01,
+                          tip=_("The position of the bottom edge of the "
+                                "subplots,\nas a fraction of the figure "
+                                "height.\nThe default is 0.11."))
+        bottom_spin.spinbox.setDecimals(2)
         bbox_inches_box = newcb(
             _("Use a tight layout for inline plots"),
             'pylab/inline/bbox_inches',
@@ -186,7 +198,8 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         inline_layout.addWidget(format_box.label, 1, 0)
         inline_layout.addWidget(format_box.combobox, 1, 1)
 
-        spinboxes = [resolution_spin, width_spin, height_spin]
+        spinboxes = [resolution_spin, width_spin, height_spin,
+                     fontsize_spin, bottom_spin]
         for counter, spinbox in enumerate(spinboxes):
             inline_layout.addWidget(spinbox.plabel, counter + 2, 0)
             inline_layout.addWidget(spinbox.spinbox, counter + 2, 1)

--- a/spyder/plugins/ipythonconsole/confpage.py
+++ b/spyder/plugins/ipythonconsole/confpage.py
@@ -172,16 +172,24 @@ class IPythonConsoleConfigPage(PluginConfigPage):
                           'pylab/inline/height', min_=1, max_=20, step=1,
                           tip=_("Default is 4"))
         fontsize_spin = self.create_spinbox(
-                          _("Font size:")+"  ", " "+_("points"),
-                          'pylab/inline/fontsize', min_=5, max_=48, step=1.0,
-                          tip=_("Default is 10"))
+            _("Font size:") + "  ",
+            " " + _("points"),
+            'pylab/inline/fontsize',
+            min_=5,
+            max_=48,
+            step=1.0,
+            tip=_("Default is 10")
+        )
         bottom_spin = self.create_spinbox(
-                          _("Bottom edge:")+"  ",
-                          " "+_("of figure height"),
-                          'pylab/inline/bottom', min_=0, max_=0.3, step=0.01,
-                          tip=_("The position of the bottom edge of the "
-                                "subplots,\nas a fraction of the figure "
-                                "height.\nThe default is 0.11."))
+            _("Bottom edge:") + "  ",
+            " " + _("of figure height"),
+            'pylab/inline/bottom',
+            min_=0,
+            max_=0.3,
+            step=0.01,
+            tip=_("The position of the bottom edge of the subplots,\nas a "
+                  "fraction of the figure height.\nThe default is 0.11.")
+        )
         bottom_spin.spinbox.setDecimals(2)
         bbox_inches_box = newcb(
             _("Use a tight layout for inline plots"),

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -17,6 +17,7 @@ import re
 import shutil
 import sys
 from textwrap import dedent
+from unittest.mock import patch
 
 # Third party imports
 from ipykernel._version import __version__ as ipykernel_version
@@ -1912,6 +1913,21 @@ def test_restart_intertactive_backend(ipyconsole, qtbot):
     qtbot.wait(1000)
     main_widget.change_possible_restart_and_mpl_conf('pylab/backend', 'tk')
     assert bool(os.environ.get('BACKEND_REQUIRE_RESTART'))
+
+
+def test_mpl_conf(ipyconsole, qtbot):
+    """
+    Test that after setting matplotlib-related config options, the member
+    function send_mpl_backend of the shellwidget is called with the new value.
+    """
+    main_widget = ipyconsole.get_widget()
+    client = main_widget.get_current_client()
+    with patch.object(client.shellwidget, 'send_mpl_backend') as mock:
+        main_widget.set_conf('pylab/inline/fontsize', 20.5)
+    mock.assert_called_once_with({'pylab/inline/fontsize': 20.5})
+    with patch.object(client.shellwidget, 'send_mpl_backend') as mock:
+        main_widget.set_conf('pylab/inline/bottom', 0.314)
+    mock.assert_called_once_with({'pylab/inline/bottom': 0.314})
 
 
 @flaky(max_runs=3)

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -871,6 +871,7 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
         'pylab', 'pylab/backend', 'pylab/autoload',
         'pylab/inline/figure_format', 'pylab/inline/resolution',
         'pylab/inline/width', 'pylab/inline/height',
+        'pylab/inline/fontsize', 'pylab/inline/bottom',
         'pylab/inline/bbox_inches'])
     def change_possible_restart_and_mpl_conf(self, option, value):
         """

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -564,6 +564,8 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
         resolution_n = 'pylab/inline/resolution'
         width_n = 'pylab/inline/width'
         height_n = 'pylab/inline/height'
+        fontsize_n = 'pylab/inline/fontsize'
+        bottom_n = 'pylab/inline/bottom'
         bbox_inches_n = 'pylab/inline/bbox_inches'
         backend_o = self.get_conf(pylab_backend_n)
 
@@ -590,6 +592,18 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
                     matplotlib_conf[width_n] = width_o
                 if height_o is not None:
                     matplotlib_conf[height_n] = height_o
+
+            # Font size
+            fontsize_o = float(self.get_conf(fontsize_n))
+            if fontsize_o is not None and (
+                    option is None or fontsize_n in option):
+                matplotlib_conf[fontsize_n] = fontsize_o
+
+            # Bottom part
+            bottom_o = float(self.get_conf(bottom_n))
+            if bottom_o is not None and (
+                    option is None or bottom_n in option):
+                matplotlib_conf[bottom_n] = bottom_o
 
             # Print figure kwargs
             bbox_inches_o = self.get_conf(bbox_inches_n)

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -595,14 +595,18 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
 
             # Font size
             fontsize_o = float(self.get_conf(fontsize_n))
-            if fontsize_o is not None and (
-                    option is None or fontsize_n in option):
+            if (
+                fontsize_o is not None
+                and (option is None or fontsize_n in option)
+            ):
                 matplotlib_conf[fontsize_n] = fontsize_o
 
             # Bottom part
             bottom_o = float(self.get_conf(bottom_n))
-            if bottom_o is not None and (
-                    option is None or bottom_n in option):
+            if (
+                bottom_o is not None
+                and (option is None or bottom_n in option)
+            ):
                 matplotlib_conf[bottom_n] = bottom_o
 
             # Print figure kwargs

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -479,6 +479,13 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
         import spyder.pyplot as plt
         from IPython.core.pylabtools import print_figure
 
+        try:
+            from matplotlib import rc_context
+        except ImportError:
+            # Ignore fontsize and bottom options if guiqwt is used
+            # as plotting library
+            from contextlib import nullcontext as rc_context
+
         if self.get_conf('pylab/inline/figure_format',
                          section='ipython_console') == 1:
             figure_format = 'svg'
@@ -497,11 +504,23 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
             bbox_inches = 'tight'
         else:
             bbox_inches = None
+        matplotlib_rc = {
+            'font.size': self.get_conf('pylab/inline/fontsize',
+                                       section='ipython_console'),
+            'figure.subplot.bottom': self.get_conf('pylab/inline/bottom',
+                                                   section='ipython_console')
+        }
 
-        fig, ax = plt.subplots(figsize=(width, height))
-        getattr(ax, funcname)(data)
-        image = print_figure(fig, fmt=figure_format, bbox_inches=bbox_inches,
-                             dpi=resolution)
+        with rc_context(matplotlib_rc):
+            fig, ax = plt.subplots(figsize=(width, height))
+            getattr(ax, funcname)(data)
+            image = print_figure(
+                fig,
+                fmt=figure_format,
+                bbox_inches=bbox_inches,
+                dpi=resolution
+            )
+
         if figure_format == 'svg':
             image = image.encode()
         self.sig_show_figure_requested.emit(image, mime_type, self.shellwidget)

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -504,6 +504,7 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
             bbox_inches = 'tight'
         else:
             bbox_inches = None
+
         matplotlib_rc = {
             'font.size': self.get_conf('pylab/inline/fontsize',
                                        section='ipython_console'),

--- a/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
@@ -231,6 +231,35 @@ def test_namespacebrowser_plot_with_mute_inline_plotting_true(
     assert blocker.args == expected_args
 
 
+def test_namespacebrowser_plot_options(namespacebrowser):
+    """
+    Test that font.size and figure.subplot.bottom in matplotlib.rcParams are
+    set to the values from the Spyder preferences when plotting.
+    """
+    def check_rc(*args):
+        from matplotlib import rcParams
+        assert rcParams['font.size'] == 20.5
+        assert rcParams['figure.subplot.bottom'] == 0.314
+
+    namespacebrowser.set_conf('mute_inline_plotting', True, section='plots')
+    namespacebrowser.plots_plugin_enabled = True
+    namespacebrowser.set_conf(
+        'pylab/inline/fontsize', 20.5, section='ipython_console')
+    namespacebrowser.set_conf(
+        'pylab/inline/bottom', 0.314, section='ipython_console')
+
+    mock_figure = Mock()
+    mock_axis = Mock()
+    mock_png = b'fake png'
+
+    with patch('spyder.pyplot.subplots',
+               return_value=(mock_figure, mock_axis)), \
+         patch('IPython.core.pylabtools.print_figure',
+               return_value=mock_png), \
+         patch.object(mock_axis, 'plot', check_rc):
+        namespacebrowser.plot([4, 2], 'plot')
+
+
 def test_namespacebrowser_plot_with_mute_inline_plotting_false(namespacebrowser):
     """
     Test that plotting a list from the namespace browser shows a plot if

--- a/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
@@ -244,9 +244,11 @@ def test_namespacebrowser_plot_options(namespacebrowser):
     namespacebrowser.set_conf('mute_inline_plotting', True, section='plots')
     namespacebrowser.plots_plugin_enabled = True
     namespacebrowser.set_conf(
-        'pylab/inline/fontsize', 20.5, section='ipython_console')
+        'pylab/inline/fontsize', 20.5, section='ipython_console'
+    )
     namespacebrowser.set_conf(
-        'pylab/inline/bottom', 0.314, section='ipython_console')
+        'pylab/inline/bottom', 0.314, section='ipython_console'
+    )
 
     mock_figure = Mock()
     mock_axis = Mock()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Add two new options, for the font size and the position of the bottom edge, for inline plots in the IPython console. The reason for this was discussed in issue #19672. Send these options to the Spyder kernels, where they will be used in a partner PR (I hope I'm doing that right, I have never done this before).

When writing the code, I noticed that the (?) icons for the tooltips of some spinboxes (resolution, width, height) was missing, so I added these as well.

The Preferences page now looks like this:

![gfxconf-new](https://github.com/spyder-ide/spyder/assets/7941918/e112a361-eec0-4f39-8fa2-b8aa79b9a98b)

For comparison, this is what it looks before the PR:

![gfxconf-old](https://github.com/spyder-ide/spyder/assets/7941918/6c67e6af-35f0-46d5-94d8-06cf0a2c128c)



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #19672
Depends on spyder-ide/spyder-kernels#477

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
