### PR TITLE
PR: Fix two tests for Python 3.11

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/test_objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/test_objectexplorer.py
@@ -106,12 +106,12 @@ def test_objectexplorer(objectexplorer):
 
 @pytest.mark.parametrize('params', [
     # variable to show, rowCount for different Python 3 versions
-    ('kjkj kj k j j kj k jkj', [71, 80]),
-    ([1, 3, 4, 'kjkj', None], [45, 47]),
-    ({1, 2, 1, 3, None, 'A', 'B', 'C', True, False}, [54, 56]),
+    ('kjkj kj k j j kj k jkj', [71, 81]),
+    ([1, 3, 4, 'kjkj', None], [45, 48]),
+    ({1, 2, 1, 3, None, 'A', 'B', 'C', True, False}, [54, 57]),
     (1.2233, [57, 59]),
     (np.random.rand(10, 10), [166, 162]),
-    (datetime.date(1945, 5, 8), [43, 47])
+    (datetime.date(1945, 5, 8), [43, 48])
 ])
 def test_objectexplorer_collection_types(objectexplorer, params):
     """Test to validate proper handling of collection data types."""
@@ -138,7 +138,7 @@ def test_objectexplorer_collection_types(objectexplorer, params):
 
 @pytest.mark.parametrize('params', [
             # show_callable_, show_special_, rowCount for python 3 and 2
-            (True, True, [34, 26], ),
+            (True, True, [35, 34, 26], ),  # 35: py3.11, 34: py3.x, 26: py2.7
             (False, False, [8, 8], )
         ])
 def test_objectexplorer_types(objectexplorer, params):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->

The row counts for Python 3.11 appear to have changed in a couple of tests in the `test_objectexplorer.py` file.  This patch allows the tests to pass in Python 3.11.  They have been successfully applied in Debian.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @juliangilbey 

<!--- Thanks for your help making Spyder better for everyone! --->
