### PR TITLE
PR: Handle infowidget possible RuntimeError when hiding it (IPython Console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1173,7 +1173,15 @@ class IPythonConsoleWidget(PluginMainWidget):
                 self.infowidget.show()
             else:
                 if self.enable_infowidget:
-                    self.infowidget.hide()
+                    try:
+                        self.infowidget.hide()
+                    except RuntimeError:
+                        # Needed to handle the possible scenario where the
+                        # `infowidget` (`FrameWebView`) related C/C++ object
+                        # has been already deleted when trying to hide it.
+                        # See spyder-ider/spyder#21509
+                        self.enable_infowidget = False
+                        self.infowidget = None
                 client.shellwidget.show()
 
             # Get reference for the control widget of the selected tab


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Handle possible `RuntimeError` when hiding IPython Console infowidget and set related attributes to not use it after. 

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21509 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
