### PR TITLE
PR: Make some UI/UX improvements to the Find pane

### DIFF
--- a/spyder/plugins/findinfiles/plugin.py
+++ b/spyder/plugins/findinfiles/plugin.py
@@ -59,7 +59,7 @@ class FindInFiles(SpyderDockablePlugin):
     def on_initialize(self):
         self.create_action(
             FindInFilesActions.FindInFiles,
-            text=_("Find in files"),
+            text=_("Search text in the Find pane"),
             tip=_("Search text in multiple files"),
             triggered=self.find,
             register_shortcut=True,

--- a/spyder/plugins/findinfiles/tests/test_plugin.py
+++ b/spyder/plugins/findinfiles/tests/test_plugin.py
@@ -17,7 +17,7 @@ import pytest
 # Local imports
 from spyder.config.manager import CONF
 from spyder.plugins.findinfiles.plugin import FindInFiles
-from spyder.plugins.findinfiles.widgets.combobox import SELECT_OTHER
+from spyder.plugins.findinfiles.widgets.combobox import SearchInComboBoxItems
 
 
 LOCATION = osp.realpath(osp.join(os.getcwd(), osp.dirname(__file__)))
@@ -59,7 +59,9 @@ def test_closing_plugin(findinfiles, qtbot, mocker, tmpdir):
             'spyder.plugins.findinfiles.widgets.combobox.getexistingdirectory',
             return_value=external_path
         )
-        path_selection_combo.setCurrentIndex(SELECT_OTHER)
+        path_selection_combo.setCurrentIndex(
+            SearchInComboBoxItems.SelectAnotherDirectory
+        )
 
     assert path_selection_combo.get_external_paths() == expected_results
 

--- a/spyder/plugins/findinfiles/widgets/combobox.py
+++ b/spyder/plugins/findinfiles/widgets/combobox.py
@@ -47,9 +47,9 @@ class SearchInComboBox(SpyderComboBox):
         self.setEditable(False)
 
         self.path = ''
-        self.project_path = None
-        self.file_path = None
-        self.external_path = None
+        self.project_path = ''
+        self.file_path = ''
+        self.external_path = ''
 
         if id_ is not None:
             self.ID = id_
@@ -187,7 +187,7 @@ class SearchInComboBox(SpyderComboBox):
         if the value of path is None.
         """
         if path is None:
-            self.project_path = None
+            self.project_path = ''
             self.model().item(PROJECT, 0).setEnabled(False)
             if self.currentIndex() == PROJECT:
                 self.setCurrentIndex(CWD)

--- a/spyder/plugins/findinfiles/widgets/combobox.py
+++ b/spyder/plugins/findinfiles/widgets/combobox.py
@@ -43,7 +43,6 @@ class SearchInComboBox(SpyderComboBox):
     def __init__(self, external_path_history=[], parent=None, id_=None):
         super().__init__(parent)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        self.setToolTip(_('Search directory'))
         self.setEditable(False)
 
         self.path = ''
@@ -55,29 +54,16 @@ class SearchInComboBox(SpyderComboBox):
             self.ID = id_
 
         self.addItem(_("Current working directory"))
-        ttip = ("Search in all files and directories present on the current"
-                " Spyder path")
-        self.setItemData(0, ttip, Qt.ToolTipRole)
 
         self.addItem(_("Project"))
-        ttip = _("Search in all files and directories present on the"
-                 " current project path (if opened)")
-        self.setItemData(1, ttip, Qt.ToolTipRole)
         self.model().item(1, 0).setEnabled(False)
 
-        self.addItem(_("File").replace('&', ''))
-        ttip = _("Search in current opened file")
-        self.setItemData(2, ttip, Qt.ToolTipRole)
+        self.addItem(_("Current file").replace('&', ''))
 
         self.insertSeparator(3)
 
-        self.addItem(_("Select other directory"))
-        ttip = _("Search in other folder present on the file system")
-        self.setItemData(4, ttip, Qt.ToolTipRole)
-
-        self.addItem(_("Clear this list"))
-        ttip = _("Clear the list of other directories")
-        self.setItemData(5, ttip, Qt.ToolTipRole)
+        self.addItem(_("Select another directory"))
+        self.addItem(_("Clear the list of other directories"))
 
         self.insertSeparator(6)
 
@@ -204,10 +190,13 @@ class SearchInComboBox(SpyderComboBox):
                 # Remove item and update the view.
                 self.removeItem(index)
                 self.showPopup()
+
                 # Set the view selection so that it doesn't bounce around.
                 new_index = min(self.count() - 1, index)
                 new_index = 0 if new_index < EXTERNAL_PATHS else new_index
                 self.view().setCurrentIndex(self.model().index(new_index, 0))
                 self.setCurrentIndex(new_index)
+
             return True
+
         return super().eventFilter(widget, event)

--- a/spyder/plugins/findinfiles/widgets/combobox.py
+++ b/spyder/plugins/findinfiles/widgets/combobox.py
@@ -20,12 +20,16 @@ from spyder.utils.encoding import to_unicode_from_fs
 
 # ---- Constants
 # ----------------------------------------------------------------------------
-CWD = 0
-PROJECT = 1
-FILE_PATH = 2
-SELECT_OTHER = 4
-CLEAR_LIST = 5
-EXTERNAL_PATHS = 7
+class SearchInComboBoxItems:
+    Cwd = 0
+    Project = 1
+    File = 2
+    FirstSeparator = 3
+    SelectAnotherDirectory = 4
+    ClearList = 5
+    SecondSeparator = 6
+    ExternalPaths = 7
+
 MAX_PATH_HISTORY = 15
 
 
@@ -56,16 +60,16 @@ class SearchInComboBox(SpyderComboBox):
         self.addItem(_("Current working directory"))
 
         self.addItem(_("Project"))
-        self.model().item(1, 0).setEnabled(False)
+        self.model().item(SearchInComboBoxItems.Project, 0).setEnabled(False)
 
         self.addItem(_("Current file").replace('&', ''))
 
-        self.insertSeparator(3)
+        self.insertSeparator(SearchInComboBoxItems.FirstSeparator)
 
         self.addItem(_("Select another directory"))
         self.addItem(_("Clear the list of other directories"))
 
-        self.insertSeparator(6)
+        self.insertSeparator(SearchInComboBoxItems.SecondSeparator)
 
         for path in external_path_history:
             self.add_external_path(path)
@@ -85,18 +89,23 @@ class SearchInComboBox(SpyderComboBox):
         self.removeItem(self.findText(path))
         self.addItem(path)
         self.setItemData(self.count() - 1, path, Qt.ToolTipRole)
-        while self.count() > MAX_PATH_HISTORY + EXTERNAL_PATHS:
-            self.removeItem(EXTERNAL_PATHS)
+        while (
+            self.count() >
+            (MAX_PATH_HISTORY + SearchInComboBoxItems.ExternalPaths)
+        ):
+            self.removeItem(SearchInComboBoxItems.ExternalPaths)
 
     def get_external_paths(self):
         """Returns a list of the external paths listed in the combobox."""
-        return [str(self.itemText(i))
-                for i in range(EXTERNAL_PATHS, self.count())]
+        return [
+            str(self.itemText(i))
+            for i in range(SearchInComboBoxItems.ExternalPaths, self.count())
+        ]
 
     def clear_external_paths(self):
         """Remove all the external paths listed in the combobox."""
-        while self.count() > EXTERNAL_PATHS:
-            self.removeItem(EXTERNAL_PATHS)
+        while self.count() > SearchInComboBoxItems.ExternalPaths:
+            self.removeItem(SearchInComboBoxItems.ExternalPaths)
 
     def get_current_searchpath(self):
         """
@@ -104,11 +113,11 @@ class SearchInComboBox(SpyderComboBox):
         in the combobox.
         """
         idx = self.currentIndex()
-        if idx == CWD:
+        if idx == SearchInComboBoxItems.Cwd:
             return self.path
-        elif idx == PROJECT:
+        elif idx == SearchInComboBoxItems.Project:
             return self.project_path
-        elif idx == FILE_PATH:
+        elif idx == SearchInComboBoxItems.File:
             return self.file_path
         else:
             return self.external_path
@@ -117,15 +126,17 @@ class SearchInComboBox(SpyderComboBox):
         """Set the current index of this combo box."""
         if index is not None:
             index = min(index, self.count() - 1)
-            index = CWD if index in [CLEAR_LIST, SELECT_OTHER] else index
+            if index in [SearchInComboBoxItems.ClearList,
+                         SearchInComboBoxItems.SelectAnotherDirectory]:
+                index = SearchInComboBoxItems.Cwd
         else:
-            index = CWD
+            index = SearchInComboBoxItems.Cwd
 
         self.setCurrentIndex(index)
 
     def is_file_search(self):
         """Returns whether the current search path is a file."""
-        if self.currentIndex() == FILE_PATH:
+        if self.currentIndex() == SearchInComboBoxItems.File:
             return True
         else:
             return False
@@ -134,22 +145,22 @@ class SearchInComboBox(SpyderComboBox):
     def path_selection_changed(self):
         """Handles when the current index of the combobox changes."""
         idx = self.currentIndex()
-        if idx == SELECT_OTHER:
+        if idx == SearchInComboBoxItems.SelectAnotherDirectory:
             external_path = self.select_directory()
             if len(external_path) > 0:
                 self.add_external_path(external_path)
                 self.setCurrentIndex(self.count() - 1)
             else:
-                self.setCurrentIndex(CWD)
-        elif idx == CLEAR_LIST:
+                self.setCurrentIndex(SearchInComboBoxItems.Cwd)
+        elif idx == SearchInComboBoxItems.ClearList:
             reply = QMessageBox.question(
                     self, _("Clear other directories"),
                     _("Do you want to clear the list of other directories?"),
                     QMessageBox.Yes | QMessageBox.No)
             if reply == QMessageBox.Yes:
                 self.clear_external_paths()
-            self.setCurrentIndex(CWD)
-        elif idx >= EXTERNAL_PATHS:
+            self.setCurrentIndex(SearchInComboBoxItems.Cwd)
+        elif idx >= SearchInComboBoxItems.ExternalPaths:
             self.external_path = str(self.itemText(idx))
 
     @Slot()
@@ -174,26 +185,31 @@ class SearchInComboBox(SpyderComboBox):
         """
         if path is None:
             self.project_path = ''
-            self.model().item(PROJECT, 0).setEnabled(False)
-            if self.currentIndex() == PROJECT:
-                self.setCurrentIndex(CWD)
+            self.model().item(
+                SearchInComboBoxItems.Project, 0
+            ).setEnabled(False)
+            if self.currentIndex() == SearchInComboBoxItems.Project:
+                self.setCurrentIndex(SearchInComboBoxItems.Cwd)
         else:
             path = osp.abspath(path)
             self.project_path = path
-            self.model().item(PROJECT, 0).setEnabled(True)
+            self.model().item(
+                SearchInComboBoxItems.Project, 0
+            ).setEnabled(True)
 
     def eventFilter(self, widget, event):
         """Used to handle key events on the QListView of the combobox."""
         if event.type() == QEvent.KeyPress and event.key() == Qt.Key_Delete:
             index = self.view().currentIndex().row()
-            if index >= EXTERNAL_PATHS:
+            if index >= SearchInComboBoxItems.ExternalPaths:
                 # Remove item and update the view.
                 self.removeItem(index)
                 self.showPopup()
 
                 # Set the view selection so that it doesn't bounce around.
                 new_index = min(self.count() - 1, index)
-                new_index = 0 if new_index < EXTERNAL_PATHS else new_index
+                if new_index < SearchInComboBoxItems.ExternalPaths:
+                    new_index = SearchInComboBoxItems.Cwd
                 self.view().setCurrentIndex(self.model().index(new_index, 0))
                 self.setCurrentIndex(new_index)
 

--- a/spyder/plugins/findinfiles/widgets/main_widget.py
+++ b/spyder/plugins/findinfiles/widgets/main_widget.py
@@ -140,6 +140,7 @@ class FindInFilesWidget(PluginMainWidget):
         self._search_in_label_width = None
         self._exclude_label_width = None
         self._is_shown = False
+        self._is_first_time = False
 
         search_text = self.get_conf('search_text', '')
         path_history = self.get_conf('path_history', [])
@@ -348,22 +349,18 @@ class FindInFilesWidget(PluginMainWidget):
             self.set_max_results_action,
             menu=menu,
         )
-        self.set_pane_empty()
 
-    def set_pane_empty(self):
-        if self.result_browser.data:
-            self.stacked_widget.setCurrentWidget(self.result_browser)
-        else:
-            self.stacked_widget.setCurrentWidget(self.pane_empty)
+        # Set pane_empty widget at the beginning
+        self.stacked_widget.setCurrentWidget(self.pane_empty)
 
     def update_actions(self):
         self.find_action.setIcon(self.create_icon(
-            'stop' if self.running else 'find'))
+            'stop' if self.running else 'find')
+        )
 
         if self.extras_toolbar and self.more_options_action:
             self.extras_toolbar.setVisible(
                 self.more_options_action.isChecked())
-        self.set_pane_empty()
 
     @on_conf_change(option='more_options')
     def on_more_options_update(self, value):
@@ -645,6 +642,12 @@ class FindInFilesWidget(PluginMainWidget):
         If there is no search running, this will start the search. If there is
         a search running, this will stop it.
         """
+        # Show result_browser the first time a user performs a search and leave
+        # it shown afterwards.
+        if not self._is_first_time:
+            self.stacked_widget.setCurrentWidget(self.result_browser)
+            self._is_first_time = True
+
         if self.running:
             self.stop()
         else:

--- a/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
+++ b/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
@@ -24,8 +24,9 @@ from spyder.config.base import running_in_ci
 from spyder.config.manager import CONF
 from spyder.plugins.findinfiles.widgets.main_widget import FindInFilesWidget
 from spyder.plugins.findinfiles.widgets.combobox import (
-    CWD, CLEAR_LIST, EXTERNAL_PATHS, FILE_PATH, PROJECT, SearchInComboBox,
-    SELECT_OTHER)
+    SearchInComboBox,
+    SearchInComboBoxItems
+)
 from spyder.plugins.findinfiles.widgets.search_thread import SearchThread
 from spyder.utils.palette import QStylePalette, SpyderPalette
 from spyder.utils.stylesheet import APP_STYLESHEET
@@ -366,10 +367,15 @@ def test_add_external_paths(searchin_combobox, mocker):
             osp.dirname(osp.dirname(osp.dirname(LOCATION))),
             osp.dirname(LOCATION)
             ]
-    assert searchin_combobox.count() == len(expected_results)+EXTERNAL_PATHS
+    assert (
+        searchin_combobox.count()
+        == len(expected_results) + SearchInComboBoxItems.ExternalPaths
+    )
     assert searchin_combobox.get_external_paths() == expected_results
     for i, expected_result in enumerate(expected_results):
-        assert expected_result == searchin_combobox.itemText(i+EXTERNAL_PATHS)
+        assert expected_result == searchin_combobox.itemText(
+            i + SearchInComboBoxItems.ExternalPaths
+        )
 
     # Add a new external path to the combobox. The new path is added at the
     # end of the combobox.
@@ -378,10 +384,15 @@ def test_add_external_paths(searchin_combobox, mocker):
         'spyder.plugins.findinfiles.widgets.combobox.getexistingdirectory',
         return_value=new_path
     )
-    searchin_combobox.setCurrentIndex(SELECT_OTHER)
+    searchin_combobox.setCurrentIndex(
+        SearchInComboBoxItems.SelectAnotherDirectory
+    )
 
     expected_results.append(new_path)
-    assert searchin_combobox.count() == len(expected_results)+EXTERNAL_PATHS
+    assert (
+        searchin_combobox.count()
+        == len(expected_results) + SearchInComboBoxItems.ExternalPaths
+    )
     assert searchin_combobox.get_external_paths() == expected_results
     assert searchin_combobox.currentIndex() == searchin_combobox.count()-1
 
@@ -392,11 +403,16 @@ def test_add_external_paths(searchin_combobox, mocker):
         'spyder.plugins.findinfiles.widgets.combobox.getexistingdirectory',
         return_value=new_path
     )
-    searchin_combobox.setCurrentIndex(SELECT_OTHER)
+    searchin_combobox.setCurrentIndex(
+        SearchInComboBoxItems.SelectAnotherDirectory
+    )
 
     expected_results.pop(0)
     expected_results.append(new_path)
-    assert searchin_combobox.count() == len(expected_results)+EXTERNAL_PATHS
+    assert (
+        searchin_combobox.count()
+        == len(expected_results) + SearchInComboBoxItems.ExternalPaths
+    )
     assert searchin_combobox.get_external_paths() == expected_results
     assert searchin_combobox.currentIndex() == searchin_combobox.count()-1
 
@@ -406,11 +422,16 @@ def test_add_external_paths(searchin_combobox, mocker):
         'spyder.plugins.findinfiles.widgets.combobox.getexistingdirectory',
         return_value=''
     )
-    searchin_combobox.setCurrentIndex(SELECT_OTHER)
+    searchin_combobox.setCurrentIndex(
+        SearchInComboBoxItems.SelectAnotherDirectory
+    )
 
-    assert searchin_combobox.count() == len(expected_results)+EXTERNAL_PATHS
+    assert (
+        searchin_combobox.count()
+        == len(expected_results) + SearchInComboBoxItems.ExternalPaths
+    )
     assert searchin_combobox.get_external_paths() == expected_results
-    assert searchin_combobox.currentIndex() == CWD
+    assert searchin_combobox.currentIndex() == SearchInComboBoxItems.Cwd
 
 
 def test_clear_this_list(searchin_combobox, mocker):
@@ -422,7 +443,7 @@ def test_clear_this_list(searchin_combobox, mocker):
 
     # Cancel the Clear the list action and assert the result.
     mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.No)
-    searchin_combobox.setCurrentIndex(CLEAR_LIST)
+    searchin_combobox.setCurrentIndex(SearchInComboBoxItems.ClearList)
 
     expected_results = [
             LOCATION,
@@ -430,18 +451,21 @@ def test_clear_this_list(searchin_combobox, mocker):
             osp.dirname(osp.dirname(osp.dirname(LOCATION))),
             osp.dirname(LOCATION)
             ]
-    assert searchin_combobox.count() == len(expected_results)+EXTERNAL_PATHS
+    assert (
+        searchin_combobox.count()
+        == len(expected_results) + SearchInComboBoxItems.ExternalPaths
+    )
     assert searchin_combobox.get_external_paths() == expected_results
-    assert searchin_combobox.currentIndex() == CWD
+    assert searchin_combobox.currentIndex() == SearchInComboBoxItems.Cwd
 
     # Clear the list of external paths and assert that the list of
     # external paths is empty.
     mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.Yes)
-    searchin_combobox.setCurrentIndex(CLEAR_LIST)
+    searchin_combobox.setCurrentIndex(SearchInComboBoxItems.ClearList)
 
-    assert searchin_combobox.count() == EXTERNAL_PATHS
+    assert searchin_combobox.count() == SearchInComboBoxItems.ExternalPaths
     assert searchin_combobox.get_external_paths() == []
-    assert searchin_combobox.currentIndex() == CWD
+    assert searchin_combobox.currentIndex() == SearchInComboBoxItems.Cwd
 
 
 def test_delete_path(searchin_combobox, qtbot, mocker):
@@ -452,48 +476,75 @@ def test_delete_path(searchin_combobox, qtbot, mocker):
     searchin_combobox.show()
 
     expected_results = [
-            LOCATION,
-            osp.dirname(osp.dirname(LOCATION)),
-            osp.dirname(osp.dirname(osp.dirname(LOCATION))),
-            osp.dirname(LOCATION)
-            ]
+        LOCATION,
+        osp.dirname(osp.dirname(LOCATION)),
+        osp.dirname(osp.dirname(osp.dirname(LOCATION))),
+        osp.dirname(LOCATION)
+    ]
 
     searchin_combobox.showPopup()
-    assert searchin_combobox.currentIndex() == CWD
-    assert searchin_combobox.view().currentIndex().row() == CWD
+    assert searchin_combobox.currentIndex() == SearchInComboBoxItems.Cwd
+    assert (
+        searchin_combobox.view().currentIndex().row()
+        == SearchInComboBoxItems.Cwd
+    )
 
     # Assert that the delete action does nothing when the selected item in
     # the combobox view is not an external path.
-    for i in range(EXTERNAL_PATHS):
+    for i in range(SearchInComboBoxItems.ExternalPaths):
         searchin_combobox.view().setCurrentIndex(
             searchin_combobox.model().index(i, 0))
         qtbot.keyPress(searchin_combobox.view(), Qt.Key_Delete)
 
-    assert searchin_combobox.count() == len(expected_results)+EXTERNAL_PATHS
+    assert (
+        searchin_combobox.count()
+        == len(expected_results) + SearchInComboBoxItems.ExternalPaths
+    )
     assert searchin_combobox.get_external_paths() == expected_results
-    assert searchin_combobox.currentIndex() == CWD
+    assert searchin_combobox.currentIndex() == SearchInComboBoxItems.Cwd
 
     # Delete the first external path in the list.
     searchin_combobox.view().setCurrentIndex(
-            searchin_combobox.model().index(EXTERNAL_PATHS, 0))
+        searchin_combobox.model().index(SearchInComboBoxItems.ExternalPaths, 0)
+    )
     qtbot.keyPress(searchin_combobox.view(), Qt.Key_Delete)
 
     expected_results.pop(0)
-    assert searchin_combobox.count() == len(expected_results)+EXTERNAL_PATHS
+    assert (
+        searchin_combobox.count()
+        == len(expected_results) + SearchInComboBoxItems.ExternalPaths
+    )
     assert searchin_combobox.get_external_paths() == expected_results
-    assert searchin_combobox.currentIndex() == EXTERNAL_PATHS
-    assert searchin_combobox.view().currentIndex().row() == EXTERNAL_PATHS
+    assert (
+        searchin_combobox.currentIndex() == SearchInComboBoxItems.ExternalPaths
+    )
+    assert (
+        searchin_combobox.view().currentIndex().row()
+        == SearchInComboBoxItems.ExternalPaths
+    )
 
     # Delete the second external path in the remaining list.
     searchin_combobox.view().setCurrentIndex(
-            searchin_combobox.model().index(EXTERNAL_PATHS+1, 0))
+        searchin_combobox.model().index(
+            SearchInComboBoxItems.ExternalPaths + 1, 0
+        )
+    )
     qtbot.keyPress(searchin_combobox.view(), Qt.Key_Delete)
 
     expected_results.pop(1)
-    assert searchin_combobox.count() == len(expected_results)+EXTERNAL_PATHS
+    assert (
+        searchin_combobox.count()
+        == len(expected_results) + SearchInComboBoxItems.ExternalPaths
+    )
     assert searchin_combobox.get_external_paths() == expected_results
-    assert searchin_combobox.currentIndex() == EXTERNAL_PATHS+1
-    assert searchin_combobox.view().currentIndex().row() == EXTERNAL_PATHS+1
+    assert (
+        searchin_combobox.currentIndex()
+        == SearchInComboBoxItems.ExternalPaths + 1
+    )
+    assert (
+        searchin_combobox.view().currentIndex().row()
+        == SearchInComboBoxItems.ExternalPaths + 1
+    )
 
     # Delete the last external path in the list.
     searchin_combobox.view().setCurrentIndex(
@@ -501,7 +552,10 @@ def test_delete_path(searchin_combobox, qtbot, mocker):
     qtbot.keyPress(searchin_combobox.view(), Qt.Key_Delete)
 
     expected_results.pop()
-    assert searchin_combobox.count() == len(expected_results)+EXTERNAL_PATHS
+    assert (
+        searchin_combobox.count()
+        == len(expected_results) + SearchInComboBoxItems.ExternalPaths
+    )
     assert searchin_combobox.get_external_paths() == expected_results
     assert searchin_combobox.currentIndex() == searchin_combobox.count()-1
     assert (searchin_combobox.view().currentIndex().row() ==
@@ -509,13 +563,17 @@ def test_delete_path(searchin_combobox, qtbot, mocker):
 
     # Delete the last remaining external path in the list.
     searchin_combobox.view().setCurrentIndex(
-            searchin_combobox.model().index(EXTERNAL_PATHS, 0))
+        searchin_combobox.model().index(SearchInComboBoxItems.ExternalPaths, 0)
+    )
     qtbot.keyPress(searchin_combobox.view(), Qt.Key_Delete)
 
-    assert searchin_combobox.count() == EXTERNAL_PATHS
+    assert searchin_combobox.count() == SearchInComboBoxItems.ExternalPaths
     assert searchin_combobox.get_external_paths() == []
-    assert searchin_combobox.currentIndex() == CWD
-    assert searchin_combobox.view().currentIndex().row() == CWD
+    assert searchin_combobox.currentIndex() == SearchInComboBoxItems.Cwd
+    assert (
+        searchin_combobox.view().currentIndex().row()
+        == SearchInComboBoxItems.Cwd
+    )
 
 
 def test_set_project_path(findinfiles, qtbot):
@@ -526,25 +584,40 @@ def test_set_project_path(findinfiles, qtbot):
     path_selection_combo = findinfiles.path_selection_combo
     findinfiles.show()
 
-    assert path_selection_combo.model().item(PROJECT, 0).isEnabled() is False
-    assert findinfiles.project_path is None
-    assert path_selection_combo.project_path is None
+    assert (
+        path_selection_combo.model().item(
+            SearchInComboBoxItems.Project, 0
+        ).isEnabled()
+        is False
+    )
+    assert findinfiles.project_path == ""
+    assert path_selection_combo.project_path == ""
 
     # Set the project path to an existing directory. For the purpose of this
     # test, it doesn't need to be a valid Spyder project path.
     project_path = NONASCII_DIR
     findinfiles.set_project_path(project_path)
-    assert path_selection_combo.model().item(PROJECT, 0).isEnabled() is True
+    assert (
+        path_selection_combo.model().item(
+            SearchInComboBoxItems.Project, 0
+        ).isEnabled()
+        is True
+    )
     assert findinfiles.project_path == project_path
     assert path_selection_combo.project_path == project_path
 
     # Disable the project path search in the widget.
-    path_selection_combo.setCurrentIndex(PROJECT)
+    path_selection_combo.setCurrentIndex(SearchInComboBoxItems.Project)
     findinfiles.disable_project_search()
-    assert path_selection_combo.model().item(PROJECT, 0).isEnabled() is False
-    assert findinfiles.project_path is None
-    assert path_selection_combo.project_path is None
-    assert path_selection_combo.currentIndex() == CWD
+    assert (
+        path_selection_combo.model().item(
+            SearchInComboBoxItems.Project, 0
+        ).isEnabled()
+        is False
+    )
+    assert findinfiles.project_path == ""
+    assert path_selection_combo.project_path == ""
+    assert path_selection_combo.currentIndex() == SearchInComboBoxItems.Cwd
 
 
 @pytest.mark.parametrize('findinfiles',
@@ -593,20 +666,22 @@ def test_current_search_path(findinfiles, qtbot):
     # Assert that the good path is returned for each option selected.
 
     # Test for the current working directory :
-    path_selection_combo.setCurrentIndex(CWD)
+    path_selection_combo.setCurrentIndex(SearchInComboBoxItems.Cwd)
     assert path_selection_combo.get_current_searchpath() == directory
     assert path_selection_combo.is_file_search() is False
     # Test for the project path :
-    path_selection_combo.setCurrentIndex(PROJECT)
+    path_selection_combo.setCurrentIndex(SearchInComboBoxItems.Project)
     assert path_selection_combo.get_current_searchpath() == project_path
     assert path_selection_combo.is_file_search() is False
     # Test for the file path :
-    path_selection_combo.setCurrentIndex(FILE_PATH)
+    path_selection_combo.setCurrentIndex(SearchInComboBoxItems.File)
     assert path_selection_combo.get_current_searchpath() == file_path
     assert path_selection_combo.is_file_search() is True
     # Test for the external file path :
     for i, path in enumerate(external_paths):
-        path_selection_combo.setCurrentIndex(EXTERNAL_PATHS+i)
+        path_selection_combo.setCurrentIndex(
+            SearchInComboBoxItems.ExternalPaths + i
+        )
         assert path_selection_combo.get_current_searchpath() == path
         assert path_selection_combo.is_file_search() is False
 
@@ -627,7 +702,10 @@ def test_max_history(searchin_combobox):
             osp.dirname(osp.dirname(osp.dirname(LOCATION))),
             osp.dirname(LOCATION)
     ]
-    assert searchin_combobox.count() == len(expected_results) + EXTERNAL_PATHS
+    assert (
+        searchin_combobox.count()
+        == len(expected_results) + SearchInComboBoxItems.ExternalPaths
+    )
     assert searchin_combobox.get_external_paths() == expected_results
 
 
@@ -659,7 +737,7 @@ def test_find_in_single_file(findinfiles, qtbot):
     """
     findinfiles.set_search_text("spam")
     findinfiles.set_file_path(osp.join(LOCATION, "data", 'spam.txt'))
-    findinfiles.path_selection_combo.setCurrentIndex(FILE_PATH)
+    findinfiles.path_selection_combo.setCurrentIndex(SearchInComboBoxItems.File)
 
     with qtbot.waitSignal(findinfiles.sig_finished):
         findinfiles.find()


### PR DESCRIPTION
## Description of Changes

- In `SearchInComboBox`, disable clear list item and hide separator between regular items and other directories when users have not selected any other directory. 
- Remove tooltips from the `SearchInComboBox` items because they were annoying and unnecessary.
- Change text of the action shown in the `Search` menu that points to the Find pane. That's to give users a better idea about it.
- Fix bug when clicking on that action and (apparently) Spyder can't grab text for it.  
- Use an enum for the index items used in `SearchInComboBox`. This allows us to access them more easily.
- Leave results browser visible after the first search is performed. This was very annoying because the empty message was shown when a new search was started or when no results were found. 

### Visual changes

**Before**

![imagen](https://github.com/spyder-ide/spyder/assets/365293/92651a5f-e007-44bc-9983-4e42f9f7805c)

**After**

![imagen](https://github.com/spyder-ide/spyder/assets/365293/47bc594f-9c98-48e1-9054-e694761aff25)

![imagen](https://github.com/spyder-ide/spyder/assets/365293/207d414d-6ba2-4d0a-bf63-80a54a4e40b1)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21538

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
