### PR TITLE
PR: Change how Spyder determines if it is a conda-based app

### DIFF
--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -64,7 +64,7 @@ jobs:
           environment-file: installers-conda/build-environment.yml
           environment-name: spy-inst
           create-args: >-
-            --channel-priority=strict
+            --channel-priority=flexible
             python=${{ matrix.python-version }}
           cache-downloads: true
           cache-environment: true

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -234,26 +234,32 @@ jobs:
 
           installer -pkg $PKG_PATH -target CurrentUserHomeDirectory >/dev/null
 
-          root_prefix=$(compgen -G $HOME/Library/spyder-*)
+          base_prefix=$(compgen -G $HOME/Library/spyder-*)
+          spy_rt=$base_prefix/envs/spyder-runtime
+          menu=$spy_rt/Menu/spyder-menu.json
+          mode=user
+          shortcut=$(${base_prefix}/bin/python - <<EOF
+          from menuinst.api import _load
+          menu, menu_items = _load("$menu", target_prefix="$spy_rt", base_prefix="$base_prefix", _mode="$mode")
+          print(menu_items[0]._paths()[0])
+          EOF
+          )
 
           echo "Install info:"
-          echo "Contents of ${root_prefix}:"
-          ls -al $root_prefix
-          echo -e "\nContents of ${root_prefix}/uninstall-spyder.sh:"
-          cat $root_prefix/uninstall-spyder.sh
+          echo "Contents of ${base_prefix}:"
+          ls -al $base_prefix
+          echo -e "\nContents of ${base_prefix}/uninstall-spyder.sh:"
+          cat $base_prefix/uninstall-spyder.sh
 
-          app_path=/Applications/Spyder.app
-          [[ -e ${root_prefix}/.nonadmin ]] && app_path=${HOME}${app_path}
-
-          if [[ -e "$app_path" ]]; then
-              echo "Contents of $app_path/Contents/MacOS:"
-              ls -al $app_path/Contents/MacOS
-              echo -e "\nContents of $app_path/Contents/Info.plist:"
-              cat $app_path/Contents/Info.plist
-              echo -e "\nContents of $app_path/Contents/MacOS/spyder-script:"
-              cat $app_path/Contents/MacOS/spyder-script
+          if [[ -e "$shortcut" ]]; then
+              echo "Contents of $shortcut/Contents/MacOS:"
+              ls -al $shortcut/Contents/MacOS
+              echo -e "\nContents of $shortcut/Contents/Info.plist:"
+              cat $shortcut/Contents/Info.plist
+              echo -e "\nContents of $shortcut/Contents/MacOS/spyder-script:"
+              cat $shortcut/Contents/MacOS/spyder-script
           else
-              echo "$app_path does not exist"
+              echo "$shortcut does not exist"
               exit 1
           fi
 
@@ -262,22 +268,28 @@ jobs:
         run: |
           $PKG_PATH -b
 
-          root_prefix=$(compgen -G $HOME/.local/spyder-*)
+          base_prefix=$(compgen -G $HOME/.local/spyder-*)
+          spy_rt=$base_prefix/envs/spyder-runtime
+          menu=$spy_rt/Menu/spyder-menu.json
+          mode=user
+          shortcut=$(${base_prefix}/bin/python - <<EOF
+          from menuinst.api import _load
+          menu, menu_items = _load("$menu", target_prefix="$spy_rt", base_prefix="$base_prefix", _mode="$mode")
+          print(menu_items[0]._paths()[0])
+          EOF
+          )
 
           echo "Install info:"
-          echo "Contents of ${root_prefix}:"
-          ls -al $root_prefix
-          echo -e "\nContents of ${root_prefix}/uninstall-spyder.sh:"
-          cat ${root_prefix}/uninstall-spyder.sh
+          echo "Contents of ${base_prefix}:"
+          ls -al $base_prefix
+          echo -e "\nContents of ${base_prefix}/uninstall-spyder.sh:"
+          cat ${base_prefix}/uninstall-spyder.sh
 
-          shortcut_path=/share/applications/spyder_spyder.desktop
-          [[ -e ${root_prefix}/.nonadmin ]] && shortcut_path=${HOME}/.local${shortcut_path} || shortcut_path=/usr${shortcut_path}
-
-          if [[ -e $shortcut_path ]]; then
-              echo -e "\nContents of ${shortcut_path}:"
-              cat $shortcut_path
+          if [[ -e $shortcut ]]; then
+              echo -e "\nContents of ${shortcut}:"
+              cat $shortcut
           else
-              echo "$shortcut_path does not exist"
+              echo "$shortcut does not exist"
               exit 1
           fi
 
@@ -287,8 +299,16 @@ jobs:
         run: |
           start /wait %PKG_PATH% /InstallationType=JustMe /NoRegistry=1 /S
 
-          set "shortcut_path=%USERPROFILE%\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\spyder\Spyder.lnk"
-          if exist "%shortcut_path%" (
+          set base_prefix=%USERPROFILE%\AppData\Local\spyder-6
+          set spy_rt=%base_prefix%\envs\spyder-runtime
+          set menu=%spy_rt%\Menu\spyder-menu.json
+          set mode=user
+          for /F "tokens=*" %%i in (
+              '%base_prefix%\python -c "from menuinst.api import _load; menu, menu_items = _load(r'%menu%', target_prefix=r'%spy_rt%', base_prefix=r'%base_prefix%', _mode='%mode%'); print(menu_items[0]._paths()[0])"'
+          ) do (
+              set shortcut=%%~fi
+          )
+          if exist "%shortcut%" (
               echo "Spyder installed successfully"
           ) else (
               echo "Spyder NOT installed successfully"

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -162,7 +162,7 @@ jobs:
           environment-file: installers-conda/build-environment.yml
           environment-name: spy-inst
           create-args: >-
-            --channel-priority=strict
+            --channel-priority=flexible
             python=${{ matrix.python-version }}
           cache-downloads: true
           cache-environment: true
@@ -185,7 +185,7 @@ jobs:
           CONDA_BLD_PATH: ${{ runner.temp }}/conda-bld
         run: |
           conda config --set bld_path $CONDA_BLD_PATH
-          mamba index $CONDA_BLD_PATH
+          conda index $CONDA_BLD_PATH
           mamba search -c local --override-channels || true
 
       - name: Create Keychain

--- a/installers-conda/build-environment.yml
+++ b/installers-conda/build-environment.yml
@@ -1,13 +1,13 @@
 name: spy-inst
 channels:
-  - napari/label/bundle_tools_3
   - conda-forge
 dependencies:
   - boa
-  - conda
-  - conda-standalone
-  - constructor
+  - conda >=23.11.0
+  - conda-standalone >=23.11.0
+  - constructor >=3.6.0
   - gitpython
-  - menuinst
+  - mamba
+  - menuinst >=2.0.2
   - ruamel.yaml.jinja2
   - setuptools_scm

--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -181,7 +181,7 @@ class BuildCondaPkg:
             self.logger.info("Building conda package "
                              f"{self.name}={self.version}...")
             check_call([
-                "mamba", "mambabuild",
+                "conda", "mambabuild",
                 "--no-test", "--skip-existing", "--build-id-pat={n}",
                 str(self._fdstk_path / "recipe")
             ])

--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -50,6 +50,7 @@ class BuildCondaPkg:
     norm = True
     source = None
     feedstock = None
+    feedstock_branch = None
     shallow_ver = None
 
     def __init__(self, data={}, debug=False, shallow=False):
@@ -104,7 +105,10 @@ class BuildCondaPkg:
 
         # Clone feedstock
         self.logger.info("Cloning feedstock...")
-        Repo.clone_from(self.feedstock, to_path=self._fdstk_path)
+        kwargs = dict(to_path=self._fdstk_path)
+        if self.feedstock_branch:
+            kwargs.update(branch=self.feedstock_branch)
+        Repo.clone_from(self.feedstock, **kwargs)
 
     def _build_cleanup(self):
         """Remove cloned source and feedstock repositories"""
@@ -197,6 +201,7 @@ class SpyderCondaPkg(BuildCondaPkg):
     norm = False
     source = os.environ.get('SPYDER_SOURCE', HERE.parent)
     feedstock = "https://github.com/conda-forge/spyder-feedstock"
+    feedstock_branch = "dev"
     shallow_ver = "v5.3.2"
 
     def _patch_source(self):
@@ -301,6 +306,7 @@ class PylspCondaPkg(BuildCondaPkg):
     name = "python-lsp-server"
     source = os.environ.get('PYTHON_LSP_SERVER_SOURCE')
     feedstock = "https://github.com/conda-forge/python-lsp-server-feedstock"
+    feedstock_branch = "main"
     shallow_ver = "v1.4.1"
 
 
@@ -308,6 +314,7 @@ class QtconsoleCondaPkg(BuildCondaPkg):
     name = "qtconsole"
     source = os.environ.get('QTCONSOLE_SOURCE')
     feedstock = "https://github.com/conda-forge/qtconsole-feedstock"
+    feedstock_branch = "main"
     shallow_ver = "5.3.1"
 
 
@@ -315,6 +322,7 @@ class SpyderKernelsCondaPkg(BuildCondaPkg):
     name = "spyder-kernels"
     source = os.environ.get('SPYDER_KERNELS_SOURCE')
     feedstock = "https://github.com/conda-forge/spyder-kernels-feedstock"
+    feedstock_branch = "rc"
     shallow_ver = "v2.3.1"
 
 

--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -66,10 +66,10 @@ class BuildCondaPkg:
         self._get_source(shallow=shallow)
         self._get_version()
 
-        self._patch_source()
-
         self.data = {'version': self.version}
         self.data.update(data)
+
+        self._patch_source()
 
         self._recipe_patched = False
 
@@ -200,6 +200,18 @@ class SpyderCondaPkg(BuildCondaPkg):
     shallow_ver = "v5.3.2"
 
     def _patch_source(self):
+        self.logger.info("Patching Spyder source...")
+        file = self._bld_src / "spyder/__init__.py"
+        file_text = file.read_text()
+        ver_str = tuple(self.version.split('.'))
+        file_text = re.sub(
+            r'^(version_info = ).*',
+            rf'\g<1>{ver_str}',
+            file_text,
+            flags=re.MULTILINE
+        )
+        file.write_text(file_text)
+
         self.logger.info("Creating Spyder menu file...")
         _menufile = RESOURCES / "spyder-menu.json"
         self.menufile = BUILD / "spyder-menu.json"

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -227,13 +227,14 @@ def _definitions():
         "reverse_domain_identifier": "org.spyder-ide.Spyder",
         "version": SPYVER,
         "channels": [
-            "napari/label/bundle_tools_3",
             "conda-forge/label/spyder_kernels_rc",
             "conda-forge",
         ],
         "conda_default_channels": ["conda-forge"],
         "specs": [
             f"python={PY_VER}",
+            "conda >=23.11.0",
+            "menuinst >=2.0.2",
             "mamba",
         ],
         "installer_filename": OUTPUT_FILE.name,
@@ -348,7 +349,7 @@ def _constructor():
     cmd_args.append(str(BUILD))
 
     env = os.environ.copy()
-    env["CONDA_CHANNEL_PRIORITY"] = "strict"
+    env["CONDA_CHANNEL_PRIORITY"] = "flexible"
 
     logger.info("Command: " + " ".join(cmd_args))
     logger.info("Configuration:")

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -242,6 +242,7 @@ def _definitions():
         "initialize_by_default": False,
         "initialize_conda": False,
         "register_python": False,
+        "register_envs": False,
         "extra_envs": {
             "spyder-runtime": {
                 "specs": [k + v for k, v in specs.items()],
@@ -279,6 +280,7 @@ def _definitions():
 
         definitions.update(
             {
+                "progress_notifications": True,
                 "post_install": str(RESOURCES / "post-install.sh"),
                 "conclusion_text": "",
                 "readme_text": "",

--- a/installers-conda/resources/post-install.bat
+++ b/installers-conda/resources/post-install.bat
@@ -1,6 +1,9 @@
 :: This script launches Spyder after install
 @echo off
 
+:: Mark as conda-based-app
+echo. > %PREFIX%\envs\spyder-runtime\Menu\conda-based-app
+
 echo %PREFIX% | findstr /b "%USERPROFILE%" > nul && (
     set shortcut_root=%APPDATA%
 ) || (

--- a/installers-conda/resources/post-install.sh
+++ b/installers-conda/resources/post-install.sh
@@ -148,6 +148,10 @@ END
 chmod u+x ${u_spy_exe}
 
 # ----
+echo "Marking as conda-based-app..."
+touch ${PREFIX}/envs/spyder-runtime/Menu/conda-based-app
+
+# ----
 if [[ "$OSTYPE" = "linux"* ]]; then
     cat <<EOF
 

--- a/installers-conda/resources/post-install.sh
+++ b/installers-conda/resources/post-install.sh
@@ -15,10 +15,8 @@ spy_exe=${PREFIX}/envs/spyder-runtime/bin/spyder
 u_spy_exe=${PREFIX}/uninstall-spyder.sh
 all_user=$([[ -e ${PREFIX}/.nonadmin ]] && echo false || echo true)
 
-sed_opts=("-i")
 alias_text="alias uninstall-spyder=${u_spy_exe}"
 if [[ "$OSTYPE" = "darwin"* ]]; then
-    sed_opts+=("", "-e")
     shortcut_path="/Applications/${INSTALLER_NAME}.app"
     if [[ "$all_user" = "false" ]]; then
         shortcut_path="${HOME}${shortcut_path}"
@@ -36,6 +34,16 @@ else
     fi
 fi
 
+
+# BSD sed requires extra "" after -i flag
+if [[ $(sed --version 2>/dev/null) ]]; then
+    # GNU sed has --version
+    sed_opts=("-i" "-e")
+else
+    # BSD sed does not have --version
+    sed_opts=("-i" "" "-e")
+fi
+
 m1="# >>> Added by Spyder >>>"
 m2="# <<< Added by Spyder <<<"
 
@@ -45,12 +53,7 @@ add_alias() {
         exit 0
     fi
 
-    # Remove old-style markers, if present; discard after EXPERIMENTAL
-    # installer attrition.
-    sed ${sed_opts[@]} "/# <<<< Added by Spyder <<<</,/# >>>> Added by Spyder >>>>/d" $shell_init
-
-    # Posix compliant sed does not like semicolons.
-    # Must use newlines to work on macOS
+    # BSD sed does not like semicolons; newlines work for both BSD and GNU.
     sed ${sed_opts[@]} "
     /$m1/,/$m2/{
         h

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -557,7 +557,7 @@ def is_conda_based_app(pyexec=sys.executable):
     else:
         env_path = osp.dirname(osp.dirname(real_pyexec))
 
-    menu_rel_path = '/Menu/spyder-menu.json'
+    menu_rel_path = '/Menu/conda-based-app'
     if (
         osp.exists(env_path + menu_rel_path)
         or glob(env_path + '/envs/*' + menu_rel_path)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* Update to latest conda 23.11.0 and menuinst 2.0.2
* The installer package post-install script now creates an empty file `conda-based-app` next to `spyder-menu.json`. `is_conda_based_app` checks for `conda-based-app` instead of `spyder-menu.json`. This is required since `spyder-menu.json` is will not be unique to our standalone installer.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Partially addresses #21640
