### PR TITLE
PR: Fix extra line in range when formatting selection

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -1858,9 +1858,10 @@ class CodeEditor(TextEditBaseWidget):
         start, end = self.get_selection_start_end()
         start_line, start_col = start
         end_line, end_col = end
-        using_spaces = self.indent_chars != '\t'
-        tab_size = (len(self.indent_chars) if using_spaces else
-                    self.tab_stop_width_spaces)
+
+        # Remove empty trailing newline from multiline selection
+        if end_line > start_line and end_col == 0:
+            end_line -= 1
 
         fmt_range = {
             'start': {
@@ -1872,6 +1873,11 @@ class CodeEditor(TextEditBaseWidget):
                 'character': end_col
             }
         }
+
+        using_spaces = self.indent_chars != '\t'
+        tab_size = (len(self.indent_chars) if using_spaces else
+                    self.tab_stop_width_spaces)
+
         params = {
             'file': self.filename,
             'range': fmt_range,


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

This fixes an issue where formatting a line selected by a double click includes and formats the next line.

In some cases this even breaks the code; when using black and selecting a line outside the range of the text the formatting wraps around:
```
> cat -n temp.py
     1	a = 'hello'
     2	b = ["a", "very", "very", "very", "very", "very", "very", "very", "very", "long", "line"]
     3	c =  42

> black --diff --line-ranges 3-3 temp.py
--- temp.py	2023-12-27 04:53:07.369501+00:00
+++ temp.py	2023-12-27 04:58:40.860306+00:00
@@ -1,3 +1,3 @@
 a = 'hello'
 b = ["a", "very", "very", "very", "very", "very", "very", "very", "very", "long", "line"]
-c =  42
+c = 42
would reformat temp.py

> black --diff --line-ranges 3-4 temp.py
--- temp.py	2023-12-27 04:53:07.369501+00:00
+++ temp.py	2023-12-27 04:58:57.782151+00:00
@@ -1,3 +1,15 @@
-a = 'hello'
-b = ["a", "very", "very", "very", "very", "very", "very", "very", "very", "long", "line"]
-c =  42
+a = "hello"
+b = [
+    "a",
+    "very",
+    "very",
+    "very",
+    "very",
+    "very",
+    "very",
+    "very",
+    "very",
+    "long",
+    "line",
+]
+c = 42
would reformat temp.py 
```
Note sure if a bug or a feature, https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#line-ranges says that 
> Black may still format lines outside of the ranges for multi-line statements.

This issue (minus the wraparound thing) also exists and is fixed with autopep8.

Before:

https://github.com/spyder-ide/spyder/assets/26257211/0c0901d5-0abe-4947-a261-e2f56ba13572

After:

https://github.com/spyder-ide/spyder/assets/26257211/2bb7366b-f541-4d53-9a8a-3817470a5e3c


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

None, let me know if I need to create one?

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: remisalmon

<!--- Thanks for your help making Spyder better for everyone! --->
