### PR TITLE
PR: Fix errors when displaying the Symbols switcher

### DIFF
--- a/spyder/plugins/editor/utils/switcher_manager.py
+++ b/spyder/plugins/editor/utils/switcher_manager.py
@@ -56,11 +56,12 @@ class EditorSwitcherManager(SpyderConfigurationAccessor):
         self._switcher.add_mode(self.SYMBOL_MODE, _('Go to Symbol in File'))
         self._switcher.sig_mode_selected.connect(self.handle_switcher_modes)
         self._switcher.sig_item_selected.connect(
-            self.handle_switcher_selection)
-        self._switcher.sig_text_changed.connect(self.handle_switcher_text)
+            self.handle_switcher_selection
+        )
         self._switcher.sig_rejected.connect(self.handle_switcher_rejection)
         self._switcher.sig_item_changed.connect(
-            self.handle_switcher_item_change)
+            self.handle_switcher_item_change
+        )
         self._switcher.sig_search_text_available.connect(
             lambda text: self._switcher.setup()
         )

--- a/spyder/plugins/editor/utils/switcher_manager.py
+++ b/spyder/plugins/editor/utils/switcher_manager.py
@@ -175,18 +175,17 @@ class EditorSwitcherManager(SpyderConfigurationAccessor):
 
             symbol_range = symbol['location']['range']
             symbol_start = symbol_range['start']['line']
-
             fold_level = editor.leading_whitespaces[symbol_start]
-
             space = ' ' * fold_level
-            formated_title = '{space}{title}'.format(title=symbol_name,
-                                                     space=space)
+            formated_title = f'{space}{symbol_name}'
+
             icon = ima.icon(SYMBOL_KIND_ICON.get(symbol_kind, 'no_match'))
             data = {
                 'title': symbol_name,
                 'line_number': symbol_start + 1
             }
             last_item = idx + 1 == total_symbols
+
             self._switcher.add_item(
                 title=formated_title,
                 icon=icon,
@@ -235,9 +234,9 @@ class EditorSwitcherManager(SpyderConfigurationAccessor):
 
     def handle_switcher_item_change(self, current):
         """Handle item selection change."""
-        editorstack = self._editorstack()
         mode = self._switcher.get_mode()
         if mode == '@' and current is not None:
+            editorstack = self._editorstack()
             line_number = int(current.get_data()['line_number'])
             editorstack.go_to_line(line_number)
 

--- a/spyder/plugins/switcher/api.py
+++ b/spyder/plugins/switcher/api.py
@@ -7,3 +7,7 @@
 """
 Spyder Switcher API.
 """
+
+class SwitcherActions:
+    FileSwitcherAction = 'file switcher'
+    SymbolFinderAction = 'symbol finder'

--- a/spyder/plugins/switcher/container.py
+++ b/spyder/plugins/switcher/container.py
@@ -14,6 +14,7 @@ from qtpy.QtWidgets import QApplication
 # Spyder imports
 from spyder.api.translations import _
 from spyder.api.widgets.main_container import PluginMainContainer
+from spyder.plugins.switcher.api import SwitcherActions
 from spyder.plugins.switcher.widgets.switcher import Switcher
 
 
@@ -26,7 +27,7 @@ class SwitcherContainer(PluginMainContainer):
 
         # Switcher shortcuts
         self.create_action(
-            'file switcher',
+            SwitcherActions.FileSwitcherAction,
             _('File switcher...'),
             icon=self._plugin.get_icon(),
             tip=_('Fast switch between files'),
@@ -36,7 +37,7 @@ class SwitcherContainer(PluginMainContainer):
         )
 
         self.create_action(
-            'symbol finder',
+            SwitcherActions.SymbolFinderAction,
             _('Symbol finder...'),
             icon=self.create_icon('symbol_find'),
             tip=_('Fast symbol search in file'),

--- a/spyder/plugins/switcher/container.py
+++ b/spyder/plugins/switcher/container.py
@@ -16,6 +16,7 @@ from spyder.api.translations import _
 from spyder.api.widgets.main_container import PluginMainContainer
 from spyder.plugins.switcher.api import SwitcherActions
 from spyder.plugins.switcher.widgets.switcher import Switcher
+from spyder.utils.stylesheet import APP_TOOLBAR_STYLESHEET
 
 
 class SwitcherContainer(PluginMainContainer):
@@ -71,18 +72,26 @@ class SwitcherContainer(PluginMainContainer):
         # Set position
         mainwindow = self._plugin.get_main()
 
-        # Note: The +8 pixel on the top makes it look better
-        default_top = (mainwindow.toolbar.toolbars_menu.geometry().height() +
-                       mainwindow.menuBar().geometry().height() + 8)
+        # Note: The +3 pixels makes it vertically align with the main menu or
+        # main menu + toolbar
+        default_top_without_toolbar = (
+            mainwindow.menuBar().geometry().height()
+            + 3
+        )
+
+        default_top_with_toolbar = (
+            int(APP_TOOLBAR_STYLESHEET.BUTTON_HEIGHT.split("px")[0])
+            + default_top_without_toolbar
+        )
 
         current_window = QApplication.activeWindow()
         if current_window == mainwindow:
             if self.get_conf('toolbars_visible', section='toolbar'):
-                delta_top = default_top
+                delta_top = default_top_with_toolbar
             else:
-                delta_top = mainwindow.menuBar().geometry().height() + 8
+                delta_top = default_top_without_toolbar
         else:
-            delta_top = default_top
+            delta_top = default_top_with_toolbar
 
         switcher.set_position(delta_top, current_window)
         switcher.show()

--- a/spyder/plugins/switcher/container.py
+++ b/spyder/plugins/switcher/container.py
@@ -10,6 +10,7 @@
 # Third-party imports
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication
+from superqt.utils import signals_blocked
 
 # Spyder imports
 from spyder.api.translations import _
@@ -21,8 +22,8 @@ from spyder.utils.stylesheet import APP_TOOLBAR_STYLESHEET
 
 class SwitcherContainer(PluginMainContainer):
 
-    # --- PluginMainContainer API
-    # ------------------------------------------------------------------------
+    # ---- PluginMainContainer API
+    # -------------------------------------------------------------------------
     def setup(self):
         self.switcher = Switcher(self._plugin.get_main())
 
@@ -50,8 +51,8 @@ class SwitcherContainer(PluginMainContainer):
     def update_actions(self):
         pass
 
-    # --- Public API
-    # ------------------------------------------------------------------------
+    # ---- Public API
+    # -------------------------------------------------------------------------
     def open_switcher(self, symbol=False):
         """Open switcher dialog."""
         switcher = self.switcher
@@ -62,7 +63,14 @@ class SwitcherContainer(PluginMainContainer):
 
         # Set mode and setup
         if symbol:
-            switcher.set_search_text('@')
+            # Avoid emitting sig_search_text_available
+            with signals_blocked(switcher.edit):
+                switcher.set_search_text('@')
+
+            # Manually set mode and emit sig_mode_selected so that symbols are
+            # shown instantly.
+            switcher._mode_on = "@"
+            switcher.sig_mode_selected.emit("@")
         else:
             switcher.set_search_text('')
 

--- a/spyder/plugins/switcher/plugin.py
+++ b/spyder/plugins/switcher/plugin.py
@@ -25,9 +25,6 @@ from spyder.plugins.switcher.container import SwitcherContainer
 from spyder.plugins.mainmenu.api import ApplicationMenus, FileMenuSections
 
 
-
-# --- Plugin
-# ----------------------------------------------------------------------------
 class Switcher(SpyderPluginV2):
     """
     Switcher plugin.
@@ -85,8 +82,8 @@ class Switcher(SpyderPluginV2):
         The current search/filter text.
     """
 
-    # --- SpyderPluginV2 API
-    # ------------------------------------------------------------------------
+    # ---- SpyderPluginV2 API
+    # -------------------------------------------------------------------------
     @staticmethod
     def get_name():
         return _("Switcher")
@@ -147,7 +144,7 @@ class Switcher(SpyderPluginV2):
 
     # ---- Public API
     # -------------------------------------------------------------------------
-    # Switcher methods
+    # --- Switcher methods
     def set_placeholder_text(self, text):
         """Set the text appearing on the empty line edit."""
         self._switcher.set_placeholder_text(text)
@@ -164,7 +161,7 @@ class Switcher(SpyderPluginV2):
         """Open symbol list management dialog."""
         self.get_container().open_symbolfinder()
 
-    # QDialog methods
+    # --- QDialog methods
     def show(self):
         """Show switcher."""
         self._switcher.show()
@@ -181,14 +178,14 @@ class Switcher(SpyderPluginV2):
         """Return if the switcher is visible."""
         return self._switcher.isVisible()
 
-    # Item methods
+    # --- Item methods
     def current_item(self):
         """Return the current selected item in the list widget."""
         return self._switcher.current_item()
 
     def add_item(self, icon=None, title=None, description=None, shortcut=None,
                  section=None, data=None, tool_tip=None, action_item=False,
-                 last_item=True, score=None, use_score=True):
+                 last_item=True, score=-1, use_score=True):
         """Add a switcher list item."""
         self._switcher.add_item(icon, title, description, shortcut,
                                 section, data, tool_tip, action_item,
@@ -214,7 +211,7 @@ class Switcher(SpyderPluginV2):
         """Remove all items in a section of the switcher."""
         self._switcher.remove_section(section)
 
-    # Mode methods
+    # --- Mode methods
     def add_mode(self, token, description):
         """Add mode by token key and description."""
         self._switcher.add_mode(token, description)
@@ -231,7 +228,7 @@ class Switcher(SpyderPluginV2):
         """Delete all modes spreviously defined."""
         self._switcher.clear_modes()
 
-    # Lineedit methods
+    # --- Lineedit methods
     def set_search_text(self, string):
         """Set the content of the search text."""
         self._switcher.set_search_text(string)

--- a/spyder/plugins/switcher/plugin.py
+++ b/spyder/plugins/switcher/plugin.py
@@ -218,7 +218,7 @@ class Switcher(SpyderPluginV2):
 
     def get_mode(self):
         """Get the current mode the switcher is in."""
-        self._switcher.get_mode()
+        return self._switcher.get_mode()
 
     def remove_mode(self, token):
         """Remove mode by token key."""

--- a/spyder/plugins/switcher/plugin.py
+++ b/spyder/plugins/switcher/plugin.py
@@ -20,15 +20,10 @@ from spyder.api.translations import _
 from spyder.api.plugins import Plugins, SpyderPluginV2
 from spyder.api.plugin_registration.decorators import (on_plugin_available,
                                                        on_plugin_teardown)
+from spyder.plugins.switcher.api import SwitcherActions
 from spyder.plugins.switcher.container import SwitcherContainer
 from spyder.plugins.mainmenu.api import ApplicationMenus, FileMenuSections
 
-
-# --- Constants
-# ----------------------------------------------------------------------------
-class SwitcherActions:
-    FileSwitcherAction = 'file switcher'
-    SymbolFinderAction = 'symbol finder'
 
 
 # --- Plugin

--- a/spyder/plugins/switcher/plugin.py
+++ b/spyder/plugins/switcher/plugin.py
@@ -45,19 +45,9 @@ class Switcher(SpyderPluginV2):
     This signal is emitted when the plugin is dismissed.
     """
 
-    sig_text_changed = Signal(str)
-    """
-    This signal is emitted when the plugin search/filter text changes.
-
-    Parameters
-    ----------
-    search_text: str
-        The current search/filter text.
-    """
-
     sig_item_changed = Signal(object)
     """
-    This signal is emitted when the plugin current item changes.
+    This signal is emitted when the current item changes.
     """
 
     sig_item_selected = Signal(object, str, str)
@@ -114,12 +104,12 @@ class Switcher(SpyderPluginV2):
         self._switcher = container.switcher
 
         self._switcher.sig_rejected.connect(self.sig_rejected)
-        self._switcher.sig_text_changed.connect(self.sig_text_changed)
         self._switcher.sig_item_changed.connect(self.sig_item_changed)
         self._switcher.sig_item_selected.connect(self.sig_item_selected)
         self._switcher.sig_mode_selected.connect(self.sig_mode_selected)
         self._switcher.sig_search_text_available.connect(
-            self.sig_search_text_available)
+            self.sig_search_text_available
+        )
 
     def on_close(self, cancellable=True):
         """Close switcher widget."""

--- a/spyder/plugins/switcher/widgets/proxymodel.py
+++ b/spyder/plugins/switcher/widgets/proxymodel.py
@@ -7,7 +7,7 @@
 """Switcher Proxy Model."""
 
 # Third party imports
-from qtpy.QtCore import (QSortFilterProxyModel, Qt)
+from qtpy.QtCore import QSortFilterProxyModel, Qt
 
 
 class SwitcherProxyModel(QSortFilterProxyModel):
@@ -15,7 +15,7 @@ class SwitcherProxyModel(QSortFilterProxyModel):
 
     def __init__(self, parent=None):
         """Proxy model to perform sorting on the scored items."""
-        super(SwitcherProxyModel, self).__init__(parent)
+        super().__init__(parent)
         self.setFilterCaseSensitivity(Qt.CaseInsensitive)
         self.setSortCaseSensitivity(Qt.CaseInsensitive)
         self.setDynamicSortFilter(True)

--- a/spyder/plugins/switcher/widgets/switcher.py
+++ b/spyder/plugins/switcher/widgets/switcher.py
@@ -63,7 +63,7 @@ class KeyPressFilter(QObject):
             elif (e.key() == Qt.Key_Return):
                 self.sig_enter_key_pressed.emit()
                 return True
-        return super(KeyPressFilter, self).eventFilter(src, e)
+        return super().eventFilter(src, e)
 
 
 class SwitcherDelegate(HTMLDelegate):
@@ -77,7 +77,7 @@ class SwitcherDelegate(HTMLDelegate):
         Override Qt method to force this delegate to look active at all times.
         """
         option.state |= QStyle.State_Active
-        super(SwitcherDelegate, self).paint(painter, option, index)
+        super().paint(painter, option, index)
 
 
 class Switcher(QDialog):
@@ -457,7 +457,7 @@ class Switcher(QDialog):
 
     def accept(self):
         """Override Qt method."""
-        super(Switcher, self).accept()
+        super().accept()
 
     def reject(self):
         """Override Qt method."""
@@ -468,7 +468,7 @@ class Switcher(QDialog):
         self.edit.blockSignals(False)
 
         self.sig_rejected.emit()
-        super(Switcher, self).reject()
+        super().reject()
 
     # ---- Helper methods: Lineedit widget
     def search_text(self):
@@ -546,7 +546,8 @@ class Switcher(QDialog):
 
         # https://doc.qt.io/qt-5/qitemselectionmodel.html#SelectionFlag-enum
         selection_model.setCurrentIndex(
-            proxy_index, selection_model.ClearAndSelect)
+            proxy_index, selection_model.ClearAndSelect
+        )
 
         # Ensure that the selected item is visible
         self.list.scrollTo(proxy_index, QAbstractItemView.EnsureVisible)

--- a/spyder/plugins/switcher/widgets/switcher.py
+++ b/spyder/plugins/switcher/widgets/switcher.py
@@ -99,16 +99,6 @@ class Switcher(QDialog):
     This signal is emitted when the plugin is dismissed.
     """
 
-    sig_text_changed = Signal(str)
-    """
-    This signal is emitted when the plugin search/filter text changes.
-
-    Parameters
-    ----------
-    search_text: str
-        The current search/filter text.
-    """
-
     sig_item_changed = Signal(object)
     """
     This signal is emitted when the plugin current item changes.
@@ -208,7 +198,6 @@ class Switcher(QDialog):
         self.filter.sig_down_key_pressed.connect(self.next_row)
         self.filter.sig_enter_key_pressed.connect(self.enter)
 
-        self.edit.textChanged.connect(self.sig_text_changed)
         self.edit.textChanged.connect(lambda: self._search_timer.start())
         self.edit.returnPressed.connect(self.enter)
 

--- a/spyder/plugins/switcher/widgets/switcher.py
+++ b/spyder/plugins/switcher/widgets/switcher.py
@@ -205,6 +205,7 @@ class Switcher(QDialog):
         self.edit.setFocus()
 
     # ---- Helper methods
+    # -------------------------------------------------------------------------
     def _add_item(self, item, last_item=True):
         """Perform common actions when adding items."""
         item.set_width(self._ITEM_WIDTH)
@@ -218,6 +219,7 @@ class Switcher(QDialog):
             self.set_height()
 
     # ---- API
+    # -------------------------------------------------------------------------
     def clear(self):
         """Remove all items from the list and clear the search text."""
         self.set_placeholder_text('')
@@ -425,7 +427,7 @@ class Switcher(QDialog):
         self.sig_item_changed.emit(self.current_item())
 
     # ---- Qt overrides
-    # ------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     @Slot()
     @Slot(QListWidgetItem)
     def enter(self, itemClicked=None):
@@ -439,10 +441,6 @@ class Switcher(QDialog):
                 item, mode, self.search_text_without_mode()
             )
 
-    def accept(self):
-        """Override Qt method."""
-        super().accept()
-
     def reject(self):
         """Override Qt method."""
         # This prevents calling _on_search_text_changed, which unnecessarily
@@ -450,10 +448,14 @@ class Switcher(QDialog):
         with signals_blocked(self.edit):
             self.set_search_text('')
 
+        # Reset mode
+        self._mode_on = ""
+
         self.sig_rejected.emit()
         super().reject()
 
     # ---- Helper methods: Lineedit widget
+    # -------------------------------------------------------------------------
     def search_text(self):
         """Get the normalized (lowecase) content of the search text."""
         return to_text_string(self.edit.text()).lower()
@@ -495,6 +497,7 @@ class Switcher(QDialog):
             self.setup()
 
     # ---- Helper methods: List widget
+    # -------------------------------------------------------------------------
     def _is_separator(self, item):
         """Check if item is an separator item (SwitcherSeparatorItem)."""
         return isinstance(item, SwitcherSeparatorItem)


### PR DESCRIPTION
## Description of Changes

- This broke in #21275.
- Expand test suite to catch this problem in the future.
- Remove direct usage of `CONF` in `EditorSwitcherManager`.
- Correctly align Switcher vertically with the main menu and toolbar.
- Fix jumping to different symbols in the editor from the Switcher. This probably broke in #20837.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
