### PR TITLE
PR: Fix some tests failing on Python 3.12

### DIFF
--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -143,12 +143,12 @@ def test_renamed_tree(editor_plugin, mocker):
 
     editor.renamed_tree('/test/directory', '/test/dir')
     assert editor.renamed.call_count == 3
-    assert editor.renamed.called_with(source='/test/directory/file1.py',
-                                      dest='test/dir/file1.py')
-    assert editor.renamed.called_with(source='/test/directory/file2.txt',
-                                      dest='test/dir/file2.txt')
-    assert editor.renamed.called_with(source='/test/directory/file4.rst',
-                                      dest='test/dir/file4.rst')
+    editor.renamed.assert_any_call(source='/test/directory/file1.py',
+                                   dest='/test/dir/file1.py')
+    editor.renamed.assert_any_call(source='/test/directory/file2.txt',
+                                   dest='/test/dir/file2.txt')
+    editor.renamed.assert_any_call(source='/test/directory/file4.rst',
+                                   dest='/test/dir/file4.rst')
 
 
 def test_no_template(editor_plugin):

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -136,19 +136,36 @@ def test_renamed_tree(editor_plugin, mocker):
     editor = editor_plugin
     mocker.patch.object(editor, 'get_filenames')
     mocker.patch.object(editor, 'renamed')
-    editor.get_filenames.return_value = ['/test/directory/file1.py',
-                                         '/test/directory/file2.txt',
-                                         '/home/spyder/testing/file3.py',
-                                         '/test/directory/file4.rst']
+    if os.name == "nt":
+        filenames = [r'C:\test\directory\file1.py',
+                     r'C:\test\directory\file2.txt',
+                     r'C:\home\spyder\testing\file3.py',
+                     r'C:\test\directory\file4.rst']
+        expected = [r'C:\test\dir\file1.py',
+                    r'C:\test\dir\file2.txt',
+                    r'C:\home\spyder\testing\file3.py',
+                    r'C:\test\dir\file4.rst']
+        sourcedir = r'C:\test\directory'
+        destdir = r'C:\test\dir'
+    else:
+        filenames = ['/test/directory/file1.py',
+                     '/test/directory/file2.txt',
+                     '/home/spyder/testing/file3.py',
+                     '/test/directory/file4.rst']
+        expected = ['/test/dir/file1.py',
+                    '/test/dir/file2.txt',
+                    '/home/spyder/testing/file3.py',
+                    '/test/dir/file4.rst']
+        sourcedir = '/test/directory'
+        destdir = '/test/dir'
 
-    editor.renamed_tree('/test/directory', '/test/dir')
+    editor.get_filenames.return_value = filenames
+
+    editor.renamed_tree(sourcedir, destdir)
     assert editor.renamed.call_count == 3
-    editor.renamed.assert_any_call(source='/test/directory/file1.py',
-                                   dest='/test/dir/file1.py')
-    editor.renamed.assert_any_call(source='/test/directory/file2.txt',
-                                   dest='/test/dir/file2.txt')
-    editor.renamed.assert_any_call(source='/test/directory/file4.rst',
-                                   dest='/test/dir/file4.rst')
+    for file in [0, 1, 3]:
+        editor.renamed.assert_any_call(source=filenames[file],
+                                       dest=expected[file])
 
 
 def test_no_template(editor_plugin):

--- a/spyder/plugins/editor/widgets/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/tests/test_warnings.py
@@ -263,7 +263,12 @@ def test_update_warnings_after_closequotes(qtbot, completions_codeeditor_linting
     editor, _ = completions_codeeditor_linting
     editor.textCursor().insertText("print('test)\n")
 
-    if sys.version_info >= (3, 10):
+    if sys.version_info >= (3, 12):
+        expected = [
+            ['unterminated string literal (detected at line 1)', 1],
+            ['E901 TokenError: unterminated string literal (detected at line 1)', 1]
+        ]
+    elif sys.version_info >= (3, 10):
         expected = [['unterminated string literal (detected at line 1)', 1]]
     else:
         expected = [['EOL while scanning string literal', 1]]
@@ -302,7 +307,12 @@ def test_update_warnings_after_closebrackets(qtbot, completions_codeeditor_linti
     editor, _ = completions_codeeditor_linting
     editor.textCursor().insertText("print('test'\n")
 
-    if sys.version_info >= (3, 10):
+    if sys.version_info >= (3, 12):
+        expected = [
+            ["'(' was never closed", 1],
+            ['E901 TokenError: unexpected EOF in multi-line statement', 1]
+        ]
+    elif sys.version_info >= (3, 10):
         expected = [
             ["'(' was never closed", 1],
             ['E901 TokenError: EOF in multi-line statement', 2]

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/test_objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/test_objectexplorer.py
@@ -110,7 +110,7 @@ def test_objectexplorer(objectexplorer):
     ([1, 3, 4, 'kjkj', None], [45, 48]),
     ({1, 2, 1, 3, None, 'A', 'B', 'C', True, False}, [54, 57]),
     (1.2233, [57, 59]),
-    (np.random.rand(10, 10), [166, 162]),
+    (np.random.rand(10, 10), [162, 167]),
     (datetime.date(1945, 5, 8), [43, 48])
 ])
 def test_objectexplorer_collection_types(objectexplorer, params):

--- a/spyder/widgets/tests/test_reporterror.py
+++ b/spyder/widgets/tests/test_reporterror.py
@@ -95,7 +95,6 @@ def test_report_issue_url(monkeypatch):
     target_url_base = __project_url__ + '/issues/new'
 
     MockQDesktopServices = MagicMock()
-    mockQDesktopServices_instance = MockQDesktopServices()
     attr_to_patch = ('spyder.widgets.reporterror.QDesktopServices')
     monkeypatch.setattr(attr_to_patch, MockQDesktopServices)
 
@@ -103,14 +102,14 @@ def test_report_issue_url(monkeypatch):
     target_url = QUrl(target_url_base + '?body=' + body)
     SpyderErrorDialog.open_web_report(body=body, title=None)
     assert MockQDesktopServices.openUrl.call_count == 1
-    mockQDesktopServices_instance.openUrl.called_with(target_url)
+    MockQDesktopServices.openUrl.assert_called_with(target_url)
 
     # Test when body != None and title != None
     target_url = QUrl(target_url_base + '?body=' + body
                       + "&title=" + title)
-    SpyderErrorDialog.open_web_report(body=body, title=None)
+    SpyderErrorDialog.open_web_report(body=body, title=title)
     assert MockQDesktopServices.openUrl.call_count == 2
-    mockQDesktopServices_instance.openUrl.called_with(target_url)
+    MockQDesktopServices.openUrl.assert_called_with(target_url)
 
 
 def test_render_issue():


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

These fix all of the issues identified in #21688 except for `test_move_to_first_breakpoint[False]`.  The tests using `called_with` were both broken, and this patch also fixes this.

### Issue(s) Resolved

Almost resolves (fixes) #21688, but not quite

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @juliangilbey 

<!--- Thanks for your help making Spyder better for everyone! --->
