### PR TITLE
PR: Improve `renamed_tree` method (Editor)

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2539,7 +2539,9 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         tofile = to_text_string(dest)
         for fname in self.get_filenames():
             if osp.abspath(fname).startswith(dirname):
-                new_filename = fname.replace(dirname, tofile)
+                source_re = "^" + re.escape(source)
+                dest_quoted = dest.replace("\\", r"\\")
+                new_filename = re.sub(source_re, dest_quoted, fname)
                 self.renamed(source=fname, dest=new_filename)
 
     #------ Source code


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->

This follows the discussion in PR #21692 and fixes the issue identified there.  Turns out that `count=1` is not needed as the regex is anchored to the start of the string.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @juliangilbey 

<!--- Thanks for your help making Spyder better for everyone! --->
