### PR TITLE
PR: Fix error when computing the size hint of `ItemDelegate` in Python 3.10+

### DIFF
--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -213,7 +213,7 @@ class ItemDelegate(QStyledItemDelegate):
         doc.setHtml(options.text)
         doc.setTextWidth(options.rect.width())
 
-        return QSize(doc.idealWidth(), doc.size().height())
+        return QSize(int(doc.idealWidth()), int(doc.size().height()))
 
 
 class IconLineEdit(QLineEdit):


### PR DESCRIPTION
## Description of Changes
Width and height values are being converted to integer type.

```python
def sizeHint(self, option, index):

    options = QStyleOptionViewItem(option)
    self.initStyleOption(options, index)

    doc = QTextDocument()
    doc.setHtml(options.text)
    doc.setTextWidth(options.rect.width())

    return QSize(int(doc.idealWidth()), int(doc.size().height()))`
```

### Issue(s) Resolved

Fixes #21694


