### PR TITLE
Uses `string.Template` when creating a new file.

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2217,14 +2217,14 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                                       text)
                 if enc_match:
                     enc = enc_match.group(1)
+
                 # Initialize template variables
-                # Only Windows has a 'USERNAME' environment variable
-                username = encoding.to_unicode_from_fs(
-                                os.environ.get('USERNAME', ''))
-                if username:
+                if os.name == 'nt':
                     # Windows
                     import ctypes
 
+                    username = encoding.to_unicode_from_fs(
+                                os.environ.get('USERNAME', ''))
                     GetUserNameEx = ctypes.windll.secur32.GetUserNameExW
                     name_display = 3
 

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -20,7 +20,6 @@ from pathlib import Path
 import re
 import string
 import sys
-import time
 from typing import Dict, Optional
 import uuid
 
@@ -2226,12 +2225,14 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                 if not username:
                     username = encoding.to_unicode_from_fs(
                                    os.environ.get('USER', '-'))
+                now = datetime.now().astimezone()
+                now.replace(microsecond=0)
                 VARS = {
-                    'date': time.ctime(),
-                    'year': time.strftime('%Y'),
-                    'month': time.strftime('%m'),
-                    'monthname': time.strftime('%B'),
-                    'day': time.strftime('%d'),
+                    'date': now.ctime(),
+                    'year': now.strftime('%Y'),
+                    'month': now.strftime('%m'),
+                    'monthname': now.strftime('%B'),
+                    'day': now.strftime('%d'),
                     'username': username,
                 }
                 try:

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2228,6 +2228,10 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                                    os.environ.get('USER', '-'))
                 VARS = {
                     'date': time.ctime(),
+                    'year': time.strftime('%Y'),
+                    'month': time.strftime('%m'),
+                    'monthname': time.strftime('%B'),
+                    'day': time.strftime('%d'),
                     'username': username,
                 }
                 try:

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2229,10 +2229,16 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                 now.replace(microsecond=0)
                 VARS = {
                     'date': now.ctime(),
+                    'isodate': now.isoformat(),
                     'year': now.strftime('%Y'),
                     'month': now.strftime('%m'),
-                    'monthname': now.strftime('%B'),
                     'day': now.strftime('%d'),
+                    'hour': now.strftime('%H'),
+                    'minute': now.strftime('%M'),
+                    'second': now.strftime('%S'),
+                    'tzname': now.strftime('%Z'),
+                    'monthname': now.strftime('%b'),
+                    'weekday': now.strftime('%a'),
                     'username': username,
                 }
                 try:

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -2224,7 +2224,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                     import ctypes
 
                     username = encoding.to_unicode_from_fs(
-                                os.environ.get('USERNAME', ''))
+                                os.environ.get('USERNAME', '-'))
                     GetUserNameEx = ctypes.windll.secur32.GetUserNameExW
                     name_display = 3
 
@@ -2234,14 +2234,20 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                     name_buffer = ctypes.create_unicode_buffer(
                                 size.contents.value)
                     GetUserNameEx(name_display, name_buffer, size)
-                    displayname = nameBuffer.value
+                    displayname = nameBuffer.value.strip()
                 else:
                     # Linux, Mac OS X
                     import pwd
 
                     username = encoding.to_unicode_from_fs(
                                    os.environ.get('USER', '-'))
-                    displayname = pwd.getpwnam(username).pw_gecos.split(',')[0]
+                    try:
+                        pwd_struct = pwd.getpwnam(username)
+                    except KeyError:
+                        displayname = ''
+                    else:
+                        # Use first element in Gecos field as user's full name
+                        displayname = pwd_struct.pw_gecos.split(',')[0].strip()
 
                 now = datetime.now().astimezone()
                 now.replace(microsecond=0)
@@ -2258,7 +2264,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                     'monthname': now.strftime('%b'),
                     'weekday': now.strftime('%a'),
                     'username': username,
-                    'fullname': displayname
+                    'fullname': displayname or 'n/a'
                 }
                 try:
                     text = string.Template(text).safe_substitute(VARS)

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -209,6 +209,8 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                 'Created on ${date}',
                 '',
                 '@author: ${username}',
+                '',
+                'Copyright ${year}  ${fullname}',
                 '"""',
                 '',
                 '']

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -18,6 +18,7 @@ import os
 import os.path as osp
 from pathlib import Path
 import re
+import string
 import sys
 import time
 from typing import Dict, Optional
@@ -205,8 +206,13 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                 shebang = ['#!/usr/bin/env python3']
             header = shebang + [
                 '# -*- coding: utf-8 -*-',
-                '"""', 'Created on %(date)s', '',
-                '@author: %(username)s', '"""', '', '']
+                '"""',
+                'Created on ${date}',
+                '',
+                '@author: ${username}',
+                '"""',
+                '',
+                '']
             try:
                 encoding.write(os.linesep.join(header), self.TEMPLATE_PATH,
                                'utf-8')
@@ -2225,7 +2231,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
                     'username': username,
                 }
                 try:
-                    text = text % VARS
+                    text = string.Template(text).safe_substitute(VARS)
                 except Exception:
                     pass
             else:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Spyder uses a file template when opening a new file. In this template known tokens are replaced by values. Currently only two tokens are recognized: `%date` and `%username`. The syntax `%<name>` also interferes with more elaborated templates (e.g. #21058).

This PR now changes the simple `text % VARS` replacement with the `string.Template` functionality built into Python. This now uses `$date` (or `${date}`) instead and the dollar signs can be escaped. This should help in writing more elaborated customary templates.

Also more template fields are made available with this PR, mainly related to the current time. But also the full name of the user is made available under `$fullname`.

It also adds a `Copyright ${year}  ${fullname}` line to the default template and uses the `datetime.datetime` module instead of `time` (because that is imported anyway for newer versions of this file).

### Caveats

It breaks the template syntax, because it uses `$` instead of `%` to mark variables in the template. On the other hand it resolves the problem due to using `%`.

The update is easy: Replace all `%<name>` with `$<name>` in your template.

Note: When backporting this PR to Spyder 5, please add the following import statement `from datetime import datetime` and remove `import time` from the file.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21058
Fixes #11426
Fixes #6379

Superseeds #14579

See also #2884

### Question

The current default template includes a `# -*- coding: utf-8 -*-` line. Is this still necessary? Python already uses utf-8 throughout …

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: sphh

<!--- Thanks for your help making Spyder better for everyone! --->
