### PR TITLE
PR: Fix several UI regressions and errors

### DIFF
--- a/spyder/api/widgets/menus.py
+++ b/spyder/api/widgets/menus.py
@@ -372,12 +372,13 @@ class SpyderMenu(QMenu, SpyderFontsMixin):
             else:
                 set_menu_icons(self, True)
 
-    def _generate_stylesheet(self):
+    @classmethod
+    def _generate_stylesheet(cls):
         """Generate base stylesheet for menus."""
         css = qstylizer.style.StyleSheet()
-        font = self.get_font(SpyderFontType.Interface)
+        font = cls.get_font(SpyderFontType.Interface)
 
-        # Add padding and border radius to follow modern standards
+        # Add padding and border to follow modern standards
         css.QMenu.setValues(
             # Only add top and bottom padding so that menu separators can go
             # completely from the left to right border.

--- a/spyder/api/widgets/menus.py
+++ b/spyder/api/widgets/menus.py
@@ -14,7 +14,7 @@ from typing import Optional, Union, TypeVar
 
 # Third party imports
 import qstylizer.style
-from qtpy.QtWidgets import QAction, QMenu, QWidget
+from qtpy.QtWidgets import QAction, QMenu, QProxyStyle, QStyle, QWidget
 
 # Local imports
 from spyder.api.config.fonts import SpyderFontType, SpyderFontsMixin
@@ -40,6 +40,24 @@ class OptionsMenuSections:
 class PluginMainWidgetMenus:
     Context = 'context_menu'
     Options = 'options_menu'
+
+
+# ---- Style
+# -----------------------------------------------------------------------------
+class SpyderMenuProxyStyle(QProxyStyle):
+    """Style adjustments that can only be done with a proxy style."""
+
+    def pixelMetric(self, metric, option=None, widget=None):
+        if metric == QStyle.PM_SmallIconSize:
+            # Change icon size for menus.
+            # Taken from https://stackoverflow.com/a/42145885/438386
+            delta = -1 if MAC else (0 if WIN else 1)
+
+            return (
+                QProxyStyle.pixelMetric(self, metric, option, widget) + delta
+            )
+
+        return QProxyStyle.pixelMetric(self, metric, option, widget)
 
 
 # ---- Widgets
@@ -118,6 +136,10 @@ class SpyderMenu(QMenu, SpyderFontsMixin):
         # Style
         self.css = self._generate_stylesheet()
         self.setStyleSheet(self.css.toString())
+
+        style = SpyderMenuProxyStyle(None)
+        style.setParent(self)
+        self.setStyle(style)
 
     # ---- Public API
     # -------------------------------------------------------------------------

--- a/spyder/api/widgets/menus.py
+++ b/spyder/api/widgets/menus.py
@@ -14,6 +14,7 @@ from typing import Optional, Union, TypeVar
 
 # Third party imports
 import qstylizer.style
+from qtpy.QtGui import QCursor
 from qtpy.QtWidgets import QAction, QMenu, QProxyStyle, QStyle, QWidget
 
 # Local imports
@@ -448,20 +449,28 @@ class SpyderMenu(QMenu, SpyderFontsMixin):
     # -------------------------------------------------------------------------
     def showEvent(self, event):
         """Adjustments when the menu is shown."""
-        # Reposition submenus vertically due to padding and border
-        if (
-            not sys.platform == "darwin"
-            and self._reposition
-            and self._is_submenu
-            and not self._is_shown
-        ):
-            self.move(
-                self.pos().x(),
-                # Current vertical pos - padding - border
-                self.pos().y() - 2 * AppStyle.MarginSize - 1
-            )
+        if not self._is_shown:
+            # Reposition submenus vertically due to padding and border
+            if self._reposition and self._is_submenu:
+                self.move(
+                    self.pos().x(),
+                    # Current vertical pos - padding - border
+                    self.pos().y() - 2 * AppStyle.MarginSize - 1
+                )
 
             self._is_shown = True
+
+        # Reposition menus horizontally due to border
+        if QCursor().pos().x() - self.pos().x() < 40:
+            # If the difference between the current cursor x position and the
+            # menu one is small, it means the menu will be shown to the right,
+            # so we need to move it in that direction.
+            delta_x = 1
+        else:
+            # This happens when the menu is shown to the left.
+            delta_x = -1
+
+        self.move(self.pos().x() + delta_x, self.pos().y())
 
         super().showEvent(event)
 

--- a/spyder/api/widgets/menus.py
+++ b/spyder/api/widgets/menus.py
@@ -425,14 +425,19 @@ class SpyderMenu(QMenu, SpyderFontsMixin):
     # -------------------------------------------------------------------------
     def showEvent(self, event):
         """Adjustments when the menu is shown."""
-        # Reposition menu vertically due to padding
+        # Reposition submenus vertically due to padding and border
         if (
             not sys.platform == "darwin"
             and self._reposition
             and self._is_submenu
             and not self._is_shown
         ):
-            self.move(self.pos().x(), self.pos().y() - 2 * AppStyle.MarginSize)
+            self.move(
+                self.pos().x(),
+                # Current vertical pos - padding - border
+                self.pos().y() - 2 * AppStyle.MarginSize - 1
+            )
+
             self._is_shown = True
 
         super().showEvent(event)

--- a/spyder/api/widgets/toolbars.py
+++ b/spyder/api/widgets/toolbars.py
@@ -23,6 +23,7 @@ from qtpy.QtWidgets import (
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
 from spyder.api.translations import _
+from spyder.api.widgets.menus import SpyderMenu, SpyderMenuProxyStyle
 from spyder.utils.icon_manager import ima
 from spyder.utils.qthelpers import SpyderAction
 from spyder.utils.stylesheet import (
@@ -113,11 +114,20 @@ class SpyderToolbar(QToolBar):
 
         self.setWindowTitle(title)
 
-        # Set icon for extension button.
+        # Set attributes for extension button.
         # From https://stackoverflow.com/a/55412455/438386
         ext_button = self.findChild(QToolButton, "qt_toolbar_ext_button")
         ext_button.setIcon(ima.icon('toolbar_ext_button'))
         ext_button.setToolTip(_("More"))
+
+        # Set style for extension button menu.
+        ext_button.menu().setStyleSheet(
+            SpyderMenu._generate_stylesheet().toString()
+        )
+
+        ext_button_menu_style = SpyderMenuProxyStyle(None)
+        ext_button_menu_style.setParent(self)
+        ext_button.menu().setStyle(ext_button_menu_style)
 
     def add_item(self, action_or_widget: ToolbarItem,
                  section: Optional[str] = None, before: Optional[str] = None,

--- a/spyder/plugins/findinfiles/widgets/main_widget.py
+++ b/spyder/plugins/findinfiles/widgets/main_widget.py
@@ -35,6 +35,7 @@ from spyder.widgets.helperwidgets import PaneEmptyWidget
 # -----------------------------------------------------------------------------
 MAIN_TEXT_COLOR = QStylePalette.COLOR_TEXT_1
 MAX_COMBOBOX_WIDTH = AppStyle.FindMinWidth + 80  # In pixels
+MIN_COMBOBOX_WIDTH = AppStyle.FindMinWidth - 80  # In pixels
 
 
 # ---- Enums
@@ -185,7 +186,7 @@ class FindInFilesWidget(PluginMainWidget):
             id_=FindInFilesWidgetToolbarItems.SearchInCombo
         )
         self.path_selection_combo.setMinimumSize(
-            MAX_COMBOBOX_WIDTH, AppStyle.FindHeight
+            MIN_COMBOBOX_WIDTH, AppStyle.FindHeight
         )
         self.path_selection_combo.setMaximumWidth(MAX_COMBOBOX_WIDTH)
 
@@ -196,7 +197,7 @@ class FindInFilesWidget(PluginMainWidget):
             id_=FindInFilesWidgetToolbarItems.ExcludePatternCombo
         )
         self.exclude_pattern_edit.setMinimumSize(
-            MAX_COMBOBOX_WIDTH, AppStyle.FindHeight
+            MIN_COMBOBOX_WIDTH, AppStyle.FindHeight
         )
         self.exclude_pattern_edit.setMaximumWidth(MAX_COMBOBOX_WIDTH)
 

--- a/spyder/plugins/findinfiles/widgets/results_browser.py
+++ b/spyder/plugins/findinfiles/widgets/results_browser.py
@@ -23,6 +23,7 @@ from spyder.plugins.findinfiles.widgets.search_thread import (
     ELLIPSIS, MAX_RESULT_LENGTH)
 from spyder.utils import icon_manager as ima
 from spyder.utils.palette import QStylePalette
+from spyder.utils.stylesheet import AppStyle
 from spyder.widgets.onecolumntree import OneColumnTree
 
 
@@ -185,6 +186,7 @@ class ItemDelegate(QStyledItemDelegate):
 
 
 class ResultsBrowser(OneColumnTree, SpyderFontsMixin):
+
     sig_edit_goto_requested = Signal(str, int, str, int, int)
     sig_max_results_reached = Signal()
 
@@ -320,6 +322,9 @@ class ResultsBrowser(OneColumnTree, SpyderFontsMixin):
 
     def set_width(self):
         """Set widget width according to its longest item."""
+        if not self.data:
+            return
+
         # File item width
         file_item_size = self.fontMetrics().size(
             Qt.TextSingleLine,
@@ -340,5 +345,29 @@ class ResultsBrowser(OneColumnTree, SpyderFontsMixin):
         else:
             width = line_item_width
 
-        # Increase width a bit to not be too near to the edge
-        self.itemDelegate().width = width + 10
+        # Compare obtained value with the available width (we have two
+        # indentation levels here and the -6 is necessary to avoid showing the
+        # horizontal scrollbar)
+        available_width = self.width() - 2 * self.indentation() - 6
+
+        if width < available_width:
+            width = available_width
+        else:
+            # Increase computed width so that the longest item is not too close
+            # to the right edge
+            if self.verticalScrollBar().isVisible():
+                width = width + self.verticalScrollBar().width()
+            else:
+                width = width + 2 * AppStyle.MarginSize
+
+        self.itemDelegate().width = width
+
+    def resizeEvent(self, event):
+        """Adjustments when the widget is resized."""
+        super().resizeEvent(event)
+
+        # This recomputes the items width according to the widget's current
+        # one, which makes the UI be rendered as expected.
+        # NOTE: Don't debounce or throttle this method because it wouldn't do
+        # its work as expected.
+        self.set_width()

--- a/spyder/plugins/shortcuts/plugin.py
+++ b/spyder/plugins/shortcuts/plugin.py
@@ -180,7 +180,7 @@ class Shortcuts(SpyderPluginV2):
                 if shortcut_sequence in self._shortcut_sequences:
                     continue
 
-                self._shortcut_sequences |= {shortcut_sequence}
+                self._shortcut_sequences |= {(context, shortcut_sequence)}
                 keyseq = QKeySequence(shortcut_sequence)
             else:
                 # Needed to remove old sequences that were cleared.

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -29,7 +29,6 @@ from spyder_kernels.utils.misc import fix_reference_name
 from spyder_kernels.utils.nsview import REMOTE_SETTINGS
 
 # Local imports
-from spyder.api.plugins import Plugins
 from spyder.api.translations import _
 from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.config.utils import IMPORT_EXT

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -27,8 +27,8 @@ from qtpy.QtGui import (
     QDesktopServices, QFontMetrics, QKeyEvent, QKeySequence, QPixmap)
 from qtpy.QtWidgets import (QAction, QApplication, QDialog, QHBoxLayout,
                             QLabel, QLineEdit, QMenu, QPlainTextEdit,
-                            QProxyStyle, QPushButton, QStyle,
-                            QToolButton, QVBoxLayout, QWidget)
+                            QPushButton, QStyle, QToolButton, QVBoxLayout,
+                            QWidget)
 
 # Local imports
 from spyder.api.config.fonts import SpyderFontsMixin, SpyderFontType
@@ -714,34 +714,6 @@ def set_menu_icons(menu, state, in_app_menu=False):
                 action.setIconVisibleInMenu(state)
         except RuntimeError:
             continue
-
-
-class SpyderProxyStyle(QProxyStyle):
-    """Style proxy to adjust qdarkstyle issues."""
-
-    def styleHint(self, hint, option=0, widget=0, returnData=0):
-        if hint == QStyle.SH_ComboBox_Popup:
-            # Disable combobox popup top & bottom areas.
-            # See spyder-ide/spyder#9682
-            # Taken from https://stackoverflow.com/a/21019371
-            return 0
-
-        return QProxyStyle.styleHint(self, hint, option, widget, returnData)
-
-    def pixelMetric(self, metric, option=None, widget=None):
-        if metric == QStyle.PM_SmallIconSize:
-            # Change icon size for menus.
-            # Taken from https://stackoverflow.com/a/42145885/438386
-            delta = (
-                -1 if sys.platform == "darwin"
-                else (0 if os.name == "nt" else 1)
-            )
-
-            return (
-                QProxyStyle.pixelMetric(self, metric, option, widget) + delta
-            )
-
-        return QProxyStyle.pixelMetric(self, metric, option, widget)
 
 
 class QInputDialogMultiline(QDialog):

--- a/spyder/widgets/simplecodeeditor.py
+++ b/spyder/widgets/simplecodeeditor.py
@@ -565,6 +565,7 @@ class SimpleCodeEditor(QPlainTextEdit, BaseEditMixin):
         """
         if self._highlighter:
             self._highlighter.rehighlight()
+            self._apply_current_line_highlight()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of Changes

- Prevent freeze when switching and moving panes. That was calling `findChildren(QTabBar)`, which takes a long time now (probably due to the new style for special tabbars). To fix that, we call that method with a timer every minute in the main window, which avoids the freeze.
- Reposition menus so they are correctly aligned both horizontally and vertically. Small glitches were introduced due to our new usage of borders in menus.
- Make menus associated to extension button toolbars look like a `SpyderMenu`.
- Fix double clicks on the Variable Explorer. That was opening two editors per variable.
- Remove global proxy style because it was interfering with the new style for menus. Instead, apply the styles declared in it on `SpyderMenu` and `SpyderComboBox`.
- Fix setting the same shortcut in different contexts. That allows to use the same local shortcuts in Files and Projects.
- Reduce min size of comboboxes in Find so they are not shown as collapsed when there's enough space to display them.

### Visual changes

**Fix incorrect padding of menu items for some menus**

This was due to our global proxy style

Before | After
-|-
![imagen](https://github.com/spyder-ide/spyder/assets/365293/6d87b8f7-f448-4c27-93d5-427abe166ee6) | ![imagen](https://github.com/spyder-ide/spyder/assets/365293/235c043e-53e9-48bd-98a6-1fbe6e98d564)

**Fix highlight color of current line when selecting different color schemes in Preferences**

Before | After
-|-
![syntax-highlighting-wrong](https://github.com/spyder-ide/spyder/assets/365293/85b37d50-b81c-482e-a181-6040e0ba1984) | ![syntax-highlighting-right](https://github.com/spyder-ide/spyder/assets/365293/310e77a8-1eb1-40f1-b9d9-27daa07c76e5)

**Make contents area scrollbar background color match its parent's one**

Before | After
-|-
![imagen](https://github.com/spyder-ide/spyder/assets/365293/f82e7622-0d65-4a3d-8f8f-38bc46bb8886) | ![imagen](https://github.com/spyder-ide/spyder/assets/365293/a5e26128-160e-4be3-a72b-3965926d51d2)

**Make width of Find items be the widget's one if the longest item is shorter than it.**

Before | After
-|-
![imagen](https://github.com/spyder-ide/spyder/assets/365293/5e1a857e-6932-47f1-8b0a-f7ae0b419d5c) | ![imagen](https://github.com/spyder-ide/spyder/assets/365293/6c19e1b2-3c1e-4847-9187-0282157bf57b)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
