### PR TITLE
PR: Improve hovers, completion hints and calltips

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -53,7 +53,8 @@ from spyder.app.tests.conftest import (
     open_file_in_editor, preferences_dialog_helper, read_asset_file,
     reset_run_code, SHELL_TIMEOUT, start_new_kernel)
 from spyder.config.base import (
-    get_home_dir, get_conf_path, get_module_path, running_in_ci)
+    get_home_dir, get_conf_path, get_module_path, running_in_ci,
+    running_in_ci_with_conda)
 from spyder.config.manager import CONF
 from spyder.dependencies import DEPENDENCIES
 from spyder.plugins.debugger.api import DebuggerWidgetActions
@@ -4168,6 +4169,10 @@ def test_ipython_magic(main_window, qtbot, tmpdir, ipython, test_cell_magic):
 
 
 @flaky(max_runs=3)
+@pytest.mark.skipif(
+    sys.platform.startswith("linux") and not running_in_ci_with_conda(),
+    reason="Sometimes hangs on Linux with pip packages"
+)
 def test_running_namespace(main_window, qtbot, tmpdir):
     """
     Test that the running namespace is correctly sent when debugging in a
@@ -4222,6 +4227,10 @@ def test_running_namespace(main_window, qtbot, tmpdir):
 
 
 @flaky(max_runs=3)
+@pytest.mark.skipif(
+    sys.platform.startswith("linux") and not running_in_ci_with_conda(),
+    reason="Sometimes hangs on Linux with pip packages"
+)
 def test_running_namespace_refresh(main_window, qtbot, tmpdir):
     """
     Test that the running namespace can be accessed recursively
@@ -4287,6 +4296,10 @@ def test_running_namespace_refresh(main_window, qtbot, tmpdir):
 
 
 @flaky(max_runs=3)
+@pytest.mark.skipif(
+    sys.platform.startswith("linux") and not running_in_ci_with_conda(),
+    reason="Sometimes hangs on Linux with pip packages"
+)
 def test_debug_namespace(main_window, qtbot, tmpdir):
     """
     Test that the running namespace is correctly sent when debugging

--- a/spyder/plugins/editor/panels/linenumber.py
+++ b/spyder/plugins/editor/panels/linenumber.py
@@ -241,15 +241,16 @@ class LineNumberArea(Panel):
         Show code analisis, if left button pressed select lines.
         """
         line_number = self.editor.get_linenumber_from_mouse_event(event)
-        block = self.editor.document().findBlockByNumber(line_number-1)
+        block = self.editor.document().findBlockByNumber(line_number - 1)
         data = block.userData()
 
-        # this disables pyflakes messages if there is an active drag/selection
-        # operation
+        # This disables messages if there is an active drag/selection operation
         check = self._released == -1
-        if data and data.code_analysis and check:
-            self.editor.show_code_analysis_results(line_number,
-                                                   data)
+        if check and data:
+            if data.code_analysis:
+                self.editor.show_code_analysis_results(line_number, data)
+            elif data.todo:
+                self.editor.show_todo(line_number, data)
         else:
             self.editor.hide_tooltip()
 

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -857,8 +857,7 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         self.todo_list_action = create_action(self,
                 _("Show todo list"), icon=ima.icon('todo_list'),
                 tip=_("Show comments list (TODO/FIXME/XXX/HINT/TIP/@todo/"
-                      "HACK/BUG/OPTIMIZE/!!!/???)"),
-                triggered=self.go_to_next_todo)
+                      "HACK/BUG/OPTIMIZE/!!!/???)"))
         self.todo_menu = QMenu(self)
         self.todo_menu.setStyleSheet("QMenu {menu-scrollable: 1;}")
         self.todo_list_action.setMenu(self.todo_menu)
@@ -2798,14 +2797,6 @@ class Editor(SpyderPluginWidget, SpyderConfigurationObserver):
         editor = self.get_current_editor()
         if editor is not None:
             editor.unblockcomment()
-    @Slot()
-    def go_to_next_todo(self):
-        self.switch_to_plugin()
-        editor = self.get_current_editor()
-        editor.go_to_next_todo()
-        filename = self.get_current_filename()
-        cursor = editor.textCursor()
-        self.add_cursor_to_history(filename, cursor)
 
     @Slot()
     def go_to_next_warning(self):

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -1227,7 +1227,7 @@ class TextEditBaseWidget(
             point.setY(point.y() - widget.height())
             delta_y = -2
         else:
-            delta_y = 6
+            delta_y = 5 if sys.platform == "darwin" else 6
 
         # Add small delta to the vertical position so that the widget is not
         # shown too close to the text

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -91,7 +91,7 @@ class TextEditBaseWidget(
         self.setup_completion()
 
         self.calltip_widget = CallTipWidget(self, hide_timer_on=False)
-        self.tooltip_widget = ToolTipWidget(self, as_tooltip=True)
+        self.tooltip_widget = ToolTipWidget(self)
 
         self.highlight_current_cell_enabled = False
 

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -1207,10 +1207,12 @@ class TextEditBaseWidget(
         point = self.cursorRect().bottomRight()
         point = self.calculate_real_position(point)
         point = self.mapToGlobal(point)
+
         # Move to left of cursor if not enough space on right
         widget_right = point.x() + widget.width()
         if widget_right > right:
             point.setX(point.x() - widget.width())
+
         # Push to right if not enough space on left
         if point.x() < left:
             point.setX(left)
@@ -1223,6 +1225,13 @@ class TextEditBaseWidget(
             point = self.mapToGlobal(point)
             point.setX(x_position)
             point.setY(point.y() - widget.height())
+            delta_y = -2
+        else:
+            delta_y = 6
+
+        # Add small delta to the vertical position so that the widget is not
+        # shown too close to the text
+        point.setY(point.y() + delta_y)
 
         if ancestor is not None:
             # Useful only if we set parent to 'ancestor' in __init__

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -496,6 +496,14 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
                 return
 
             # --- Show LSP hovers
+            # This prevents requesting a new hover while trying to reach the
+            # current one to click on it.
+            if (
+                self.tooltip_widget.is_hover()
+                and self.tooltip_widget.is_hovered()
+            ):
+                return
+
             text = self.get_word_at(pos)
             cursor = self.cursorForPosition(pos)
             cursor_offset = cursor.position()

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -73,11 +73,7 @@ from spyder.utils.qthelpers import (add_actions, create_action, file_uri,
                                     mimedata2url, start_file)
 from spyder.utils.vcs import get_git_remotes, remote_to_url
 from spyder.utils.qstringhelpers import qstring_length
-from spyder.widgets.mixins import (
-    COMPLETION_HINT_MAX_WIDTH,
-    HINT_MAX_WIDTH,
-    TIP_MAX_LINES
-)
+from spyder.widgets.mixins import HINT_MAX_WIDTH
 
 
 try:
@@ -1986,9 +1982,6 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
                     inspect_word=word,
                     at_point=at_point,
                     completion_doc=completion_doc,
-                    max_lines=TIP_MAX_LINES,
-                    max_width=COMPLETION_HINT_MAX_WIDTH,
-                    show_help_on_click=True,
                 )
                 self.tooltip_widget.move(at_point)
             else:

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -74,9 +74,9 @@ from spyder.utils.qthelpers import (add_actions, create_action, file_uri,
 from spyder.utils.vcs import get_git_remotes, remote_to_url
 from spyder.utils.qstringhelpers import qstring_length
 from spyder.widgets.mixins import (
-    DEFAULT_COMPLETION_HINT_MAX_WIDTH,
-    DEFAULT_MAX_HINT_WIDTH,
-    DEFAULT_MAX_LINES
+    COMPLETION_HINT_MAX_WIDTH,
+    HINT_MAX_WIDTH,
+    TIP_MAX_LINES
 )
 
 
@@ -1986,8 +1986,8 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
                     inspect_word=word,
                     at_point=at_point,
                     completion_doc=completion_doc,
-                    max_lines=DEFAULT_MAX_LINES,
-                    max_width=DEFAULT_COMPLETION_HINT_MAX_WIDTH,
+                    max_lines=TIP_MAX_LINES,
+                    max_width=COMPLETION_HINT_MAX_WIDTH,
                     show_help_on_click=True,
                 )
                 self.tooltip_widget.move(at_point)
@@ -2034,7 +2034,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
             for paragraph in paragraphs:
                 new_paragraph = textwrap.wrap(
                     paragraph,
-                    width=DEFAULT_MAX_HINT_WIDTH
+                    width=HINT_MAX_WIDTH
                 )
 
                 if lines_per_message > 2:

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -1953,7 +1953,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
         self._timer_mouse_moving.stop()
         self._last_hover_word = None
         self.clear_extra_selections('code_analysis_highlight')
-        if self.tooltip_widget.isVisible():
+        if self.tooltip_widget.isVisible() and not self.tooltip_widget.is_hint():
             self.tooltip_widget.hide()
 
     def _set_completions_hint_idle(self):

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -52,7 +52,6 @@ from spyder.plugins.editor.extensions import (CloseBracketsExtension,
                                               QMenuOnlyForEnter,
                                               EditorExtensionsManager,
                                               SnippetsExtension)
-from spyder.plugins.completion.api import DiagnosticSeverity
 from spyder.plugins.editor.panels import (
     ClassFunctionDropdown, EdgeLine, FoldingPanel, IndentationGuide,
     LineNumberArea, PanelsManager, ScrollFlagArea)
@@ -2052,7 +2051,6 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
             self.show_tooltip(
                 title=_("Code analysis"),
                 text='\n'.join(msglist),
-                title_color=SpyderPalette.COLOR_SUCCESS_2,
                 at_line=line_number,
                 with_html_format=True
             )

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -69,7 +69,7 @@ from spyder.utils import encoding, sourcecode
 from spyder.utils.clipboard_helper import CLIPBOARD_HELPER
 from spyder.utils.icon_manager import ima
 from spyder.utils import syntaxhighlighters as sh
-from spyder.utils.palette import SpyderPalette, QStylePalette
+from spyder.utils.palette import SpyderPalette
 from spyder.utils.qthelpers import (add_actions, create_action, file_uri,
                                     mimedata2url, start_file)
 from spyder.utils.vcs import get_git_remotes, remote_to_url
@@ -2189,28 +2189,15 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
 
     # ---- Tasks management
     # -------------------------------------------------------------------------
-    def go_to_next_todo(self):
-        """Go to next todo and return new cursor position"""
-        block = self.textCursor().block()
-        line_count = self.document().blockCount()
-        while True:
-            if block.blockNumber()+1 < line_count:
-                block = block.next()
-            else:
-                block = self.document().firstBlock()
-            data = block.userData()
-            if data and data.todo:
-                break
-        line_number = block.blockNumber()+1
-        self.go_to_line(line_number)
+    def show_todo(self, line_number, data):
+        """
+        Show TODO tooltip when hovering their markers in the line number area.
+        """
         self.show_tooltip(
             title=_("To do"),
             text=data.todo,
-            title_color=QStylePalette.COLOR_ACCENT_4,
             at_line=line_number,
         )
-
-        return self.get_position('cursor')
 
     def process_todo(self, todo_results):
         """Process todo finder results"""

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -1974,7 +1974,9 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
                     at_point=at_point,
                     completion_doc=completion_doc,
                     max_lines=self._DEFAULT_MAX_LINES,
-                    max_width=self._DEFAULT_COMPLETION_HINT_MAX_WIDTH)
+                    max_width=self._DEFAULT_COMPLETION_HINT_MAX_WIDTH,
+                    show_help_on_click=True
+                )
                 self.tooltip_widget.move(at_point)
             else:
                 self.hide_tooltip()

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -1950,7 +1950,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
 
     def _set_completions_hint_idle(self):
         self._completions_hint_idle = True
-        self.completion_widget.trigger_completion_hint()
+        self.completion_widget.request_completion_hint()
 
     def show_hint_for_completion(self, word, documentation, at_point):
         """Show hint for completion element."""
@@ -1960,6 +1960,15 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
                               'signature': documentation}
 
             if documentation and len(documentation) > 0:
+                # This means that only the object's signature could be resolved
+                # by the server, which won't update the hint contents.
+                if (
+                    len(documentation.split('\n\n')) == 2
+                    and documentation.startswith(word)
+                ):
+                    self.hide_tooltip()
+                    return
+
                 self.show_hint(
                     documentation,
                     inspect_word=word,
@@ -1968,8 +1977,10 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
                     max_lines=self._DEFAULT_MAX_LINES,
                     max_width=self._DEFAULT_COMPLETION_HINT_MAX_WIDTH)
                 self.tooltip_widget.move(at_point)
-                return
-        self.hide_tooltip()
+            else:
+                self.hide_tooltip()
+        else:
+            self.hide_tooltip()
 
     def update_decorations(self):
         """Update decorations on the visible portion of the screen."""

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -73,6 +73,11 @@ from spyder.utils.qthelpers import (add_actions, create_action, file_uri,
                                     mimedata2url, start_file)
 from spyder.utils.vcs import get_git_remotes, remote_to_url
 from spyder.utils.qstringhelpers import qstring_length
+from spyder.widgets.mixins import (
+    DEFAULT_COMPLETION_HINT_MAX_WIDTH,
+    DEFAULT_MAX_HINT_WIDTH,
+    DEFAULT_MAX_LINES
+)
 
 
 try:
@@ -1981,9 +1986,9 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
                     inspect_word=word,
                     at_point=at_point,
                     completion_doc=completion_doc,
-                    max_lines=self._DEFAULT_MAX_LINES,
-                    max_width=self._DEFAULT_COMPLETION_HINT_MAX_WIDTH,
-                    show_help_on_click=True
+                    max_lines=DEFAULT_MAX_LINES,
+                    max_width=DEFAULT_COMPLETION_HINT_MAX_WIDTH,
+                    show_help_on_click=True,
                 )
                 self.tooltip_widget.move(at_point)
             else:
@@ -2029,7 +2034,9 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
             for paragraph in paragraphs:
                 new_paragraph = textwrap.wrap(
                     paragraph,
-                    width=self._DEFAULT_MAX_HINT_WIDTH)
+                    width=DEFAULT_MAX_HINT_WIDTH
+                )
+
                 if lines_per_message > 2:
                     if len(new_paragraph) > 1:
                         new_paragraph = '<br>'.join(new_paragraph[:2]) + '...'

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -4086,10 +4086,6 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
                 event.accept()
                 return
 
-        if self.has_selected_text():
-            TextEditBaseWidget.mouseMoveEvent(self, event)
-            return
-
         if self.go_to_definition_enabled and ctrl:
             if self._handle_goto_definition_event(pos):
                 event.accept()
@@ -4098,8 +4094,10 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
         if self.__cursor_changed:
             self._restore_editor_cursor_and_selections()
         else:
-            if (not self._should_display_hover(pos)
-                    and not self.is_completion_widget_visible()):
+            if (
+                not self._should_display_hover(pos)
+                and not self.is_completion_widget_visible()
+            ):
                 self.hide_tooltip()
 
         TextEditBaseWidget.mouseMoveEvent(self, event)

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -1983,28 +1983,11 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
 
     def show_code_analysis_results(self, line_number, block_data):
         """Show warning/error messages."""
-        # Diagnostic severity
-        icons = {
-            DiagnosticSeverity.ERROR: 'error',
-            DiagnosticSeverity.WARNING: 'warning',
-            DiagnosticSeverity.INFORMATION: 'information',
-            DiagnosticSeverity.HINT: 'hint',
-        }
-
         code_analysis = block_data.code_analysis
-
-        # Size must be adapted from font
-        fm = self.fontMetrics()
-        size = fm.height()
-        template = (
-            '<img src="data:image/png;base64, {}"'
-            ' height="{size}" width="{size}" />&nbsp;'
-            '{} <i>({} {})</i>'
-        )
-
         msglist = []
         max_lines_msglist = 25
         sorted_code_analysis = sorted(code_analysis, key=lambda i: i[2])
+
         for src, code, sev, msg in sorted_code_analysis:
             if src == 'pylint' and '[' in msg and ']' in msg:
                 # Remove extra redundant info from pylint messages
@@ -2051,16 +2034,14 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
             else:
                 msg = '<br>'.join(new_paragraphs)
 
-            base_64 = ima.base64_from_icon(icons[sev], size, size)
             if max_lines_msglist >= 0:
-                msglist.append(template.format(base_64, msg, src,
-                                               code, size=size))
+                msglist.append(f'{msg} <i>({src} {code})</i>')
 
         if msglist:
             self.show_tooltip(
                 title=_("Code analysis"),
                 text='\n'.join(msglist),
-                title_color=QStylePalette.COLOR_ACCENT_4,
+                title_color=SpyderPalette.COLOR_SUCCESS_2,
                 at_line=line_number,
                 with_html_format=True
             )

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -1953,7 +1953,10 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
         self._timer_mouse_moving.stop()
         self._last_hover_word = None
         self.clear_extra_selections('code_analysis_highlight')
-        if self.tooltip_widget.isVisible() and not self.tooltip_widget.is_hint():
+        if (
+            self.tooltip_widget.isVisible()
+            and not self.tooltip_widget.is_hint()
+        ):
             self.tooltip_widget.hide()
 
     def _set_completions_hint_idle(self):

--- a/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
@@ -915,7 +915,8 @@ class LSPMixin:
 
                 # Show hover
                 self.show_hint(
-                    content, inspect_word=word, at_point=self._last_point
+                    content, inspect_word=word, at_point=self._last_point,
+                    vertical_position='top'
                 )
 
                 self._last_point = None

--- a/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
@@ -905,13 +905,19 @@ class LSPMixin:
             self.sig_display_object_info.emit(
                 content, self._request_hover_clicked
             )
+
             if content is not None and self._show_hint and self._last_point:
                 # This is located in spyder/widgets/mixins.py
                 word = self._last_hover_word
+
+                # Replace non-breaking spaces for real ones.
                 content = content.replace("\xa0", " ")
+
+                # Show hover
                 self.show_hint(
                     content, inspect_word=word, at_point=self._last_point
                 )
+
                 self._last_point = None
         except RuntimeError:
             # This is triggered when a codeeditor instance was removed

--- a/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
@@ -915,8 +915,11 @@ class LSPMixin:
 
                 # Show hover
                 self.show_hint(
-                    content, inspect_word=word, at_point=self._last_point,
-                    vertical_position='top', show_help_on_click=True
+                    content,
+                    inspect_word=word,
+                    at_point=self._last_point,
+                    vertical_position='top',
+                    as_hover=True,
                 )
 
                 self._last_point = None

--- a/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
@@ -916,7 +916,7 @@ class LSPMixin:
                 # Show hover
                 self.show_hint(
                     content, inspect_word=word, at_point=self._last_point,
-                    vertical_position='top'
+                    vertical_position='top', show_help_on_click=True
                 )
 
                 self._last_point = None

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_codeeditor.py
@@ -15,6 +15,9 @@ from qtpy.QtGui import QTextCursor, QMouseEvent
 from qtpy.QtWidgets import QApplication, QTextEdit
 import pytest
 
+# Local imports
+from spyder.widgets.mixins import TIP_PARAMETER_HIGHLIGHT_COLOR
+
 
 HERE = osp.dirname(osp.abspath(__file__))
 ASSETS = osp.join(HERE, 'assets')
@@ -482,38 +485,39 @@ def test_format_signature(codeeditor):
     concatenate((a1, a2, a...), [b1, b2, b...], axis={}, index=[],
                 *args, **kargs)"""
     editor = codeeditor
+    color = TIP_PARAMETER_HIGHLIGHT_COLOR
 
     format_signature = editor._format_signature(signature, parameter="(a1")
 
-    assert "color:#259AE9'><b>a1</b></span>" in format_signature
+    assert f"color:{color}'><b>a1</b></span>" in format_signature
 
     format_signature = editor._format_signature(signature, parameter="a2")
-    assert "color:#259AE9'><b>a2</b></span>" in format_signature
+    assert f"color:{color}'><b>a2</b></span>" in format_signature
 
     format_signature = editor._format_signature(signature, parameter="a...")
     print(format_signature)
-    assert "color:#259AE9'><b>a...</b></span>" in format_signature
+    assert f"color:{color}'><b>a...</b></span>" in format_signature
 
     format_signature = editor._format_signature(signature, parameter="[b1")
-    assert "color:#259AE9'><b>b1</b></span>" in format_signature
+    assert f"color:{color}'><b>b1</b></span>" in format_signature
 
     format_signature = editor._format_signature(signature, parameter="b2")
-    assert "color:#259AE9'><b>b2</b></span>" in format_signature
+    assert f"color:{color}'><b>b2</b></span>" in format_signature
 
     format_signature = editor._format_signature(signature, parameter="b...")
-    assert "color:#259AE9'><b>b...</b></span>" in format_signature
+    assert f"color:{color}'><b>b...</b></span>" in format_signature
 
     format_signature = editor._format_signature(signature, parameter="axis")
-    assert "color:#259AE9'><b>axis</b></span>" in format_signature
+    assert f"color:{color}'><b>axis</b></span>" in format_signature
 
     format_signature = editor._format_signature(signature, parameter="index")
-    assert "color:#259AE9'><b>index</b></span>" in format_signature
+    assert f"color:{color}'><b>index</b></span>" in format_signature
 
     format_signature = editor._format_signature(signature, parameter="*args")
-    assert "color:#259AE9'><b>*args</b></span>" in format_signature
+    assert f"color:{color}'><b>*args</b></span>" in format_signature
 
     format_signature = editor._format_signature(signature, parameter="**kargs")
-    assert "color:#259AE9'><b>**kargs</b></span>" in format_signature
+    assert f"color:{color}'><b>**kargs</b></span>" in format_signature
 
 
 def test_delete(codeeditor):

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_formatting.py
@@ -6,15 +6,9 @@
 
 """Tests for code formatting using CodeEditor instances."""
 
-# Standard library imports
-import random
-
 # Third party imports
-from flaky import flaky
 import pytest
-from qtpy.QtCore import Qt
 from qtpy.QtGui import QTextCursor
-from qtpy.QtWidgets import QMessageBox
 
 # Local imports
 from spyder.config.manager import CONF

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_hints_and_calltips.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_hints_and_calltips.py
@@ -3,7 +3,8 @@
 # Copyright © Spyder Project Contributors
 # Licensed under the terms of the MIT License
 #
-"""Tests for editor calltips and hover hints tooltips."""
+
+"""Tests for editor calltips, hovers and hints."""
 
 # Standard library imports
 import os
@@ -148,7 +149,7 @@ def test_get_hints(qtbot, completions_codeeditor, params, capsys):
     # Wait a bit in case the window manager repositions the window.
     qtbot.wait(1000)
 
-    # Position cursor on top of word we want the hover for.
+    # Position cursor on top of the word we want the hover for.
     x, y = code_editor.get_coordinates('cursor')
     point = code_editor.calculate_real_position(QPoint(x, y))
 
@@ -209,3 +210,206 @@ def test_get_hints_not_triggered(qtbot, completions_codeeditor, text):
         qtbot.mouseClick(code_editor, Qt.LeftButton, pos=point)
         qtbot.wait(1000)
         assert not code_editor.tooltip_widget.isVisible()
+
+
+@pytest.mark.order(2)
+@pytest.mark.skipif(sys.platform == 'darwin', reason='Fails on Mac')
+@pytest.mark.parametrize(
+    "params",
+    [
+        ("an_int = 10", "This is an integer"),
+        ("a_dict = {1: 2}", "This is a dictionary"),
+        ('a_string = "foo"', "This is a string"),
+    ],
+)
+def test_get_hints_for_builtins(qtbot, completions_codeeditor, params):
+    """Test that the editor is showing the right hover hints for builtins."""
+    code_editor, _ = completions_codeeditor
+    text, expected = params
+
+    # Set text in editor
+    code_editor.set_text(text)
+
+    # Move mouse to another position.
+    qtbot.mouseMove(code_editor, QPoint(400, 400))
+
+    # Move cursor at the beginning of the last line
+    code_editor.moveCursor(QTextCursor.End)
+    code_editor.moveCursor(QTextCursor.StartOfLine)
+
+    for _ in range(3):
+        qtbot.keyPress(code_editor, Qt.Key_Right)
+
+    # Wait a bit in case the window manager repositions the window.
+    qtbot.wait(1000)
+
+    # Position cursor on top of the word we want the hover for.
+    x, y = code_editor.get_coordinates('cursor')
+    point = code_editor.calculate_real_position(QPoint(x, y))
+
+    # Check the generated hover.
+    with qtbot.waitSignal(
+        code_editor.sig_display_object_info, timeout=30000
+    ):
+        # Give focus to the editor
+        qtbot.mouseClick(code_editor, Qt.LeftButton, pos=point)
+
+        # These two mouse moves are necessary to ensure the hover is shown.
+        qtbot.mouseMove(code_editor, point)
+        qtbot.mouseMove(
+            code_editor,
+            QPoint(point.x() + 2, point.y() + 2),
+            delay=100
+        )
+
+        # Check hover is shown and contains the expected text
+        qtbot.waitUntil(code_editor.tooltip_widget.isVisible, timeout=10000)
+        assert expected in code_editor.tooltip_widget.text()
+
+
+@pytest.mark.order(2)
+@pytest.mark.skipif(sys.platform == 'darwin', reason='Fails on Mac')
+@pytest.mark.parametrize(
+    "params",
+    [
+        ("import pandas as pd\npd.DataFrame", "bottom"),
+        ("\n" * 15 + "import pandas as pd\npd.DataFrame", "top"),
+    ],
+)
+def test_hints_vertical_position(qtbot, completions_codeeditor, params):
+    """
+    Test that we show hovers at the top or bottom of the text according to
+    its length and text positioning in the editor.
+    """
+    code_editor, _ = completions_codeeditor
+    text, expected = params
+
+    # Set text in editor
+    code_editor.set_text(text)
+
+    # Move mouse to another position.
+    qtbot.mouseMove(code_editor, QPoint(400, 400))
+
+    # Move cursor at the beginning of the last line
+    code_editor.moveCursor(QTextCursor.End)
+    code_editor.moveCursor(QTextCursor.StartOfLine)
+
+    for _ in range(4):
+        qtbot.keyPress(code_editor, Qt.Key_Right)
+
+    # Wait a bit in case the window manager repositions the window.
+    qtbot.wait(1000)
+
+    # Position cursor on top of the word we want the hover for.
+    x, y = code_editor.get_coordinates('cursor')
+    point = code_editor.calculate_real_position(QPoint(x, y))
+
+    # Check the generated hover.
+    with qtbot.waitSignal(
+        code_editor.sig_display_object_info, timeout=30000
+    ):
+        # Give focus to the editor
+        qtbot.mouseClick(code_editor, Qt.LeftButton, pos=point)
+
+        # These two mouse moves are necessary to ensure the hover is shown.
+        qtbot.mouseMove(code_editor, point)
+        qtbot.mouseMove(
+            code_editor,
+            QPoint(point.x() + 2, point.y() + 2),
+            delay=100
+        )
+
+        qtbot.waitUntil(code_editor.tooltip_widget.isVisible, timeout=10000)
+
+        # Check hover is shown in the right position
+        global_point = code_editor._calculate_position(at_point=point)
+        if expected == "top":
+            assert code_editor.tooltip_widget.pos().y() < global_point.y()
+        else:
+            assert code_editor.tooltip_widget.pos().y() > global_point.y()
+
+
+@pytest.mark.order(2)
+@pytest.mark.skipif(sys.platform == 'darwin', reason='Fails on Mac')
+def test_completion_hints(qtbot, completions_codeeditor):
+    """Test that the editor is returning hover hints."""
+    code_editor, _ = completions_codeeditor
+    completion_widget = code_editor.completion_widget
+    tooltip_widget = code_editor.tooltip_widget
+
+    # Move mouse to another position to be sure the hover is displayed when
+    # the cursor is put on top of the tested word.
+    qtbot.mouseMove(code_editor, QPoint(400, 400))
+
+    # Set text in editor
+    code_editor.set_text("import pandas as pd\npd.")
+
+    # Wait a bit in case the window manager repositions the window.
+    qtbot.wait(1000)
+
+    # Trigger a code completion
+    with qtbot.waitSignal(
+        code_editor.completions_response_signal,
+        timeout=30000
+    ):
+        # Get completions
+        code_editor.moveCursor(QTextCursor.End)
+        qtbot.keyPress(code_editor, Qt.Key_Tab)
+
+    # Check the hint is shown and placed where it should be
+    qtbot.waitUntil(tooltip_widget.isVisible)
+    assert tooltip_widget.is_hint()
+    assert (
+        (completion_widget.x() + completion_widget.width() - 1)
+        == tooltip_widget.x()
+    )
+    assert completion_widget.y() == tooltip_widget.y()
+
+    # Move mouse to be on top of the hint
+    x, y = code_editor.get_coordinates('cursor')
+    point = code_editor.calculate_real_position(QPoint(x, y))
+    hint_point = QPoint(
+        point.x() + completion_widget.width() + 60,
+        point.y() + 60
+    )
+    qtbot.mouseMove(code_editor, hint_point, delay=100)
+
+    # Do a click on top of the hint and check it doesn't hide.
+    with qtbot.waitSignal(
+        tooltip_widget.sig_completion_help_requested,
+        timeout=30000
+    ):
+        qtbot.mouseClick(tooltip_widget, Qt.LeftButton, pos=hint_point)
+
+    qtbot.wait(200)
+    assert tooltip_widget.isVisible()
+
+    # Move cursor out of the hint and check it's still visible
+    qtbot.mouseMove(
+        code_editor,
+        QPoint(hint_point.x(), hint_point.y() + tooltip_widget.height() + 20),
+        delay=100
+    )
+
+    qtbot.wait(200)
+    assert tooltip_widget.isVisible()
+
+    # Move cursor to the line number area and check hint is still visible
+    code_editor.moveCursor(QTextCursor.StartOfLine)
+    x, y = code_editor.get_coordinates('cursor')
+    point_1 = code_editor.calculate_real_position(QPoint(x, y))
+
+    qtbot.mouseMove(
+        code_editor,
+        QPoint(
+            point_1.x() - code_editor.linenumberarea.width() / 2, point_1.y()
+        ),
+        delay=100,
+    )
+
+    qtbot.wait(200)
+    assert tooltip_widget.isVisible()
+
+    # Hide completion widget and check hint is hidden too.
+    completion_widget.hide()
+    qtbot.waitUntil(lambda: not tooltip_widget.isVisible(), timeout=500)

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_hints_and_calltips.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_hints_and_calltips.py
@@ -16,8 +16,10 @@ from qtpy.QtGui import QTextCursor
 import pytest
 
 # Local imports
+from spyder.config.base import running_in_ci
 from spyder.plugins.editor.extensions.closebrackets import (
-        CloseBracketsExtension)
+    CloseBracketsExtension
+)
 
 # Constants
 TEST_SIG = 'some_function(foo={}, hello=None)'
@@ -330,7 +332,10 @@ def test_hints_vertical_position(qtbot, completions_codeeditor, params):
 
 
 @pytest.mark.order(2)
-@pytest.mark.skipif(sys.platform == 'darwin', reason='Fails on Mac')
+@pytest.mark.skipif(
+    running_in_ci() and not os.name == 'nt',
+    reason="Only works on Windows"
+)
 def test_completion_hints(qtbot, completions_codeeditor):
     """Test that the editor is returning hover hints."""
     code_editor, _ = completions_codeeditor
@@ -402,7 +407,7 @@ def test_completion_hints(qtbot, completions_codeeditor):
     qtbot.mouseMove(
         code_editor,
         QPoint(
-            point_1.x() - code_editor.linenumberarea.width() / 2, point_1.y()
+            point_1.x() - code_editor.linenumberarea.width() // 2, point_1.y()
         ),
         delay=100,
     )

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -305,7 +305,12 @@ class CompletionWidget(QListWidget, SpyderConfigurationAccessor):
 
         tooltip = getattr(self.textedit, 'tooltip_widget', None)
         if tooltip:
-            tooltip.hide()
+            # This is necessary to reuse this widget as a tooltip or hover.
+            tooltip.reset_state()
+
+            # Use this method to hide the widget immediately instead of using a
+            # time, which can generate odd UX situations.
+            tooltip._hide()
 
         QListWidget.hide(self)
         QToolTip.hideText()

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -508,7 +508,8 @@ class CompletionWidget(QListWidget, SpyderConfigurationAccessor):
                 insert_text = insert_text.split(ch)[0]
         return insert_text
 
-    def trigger_completion_hint(self, row=None):
+    def request_completion_hint(self, row=None):
+        """Request LSP for completion hint"""
         self.current_selected_item_label = None
         self.current_selected_item_point = None
 
@@ -526,24 +527,18 @@ class CompletionWidget(QListWidget, SpyderConfigurationAccessor):
         self.current_selected_item_label = item['label']
         self.current_selected_item_point = item['point']
 
-        insert_text = self._get_insert_text(item)
-
+        # Ask LSP for completion hint
         if hasattr(self.textedit, 'resolve_completion_item'):
             if item.get('resolve', False):
                 to_resolve = item.copy()
                 to_resolve.pop('point')
                 to_resolve.pop('resolve')
                 self.textedit.resolve_completion_item(to_resolve)
-
-        if isinstance(item['documentation'], dict):
-            item['documentation'] = item['documentation']['value']
-
-        self.sig_completion_hint.emit(
-            insert_text,
-            item['documentation'],
-            item['point'])
+            else:
+                self.textedit.hide_tooltip()
 
     def augment_completion_info(self, item):
+        """Augment completion info with hints that come from the server."""
         if self.current_selected_item_label == item['label']:
             insert_text = self._get_insert_text(item)
 
@@ -557,5 +552,5 @@ class CompletionWidget(QListWidget, SpyderConfigurationAccessor):
 
     @Slot(int)
     def row_changed(self, row):
-        """Set completion hint info and show it."""
-        self.trigger_completion_hint(row)
+        """Actions to take when the row has changed."""
+        self.request_completion_hint(row)

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -26,7 +26,7 @@ from spyder.widgets.helperwidgets import HTMLDelegate
 
 COMPLETION_ITEM_HEIGHT = 15
 COMPLETION_ITEM_WIDTH = 250
-COMPLETION_DELTA_FOR_SCROLLBAR = 7
+COMPLETION_DELTA_FOR_SCROLLBAR = 7 if sys.platform.startswith("linux") else 0
 
 
 class CompletionWidget(QListWidget, SpyderConfigurationAccessor):

--- a/spyder/plugins/findinfiles/widgets/main_widget.py
+++ b/spyder/plugins/findinfiles/widgets/main_widget.py
@@ -434,6 +434,16 @@ class FindInFilesWidget(PluginMainWidget):
 
         super().showEvent(event)
 
+    def resizeEvent(self, event):
+        """Adjustments when the widget is resized."""
+        super().resizeEvent(event)
+
+        # This recomputes the result items width according to this widget's
+        # width, which makes the UI be rendered as expected.
+        # NOTE: Don't debounce or throttle `set_width` because then it wouldn't
+        # do its job as expected.
+        self.result_browser.set_width()
+
     # ---- Private API
     # ------------------------------------------------------------------------
     def _get_options(self):

--- a/spyder/plugins/findinfiles/widgets/results_browser.py
+++ b/spyder/plugins/findinfiles/widgets/results_browser.py
@@ -361,13 +361,3 @@ class ResultsBrowser(OneColumnTree, SpyderFontsMixin):
                 width = width + 2 * AppStyle.MarginSize
 
         self.itemDelegate().width = width
-
-    def resizeEvent(self, event):
-        """Adjustments when the widget is resized."""
-        super().resizeEvent(event)
-
-        # This recomputes the items width according to the widget's current
-        # one, which makes the UI be rendered as expected.
-        # NOTE: Don't debounce or throttle this method because it wouldn't do
-        # its work as expected.
-        self.set_width()

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -78,12 +78,12 @@ def test_banners(ipyconsole, qtbot):
     [("np.arange",  # Check we get the signature from the object's docstring
       ["start", "stop"],
       ["Return evenly spaced values within a given interval.<br>",
-       "open interval ..."]),
+       "open interval<br>..."]),
      ("np.vectorize",  # Numpy function with a proper signature
       ["pyfunc", "otype", "signature"],
-      ["Returns an object that acts like pyfunc, but takes arrays as<br>input."
+      ["Returns an object that acts like pyfunc, but takes<br>arrays as input."
        "<br>",
-       "Define a vectorized function which takes a nested sequence ..."]),
+       "Define a vectorized function which takes a nested<br>..."]),
      ("np.abs",  # np.abs has the same signature as np.absolute
       ["x", "/", "out"],
       ["Calculate the absolute value"]),

--- a/spyder/plugins/ipythonconsole/widgets/help.py
+++ b/spyder/plugins/ipythonconsole/widgets/help.py
@@ -16,11 +16,12 @@ import re
 from pickle import UnpicklingError
 from qtconsole.ansi_code_processor import ANSI_PATTERN
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
-
-# Local imports
 from spyder_kernels.utils.dochelpers import (getargspecfromtext,
                                              getsignaturefromtext)
 from spyder_kernels.comms.commbase import CommError
+
+# Local imports
+from spyder.widgets.mixins import HINT_MAX_LINES
 
 
 class HelpWidget(RichJupyterWidget):
@@ -202,6 +203,6 @@ class HelpWidget(RichJupyterWidget):
                     signature,
                     documentation=documentation,
                     language=self.language_name,
-                    max_lines=7,
+                    max_lines=HINT_MAX_LINES,
                     text_new_line=new_line
                 )

--- a/spyder/widgets/calltip.py
+++ b/spyder/widgets/calltip.py
@@ -208,9 +208,9 @@ class ToolTipWidget(QLabel):
             # Ubuntu Mono has a strange behavior regarding its height that we
             # need to account for. Other monospaced fonts behave as expected.
             if font.family() == 'Ubuntu Mono':
-                padding = 0
+                padding = 2
             else:
-                padding = 3
+                padding = 1 if sys.platform == "darwin" else 5
 
             # Qt sets the mouse coordinates (given by `point`) a bit above the
             # line where it's placed, i.e. not exactly where the text
@@ -305,6 +305,9 @@ class ToolTipWidget(QLabel):
 
     def leaveEvent(self, event):
         """Reimplemented to hide tooltip on leave."""
+        # This is necessary to set the cursor correctly in enterEvent on Mac
+        self.unsetCursor()
+
         super().leaveEvent(event)
 
         # Prevent to hide the widget when it's used as a completion hint and

--- a/spyder/widgets/calltip.py
+++ b/spyder/widgets/calltip.py
@@ -165,7 +165,14 @@ class ToolTipWidget(QLabel):
         tip_width = self.size().width()
 
         text_edit_height = text_edit.size().height()
-        text_edit_gpos = text_edit.mapToGlobal(text_edit.pos())
+        text_edit_gpos = (
+            # If text_edit is a window in itself (e.g. when used indenpendently
+            # in our tests) we don't need to get its global position because
+            # text_edit.pos() already gives it.
+            text_edit.mapToGlobal(text_edit.pos())
+            if not text_edit.isWindow()
+            else text_edit.pos()
+        )
 
         vertical = vertical_position
         horizontal = 'Right'

--- a/spyder/widgets/calltip.py
+++ b/spyder/widgets/calltip.py
@@ -550,7 +550,7 @@ class CallTipWidget(QLabel):
             point_ = text_edit.mapToGlobal(cursor_rect.topRight())
             # If tip is still off screen, check if point is in top or bottom
             # half of screen.
-            if point_.y() < tip_height :
+            if point_.y() < tip_height:
                 # If point is in upper half of screen, show tip below it.
                 # otherwise above it.
                 if 2 * point.y() < window_rect.height():

--- a/spyder/widgets/calltip.py
+++ b/spyder/widgets/calltip.py
@@ -64,6 +64,7 @@ class ToolTipWidget(QLabel):
         self.app = QCoreApplication.instance()
         self._as_hover = False
         self._as_hint = False
+        self._hovered = False
         self._timer_hide = QTimer()
         self._text_edit = parent
         self.show_help_on_click = False
@@ -254,6 +255,14 @@ class ToolTipWidget(QLabel):
         """Check if the widget is used as a completion hint."""
         return self._as_hint
 
+    def is_hover(self):
+        """Check if the widget is used as a hover."""
+        return self._as_hover
+
+    def is_hovered(self):
+        """Check if the the mouse is on top of this widget."""
+        return self._hovered
+
     def reset_state(self):
         """Reset widget state as a hover, tooltip or hint."""
         self._as_hint = False
@@ -300,6 +309,7 @@ class ToolTipWidget(QLabel):
         else:
             self.setCursor(Qt.ArrowCursor)
 
+        self._hovered = True
         self._timer_hide.stop()
         super().enterEvent(event)
 
@@ -308,6 +318,7 @@ class ToolTipWidget(QLabel):
         # This is necessary to set the cursor correctly in enterEvent on Mac
         self.unsetCursor()
 
+        self._hovered = False
         super().leaveEvent(event)
 
         # Prevent to hide the widget when it's used as a completion hint and

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -74,6 +74,7 @@ TIP_MAX_WIDTH = 55
 COMPLETION_HINT_MAX_WIDTH = 50
 HINT_MAX_LINES = 7
 HINT_MAX_WIDTH = 55
+SIGNATURE_MAX_LINES = 4
 BUILTINS_DOCSTRING_MAP = {
     int.__doc__: 'integer',
     list.__doc__: 'list',
@@ -414,7 +415,7 @@ class BaseEditMixin(object):
             indent = ' ' * (len(name) + 1)
             rows = textwrap.wrap(signature, width=max_width,
                                  subsequent_indent=indent)
-            for row in rows:
+            for row in rows[:SIGNATURE_MAX_LINES]:
                 if parameter and language == 'python':
                     # Add template to highlight the active parameter
                     row = re.sub(pattern, handle_sub, row)

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -575,6 +575,10 @@ class BaseEditMixin(object):
         with_html_format=False,
     ):
         """Show a tooltip."""
+        # Prevent to hide the widget when used as a completion hint to reuse it
+        # as a tooltip
+        if self.tooltip_widget.is_hint():
+            return
 
         # Find position
         point = self._calculate_position(at_line=at_line, at_point=at_point)
@@ -595,6 +599,7 @@ class BaseEditMixin(object):
         )
 
         # Display tooltip
+        self.tooltip_widget.set_as_tooltip()
         self.tooltip_widget.show_tip(point, tiptext)
 
     def show_hint(
@@ -609,9 +614,16 @@ class BaseEditMixin(object):
         """Show code completion hint or hover."""
         # Max lines and width
         if as_hover:
+            # Prevent to hide the widget when used as a completion hint to
+            # reuse as a hover
+            if self.tooltip_widget.is_hint():
+                return
+
+            self.tooltip_widget.set_as_hover()
             max_lines = HINT_MAX_LINES
             max_width = HINT_MAX_WIDTH
         else:
+            self.tooltip_widget.set_as_hint()
             max_lines = TIP_MAX_LINES
             max_width = COMPLETION_HINT_MAX_WIDTH
 
@@ -643,6 +655,7 @@ class BaseEditMixin(object):
                 )
                 display_link = False
                 show_help_on_click = False
+                completion_doc = None
 
         res = self._check_signature_and_format(text, max_width=max_width,
                                                inspect_word=inspect_word)

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -534,8 +534,15 @@ class BaseEditMixin(object):
                 builtin
             )
 
-    def show_calltip(self, signature, parameter=None, documentation=None,
-                     language=TIP_DEFAULT_LANGUAGE, text_new_line=True):
+    def show_calltip(
+        self,
+        signature,
+        parameter=None,
+        documentation=None,
+        language=TIP_DEFAULT_LANGUAGE,
+        max_lines=TIP_MAX_LINES,
+        text_new_line=True
+    ):
         """
         Show calltip.
 
@@ -576,7 +583,7 @@ class BaseEditMixin(object):
             inspect_word=inspect_word,
             display_link=False,
             text=documentation,
-            max_lines=TIP_MAX_LINES,
+            max_lines=max_lines,
             max_width=TIP_MAX_WIDTH,
             text_new_line=text_new_line
         )

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -140,13 +140,13 @@ class BaseEditMixin(object):
             # Ubuntu Mono has a strange behavior regarding its height that we
             # need to account for. Other monospaced fonts behave as expected.
             if self.font().family() == 'Ubuntu Mono':
-                padding = 3
+                padding = 5
             else:
-                padding = 0
+                padding = 1 if sys.platform == "darwin" else 3
 
             # This is necessary because the point Qt returns for the cursor is
             # much below the line's bottom position.
-            cy = int(cy - QFontMetrics(self.font()).xHeight() + padding)
+            cy = int(cy - QFontMetrics(self.font()).capHeight() + padding)
 
         # Map to global coordinates
         point = self.mapToGlobal(QPoint(cx, cy))

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -708,6 +708,10 @@ class BaseEditMixin(object):
         self._last_point = None
         self.tooltip_widget.hide()
 
+    def hide_calltip(self):
+        """Hide the calltip widget."""
+        self.calltip_widget.hide()
+
     # ----- Required methods for the LSP
     def document_did_change(self, text=None):
         pass

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -61,10 +61,6 @@ EOL_SYMBOLS = [
 
 class BaseEditMixin(object):
 
-    _BACKGROUND_COLOR = (
-        QStylePalette.COLOR_BACKGROUND_4 if is_dark_interface() else
-        QStylePalette.COLOR_BACKGROUND_2
-    )
     _DEFAULT_TEXT_COLOR = QStylePalette.COLOR_TEXT_2
     _PARAMETER_HIGHLIGHT_COLOR = QStylePalette.COLOR_TEXT_1
     _DEFAULT_TITLE_COLOR = Green.B80 if is_dark_interface() else Green.B20
@@ -94,8 +90,6 @@ class BaseEditMixin(object):
     sig_will_insert_text = None
     sig_will_remove_selection = None
     sig_text_was_inserted = None
-
-    _styled_widgets = set()
 
     def __init__(self):
         self.eol_chars = None
@@ -151,26 +145,6 @@ class BaseEditMixin(object):
         point = self.calculate_real_position(point)
 
         return point
-
-    def _update_stylesheet(self, widget):
-        """Update the background stylesheet to make it lighter."""
-        # Update the stylesheet for a given widget at most once
-        # because Qt is slow to repeatedly parse & apply CSS
-        if id(widget) in self._styled_widgets:
-            return
-
-        self._styled_widgets.add(id(widget))
-        name = widget.__class__.__name__
-        widget.setObjectName(name)
-
-        # Don't use qstylizer here to run this faster.
-        css = (
-            f'{name}#{name} {{'
-            f'    background-color: {self._BACKGROUND_COLOR};'
-            f'    border: 1px solid {QStylePalette.COLOR_TEXT_4};'
-            f'}}'
-        )
-        widget.setStyleSheet(css)
 
     @property
     def _tip_text_size(self):
@@ -582,8 +556,6 @@ class BaseEditMixin(object):
             text_new_line=text_new_line
         )
 
-        self._update_stylesheet(self.calltip_widget)
-
         # Set a max width so the widget doesn't show up too large due to its
         # content, which looks bad.
         self.calltip_widget.setMaximumWidth(
@@ -622,8 +594,6 @@ class BaseEditMixin(object):
             with_html_format=with_html_format,
             text_new_line=text_new_line
         )
-
-        self._update_stylesheet(self.tooltip_widget)
 
         # Set a max width so the widget doesn't show up too large due to its
         # content, which looks bad.

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -322,7 +322,7 @@ class BaseEditMixin(object):
         text = text.replace('\n', '<br>')
         if text_new_line and signature:
             # If there's enough content in the docstring or signature, then we
-            # an hr to separate them.
+            # add an hr to separate them.
             if len(lines) > 2 or signature.count('<br>') > 2:
                 separator = '<hr>'
             else:
@@ -341,7 +341,7 @@ class BaseEditMixin(object):
             help_text = (
                 f'<span style="font-family: \'{font_family}\';'
                 f'font-size:{text_size}pt;">'
-                f'Click anywhere in this tooltip for additional help'
+                f'Click on this tooltip for additional help'
                 f'</span>'
             )
 
@@ -602,7 +602,8 @@ class BaseEditMixin(object):
                      with_html_format=False,
                      text_new_line=True,
                      completion_doc=None,
-                     vertical_position='bottom'):
+                     vertical_position='bottom',
+                     show_help_on_click=False):
         """Show tooltip."""
 
         # Find position
@@ -633,7 +634,8 @@ class BaseEditMixin(object):
         # Display tooltip
         self.tooltip_widget.show_tip(
             point, tiptext, completion_doc=completion_doc,
-            vertical_position=vertical_position
+            vertical_position=vertical_position,
+            show_help_on_click=show_help_on_click
         )
 
     def show_hint(self, text, inspect_word, at_point,
@@ -641,7 +643,8 @@ class BaseEditMixin(object):
                   max_width=_DEFAULT_MAX_HINT_WIDTH,
                   text_new_line=True,
                   completion_doc=None,
-                  vertical_position='bottom'):
+                  vertical_position='bottom',
+                  show_help_on_click=False):
         """Show code hint and crop text as needed."""
         # Don't show full docstring for builtin types, just its type
         display_link = True
@@ -668,6 +671,7 @@ class BaseEditMixin(object):
                     builtin
                 )
                 display_link = False
+                show_help_on_click = False
 
         res = self._check_signature_and_format(text, max_width=max_width,
                                                inspect_word=inspect_word)
@@ -687,7 +691,8 @@ class BaseEditMixin(object):
                               display_link=display_link, max_lines=max_lines,
                               max_width=max_width, text_new_line=text_new_line,
                               completion_doc=completion_doc,
-                              vertical_position=vertical_position)
+                              vertical_position=vertical_position,
+                              show_help_on_click=show_help_on_click)
 
     def hide_tooltip(self):
         """

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -183,7 +183,7 @@ class BaseEditMixin(object):
         | `text` (ellided to `max_lines`)      |
         |                                      |
         ----------------------------------------
-        | Link or shortcut with `inspect_word` |
+        | Help message                         |
         ----------------------------------------
         """
         BASE_TEMPLATE = """
@@ -302,33 +302,13 @@ class BaseEditMixin(object):
         )
 
         help_text = ''
-        if inspect_word:
-            if display_link:
-                help_text = (
-                    '<span style="font-family: \'{font_family}\';'
-                    'font-size:{font_size}pt;">'
-                    'Click anywhere in this tooltip for additional help'
-                    '</span>'.format(
-                        font_size=text_size,
-                        font_family=font_family,
-                    )
-                )
-            else:
-                shortcut = self._get_inspect_shortcut()
-                if shortcut:
-                    base_style = (
-                        f'background-color:{QStylePalette.COLOR_BACKGROUND_4};'
-                        f'color:{QStylePalette.COLOR_TEXT_1};'
-                        'font-size:11px;'
-                    )
-                    help_text = ''
-                    # (
-                    #     'Press '
-                    #     '<kbd style="{1}">[</kbd>'
-                    #     '<kbd style="{1}text-decoration:underline;">'
-                    #     '{0}</kbd><kbd style="{1}">]</kbd> for aditional '
-                    #     'help'.format(shortcut, base_style)
-                    # )
+        if inspect_word and display_link:
+            help_text = (
+                f'<span style="font-family: \'{font_family}\';'
+                f'font-size:{text_size}pt;">'
+                f'Click anywhere in this tooltip for additional help'
+                f'</span>'
+            )
 
         if help_text and inspect_word:
             if display_link:

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -34,7 +34,7 @@ from spyder.py3compat import to_text_string
 from spyder.utils import encoding, sourcecode
 from spyder.utils import syntaxhighlighters as sh
 from spyder.utils.misc import get_error_match
-from spyder.utils.palette import QStylePalette
+from spyder.utils.palette import QStylePalette, SpyderPalette
 from spyder.widgets.arraybuilder import ArrayBuilderDialog
 
 
@@ -59,16 +59,16 @@ EOL_SYMBOLS = [
 
 class BaseEditMixin(object):
 
-    _PARAMETER_HIGHLIGHT_COLOR = QStylePalette.COLOR_ACCENT_4
+    _PARAMETER_HIGHLIGHT_COLOR = SpyderPalette.COLOR_SUCCESS_2
     _DEFAULT_TITLE_COLOR = QStylePalette.COLOR_ACCENT_4
-    _CHAR_HIGHLIGHT_COLOR = QStylePalette.COLOR_ACCENT_4
+    _CHAR_HIGHLIGHT_COLOR = SpyderPalette.COLOR_SUCCESS_2
     _DEFAULT_TEXT_COLOR = QStylePalette.COLOR_TEXT_2
     _DEFAULT_LANGUAGE = 'python'
     _DEFAULT_MAX_LINES = 10
-    _DEFAULT_MAX_WIDTH = 60
-    _DEFAULT_COMPLETION_HINT_MAX_WIDTH = 52
-    _DEFAULT_MAX_HINT_LINES = 20
-    _DEFAULT_MAX_HINT_WIDTH = 85
+    _DEFAULT_MAX_WIDTH = 55
+    _DEFAULT_COMPLETION_HINT_MAX_WIDTH = 50
+    _DEFAULT_MAX_HINT_LINES = 7
+    _DEFAULT_MAX_HINT_WIDTH = 55
 
     # The following signals are used to indicate text changes on the editor.
     sig_will_insert_text = None
@@ -186,13 +186,13 @@ class BaseEditMixin(object):
         | Link or shortcut with `inspect_word` |
         ----------------------------------------
         """
-        BASE_TEMPLATE = u'''
-            <div style=\'font-family: "{font_family}";
+        BASE_TEMPLATE = """
+            <div style='font-family: "{font_family}";
                         font-size: {size}pt;
-                        color: {color}\'>
+                        color: {color};'>
                 {main_text}
             </div>
-        '''
+        """
         # Get current font properties
         font = self.font()
         font_family = font.family()
@@ -274,13 +274,25 @@ class BaseEditMixin(object):
         # Limit max number of text displayed
         if max_lines:
             if len(lines) > max_lines:
-                text = '\n'.join(lines[:max_lines]) + ' ...'
+                text = '\n'.join(lines[:max_lines])
+
+                # Add ellipsis in a new line if necessary
+                if text[-1] == '\n':
+                    text = text + '...'
+                else:
+                    text = text + '\n...'
             else:
                 text = '\n'.join(lines)
 
         text = text.replace('\n', '<br>')
         if text_new_line and signature:
-            text = '<br>' + text
+            # If there's enough content in the docstring or signature, then we
+            # an hr to separate them.
+            if len(lines) > 2 or signature.count('<br>') > 2:
+                separator = '<hr>'
+            else:
+                separator = '<br>'
+            text = separator + text
 
         template += BASE_TEMPLATE.format(
             font_family=font_family,
@@ -321,14 +333,12 @@ class BaseEditMixin(object):
         if help_text and inspect_word:
             if display_link:
                 template += (
-                    '<hr>'
-                    '<div align="left">'
-                    f'<span style="color: {QStylePalette.COLOR_ACCENT_4};'
-                    'text-decoration:none;'
-                    'font-family:"{font_family}";font-size:{size}pt;><i>'
-                    ''.format(font_family=font_family,
-                              size=text_size)
-                    ) + help_text + '</i></span></div>'
+                    f'<hr>'
+                    f'<div align="left">'
+                    f'<span style="color: {SpyderPalette.COLOR_SUCCESS_2};'
+                    f'text-decoration:none;'
+                    f'font-family:"{font_family}";font-size:{text_size}pt;>'
+                ) + help_text + '</span></div>'
             else:
                 template += (
                     '<hr>'

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -62,18 +62,18 @@ EOL_SYMBOLS = [
 ]
 
 # Tips style
-DEFAULT_TEXT_COLOR = QStylePalette.COLOR_TEXT_2
-PARAMETER_HIGHLIGHT_COLOR = QStylePalette.COLOR_TEXT_1
-DEFAULT_TITLE_COLOR = Green.B80 if is_dark_interface() else Green.B20
-CHAR_HIGHLIGHT_COLOR = Orange.B90 if is_dark_interface() else Orange.B30
+TIP_TEXT_COLOR = QStylePalette.COLOR_TEXT_2
+TIP_PARAMETER_HIGHLIGHT_COLOR = QStylePalette.COLOR_TEXT_1
+TIP_TITLE_COLOR = Green.B80 if is_dark_interface() else Green.B20
+TIP_CHAR_HIGHLIGHT_COLOR = Orange.B90 if is_dark_interface() else Orange.B30
 
 # Tips content
-DEFAULT_LANGUAGE = 'python'
-DEFAULT_MAX_LINES = 10
-DEFAULT_MAX_WIDTH = 55
-DEFAULT_COMPLETION_HINT_MAX_WIDTH = 50
-DEFAULT_MAX_HINT_LINES = 7
-DEFAULT_MAX_HINT_WIDTH = 55
+TIP_DEFAULT_LANGUAGE = 'python'
+TIP_MAX_LINES = 10
+TIP_MAX_WIDTH = 55
+COMPLETION_HINT_MAX_WIDTH = 50
+HINT_MAX_LINES = 7
+HINT_MAX_WIDTH = 55
 BUILTINS_DOCSTRING_MAP = {
     int.__doc__: 'integer',
     list.__doc__: 'list',
@@ -183,7 +183,7 @@ class BaseEditMixin(object):
 
     def _format_text(self, title=None, signature=None, text=None,
                      inspect_word=None, max_lines=None,
-                     max_width=DEFAULT_MAX_WIDTH, display_link=False,
+                     max_width=TIP_MAX_WIDTH, display_link=False,
                      text_new_line=False,  with_html_format=False):
         """
         Create HTML template for calltips and tooltips.
@@ -213,14 +213,14 @@ class BaseEditMixin(object):
         # Get current font properties
         font_family = self.font().family()
         text_size = self._tip_text_size
-        text_color = DEFAULT_TEXT_COLOR
+        text_color = TIP_TEXT_COLOR
 
         template = ''
         if title:
             template += BASE_TEMPLATE.format(
                 font_family=font_family,
                 size=text_size,
-                color=DEFAULT_TITLE_COLOR,
+                color=TIP_TITLE_COLOR,
                 main_text=title,
             )
 
@@ -330,7 +330,7 @@ class BaseEditMixin(object):
                 template += (
                     f'<hr>'
                     f'<div align="left">'
-                    f'<span style="color: {DEFAULT_TITLE_COLOR};'
+                    f'<span style="color: {TIP_TITLE_COLOR};'
                     f'text-decoration:none;'
                     f'font-family:"{font_family}";font-size:{text_size}pt;>'
                 ) + help_text + '</span></div>'
@@ -345,7 +345,7 @@ class BaseEditMixin(object):
         return template
 
     def _format_signature(self, signatures, parameter=None,
-                          max_width=DEFAULT_MAX_WIDTH):
+                          max_width=TIP_MAX_WIDTH):
         """
         Create HTML template for signature.
 
@@ -354,7 +354,7 @@ class BaseEditMixin(object):
 
         Special chars depend on the language.
         """
-        language = getattr(self, 'language', DEFAULT_LANGUAGE).lower()
+        language = getattr(self, 'language', TIP_DEFAULT_LANGUAGE).lower()
         active_parameter_template = (
             '<span style=\'font-family:"{font_family}";'
             'font-size:{font_size}pt;'
@@ -363,7 +363,7 @@ class BaseEditMixin(object):
             '</span>'
         )
         chars_template = (
-            '<span style="color:{0};'.format(CHAR_HIGHLIGHT_COLOR) +
+            '<span style="color:{0};'.format(TIP_CHAR_HIGHLIGHT_COLOR) +
             'font-weight:bold"><b>{char}</b>'
             '</span>'
         )
@@ -440,7 +440,7 @@ class BaseEditMixin(object):
                 title = title_template.format(
                     font_size=self._tip_text_size,
                     font_family=font_family,
-                    color=PARAMETER_HIGHLIGHT_COLOR,
+                    color=TIP_PARAMETER_HIGHLIGHT_COLOR,
                     parameter=parameter,
                 )
             else:
@@ -451,7 +451,7 @@ class BaseEditMixin(object):
 
     def _check_signature_and_format(self, signature_or_text, parameter=None,
                                     inspect_word=None,
-                                    max_width=DEFAULT_MAX_WIDTH):
+                                    max_width=TIP_MAX_WIDTH):
         """
         LSP hints might provide docstrings instead of signatures.
 
@@ -459,7 +459,7 @@ class BaseEditMixin(object):
         the text accordingly.
         """
         has_signature = False
-        language = getattr(self, 'language', DEFAULT_LANGUAGE).lower()
+        language = getattr(self, 'language', TIP_DEFAULT_LANGUAGE).lower()
         signature_or_text = signature_or_text.replace('\\*', '*')
 
         # Remove special symbols that could interfere with ''.format
@@ -510,7 +510,7 @@ class BaseEditMixin(object):
         return new_signature, extra_text, inspect_word
 
     def show_calltip(self, signature, parameter=None, documentation=None,
-                     language=DEFAULT_LANGUAGE, text_new_line=True):
+                     language=TIP_DEFAULT_LANGUAGE, text_new_line=True):
         """
         Show calltip.
 
@@ -522,7 +522,7 @@ class BaseEditMixin(object):
         point = self._calculate_position()
         signature = signature.strip()
         inspect_word = None
-        language = getattr(self, 'language', DEFAULT_LANGUAGE).lower()
+        language = getattr(self, 'language', TIP_DEFAULT_LANGUAGE).lower()
         if language == 'python' and signature:
             inspect_word = signature.split('(')[0]
             # Check if documentation is better than signature, sometimes
@@ -544,22 +544,22 @@ class BaseEditMixin(object):
         # Format
         res = self._check_signature_and_format(signature, parameter,
                                                inspect_word=inspect_word,
-                                               max_width=DEFAULT_MAX_WIDTH)
+                                               max_width=TIP_MAX_WIDTH)
         new_signature, text, inspect_word = res
         text = self._format_text(
             signature=new_signature,
             inspect_word=inspect_word,
             display_link=False,
             text=documentation,
-            max_lines=DEFAULT_MAX_LINES,
-            max_width=DEFAULT_MAX_WIDTH,
+            max_lines=TIP_MAX_LINES,
+            max_width=TIP_MAX_WIDTH,
             text_new_line=text_new_line
         )
 
         # Set a max width so the widget doesn't show up too large due to its
         # content, which looks bad.
         self.calltip_widget.setMaximumWidth(
-            self._tip_width_in_pixels(DEFAULT_MAX_WIDTH)
+            self._tip_width_in_pixels(TIP_MAX_WIDTH)
         )
 
         # Show calltip
@@ -569,8 +569,8 @@ class BaseEditMixin(object):
     def show_tooltip(self, title=None, signature=None, text=None,
                      inspect_word=None,
                      at_line=None, at_point=None, display_link=False,
-                     max_lines=DEFAULT_MAX_LINES,
-                     max_width=DEFAULT_MAX_WIDTH,
+                     max_lines=TIP_MAX_LINES,
+                     max_width=TIP_MAX_WIDTH,
                      with_html_format=False,
                      text_new_line=True,
                      completion_doc=None,
@@ -608,8 +608,8 @@ class BaseEditMixin(object):
         )
 
     def show_hint(self, text, inspect_word, at_point,
-                  max_lines=DEFAULT_MAX_HINT_LINES,
-                  max_width=DEFAULT_MAX_HINT_WIDTH,
+                  max_lines=HINT_MAX_LINES,
+                  max_width=HINT_MAX_WIDTH,
                   text_new_line=True,
                   completion_doc=None,
                   vertical_position='bottom',
@@ -617,7 +617,7 @@ class BaseEditMixin(object):
         """Show code hint and crop text as needed."""
         # Don't show full docstring for builtin types, just its type
         display_link = True
-        language = getattr(self, 'language', DEFAULT_LANGUAGE).lower()
+        language = getattr(self, 'language', TIP_DEFAULT_LANGUAGE).lower()
         if language == 'python':
             builtin = ''
             # Check if `text` matches a builtin docstring

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -40,6 +40,9 @@ from spyder.utils.palette import QStylePalette
 from spyder.widgets.arraybuilder import ArrayBuilderDialog
 
 
+# ---- Constants
+# -----------------------------------------------------------------------------
+
 # List of possible EOL symbols
 EOL_SYMBOLS = [
     # Put first as it correspond to a single line return
@@ -58,33 +61,36 @@ EOL_SYMBOLS = [
     "\u2029",   # Paragraph Separator
 ]
 
+# Tips style
+DEFAULT_TEXT_COLOR = QStylePalette.COLOR_TEXT_2
+PARAMETER_HIGHLIGHT_COLOR = QStylePalette.COLOR_TEXT_1
+DEFAULT_TITLE_COLOR = Green.B80 if is_dark_interface() else Green.B20
+CHAR_HIGHLIGHT_COLOR = Orange.B90 if is_dark_interface() else Orange.B30
 
+# Tips content
+DEFAULT_LANGUAGE = 'python'
+DEFAULT_MAX_LINES = 10
+DEFAULT_MAX_WIDTH = 55
+DEFAULT_COMPLETION_HINT_MAX_WIDTH = 50
+DEFAULT_MAX_HINT_LINES = 7
+DEFAULT_MAX_HINT_WIDTH = 55
+BUILTINS_DOCSTRING_MAP = {
+    int.__doc__: 'integer',
+    list.__doc__: 'list',
+    dict.__doc__: 'dictionary',
+    set.__doc__: 'set',
+    float.__doc__: 'float',
+    tuple.__doc__: 'tuple',
+    str.__doc__: 'string',
+    bool.__doc__: 'bool',
+    bytes.__doc__: 'bytes string',
+    range.__doc__: 'range object'
+}
+
+
+# ---- Mixins
+# -----------------------------------------------------------------------------
 class BaseEditMixin(object):
-
-    _DEFAULT_TEXT_COLOR = QStylePalette.COLOR_TEXT_2
-    _PARAMETER_HIGHLIGHT_COLOR = QStylePalette.COLOR_TEXT_1
-    _DEFAULT_TITLE_COLOR = Green.B80 if is_dark_interface() else Green.B20
-    _CHAR_HIGHLIGHT_COLOR = Orange.B90 if is_dark_interface() else Orange.B30
-
-    _DEFAULT_LANGUAGE = 'python'
-    _DEFAULT_MAX_LINES = 10
-    _DEFAULT_MAX_WIDTH = 55
-    _DEFAULT_COMPLETION_HINT_MAX_WIDTH = 50
-    _DEFAULT_MAX_HINT_LINES = 7
-    _DEFAULT_MAX_HINT_WIDTH = 55
-
-    _BUILTINS_DOCSTRING_MAP = {
-        int.__doc__: 'integer',
-        list.__doc__: 'list',
-        dict.__doc__: 'dictionary',
-        set.__doc__: 'set',
-        float.__doc__: 'float',
-        tuple.__doc__: 'tuple',
-        str.__doc__: 'string',
-        bool.__doc__: 'bool',
-        bytes.__doc__: 'bytes string',
-        range.__doc__: 'range object'
-    }
 
     # The following signals are used to indicate text changes on the editor.
     sig_will_insert_text = None
@@ -176,8 +182,8 @@ class BaseEditMixin(object):
         return max_width_in_pixels.width() + 20
 
     def _format_text(self, title=None, signature=None, text=None,
-                     inspect_word=None, title_color=None, max_lines=None,
-                     max_width=_DEFAULT_MAX_WIDTH, display_link=False,
+                     inspect_word=None, max_lines=None,
+                     max_width=DEFAULT_MAX_WIDTH, display_link=False,
                      text_new_line=False,  with_html_format=False):
         """
         Create HTML template for calltips and tooltips.
@@ -207,14 +213,14 @@ class BaseEditMixin(object):
         # Get current font properties
         font_family = self.font().family()
         text_size = self._tip_text_size
-        text_color = self._DEFAULT_TEXT_COLOR
+        text_color = DEFAULT_TEXT_COLOR
 
         template = ''
         if title:
             template += BASE_TEMPLATE.format(
                 font_family=font_family,
                 size=text_size,
-                color=title_color,
+                color=DEFAULT_TITLE_COLOR,
                 main_text=title,
             )
 
@@ -324,7 +330,7 @@ class BaseEditMixin(object):
                 template += (
                     f'<hr>'
                     f'<div align="left">'
-                    f'<span style="color: {self._DEFAULT_TITLE_COLOR};'
+                    f'<span style="color: {DEFAULT_TITLE_COLOR};'
                     f'text-decoration:none;'
                     f'font-family:"{font_family}";font-size:{text_size}pt;>'
                 ) + help_text + '</span></div>'
@@ -339,10 +345,7 @@ class BaseEditMixin(object):
         return template
 
     def _format_signature(self, signatures, parameter=None,
-                          max_width=_DEFAULT_MAX_WIDTH,
-                          parameter_color=_PARAMETER_HIGHLIGHT_COLOR,
-                          char_color=_CHAR_HIGHLIGHT_COLOR,
-                          language=_DEFAULT_LANGUAGE):
+                          max_width=DEFAULT_MAX_WIDTH):
         """
         Create HTML template for signature.
 
@@ -351,7 +354,7 @@ class BaseEditMixin(object):
 
         Special chars depend on the language.
         """
-        language = getattr(self, 'language', language).lower()
+        language = getattr(self, 'language', DEFAULT_LANGUAGE).lower()
         active_parameter_template = (
             '<span style=\'font-family:"{font_family}";'
             'font-size:{font_size}pt;'
@@ -360,7 +363,7 @@ class BaseEditMixin(object):
             '</span>'
         )
         chars_template = (
-            '<span style="color:{0};'.format(self._CHAR_HIGHLIGHT_COLOR) +
+            '<span style="color:{0};'.format(CHAR_HIGHLIGHT_COLOR) +
             'font-weight:bold"><b>{char}</b>'
             '</span>'
         )
@@ -437,7 +440,7 @@ class BaseEditMixin(object):
                 title = title_template.format(
                     font_size=self._tip_text_size,
                     font_family=font_family,
-                    color=parameter_color,
+                    color=PARAMETER_HIGHLIGHT_COLOR,
                     parameter=parameter,
                 )
             else:
@@ -448,8 +451,7 @@ class BaseEditMixin(object):
 
     def _check_signature_and_format(self, signature_or_text, parameter=None,
                                     inspect_word=None,
-                                    max_width=_DEFAULT_MAX_WIDTH,
-                                    language=_DEFAULT_LANGUAGE):
+                                    max_width=DEFAULT_MAX_WIDTH):
         """
         LSP hints might provide docstrings instead of signatures.
 
@@ -457,7 +459,7 @@ class BaseEditMixin(object):
         the text accordingly.
         """
         has_signature = False
-        language = getattr(self, 'language', language).lower()
+        language = getattr(self, 'language', DEFAULT_LANGUAGE).lower()
         signature_or_text = signature_or_text.replace('\\*', '*')
 
         # Remove special symbols that could interfere with ''.format
@@ -508,8 +510,7 @@ class BaseEditMixin(object):
         return new_signature, extra_text, inspect_word
 
     def show_calltip(self, signature, parameter=None, documentation=None,
-                     language=_DEFAULT_LANGUAGE, max_lines=_DEFAULT_MAX_LINES,
-                     max_width=_DEFAULT_MAX_WIDTH, text_new_line=True):
+                     language=DEFAULT_LANGUAGE, text_new_line=True):
         """
         Show calltip.
 
@@ -521,7 +522,7 @@ class BaseEditMixin(object):
         point = self._calculate_position()
         signature = signature.strip()
         inspect_word = None
-        language = getattr(self, 'language', language).lower()
+        language = getattr(self, 'language', DEFAULT_LANGUAGE).lower()
         if language == 'python' and signature:
             inspect_word = signature.split('(')[0]
             # Check if documentation is better than signature, sometimes
@@ -543,23 +544,22 @@ class BaseEditMixin(object):
         # Format
         res = self._check_signature_and_format(signature, parameter,
                                                inspect_word=inspect_word,
-                                               language=language,
-                                               max_width=max_width)
+                                               max_width=DEFAULT_MAX_WIDTH)
         new_signature, text, inspect_word = res
         text = self._format_text(
             signature=new_signature,
             inspect_word=inspect_word,
             display_link=False,
             text=documentation,
-            max_lines=max_lines,
-            max_width=max_width,
+            max_lines=DEFAULT_MAX_LINES,
+            max_width=DEFAULT_MAX_WIDTH,
             text_new_line=text_new_line
         )
 
         # Set a max width so the widget doesn't show up too large due to its
         # content, which looks bad.
         self.calltip_widget.setMaximumWidth(
-            self._tip_width_in_pixels(max_width)
+            self._tip_width_in_pixels(DEFAULT_MAX_WIDTH)
         )
 
         # Show calltip
@@ -567,10 +567,10 @@ class BaseEditMixin(object):
         self.calltip_widget.show()
 
     def show_tooltip(self, title=None, signature=None, text=None,
-                     inspect_word=None, title_color=_DEFAULT_TITLE_COLOR,
+                     inspect_word=None,
                      at_line=None, at_point=None, display_link=False,
-                     max_lines=_DEFAULT_MAX_LINES,
-                     max_width=_DEFAULT_MAX_WIDTH,
+                     max_lines=DEFAULT_MAX_LINES,
+                     max_width=DEFAULT_MAX_WIDTH,
                      with_html_format=False,
                      text_new_line=True,
                      completion_doc=None,
@@ -586,7 +586,6 @@ class BaseEditMixin(object):
             title=title,
             signature=signature,
             text=text,
-            title_color=title_color,
             inspect_word=inspect_word,
             display_link=display_link,
             max_lines=max_lines,
@@ -609,8 +608,8 @@ class BaseEditMixin(object):
         )
 
     def show_hint(self, text, inspect_word, at_point,
-                  max_lines=_DEFAULT_MAX_HINT_LINES,
-                  max_width=_DEFAULT_MAX_HINT_WIDTH,
+                  max_lines=DEFAULT_MAX_HINT_LINES,
+                  max_width=DEFAULT_MAX_HINT_WIDTH,
                   text_new_line=True,
                   completion_doc=None,
                   vertical_position='bottom',
@@ -618,18 +617,18 @@ class BaseEditMixin(object):
         """Show code hint and crop text as needed."""
         # Don't show full docstring for builtin types, just its type
         display_link = True
-        language = getattr(self, 'language', self._DEFAULT_LANGUAGE).lower()
+        language = getattr(self, 'language', DEFAULT_LANGUAGE).lower()
         if language == 'python':
             builtin = ''
             # Check if `text` matches a builtin docstring
-            if self._BUILTINS_DOCSTRING_MAP.get(text):
-                builtin = self._BUILTINS_DOCSTRING_MAP[text]
+            if BUILTINS_DOCSTRING_MAP.get(text):
+                builtin = BUILTINS_DOCSTRING_MAP[text]
 
             # Another possibility is that the text after the signature matches
             # a buitin docstring (e.g. that's the case for Numpy objects).
             text_after_signature = '\n\n'.join(text.split('\n\n')[1:])
-            if self._BUILTINS_DOCSTRING_MAP.get(text_after_signature):
-                builtin = self._BUILTINS_DOCSTRING_MAP[text_after_signature]
+            if BUILTINS_DOCSTRING_MAP.get(text_after_signature):
+                builtin = BUILTINS_DOCSTRING_MAP[text_after_signature]
 
             if builtin:
                 text = (

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -60,7 +60,7 @@ EOL_SYMBOLS = [
 class BaseEditMixin(object):
 
     _PARAMETER_HIGHLIGHT_COLOR = SpyderPalette.COLOR_SUCCESS_2
-    _DEFAULT_TITLE_COLOR = QStylePalette.COLOR_ACCENT_4
+    _DEFAULT_TITLE_COLOR = SpyderPalette.COLOR_SUCCESS_2
     _CHAR_HIGHLIGHT_COLOR = SpyderPalette.COLOR_SUCCESS_2
     _DEFAULT_TEXT_COLOR = QStylePalette.COLOR_TEXT_2
     _DEFAULT_LANGUAGE = 'python'
@@ -196,8 +196,9 @@ class BaseEditMixin(object):
         # Get current font properties
         font = self.font()
         font_family = font.family()
-        title_size = font.pointSize()
-        text_size = title_size - 1 if title_size > 9 else title_size
+        font_size = font.pointSize()
+        title_size = font_size - 1 if font_size > 9 else font_size
+        text_size = title_size
         text_color = self._DEFAULT_TEXT_COLOR
 
         template = ''


### PR DESCRIPTION
## Description of Changes

* Show hovers on top of objects if there's space available. That prevents cluttering the view of code users are writing in the moment (I took this idea from VSCode).
* Show pointing hand cursor on top of hovers and completion hints that can display help.
* Hide calltip widget when users are scrolling the file and when they press the page up/down keys.
* Prevent hiding completion hints when clicking on them or moving the mouse out of them. Now they are hidden only when the completion widget is.
* Remove support for showing multiple signatures on hints and calltips. That failed in most cases because it was extracting signatures from anywhere in the corresponding docstring.
* Refactor code in `BaseEditMixin` related to tips so it's easier to understand and extend in the future.
* Cover several of these changes with new tests.

### Visual changes

**Improve style of hovers, hints and calltips**

Before | After
-- | --
![image](https://github.com/spyder-ide/spyder/assets/365293/c4f4c459-39d8-4ee3-9ccf-6e6b09332c94) | ![image](https://github.com/spyder-ide/spyder/assets/365293/3b77b46d-a97a-4f13-a222-bca9c77fc531)

**Improve style of linting messages**

Before | After
-- | --
![image](https://github.com/spyder-ide/spyder/assets/365293/2d7a0a5c-5df3-4c20-84bf-5d0f194bbf0d) | ![image](https://github.com/spyder-ide/spyder/assets/365293/9e962bd1-2aa4-4bba-994a-64e135433789)

**Don't show docstring in hovers for builtin types, just its type**

Before | After
-- | --
![image](https://github.com/spyder-ide/spyder/assets/365293/3f75823e-4b1f-4563-a888-8160933598e6) | ![image](https://github.com/spyder-ide/spyder/assets/365293/351a52bd-5b98-44fd-b08f-72d4ff8d24f5)

**Show TODO messages when hovering over their markers**

This is to have consistency with the other markers (i.e. errors and warnings) used in the line/number area.

![image](https://github.com/spyder-ide/spyder/assets/365293/5194a118-2c1e-44bf-ac60-e944ca5fefb6)

**Prevent to show the completion widget too close to the text and its vertical scrollbar to crop text to the right on Linux**

Before | After
-- | --
![image](https://github.com/spyder-ide/spyder/assets/365293/152b1e55-b2d3-45e6-a354-b285f57fff7d) | ![image](https://github.com/spyder-ide/spyder/assets/365293/95d4a407-b390-4215-9a42-1eb5d5f4bdbe)

**Take a max number of rows in signatures shown in hovers and hints**

Before | After
-- | --
![image](https://github.com/spyder-ide/spyder/assets/365293/81682025-c3f6-415a-9e81-f25c1272e1b8) | ![image](https://github.com/spyder-ide/spyder/assets/365293/519e6ca2-50f0-4b45-b9f9-a52cfb8c2b2e)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #15264

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
