### PR TITLE
PR: Change icon for "Remove all plots"

### DIFF
--- a/spyder/plugins/plots/widgets/main_widget.py
+++ b/spyder/plugins/plots/widgets/main_widget.py
@@ -154,7 +154,7 @@ class PlotsWidget(ShellConnectMainWidget):
             name=PlotsWidgetActions.CloseAll,
             text=_("Remove all plots"),
             tip=_("Remove all plots"),
-            icon=self.create_icon('filecloseall'),
+            icon=self.create_icon('editdelete'),
             triggered=self.remove_all_plots,
             register_shortcut=True,
         )


### PR DESCRIPTION
## Description of Changes

Change the icon for "Remove all plots" in the Plots pane to two rubbish bins, for consistency with the icon for "Remove plot" which is a simple rubbish bin.

Before | After
-- | --
![plot-pane-before](https://github.com/spyder-ide/spyder/assets/7941918/9ed2fe2e-a913-4ba9-9e2b-70b1088f33e4) | ![plot-pane-after](https://github.com/spyder-ide/spyder/assets/7941918/1af87f97-ac4b-417e-b935-4dbd2de1fbc3)


### Issue(s) Resolved

Fixes #21675


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
