### PR TITLE
PR: Make `get_spyder_conda_channel` return a tuple of None's if it fails (Utils)

### DIFF
--- a/spyder/utils/conda.py
+++ b/spyder/utils/conda.py
@@ -203,7 +203,7 @@ def get_spyder_conda_channel():
     conda = find_conda()
 
     if conda is None:
-        return None
+        return None, None
 
     env = get_conda_env_path(sys.executable)
     cmdstr = ' '.join([conda, 'list', 'spyder', '--json', '--prefix', env])
@@ -213,7 +213,7 @@ def get_spyder_conda_channel():
         out = out.decode()
         out = json.loads(out)
     except Exception:
-        return None
+        return None, None
 
     for package_info in out:
         if package_info["name"] == 'spyder':

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -115,7 +115,7 @@ class WorkerUpdates(QObject):
         elif is_anaconda():
             channel, channel_url = get_spyder_conda_channel()
 
-            if channel_url is None:
+            if channel is None or channel_url is None:
                 return
             elif channel == "pypi":
                 self.url = pypi_url


### PR DESCRIPTION
## Description of Changes

- That's necessary to unpack its result correctly in the worker in charge of checking if a new Spyder version is available.
- Also, improve a bit condition that checks the result of that function in the worker.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21711 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
