### PR TITLE
PR: Remove old `python-lsp-black` related code

### DIFF
--- a/spyder/config/lsp.py
+++ b/spyder/config/lsp.py
@@ -47,11 +47,6 @@ PYTHON_CONFIG = {
                 'autopep8': {
                     'enabled': True
                 },
-                'pylsp_black': {
-                    # This is necessary for python-lsp-black less than 2.0.
-                    # See python-lsp/python-lsp-black#41
-                    'enabled': False
-                },
                 'black': {
                     'enabled': False,
                     'line_length': 79,

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -784,22 +784,8 @@ class LanguageServerProvider(SpyderCompletionProvider):
         # Autoformatting configuration
         formatter = self.get_conf('formatting')
 
-        # This is necessary to support python-lsp-black 1 and 2 in the same
-        # codebase. See python-lsp/python-lsp-black#41 for details.
-        # TODO: Remove this in Spyder 6 to only support version 2.
-        old_pylsp_black = is_module_installed(
-            'pylsp_black', '<2.0.0', distribution_name='python_lsp_black'
-        )
-
-        if old_pylsp_black:
-            black_formatter = 'pylsp_black'
-            if formatter == 'black':
-                formatter = 'pylsp_black'
-        else:
-            black_formatter = 'black'
-
         # Enabling/disabling formatters
-        formatters = ['autopep8', 'yapf', black_formatter]
+        formatters = ['autopep8', 'yapf', 'black']
         formatter_options = {
             fmt: {
                 'enabled': fmt == formatter
@@ -812,9 +798,7 @@ class LanguageServerProvider(SpyderCompletionProvider):
         # 1. The autopep8 plugin shares the same maxLineLength value with the
         #    pycodestyle one. That's why it's not necessary to set it here.
         # 2. The yapf pylsp plugin doesn't support this yet.
-        if not old_pylsp_black:
-            # TODO: Remove this if in Spyder 6.
-            formatter_options['black']['line_length'] = cs_max_line_length
+        formatter_options['black']['line_length'] = cs_max_line_length
 
         # PyLS-Spyder configuration
         group_cells = self.get_conf(
@@ -890,10 +874,5 @@ class LanguageServerProvider(SpyderCompletionProvider):
         plugins['preload']['modules'] = self.get_conf('preload_modules')
         for fmt in formatters:
             plugins[fmt].update(formatter_options[fmt])
-
-        # TODO: Remove the code in this if in Spyder 6 because it won't be
-        # necessary.
-        if old_pylsp_black:
-            plugins['black']['line_length'] = cs_max_line_length
 
         return python_config

--- a/spyder/plugins/editor/widgets/codeeditor/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/conftest.py
@@ -69,8 +69,8 @@ yapf = pytest.param(
 black = pytest.param(
     'black',
     marks=pytest.mark.skipif(
-        is_module_installed('python-lsp-black', '<1.2.0'),
-        reason="Versions older than 1.2 don't handle eol's correctly"
+        is_module_installed('python-lsp-black', '<2.0.0'),
+        reason='Versions older than 2.0 use a different entrypoint name'
     )
 )
 


### PR DESCRIPTION
## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

This is a follow up to https://github.com/spyder-ide/spyder/pull/21629 removing some unused code for python-lsp-black 1.x that was removed in that pull request.

This is merging into master since some comments are mentioning Spyder 6. 

### Issue(s) Resolved

None

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: remisalmon