### PR TITLE
PR: Improve performance of workspace watcher (Projects)

### DIFF
--- a/spyder/config/utils.py
+++ b/spyder/config/utils.py
@@ -151,11 +151,10 @@ def get_edit_filters():
 
 def get_edit_extensions():
     """
-    Return extensions associated with the file types
-    supported by the Editor
+    Return extensions associated with the file types supported by the Editor.
     """
     edit_filetypes = get_edit_filetypes(ignore_pygments_extensions=False)
-    return _get_extensions(edit_filetypes) + ['']
+    return _get_extensions(edit_filetypes)
 
 
 #==============================================================================

--- a/spyder/plugins/projects/tests/test_plugin.py
+++ b/spyder/plugins/projects/tests/test_plugin.py
@@ -379,16 +379,16 @@ def test_filesystem_notifications(qtbot, projects, tmpdir):
     project_root = tmpdir.mkdir('project0')
     folder0 = project_root.mkdir('folder0')
     folder1 = project_root.mkdir('folder1')
-    file0 = project_root.join('file0')
-    file1 = folder0.join('file1')
-    file2 = folder0.join('file2')
-    file3 = folder1.join('file3')
+    file0 = project_root.join('file0.txt')
+    file1 = folder0.join('file1.txt')
+    file2 = folder0.join('file2.txt')
+    file3 = folder1.join('file3.txt')
     file0.write('')
     file1.write('')
     file3.write('ab')
 
     # Open the project
-    projects.open_project(path=to_text_string(project_root))
+    projects.open_project(path=str(project_root))
 
     # Get a reference to the filesystem event handler
     fs_handler = projects.get_widget().watcher.event_handler
@@ -399,7 +399,7 @@ def test_filesystem_notifications(qtbot, projects, tmpdir):
         file2.write('')
 
     file_created, is_dir = blocker.args
-    assert file_created == to_text_string(file2)
+    assert file_created == str(file2)
     assert not is_dir
 
     # Test folder creation
@@ -408,47 +408,47 @@ def test_filesystem_notifications(qtbot, projects, tmpdir):
         folder2 = project_root.mkdir('folder2')
 
     folder_created, is_dir = blocker.args
-    assert folder_created == osp.join(to_text_string(project_root), 'folder2')
+    assert folder_created == osp.join(str(project_root), 'folder2')
 
     # Test file move/renaming
-    new_file = osp.join(to_text_string(folder0), 'new_file')
+    new_file = osp.join(str(folder0), 'new_file.txt')
     with qtbot.waitSignal(fs_handler.sig_file_moved,
                           timeout=3000) as blocker:
-        shutil.move(to_text_string(file1), new_file)
+        shutil.move(str(file1), new_file)
 
     original_file, file_moved, is_dir = blocker.args
-    assert original_file == to_text_string(file1)
+    assert original_file == str(file1)
     assert file_moved == new_file
     assert not is_dir
 
     # Test folder move/renaming
-    new_folder = osp.join(to_text_string(project_root), 'new_folder')
+    new_folder = osp.join(str(project_root), 'new_folder')
     with qtbot.waitSignal(fs_handler.sig_file_moved,
                           timeout=3000) as blocker:
-        shutil.move(to_text_string(folder2), new_folder)
+        shutil.move(str(folder2), new_folder)
 
     original_folder, folder_moved, is_dir = blocker.args
-    assert original_folder == to_text_string(folder2)
+    assert original_folder == str(folder2)
     assert folder_moved == new_folder
     assert is_dir
 
     # Test file deletion
     with qtbot.waitSignal(fs_handler.sig_file_deleted,
                           timeout=3000) as blocker:
-        os.remove(to_text_string(file0))
+        os.remove(str(file0))
 
     deleted_file, is_dir = blocker.args
-    assert deleted_file == to_text_string(file0)
+    assert deleted_file == str(file0)
     assert not is_dir
-    assert not osp.exists(to_text_string(file0))
+    assert not osp.exists(str(file0))
 
     # Test folder deletion
     with qtbot.waitSignal(fs_handler.sig_file_deleted,
                           timeout=3000) as blocker:
-        shutil.rmtree(to_text_string(folder0))
+        shutil.rmtree(str(folder0))
 
     deleted_folder, is_dir = blocker.args
-    assert to_text_string(folder0) in deleted_folder
+    assert str(folder0) in deleted_folder
 
     # For some reason this fails in macOS
     if not sys.platform == 'darwin':
@@ -458,7 +458,7 @@ def test_filesystem_notifications(qtbot, projects, tmpdir):
             file3.write('abc')
 
         modified_file, is_dir = blocker.args
-        assert modified_file in to_text_string(file3)
+        assert modified_file in str(file3)
 
 
 def test_loaded_and_closed_signals(create_projects, tmpdir, mocker, qtbot):

--- a/spyder/plugins/projects/utils/watcher.py
+++ b/spyder/plugins/projects/utils/watcher.py
@@ -7,19 +7,17 @@
 """Watcher to detect filesystem changes in the project's directory."""
 
 # Standard lib imports
+import os
 import logging
 
 # Third-party imports
 from qtpy.QtCore import QObject, Signal
-from qtpy.QtWidgets import QMessageBox
 from superqt.utils import qthrottled
 import watchdog
-from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler, PatternMatchingEventHandler
+from watchdog.observers.polling import PollingObserverVFS
 
 # Local imports
-from spyder.config.base import _
-from spyder.py3compat import to_text_string
 from spyder.config.utils import get_edit_extensions
 
 
@@ -142,42 +140,26 @@ class WorkspaceWatcher(QObject):
         self.sig_file_modified.connect(project.file_modified)
 
     def start(self, workspace_folder):
-        # Needed to handle an error caused by the inotify limit reached.
-        # See spyder-ide/spyder#10478
+        # We use a polling observer because:
+        # * It doesn't introduce long freezes on Linux when switching git
+        #   branches that have many changes between them. That's because the
+        #   OS-based observer (i.e. inotify) generates way too many events.
+        # * The OS-based observer on Windows has many shortcomings (see
+        #   openmsi/openmsistream#56).
+        # * There doesn't seem to be issues on Mac, but it's simpler to use a
+        #   single observer for all OSes.
+        self.observer = PollingObserverVFS(stat=os.stat, listdir=os.scandir)
+
+        self.observer.schedule(
+            self.event_handler, workspace_folder, recursive=True
+        )
+
         try:
-            self.observer = Observer()
-            self.observer.schedule(
-                self.event_handler, workspace_folder, recursive=True)
-            try:
-                self.observer.start()
-            except OSError:
-                # This error happens frequently on Linux
-                logger.debug("Watcher could not be started.")
-        except OSError as e:
-            self.observer = None
-            if u'inotify' in to_text_string(e):
-                QMessageBox.warning(
-                    self.parent(),
-                    "Spyder",
-                    _("File system changes for this project can't be tracked "
-                      "because it contains too many files. To fix this you "
-                      "need to increase the inotify limit in your system, "
-                      "with the following command:"
-                      "<br><br>"
-                      "<code>"
-                      "sudo sysctl -n -w fs.inotify.max_user_watches=524288"
-                      "</code>"
-                      "<br><br>For a permanent solution you need to add to"
-                      "<code>/etc/sysctl.conf</code>"
-                      "the following line:<br><br>"
-                      "<code>"
-                      "fs.inotify.max_user_watches=524288"
-                      "</code>"
-                      "<br><br>"
-                      "After doing that, you need to close and start Spyder "
-                      "again so those changes can take effect."))
-            else:
-                raise e
+            self.observer.start()
+        except Exception:
+            logger.debug(
+                f"Observer could not be started for: {workspace_folder}."
+            )
 
     def stop(self):
         if self.observer is not None:


### PR DESCRIPTION
## Description of Changes

- Switch from Watchdog's OS-based observer to the polling one because it emits less events on Linux and behaves better on Windows (there doesn't seem to be problems on Mac, but we prefer to have a single solution for all OSes).
- Exclude binary files and hidden directories from the watcher.
- Exclude directories such as `__pycache__` and `build` from the watcher too.
- Throttle changes reported by the watcher to avoid sending too many events to LSP servers.

### Issue(s) Resolved

Part of #10664.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
