### PR TITLE
PR: Fix error when trying to set an empty scale factor (Preferences)

### DIFF
--- a/spyder/plugins/application/confpage.py
+++ b/spyder/plugins/application/confpage.py
@@ -30,7 +30,6 @@ HDPI_QT_PAGE = "https://doc.qt.io/qt-5/highdpi.html"
 
 
 class ApplicationConfigPage(PluginConfigPage):
-    APPLY_CONF_PAGE_SETTINGS = True
 
     def setup_page(self):
         newcb = self.create_checkbox
@@ -205,8 +204,9 @@ class ApplicationConfigPage(PluginConfigPage):
             tip=_("Enter values for different screens separated by semicolons "
                   "';'.\n Float values are supported"),
             alignment=Qt.Horizontal,
-            regex=r"[0-9]+(?:\.[0-9]*)(;[0-9]+(?:\.[0-9]*))*",
-            restart=True)
+            regex=r"[1-9]+(?:\.[0-9]*)(;[1-9]+(?:\.[0-9]*))*",
+            restart=True
+        )
 
         normal_radio.toggled.connect(self.custom_scaling_edit.setDisabled)
         auto_scale_radio.toggled.connect(self.custom_scaling_edit.setDisabled)
@@ -242,36 +242,6 @@ class ApplicationConfigPage(PluginConfigPage):
         vlayout.addWidget(self.tabs)
         self.setLayout(vlayout)
 
-    def apply_settings(self, options):
-        if 'high_dpi_custom_scale_factors' in options:
-            scale_factors = self.get_option(
-                'high_dpi_custom_scale_factors'
-            ).split(';')
-
-            change_min_scale_factor = False
-            for idx, scale_factor in enumerate(scale_factors[:]):
-                scale_factor = float(scale_factor)
-                if scale_factor < 1.0:
-                    change_min_scale_factor = True
-                    scale_factors[idx] = "1.0"
-
-            if change_min_scale_factor:
-                scale_factors_text = ";".join(scale_factors)
-                QMessageBox.critical(
-                    self,
-                    _("Error"),
-                    _("We're sorry but setting a scale factor bellow 1.0 "
-                      "isn't possible. Any scale factor bellow 1.0 will "
-                      "be set to 1.0"),
-                    QMessageBox.Ok
-                )
-                self.custom_scaling_edit.textbox.setText(scale_factors_text)
-                self.set_option(
-                    'high_dpi_custom_scale_factors', scale_factors_text
-                )
-                self.changed_options.add('high_dpi_custom_scale_factors')
-
-        self.plugin.apply_settings()
 
     def _save_lang(self):
         """

--- a/spyder/plugins/application/confpage.py
+++ b/spyder/plugins/application/confpage.py
@@ -178,30 +178,32 @@ class ApplicationConfigPage(PluginConfigPage):
         screen_resolution_label.setOpenExternalLinks(True)
 
         normal_radio = self.create_radiobutton(
-                                _("Normal"),
-                                'normal_screen_resolution',
-                                button_group=screen_resolution_bg)
+            _("Normal"),
+            'normal_screen_resolution',
+            button_group=screen_resolution_bg
+        )
         auto_scale_radio = self.create_radiobutton(
-                                _("Enable auto high DPI scaling"),
-                                'high_dpi_scaling',
-                                button_group=screen_resolution_bg,
-                                tip=_("Set this for high DPI displays"),
-                                restart=True)
+            _("Enable auto high DPI scaling"),
+            'high_dpi_scaling',
+            button_group=screen_resolution_bg,
+            tip=_("Set this for high DPI displays"),
+            restart=True
+        )
 
         custom_scaling_radio = self.create_radiobutton(
-                                _("Set a custom high DPI scaling"),
-                                'high_dpi_custom_scale_factor',
-                                button_group=screen_resolution_bg,
-                                tip=_("Set this for high DPI displays when "
-                                      "auto scaling does not work"),
-                                restart=True)
+            _("Set a custom high DPI scaling"),
+            'high_dpi_custom_scale_factor',
+            button_group=screen_resolution_bg,
+            tip=_("Set this for high DPI displays when auto scaling does not "
+                  "work"),
+            restart=True
+        )
 
         self.custom_scaling_edit = self.create_lineedit(
             "",
             'high_dpi_custom_scale_factors',
-            tip=_("Enter values for different screens "
-                  "separated by semicolons ';'.\n"
-                  "Float values are supported"),
+            tip=_("Enter values for different screens separated by semicolons "
+                  "';'.\n Float values are supported"),
             alignment=Qt.Horizontal,
             regex=r"[0-9]+(?:\.[0-9]*)(;[0-9]+(?:\.[0-9]*))*",
             restart=True)
@@ -243,25 +245,32 @@ class ApplicationConfigPage(PluginConfigPage):
     def apply_settings(self, options):
         if 'high_dpi_custom_scale_factors' in options:
             scale_factors = self.get_option(
-                'high_dpi_custom_scale_factors').split(';')
+                'high_dpi_custom_scale_factors'
+            ).split(';')
+
             change_min_scale_factor = False
             for idx, scale_factor in enumerate(scale_factors[:]):
                 scale_factor = float(scale_factor)
                 if scale_factor < 1.0:
                     change_min_scale_factor = True
                     scale_factors[idx] = "1.0"
+
             if change_min_scale_factor:
                 scale_factors_text = ";".join(scale_factors)
                 QMessageBox.critical(
-                    self, _("Error"),
+                    self,
+                    _("Error"),
                     _("We're sorry but setting a scale factor bellow 1.0 "
                       "isn't possible. Any scale factor bellow 1.0 will "
                       "be set to 1.0"),
-                    QMessageBox.Ok)
+                    QMessageBox.Ok
+                )
                 self.custom_scaling_edit.textbox.setText(scale_factors_text)
                 self.set_option(
-                    'high_dpi_custom_scale_factors', scale_factors_text)
+                    'high_dpi_custom_scale_factors', scale_factors_text
+                )
                 self.changed_options.add('high_dpi_custom_scale_factors')
+
         self.plugin.apply_settings()
 
     def _save_lang(self):
@@ -278,9 +287,11 @@ class ApplicationConfigPage(PluginConfigPage):
             self.set_option('interface_language', value)
         except Exception:
             QMessageBox.critical(
-                self, _("Error"),
+                self,
+                _("Error"),
                 _("We're sorry but the following error occurred while trying "
                   "to set your selected language:<br><br>"
                   "<tt>{}</tt>").format(traceback.format_exc()),
-                QMessageBox.Ok)
+                QMessageBox.Ok
+            )
             return


### PR DESCRIPTION
## Description of Changes

- Prevent setting scale factors less than one by making the regular expression we use to check for correct ones start at that value.
- If users try to set an empty scale factor, select automatically the `Normal` option instead.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21733 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
