### PR TITLE
PR: Build arm64 versions of Spyder's standalone macOS application

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -47,11 +47,12 @@ jobs:
         echo "build_type=[${build_type}]" >> $GITHUB_OUTPUT
   build:
     name: macOS App Bundle
-    runs-on: macos-11
+    runs-on: ${{ matrix.os }}
     needs: matrix_prep
     strategy:
       matrix:
         build_type: ${{fromJson(needs.matrix_prep.outputs.build_type)}}
+        os: ["macos-11", "macos-14"]
     defaults:
       run:
         shell: bash -l {0}
@@ -69,10 +70,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.9.14'
-          architecture: 'x64'
+          python-version: '3.10.11'
       - name: Install pcregrep
         run: |
           if [[ -z "$(which pcregrep)" ]]; then
@@ -88,8 +88,8 @@ jobs:
           fi
           ${pythonLocation}/bin/python -m pip install -U pip setuptools wheel
           ${pythonLocation}/bin/python -m pip install -r req-build.txt -r req-extras.txt -r req-plugins.txt "${INSTALL_FLAGS[@]}" -e ${GITHUB_WORKSPACE}
-      - name: Add mising file to Black dist-info
-        run: touch ${pythonLocation}/lib/python3.9/site-packages/black-23.12.0.dist-info/top_level.txt
+      - name: Add missing file to Black dist-info
+        run: touch ${pythonLocation}/lib/python3.10/site-packages/black-24.1.1.dist-info/top_level.txt
       - name: Install Subrepos
         if: ${{github.event_name == 'pull_request'}}
         run: ${pythonLocation}/bin/python -bb -X dev -W error ${GITHUB_WORKSPACE}/install_dev_repos.py --not-editable --no-install spyder
@@ -105,7 +105,7 @@ jobs:
       - name: Build Application Bundle
         run: ${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dist-dir ${DISTDIR}
       - name: Add missing Black module to bundle
-        run: cp -v ${pythonLocation}/lib/python3.9/site-packages/629853fdff261ed89b74__mypyc* ${DISTDIR}/Spyder.app/Contents/Resources/lib/python3.9/
+        run: cp -v ${pythonLocation}/lib/python3.10/site-packages/629853fdff261ed89b74__mypyc* ${DISTDIR}/Spyder.app/Contents/Resources/lib/python3.10/
       - name: Create Keychain
         if: ${{env.IS_RELEASE == 'true' || env.IS_PRE == 'true'}}
         run: ./certkeychain.sh "${MACOS_CERTIFICATE}" "${MACOS_CERTIFICATE_PWD}"
@@ -119,7 +119,10 @@ jobs:
       - name: Test Application Bundle
         run: ./test_app.sh -t 60 -d 10 ${DISTDIR}
       - name: Build Disk Image
-        run: ${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dist-dir ${DISTDIR} --dmg --no-app
+        run: |
+          DMGNAME=$(${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dmg-name)
+          ${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dist-dir ${DISTDIR} --dmg --no-app
+          echo "DMGNAME=$DMGNAME" >> $GITHUB_ENV
       - name: Sign Disk Image
         if: ${{env.IS_RELEASE == 'true' || env.IS_PRE == 'true'}}
         run: ./codesign.sh "${DISTDIR}/${DMGNAME}"
@@ -136,7 +139,7 @@ jobs:
         id: get_release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        uses: bruceadams/get-release@v1.2.0
+        uses: bruceadams/get-release@v1.3.2
       - name: Upload Release Asset
         if: ${{env.IS_RELEASE == 'true'}}
         uses: actions/upload-release-asset@v1

--- a/installers/macOS/req-build.txt
+++ b/installers/macOS/req-build.txt
@@ -2,4 +2,4 @@
 dmgbuild>=1.4.2
 py2app==0.28.4
 sphinx==5.1.1  # See spyder-ide/spyder#19618 for details.
-black==23.12.0  # Pin it to add missing modules to the bundle. See workflow file for the details.
+black==24.1.1  # Pin it to add missing modules to the bundle. See workflow file for the details.

--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -16,6 +16,7 @@ import shutil
 from logging import getLogger, StreamHandler, Formatter
 from pathlib import Path
 from setuptools import setup
+from platform import machine
 
 from spyder import get_versions
 
@@ -98,6 +99,18 @@ def make_app_bundle(dist_dir, make_lite=False):
     return
 
 
+def disk_image_name(make_lite=False):
+    """
+    Return disk image name
+    """
+    dmg_name = f'Spyder-{SPYVER}_{machine()}'
+    if make_lite:
+        dmg_name += '-Lite'
+    dmg_name += '.dmg'
+
+    return dmg_name
+
+
 def make_disk_image(dist_dir, make_lite=False):
     """
     Make macOS disk image containing Spyder.app application bundle.
@@ -117,12 +130,9 @@ def make_disk_image(dist_dir, make_lite=False):
     from dmgbuild.core import DMGError
 
     volume_name = '{}-{} Py-{}.{}.{}'.format(APP_BASE_NAME, SPYVER, *PYVER)
-    dmg_name = 'Spyder'
     if make_lite:
         volume_name += ' Lite'
-        dmg_name += '-Lite'
-    dmg_name += '.dmg'
-    dmgfile = (dist_dir / dmg_name).as_posix()
+    dmgfile = (dist_dir / disk_image_name(make_lite)).as_posix()
 
     settings_file = (THISDIR / 'dmg_settings.py').as_posix()
     settings = {
@@ -162,8 +172,16 @@ if __name__ == '__main__':
     parser.add_argument('-b', '--bdist-base', dest='build_dir',
                         default='build',
                         help='Build directory; passed to py2app')
+    parser.add_argument(
+        '-m', '--dmg-name', dest='dmg_name', action='store_true',
+        help='Return the DMG name: Spyder-{VER}_{ARCH}-{LITE}.dmg'
+    )
 
     args, rem = parser.parse_known_args()
+
+    if args.dmg_name:
+        print(disk_image_name(args.make_lite))
+        sys.exit()
 
     # Groom sys.argv for py2app
     sys.argv = sys.argv[:1] + ['py2app'] + rem


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Add arm64 to build matrix
* Update Python to 3.10.11 (arm64 builds not available for Python 3.9 from setup-python)
* Update DMG name to include Spyder version and architecture

Note that py2app 0.28.5, I believe, should have updated the `black` recipe and resolved #19743. However, there is still an issue; see ronaldoussoren/py2app#518. The kluges from #21629 are still required.

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #20232


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
