### PR TITLE
PR: Use Python 3.9.14 for x86_64 macOS application build

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -53,6 +53,11 @@ jobs:
       matrix:
         build_type: ${{fromJson(needs.matrix_prep.outputs.build_type)}}
         os: ["macos-11", "macos-14"]
+        include:
+          - os: "macos-11"
+            pyver: "3.9.14"
+          - os: "macos-14"
+            pyver: "3.10.11"
     defaults:
       run:
         shell: bash -l {0}
@@ -72,7 +77,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10.11'
+          python-version: ${{ matrix.pyver }}
       - name: Install pcregrep
         run: |
           if [[ -z "$(which pcregrep)" ]]; then
@@ -88,8 +93,6 @@ jobs:
           fi
           ${pythonLocation}/bin/python -m pip install -U pip setuptools wheel
           ${pythonLocation}/bin/python -m pip install -r req-build.txt -r req-extras.txt -r req-plugins.txt "${INSTALL_FLAGS[@]}" -e ${GITHUB_WORKSPACE}
-      - name: Add missing file to Black dist-info
-        run: touch ${pythonLocation}/lib/python3.10/site-packages/black-24.1.1.dist-info/top_level.txt
       - name: Install Subrepos
         if: ${{github.event_name == 'pull_request'}}
         run: ${pythonLocation}/bin/python -bb -X dev -W error ${GITHUB_WORKSPACE}/install_dev_repos.py --not-editable --no-install spyder
@@ -103,9 +106,15 @@ jobs:
           curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
           install_name_tool -change @rpath/libc++.1.dylib /usr/lib/libc++.1.dylib bin/micromamba
       - name: Build Application Bundle
-        run: ${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dist-dir ${DISTDIR}
-      - name: Add missing Black module to bundle
-        run: cp -v ${pythonLocation}/lib/python3.10/site-packages/629853fdff261ed89b74__mypyc* ${DISTDIR}/Spyder.app/Contents/Resources/lib/python3.10/
+        run: |
+          echo "Patch Black 1 of 2"
+          sitepkgs=$($pythonLocation/bin/python -c "import site; print(site.getsitepackages()[0])")
+          touch ${sitepkgs}/black-24.1.1.dist-info/top_level.txt
+
+          ${pythonLocation}/bin/python setup.py ${LITE_FLAG} --dist-dir ${DISTDIR}
+
+          echo "Patch Black 2 of 2"
+          cp -v ${sitepkgs}/629853fdff261ed89b74__mypyc* ${DISTDIR}/Spyder.app/Contents/Resources/lib/python*/
       - name: Create Keychain
         if: ${{env.IS_RELEASE == 'true' || env.IS_PRE == 'true'}}
         run: ./certkeychain.sh "${MACOS_CERTIFICATE}" "${MACOS_CERTIFICATE_PWD}"


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Spyder 5.5.1rc0 macOS x86_64 exhibits
```python
RuntimeError: tk.h version (8.5) doesn't match libtk.a version (8.6)
```
This exhibited previously for local arm64 builds and seemed to be the result of incorrect tcl-tk Python build flags. However, this did not exhibit for Python 3.9.14 x86_64. I suspect that there is a change in the `setup-python` build flags between 3.9, 3.10, x86_64, and arm64. Nevertheless, the easiest fix right now is to revert to 3.9.14 for x86_64. 🤞🏼 