### PR TITLE
PR: Do not use version in macOS artifact name and fix names for the future Spyder 6 installers (Installers)

### DIFF
--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -103,9 +103,9 @@ def disk_image_name(make_lite=False):
     """
     Return disk image name
     """
-    dmg_name = f'Spyder_{machine()}'
+    dmg_name = f'Spyder-{machine()}'
     if make_lite:
-        dmg_name += '_Lite'
+        dmg_name += '-Lite'
     dmg_name += '.dmg'
 
     return dmg_name

--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -15,8 +15,8 @@ import sys
 import shutil
 from logging import getLogger, StreamHandler, Formatter
 from pathlib import Path
+import platform
 from setuptools import setup
-from platform import machine
 
 from spyder import get_versions
 
@@ -103,7 +103,8 @@ def disk_image_name(make_lite=False):
     """
     Return disk image name
     """
-    dmg_name = f'Spyder-{machine()}'
+    mach = "_arm64" if "ARM64" in platform.version() else ""
+    dmg_name = f'Spyder{mach}'
     if make_lite:
         dmg_name += '-Lite'
     dmg_name += '.dmg'

--- a/installers/macOS/setup.py
+++ b/installers/macOS/setup.py
@@ -103,9 +103,9 @@ def disk_image_name(make_lite=False):
     """
     Return disk image name
     """
-    dmg_name = f'Spyder-{SPYVER}_{machine()}'
+    dmg_name = f'Spyder_{machine()}'
     if make_lite:
-        dmg_name += '-Lite'
+        dmg_name += '_Lite'
     dmg_name += '.dmg'
 
     return dmg_name

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -108,9 +108,13 @@ class ApplicationContainer(PluginMainContainer):
         self.dialog_manager = DialogManager()
 
         self.application_update_status = ApplicationUpdateStatus(
-            parent=self)
+            parent=self
+        )
+
+        # Users can only use this widget in our apps.
         if not is_pynsist() and not running_in_mac_app():
             self.application_update_status.hide()
+
         (self.application_update_status.sig_check_for_updates_requested
          .connect(self.check_updates))
         (self.application_update_status.sig_install_on_close_requested

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -106,15 +106,17 @@ class ApplicationContainer(PluginMainContainer):
 
         # Attributes
         self.dialog_manager = DialogManager()
-        self.application_update_status = None
-        if is_pynsist() or running_in_mac_app():
-            self.application_update_status = ApplicationUpdateStatus(
-                parent=self)
-            (self.application_update_status.sig_check_for_updates_requested
-             .connect(self.check_updates))
-            (self.application_update_status.sig_install_on_close_requested
-                 .connect(self.set_installer_path))
-            self.application_update_status.set_no_status()
+
+        self.application_update_status = ApplicationUpdateStatus(
+            parent=self)
+        if not is_pynsist() and not running_in_mac_app():
+            self.application_update_status.hide()
+        (self.application_update_status.sig_check_for_updates_requested
+         .connect(self.check_updates))
+        (self.application_update_status.sig_install_on_close_requested
+             .connect(self.set_installer_path))
+        self.application_update_status.set_no_status()
+
         self.give_updates_feedback = False
         self.thread_updates = None
         self.worker_updates = None

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -228,7 +228,7 @@ class WorkerDownloadInstaller(QObject):
         """Donwload latest Spyder standalone installer executable."""
         tmpdir = tempfile.gettempdir()
 
-        # If running on macOS unde Rosetta, platform.machine will not be
+        # If running on macOS under Rosetta, platform.machine will not be
         # correct so check for ARM64 in version instead. All other
         # platforms will be x86_64.
         mach = "arm64" if "ARM64" in platform.version() else "x86_64"
@@ -241,7 +241,7 @@ class WorkerDownloadInstaller(QObject):
                 plat, ext = 'macOS', 'pkg'
             else:
                 plat, ext = 'Linux', 'sh'
-            name = f'Spyder_{plat}_{mach}.{ext}'
+            name = f'Spyder-{plat}-{mach}.{ext}'
         else:
             # 5.x installer name
             is_full_installer = (is_module_installed('numpy') or
@@ -251,8 +251,8 @@ class WorkerDownloadInstaller(QObject):
                     'full' if is_full_installer else 'lite'
                 )
             else:
-                name = 'Spyder_{}{}.dmg'.format(
-                    mach, '' if is_full_installer else '_Lite'
+                name = 'Spyder-{}{}.dmg'.format(
+                    mach, '' if is_full_installer else '-Lite'
                 )
 
         url = ('https://github.com/spyder-ide/spyder/releases/download/'

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -233,7 +233,7 @@ class WorkerDownloadInstaller(QObject):
         # platforms will be x86_64.
         mach = "arm64" if "ARM64" in platform.version() else "x86_64"
 
-        if parse(self.latest_release_version) >= parse("5"):
+        if parse(self.latest_release_version) > parse("5"):
             # conda-based installer name
             if os.name == 'nt':
                 plat, ext = 'Windows', 'exe'
@@ -251,8 +251,9 @@ class WorkerDownloadInstaller(QObject):
                     'full' if is_full_installer else 'lite'
                 )
             else:
-                name = 'Spyder-{}{}.dmg'.format(
-                    mach, '' if is_full_installer else '-Lite'
+                name = 'Spyder{}{}.dmg'.format(
+                    '-{mach}' if mach == 'arm64' else '',
+                    '' if is_full_installer else '-Lite'
                 )
 
         url = ('https://github.com/spyder-ide/spyder/releases/download/'

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -252,7 +252,7 @@ class WorkerDownloadInstaller(QObject):
                 )
             else:
                 name = 'Spyder{}{}.dmg'.format(
-                    '-{mach}' if mach == 'arm64' else '',
+                    '_{mach}' if mach == 'arm64' else '',
                     '' if is_full_installer else '-Lite'
                 )
 

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -12,6 +12,8 @@ import tempfile
 import traceback
 
 # Third party imports
+from packaging.version import parse
+import platform
 from qtpy.QtCore import QObject, Signal
 import requests
 from requests.exceptions import ConnectionError, HTTPError, SSLError
@@ -225,16 +227,37 @@ class WorkerDownloadInstaller(QObject):
     def _download_installer(self):
         """Donwload latest Spyder standalone installer executable."""
         tmpdir = tempfile.gettempdir()
-        is_full_installer = (is_module_installed('numpy') or
-                             is_module_installed('pandas'))
-        if os.name == 'nt':
-            name = 'Spyder_64bit_{}.exe'.format('full' if is_full_installer
-                                                else 'lite')
-        else:
-            name = 'Spyder{}.dmg'.format('' if is_full_installer else '-Lite')
 
-        url = ('https://github.com/spyder-ide/spyder/releases/latest/'
-               f'download/{name}')
+        # If running on macOS unde Rosetta, platform.machine will not be
+        # correct so check for ARM64 in version instead. All other
+        # platforms will be x86_64.
+        mach = "arm64" if "ARM64" in platform.version() else "x86_64"
+
+        if parse(self.latest_release_version) >= parse("5"):
+            # conda-based installer name
+            if os.name == 'nt':
+                plat, ext = 'Windows', 'exe'
+            elif platform.system == 'Darwin':
+                plat, ext = 'macOS', 'pkg'
+            else:
+                plat, ext = 'Linux', 'sh'
+            name = f'Spyder_{plat}_{mach}.{ext}'
+        else:
+            # 5.x installer name
+            is_full_installer = (is_module_installed('numpy') or
+                                 is_module_installed('pandas'))
+            if os.name == 'nt':
+                name = 'Spyder_64bit_{}.exe'.format(
+                    'full' if is_full_installer else 'lite'
+                )
+            else:
+                name = 'Spyder_{}{}.dmg'.format(
+                    mach, '' if is_full_installer else '_Lite'
+                )
+
+        url = ('https://github.com/spyder-ide/spyder/releases/download/'
+               f'v{self.latest_release_version}/{name}')
+
         dir_path = osp.join(tmpdir, 'spyder', 'updates')
         os.makedirs(dir_path, exist_ok=True)
         installer_dir_path = osp.join(

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -8,12 +8,12 @@
 import logging
 import os
 import os.path as osp
+import platform
 import tempfile
 import traceback
 
 # Third party imports
 from packaging.version import parse
-import platform
 from qtpy.QtCore import QObject, Signal
 import requests
 from requests.exceptions import ConnectionError, HTTPError, SSLError
@@ -252,7 +252,7 @@ class WorkerDownloadInstaller(QObject):
                 )
             else:
                 name = 'Spyder{}{}.dmg'.format(
-                    '_{mach}' if mach == 'arm64' else '',
+                    f'_{mach}' if mach == 'arm64' else '',
                     '' if is_full_installer else '-Lite'
                 )
 


### PR DESCRIPTION
Do not use version in artifact name. Instantiate `ApplicationUpdateStatus` for all installation types, but leave only visible for Windows and macOS standalone applications.

Fixes #21781