### PR TITLE
PR: Avoid `conda run` capturing output in env activation (IPython console)

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -5521,10 +5521,11 @@ crash_func()
     # Click the run button
     qtbot.mouseClick(main_window.run_button, Qt.LeftButton)
 
+    # Check segfault info is printed in the console
     qtbot.waitUntil(lambda: 'Segmentation fault' in control.toPlainText(),
                     timeout=SHELL_TIMEOUT)
-    assert 'Segmentation fault' in control.toPlainText()
-    assert 'in crash_func' in control.toPlainText()
+    qtbot.waitUntil(lambda: 'in crash_func' in control.toPlainText(),
+                    timeout=SHELL_TIMEOUT)
 
 
 @flaky(max_runs=3)

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_hints_and_calltips.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_hints_and_calltips.py
@@ -16,7 +16,7 @@ from qtpy.QtGui import QTextCursor
 import pytest
 
 # Local imports
-from spyder.config.base import running_in_ci, running_in_ci_with_conda
+from spyder.config.base import running_in_ci
 from spyder.plugins.editor.extensions.closebrackets import (
     CloseBracketsExtension
 )
@@ -214,11 +214,9 @@ def test_get_hints_not_triggered(qtbot, completions_codeeditor, text):
 @pytest.mark.skipif(
     (
         sys.platform == "darwin"
-        or (
-            sys.platform.startswith("linux") and not running_in_ci_with_conda()
-        )
+        or (sys.platform.startswith("linux") and running_in_ci())
     ),
-    reason="Fails on Linux with pip packages and Mac",
+    reason="Fails on CIs for Linux and Mac",
 )
 @pytest.mark.parametrize(
     "params",
@@ -277,11 +275,9 @@ def test_get_hints_for_builtins(qtbot, completions_codeeditor, params):
 @pytest.mark.skipif(
     (
         sys.platform == "darwin"
-        or (
-            sys.platform.startswith("linux") and not running_in_ci_with_conda()
-        )
+        or (sys.platform.startswith("linux") and running_in_ci())
     ),
-    reason="Fails on Linux with pip packages and Mac",
+    reason="Fails on CIs for Linux and Mac",
 )
 @pytest.mark.parametrize(
     "params",

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1067,11 +1067,11 @@ def test_kernel_crash(ipyconsole, qtbot):
         qtbot.waitUntil(lambda: bool(
             ipyconsole.get_widget()._cached_kernel_properties[-1]._init_stderr
         ))
+
         # Create a new client
         ipyconsole.create_new_client()
 
         # Assert that the console is showing an error
-        # even if the error happened before the connection
         error_client = ipyconsole.get_clients()[-1]
         qtbot.waitUntil(lambda: bool(error_client.error_text), timeout=6000)
     finally:

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -545,7 +545,9 @@ def test_request_syspath(ipyconsole, qtbot, tmpdir):
 
 
 @flaky(max_runs=10)
-@pytest.mark.skipif(os.name == 'nt', reason="It doesn't work on Windows")
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="Fails on Windows and Mac"
+)
 def test_save_history_dbg(ipyconsole, qtbot):
     """Test that browsing command history is working while debugging."""
     shell = ipyconsole.get_current_shellwidget()
@@ -622,8 +624,7 @@ def test_save_history_dbg(ipyconsole, qtbot):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(IPython.version_info < (7, 17),
-                    reason="insert is not the same in pre 7.17 ipython")
+@pytest.mark.skipif(sys.platform == "darwin", reason="Hangs on Mac")
 def test_dbg_input(ipyconsole, qtbot):
     """Test that spyder doesn't send pdb commands to unrelated input calls."""
     shell = ipyconsole.get_current_shellwidget()
@@ -674,8 +675,10 @@ def test_unicode_vars(ipyconsole, qtbot):
 
 @flaky(max_runs=10)
 @pytest.mark.no_xvfb
-@pytest.mark.skipif(running_in_ci() and os.name == 'nt',
-                    reason="Times out on Windows")
+@pytest.mark.skipif(
+    (running_in_ci() and os.name == 'nt') or sys.platform == "darwin",
+    reason="Hangs on CIs for Windows and Mac"
+)
 def test_values_dbg(ipyconsole, qtbot):
     """
     Test that getting, setting, copying and removing values is working while
@@ -727,6 +730,7 @@ def test_values_dbg(ipyconsole, qtbot):
 
 
 @flaky(max_runs=3)
+@pytest.mark.skipif(sys.platform == "darwin", reason="Hangs on Mac")
 def test_execute_events_dbg(ipyconsole, qtbot):
     """Test execute events while debugging"""
 
@@ -850,7 +854,10 @@ def test_mpl_backend_change(ipyconsole, qtbot):
 
 
 @flaky(max_runs=10)
-@pytest.mark.skipif(os.name == 'nt', reason="It doesn't work on Windows")
+@pytest.mark.skipif(
+    os.name == 'nt' or sys.platform == "darwin",
+    reason="Doesn't work on Windows and hangs on Mac"
+)
 def test_clear_and_reset_magics_dbg(ipyconsole, qtbot):
     """
     Test that clear and reset magics are working while debugging

--- a/spyder/plugins/ipythonconsole/utils/kernel_handler.py
+++ b/spyder/plugins/ipythonconsole/utils/kernel_handler.py
@@ -20,6 +20,7 @@ from zmq.ssh import tunnel as zmqtunnel
 
 # Local imports
 from spyder.api.translations import _
+from spyder.config.base import running_under_pytest
 from spyder.plugins.ipythonconsole import (
     SPYDER_KERNELS_MIN_VERSION, SPYDER_KERNELS_MAX_VERSION,
     SPYDER_KERNELS_VERSION, SPYDER_KERNELS_CONDA, SPYDER_KERNELS_PIP)
@@ -488,7 +489,10 @@ class KernelHandler(QObject):
             km.stop_restarter()
             self.disconnect_std_pipes()
 
-            if now:
+            # This is probably necessary due to a weird interaction between
+            # `conda run --no-capture-output` and pytest capturing output
+            # facilities.
+            if now or running_under_pytest():
                 km.shutdown_kernel(now=True)
                 self.after_shutdown()
             else:

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -131,8 +131,11 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
             # runtime environment, we need to activate the environment to run
             # spyder-kernels
             kernel_cmd[:0] = [
-                find_conda(), 'run',
-                '-p', get_conda_env_path(pyexec),
+                find_conda(),
+                'run',
+                '--no-capture-output',
+                '--prefix',
+                get_conda_env_path(pyexec),
             ]
 
         logger.info('Kernel command: {}'.format(kernel_cmd))

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1767,8 +1767,9 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
         open_clients = self.clients.copy()
         for client in self.clients:
             is_last_client = (
-                len(self.get_related_clients(client, open_clients)) == 0)
-            client.close_client(is_last_client)
+                len(self.get_related_clients(client, open_clients)) == 0
+            )
+            client.close_client(is_last_client, close_console=True)
             open_clients.remove(client)
 
         # Wait for all KernelHandler threads to shutdown.

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -350,10 +350,6 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
         # Update the list of envs at startup
         self.get_envs()
 
-    def on_close(self):
-        self.mainwindow_close = True
-        self.close_all_clients()
-
     # ---- PluginMainWidget API and settings handling
     # ------------------------------------------------------------------------
     def get_title(self):

--- a/spyder/plugins/ipythonconsole/widgets/mixins.py
+++ b/spyder/plugins/ipythonconsole/widgets/mixins.py
@@ -63,11 +63,15 @@ class CachedKernelMixin:
             self.close_cached_kernel()
             return new_kernel_handler
 
-        # Check cached kernel has the same configuration as is being asked
+        # Check cached kernel has the same configuration as is being asked or
+        # it crashed.
         cached_kernel_handler = None
         if self._cached_kernel_properties is not None:
             cached_kernel_handler = self._cached_kernel_properties[-1]
-            if not self.check_cached_kernel_spec(kernel_spec):
+            if (
+                not self.check_cached_kernel_spec(kernel_spec)
+                or cached_kernel_handler._init_stderr
+            ):
                 # Close the kernel
                 self.close_cached_kernel()
                 cached_kernel_handler = None


### PR DESCRIPTION
## Description of Changes

- We need this fix in master after #21783.
- Stop debugging before closing clients. That avoids freezes and segfaults when closing Spyder, which are side effects from the fixes done here.
- Disable `pdb_prevent_closing` option when opening/closing projects. That's necessary to correctly restore the project or program session when a console is left in debugging mode (I discovered that bug while testing these changes).

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
