### PR TITLE
PR: Change default resolution of plots to 144 dpi

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -149,7 +149,7 @@ DEFAULTS = [
               'pylab/autoload': False,
               'pylab/backend': 'inline',
               'pylab/inline/figure_format': 'png',
-              'pylab/inline/resolution': 72,
+              'pylab/inline/resolution': 144,
               'pylab/inline/width': 6,
               'pylab/inline/height': 4,
               'pylab/inline/fontsize': 10.0,
@@ -670,4 +670,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '82.1.0'
+CONF_VERSION = '82.2.0'

--- a/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
@@ -226,7 +226,7 @@ def test_namespacebrowser_plot_with_mute_inline_plotting_true(
 
     mock_axis.plot.assert_called_once_with(my_list)
     mock_print_figure.assert_called_once_with(
-        mock_figure, fmt='png', bbox_inches='tight', dpi=72)
+        mock_figure, fmt='png', bbox_inches='tight', dpi=144)
     expected_args = [mock_png, 'image/png', namespacebrowser.shellwidget]
     assert blocker.args == expected_args
 


### PR DESCRIPTION
## Description of Changes

Change the default value for the config option `pylab/inline/resolution` from 72 to 144, as discussed at our last development meeting. This is a quick but incomplete fix for issue #9148, that plots are of low quality. See the discussion of that issue for further explanation.

(I deleted the checklist because none of the items are applicable.)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9148


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
