### PR TITLE
PR: Additional UI/UX improvements for Files and Projects

### DIFF
--- a/spyder/api/widgets/mixins.py
+++ b/spyder/api/widgets/mixins.py
@@ -169,9 +169,9 @@ class SpyderToolbarMixin:
         return stretcher
 
     def create_toolbar(
-            self,
-            name: str,
-            register: bool = True
+        self,
+        name: str,
+        register: bool = True
     ) -> SpyderToolbar:
         """
         Create a Spyder toolbar.

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -111,7 +111,7 @@ if os.name == 'nt':
 logger = logging.getLogger(__name__)
 
 #==============================================================================
-# Install Qt messaage handler
+# Install Qt message handler
 #==============================================================================
 qInstallMessageHandler(qt_message_handler)
 

--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -18,13 +18,16 @@ import sys
 import psutil
 from qtpy.QtCore import QCoreApplication, Qt
 from qtpy.QtGui import QColor, QIcon, QPalette, QPixmap, QPainter, QImage
-from qtpy.QtWidgets import QApplication, QSplashScreen
+from qtpy.QtWidgets import QSplashScreen
 from qtpy.QtSvg import QSvgRenderer
 
 # Local imports
 from spyder.config.base import (
-    DEV, get_conf_path, get_debug_level, is_conda_based_app,
-    running_under_pytest)
+    get_conf_path,
+    get_debug_level,
+    is_conda_based_app,
+    running_under_pytest,
+)
 from spyder.config.manager import CONF
 from spyder.utils.external.dafsa.dafsa import DAFSA
 from spyder.utils.image_path_manager import get_image_path
@@ -174,15 +177,18 @@ def qt_message_handler(msg_type, msg_log_context, msg_string):
 
     On some operating systems, warning messages might be displayed
     even if the actual message does not apply. This filter adds a
-    blacklist for messages that are being printed for no apparent
-    reason. Anything else will get printed in the internal console.
-
-    In DEV mode, all messages are printed.
+    blacklist for messages that are unnecessary. Anything else will
+    get printed in the internal console.
     """
     BLACKLIST = [
         'QMainWidget::resizeDocks: all sizes need to be larger than 0',
+        # This is shown at startup due to our splash screen but it's harmless
+        "fromIccProfile: failed minimal tag size sanity",
+        # This is shown when expanding/collpasing folders in the Files plugin
+        # after spyder-ide/spyder#
+        "QFont::setPixelSize: Pixel size <= 0 (0)",
     ]
-    if DEV or msg_string not in BLACKLIST:
+    if msg_string not in BLACKLIST:
         print(msg_string)  # spyder: test-skip
 
 

--- a/spyder/config/utils.py
+++ b/spyder/config/utils.py
@@ -157,6 +157,8 @@ def get_edit_extensions():
     return _get_extensions(edit_filetypes)
 
 
+EDIT_EXTENSIONS = get_edit_extensions()
+
 #==============================================================================
 # Detection of OS specific versions
 #==============================================================================

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -1684,7 +1684,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
     def reset_icon_provider(self):
         """Reset file system model icon provider
         The purpose of this is to refresh files/directories icons"""
-        self.fsmodel.setIconProvider(IconProvider(self))
+        self.fsmodel.setIconProvider(IconProvider())
 
     def convert_notebook(self, fname):
         """Convert an IPython notebook to a Python script in editor"""

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -175,6 +175,13 @@ class DirViewStyle(QProxyStyle):
 
 class DirViewItemDelegate(QStyledItemDelegate):
 
+    def __init__(self, parent):
+        super().__init__(parent)
+        self._project_dir = ""
+
+    def set_project_dir(self, project_dir):
+        self._project_dir = project_dir
+
     def initStyleOption(self, option, index):
         """
         To change the item icon when expanding a folder.
@@ -192,8 +199,20 @@ class DirViewItemDelegate(QStyledItemDelegate):
             else:
                 is_dir = model.isDir(index)
 
-            if is_dir and (option.state & QStyle.State_Open):
-                option.icon = ima.icon("DirOpenIcon")
+            if is_dir:
+                # This is necessary because Projects has a root directory and
+                # we want to set a different icon for it.
+                if isinstance(model, QSortFilterProxyModel):
+                    dir_path = model.sourceModel().filePath(
+                        model.mapToSource(index)
+                    )
+                else:
+                    dir_path = None
+
+                if dir_path == self._project_dir:
+                    option.icon = ima.icon("project_spyder")
+                elif (option.state & QStyle.State_Open):
+                    option.icon = ima.icon("DirOpenIcon")
 
 
 # ---- Widgets

--- a/spyder/plugins/explorer/widgets/utils.py
+++ b/spyder/plugins/explorer/widgets/utils.py
@@ -94,22 +94,21 @@ def has_subdirectories(path, include, exclude):
 class IconProvider(QFileIconProvider):
     """Project tree widget icon provider"""
 
-    def __init__(self, treeview):
-        super(IconProvider, self).__init__()
-        self.treeview = treeview
-
     @Slot(int)
     @Slot(QFileInfo)
     def icon(self, icontype_or_qfileinfo):
         """Reimplement Qt method"""
         if isinstance(icontype_or_qfileinfo, QFileIconProvider.IconType):
-            return super(IconProvider, self).icon(icontype_or_qfileinfo)
+            return super().icon(icontype_or_qfileinfo)
         else:
             qfileinfo = icontype_or_qfileinfo
             fname = osp.normpath(str(qfileinfo.absoluteFilePath()))
+
             if osp.isfile(fname) or osp.isdir(fname):
-                icon = ima.get_icon_by_extension_or_type(fname,
-                                                         scale_factor=1.0)
+                icon = ima.get_icon_by_extension_or_type(
+                    fname, scale_factor=1.0
+                )
             else:
                 icon = ima.icon('binary')
+
             return icon

--- a/spyder/plugins/findinfiles/widgets/search_thread.py
+++ b/spyder/plugins/findinfiles/widgets/search_thread.py
@@ -18,6 +18,7 @@ from qtpy.QtCore import QMutex, QMutexLocker, QThread, Signal
 
 # Local imports
 from spyder.api.translations import _
+from spyder.config.utils import EDIT_EXTENSIONS
 from spyder.utils.encoding import is_text_file
 from spyder.utils.palette import SpyderPalette
 
@@ -174,9 +175,12 @@ class SearchThread(QThread):
 
                     # It's much faster to check for extension first before
                     # validating if the file is plain text.
-                    if (ext in self.PYTHON_EXTENSIONS or
-                            ext in self.USEFUL_EXTENSIONS or
-                            is_text_file(filename)):
+                    if (
+                        ext in self.PYTHON_EXTENSIONS
+                        or ext in self.USEFUL_EXTENSIONS
+                        or ext in EDIT_EXTENSIONS
+                        or is_text_file(filename)
+                    ):
                         self.find_string_in_file(filename)
             except re.error:
                 self.error_flag = _("invalid regular expression")

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -95,7 +95,7 @@ class Projects(SpyderDockablePlugin):
 
     @classmethod
     def get_icon(cls):
-        return cls.create_icon('project')
+        return cls.create_icon('project_spyder')
 
     def on_initialize(self):
         """Register plugin in Spyder's main window"""

--- a/spyder/plugins/projects/utils/watcher.py
+++ b/spyder/plugins/projects/utils/watcher.py
@@ -19,14 +19,12 @@ from watchdog.events import FileSystemEventHandler, PatternMatchingEventHandler
 from watchdog.observers.polling import PollingObserverVFS
 
 # Local imports
-from spyder.config.utils import get_edit_extensions
+from spyder.config.utils import EDIT_EXTENSIONS
 
 
 # ---- Constants
 # -----------------------------------------------------------------------------
 logger = logging.getLogger(__name__)
-
-EDIT_EXTENSIONS = get_edit_extensions()
 
 FOLDERS_TO_IGNORE = [
     "__pycache__",

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -28,7 +28,7 @@ from spyder.api.translations import _
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.config.base import (
     get_home_dir, get_project_config_folder, running_under_pytest)
-from spyder.config.utils import get_edit_extensions
+from spyder.config.utils import EDIT_EXTENSIONS
 from spyder.plugins.completion.api import (
     CompletionRequestTypes, FileChangeType)
 from spyder.plugins.completion.decorators import (
@@ -195,9 +195,6 @@ class ProjectExplorerWidget(PluginMainWidget):
 
         # -- Worker manager for calls to fzf
         self._worker_manager = WorkerManager(self)
-
-        # -- List of possible file extensions that can be opened in the Editor
-        self._edit_extensions = get_edit_extensions()
 
         # -- Signals
         self.sig_project_loaded.connect(self._setup_project)
@@ -1072,7 +1069,7 @@ class ProjectExplorerWidget(PluginMainWidget):
         # Filter files that can be opened in the editor
         result_list = [
             path for path in result_list
-            if osp.splitext(path)[1] in self._edit_extensions
+            if osp.splitext(path)[1] in EDIT_EXTENSIONS
         ]
 
         # Limit the number of results to not introduce lags when displaying

--- a/spyder/plugins/projects/widgets/projectexplorer.py
+++ b/spyder/plugins/projects/widgets/projectexplorer.py
@@ -199,9 +199,11 @@ class FilteredDirView(DirView):
             List with the folder names.
         """
         assert self.root_path is not None
-        path_list = [osp.join(self.root_path, dirname)
-                     for dirname in folder_names]
+        path_list = [
+            osp.join(self.root_path, dirname) for dirname in folder_names
+        ]
         self.proxymodel.setup_filter(self.root_path, path_list)
+        self.itemDelegate().set_project_dir(self.proxymodel.path_list[0])
 
     def get_filename(self, index):
         """

--- a/spyder/plugins/projects/widgets/projectexplorer.py
+++ b/spyder/plugins/projects/widgets/projectexplorer.py
@@ -105,6 +105,12 @@ class ProxyModel(QSortFilterProxyModel):
             root_dir = self.path_list[0].split(osp.sep)[-1]
             if index.data() == root_dir:
                 return osp.join(self.root_path, root_dir)
+            else:
+                # We can't set None or an empty string here because Qt will
+                # return the index's full path, which beats the purpose of
+                # this method.
+                return index.data()
+
         return QSortFilterProxyModel.data(self, index, role)
 
     def type(self, index):

--- a/spyder/plugins/projects/widgets/projectexplorer.py
+++ b/spyder/plugins/projects/widgets/projectexplorer.py
@@ -47,6 +47,10 @@ class ProxyModel(QSortFilterProxyModel):
         '.github'
     ]
 
+    EXTENSIONS_TO_HIDE = [
+        ".orig"
+    ]
+
     def __init__(self, parent):
         """Initialize the proxy model."""
         super(ProxyModel, self).__init__(parent)
@@ -78,8 +82,9 @@ class ProxyModel(QSortFilterProxyModel):
         if self.root_path is None:
             return True
         index = self.sourceModel().index(row, 0, parent_index)
-        path = osp.normcase(osp.normpath(
-            str(self.sourceModel().filePath(index))))
+        path = osp.normcase(
+            osp.normpath(str(self.sourceModel().filePath(index)))
+        )
 
         if osp.normcase(self.root_path).startswith(path):
             # This is necessary because parent folders need to be scanned
@@ -87,13 +92,24 @@ class ProxyModel(QSortFilterProxyModel):
         else:
             for p in [osp.normcase(p) for p in self.path_list]:
                 if path == p or path.startswith(p + os.sep):
-                    if not any([path.endswith(os.sep + d)
-                                for d in self.PATHS_TO_SHOW]):
-                        if any([path.endswith(os.sep + d)
-                                for d in self.PATHS_TO_HIDE]):
+                    if not any(
+                        [path.endswith(os.sep + d) for d in self.PATHS_TO_SHOW]
+                    ):
+                        if any(
+                            [
+                                path.endswith(os.sep + d)
+                                for d in self.PATHS_TO_HIDE
+                            ]
+                        ):
                             return False
                         else:
-                            return True
+                            if (
+                                osp.splitext(path)[1]
+                                in self.EXTENSIONS_TO_HIDE
+                            ):
+                                return False
+                            else:
+                                return True
                     else:
                         return True
             else:

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -1886,7 +1886,8 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
 
         options_menu = self.create_menu(
             DataframeEditorMenus.Options,
-            register=False)
+            register=False
+        )
         for action in [self.bgcolor_action, self.bgcolor_global_action,
                        self.format_action]:
             self.add_item_to_menu(action, options_menu)

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -35,6 +35,9 @@ from spyder.utils.stylesheet import AppStyle, MAC
 from spyder.widgets.simplecodeeditor import SimpleCodeEditor
 
 
+logger = logging.getLogger(__name__)
+
+
 class ObjectExplorerActions:
     Refresh = 'refresh_action'
     ShowCallable = 'show_callable_action'
@@ -49,10 +52,6 @@ class ObjectExplorerWidgets:
     OptionsToolButton = 'options_button_widget'
     Toolbar = 'toolbar'
     ToolbarStretcher = 'toolbar_stretcher'
-
-
-logger = logging.getLogger(__name__)
-
 
 # About message
 EDITOR_NAME = 'Object'

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
@@ -16,7 +16,8 @@ from typing import Any, Callable, Optional
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import (
     QAbstractItemView, QActionGroup, QHeaderView, QTableWidget, QTreeView,
-    QTreeWidget)
+    QTreeWidget
+)
 
 # Local imports
 from spyder.api.widgets.mixins import SpyderWidgetMixin

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -17,8 +17,8 @@ from qtpy.QtWidgets import QStyle, QWidget
 
 # Local imports
 from spyder.config.manager import CONF
+from spyder.config.utils import EDIT_EXTENSIONS
 from spyder.utils.image_path_manager import get_image_path
-from spyder.utils.encoding import is_text_file
 from spyder.utils.palette import QStylePalette, SpyderPalette
 import qtawesome as qta
 
@@ -246,6 +246,7 @@ class IconManager():
             'MessageBoxInformation':   [('mdi.information-outline',), {'color': self.MAIN_FG_COLOR}],
             'DirOpenIcon':             [('mdi.folder-open',), {'color': self.MAIN_FG_COLOR}],
             'FileIcon':                [('mdi.file',), {'color': self.MAIN_FG_COLOR}],
+            'GenericFileIcon':         [('mdi.file-outline',), {'color': self.MAIN_FG_COLOR}],
             'ExcelFileIcon':           [('mdi.file-excel',), {'color': self.MAIN_FG_COLOR}],
             'WordFileIcon':            [('mdi.file-word',), {'color': self.MAIN_FG_COLOR}],
             'PowerpointFileIcon':      [('mdi.file-powerpoint',), {'color': self.MAIN_FG_COLOR}],
@@ -269,8 +270,7 @@ class IconManager():
             'MarkdownFileIcon':        [('mdi.markdown',), {'color': self.MAIN_FG_COLOR}],
             'JsonFileIcon':            [('mdi.json',), {'color': self.MAIN_FG_COLOR}],
             'ExclamationFileIcon':     [('mdi.exclamation',), {'color': self.MAIN_FG_COLOR}],
-            'CodeFileIcon':             [('mdi.xml',), {'color': self.MAIN_FG_COLOR}],
-            'project':                 [('mdi.folder-open',), {'color': self.MAIN_FG_COLOR}],
+            'CodeFileIcon':            [('mdi.xml',), {'color': self.MAIN_FG_COLOR}],
             'arrow':                   [('mdi.arrow-right-bold',), {'color': self.MAIN_FG_COLOR}],
             'collapse':                [('mdi.collapse-all',), {'color': self.MAIN_FG_COLOR}],
             'expand':                  [('mdi.expand-all',), {'color': self.MAIN_FG_COLOR}],
@@ -482,7 +482,7 @@ class IconManager():
         if osp.isdir(fname):
             icon_by_extension = self.icon('DirOpenIcon', scale_factor)
         else:
-            icon_by_extension = self.icon('binary')
+            icon_by_extension = self.icon('GenericFileIcon')
 
             if extension in self.OFFICE_FILES:
                 icon_by_extension = self.icon(
@@ -495,7 +495,7 @@ class IconManager():
                     icon_by_extension = self.icon('notebook')
                 elif extension == '.tex':
                     icon_by_extension = self.icon('file_type_tex')
-                elif is_text_file(fname):
+                elif extension in EDIT_EXTENSIONS:
                     icon_by_extension = self.icon('TextFileIcon', scale_factor)
                 elif mime_type is not None:
                     try:

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -480,7 +480,7 @@ class IconManager():
             return self.ICONS_BY_EXTENSION[(extension, scale_factor)]
 
         if osp.isdir(fname):
-            icon_by_extension = self.icon('DirOpenIcon', scale_factor)
+            icon_by_extension = self.icon('DirClosedIcon', scale_factor)
         else:
             icon_by_extension = self.icon('GenericFileIcon')
 

--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -270,6 +270,15 @@ class AppStylesheet(SpyderStyleSheet, SpyderConfigurationAccessor):
             left='0px',
         )
 
+        # Add padding to tree widget items to make them look better
+        css["QTreeWidget::item"].setValues(
+            padding=f"{AppStyle.MarginSize - 1}px 0px",
+        )
+
+        css["QTreeView::item"].setValues(
+            padding=f"{AppStyle.MarginSize - 1}px 0px",
+        )
+
 
 APP_STYLESHEET = AppStylesheet()
 

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -677,6 +677,9 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
         # it to show any information on it.
         self.verticalHeader().hide()
 
+        # To use mouseMoveEvent
+        self.setMouseTracking(True)
+
         # Delay editing values for a bit so that when users do a double click
         # (the default behavior for editing since Spyder was created; now they
         # only have to do a single click), our editor dialogs are focused.

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -63,6 +63,9 @@ from spyder.utils.palette import SpyderPalette
 from spyder.utils.stylesheet import AppStyle, MAC
 
 
+# =============================================================================
+# ---- Constants
+# =============================================================================
 class CollectionsEditorActions:
     Copy = 'copy_action'
     Duplicate = 'duplicate_action'
@@ -119,6 +122,9 @@ ROWS_TO_LOAD = 50
 NUMERIC_TYPES = (int, float) + get_numeric_numpy_types()
 
 
+# =============================================================================
+# ---- Utility functions and classes
+# =============================================================================
 def natsort(s):
     """
     Natural sorting, e.g. test3 comes before test100.
@@ -172,6 +178,9 @@ class ProxyObject(object):
                 raise
 
 
+# =============================================================================
+# ---- Widgets
+# =============================================================================
 class ReadOnlyCollectionsModel(QAbstractTableModel, SpyderFontsMixin):
     """CollectionsEditor Read-Only Table Model"""
 
@@ -820,7 +829,8 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
 
         menu = self.create_menu(
             CollectionsEditorMenus.Context,
-            register=False)
+            register=False
+        )
 
         for action in [self.copy_action, self.paste_action, self.rename_action,
                        self.edit_action, self.save_array_action]:
@@ -849,7 +859,8 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
 
         self.empty_ws_menu = self.create_menu(
             CollectionsEditorMenus.ContextIfEmpty,
-            register=False)
+            register=False
+        )
 
         for action in [self.insert_action, self.paste_action]:
             self.add_item_to_menu(action, self.empty_ws_menu)


### PR DESCRIPTION
## Description of Changes

- Use a generic icon for unknown files instead of trying to detect if they are binary or not. That should speed up performance because relying on `chardet` for binary detection is slow.
- Don't show full path in tooltips of files and directories in Projects because it's not really necessary.
- Hide `.orig` files from view in Projects. Those are generated by git when a merge fails so we don't really need to display them.
- Add more padding to QTreeWidget/QTreeView items to make the interface look less packed.
- Switch between open/closed folder icons when collapsing/expanding directories in Files and Projects. That provides a better UI for those panes.
- Use Spyder project icon for the project root directory and its plugin.

### Visual changes

| Before | After |
| - | - | 
| ![imagen](https://github.com/spyder-ide/spyder/assets/365293/4939fcc5-82dd-488d-8049-cd47c776a509) | ![imagen](https://github.com/spyder-ide/spyder/assets/365293/87a2095e-7ca3-49b1-9bd1-ee4b5d7cc319) |

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #10081.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
