### PR TITLE
PR: Only show UpdateManager statusbar widget while updating and when updates are available

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -54,6 +54,7 @@ name: Nightly conda-based installers
 
 env:
   IS_RELEASE: ${{ github.event_name == 'release' }}
+  IS_PRE_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.pre }}
   ENABLE_SSH: ${{ github.event_name == 'workflow_dispatch' && inputs.ssh }}
   BUILD_MAC: ${{ github.event_name != 'workflow_dispatch' || inputs.macos-x86_64 }}
   BUILD_ARM: ${{ github.event_name != 'workflow_dispatch' || inputs.macos-arm64 }}
@@ -125,7 +126,6 @@ jobs:
       MACOS_INSTALLER_CERTIFICATE: ${{ secrets.MACOS_INSTALLER_CERTIFICATE }}
       APPLICATION_PWD: ${{ secrets.APPLICATION_PWD }}
       CONSTRUCTOR_TARGET_PLATFORM: ${{ matrix.target-platform }}
-      NSIS_USING_LOG_BUILD: 1
 
     steps:
       - name: Checkout Code
@@ -193,11 +193,17 @@ jobs:
           cache-environment: true
 
       - name: Env Variables
-        run: env | sort
+        run: |
+          NSIS_USING_LOG_BUILD=1
+          [[ "$IS_RELEASE" == "true" || "$IS_PRE_RELEASE" == "true" ]] && NSIS_USING_LOG_BUILD=0
+          CONDA_BLD_PATH=${RUNNER_TEMP}/conda-bld
+
+          echo "NSIS_USING_LOG_BUILD=$NSIS_USING_LOG_BUILD" >> $GITHUB_ENV
+          echo "CONDA_BLD_PATH=$CONDA_BLD_PATH" >> $GITHUB_ENV
+
+          env | sort
 
       - name: Build ${{ matrix.target-platform }} spyder Conda Package
-        env:
-          CONDA_BLD_PATH: ${{ runner.temp }}/conda-bld
         run: |
           # Copy built packages to new build location because spyder cannot be
           # built in workspace
@@ -206,8 +212,6 @@ jobs:
           python build_conda_pkgs.py --build spyder
 
       - name: Create Local Conda Channel
-        env:
-          CONDA_BLD_PATH: ${{ runner.temp }}/conda-bld
         run: |
           conda config --set bld_path $CONDA_BLD_PATH
           conda index $CONDA_BLD_PATH

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -33,7 +33,7 @@ import os
 from pathlib import Path
 import platform
 import re
-from subprocess import check_call
+from subprocess import run
 import sys
 from textwrap import dedent, indent
 from time import time
@@ -217,6 +217,14 @@ def _get_condarc():
     return str(file)
 
 
+def _get_conda_bld_path_url():
+    bld_path_url = "file://"
+    if WINDOWS:
+        bld_path_url += "/"
+    bld_path_url += Path(os.getenv('CONDA_BLD_PATH')).as_posix()
+    return bld_path_url
+
+
 def _definitions():
     condarc = _get_condarc()
     definitions = {
@@ -246,6 +254,12 @@ def _definitions():
                 "specs": [k + v for k, v in specs.items()],
             },
         },
+        "channels_remap": [
+            {
+                "src": _get_conda_bld_path_url(),
+                "dest": "https://conda.anaconda.org/conda-forge"
+            }
+        ]
     }
 
     if not args.no_local:
@@ -371,7 +385,7 @@ def _constructor():
 
     yaml.dump(definitions, BUILD / "construct.yaml")
 
-    check_call(cmd_args, env=env)
+    run(cmd_args, check=True, env=env)
 
 
 def licenses():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "packaging",
+]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,7 @@ requires = [
     "setuptools>=42",
     "packaging",
 ]
-build-backend = "setuptools.build_meta"
+
+# We're not ready yet to build Spyder with the setuptools backend, but we're
+# leaving this for the future.
+# build-backend = "setuptools.build_meta"

--- a/spyder/__init__.py
+++ b/spyder/__init__.py
@@ -29,9 +29,11 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 """
 
-version_info = (6, 0, 0, "dev0")
+from packaging.version import parse
 
-__version__ = '.'.join(map(str, version_info))
+version_info = (6, 0, 0, "a5", "dev0")
+
+__version__ = str(parse('.'.join(map(str, version_info))))
 __installer_version__ = __version__
 __title__ = 'Spyder'
 __author__ = 'Spyder Project Contributors and others'

--- a/spyder/plugins/updatemanager/container.py
+++ b/spyder/plugins/updatemanager/container.py
@@ -20,10 +20,7 @@ from qtpy.QtCore import Slot
 from spyder.api.translations import _
 from spyder.api.widgets.main_container import PluginMainContainer
 from spyder.plugins.updatemanager.widgets.status import UpdateManagerStatus
-from spyder.plugins.updatemanager.widgets.update import (
-    UpdateManagerWidget,
-    NO_STATUS
-)
+from spyder.plugins.updatemanager.widgets.update import UpdateManagerWidget
 from spyder.utils.qthelpers import DialogManager
 
 # Logger setup
@@ -74,8 +71,6 @@ class UpdateManagerContainer(PluginMainContainer):
         self.update_manager_status.sig_start_update.connect(self.start_update)
         self.update_manager_status.sig_show_progress_dialog.connect(
             self.update_manager.show_progress_dialog)
-
-        self.set_status(NO_STATUS)
 
     def update_actions(self):
         pass

--- a/spyder/plugins/updatemanager/container.py
+++ b/spyder/plugins/updatemanager/container.py
@@ -56,12 +56,13 @@ class UpdateManagerContainer(PluginMainContainer):
         # Signals
         self.update_manager.sig_set_status.connect(self.set_status)
         self.update_manager.sig_disable_actions.connect(
-            self._set_actions_state
-        )
+            self._set_actions_state)
         self.update_manager.sig_block_status_signals.connect(
             self.update_manager_status.blockSignals)
         self.update_manager.sig_download_progress.connect(
             self.update_manager_status.set_download_progress)
+        self.update_manager.sig_exception_occurred.connect(
+            self.sig_exception_occurred)
         self.update_manager.sig_install_on_close.connect(
             self.set_install_on_close)
         self.update_manager.sig_quit_requested.connect(self.sig_quit_requested)

--- a/spyder/plugins/updatemanager/container.py
+++ b/spyder/plugins/updatemanager/container.py
@@ -56,13 +56,15 @@ class UpdateManagerContainer(PluginMainContainer):
         # Signals
         self.update_manager.sig_set_status.connect(self.set_status)
         self.update_manager.sig_disable_actions.connect(
-            self._set_actions_state)
+            self._set_actions_state
+        )
         self.update_manager.sig_block_status_signals.connect(
             self.update_manager_status.blockSignals)
         self.update_manager.sig_download_progress.connect(
             self.update_manager_status.set_download_progress)
         self.update_manager.sig_exception_occurred.connect(
-            self.sig_exception_occurred)
+            self.sig_exception_occurred
+        )
         self.update_manager.sig_install_on_close.connect(
             self.set_install_on_close)
         self.update_manager.sig_quit_requested.connect(self.sig_quit_requested)

--- a/spyder/plugins/updatemanager/plugin.py
+++ b/spyder/plugins/updatemanager/plugin.py
@@ -93,6 +93,9 @@ class UpdateManager(SpyderPluginV2):
         """Actions after the mainwindow in visible."""
         container = self.get_container()
 
+        # Hide statusbar widget on startup
+        container.update_manager_status.set_no_status()
+
         # Check for updates on startup
         if self.get_conf('check_updates_on_startup'):
             container.start_check_update(startup=True)

--- a/spyder/plugins/updatemanager/plugin.py
+++ b/spyder/plugins/updatemanager/plugin.py
@@ -9,14 +9,12 @@ Update Manager Plugin.
 """
 
 # Local imports
-from spyder import __version__
 from spyder.api.plugins import Plugins, SpyderPluginV2
 from spyder.api.translations import _
 from spyder.api.plugin_registration.decorators import (
     on_plugin_available,
     on_plugin_teardown
 )
-from spyder.config.base import DEV
 from spyder.plugins.updatemanager.container import (
     UpdateManagerActions,
     UpdateManagerContainer
@@ -96,11 +94,7 @@ class UpdateManager(SpyderPluginV2):
         container = self.get_container()
 
         # Check for updates on startup
-        if (
-            DEV is None                   # Not bootstrap
-            and 'dev' not in __version__  # Not dev version
-            and self.get_conf('check_updates_on_startup')
-        ):
+        if self.get_conf('check_updates_on_startup'):
             container.start_check_update(startup=True)
 
     # ---- Private API

--- a/spyder/plugins/updatemanager/plugin.py
+++ b/spyder/plugins/updatemanager/plugin.py
@@ -93,7 +93,8 @@ class UpdateManager(SpyderPluginV2):
         """Actions after the mainwindow in visible."""
         container = self.get_container()
 
-        # Hide statusbar widget on startup
+        # Initialize status.
+        # Note that NO_STATUS also hides the statusbar widget.
         container.update_manager_status.set_no_status()
 
         # Check for updates on startup

--- a/spyder/plugins/updatemanager/scripts/install.bat
+++ b/spyder/plugins/updatemanager/scripts/install.bat
@@ -23,6 +23,8 @@ echo IMPORTANT: Do not close this window until it has finished
 echo =========================================================
 echo.
 
+call :wait_for_spyder_quit
+
 IF not "%conda%"=="" IF not "%spy_ver%"=="" (
     call :update_subroutine
     call :launch_spyder
@@ -39,8 +41,6 @@ exit %ERRORLEVEL%
 
 :install_subroutine
     echo Installing Spyder from: %install_exe%
-
-    call :wait_for_spyder_quit
 
     :: Uninstall Spyder
     for %%I in ("%prefix%\..\..") do set "conda_root=%%~fI"
@@ -69,16 +69,14 @@ exit %ERRORLEVEL%
 :update_subroutine
     echo Updating Spyder
 
-    call :wait_for_spyder_quit
-
     %conda% install -p %prefix% -y spyder=%spy_ver%
-    set /P CONT=Press any key to exit...
+    set /P =Press any key to exit...
     goto :EOF
 
 :wait_for_spyder_quit
     echo Waiting for Spyder to quit...
     :loop
-    tasklist /fi "ImageName eq spyder.exe" /fo csv 2>NUL | find /i "spyder.exe">NUL
+    tasklist /v /fi "ImageName eq pythonw.exe" /fo csv 2>NUL | find "Spyder">NUL
     IF "%ERRORLEVEL%"=="0" (
         timeout /t 1 /nobreak > nul
         goto loop

--- a/spyder/plugins/updatemanager/scripts/install.bat
+++ b/spyder/plugins/updatemanager/scripts/install.bat
@@ -85,10 +85,11 @@ exit %ERRORLEVEL%
     goto :EOF
 
 :launch_spyder
-    echo %prefix% | findstr /b "%USERPROFILE%" > nul && (
-        set shortcut_root=%APPDATA%
-    ) || (
-        set shortcut_root=%ALLUSERSPROFILE%
-    )
-    start "" /B "%shortcut_root%\Microsoft\Windows\Start Menu\Programs\spyder\Spyder.lnk"
+    for %%C in ("%conda%") do set scripts=%%~dpC
+    set pythonexe=%scripts%..\python.exe
+    set menuinst=%scripts%menuinst_cli.py
+    if exist "%prefix%\.nonadmin" (set mode=user) else set mode=system
+    for /f "delims=" %%s in ('%pythonexe% %menuinst% shortcut --mode=%mode%') do set "shortcut_path=%%~s"
+
+    start "" /B "%shortcut_path%"
     goto :EOF

--- a/spyder/plugins/updatemanager/scripts/install.bat
+++ b/spyder/plugins/updatemanager/scripts/install.bat
@@ -70,7 +70,7 @@ exit %ERRORLEVEL%
     echo Updating Spyder
 
     %conda% install -p %prefix% -y spyder=%spy_ver%
-    set /P =Press any key to exit...
+    set /P =Press return to exit...
     goto :EOF
 
 :wait_for_spyder_quit

--- a/spyder/plugins/updatemanager/scripts/install.sh
+++ b/spyder/plugins/updatemanager/scripts/install.sh
@@ -14,7 +14,7 @@ shift $(($OPTIND - 1))
 
 update_spyder(){
     $conda install -p $prefix -y spyder=$spy_ver
-    read -p "Press any key to exit..."
+    read -p "Press return to exit..."
 }
 
 launch_spyder(){

--- a/spyder/plugins/updatemanager/scripts/install.sh
+++ b/spyder/plugins/updatemanager/scripts/install.sh
@@ -18,11 +18,16 @@ update_spyder(){
 }
 
 launch_spyder(){
+    root=$(dirname $conda)
+    pythonexe=$root/python
+    menuinst=$root/menuinst_cli.py
+    mode=$([[ -e "${prefix}/.nonadmin" ]] && echo "user" || echo "system")
+    shortcut_path=$($pythonexe $menuinst shortcut --mode=$mode)
+
     if [[ "$OSTYPE" = "darwin"* ]]; then
-        shortcut=/Applications/Spyder.app
-        [[ "$prefix" = "$HOME"* ]] && open -a $HOME$shortcut || open -a $shortcut
+        open -a $shortcut
     elif [[ -n "$(which gtk-launch)" ]]; then
-        gtk-launch spyder_spyder
+        gtk-launch $(basename ${shortcut_path%.*})
     else
         nohup $prefix/bin/spyder &>/dev/null &
     fi

--- a/spyder/plugins/updatemanager/widgets/status.py
+++ b/spyder/plugins/updatemanager/widgets/status.py
@@ -10,10 +10,9 @@ Status widget for Spyder updates.
 
 # Standard library imports
 import logging
-import os
 
 # Third party imports
-from qtpy.QtCore import QPoint, Qt, Signal, Slot
+from qtpy.QtCore import Qt, Signal, Slot
 from qtpy.QtWidgets import QLabel
 
 # Local imports
@@ -29,7 +28,6 @@ from spyder.plugins.updatemanager.widgets.update import (
     PENDING
 )
 from spyder.utils.icon_manager import ima
-from spyder.utils.qthelpers import add_actions, create_action
 
 
 # Setup logger
@@ -131,18 +129,3 @@ class UpdateManagerStatus(StatusBarWidget):
             self.sig_show_progress_dialog.emit(True)
         elif self.value in (PENDING, DOWNLOAD_FINISHED, INSTALL_ON_CLOSE):
             self.sig_start_update.emit()
-        elif self.value == NO_STATUS:
-            self.menu.clear()
-            check_for_updates_action = create_action(
-                self,
-                text=_("Check for updates..."),
-                triggered=self.sig_check_update.emit
-            )
-
-            add_actions(self.menu, [check_for_updates_action])
-            rect = self.contentsRect()
-            os_height = 7 if os.name == 'nt' else 12
-            pos = self.mapToGlobal(
-                rect.topLeft() + QPoint(-10, -rect.height() - os_height)
-            )
-            self.menu.popup(pos)

--- a/spyder/plugins/updatemanager/widgets/status.py
+++ b/spyder/plugins/updatemanager/widgets/status.py
@@ -58,7 +58,7 @@ class UpdateManagerStatus(StatusBarWidget):
 
     def __init__(self, parent):
 
-        self.tooltip = None
+        self.tooltip = ""
         super().__init__(parent)
 
         # Check for updates action menu
@@ -89,7 +89,7 @@ class UpdateManagerStatus(StatusBarWidget):
             self.custom_widget.hide()
             self.show()
         else:
-            self.tooltip = None
+            self.tooltip = ""
             if self.custom_widget:
                 self.custom_widget.hide()
             self.hide()

--- a/spyder/plugins/updatemanager/widgets/status.py
+++ b/spyder/plugins/updatemanager/widgets/status.py
@@ -59,7 +59,7 @@ class UpdateManagerStatus(StatusBarWidget):
     def __init__(self, parent):
 
         self.tooltip = None
-        super().__init__(parent, show_spinner=True)
+        super().__init__(parent)
 
         # Check for updates action menu
         self.menu = SpyderMenu(self)
@@ -78,29 +78,20 @@ class UpdateManagerStatus(StatusBarWidget):
                 "Downloading the update will continue in the background.\n"
                 "Click here to show the download dialog again."
             )
-            self.spinner.hide()
-            self.spinner.stop()
             self.custom_widget.show()
             self.show()
         elif value == CHECKING:
             self.tooltip = value
             self.custom_widget.hide()
-            self.spinner.show()
-            self.spinner.start()
-            self.show()
+            self.hide()
         elif value == PENDING:
             self.tooltip = value
             self.custom_widget.hide()
-            self.spinner.hide()
-            self.spinner.stop()
             self.show()
         else:
             self.tooltip = None
             if self.custom_widget:
                 self.custom_widget.hide()
-            if self.spinner:
-                self.spinner.hide()
-                self.spinner.stop()
             self.hide()
 
         self.update_tooltip()

--- a/spyder/plugins/updatemanager/widgets/status.py
+++ b/spyder/plugins/updatemanager/widgets/status.py
@@ -84,16 +84,19 @@ class UpdateManagerStatus(StatusBarWidget):
             self.spinner.hide()
             self.spinner.stop()
             self.custom_widget.show()
+            self.show()
         elif value == CHECKING:
             self.tooltip = self.BASE_TOOLTIP
             self.custom_widget.hide()
             self.spinner.show()
             self.spinner.start()
+            self.show()
         elif value == PENDING:
             self.tooltip = value
             self.custom_widget.hide()
             self.spinner.hide()
             self.spinner.stop()
+            self.show()
         else:
             self.tooltip = self.BASE_TOOLTIP
             if self.custom_widget:
@@ -101,8 +104,8 @@ class UpdateManagerStatus(StatusBarWidget):
             if self.spinner:
                 self.spinner.hide()
                 self.spinner.stop()
+            self.hide()
 
-        self.setVisible(True)
         self.update_tooltip()
         value = f"Spyder: {value}"
         logger.debug(f"Update manager status: {value}")

--- a/spyder/plugins/updatemanager/widgets/status.py
+++ b/spyder/plugins/updatemanager/widgets/status.py
@@ -38,7 +38,6 @@ logger = logging.getLogger(__name__)
 
 class UpdateManagerStatus(StatusBarWidget):
     """Status bar widget for update manager."""
-    BASE_TOOLTIP = _("Application update status")
     ID = 'update_manager_status'
 
     sig_check_update = Signal()
@@ -61,7 +60,7 @@ class UpdateManagerStatus(StatusBarWidget):
 
     def __init__(self, parent):
 
-        self.tooltip = self.BASE_TOOLTIP
+        self.tooltip = None
         super().__init__(parent, show_spinner=True)
 
         # Check for updates action menu
@@ -86,7 +85,7 @@ class UpdateManagerStatus(StatusBarWidget):
             self.custom_widget.show()
             self.show()
         elif value == CHECKING:
-            self.tooltip = self.BASE_TOOLTIP
+            self.tooltip = value
             self.custom_widget.hide()
             self.spinner.show()
             self.spinner.start()
@@ -98,7 +97,7 @@ class UpdateManagerStatus(StatusBarWidget):
             self.spinner.stop()
             self.show()
         else:
-            self.tooltip = self.BASE_TOOLTIP
+            self.tooltip = None
             if self.custom_widget:
                 self.custom_widget.hide()
             if self.spinner:

--- a/spyder/plugins/updatemanager/widgets/status.py
+++ b/spyder/plugins/updatemanager/widgets/status.py
@@ -107,7 +107,6 @@ class UpdateManagerStatus(StatusBarWidget):
             self.hide()
 
         self.update_tooltip()
-        value = f"Spyder: {value}"
         logger.debug(f"Update manager status: {value}")
         super().set_value(value)
 
@@ -129,12 +128,11 @@ class UpdateManagerStatus(StatusBarWidget):
     @Slot()
     def show_dialog_or_menu(self):
         """Show download dialog or status bar menu."""
-        value = self.value.split(":")[-1].strip()
-        if value == DOWNLOADING_INSTALLER:
+        if self.value == DOWNLOADING_INSTALLER:
             self.sig_show_progress_dialog.emit(True)
-        elif value in (PENDING, DOWNLOAD_FINISHED, INSTALL_ON_CLOSE):
+        elif self.value in (PENDING, DOWNLOAD_FINISHED, INSTALL_ON_CLOSE):
             self.sig_start_update.emit()
-        elif value == NO_STATUS:
+        elif self.value == NO_STATUS:
             self.menu.clear()
             check_for_updates_action = create_action(
                 self,

--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -36,15 +36,12 @@ from spyder.widgets.helperwidgets import MessageCheckBox
 # Logger setup
 logger = logging.getLogger(__name__)
 
-# Update installation process statuses
+# Update manager process statuses
 NO_STATUS = __version__
 DOWNLOADING_INSTALLER = _("Downloading update")
 DOWNLOAD_FINISHED = _("Download finished")
-INSTALLING = _("Installing update")
-FINISHED = _("Installation finished")
 PENDING = _("Update available")
 CHECKING = _("Checking for updates")
-CANCELLED = _("Cancelled update")
 INSTALL_ON_CLOSE = _("Install on close")
 
 HEADER = _("<h3>Spyder {} is available!</h3><br>")

--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -10,9 +10,9 @@
 import logging
 import os
 import os.path as osp
-import sys
-import subprocess
 import platform
+import subprocess
+import sys
 
 # Third-party imports
 from packaging.version import parse
@@ -96,6 +96,11 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         Latest release version detected.
     """
 
+    sig_exception_occurred = Signal(dict)
+    """
+    Pass untracked exceptions from workers to error reporter.
+    """
+
     sig_install_on_close = Signal(bool)
     """
     Signal to request running the install process on close.
@@ -167,6 +172,9 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
 
         self.update_thread = QThread(None)
         self.update_worker = WorkerUpdate(self.get_conf('check_stable_only'))
+        self.update_worker.sig_exception_occurred.connect(
+            self.sig_exception_occurred
+        )
         self.update_worker.sig_ready.connect(self._process_check_update)
         self.update_worker.sig_ready.connect(self.update_thread.quit)
         self.update_worker.sig_ready.connect(
@@ -319,6 +327,9 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         self.progress_dialog.cancel.clicked.connect(self._cancel_download)
 
         self.download_thread = QThread(None)
+        self.download_worker.sig_exception_occurred.connect(
+            self.sig_exception_occurred
+        )
         self.download_worker.sig_ready.connect(self._confirm_install)
         self.download_worker.sig_ready.connect(self.download_thread.quit)
         self.download_worker.sig_ready.connect(

--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -11,6 +11,7 @@ import logging
 import os
 import os.path as osp
 import platform
+import shutil
 import subprocess
 import sys
 
@@ -414,11 +415,14 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         """Install from downloaded installer or update through conda."""
 
         # Install script
-        script = osp.abspath(__file__ + '/../../scripts/install.' +
-                             ('bat' if os.name == 'nt' else 'sh'))
+        # Copy to temp location to be safe
+        script_name = 'install.' + ('bat' if os.name == 'nt' else 'sh')
+        script_path = osp.abspath(__file__ + '/../../scripts/' + script_name)
+        tmpscript_path = osp.join(get_temp_dir(), script_name)
+        shutil.copy2(script_path, tmpscript_path)
 
         # Sub command
-        sub_cmd = [script, '-p', sys.prefix]
+        sub_cmd = [tmpscript_path, '-p', sys.prefix]
         if osp.exists(self.installer_path):
             # Run downloaded installer
             sub_cmd.extend(['-i', self.installer_path])

--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -101,7 +101,6 @@ class WorkerUpdate(QObject):
         error_msg = None
         pypi_url = "https://pypi.org/pypi/spyder/json"
         github_url = 'https://api.github.com/repos/spyder-ide/spyder/releases'
-        cf_url = 'https://conda.anaconda.org/conda-forge'
 
         if is_conda_based_app():
             url = github_url
@@ -112,8 +111,8 @@ class WorkerUpdate(QObject):
                 logger.debug(
                     f"channel = {self.channel}; channel_url = {channel_url}. "
                 )
-                # Spyder installed in development mode, use conda-forge
-                url = cf_url + '/channeldata.json'
+                # Spyder installed in development mode, use GitHub
+                url = github_url
             elif self.channel == "pypi":
                 url = pypi_url
             else:

--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -8,7 +8,6 @@
 import logging
 import os
 import os.path as osp
-import shutil
 from time import sleep
 import traceback
 
@@ -278,16 +277,9 @@ class WorkerDownloadInstaller(Worker):
     def _clean_installer_path(self):
         """Remove downloaded file"""
         if osp.exists(self.installer_path):
-            try:
-                shutil.rmtree(self.installer_path)
-            except OSError as err:
-                logger.debug(err, stack_info=True)
-
+            os.remove(self.installer_path)
         if osp.exists(self.installer_size_path):
-            try:
-                shutil.rmtree(self.installer_size_path)
-            except OSError as err:
-                logger.debug(err, stack_info=True)
+            os.remove(self.installer_size_path)
 
     def start(self):
         """Main method of the worker."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* The update manager statusbar widget is now hidden except when
  * An update is available
  * Downloading an update
* Bootstrap and dev versions no longer block checking for updates at startup. Bootstrap and editable installs of Spyder check for updates using the release url.
* "Check for updates" action removed from the statusbar widget
* "Spyder: " text is removed from the statusbar status value. This was used previously as a prefix to the Spyder version that would be displayed when idle. Now that the widget is hidden when idle, "Spyder: " prefix seems unnecessary.
* Uncaught exceptions in the update worker are sent to the error reporter.
* `version_info` now includes pre-release item. To ensure that the development version is greater than the latest release tag, including unstable releases, this field should be used immediately following unstable releases, i.e. returning to work.
* Local conda channels are remapped to conda-forge when the installer is built. This ensures that the updater correctly identifies Spyder's conda channel.
* Fixed issue where shortcut name was incorrect when launching after update.
* Fixed issue where `install.bat` executes incorrectly because it is over-written during update.

Fixes #21882

Requres conda-forge/spyder-feedstock#167