### PR TITLE
PR: Add `condabin` directory, relative to `sys.executable` and provided `pyexec`, to paths searched for conda executable

### DIFF
--- a/spyder/utils/conda.py
+++ b/spyder/utils/conda.py
@@ -83,14 +83,17 @@ def get_conda_root_prefix(pyexec=None, quote=False):
     return root_prefix
 
 
-def get_conda_activation_script(quote=False):
+def get_conda_activation_script(pyexec=None, quote=False):
     """
     Return full path to conda activation script.
+
+    `pyexec` is optional python executable, the relative location from which to
+    attempt to find the activation script.
 
     If `quote` is True, then quotes are added if spaces are found in the path.
     """
     # Use micromamba bundled with Spyder installers or find conda exe
-    exe = get_spyder_umamba_path() or find_conda()
+    exe = get_spyder_umamba_path() or find_conda(pyexec)
 
     if osp.basename(exe).startswith('micromamba'):
         # For Micromamba, use the executable
@@ -130,14 +133,24 @@ def get_conda_env_path(pyexec, quote=False):
     return conda_env
 
 
-def find_conda():
-    """Find conda executable."""
+def find_conda(pyexec=None):
+    """
+    Find conda executable.
+
+    `pyexec` is a python executable, the relative location from which to
+    attempt to locate a conda executable.
+    """
     # First try the environment variables
     conda = os.environ.get('CONDA_EXE') or os.environ.get('MAMBA_EXE')
     if conda is None:
         # Try searching for the executable
         conda_exec = 'conda.bat' if WINDOWS else 'conda'
-        conda = find_program(conda_exec)
+        extra_paths = [
+            osp.join(get_conda_root_prefix(_pyexec), 'condabin')
+            for _pyexec in [sys.executable, pyexec]
+        ]
+        conda = find_program(conda_exec, extra_paths)
+
     return conda
 
 

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -68,7 +68,7 @@ def get_temp_dir(suffix=None):
     return tempdir
 
 
-def is_program_installed(basename):
+def is_program_installed(basename, extra_paths=[]):
     """
     Return program absolute path if installed in PATH.
     Otherwise, return None.
@@ -76,7 +76,7 @@ def is_program_installed(basename):
     Also searches specific platform dependent paths that are not already in
     PATH. This permits general use without assuming user profiles are
     sourced (e.g. .bash_Profile), such as when login shells are not used to
-    launch Spyder.
+    launch Spyder. Additionally, extra_paths are searched.
 
     On macOS systems, a .app is considered installed if it exists.
     """
@@ -107,15 +107,15 @@ def is_program_installed(basename):
              'Miniconda3', 'Anaconda3', 'Miniconda', 'Anaconda']
 
     conda = [osp.join(*p, 'condabin') for p in itertools.product(a, b)]
-    req_paths.extend(pyenv + conda)
+    req_paths.extend(pyenv + conda + extra_paths)
 
-    for path in os.environ['PATH'].split(os.pathsep) + req_paths:
+    for path in set(os.environ['PATH'].split(os.pathsep) + req_paths):
         abspath = osp.join(path, basename)
         if osp.isfile(abspath):
             return abspath
 
 
-def find_program(basename):
+def find_program(basename, extra_paths=[]):
     """
     Find program in PATH and return absolute path
 
@@ -129,7 +129,7 @@ def find_program(basename):
         if not basename.endswith(extensions):
             names = [basename + ext for ext in extensions] + [basename]
     for name in names:
-        path = is_program_installed(name)
+        path = is_program_installed(name, extra_paths)
         if path:
             return path
 

--- a/spyder/utils/tests/test_conda.py
+++ b/spyder/utils/tests/test_conda.py
@@ -65,7 +65,16 @@ def test_get_conda_root_prefix():
 
 @pytest.mark.skipif(not running_in_ci(), reason="Only meant for CIs")
 def test_find_conda():
+    # Temporarily remove CONDA_EXE and MAMBA_EXE, if present
+    conda_exe = os.environ.pop('CONDA_EXE', None)
+    mamba_exe = os.environ.pop('MAMBA_EXE', None)
+
     assert find_conda()
+
+    if conda_exe is not None:
+        os.environ['CONDA_EXE'] = conda_exe
+    if mamba_exe is not None:
+        os.environ['MAMBA_EXE'] = mamba_exe
 
 
 @pytest.mark.skipif(not running_in_ci(), reason="Only meant for CIs")

--- a/spyder/utils/tests/test_conda.py
+++ b/spyder/utils/tests/test_conda.py
@@ -17,11 +17,11 @@ import pytest
 # Local imports
 from spyder.config.base import running_in_ci
 from spyder.config.utils import is_anaconda
+from spyder.plugins.ipythonconsole.tests.conftest import get_conda_test_env
 from spyder.utils.conda import (
     add_quotes, find_conda, get_conda_activation_script, get_conda_env_path,
     get_conda_root_prefix, get_list_conda_envs, get_list_conda_envs_cache,
     get_spyder_conda_channel)
-
 
 if not is_anaconda():
     pytest.skip("Requires conda to be installed", allow_module_level=True)
@@ -65,12 +65,19 @@ def test_get_conda_root_prefix():
 
 @pytest.mark.skipif(not running_in_ci(), reason="Only meant for CIs")
 def test_find_conda():
+    # Standard test
+    assert find_conda()
+
+    # Test with test environment
+    pyexec = get_conda_test_env()[1]
+
     # Temporarily remove CONDA_EXE and MAMBA_EXE, if present
     conda_exe = os.environ.pop('CONDA_EXE', None)
     mamba_exe = os.environ.pop('MAMBA_EXE', None)
 
-    assert find_conda()
+    assert find_conda(pyexec)
 
+    # Restore os.environ
     if conda_exe is not None:
         os.environ['CONDA_EXE'] = conda_exe
     if mamba_exe is not None:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

For the cases where conda environments are in non-standard locations, including possibly Spyder's runtime environment for conda installations, a conda executable may not be found.
This PR adds `condabin` directories, relative to Spyder's runtime executable and an optional Python executable, to the paths searched.

Optional extra search paths are added to `is_program_installed`.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #20357.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
