### PR TITLE
PR: Fix visibility of status bar widget that checks for Spyder updates (Application)

### DIFF
--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -114,12 +114,13 @@ class ApplicationContainer(PluginMainContainer):
         # Users can only use this widget in our apps.
         if not is_pynsist() and not running_in_mac_app():
             self.application_update_status.hide()
+        else:
+            self.application_update_status.set_no_status()
 
         (self.application_update_status.sig_check_for_updates_requested
          .connect(self.check_updates))
         (self.application_update_status.sig_install_on_close_requested
              .connect(self.set_installer_path))
-        self.application_update_status.set_no_status()
 
         self.give_updates_feedback = False
         self.thread_updates = None
@@ -296,10 +297,10 @@ class ApplicationContainer(PluginMainContainer):
             box.setText(error_msg)
             box.set_check_visible(False)
             box.show()
-            if self.application_update_status:
+            if self.application_update_status.isVisible():
                 self.application_update_status.set_no_status()
         elif update_available:
-            if self.application_update_status:
+            if self.application_update_status.isVisible():
                 self.application_update_status.set_status_pending(
                     latest_release)
 
@@ -425,10 +426,10 @@ class ApplicationContainer(PluginMainContainer):
         elif feedback:
             box.setText(_("Spyder is up to date."))
             box.show()
-            if self.application_update_status:
+            if self.application_update_status.isVisible():
                 self.application_update_status.set_no_status()
         else:
-            if self.application_update_status:
+            if self.application_update_status.isVisible():
                 self.application_update_status.set_no_status()
 
         self.set_conf(option, box.is_checked())
@@ -444,7 +445,7 @@ class ApplicationContainer(PluginMainContainer):
         """Check for spyder updates on github releases using a QThread."""
         # Disable check_updates_action while the thread is working
         self.check_updates_action.setDisabled(True)
-        if self.application_update_status:
+        if self.application_update_status.isVisible():
             self.application_update_status.set_status_checking()
 
         if self.thread_updates is not None:

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -434,8 +434,10 @@ class ApplicationContainer(PluginMainContainer):
 
         self.set_conf(option, box.is_checked())
 
-        # Enable check_updates_action after the thread has finished
+        # Enable check_updates_action and restore its text after the thread has
+        # finished
         self.check_updates_action.setDisabled(False)
+        self.check_updates_action.setText(_("Check for updates..."))
 
         # Provide feeback when clicking menu if check on startup is on
         self.give_updates_feedback = True
@@ -443,8 +445,11 @@ class ApplicationContainer(PluginMainContainer):
     @Slot()
     def check_updates(self, startup=False):
         """Check for spyder updates on github releases using a QThread."""
-        # Disable check_updates_action while the thread is working
+        # Disable check_updates_action and change its text while the thread is
+        # working
         self.check_updates_action.setDisabled(True)
+        self.check_updates_action.setText(_("Checking for updates..."))
+
         if self.application_update_status.isVisible():
             self.application_update_status.set_status_checking()
 

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -99,19 +99,15 @@ class Application(SpyderPluginV2):
 
     @on_plugin_available(plugin=Plugins.StatusBar)
     def on_statusbar_available(self):
-        # Add status widget if created
-        if self.application_update_status:
-            statusbar = self.get_plugin(Plugins.StatusBar)
-            statusbar.add_status_widget(self.application_update_status)
+        statusbar = self.get_plugin(Plugins.StatusBar)
+        statusbar.add_status_widget(self.application_update_status)
 
     # -------------------------- PLUGIN TEARDOWN ------------------------------
 
     @on_plugin_teardown(plugin=Plugins.StatusBar)
     def on_statusbar_teardown(self):
-        # Remove status widget if created
-        if self.application_update_status:
-            statusbar = self.get_plugin(Plugins.StatusBar)
-            statusbar.remove_status_widget(self.application_update_status.ID)
+        statusbar = self.get_plugin(Plugins.StatusBar)
+        statusbar.remove_status_widget(self.application_update_status.ID)
 
     @on_plugin_teardown(plugin=Plugins.Preferences)
     def on_preferences_teardown(self):
@@ -150,6 +146,11 @@ class Application(SpyderPluginV2):
         if DEV is None and self.get_conf('check_updates_on_startup'):
             container.give_updates_feedback = False
             container.check_updates(startup=True)
+
+        # Hide status bar widget for updates if it doesn't need to be visible.
+        # Note: This can only be done at this point to take effect.
+        if not self.application_update_status.isVisible():
+            self.application_update_status.setVisible(False)
 
         # Handle DPI scale and window changes to show a restart message.
         # Don't activate this functionality on macOS because it's being

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -118,6 +118,13 @@ class WorkerUpdates(QObject):
             channel, channel_url = get_spyder_conda_channel()
 
             if channel is None or channel_url is None:
+                # Emit signal before returning so the slots connected to it
+                # can do their job.
+                try:
+                    self.sig_ready.emit()
+                except RuntimeError:
+                    pass
+
                 return
             elif channel == "pypi":
                 self.url = pypi_url


### PR DESCRIPTION
## Description of Changes

- The widget was not actually hidden when Spyder is not installed through our Windows and Mac apps (this is a follow-up of #21784, which tried to do the same).
- Avoid updating the widget status when it's not visible.
- Also, make worker that checks for updates emit `sig_ready` when it can't find the conda channel from which Spyder was installed. That allows the slots connected to that signal to do its job as expected.
- And change the text of `check_updates_action` when checking for updates to give better feedback to users about why that action is disabled.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
