### PR TITLE
PR: Update to `codecove/action@v4` (CI)

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -154,7 +154,7 @@ jobs:
           .github/scripts/run_tests.sh || \
           .github/scripts/run_tests.sh
       - name: Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -119,7 +119,7 @@ jobs:
           .github/scripts/run_tests.sh || \
           .github/scripts/run_tests.sh
       - name: Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -143,7 +143,7 @@ jobs:
           .github/scripts/run_tests.sh || \
           .github/scripts/run_tests.sh
       - name: Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Resolves warning "Node.js 16 actions are deprecated" in CI workflows.
