### PR TITLE
PR: Fix showing update status bar widget in our apps at startup and other fixes to the update process (Application)

### DIFF
--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -111,16 +111,11 @@ class ApplicationContainer(PluginMainContainer):
             parent=self
         )
 
-        # Users can only use this widget in our apps.
-        if not is_pynsist() and not running_in_mac_app():
-            self.application_update_status.hide()
-        else:
-            self.application_update_status.set_no_status()
-
         (self.application_update_status.sig_check_for_updates_requested
          .connect(self.check_updates))
         (self.application_update_status.sig_install_on_close_requested
              .connect(self.set_installer_path))
+        self.application_update_status.set_no_status()
 
         self.give_updates_feedback = False
         self.thread_updates = None

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -111,11 +111,13 @@ class ApplicationContainer(PluginMainContainer):
             parent=self
         )
 
+        if self.is_installer():
+            self.application_update_status.set_no_status()
+
         (self.application_update_status.sig_check_for_updates_requested
          .connect(self.check_updates))
         (self.application_update_status.sig_install_on_close_requested
              .connect(self.set_installer_path))
-        self.application_update_status.set_no_status()
 
         self.give_updates_feedback = False
         self.thread_updates = None
@@ -292,10 +294,10 @@ class ApplicationContainer(PluginMainContainer):
             box.setText(error_msg)
             box.set_check_visible(False)
             box.show()
-            if self.application_update_status.isVisible():
+            if self.is_installer():
                 self.application_update_status.set_no_status()
         elif update_available:
-            if self.application_update_status.isVisible():
+            if self.is_installer():
                 self.application_update_status.set_status_pending(
                     latest_release)
 
@@ -307,7 +309,7 @@ class ApplicationContainer(PluginMainContainer):
                 box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
                 box.setDefaultButton(QMessageBox.Yes)
 
-                if not is_pynsist() and not running_in_mac_app():
+                if not self.is_installer():
                     installers_url = url_i + "#standalone-installers"
                     msg = (
                         header +
@@ -337,8 +339,7 @@ class ApplicationContainer(PluginMainContainer):
                 not box.result()  # The installer dialog was skipped
                 or (
                     box.result() == QMessageBox.No
-                    and not is_pynsist()
-                    and not running_in_mac_app()
+                    and not self.is_installer()
                 )
             ):
                 # Update-at-startup checkbox visible only if manual update
@@ -421,10 +422,10 @@ class ApplicationContainer(PluginMainContainer):
         elif feedback:
             box.setText(_("Spyder is up to date."))
             box.show()
-            if self.application_update_status.isVisible():
+            if self.is_installer():
                 self.application_update_status.set_no_status()
         else:
-            if self.application_update_status.isVisible():
+            if self.is_installer():
                 self.application_update_status.set_no_status()
 
         self.set_conf(option, box.is_checked())
@@ -445,7 +446,7 @@ class ApplicationContainer(PluginMainContainer):
         self.check_updates_action.setDisabled(True)
         self.check_updates_action.setText(_("Checking for updates..."))
 
-        if self.application_update_status.isVisible():
+        if self.is_installer():
             self.application_update_status.set_status_checking()
 
         if self.thread_updates is not None:
@@ -475,6 +476,9 @@ class ApplicationContainer(PluginMainContainer):
     def set_installer_path(self, installer_path):
         """Set installer executable path to be run when closing."""
         self.installer_path = installer_path
+
+    def is_installer(self):
+        return is_pynsist() or running_in_mac_app()
 
     # ---- Dependencies
     # -------------------------------------------------------------------------

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -25,7 +25,6 @@ from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
 from spyder.api.widgets.menus import MENU_SEPARATOR
 from spyder.config.base import (DEV, get_module_path, get_debug_level,
-                                is_pynsist, running_in_mac_app,
                                 running_under_pytest)
 from spyder.plugins.application.confpage import ApplicationConfigPage
 from spyder.plugins.application.container import (
@@ -150,7 +149,7 @@ class Application(SpyderPluginV2):
 
         # Users only need to see this widget in our apps.
         # Note: This can only be done at this point to take effect.
-        if not (is_pynsist() or running_in_mac_app()):
+        if not container.is_installer():
             self.application_update_status.setVisible(False)
 
         # Handle DPI scale and window changes to show a restart message.

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -25,6 +25,7 @@ from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
 from spyder.api.widgets.menus import MENU_SEPARATOR
 from spyder.config.base import (DEV, get_module_path, get_debug_level,
+                                is_pynsist, running_in_mac_app,
                                 running_under_pytest)
 from spyder.plugins.application.confpage import ApplicationConfigPage
 from spyder.plugins.application.container import (
@@ -147,9 +148,9 @@ class Application(SpyderPluginV2):
             container.give_updates_feedback = False
             container.check_updates(startup=True)
 
-        # Hide status bar widget for updates if it doesn't need to be visible.
+        # Users only need to see this widget in our apps.
         # Note: This can only be done at this point to take effect.
-        if not self.application_update_status.isVisible():
+        if not (is_pynsist() or running_in_mac_app()):
             self.application_update_status.setVisible(False)
 
         # Handle DPI scale and window changes to show a restart message.

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -177,13 +177,14 @@ class WorkerUpdates(QObject):
             ).format(formatted_error)
             logger.debug(err, stack_info=True)
 
-        # Don't show dialog when starting up spyder and an error occur
-        if not (self.startup and error_msg is not None):
-            self.error = error_msg
-            try:
-                self.sig_ready.emit()
-            except RuntimeError:
-                pass
+        # At this point we **must** emit the signal below so that the "Check
+        # for updates" action in the Help menu is enabled again after the check
+        # has finished (it's disabled while the check is running).
+        self.error = error_msg
+        try:
+            self.sig_ready.emit()
+        except RuntimeError:
+            pass
 
 
 class WorkerDownloadInstaller(QObject):
@@ -336,6 +337,7 @@ class WorkerDownloadInstaller(QObject):
                 '<tt>{}</tt>'
             ).format(formatted_error)
             logger.debug(err, stack_info=True)
+
         self.error = error_msg
         try:
             self.sig_ready.emit(self.installer_path)

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -166,15 +166,10 @@ class WorkerUpdates(QObject):
             error_msg = HTTP_ERROR_MSG.format(status_code=page.status_code)
             logger.debug(err, stack_info=True)
         except Exception as err:
-            error = traceback.format_exc()
-            formatted_error = error.replace('\n', '<br>').replace(' ', '&nbsp;')
-
-            error_msg = _(
-                'It was not possible to check for Spyder updates due to the '
-                'following error:'
-                '<br><br>'
-                '<tt>{}</tt>'
-            ).format(formatted_error)
+            # Only log the error when it's a generic one because we can't give
+            # users proper feedback on how to address it. Otherwise we'd show
+            # a long traceback that most probably would be incomprehensible to
+            # them.
             logger.debug(err, stack_info=True)
 
         # At this point we **must** emit the signal below so that the "Check


### PR DESCRIPTION
## Description of Changes

- This is a follow up of #21851, which fixed the widget issue for our Linux experimental installer but broke things for our Windows and Mac apps.
- Don't show generic errors while checking for updates to users because we can't give proper feedback to them on how to address the error. They'd only see a long and probably incomprehensible traceback, which wouldn't be really useful.
- Always emit the `sig_ready` signal after a check was performed so that the `Check for updates` action in the Help menu is enabled again (it's disabled while doing the check and it depends on `sig_ready` to be enabled after the check ends).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21861.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
