### PR TITLE
PR: Fix issue where Spyder started automatically before conda-based installer exited

### DIFF
--- a/installers-conda/resources/post-install.bat
+++ b/installers-conda/resources/post-install.bat
@@ -19,7 +19,7 @@ if not exist "%tmpdir%" mkdir "%tmpdir%"
 (
 echo @echo off
 echo :loop
-echo tasklist /fi "ImageName eq Spyder-*" /fo csv 2^>NUL ^| findstr /r "Spyder-.*-Windows-x86_64.exe"^>NUL
+echo tasklist /fi "ImageName eq Spyder-*" /fo csv 2^>NUL ^| findstr /r "Spyder-.*Windows-x86_64.exe"^>NUL
 echo if "%%errorlevel%%"=="0" ^(
 echo     timeout /t 1 /nobreak ^> nul
 echo     goto loop


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Fix an issue where Spyder would automatically startup before the conda-based installer exited. This was due to a glob pattern that was not updated in Spyder's post-install script to accommodate removing the version from the installer file name.

