### PR TITLE
PR: Pass paths from the Pythonpath manager to the Pylint plugin

### DIFF
--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -373,21 +373,7 @@ class PylintWidget(PluginMainWidget):
             lambda ec, es=QProcess.ExitStatus: self._finished(ec, es))
 
         command_args = self.get_command(self.get_filename())
-        processEnvironment = QProcessEnvironment()
-        processEnvironment.insert("PYTHONIOENCODING", "utf8")
-
-        if os.name == 'nt':
-            # Needed due to changes in Pylint 2.14.0
-            # See spyder-ide/spyder#18175
-            home_dir = get_home_dir()
-            user_profile = os.environ.get("USERPROFILE", home_dir)
-            processEnvironment.insert("USERPROFILE", user_profile)
-            # Needed for Windows installations using standalone Python and pip.
-            # See spyder-ide/spyder#19385
-            if not is_conda_env(sys.prefix):
-                processEnvironment.insert("APPDATA", os.environ.get("APPDATA"))
-
-        process.setProcessEnvironment(processEnvironment)
+        process.setProcessEnvironment(self.get_environment())
         process.start(sys.executable, command_args)
         running = process.waitForStarted()
         if not running:
@@ -945,6 +931,25 @@ class PylintWidget(PluginMainWidget):
 
         command_args.append(filename)
         return command_args
+
+    @staticmethod
+    def get_environment() -> QProcessEnvironment:
+        """Get evironment variables for pylint command."""
+        process_environment = QProcessEnvironment()
+        process_environment.insert("PYTHONIOENCODING", "utf8")
+
+        if os.name == 'nt':
+            # Needed due to changes in Pylint 2.14.0
+            # See spyder-ide/spyder#18175
+            home_dir = get_home_dir()
+            user_profile = os.environ.get("USERPROFILE", home_dir)
+            process_environment.insert("USERPROFILE", user_profile)
+            # Needed for Windows installations using standalone Python and pip.
+            # See spyder-ide/spyder#19385
+            if not is_conda_env(sys.prefix):
+                process_environment.insert("APPDATA", os.environ.get("APPDATA"))
+
+        return process_environment
 
     def parse_output(self, output):
         """

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -374,9 +374,11 @@ class PylintWidget(PluginMainWidget):
 
         command_args = self.get_command(self.get_filename())
         pythonpath_manager_values = self.get_conf(
-            'spyder_pythonpath', default=[], section='pythonpath_manager')
+            'spyder_pythonpath', default=[], section='pythonpath_manager'
+        )
         process.setProcessEnvironment(
-            self.get_environment(pythonpath_manager_values))
+            self.get_environment(pythonpath_manager_values)
+        )
         process.start(sys.executable, command_args)
         running = process.waitForStarted()
         if not running:
@@ -936,8 +938,9 @@ class PylintWidget(PluginMainWidget):
         return command_args
 
     @staticmethod
-    def get_environment(pythonpath_manager_values: list
-                        ) -> QProcessEnvironment:
+    def get_environment(
+        pythonpath_manager_values: list
+    ) -> QProcessEnvironment:
         """Get evironment variables for pylint command."""
         process_environment = QProcessEnvironment()
         process_environment.insert("PYTHONIOENCODING", "utf8")
@@ -956,7 +959,9 @@ class PylintWidget(PluginMainWidget):
             # Needed for Windows installations using standalone Python and pip.
             # See spyder-ide/spyder#19385
             if not is_conda_env(sys.prefix):
-                process_environment.insert("APPDATA", os.environ.get("APPDATA"))
+                process_environment.insert(
+                    "APPDATA", os.environ.get("APPDATA")
+                )
 
         return process_environment
 

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -373,7 +373,10 @@ class PylintWidget(PluginMainWidget):
             lambda ec, es=QProcess.ExitStatus: self._finished(ec, es))
 
         command_args = self.get_command(self.get_filename())
-        process.setProcessEnvironment(self.get_environment())
+        pythonpath_manager_values = self.get_conf(
+            'spyder_pythonpath', default=[], section='pythonpath_manager')
+        process.setProcessEnvironment(
+            self.get_environment(pythonpath_manager_values))
         process.start(sys.executable, command_args)
         running = process.waitForStarted()
         if not running:
@@ -933,10 +936,16 @@ class PylintWidget(PluginMainWidget):
         return command_args
 
     @staticmethod
-    def get_environment() -> QProcessEnvironment:
+    def get_environment(pythonpath_manager_values: list
+                        ) -> QProcessEnvironment:
         """Get evironment variables for pylint command."""
         process_environment = QProcessEnvironment()
         process_environment.insert("PYTHONIOENCODING", "utf8")
+
+        if pythonpath_manager_values:
+            pypath = os.pathsep.join(pythonpath_manager_values)
+            # See PR spyder-ide/spyder#21891
+            process_environment.insert("PYTHONPATH", pypath)
 
         if os.name == 'nt':
             # Needed due to changes in Pylint 2.14.0

--- a/spyder/plugins/pylint/tests/test_pylint.py
+++ b/spyder/plugins/pylint/tests/test_pylint.py
@@ -340,11 +340,7 @@ def test_get_environment(mocker):
     """Test that the environment variables depend on the OS."""
     if os.name == 'nt':
         mocker.patch(
-            "spyder.plugins.pylint.main_widget.is_conda_based_app",
-            return_value=False
-        )
-        mocker.patch(
-            "spyder.plugins.pylint.main_widget.is_anaconda",
+            "spyder.plugins.pylint.main_widget.is_conda_env",
             return_value=False
         )
         mocker.patch(

--- a/spyder/plugins/pylint/tests/test_pylint.py
+++ b/spyder/plugins/pylint/tests/test_pylint.py
@@ -347,10 +347,11 @@ def test_get_environment(mocker):
                      return_value='')
 
     etalon = {
-        "nt": ["APPDATA", "PYTHONIOENCODING", "USERPROFILE"],
-        "posix": ["PYTHONIOENCODING"]}
+        "nt": ["APPDATA", "PYTHONIOENCODING", "PYTHONPATH", "USERPROFILE"],
+        "posix": ["PYTHONIOENCODING", "PYTHONPATH"]}
 
-    process_environment = Pylint.WIDGET_CLASS.get_environment()
+    process_environment = Pylint.WIDGET_CLASS.get_environment(
+        pythonpath_manager_values=["project_dir"])
 
     assert process_environment.keys() == etalon[os.name]
 

--- a/spyder/plugins/pylint/tests/test_pylint.py
+++ b/spyder/plugins/pylint/tests/test_pylint.py
@@ -9,6 +9,7 @@
 
 # Standard library imports
 from io import open
+import os
 import os.path as osp
 import sys
 from unittest.mock import Mock, MagicMock
@@ -333,6 +334,25 @@ def test_custom_interpreter(pylint_plugin, tmp_path, qtbot,
         assert not errors
     else:
         assert errors
+
+
+def test_get_environment(mocker):
+    """Test that the environment variables depend on the OS."""
+    if os.name == 'nt':
+        mocker.patch("spyder.plugins.pylint.main_widget.is_conda_based_app",
+                     return_value=False)
+        mocker.patch("spyder.plugins.pylint.main_widget.is_anaconda",
+                     return_value=False)
+        mocker.patch("spyder.plugins.pylint.main_widget.get_home_dir",
+                     return_value='')
+
+    etalon = {
+        "nt": ["APPDATA", "PYTHONIOENCODING", "USERPROFILE"],
+        "posix": ["PYTHONIOENCODING"]}
+
+    process_environment = Pylint.WIDGET_CLASS.get_environment()
+
+    assert process_environment.keys() == etalon[os.name]
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/pylint/tests/test_pylint.py
+++ b/spyder/plugins/pylint/tests/test_pylint.py
@@ -339,21 +339,29 @@ def test_custom_interpreter(pylint_plugin, tmp_path, qtbot,
 def test_get_environment(mocker):
     """Test that the environment variables depend on the OS."""
     if os.name == 'nt':
-        mocker.patch("spyder.plugins.pylint.main_widget.is_conda_based_app",
-                     return_value=False)
-        mocker.patch("spyder.plugins.pylint.main_widget.is_anaconda",
-                     return_value=False)
-        mocker.patch("spyder.plugins.pylint.main_widget.get_home_dir",
-                     return_value='')
+        mocker.patch(
+            "spyder.plugins.pylint.main_widget.is_conda_based_app",
+            return_value=False
+        )
+        mocker.patch(
+            "spyder.plugins.pylint.main_widget.is_anaconda",
+            return_value=False
+        )
+        mocker.patch(
+            "spyder.plugins.pylint.main_widget.get_home_dir",
+            return_value=''
+        )
 
-    etalon = {
+    expected_vars = {
         "nt": ["APPDATA", "PYTHONIOENCODING", "PYTHONPATH", "USERPROFILE"],
-        "posix": ["PYTHONIOENCODING", "PYTHONPATH"]}
+        "posix": ["PYTHONIOENCODING", "PYTHONPATH"]
+    }
 
     process_environment = Pylint.WIDGET_CLASS.get_environment(
-        pythonpath_manager_values=["project_dir"])
+        pythonpath_manager_values=["project_dir"]
+    )
 
-    assert process_environment.keys() == etalon[os.name]
+    assert process_environment.keys() == expected_vars[os.name]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of Changes

Add the `PYTHONPATH` environment from pythonpath-manager to the `pylint` plugin to access the root of the project without packages.

Example:

Suppose, you have a project with a single script (for simplicity in a spyder environment):

```
my-project
| - do_something.py
```

and you write a test:

```
my-project
| - do_something.py
| - tests
  | - test_do_something.py
```

In *test_do_something.py* you access to `import do_something`. So if you start *Source -> Run code analysis* it will show the error *Unable to import 'do_something'*. But in the IPython console `!pylint tests/test_do_something.py` doesn't show this error because there is PYTHONPATH environment.

And you should take additional steps to solve this problem, for example, make a packages:

```
my-project
| - my_project
  | - __init__.py
  | - do_something.py
  | - tests
    | - __init__.py
    | - test_do_something.py
```

or fix paths in *pylintrc* or *pyproject.toml* (section *[tool.pylint]*, value *init-hook=...*):

```
my-project
| - do_something.py
| - tests
  | - test_do_something.py
| - pyproject.toml
```

No hacks are needed with this PR - it works out of the box.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: [@Znapy](https://github.com/Znapy)
