### PR TITLE
PR: Fix validation to use Spyder 5 installer names when needed

### DIFF
--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -237,7 +237,7 @@ class WorkerDownloadInstaller(QObject):
         # platforms will be x86_64.
         mach = "arm64" if "ARM64" in platform.version() else "x86_64"
 
-        if parse(self.latest_release_version) >= parse("6"):
+        if parse(self.latest_release_version) >= parse("6.0.0"):
             # conda-based installer name
             if os.name == 'nt':
                 plat, ext = 'Windows', 'exe'
@@ -266,8 +266,10 @@ class WorkerDownloadInstaller(QObject):
         dir_path = osp.join(tmpdir, 'spyder', 'updates')
         os.makedirs(dir_path, exist_ok=True)
         installer_dir_path = osp.join(
-            dir_path, self.latest_release_version)
+            dir_path, self.latest_release_version
+        )
         os.makedirs(installer_dir_path, exist_ok=True)
+
         for dir_version in os.listdir(dir_path):
             if dir_version not in [__version__, self.latest_release_version]:
                 remove_dir = osp.join(dir_path, dir_version)

--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -9,6 +9,7 @@ import logging
 import os
 import os.path as osp
 import platform
+import shutil
 import tempfile
 import traceback
 
@@ -236,7 +237,7 @@ class WorkerDownloadInstaller(QObject):
         # platforms will be x86_64.
         mach = "arm64" if "ARM64" in platform.version() else "x86_64"
 
-        if parse(self.latest_release_version) > parse("5"):
+        if parse(self.latest_release_version) >= parse("6"):
             # conda-based installer name
             if os.name == 'nt':
                 plat, ext = 'Windows', 'exe'
@@ -267,10 +268,13 @@ class WorkerDownloadInstaller(QObject):
         installer_dir_path = osp.join(
             dir_path, self.latest_release_version)
         os.makedirs(installer_dir_path, exist_ok=True)
-        for file in os.listdir(dir_path):
-            if file not in [__version__, self.latest_release_version]:
-                remove = osp.join(dir_path, file)
-                os.remove(remove)
+        for dir_version in os.listdir(dir_path):
+            if dir_version not in [__version__, self.latest_release_version]:
+                remove_dir = osp.join(dir_path, dir_version)
+                try:
+                    shutil.rmtree(remove_dir)
+                except OSError as err:
+                    logger.debug(err, stack_info=True)
 
         installer_path = osp.join(installer_dir_path, name)
         self.installer_path = installer_path


### PR DESCRIPTION


<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Fix validation to use 5.x installers names. The validation was giving the 6.x/conda installers formatting for the installers names since the validation was doing something like `parse("5.5.3") > parse("5")` which evaluates to `True`. That was making things fail since there are not assets over the 5.x releases using the new naming.

Also, updated some code and added a try-catch to prevent errors when trying to remove outdated files/directories from the directory used to download the installers.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21905 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
