### PR TITLE
PR: Add bening error when `debugpy` is not available (IPython console)

### DIFF
--- a/spyder/api/shellconnect/main_widget.py
+++ b/spyder/api/shellconnect/main_widget.py
@@ -107,8 +107,15 @@ class ShellConnectMainWidget(PluginMainWidget):
         shellwidget_id = id(shellwidget)
         if shellwidget_id in self._shellwidgets:
             widget = self._shellwidgets.pop(shellwidget_id)
-            self._stack.removeWidget(widget)
-            self.close_widget(widget)
+
+            # If `widget` is an empty pane, we don't need to remove it from the
+            # stack (because it's the one we need to show since the console is
+            # showing an error) nor try to close it (because it makes no
+            # sense).
+            if not isinstance(widget, PaneEmptyWidget):
+                self._stack.removeWidget(widget)
+                self.close_widget(widget)
+
             self.update_actions()
 
     def set_shellwidget(self, shellwidget):
@@ -131,18 +138,24 @@ class ShellConnectMainWidget(PluginMainWidget):
         consoles with dead kernels.
         """
         shellwidget_id = id(shellwidget)
-        if shellwidget_id not in self._shellwidgets:
-            widget = PaneEmptyWidget(
-                self,
-                "console-off",
-                _("No connected console"),
-                _("The current console failed to start, so there is no "
-                  "content to show here.")
-            )
 
-            self._stack.addWidget(widget)
-            self._shellwidgets[shellwidget_id] = widget
-            self.set_shellwidget(shellwidget)
+        # This can happen if the kernel started without issues but something is
+        # printed to its stderr stream, which we display as an error in the
+        # console. In that case, we need to remove the current widget
+        # associated to shellwidget and replace it by an empty one.
+        if shellwidget_id in self._shellwidgets:
+            self._shellwidgets.pop(shellwidget_id)
+
+        widget = PaneEmptyWidget(
+            self,
+            "console-off",
+            _("No connected console"),
+            _("The current console failed to start, so there is no "
+              "content to show here.")
+        )
+        self._stack.addWidget(widget)
+        self._shellwidgets[shellwidget_id] = widget
+        self.set_shellwidget(shellwidget)
 
     def create_new_widget(self, shellwidget):
         """Create a widget to communicate with shellwidget."""

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -508,7 +508,11 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
             "The following argument was not expected",
             # Avoid showing error for kernel restarts after kernel dies when
             # using an external interpreter
-            "conda.cli.main_run"
+            "conda.cli.main_run",
+            # Warning when debugpy is not available because it's an optional
+            # dependency of IPykernel.
+            # See spyder-ide/spyder#21900
+            "debugpy_stream undefined, debugging will not be enabled",
         ]
 
         return any([err in error for err in benign_errors])


### PR DESCRIPTION
## Description of Changes

- `debugpy` is an optional dependency of IPykernel, so it is not necessarily installed with it.
- Also, fix showing an error message in panes connected to the IPython console when something is printed to the kernel stderr stream after it starts but before the prompt is shown. 

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21900.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
