### PR TITLE
PR: Remove icons from standard buttons in dialogs (UI/UX)

### DIFF
--- a/spyder/api/widgets/dialogs.py
+++ b/spyder/api/widgets/dialogs.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Spyder dialog widgets.
+"""
+
+# Third-party imports
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QDialogButtonBox
+
+
+class SpyderDialogButtonBox(QDialogButtonBox):
+    """
+    QDialogButtonBox widget for Spyder that doesn't display icons on its
+    standard buttons.
+    """
+
+    def __init__(self, buttons=None, orientation=Qt.Horizontal, parent=None):
+        if buttons:
+            super().__init__(buttons, orientation, parent)
+        elif orientation:
+            super().__init__(orientation=orientation, parent=parent)
+        else:
+            super().__init__(parent=parent)
+
+        button_constants = [
+            QDialogButtonBox.Ok,
+            QDialogButtonBox.Open,
+            QDialogButtonBox.Save,
+            QDialogButtonBox.Cancel,
+            QDialogButtonBox.Close,
+            QDialogButtonBox.Discard,
+            QDialogButtonBox.Apply,
+            QDialogButtonBox.Reset,
+            QDialogButtonBox.RestoreDefaults,
+            QDialogButtonBox.Help,
+            QDialogButtonBox.SaveAll,
+            QDialogButtonBox.Yes,
+            QDialogButtonBox.YesToAll,
+            QDialogButtonBox.No,
+            QDialogButtonBox.NoToAll,
+            QDialogButtonBox.Abort,
+            QDialogButtonBox.Retry,
+            QDialogButtonBox.Ignore,
+        ]
+
+        for constant in button_constants:
+            button = self.button(constant)
+            if button is not None:
+                button.setIcon(QIcon())

--- a/spyder/api/widgets/menus.py
+++ b/spyder/api/widgets/menus.py
@@ -466,14 +466,17 @@ class SpyderMenu(QMenu, SpyderFontsMixin):
             self._is_shown = True
 
         # Reposition menus horizontally due to border
-        if QCursor().pos().x() - self.pos().x() < 40:
-            # If the difference between the current cursor x position and the
-            # menu one is small, it means the menu will be shown to the right,
-            # so we need to move it in that direction.
-            delta_x = 1
+        if self.APP_MENU:
+            delta_x = 0 if MAC else 3
         else:
-            # This happens when the menu is shown to the left.
-            delta_x = -1
+            if QCursor().pos().x() - self.pos().x() < 40:
+                # If the difference between the current cursor x position and
+                # the menu one is small, it means the menu will be shown to the
+                # right, so we need to move it in that direction.
+                delta_x = 1
+            else:
+                # This happens when the menu is shown to the left.
+                delta_x = -1
 
         self.move(self.pos().x() + delta_x, self.pos().y())
 

--- a/spyder/plugins/appearance/widgets.py
+++ b/spyder/plugins/appearance/widgets.py
@@ -11,6 +11,7 @@ from qtpy.QtWidgets import (QDialog, QDialogButtonBox, QGridLayout, QGroupBox,
                             QHBoxLayout, QVBoxLayout, QWidget)
 
 from spyder.api.translations import _
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.utils import syntaxhighlighters
 
 
@@ -30,7 +31,9 @@ class SchemeEditor(QDialog):
         self.last_used_scheme = None
 
         # Widgets
-        bbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        bbox = SpyderDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
 
         # Layout
         layout = QVBoxLayout()

--- a/spyder/plugins/application/widgets/about.py
+++ b/spyder/plugins/application/widgets/about.py
@@ -24,6 +24,7 @@ from spyder import (
     __website_url__ as website_url,
     get_versions, get_versions_text
 )
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.api.widgets.mixins import SvgToScaledPixmap
 from spyder.config.base import _
 from spyder.utils.icon_manager import ima
@@ -230,7 +231,7 @@ class AboutDialog(QDialog, SvgToScaledPixmap):
 
         # -- Buttons
         info_btn = QPushButton(_("Copy version info"))
-        ok_btn = QDialogButtonBox(QDialogButtonBox.Ok)
+        ok_btn = SpyderDialogButtonBox(QDialogButtonBox.Ok)
 
         # Apply style to buttons
         for button in [info_btn, ok_btn]:

--- a/spyder/plugins/completion/providers/languageserver/widgets/serversconfig.py
+++ b/spyder/plugins/completion/providers/languageserver/widgets/serversconfig.py
@@ -24,6 +24,7 @@ from qtpy.QtWidgets import (QAbstractItemView, QCheckBox,
 # Local imports
 from spyder.api.config.fonts import SpyderFontsMixin, SpyderFontType
 from spyder.api.widgets.comboboxes import SpyderComboBox
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.config.base import _
 from spyder.plugins.completion.api import SUPPORTED_LANGUAGES
 from spyder.utils.misc import check_connection_port
@@ -165,8 +166,9 @@ class LSPServerEditor(QDialog, SpyderFontsMixin):
         self.conf_label = QLabel(_('<b>Server Configuration:</b>'))
         self.conf_input = SimpleCodeEditor(None)
 
-        self.bbox = QDialogButtonBox(QDialogButtonBox.Ok |
-                                     QDialogButtonBox.Cancel)
+        self.bbox = SpyderDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
         self.button_ok = self.bbox.button(QDialogButtonBox.Ok)
         self.button_cancel = self.bbox.button(QDialogButtonBox.Cancel)
 

--- a/spyder/plugins/completion/providers/snippets/widgets/snippetsconfig.py
+++ b/spyder/plugins/completion/providers/snippets/widgets/snippetsconfig.py
@@ -24,6 +24,7 @@ from qtpy.QtWidgets import (QAbstractItemView, QCheckBox, QDialog,
 # Local imports
 from spyder.api.config.fonts import SpyderFontsMixin, SpyderFontType
 from spyder.api.widgets.comboboxes import SpyderComboBox
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.config.base import _
 from spyder.plugins.completion.api import SUPPORTED_LANGUAGES
 from spyder.utils.snippets.ast import build_snippet_ast
@@ -275,8 +276,9 @@ class SnippetEditor(QDialog, SpyderFontsMixin):
         self.snippet_input = SimpleCodeEditor(None)
 
         # Dialog buttons
-        self.bbox = QDialogButtonBox(QDialogButtonBox.Ok |
-                                     QDialogButtonBox.Cancel)
+        self.bbox = SpyderDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
         self.button_ok = self.bbox.button(QDialogButtonBox.Ok)
         self.button_cancel = self.bbox.button(QDialogButtonBox.Cancel)
 

--- a/spyder/plugins/editor/widgets/autosaveerror.py
+++ b/spyder/plugins/editor/widgets/autosaveerror.py
@@ -14,6 +14,7 @@ from qtpy.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox, QLabel,
                             QVBoxLayout)
 
 # Local imports
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.config.base import _
 
 
@@ -59,7 +60,7 @@ class AutosaveErrorDialog(QDialog):
         layout.addWidget(self.dismiss_box)
         layout.addSpacing(15)
 
-        button_box = QDialogButtonBox(QDialogButtonBox.Ok)
+        button_box = SpyderDialogButtonBox(QDialogButtonBox.Ok)
         button_box.accepted.connect(self.accept)
         layout.addWidget(button_box)
 

--- a/spyder/plugins/editor/widgets/gotoline.py
+++ b/spyder/plugins/editor/widgets/gotoline.py
@@ -10,6 +10,7 @@ from qtpy.QtWidgets import (QDialog, QLabel, QLineEdit, QGridLayout,
                             QDialogButtonBox, QVBoxLayout, QHBoxLayout)
 
 from spyder.api.translations import _
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 
 
 class GoToLineDialog(QDialog):
@@ -48,8 +49,9 @@ class GoToLineDialog(QDialog):
         glayout.addWidget(last_label, 2, 0, Qt.AlignVCenter | Qt.AlignRight)
         glayout.addWidget(last_label_v, 2, 1, Qt.AlignVCenter)
 
-        bbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
-                                Qt.Vertical, self)
+        bbox = SpyderDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel, Qt.Vertical, self
+        )
         bbox.accepted.connect(self.accept)
         bbox.rejected.connect(self.reject)
         btnlayout = QVBoxLayout()

--- a/spyder/plugins/editor/widgets/recover.py
+++ b/spyder/plugins/editor/widgets/recover.py
@@ -15,10 +15,20 @@ import time
 # Third party imports
 from qtpy.compat import getsavefilename
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
-                            QHBoxLayout, QLabel, QMessageBox, QPushButton,
-                            QTableWidget, QVBoxLayout, QWidget)
+from qtpy.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
 # Local imports
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.config.base import _, running_under_pytest
 
 
@@ -217,7 +227,9 @@ class RecoveryDialog(QDialog):
 
     def add_cancel_button(self):
         """Add a cancel button at the bottom of the dialog window."""
-        button_box = QDialogButtonBox(QDialogButtonBox.Cancel, self)
+        button_box = SpyderDialogButtonBox(
+            QDialogButtonBox.Cancel, parent=self
+        )
         button_box.rejected.connect(self.reject)
         self.layout.addWidget(button_box)
 
@@ -352,7 +364,7 @@ def test():  # pragma: no cover
     import tempfile
     from spyder.utils.qthelpers import qapplication
 
-    app = qapplication()
+    app = qapplication()  # noqa
     tempdir = tempfile.mkdtemp()
     unused, unused, autosave_mapping = make_temporary_files(tempdir)
     dialog = RecoveryDialog(autosave_mapping)

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -55,6 +55,7 @@ from qtpy.QtWidgets import (
 # Local imports
 from spyder.api.config.decorators import on_conf_change
 from spyder.api.translations import _
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.config.base import get_home_dir
 from spyder.config.main import NAME_FILTERS
@@ -1076,9 +1077,11 @@ class DirView(QTreeView, SpyderWidgetMixin):
             filters.setPlainText(", ".join(self.get_conf('name_filters')))
 
         # Dialog buttons
-        button_box = QDialogButtonBox(QDialogButtonBox.Reset |
-                                      QDialogButtonBox.Ok |
-                                      QDialogButtonBox.Cancel)
+        button_box = SpyderDialogButtonBox(
+            QDialogButtonBox.Reset
+            | QDialogButtonBox.Ok
+            | QDialogButtonBox.Cancel
+        )
         button_box.accepted.connect(handle_ok)
         button_box.rejected.connect(dialog.reject)
         button_box.button(QDialogButtonBox.Reset).clicked.connect(handle_reset)

--- a/spyder/plugins/explorer/widgets/fileassociations.py
+++ b/spyder/plugins/explorer/widgets/fileassociations.py
@@ -22,6 +22,7 @@ from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
                             QListWidget, QListWidgetItem, QPushButton,
                             QVBoxLayout, QWidget)
 # Local imports
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.config.base import _
 from spyder.utils.encoding import is_text_file
 from spyder.utils.programs import (get_application_icon,
@@ -41,8 +42,9 @@ class InputTextDialog(QDialog):
         # Widgets
         self.label = QLabel()
         self.lineedit = QLineEdit()
-        self.button_box = QDialogButtonBox(QDialogButtonBox.Ok
-                                           | QDialogButtonBox.Cancel)
+        self.button_box = SpyderDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
         self.button_ok = self.button_box.button(QDialogButtonBox.Ok)
         self.button_cancel = self.button_box.button(QDialogButtonBox.Cancel)
 
@@ -109,8 +111,9 @@ class ApplicationsDialog(QDialog):
         self.edit_filter = QLineEdit()
         self.list = QListWidget()
         self.button_browse = QPushButton(_('Browse...'))
-        self.button_box = QDialogButtonBox(QDialogButtonBox.Ok
-                                           | QDialogButtonBox.Cancel)
+        self.button_box = SpyderDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
         self.button_ok = self.button_box.button(QDialogButtonBox.Ok)
         self.button_cancel = self.button_box.button(QDialogButtonBox.Cancel)
 

--- a/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
@@ -22,6 +22,7 @@ from qtpy.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox, QGridLayout,
 
 # Local imports
 from spyder.api.config.mixins import SpyderConfigurationAccessor
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.config.base import _, get_home_dir
 
 
@@ -136,9 +137,11 @@ class KernelConnectionDialog(QDialog, SpyderConfigurationAccessor):
         self.rm_group.toggled.connect(self.pw_radio.setChecked)
 
         # Ok and Cancel buttons
-        self.accept_btns = QDialogButtonBox(
+        self.accept_btns = SpyderDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
-            Qt.Horizontal, self)
+            Qt.Horizontal,
+            self,
+        )
 
         self.accept_btns.accepted.connect(self.save_connection_settings)
         self.accept_btns.accepted.connect(self.accept)

--- a/spyder/plugins/layout/widgets/dialog.py
+++ b/spyder/plugins/layout/widgets/dialog.py
@@ -18,6 +18,7 @@ from qtpy.QtWidgets import (QAbstractItemView, QDialog,
 
 # Local imports
 from spyder.api.widgets.comboboxes import SpyderComboBox
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.config.base import _
 from spyder.py3compat import to_text_string
 
@@ -146,9 +147,9 @@ class LayoutSaveDialog(QDialog):
         self.combo_box.addItems(order)
         self.combo_box.setEditable(True)
         self.combo_box.clearEditText()
-        self.button_box = QDialogButtonBox(QDialogButtonBox.Ok |
-                                           QDialogButtonBox.Cancel,
-                                           Qt.Horizontal, self)
+        self.button_box = SpyderDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel, Qt.Horizontal, self
+        )
         self.button_ok = self.button_box.button(QDialogButtonBox.Ok)
         self.button_cancel = self.button_box.button(QDialogButtonBox.Cancel)
 
@@ -196,9 +197,9 @@ class LayoutSettingsDialog(QDialog):
         self.button_move_up = QPushButton(_('Move Up'))
         self.button_move_down = QPushButton(_('Move Down'))
         self.button_delete = QPushButton(_('Delete Layout'))
-        self.button_box = QDialogButtonBox(QDialogButtonBox.Ok |
-                                           QDialogButtonBox.Cancel,
-                                           Qt.Horizontal, self)
+        self.button_box = SpyderDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel, Qt.Horizontal, self
+        )
         self.group_box = QGroupBox(_("Layout Display and Order"))
         self.table = QTableView(self)
         self.ok_button = self.button_box.button(QDialogButtonBox.Ok)

--- a/spyder/plugins/mainmenu/plugin.py
+++ b/spyder/plugins/mainmenu/plugin.py
@@ -106,7 +106,7 @@ class MainMenu(SpyderPluginV2):
             plugin_instance = PLUGIN_REGISTRY.get_plugin(plugin_name)
             if isinstance(plugin_instance, SpyderDockablePlugin):
                 if plugin_instance.CONF_SECTION == 'editor':
-                    editorstack = self.editor.get_current_editorstack()
+                    editorstack = self._main.editor.get_current_editorstack()
                     editorstack.menu.hide()
                 else:
                     try:

--- a/spyder/plugins/preferences/widgets/configdialog.py
+++ b/spyder/plugins/preferences/widgets/configdialog.py
@@ -10,14 +10,12 @@ from qtpy.QtWidgets import QDialog, QDialogButtonBox, QHBoxLayout, QPushButton
 from superqt.utils import qdebounced
 
 # Local imports
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.config.base import _, load_lang_conf
 from spyder.config.manager import CONF
 from spyder.utils.icon_manager import ima
 from spyder.utils.stylesheet import MAC, WIN
 from spyder.widgets.sidebardialog import SidebarDialog
-from spyder.utils.palette import SpyderPalette
-from spyder.utils.stylesheet import (
-    AppStyle, MAC, PREFERENCES_TABBAR_STYLESHEET, WIN)
 
 
 class ConfigDialog(SidebarDialog):
@@ -94,8 +92,11 @@ class ConfigDialog(SidebarDialog):
         super().add_page(page)
 
     def create_buttons(self):
-        bbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Apply |
-                                QDialogButtonBox.Cancel)
+        bbox = SpyderDialogButtonBox(
+            QDialogButtonBox.Ok
+            | QDialogButtonBox.Apply
+            | QDialogButtonBox.Cancel
+        )
         self.apply_btn = bbox.button(QDialogButtonBox.Apply)
 
         # This is needed for our tests

--- a/spyder/plugins/projects/widgets/projectdialog.py
+++ b/spyder/plugins/projects/widgets/projectdialog.py
@@ -22,6 +22,7 @@ from qtpy.QtWidgets import (QDialog, QDialogButtonBox, QGridLayout,
 
 # Local imports
 from spyder.api.widgets.comboboxes import SpyderComboBox
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.config.base import _, get_home_dir
 from spyder.utils.icon_manager import ima
 from spyder.utils.qthelpers import create_toolbutton
@@ -103,7 +104,7 @@ class ProjectDialog(QDialog):
         self.button_cancel = QPushButton(_('Cancel'))
         self.button_create = QPushButton(_('Create'))
 
-        self.bbox = QDialogButtonBox(Qt.Horizontal)
+        self.bbox = SpyderDialogButtonBox(orientation=Qt.Horizontal)
         self.bbox.addButton(self.button_cancel, QDialogButtonBox.ActionRole)
         self.bbox.addButton(self.button_create, QDialogButtonBox.ActionRole)
 

--- a/spyder/plugins/pythonpath/widgets/pathmanager.py
+++ b/spyder/plugins/pythonpath/widgets/pathmanager.py
@@ -22,6 +22,7 @@ from qtpy.QtWidgets import (QDialog, QDialogButtonBox, QHBoxLayout,
                             QVBoxLayout, QLabel)
 
 # Local imports
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.config.base import _
 from spyder.plugins.pythonpath.utils import check_path, get_system_pythonpath
@@ -97,7 +98,7 @@ class PathManager(QDialog, SpyderWidgetMixin):
         self.selection_widgets = []
         self.right_buttons = self._setup_right_toolbar()
         self.listwidget = QListWidget(self)
-        self.bbox = QDialogButtonBox(
+        self.bbox = SpyderDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         )
         self.button_ok = self.bbox.button(QDialogButtonBox.Ok)

--- a/spyder/plugins/run/widgets.py
+++ b/spyder/plugins/run/widgets.py
@@ -22,6 +22,7 @@ from qtpy.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox,
 # Local imports
 from spyder.api.translations import _
 from spyder.api.widgets.comboboxes import SpyderComboBox
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.plugins.run.api import (
     RunParameterFlags, WorkingDirSource, WorkingDirOpts,
     RunExecutionParameters, ExtendedRunExecutionParameters,
@@ -103,7 +104,7 @@ class BaseRunConfigDialog(QDialog):
 
     def add_button_box(self, stdbtns):
         """Create dialog button box and add it to the dialog layout"""
-        self.bbox = QDialogButtonBox(stdbtns)
+        self.bbox = SpyderDialogButtonBox(stdbtns)
 
         if not self.disable_run_btn:
             run_btn = self.bbox.addButton(

--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -233,11 +233,18 @@ class AppStylesheet(SpyderStyleSheet, SpyderConfigurationAccessor):
         # Adjust padding of QPushButton's in QDialog's
         for widget in ["QPushButton", "QPushButton:disabled"]:
             css[f"QDialog {widget}"].setValues(
-                padding='3px 15px 3px 15px',
+                padding=(
+                    f"{AppStyle.MarginSize + 1}px {5 * AppStyle.MarginSize}px"
+                ),
             )
 
         css["QDialogButtonBox QPushButton:!default"].setValues(
-            padding='3px 0px 3px 0px',
+            padding=f"{AppStyle.MarginSize + 1}px 0px",
+        )
+
+        # Remove icons in QMessageBoxes
+        css["QDialogButtonBox"]["dialogbuttonbox-buttons-have-icons"].setValue(
+            "0"
         )
 
         # Set font for widgets that don't inherit it from the application

--- a/spyder/widgets/dependencies.py
+++ b/spyder/widgets/dependencies.py
@@ -17,6 +17,7 @@ from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
 
 # Local imports
 from spyder import __version__
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.config.base import _
 from spyder.config.gui import is_dark_interface
 from spyder.dependencies import OPTIONAL, PLUGIN
@@ -127,7 +128,7 @@ class DependenciesDialog(QDialog):
 
         self.treewidget = DependenciesTreeWidget(self)
         self.copy_btn = QPushButton(_("Copy to clipboard"))
-        ok_btn = QDialogButtonBox(QDialogButtonBox.Ok)
+        ok_btn = SpyderDialogButtonBox(QDialogButtonBox.Ok)
 
         # Widget setup
         self.setWindowTitle(

--- a/spyder/widgets/sidebardialog.py
+++ b/spyder/widgets/sidebardialog.py
@@ -163,7 +163,9 @@ class SidebarDialog(QDialog, SpyderFontsMixin):
 
         layout = QVBoxLayout()
         layout.addLayout(contents_and_pages_layout)
-        layout.addSpacing(3)
+        layout.addSpacing(
+            - (2 * AppStyle.MarginSize) if MAC else AppStyle.MarginSize
+        )
         layout.addLayout(buttons_layout)
 
         self.setLayout(layout)

--- a/spyder/widgets/sidebardialog.py
+++ b/spyder/widgets/sidebardialog.py
@@ -29,6 +29,7 @@ from superqt.utils import qdebounced, signals_blocked
 
 # Local imports
 from spyder.api.config.fonts import SpyderFontType, SpyderFontsMixin
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.utils.icon_manager import ima
 from spyder.utils.palette import SpyderPalette
 from spyder.utils.stylesheet import (
@@ -208,7 +209,7 @@ class SidebarDialog(QDialog, SpyderFontsMixin):
 
         Override this method if you want different buttons in it.
         """
-        bbox = QDialogButtonBox(QDialogButtonBox.Ok)
+        bbox = SpyderDialogButtonBox(QDialogButtonBox.Ok)
 
         layout = QHBoxLayout()
         layout.addWidget(bbox)


### PR DESCRIPTION
## Description of Changes

- On Linux, Qt adds by default icons to the standard buttons used in dialogs (e.g. `Ok`, `Cancel` , `Reset`, etc). However, that usually doesn't look good in Spyder because those icons come the operating system icon theme. So, in this PR I decided to remove them.
- Increase vertical padding of buttons a bit (from `3px` to `4px`) to make them look better.
- Fix a visual glitch with the positioning of app menus on Windows and Linux.
- Fix an error displaying app menus on Mac.

### Visual changes

- No icons for buttons in dialogs and increased vertical padding for them

    Before | After
    -- | --
    ![imagen](https://github.com/spyder-ide/spyder/assets/365293/87172380-1114-41bd-adbc-4e81c58584e7) | ![imagen](https://github.com/spyder-ide/spyder/assets/365293/293ec095-a572-4867-b3e8-92ee34af7359)

- Visual glitch in app menus

    Before | After
    -- | --
    ![imagen](https://github.com/spyder-ide/spyder/assets/365293/d768acf3-967e-4ee5-8ef0-401655713544) | ![imagen](https://github.com/spyder-ide/spyder/assets/365293/c194625d-b890-45fc-9b94-a7949c0cc5c8)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
