### PR TITLE
PR: Fix starting kernels in conda envs placed in directories with spaces (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/scripts/conda-activate.bat
+++ b/spyder/plugins/ipythonconsole/scripts/conda-activate.bat
@@ -14,13 +14,13 @@ chcp 65001>nul
 echo %CONDA_ACTIVATE_SCRIPT%| findstr /e micromamba.exe>Nul && goto micromamba || goto conda
 
 :micromamba Activate using micromamba
-for /f %%i in ('"%CONDA_ACTIVATE_SCRIPT%" shell activate %CONDA_ENV_PATH%') do set SCRIPT=%%i
+for /f %%i in ('"%CONDA_ACTIVATE_SCRIPT%" shell activate "%CONDA_ENV_PATH%"') do set SCRIPT=%%i
 call %SCRIPT%
 goto start
 
 :conda Activate using conda
-call %CONDA_ACTIVATE_SCRIPT% %CONDA_ENV_PATH%
+call "%CONDA_ACTIVATE_SCRIPT%" "%CONDA_ENV_PATH%"
 goto start
 
 :start Start kernel
-%CONDA_ENV_PYTHON% -m spyder_kernels.console -f %SPYDER_KERNEL_SPEC%
+"%CONDA_ENV_PYTHON%" -m spyder_kernels.console -f %SPYDER_KERNEL_SPEC%

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1386,9 +1386,9 @@ class IPythonConsoleWidget(PluginMainWidget):
             import subprocess
             versions = {}
             pyexec = self.get_conf('executable', section='main_interpreter')
-            py_cmd = u'%s -c "import sys; print(sys.version)"' % pyexec
+            py_cmd = '"%s" -c "import sys; print(sys.version)"' % pyexec
             ipy_cmd = (
-                u'%s -c "import IPython.core.release as r; print(r.version)"'
+                '%s -c "import IPython.core.release as r; print(r.version)"'
                 % pyexec
             )
             for cmd in [py_cmd, ipy_cmd]:


### PR DESCRIPTION
## Description of Changes

This also fixes getting the Python version for external interpreters located in directories with spaces (getting the IPython version will be fixed in master because it requires additional changes).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21662.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
