### PR TITLE
PR: Prevent error when we don't get git output to update the `VCSStatus` widget (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/status.py
+++ b/spyder/plugins/editor/widgets/status.py
@@ -118,7 +118,13 @@ class VCSStatus(StatusBarWidget):
 
     def process_git_data(self, worker, output, error):
         """Receive data from git and update gui."""
-        branches, branch, files_modified = output
+        # Output can be None under some circumstances, so we need to deal with
+        # it here.
+        # Fixes spyder-ide/spyder#21865
+        if output is None:
+            branch, files_modified = None, []
+        else:
+            __, branch, files_modified = output
 
         text = branch if branch else ''
         if len(files_modified):


### PR DESCRIPTION
## Description of Changes

- The worker we use to get git output in order to update `VCSStatus` can return `None` sometimes.
- This PR deals with that possibility to not report an error to users.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21865.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
