### PR TITLE
PR: Update `pytest` constraint to `<8.0`

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -58,7 +58,7 @@ dependencies:
 - matplotlib
 - pandas
 - pillow
-- pytest <7.0
+- pytest <8.0
 - pytest-cov
 - pytest-lazy-fixture
 - pytest-mock

--- a/requirements/tests.yml
+++ b/requirements/tests.yml
@@ -11,7 +11,7 @@ dependencies:
   - matplotlib
   - pandas
   - pillow
-  - pytest <7.0
+  - pytest <8.0
   - pytest-cov
   - pytest-lazy-fixture
   - pytest-mock

--- a/setup.py
+++ b/setup.py
@@ -267,7 +267,7 @@ extras_require = {
         'matplotlib',
         'pandas',
         'pillow',
-        'pytest<7.0',
+        'pytest<8.0',
         'pytest-cov',
         'pytest-lazy-fixture',
         'pytest-mock',


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Latest `pytest-timeout` (2.3.1) seems like is not compatible with `pytest` 6.x. This doesn't affect pip slots over the CI since there the package version selected to be installed is 2.2.0 but seems like the constraint is missing for the conda-forge recipe so the environment ends up having `pytest` 6.2.5 and `pytest-timeout` 2.3.1. See https://github.com/conda-forge/pytest-timeout-feedstock/issues/19

Try to overcome this by updating the `pytest` contraint from `<7.0` to `<8.0`


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
