### PR TITLE
PR: Reapply dock tabbar style if previous session was a Spyder 6 one (Layout)

### DIFF
--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -208,6 +208,10 @@ class Layout(SpyderPluginV2):
         # interface.
         self.restore_visible_plugins()
 
+        # This is necessary to correctly display dock tabbars when the previous
+        # seesion was a Spyder 6 one.
+        self._reapply_docktabbar_style()
+
         # Update panes and toolbars lock status
         self.toggle_lock(self._interface_locked)
 
@@ -240,6 +244,24 @@ class Layout(SpyderPluginV2):
             text = _('Lock panes and toolbars')
         self.lock_interface_action.setIcon(icon)
         self.lock_interface_action.setText(text)
+
+    def _reapply_docktabbar_style(self):
+        """Reapply dock tabbar style if necessary."""
+        saved_state_version = self.get_conf(
+            "window_state_version", default=WINDOW_STATE_VERSION
+        )
+
+        # Reapplying style if the previous session was a Spyder 6 one, which
+        # has a higher window state version.
+        if saved_state_version > WINDOW_STATE_VERSION:
+            plugins = self.get_dockable_plugins()
+            for plugin in plugins:
+                if plugin.dockwidget.dock_tabbar is not None:
+                    plugin.dockwidget.dock_tabbar.setStyleSheet(
+                        plugin.dockwidget.dock_tabbar.filter._tabbar_stylesheet
+                    )
+
+            self.set_conf("window_state_version", WINDOW_STATE_VERSION)
 
     # ---- Helper methods
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## Description of Changes

- This is necessary if users start a Spyder 5 session after running a Spyder 6 one before.
- The reason is that we had to bump the window state version in Spyder 6 due to the migration of the Editor to the new API. And that requires reapplying the dock tabbar style because it's reset by Qt when a different state version is used.
- The changes in master to account for the inverse situation (i.e. starting Spyder 6 after a Spyder 5 session) are different. I'll apply them when merging this PR with that branch.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
