### PR TITLE
PR: Fix macOS check when defining installer name string for download (Installers)

### DIFF
--- a/spyder/workers/updates.py
+++ b/spyder/workers/updates.py
@@ -241,7 +241,7 @@ class WorkerDownloadInstaller(QObject):
             # conda-based installer name
             if os.name == 'nt':
                 plat, ext = 'Windows', 'exe'
-            elif platform.system == 'Darwin':
+            elif platform.system() == 'Darwin':
                 plat, ext = 'macOS', 'pkg'
             else:
                 plat, ext = 'Linux', 'sh'


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->
The validation used when defining the installer name to be downloaded (to go from 5.x to 6.x) was using `platform.system == 'Darwin'` instead of `platform.system() == 'Darwin'`. That causes that the `.sh` Linux installer gets downloaded for not only Linux but also macOS. Noticed this when trying to update Spyder 5.5.3 to 5.5.4 on macOS.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
