### PR TITLE
PR: Fix adding corner widgets in dockable plugins (API)

### DIFF
--- a/spyder/api/widgets/__init__.py
+++ b/spyder/api/widgets/__init__.py
@@ -7,3 +7,17 @@
 """
 Widgets to extend Spyder through its API.
 """
+
+
+class PluginMainWidgetWidgets:
+    CornerWidget = 'corner_widget'
+    MainToolbar = 'main_toolbar_widget'
+    OptionsToolButton = 'options_button_widget'
+    Spinner = 'spinner_widget'
+
+
+class PluginMainWidgetActions:
+    ClosePane = 'close_pane'
+    DockPane = 'dock_pane'
+    UndockPane = 'undock_pane'
+    LockUnlockPosition = 'lock_unlock_position'

--- a/spyder/api/widgets/auxiliary_widgets.py
+++ b/spyder/api/widgets/auxiliary_widgets.py
@@ -85,26 +85,31 @@ class MainCornerWidget(QToolBar):
         self._strut.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.addWidget(self._strut)
 
-    def add_widget(self, widget_id, widget):
+    def add_widget(self, widget):
         """
         Add a widget to the left of the last widget added to the corner.
         """
-        if widget_id in self._widgets:
+        if not hasattr(widget, "name"):
+            raise SpyderAPIError(
+                "Widget doesn't have a name, provided by the attribute `name`"
+            )
+
+        if widget.name in self._widgets:
             raise SpyderAPIError(
                 'Wigdet with name "{}" already added. Current names are: {}'
-                ''.format(widget_id, list(self._widgets.keys()))
+                ''.format(widget.name, list(self._widgets.keys()))
             )
 
         if (
             not self._widgets
-            and widget_id != PluginMainWidgetWidgets.OptionsToolButton
+            and widget.name != PluginMainWidgetWidgets.OptionsToolButton
         ):
             raise SpyderAPIError(
                 "The options button must be the first one to be added to the "
                 "corner widget of dockable plugins."
             )
 
-        if widget_id == PluginMainWidgetWidgets.OptionsToolButton:
+        if widget.name == PluginMainWidgetWidgets.OptionsToolButton:
             # This is only necessary for the options button because it's the
             # first one to be added
             action = self.addWidget(widget)
@@ -112,8 +117,7 @@ class MainCornerWidget(QToolBar):
             # All other buttons are added to the left of the last one
             action = self.insertWidget(self._actions[-1], widget)
 
-        widget.ID = widget_id
-        self._widgets[widget_id] = widget
+        self._widgets[widget.name] = widget
         self._actions.append(action)
 
     def get_widget(self, widget_id):

--- a/spyder/api/widgets/auxiliary_widgets.py
+++ b/spyder/api/widgets/auxiliary_widgets.py
@@ -85,19 +85,27 @@ class MainCornerWidget(QToolBar):
         self._strut.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.addWidget(self._strut)
 
-    def add_widget(self, widget):
+    def add_widget(self, widget, before=None):
         """
         Add a widget to the left of the last widget added to the corner.
         """
-        if not hasattr(widget, "name"):
+        if not hasattr(widget, "name") or (
+            before is not None and not hasattr(before, "name")
+        ):
             raise SpyderAPIError(
-                "Widget doesn't have a name, provided by the attribute `name`"
+                f"Widget {widget} or {before} doesn't have a name, which must "
+                f"be provided by the attribute `name`"
             )
 
         if widget.name in self._widgets:
             raise SpyderAPIError(
                 'Wigdet with name "{}" already added. Current names are: {}'
                 ''.format(widget.name, list(self._widgets.keys()))
+            )
+
+        if before is not None and before.name not in self._widgets:
+            raise SpyderAPIError(
+                f"Wigdet with name '{before.name}' not in this corner widget"
             )
 
         if (
@@ -114,13 +122,31 @@ class MainCornerWidget(QToolBar):
             # first one to be added
             action = self.addWidget(widget)
         else:
-            # All other buttons are added to the left of the last one
-            action = self.insertWidget(self._actions[-1], widget)
+            if before is not None:
+                before_action = self.get_action(before.name)
+            else:
+                # By default other buttons are added to the left of the last
+                # one
+                before_action = self._actions[-1]
 
-        self._widgets[widget.name] = widget
+            # Allow to add either widgets or actions
+            if isinstance(widget, QWidget):
+                action = self.insertWidget(before_action, widget)
+            else:
+                action = widget
+                self.insertAction(before_action, action)
+                widget = self.widgetForAction(action)
+                widget.name = action.name
+
+        self._widgets[widget.name] = (widget, action)
         self._actions.append(action)
 
     def get_widget(self, widget_id):
         """Return a widget by unique id."""
         if widget_id in self._widgets:
-            return self._widgets[widget_id]
+            return self._widgets[widget_id][0]
+
+    def get_action(self, widget_id):
+        """Return action corresponding to `widget_id`."""
+        if widget_id in self._widgets:
+            return self._widgets[widget_id][1]

--- a/spyder/api/widgets/auxiliary_widgets.py
+++ b/spyder/api/widgets/auxiliary_widgets.py
@@ -14,6 +14,7 @@ from qtpy.QtWidgets import QMainWindow, QSizePolicy, QToolBar, QWidget
 
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
+from spyder.api.widgets import PluginMainWidgetWidgets
 from spyder.api.widgets.mixins import SpyderMainWindowMixin
 from spyder.utils.stylesheet import APP_STYLESHEET
 
@@ -94,9 +95,26 @@ class MainCornerWidget(QToolBar):
                 ''.format(widget_id, list(self._widgets.keys()))
             )
 
+        if (
+            not self._widgets
+            and widget_id != PluginMainWidgetWidgets.OptionsToolButton
+        ):
+            raise SpyderAPIError(
+                "The options button must be the first one to be added to the "
+                "corner widget of dockable plugins."
+            )
+
+        if widget_id == PluginMainWidgetWidgets.OptionsToolButton:
+            # This is only necessary for the options button because it's the
+            # first one to be added
+            action = self.addWidget(widget)
+        else:
+            # All other buttons are added to the left of the last one
+            action = self.insertWidget(self._actions[-1], widget)
+
         widget.ID = widget_id
         self._widgets[widget_id] = widget
-        self._actions.append(self.addWidget(widget))
+        self._actions.append(action)
 
     def get_widget(self, widget_id):
         """Return a widget by unique id."""

--- a/spyder/api/widgets/main_container.py
+++ b/spyder/api/widgets/main_container.py
@@ -16,10 +16,10 @@ from qtpy import PYQT5, PYQT6
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QWidget
 
-from spyder.api.widgets.mixins import SpyderToolbarMixin, SpyderWidgetMixin
+from spyder.api.widgets.mixins import SpyderWidgetMixin
 
 
-class PluginMainContainer(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
+class PluginMainContainer(QWidget, SpyderWidgetMixin):
     """
     Spyder plugin main container class.
 

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -33,7 +33,7 @@ from spyder.api.widgets.menus import (
     OptionsMenuSections,
     PluginMainWidgetMenus
 )
-from spyder.api.widgets.mixins import SpyderToolbarMixin, SpyderWidgetMixin
+from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.api.widgets.toolbars import MainWidgetToolbar
 from spyder.py3compat import qbytearray_to_str
 from spyder.utils.qthelpers import create_waitspinner
@@ -49,7 +49,7 @@ from spyder.widgets.tabs import Tabs
 logger = logging.getLogger(__name__)
 
 
-class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
+class PluginMainWidget(QWidget, SpyderWidgetMixin):
     """
     Spyder plugin main widget class.
 

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -501,26 +501,26 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
 
         return ACTION_REGISTRY.get_reference(name, plugin, context)
 
-    def add_corner_widget(self, widget, before=None):
+    def add_corner_widget(self, action_or_widget, before=None):
         """
         Add widget to corner, that is to the left of the last added widget.
 
         Parameters
         ----------
-        widget: QWidget
-            Any QWidget to add in the corner widget.
-        before: QWidget
-            Insert the widget before this widget.
+        action_or_widget: QAction or QWidget
+            Any action or widget to add to the corner widget.
+        before: QAction or QWidget
+            Insert action_or_widget before this one.
 
         Notes
         -----
         By default widgets are added to the left of the last corner widget.
 
         The central widget provides an options menu button and a spinner so any
-        additional widgets will be placed to the left of the spinner,
-        if visible.
+        additional widgets will be placed by default to the left of the
+        spinner, if visible.
         """
-        self._corner_widget.add_widget(widget)
+        self._corner_widget.add_widget(action_or_widget, before=before)
 
     def get_corner_widget(self, name):
         """

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -25,6 +25,7 @@ from qtpy.QtWidgets import (QApplication, QHBoxLayout, QSizePolicy,
 
 # Local imports
 from spyder.api.translations import _
+from spyder.api.widgets import PluginMainWidgetActions, PluginMainWidgetWidgets
 from spyder.api.widgets.auxiliary_widgets import (MainCornerWidget,
                                                   SpyderWindowWidget)
 from spyder.api.widgets.menus import (
@@ -46,20 +47,6 @@ from spyder.widgets.tabs import Tabs
 
 # Logging
 logger = logging.getLogger(__name__)
-
-
-class PluginMainWidgetWidgets:
-    CornerWidget = 'corner_widget'
-    MainToolbar = 'main_toolbar_widget'
-    OptionsToolButton = 'options_button_widget'
-    Spinner = 'spinner_widget'
-
-
-class PluginMainWidgetActions:
-    ClosePane = 'close_pane'
-    DockPane = 'dock_pane'
-    UndockPane = 'undock_pane'
-    LockUnlockPosition = 'lock_unlock_position'
 
 
 class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -244,7 +244,9 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
         self._spinner = None
 
         if self.ENABLE_SPINNER:
-            self._spinner = create_waitspinner(size=16, parent=self)
+            self._spinner = create_waitspinner(
+                size=16, parent=self, name=PluginMainWidgetWidgets.Spinner
+            )
 
         self._corner_widget = MainCornerWidget(
             parent=self,
@@ -335,16 +337,10 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
             icon=self.create_icon('tooloptions'),
         )
 
-        self.add_corner_widget(
-            PluginMainWidgetWidgets.OptionsToolButton,
-            self._options_button,
-        )
+        self.add_corner_widget(self._options_button)
 
         if self.ENABLE_SPINNER:
-            self.add_corner_widget(
-                PluginMainWidgetWidgets.Spinner,
-                self._spinner,
-            )
+            self.add_corner_widget(self._spinner)
 
         # Widget setup
         # --------------------------------------------------------------------
@@ -505,14 +501,12 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
 
         return ACTION_REGISTRY.get_reference(name, plugin, context)
 
-    def add_corner_widget(self, widget_id, widget, before=None):
+    def add_corner_widget(self, widget, before=None):
         """
         Add widget to corner, that is to the left of the last added widget.
 
         Parameters
         ----------
-        widget_id: str
-            Unique name of the widget.
         widget: QWidget
             Any QWidget to add in the corner widget.
         before: QWidget
@@ -526,7 +520,7 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
         additional widgets will be placed to the left of the spinner,
         if visible.
         """
-        self._corner_widget.add_widget(widget_id, widget)
+        self._corner_widget.add_widget(widget)
 
     def get_corner_widget(self, name):
         """

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -335,16 +335,16 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin, SpyderToolbarMixin):
             icon=self.create_icon('tooloptions'),
         )
 
+        self.add_corner_widget(
+            PluginMainWidgetWidgets.OptionsToolButton,
+            self._options_button,
+        )
+
         if self.ENABLE_SPINNER:
             self.add_corner_widget(
                 PluginMainWidgetWidgets.Spinner,
                 self._spinner,
             )
-
-        self.add_corner_widget(
-            PluginMainWidgetWidgets.OptionsToolButton,
-            self._options_button,
-        )
 
         # Widget setup
         # --------------------------------------------------------------------

--- a/spyder/plugins/ipythonconsole/api.py
+++ b/spyder/plugins/ipythonconsole/api.py
@@ -127,3 +127,9 @@ class ClientContextMenuActions:
     # Svg section
     CopySvg = 'copy_svg'
     SaveSvg = 'save_svg'
+
+
+class IPythonConsoleWidgetCornerWidgets:
+    ResetButton = "reset_button"
+    InterruptButton = "interrupt_button"
+    TimeElapsedLabel = "time_elapsed_label"

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -636,9 +636,9 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
         self.time_label = QLabel("")
 
         # --- Add tab corner widgets.
-        self.add_corner_widget('timer', self.time_label)
-        self.add_corner_widget('reset', self.reset_button)
         self.add_corner_widget('start_interrupt', self.stop_button)
+        self.add_corner_widget('reset', self.reset_button)
+        self.add_corner_widget('timer', self.time_label)
 
         # --- Tabs context menu
         tabs_context_menu = self.create_menu(

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -38,6 +38,7 @@ from spyder.plugins.ipythonconsole.api import (
     ClientContextMenuActions,
     IPythonConsoleWidgetActions,
     IPythonConsoleWidgetMenus,
+    IPythonConsoleWidgetCornerWidgets,
     IPythonConsoleWidgetOptionsMenuSections,
     IPythonConsoleWidgetTabsContextMenuSections
 )
@@ -620,25 +621,28 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
 
         # --- Widgets for the tab corner
         self.reset_button = self.create_toolbutton(
-            'reset',
+            IPythonConsoleWidgetCornerWidgets.ResetButton,
             text=_("Remove all variables"),
-            tip=_("Remove all variables from kernel namespace"),
+            tip=_("Remove all variables from namespace"),
             icon=self.create_icon("editdelete"),
             triggered=self.reset_namespace,
         )
         self.stop_button = self.create_toolbutton(
-            'interrupt',
+            IPythonConsoleWidgetCornerWidgets.InterruptButton,
             text=_("Interrupt kernel"),
             tip=_("Interrupt kernel"),
             icon=self.create_icon('stop'),
             triggered=self.interrupt_kernel,
         )
         self.time_label = QLabel("")
+        self.time_label.name = (
+            IPythonConsoleWidgetCornerWidgets.TimeElapsedLabel
+        )
 
         # --- Add tab corner widgets.
-        self.add_corner_widget('start_interrupt', self.stop_button)
-        self.add_corner_widget('reset', self.reset_button)
-        self.add_corner_widget('timer', self.time_label)
+        self.add_corner_widget(self.stop_button)
+        self.add_corner_widget(self.reset_button)
+        self.add_corner_widget(self.time_label)
 
         # --- Tabs context menu
         tabs_context_menu = self.create_menu(

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -447,18 +447,16 @@ class VariableExplorerWidget(ShellConnectMainWidget):
             toggled=self._enable_filter_actions,
             option='filter_on',
             tip=_("Filter variables")
-            )
+        )
         self.filter_button.setCheckable(True)
         self.filter_button.toggled.connect(self._set_filter_button_state)
 
-        corner_widget = self._corner_widget
-        for action in corner_widget.actions():
-            if action.defaultWidget() == self.get_options_menu_button():
-                options_menu_action = action
-
-        for action in [self.search_action, self.filter_button,
-                       self.refresh_action]:
-            corner_widget.insertAction(options_menu_action, action)
+        for action in [
+            self.search_action,
+            self.filter_button,
+            self.refresh_action,
+        ]:
+            self.add_corner_widget(action, before=self._options_button)
 
     def update_actions(self):
         """Update the actions."""

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -293,7 +293,7 @@ def create_toolbutton(parent, text=None, shortcut=None, icon=None, tip=None,
     return button
 
 
-def create_waitspinner(size=32, n=11, parent=None):
+def create_waitspinner(size=32, n=11, parent=None, name=None):
     """
     Create a wait spinner with the specified size built with n circling dots.
     """
@@ -313,6 +313,8 @@ def create_waitspinner(size=32, n=11, parent=None):
     spinner.setLineWidth(dot_size)
     spinner.setInnerRadius(inner_radius)
     spinner.setColor(SpyderPalette.COLOR_TEXT_1)
+
+    spinner.name = name
 
     return spinner
 


### PR DESCRIPTION
## Description of Changes

- Corner widgets were not added in the right order after #21353. This is clear for the IPython console corner widgets, as seen below.
- Fix `before` kwarg of `PluginMainWidget.add_corner_widget` and remove the need to pass an ID to it to make it simpler.
- Allow to pass actions (i.e. not only widgets) to `PluginMainWidget.add_corner_widget`.
- Use these fixes to add corner widgets to the Variable Explorer using our API.

### Visual changes

| Before | After
| - | - |
| ![image](https://github.com/spyder-ide/spyder/assets/365293/53ee9663-6d93-4cc1-b161-31929d6ab940) | ![image](https://github.com/spyder-ide/spyder/assets/365293/67a3b7e0-4b34-4681-b901-9ab75fe427ab)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
