### PR TITLE
PR: Improve drag & drop out of file explorer plugin

### DIFF
--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -865,7 +865,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
     def startDrag(self, dropActions):
         """Reimplement Qt Method - handle drag event"""
         data = QMimeData()
-        data.setUrls([QUrl(fname) for fname in self.get_selected_filenames()])
+        data.setUrls([QUrl.fromLocalFile(fname) for fname in self.get_selected_filenames()])
         drag = QDrag(self)
         drag.setMimeData(data)
         drag.exec_()


### PR DESCRIPTION
## Description of Changes

We discovered issues with drag & drop out of the file explorer plugin, both on Linux (GNOME) and Windows. This PR improves (fixes) drag & drop out of the the file explorer plugin.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:

rear1019
