### PR TITLE
PR: Quote kernel connection file in conda activation script (IPython Console)

### DIFF
--- a/spyder/plugins/ipythonconsole/scripts/conda-activate.bat
+++ b/spyder/plugins/ipythonconsole/scripts/conda-activate.bat
@@ -24,4 +24,4 @@ call "%CONDA_ACTIVATE_SCRIPT%" "%CONDA_ENV_PATH%"
 goto start
 
 :start Start kernel
-"%CONDA_ENV_PYTHON%" -m spyder_kernels.console -f %SPYDER_KERNEL_SPEC%
+"%CONDA_ENV_PYTHON%" -m spyder_kernels.console -f "%SPYDER_KERNEL_SPEC%"


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Kernel connection file argument needs to be quoted to prevent trying to use a faulty started kernel when the connection file path used has spaces (when, for example, the current user account name has spaces).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21937


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
