### PR TITLE
PR: Make Matplotlib status bar widget show the right backend and fix some errors related to kernel restarts for options that require them

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/ccordoba12/spyder-kernels.git
-	branch = mpl-fixes
-	commit = 2bc4687625c5ad9d1a5e28e6578ac16a789b371b
-	parent = f066ce713282e0b41d5a4abedf39ab4221e8de4b
+	remote = https://github.com/spyder-ide/spyder-kernels.git
+	branch = master
+	commit = 4ecb144341da8ed59a6aca1d74a8a29b01623191
+	parent = bba8dbe36d1bc64fa3f045f5ceb1f7874d7d4963
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = master
-	commit = 6110b633226183eba4e95a6d20ca9fe83e57493a
-	parent = 5db16784347b876cb2ae9319c5d3adbe9647f889
+	remote = https://github.com/ccordoba12/spyder-kernels.git
+	branch = mpl-fixes
+	commit = 2bc4687625c5ad9d1a5e28e6578ac16a789b371b
+	parent = f066ce713282e0b41d5a4abedf39ab4221e8de4b
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/comms/utils.py
+++ b/external-deps/spyder-kernels/spyder_kernels/comms/utils.py
@@ -53,7 +53,13 @@ class WriteWrapper(object):
             # Fixes spyder-ide/spyder-kernels#343
             'DeprecationWarning',
             # Fixes spyder-ide/spyder-kernels#365
-            'IOStream.flush timed out'
+            'IOStream.flush timed out',
+            # Avoid unnecessary messages from set_configuration when changing
+            # Matplotlib options.
+            "Warning: Cannot change to a different GUI toolkit",
+            "%pylab is deprecated",
+            "Populating the interactive namespace",
+            "\n"
         ]
 
         return any([msg in message for msg in benign_messages])

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -23,7 +23,7 @@ import threading
 
 # Third-party imports
 from ipykernel.ipkernel import IPythonKernel
-from ipykernel import eventloops, get_connection_info
+from ipykernel import get_connection_info
 from traitlets.config.loader import LazyConfigValue
 import zmq
 from zmq.utils.garbage import gc
@@ -75,6 +75,9 @@ class SpyderKernel(IPythonKernel):
 
         # Socket to signal shell_stream locally
         self.loopback_socket = None
+
+        # To track the interactive backend
+        self.interactive_backend = None
 
     @property
     def kernel_info(self):
@@ -505,43 +508,20 @@ class SpyderKernel(IPythonKernel):
         Get current Matplotlib interactive backend.
 
         This is different from the current backend because, for instance, the
-        user can set first the Qt5 backend, then the Inline one. In that case,
-        the current backend is Inline, but the current interactive one is Qt5,
+        user can set first the Qt backend, then the Inline one. In that case,
+        the current backend is Inline, but the current interactive one is Qt,
         and this backend can't be changed without a kernel restart.
         """
-        # Mapping from frameworks to backend names.
-        mapping = {
-            'qt': 'QtAgg',
-            'tk': 'TkAgg',
-            'macosx': 'MacOSX'
-        }
-
-        # --- Get interactive framework
-        framework = None
-
-        # Detect if there is a graphical framework running by checking the
-        # eventloop function attached to the kernel.eventloop attribute (see
-        # `ipykernel.eventloops.enable_gui` for context).
-        loop_func = self.eventloop
-
-        if loop_func is not None:
-            if loop_func == eventloops.loop_tk:
-                framework = 'tk'
-            elif loop_func == eventloops.loop_qt5:
-                framework = 'qt'
-            elif loop_func == eventloops.loop_cocoa:
-                framework = 'macosx'
-            else:
-                # Spyder doesn't handle other backends
-                framework = 'other'
+        # Backends that Spyder can handle
+        recognized_backends = {'qt', 'tk', 'macosx'}
 
         # --- Return backend according to framework
-        if framework is None:
-            # Since no interactive backend has been set yet, this is
-            # equivalent to having the inline one.
+        if self.interactive_backend is None:
+            # Since no interactive backend has been set yet, this is equivalent
+            # to having the inline one.
             return 'inline'
-        elif framework in mapping:
-            return MPL_BACKENDS_TO_SPYDER[mapping[framework]]
+        elif self.interactive_backend in recognized_backends:
+            return self.interactive_backend
         else:
             # This covers the case of other backends (e.g. Wx or Gtk)
             # which users can set interactively with the %matplotlib

--- a/external-deps/spyder-kernels/spyder_kernels/console/shell.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/shell.py
@@ -87,7 +87,19 @@ class SpyderShell(ZMQInteractiveShell):
         """Enable matplotlib."""
         if gui is None or gui.lower() == "auto":
             gui = automatic_backend()
-        gui, backend = super(SpyderShell, self).enable_matplotlib(gui)
+
+        enabled_gui, backend = super().enable_matplotlib(gui)
+
+        # This is necessary for IPython 8.24+, which returns None after
+        # enabling the Inline backend.
+        if enabled_gui is None and gui == "inline":
+            enabled_gui = "inline"
+        gui = enabled_gui
+
+        # To easily track the current interactive backend
+        if self.kernel.interactive_backend is None:
+            self.kernel.interactive_backend = gui if gui != "inline" else None
+
         if self.update_gui_frontend:
             try:
                 self.kernel.frontend_call(
@@ -95,6 +107,7 @@ class SpyderShell(ZMQInteractiveShell):
                 ).update_matplotlib_gui(gui)
             except Exception:
                 pass
+
         return gui, backend
 
     # --- For Pdb namespace integration

--- a/spyder/plugins/ipythonconsole/confpage.py
+++ b/spyder/plugins/ipythonconsole/confpage.py
@@ -116,13 +116,7 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         inline = _("Inline")
         automatic = _("Automatic")
         backend_group = QGroupBox(_("Graphics backend"))
-        bend_label = QLabel(_("Decide how graphics are going to be displayed "
-                              "in the console. If unsure, please select "
-                              "<b>%s</b> to put graphics inside the "
-                              "console or <b>%s</b> to interact with "
-                              "them (through zooming and panning) in a "
-                              "separate window.") % (inline, automatic))
-        bend_label.setWordWrap(True)
+        bend_label = QLabel(_("Decide how Matplotlib graphics are displayed"))
 
         backends = [
             (inline, 'inline'),
@@ -139,8 +133,12 @@ class IPythonConsoleConfigPage(PluginConfigPage):
             _("Backend:") + "   ",
             backends,
             'pylab/backend', default='inline',
-            tip=_("This option will be applied the next time a console is "
-                  "opened."))
+            tip=_(
+                "If unsure, select <b>%s</b> to put graphics in the Plots "
+                "pane or <b>%s</b> to interact with them (through zooming and "
+                "panning) in a separate window."
+            ) % (inline, automatic)
+        )
 
         backend_layout = QVBoxLayout()
         backend_layout.addWidget(bend_label)

--- a/spyder/plugins/ipythonconsole/confpage.py
+++ b/spyder/plugins/ipythonconsole/confpage.py
@@ -98,12 +98,14 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         pylab_group = QGroupBox(_("Support for graphics (Matplotlib)"))
         pylab_box = newcb(_("Activate support"), 'pylab')
         autoload_pylab_box = newcb(
-            _("Automatically load Pylab and NumPy modules"),
+            _("Automatically load Matplotlib and NumPy modules"),
             'pylab/autoload',
-            tip=_("This lets you load graphics support without importing\n"
-                  "the commands to do plots. Useful to work with other\n"
-                  "plotting libraries different to Matplotlib or to develop\n"
-                  "GUIs with Spyder."))
+            tip=_(
+                "This lets you generate graphics and work with arrays "
+                "<b>without</b> importing the commands to do it. It's also "
+                "useful to develop GUIs with Spyder."
+            )
+        )
         autoload_pylab_box.setEnabled(self.get_option('pylab'))
         pylab_box.checkbox.toggled.connect(autoload_pylab_box.setEnabled)
 

--- a/spyder/plugins/ipythonconsole/confpage.py
+++ b/spyder/plugins/ipythonconsole/confpage.py
@@ -127,8 +127,8 @@ class IPythonConsoleConfigPage(PluginConfigPage):
         backends = [
             (inline, 'inline'),
             (automatic, 'auto'),
-            ("Qt5", 'qt'),
-            ("Tkinter", 'tk')
+            ("Qt", 'qt'),
+            ("Tk", 'tk')
         ]
 
         if sys.platform == 'darwin':

--- a/spyder/plugins/ipythonconsole/tests/conftest.py
+++ b/spyder/plugins/ipythonconsole/tests/conftest.py
@@ -207,6 +207,7 @@ def ipyconsole(qtbot, request, tmpdir):
     debugger.on_ipython_console_available()
     console.on_initialize()
     console._register()
+    console.get_widget().matplotlib_status.register_ipythonconsole(console)
     console.create_new_client(
         special=special,
         given_name=given_name,

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -2094,6 +2094,7 @@ def test_startup_run_lines_project_directory(ipyconsole, qtbot, tmpdir):
     qtbot.waitUntil(
         lambda: shell.spyder_kernel_ready and shell._prompt_html is not None,
         timeout=SHELL_TIMEOUT)
+    qtbot.wait(500)
     assert shell.get_value('pi')
 
     # Reset config for the 'spyder_pythonpath' and 'startup/run_lines'

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -21,7 +21,6 @@ from unittest.mock import patch
 
 # Third party imports
 from ipykernel._version import __version__ as ipykernel_version
-import IPython
 from IPython.core import release as ipy_release
 from IPython.core.application import get_ipython_dir
 from flaky import flaky
@@ -1909,17 +1908,61 @@ def test_pdb_comprehension_namespace(ipyconsole, qtbot, tmpdir):
         assert "_spyderpdb" not in key
 
 
-@flaky(max_runs=3)
+@flaky(max_runs=10)
 @pytest.mark.auto_backend
-def test_restart_intertactive_backend(ipyconsole, qtbot):
+@pytest.mark.skipif(os.name == 'nt', reason="Fails on windows")
+def test_restart_interactive_backend(ipyconsole, qtbot):
     """
-    Test that we ask for a restart after switching to a different interactive
-    backend in preferences.
+    Test that we ask for a restart or not after switching to different
+    interactive backends.
+
+    Also, check that we show the right backend in the Matplotlib status widget.
     """
-    main_widget = ipyconsole.get_widget()
-    qtbot.wait(1000)
-    main_widget.change_possible_restart_and_mpl_conf('pylab/backend', 'tk')
+    shell = ipyconsole.get_current_shellwidget()
+    matplotlib_status = ipyconsole.get_widget().matplotlib_status
+
+    # This is necessary to test no spurious messages are printed to the console
+    shell.clear_console()
+    qtbot.waitUntil(lambda: '\nIn [2]: ' == shell._control.toPlainText())
+
+    # Switch to the tk backend
+    ipyconsole.set_conf('pylab/backend', 'tk')
     assert bool(os.environ.get('BACKEND_REQUIRE_RESTART'))
+    assert shell.get_matplotlib_backend() == "qt"
+    assert matplotlib_status.value == "Qt"
+
+    # Switch to the inline backend
+    os.environ.pop('BACKEND_REQUIRE_RESTART')
+    ipyconsole.set_conf('pylab/backend', 'inline')
+    assert not bool(os.environ.get('BACKEND_REQUIRE_RESTART'))
+    qtbot.waitUntil(lambda: shell.get_matplotlib_backend() == "inline")
+    assert matplotlib_status.value == "Inline"
+
+    # Switch to the auto backend
+    ipyconsole.set_conf('pylab/backend', 'auto')
+    assert not bool(os.environ.get('BACKEND_REQUIRE_RESTART'))
+    qtbot.waitUntil(lambda: shell.get_matplotlib_backend() == "qt")
+    assert matplotlib_status.value == "Qt"
+
+    # Switch to the qt backend
+    ipyconsole.set_conf('pylab/backend', 'qt')
+    assert not bool(os.environ.get('BACKEND_REQUIRE_RESTART'))
+    assert matplotlib_status.value == "Qt"
+
+    # Switch to the tk backend again
+    ipyconsole.set_conf('pylab/backend', 'tk')
+    assert bool(os.environ.get('BACKEND_REQUIRE_RESTART'))
+
+    # Check we no spurious messages are shown before the restart below
+    assert "\nIn [2]: " == shell._control.toPlainText()
+
+    # Restart kernel to check if the new interactive backend is set
+    ipyconsole.restart_kernel()
+    qtbot.waitUntil(lambda: shell.spyder_kernel_ready, timeout=SHELL_TIMEOUT)
+    qtbot.wait(SHELL_TIMEOUT)
+    qtbot.waitUntil(lambda: shell.get_matplotlib_backend() == "tk")
+    assert shell.get_mpl_interactive_backend() == "tk"
+    assert matplotlib_status.value == "Tk"
 
 
 def test_mpl_conf(ipyconsole, qtbot):

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -966,21 +966,21 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
                 else:
                     # Must ask the kernel. Will not work if the kernel was set
                     # to another backend and is not now inline
-                    interactive_backend = (
-                        client.shellwidget.get_mpl_interactive_backend()
-                    )
+                    interactive_backend = sw.get_mpl_interactive_backend()
 
                 if (
                     # There was an error getting the interactive backend in
                     # the kernel, so we can't proceed.
-                    interactive_backend is not None and
+                    interactive_backend is not None
                     # There has to be an interactive backend (i.e. different
                     # from inline) set in the kernel before. Else, a restart
                     # is not necessary.
-                    interactive_backend != inline_backend and
+                    and interactive_backend != inline_backend
                     # The interactive backend to switch to has to be different
                     # from the current one
-                    interactive_backend != pylab_backend_o
+                    and interactive_backend != pylab_backend_o
+                    # There's no need to request a restart for the auto backend
+                    and pylab_backend_o != "auto"
                 ):
                     clients_backend_require_restart.append(True)
 

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -875,14 +875,25 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
                 client.shellwidget.set_autocall,
                 value)
 
-    @on_conf_change(option=[
-        'symbolic_math', 'hide_cmd_windows',
-        'startup/run_lines', 'startup/use_run_file', 'startup/run_file',
-        'pylab', 'pylab/backend', 'pylab/autoload',
-        'pylab/inline/figure_format', 'pylab/inline/resolution',
-        'pylab/inline/width', 'pylab/inline/height',
-        'pylab/inline/fontsize', 'pylab/inline/bottom',
-        'pylab/inline/bbox_inches'])
+    @on_conf_change(
+        option=[
+            "symbolic_math",
+            "hide_cmd_windows",
+            "startup/run_lines",
+            "startup/use_run_file",
+            "startup/run_file",
+            "pylab",
+            "pylab/backend",
+            "pylab/autoload",
+            "pylab/inline/figure_format",
+            "pylab/inline/resolution",
+            "pylab/inline/width",
+            "pylab/inline/height",
+            "pylab/inline/fontsize",
+            "pylab/inline/bottom",
+            "pylab/inline/bbox_inches",
+        ]
+    )
     def change_possible_restart_and_mpl_conf(self, option, value):
         """
         Apply options that possibly require a kernel restart or related to
@@ -898,7 +909,9 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
 
         restart_needed = False
         restart_options = []
+
         # Startup options (needs a restart)
+        autoload_n = "pylab/autoload"
         run_lines_n = 'startup/run_lines'
         use_run_file_n = 'startup/use_run_file'
         run_file_n = 'startup/run_file'
@@ -912,8 +925,14 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
         symbolic_math_n = 'symbolic_math'
         hide_cmd_windows_n = 'hide_cmd_windows'
 
-        restart_options += [run_lines_n, use_run_file_n, run_file_n,
-                            symbolic_math_n, hide_cmd_windows_n]
+        restart_options += [
+            autoload_n,
+            run_lines_n,
+            use_run_file_n,
+            run_file_n,
+            symbolic_math_n,
+            hide_cmd_windows_n,
+        ]
         restart_needed = option in restart_options
 
         inline_backend = 'inline'
@@ -993,6 +1012,11 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
             )
 
             if not (restart and restart_all) or no_restart:
+                # Autoload can't be applied without a restart. This avoids an
+                # incorrect message in the console too.
+                if autoload_n in options:
+                    options.pop(autoload_n)
+
                 sw = client.shellwidget
                 if sw.is_debugging() and sw._executing:
                     # Apply conf when the next Pdb prompt is available

--- a/spyder/plugins/ipythonconsole/widgets/restartdialog.py
+++ b/spyder/plugins/ipythonconsole/widgets/restartdialog.py
@@ -22,7 +22,7 @@ from qtpy.QtWidgets import (
 
 # Local imports
 from spyder.config.base import _
-from spyder.utils.stylesheet import AppStyle
+from spyder.utils.stylesheet import AppStyle, MAC
 
 
 class ConsoleRestartDialog(QDialog):
@@ -99,7 +99,9 @@ class ConsoleRestartDialog(QDialog):
         layout.addWidget(self._no_restart_btn)
         layout.addWidget(self._restart_current_btn)
         layout.addWidget(self._restart_all_btn)
-        layout.addSpacing(3 * AppStyle.MarginSize)
+        layout.addSpacing(
+            2 * AppStyle.MarginSize if MAC else 3 * AppStyle.MarginSize
+        )
         layout.addWidget(self._action_button, 0, Qt.AlignRight)
         layout.setContentsMargins(*((7 * AppStyle.MarginSize,) * 4))
         self.setLayout(layout)

--- a/spyder/plugins/ipythonconsole/widgets/status.py
+++ b/spyder/plugins/ipythonconsole/widgets/status.py
@@ -53,9 +53,9 @@ class MatplotlibStatus(StatusBarWidget, ShellConnectMixin):
         if shellwidget_id in self._shellwidget_dict:
             self._shellwidget_dict[shellwidget_id]["gui"] = gui
             if shellwidget_id == self._current_id:
-                self.update(gui)
+                self.update_status(gui)
 
-    def update(self, gui):
+    def update_status(self, gui):
         """Update interactive state."""
         self._gui = gui
         if gui == "inline":
@@ -93,7 +93,7 @@ class MatplotlibStatus(StatusBarWidget, ShellConnectMixin):
         self._current_id = None
         shellwidget_id = id(shellwidget)
         if shellwidget_id in self._shellwidget_dict:
-            self.update(self._shellwidget_dict[shellwidget_id]["gui"])
+            self.update_status(self._shellwidget_dict[shellwidget_id]["gui"])
             self._current_id = shellwidget_id
 
     def remove_shellwidget(self, shellwidget):

--- a/spyder/plugins/ipythonconsole/widgets/status.py
+++ b/spyder/plugins/ipythonconsole/widgets/status.py
@@ -7,12 +7,14 @@
 """Status bar widgets."""
 
 # Standard library imports
+import sys
 import textwrap
 
 # Local imports
 from spyder.api.shellconnect.mixins import ShellConnectMixin
+from spyder.api.translations import _
 from spyder.api.widgets.status import StatusBarWidget
-from spyder.config.base import _
+from spyder.config.base import running_in_ci
 
 
 class MatplotlibStatus(StatusBarWidget, ShellConnectMixin):
@@ -125,8 +127,14 @@ class MatplotlibStatus(StatusBarWidget, ShellConnectMixin):
         # Reset value of interactive backend
         self._interactive_gui = None
 
-        # Hide widget if Matplotlib is not available
-        if shellwidget.get_matplotlib_backend() is None:
+        # Avoid errors when running our test suite on Mac.
+        if running_in_ci() and sys.platform == "darwin":
+            mpl_backend = "inline"
+        else:
+            mpl_backend = shellwidget.get_matplotlib_backend()
+
+        # Hide widget if Matplotlib is not available or failed to import
+        if mpl_backend is None:
             gui = "failed"
             self._shellwidget_dict[id(shellwidget)]['gui'] = gui
             self.hide()

--- a/spyder/plugins/ipythonconsole/widgets/status.py
+++ b/spyder/plugins/ipythonconsole/widgets/status.py
@@ -63,7 +63,8 @@ class MatplotlibStatus(StatusBarWidget, ShellConnectMixin):
         elif gui == 'failed':
             text = _('No backend')
         else:
-            text = _("Interactive")
+            text = gui.capitalize()
+
         self.set_value(text)
 
     def add_shellwidget(self, shellwidget):


### PR DESCRIPTION
## Description of Changes

- The widget was not showing the actual backend but instead `Interactive` for interactive backends.
- Make the widget show the right backend after kernel restarts.
- Hide the widget on kernel failure or if Matplotlib is not available in the kernel (there's no need to show it if there's nothing to report) 
- Make `pylab/autoload` option require a kernel restart (that's necessary when disabled so that the Numpy and Matplotlib star imports are removed).
- Fix applying several options that require a kernel restart (before we were applying only the first option).
- Expand tests to cover most of these changes. 
- Depends on https://github.com/spyder-ide/spyder-kernels/pull/485

### Visual changes

- Move text about backend options to a tip in the IPython console config page

    | Before | After |
    | - | - |
    | ![imagen](https://github.com/spyder-ide/spyder/assets/365293/930fe757-4d88-4eac-b3d0-0277d8669b13) | ![imagen](https://github.com/spyder-ide/spyder/assets/365293/e9088e9a-9b24-4ec2-b001-1ba50c469a26) |


- Improve UI/UX of `ConsoleRestartDialog`

    | Before | After |
    | - | - |
    | ![imagen](https://github.com/spyder-ide/spyder/assets/365293/92394506-604d-4cb4-98df-bf28e26ba3a7) | ![imagen](https://github.com/spyder-ide/spyder/assets/365293/ac825a9e-437e-41eb-b176-eba8770e19a2)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
