### PR TITLE
PR: Use conda-lock files to incrementally update conda-based installers

### DIFF
--- a/.github/scripts/installer_test.sh
+++ b/.github/scripts/installer_test.sh
@@ -28,7 +28,7 @@ check_prefix() {
         echo "\nContents of ${base_prefix}:"
         ls -al $base_prefix
     else
-        echo "$base_prefix does not exist!"
+        echo "Base prefix does not exist!"
         exit 1
     fi
 }
@@ -66,7 +66,7 @@ check_shortcut() {
     fi
 }
 
-install
+install || exit 1
 echo "Install info:"
 check_prefix
 check_uninstall

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -250,6 +250,7 @@ jobs:
           LCK_NAME=$(ls $DISTDIR | grep conda-)
           echo "PKG_NAME=$PKG_NAME" >> $GITHUB_ENV
           echo "LCK_NAME=$LCK_NAME" >> $GITHUB_ENV
+          echo "PKG_PATH=$DISTDIR/$PKG_NAME" >> $GITHUB_ENV
 
       - name: Test macOS or Linux Installer
         if: runner.os != 'Windows'

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -171,6 +171,10 @@ jobs:
         if: runner.os == 'Windows'
         uses: mamba-org/setup-micromamba@v1
         with:
+          condarc: |
+            conda_build:
+              pkg_format: '2'
+              zstd_compression_level: '19'
           environment-file: installers-conda/build-environment.yml
           environment-name: spy-inst
           create-args: >-
@@ -184,6 +188,10 @@ jobs:
         if: runner.os != 'Windows'
         uses: mamba-org/setup-micromamba@v1
         with:
+          condarc: |
+            conda_build:
+              pkg_format: '2'
+              zstd_compression_level: '19'
           environment-file: installers-conda/build-environment.yml
           environment-name: spy-inst
           create-args: >-

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -250,6 +250,7 @@ jobs:
           LCK_NAME=$(ls $DISTDIR | grep conda-)
           echo "PKG_NAME=$PKG_NAME" >> $GITHUB_ENV
           echo "LCK_NAME=$LCK_NAME" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=${PKG_NAME%.*}" >> $GITHUB_ENV
           echo "PKG_PATH=$DISTDIR/$PKG_NAME" >> $GITHUB_ENV
 
       - name: Test macOS or Linux Installer
@@ -285,7 +286,7 @@ jobs:
               ./notarize.sh -p $APPLICATION_PWD $PKG_PATH
           else
               cd $DISTDIR
-              echo $(sha256sum $PKG_NAME) > "${PKG_NAME%.*}-sha256sum.txt"
+              echo $(sha256sum $PKG_NAME) > "${ARTIFACT_NAME}-sha256sum.txt"
           fi
 
       - name: Upload Artifact
@@ -293,7 +294,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ${{ env.DISTDIR }}
-          name: ${{ env.PKG_NAME }}
+          name: ${{ env.ARTIFACT_NAME }}
 
       - name: Get Release
         if: env.IS_RELEASE == 'true'

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -245,14 +245,11 @@ jobs:
         run: |
           [[ -n $CNAME ]] && args=("--cert-id" "$CNAME") || args=()
           python build_installers.py ${args[@]}
-          PKG_PATH=$(python build_installers.py --artifact-name)
-          PKG_NAME=$(basename $PKG_PATH)
-          PKG_GLOB=${PKG_PATH%.*}
-          PKG_BASE_NAME=${PKG_NAME%.*}
-          echo "PKG_PATH=$PKG_PATH" >> $GITHUB_ENV
+
+          PKG_NAME=$(ls $DISTDIR | grep Spyder-)
+          LCK_NAME=$(ls $DISTDIR | grep conda-)
           echo "PKG_NAME=$PKG_NAME" >> $GITHUB_ENV
-          echo "PKG_GLOB=$PKG_GLOB" >> $GITHUB_ENV
-          echo "PKG_BASE_NAME=$PKG_BASE_NAME" >> $GITHUB_ENV
+          echo "LCK_NAME=$LCK_NAME" >> $GITHUB_ENV
 
       - name: Test macOS or Linux Installer
         if: runner.os != 'Windows'
@@ -286,16 +283,16 @@ jobs:
           if [[ $RUNNER_OS == "macOS" ]]; then
               ./notarize.sh -p $APPLICATION_PWD $PKG_PATH
           else
-              cd $(dirname $PKG_PATH)
-              echo $(sha256sum $PKG_NAME) > "${PKG_GLOB}-sha256sum.txt"
+              cd $DISTDIR
+              echo $(sha256sum $PKG_NAME) > "${PKG_NAME%.*}-sha256sum.txt"
           fi
 
       - name: Upload Artifact
         if: env.IS_RELEASE == 'false'
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ env.PKG_GLOB }}*
-          name: ${{ env.PKG_BASE_NAME }}
+          path: ${{ env.DISTDIR }}
+          name: ${{ env.PKG_NAME }}
 
       - name: Get Release
         if: env.IS_RELEASE == 'true'
@@ -311,4 +308,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ${{ env.PKG_GLOB }}*
+          asset_path: ${{ env.DISTDIR }}/*

--- a/installers-conda/build-environment.yml
+++ b/installers-conda/build-environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - boa <0.17.0  # See https://github.com/conda-forge/boa-feedstock/issues/81
   - conda >=23.11.0
+  - conda-lock >=2.5.7
   - conda-standalone >=23.11.0
   - constructor >=3.6.0
   - gitpython

--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -177,7 +177,8 @@ class BuildCondaPkg:
                              f"{self.name}={self.version}...")
             check_call([
                 "conda", "mambabuild",
-                "--no-test", "--skip-existing", "--build-id-pat={n}",
+                "--skip-existing", "--build-id-pat={n}",
+                "--no-test", "--no-anaconda-upload",
                 str(self._fdstk_path / "recipe")
             ])
         finally:

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -164,6 +164,7 @@ for spec in args.extra_specs:
     if k == "spyder":
         SPYVER = v[-1]
 
+LOCK_FILE = DIST / f"conda-{TARGET_PLATFORM}.lock"
 OUTPUT_FILE = DIST / f"{APP}-{OS}-{ARCH}.{args.install_type}"
 INSTALLER_DEFAULT_PATH_STEM = f"{APP.lower()}-{SPYVER.split('.')[0]}"
 
@@ -201,6 +202,7 @@ def _create_conda_lock():
         "--kind", "explicit",
         "--file", str(env_file),
         "--filename-template", str(DIST / "conda-{platform}.lock")
+        # Note conda-lock doesn't provide output file option, only template
     ]
 
     run(cmd_args, check=True, env=env)
@@ -472,8 +474,17 @@ def main():
     t0 = time()
     try:
         DIST.mkdir(exist_ok=True)
+        _create_conda_lock()
+        assert LOCK_FILE.exists()
+        logger.info(f"Created {LOCK_FILE}")
+    finally:
+        elapse = timedelta(seconds=int(time() - t0))
+        logger.info(f"Build time: {elapse}")
+
+    t0 = time()
+    try:
         _constructor()
-        assert Path(OUTPUT_FILE).exists()
+        assert OUTPUT_FILE.exists()
         logger.info(f"Created {OUTPUT_FILE}")
     finally:
         elapse = timedelta(seconds=int(time() - t0))

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -208,10 +208,12 @@ def _create_conda_lock():
 
 
 def _patch_conda_lock():
-    # Replace local channel url with conda-forge
+    # Replace local channel url with conda-forge and remove checksum
     tmp_text = TMP_LOCK_FILE.read_text()
-    text = tmp_text.replace(
-        _get_conda_bld_path_url(), "https://conda.anaconda.org/conda-forge"
+    text = re.sub(
+        f"^{_get_conda_bld_path_url()}(.*)#.*$",
+        r"https://conda.anaconda.org/conda-forge\1",
+        tmp_text, flags=re.MULTILINE
     )
     LOCK_FILE.write_text(text)
 
@@ -517,6 +519,7 @@ if __name__ == "__main__":
         sys.exit()
     if args.conda_lock:
         _create_conda_lock()
+        _patch_conda_lock()
         sys.exit()
 
     main()

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -149,6 +149,7 @@ if SPECS.exists():
     logger.info(f"Reading specs from {SPECS}...")
     _specs = yaml.load(SPECS.read_text())
     specs.update(_specs)
+    SPYVER = re.split('([<>= ]+)', specs['spyder'])[-1]
 else:
     logger.info(f"Did not read specs from {SPECS}")
 

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -203,8 +203,8 @@ def _get_condarc():
     contents = dedent(
         """
         channels:  #!final
-          - conda-forge/label/spyder_kernels_rc
           - conda-forge/label/spyder_dev
+          - conda-forge/label/spyder_kernels_rc
           - conda-forge
         repodata_fns:  #!final
           - repodata.json
@@ -212,6 +212,7 @@ def _get_condarc():
         notify_outdated_conda: false  #!final
         channel_priority: flexible  #!final
         env_prompt: '[spyder]({default_env}) '  #! final
+        register_envs: false  #! final
         """
     )
     # the undocumented #!final comment is explained here

--- a/installers-conda/resources/post-install.sh
+++ b/installers-conda/resources/post-install.sh
@@ -16,7 +16,7 @@ if [[ $(sed --version 2>/dev/null) ]]; then
     sed_opts=("-i" "-e")
 else
     # BSD sed does not have --version
-    sed_opts=("-i" "''" "-e")
+    sed_opts=("-i" "" "-e")
 fi
 
 # ---- Shortcut

--- a/installers-conda/resources/post-install.sh
+++ b/installers-conda/resources/post-install.sh
@@ -9,16 +9,6 @@ echo "Environment variables:"
 env | sort
 echo ""
 
-# ---- Sed options
-# BSD sed requires extra "" after -i flag
-if [[ $(sed --version 2>/dev/null) ]]; then
-    # GNU sed has --version
-    sed_opts=("-i" "-e")
-else
-    # BSD sed does not have --version
-    sed_opts=("-i" "" "-e")
-fi
-
 # ---- Shortcut
 pythonexe=${PREFIX}/bin/python
 menuinst=${PREFIX}/bin/menuinst_cli.py
@@ -42,7 +32,7 @@ add_alias() {
     fi
 
     # BSD sed does not like semicolons; newlines work for both BSD and GNU.
-    sed ${sed_opts[@]} "
+    sed -i.bak -e "
     /$m1/,/$m2/{
         h
         /$m2/ s|.*|$m1\n$alias_text\n$m2|
@@ -57,6 +47,7 @@ add_alias() {
         }
         x
     }" $shell_init
+    rm $shell_init.bak
 }
 
 if [[ "$mode" == "system" && "$OSTYPE" == "darwin"* ]]; then
@@ -131,7 +122,8 @@ done
 for x in ${shell_init_list[@]}; do
     [[ ! -f "\$x" ]] && continue
     echo "Removing Spyder shell commands from \$x..."
-    sed ${sed_opts[@]} "/$m1/,/$m2/d" \$x
+    sed -i.bak -e "/$m1/,/$m2/d" \$x
+    rm \$x.bak
 done
 
 # Remove shortcut and environment

--- a/installers-conda/resources/runtime_env.yml
+++ b/installers-conda/resources/runtime_env.yml
@@ -1,8 +1,0 @@
-channels:
-  - local
-  - conda-forge/label/spyder_dev
-  - conda-forge/label/spyder_kernels_rc
-  - conda-forge
-dependencies:
-  - python=3.10
-  - spyder=6.0.0a6.dev13

--- a/installers-conda/resources/runtime_env.yml
+++ b/installers-conda/resources/runtime_env.yml
@@ -1,0 +1,8 @@
+channels:
+  - local
+  - conda-forge/label/spyder_dev
+  - conda-forge/label/spyder_kernels_rc
+  - conda-forge
+dependencies:
+  - python=3.10
+  - spyder=6.0.0a6.dev13

--- a/spyder/plugins/updatemanager/scripts/install.bat
+++ b/spyder/plugins/updatemanager/scripts/install.bat
@@ -4,10 +4,9 @@
 :: Create variables from arguments
 :parse
 IF "%~1"=="" GOTO endparse
-IF "%~1"=="-p" set prefix=%~2& SHIFT
-IF "%~1"=="-i" set install_exe=%~2& SHIFT
+IF "%~1"=="-i" set install_file=%~2& SHIFT
 IF "%~1"=="-c" set conda=%~2& SHIFT
-IF "%~1"=="-v" set spy_ver=%~2& SHIFT
+IF "%~1"=="-p" set prefix=%~2& SHIFT
 SHIFT
 GOTO parse
 :endparse
@@ -25,13 +24,13 @@ echo.
 
 call :wait_for_spyder_quit
 
-IF not "%conda%"=="" IF not "%spy_ver%"=="" (
+IF not "%conda%"=="" IF not "%prefix%"=="" (
     call :update_subroutine
     call :launch_spyder
     goto exit
 )
 
-IF not "%install_exe%"=="" (
+IF not "%install_file%"=="" (
     call :install_subroutine
     goto exit
 )
@@ -40,7 +39,7 @@ IF not "%install_exe%"=="" (
 exit %ERRORLEVEL%
 
 :install_subroutine
-    echo Installing Spyder from: %install_exe%
+    echo Installing Spyder from: %install_file%
 
     :: Uninstall Spyder
     for %%I in ("%prefix%\..\..") do set "conda_root=%%~fI"
@@ -63,13 +62,13 @@ exit %ERRORLEVEL%
     IF "%ERRORLEVEL%"=="0" goto wait_for_uninstall
     echo Uninstall complete.
 
-    start %install_exe%
+    start %install_file%
     goto :EOF
 
 :update_subroutine
     echo Updating Spyder
 
-    %conda% install -p %prefix% -y spyder=%spy_ver%
+    %conda% update -p %prefix% -y --file %install_file%
     set /P =Press return to exit...
     goto :EOF
 

--- a/spyder/plugins/updatemanager/scripts/install.sh
+++ b/spyder/plugins/updatemanager/scripts/install.sh
@@ -2,18 +2,17 @@
 
 unset HISTFILE  # Do not write to history with interactive shell
 
-while getopts "i:c:p:v:" option; do
+while getopts "i:c:p:" option; do
     case "$option" in
-        (i) install_exe=$OPTARG ;;
+        (i) install_file=$OPTARG ;;
         (c) conda=$OPTARG ;;
         (p) prefix=$OPTARG ;;
-        (v) spy_ver=$OPTARG ;;
     esac
 done
 shift $(($OPTIND - 1))
 
 update_spyder(){
-    $conda install -p $prefix -y spyder=$spy_ver
+    $conda update -p $prefix -y --file $install_file
     read -p "Press return to exit..."
 }
 
@@ -44,7 +43,7 @@ install_spyder(){
     fi
 
     # Run installer
-    [[ "$OSTYPE" = "darwin"* ]] && open $install_exe || sh $install_exe
+    [[ "$OSTYPE" = "darwin"* ]] && open $install_file || sh $install_file
 }
 
 cat <<EOF
@@ -64,10 +63,10 @@ done
 
 echo "Spyder quit."
 
-if [[ -e "$conda" && -d "$prefix" && -n "$spy_ver" ]]; then
+if [[ -e "$conda" && -d "$prefix" ]]; then
     update_spyder
     launch_spyder
-elif [[ -e "$install_exe" ]]; then
+else
     install_spyder
 fi
 

--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -322,6 +322,8 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         and set downloading status.
         """
         self.cancelled = False
+        self.progress_dialog = None
+
         self.download_worker = WorkerDownloadInstaller(
             self.latest_release, self.installer_path, self.installer_size_path
         )
@@ -329,12 +331,12 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         self.sig_disable_actions.emit(True)
         self.set_status(DOWNLOADING_INSTALLER)
 
-        self.progress_dialog = ProgressDialog(
-            self,
-            _("Downloading update for Spyder {} ...").format(
-                self.latest_release)
-        )
-        self.progress_dialog.cancel.clicked.connect(self._cancel_download)
+        # Only show progress bar for installers
+        if not self.installer_path.endswith('lock'):
+            self.progress_dialog = ProgressDialog(
+                self, _("Downloading Spyder {} ...").format(self.latest_release)
+            )
+            self.progress_dialog.cancel.clicked.connect(self._cancel_download)
 
         self.download_thread = QThread(None)
         self.download_worker.sig_exception_occurred.connect(


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

The update manager plugin now uses an explicitly rendered conda-lock file in order to perform an incremental (minor/micro) update to Spyder in a conda-based installation environment. Previously the update manager simply performed a `conda install`.

Since conda-forge packages for releases are not available at the time of installer workflow runs, the checksum is removed from the Spyder spec in the conda-lock file. The checksum will be different for the Spyder conda package built on our CI vs. conda-forge, resulting in a `ChecksumMismatchError`. Removing the checksum in the conda-lock file avoids this error.

<!--- Explain what you've done and why --->
