### PR TITLE
PR: Fix workflow glob (Installers)

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -318,4 +318,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ${{ env.DISTDIR }}/*
+          asset_path: ${{ env.DISTDIR }}/*.*


### PR DESCRIPTION
Resolves "Error: EISDIR: illegal operation on a directory, read" on linux for release asset upload. constructor creates a tmp directory in the distribution directory for some reason, so must exclude it.

Successfully tested with a release on my fork: https://github.com/mrclary/spyder/releases/tag/v6.0.0b2.dev2