### PR TITLE
PR: Fix detecting Matplotlib backend for its 3.9.0 version (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = 2.x
-	commit = 3b3765cea8ffdb039f9c33119f9688ebb17c0281
-	parent = 34676f45e8828e2bd1a01c4e326dadf5ca8605f4
+	commit = 3ca2930b50820e7bba78da41510baf0c3b7b29ad
+	parent = edd5881efe18b2585be5ed6c03df88367415a1a1
 	method = merge
-	cmdver = 0.4.3
+	cmdver = 0.4.6

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -382,7 +382,7 @@ class SpyderKernel(IPythonKernel):
         """Get current matplotlib backend."""
         try:
             import matplotlib
-            return MPL_BACKENDS_TO_SPYDER[matplotlib.get_backend()]
+            return MPL_BACKENDS_TO_SPYDER[matplotlib.get_backend().lower()]
         except Exception:
             return None
 
@@ -428,7 +428,7 @@ class SpyderKernel(IPythonKernel):
             # equivalent to having the inline one.
             return 0
         elif framework in mapping:
-            return MPL_BACKENDS_TO_SPYDER[mapping[framework]]
+            return MPL_BACKENDS_TO_SPYDER[mapping[framework].lower()]
         else:
             # This covers the case of other backends (e.g. Wx or Gtk)
             # which users can set interactively with the %matplotlib

--- a/external-deps/spyder-kernels/spyder_kernels/utils/mpl.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/mpl.py
@@ -27,11 +27,12 @@ else:
 
 # Mapping of matlotlib backends options to Spyder
 MPL_BACKENDS_TO_SPYDER = {
-    inline_backend: 0,
-    'Qt5Agg': 2,
-    'QtAgg': 2,  # For Matplotlib 3.5+
-    'TkAgg': 3,
-    'MacOSX': 4,
+    'inline': 0,  # For Matplotlib >=3.9
+    inline_backend: 0,  # For Matplotlib <3.9
+    'qt5agg': 2,
+    'qtagg': 2,  # For Matplotlib 3.5+
+    'tkagg': 3,
+    'macosx': 4,
 }
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

- Matplotlib get_backend returns lowercase in version >=3.9.0.
- Update to `spyder-kernels` accommodates this change.
- Dependes on https://github.com/spyder-ide/spyder-kernels/pull/489.
