### PR TITLE
PR: Update macOS from 11 to 12 in installer workflow

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -54,7 +54,7 @@ jobs:
         build_type: ${{fromJson(needs.matrix_prep.outputs.build_type)}}
         os: ["macos-11", "macos-14"]
         include:
-          - os: "macos-11"
+          - os: "macos-12"
             pyver: "3.9.14"
           - os: "macos-14"
             pyver: "3.10.11"


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Update macOS from 11 to 12. macOS 11 runner image will be removed from Github on 2024/6/28.
