### PR TITLE
PR: Update macOS from 11 to 12 in installer workflow

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -78,7 +78,7 @@ jobs:
       run: |
         if [[ $BUILD_MAC == "true" ]]; then
             target_platform="'osx-64'"
-            include="{'os': 'macos-11', 'target-platform': 'osx-64', 'spyk-arch': 'unix'}"
+            include="{'os': 'macos-12', 'target-platform': 'osx-64', 'spyk-arch': 'unix'}"
         fi
         if [[ $BUILD_ARM == "true" ]]; then
             target_platform=${target_platform:+"$target_platform, "}"'osx-arm64'"


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Update macOS from 11 to 12. macOS 11 runner image will be removed from Github on 2024/6/28.
