### PR TITLE
PR: Accommodate Matplotlib 3.9.0 in spyder-kernels 3.x

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = master
-	commit = 09c370aab411c954f869649279481636f666098b
-	parent = 24853bc4073c12c2ecdd78022bf8a796fbfb8925
+	remote = https://github.com/mrclary/spyder-kernels.git
+	branch = mpl390
+	commit = 335583b37f50d322e7dd4ae51e1c0cfb5318bc2b
+	parent = eeb9c783438ff9cb82cfc61b60a79181349a9bc5
 	method = merge
-	cmdver = 0.4.3
+	cmdver = 0.4.6

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -498,7 +498,7 @@ class SpyderKernel(IPythonKernel):
         """Get current matplotlib backend."""
         try:
             import matplotlib
-            return MPL_BACKENDS_TO_SPYDER[matplotlib.get_backend()]
+            return MPL_BACKENDS_TO_SPYDER[matplotlib.get_backend().lower()]
         except Exception:
             return None
 

--- a/external-deps/spyder-kernels/spyder_kernels/utils/mpl.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/mpl.py
@@ -20,11 +20,12 @@ else:
 
 # Mapping of matlotlib backends options to Spyder
 MPL_BACKENDS_TO_SPYDER = {
-    inline_backend: "inline",
-    'Qt5Agg': 'qt',
-    'QtAgg': 'qt',  # For Matplotlib 3.5+
-    'TkAgg': 'tk',
-    'MacOSX': 'osx',
+    'inline': 'inline',  # For Matplotlib >=3.9
+    inline_backend: "inline",  # For Matplotlib <3.9
+    'qt5agg': 'qt',
+    'qtagg': 'qt',  # For Matplotlib 3.5+
+    'tkagg': 'tk',
+    'macosx': 'osx',
 }
 
 


### PR DESCRIPTION
Matplotlib get_backend returns lowercase in version >=3.9.0.
Update to spyder-kernels accommodates this change.