### PR TITLE
PR: Constrain setuptools for macOS standalone installer

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -91,7 +91,7 @@ jobs:
           if [[ -z ${LITE_FLAG} ]]; then
               INSTALL_FLAGS+=('-r' 'req-scientific.txt')
           fi
-          ${pythonLocation}/bin/python -m pip install -U pip setuptools wheel
+          ${pythonLocation}/bin/python -m pip install -U pip wheel
           ${pythonLocation}/bin/python -m pip install -r req-build.txt -r req-extras.txt -r req-plugins.txt "${INSTALL_FLAGS[@]}" -e ${GITHUB_WORKSPACE}
       - name: Install Subrepos
         if: ${{github.event_name == 'pull_request'}}

--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         build_type: ${{fromJson(needs.matrix_prep.outputs.build_type)}}
-        os: ["macos-11", "macos-14"]
+        os: ["macos-12", "macos-14"]
         include:
           - os: "macos-12"
             pyver: "3.9.14"

--- a/installers/macOS/req-build.txt
+++ b/installers/macOS/req-build.txt
@@ -1,5 +1,6 @@
 # For building standalone Mac app
+black==24.1.1  # Pin it to add missing modules to the bundle. See workflow file for the details.
 dmgbuild>=1.4.2
 py2app==0.28.4
+setuptools<70.0.0
 sphinx==5.1.1  # See spyder-ide/spyder#19618 for details.
-black==24.1.1  # Pin it to add missing modules to the bundle. See workflow file for the details.


### PR DESCRIPTION
Constrain `setuptools<70.0.0` for macOS standalone installer to resolve "ImportError: cannot import name 'packaging' from 'pkg_resources'".

Also, missed a macos-11 spec on PR #22102.