### PR TITLE
PR: Fix error when we can't detect Spyder in `conda list` output (Utils)

### DIFF
--- a/spyder/utils/conda.py
+++ b/spyder/utils/conda.py
@@ -232,6 +232,11 @@ def get_spyder_conda_channel():
     if 'error' in out:
         return None, None
 
+    # These variables can be unassigned after the next for, so we need to give
+    # them a default value at this point.
+    # Fixes spyder-ide/spyder#22054
+    channel, channel_url = None, None
+
     for package_info in out:
         if package_info["name"] == 'spyder':
             channel = package_info["channel"]


### PR DESCRIPTION
## Description of Changes

I really don't know when this situation could happen, i.e. Spyder installed in a conda env and yet not available in the output of `conda list`. But since it was reported by a user, we need to address it.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22054.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
