### PR TITLE
PR: Allow an adjustable time difference for modification detection (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2411,8 +2411,8 @@ class EditorStack(QWidget):
                         self.msgbox = QMessageBox(
                             QMessageBox.Question,
                             self.title,
-                            _("It looks like <b>{}</b> has been modified "
-                              "outside Spyder. The working copy is from {} milliseconds ago."
+                            _("The file <b>{}</b> has been modified outside "
+                              "Spyder."
                               "<br><br>"
                               "Do you want to reload it and lose all your "
                               "changes?").format(name, dt),

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2415,7 +2415,7 @@ class EditorStack(QWidget):
                               "Spyder."
                               "<br><br>"
                               "Do you want to reload it and lose all your "
-                              "changes?").format(name, dt),
+                              "changes?").format(name),
                             QMessageBox.Yes | QMessageBox.No,
                             self
                         )

--- a/spyder/plugins/editor/widgets/editor.py
+++ b/spyder/plugins/editor/widgets/editor.py
@@ -2400,7 +2400,8 @@ class EditorStack(QWidget):
         else:
             # Else, testing if it has been modified elsewhere:
             lastm = QFileInfo(finfo.filename).lastModified()
-            if str(lastm.toString()) != str(finfo.lastmodified.toString()):
+            dt = finfo.lastmodified.msecsTo(lastm)
+            if dt > 1000:
                 # Catch any error when trying to reload a file and close it if
                 # that's the case to prevent users from destroying external
                 # changes in Spyder.
@@ -2410,11 +2411,11 @@ class EditorStack(QWidget):
                         self.msgbox = QMessageBox(
                             QMessageBox.Question,
                             self.title,
-                            _("The file <b>{}</b> has been modified outside "
-                              "Spyder."
+                            _("It looks like <b>{}</b> has been modified "
+                              "outside Spyder. The working copy is from {} milliseconds ago."
                               "<br><br>"
                               "Do you want to reload it and lose all your "
-                              "changes?").format(name),
+                              "changes?").format(name, dt),
                             QMessageBox.Yes | QMessageBox.No,
                             self
                         )


### PR DESCRIPTION
For CIFS (and perhaps other network file systems), where caching file attributes is used, expecting identical timestamps causes many false positives. This hacky patch allows for some deviation.

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21877 hopefully, we'll see next week when much more testing is planed in production.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: and1bm

<!--- Thanks for your help making Spyder better for everyone! --->
