### PR TITLE
PR: Make QtWebEngine Optional

### DIFF
--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -159,6 +159,13 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
     # disabled. Default: True
     CAN_BE_DISABLED = True
 
+    # Qt Web Widgets may be a heavy dependency for many packagers
+    # (e.g. conda-forge)
+    # We thus ask plugins to declare whether or not they need
+    # web widgets to enhance the distribution of Spyder to users
+    # https://github.com/spyder-ide/spyder/pull/22196#issuecomment-2189377043
+    REQUIRE_WEB_WIDGETS = False
+
     # --- API: Signals -------------------------------------------------------
     # ------------------------------------------------------------------------
     # Signals here are automatically connected by the Spyder main window and

--- a/spyder/plugins/help/plugin.py
+++ b/spyder/plugins/help/plugin.py
@@ -44,6 +44,7 @@ class Help(SpyderDockablePlugin):
     CONF_FILE = False
     LOG_PATH = get_conf_path(CONF_SECTION)
     DISABLE_ACTIONS_WHEN_HIDDEN = False
+    REQUIRE_WEB_WIDGETS = True
 
     # Signals
     sig_focus_changed = Signal()  # TODO: What triggers this?

--- a/spyder/plugins/help/widgets.py
+++ b/spyder/plugins/help/widgets.py
@@ -17,7 +17,6 @@ import sys
 from qtpy import PYQT5, PYQT6
 from qtpy.QtCore import Qt, QUrl, Signal, Slot, QPoint
 from qtpy.QtGui import QColor
-from qtpy.QtWebEngineWidgets import WEBENGINE, QWebEnginePage
 from qtpy.QtWidgets import (QActionGroup, QLabel, QLineEdit,
                             QMessageBox, QSizePolicy, QStackedWidget,
                             QVBoxLayout, QWidget)
@@ -37,10 +36,15 @@ from spyder.utils import programs
 from spyder.utils.image_path_manager import get_image_path
 from spyder.utils.palette import SpyderPalette
 from spyder.utils.qthelpers import start_file
-from spyder.widgets.browser import FrameWebView
 from spyder.widgets.comboboxes import EditableComboBox
 from spyder.widgets.findreplace import FindReplace
 from spyder.widgets.simplecodeeditor import SimpleCodeEditor
+
+# In case WebEngine is not available (e.g. in Conda-forge)
+try:
+    from qtpy.QtWebEngineWidgets import WEBENGINE
+except ImportError:
+    WEBENGINE = False
 
 
 # --- Constants
@@ -157,6 +161,9 @@ class RichText(QWidget, SpyderWidgetMixin):
         else:
             QWidget.__init__(self, parent)
             SpyderWidgetMixin.__init__(self, class_parent=parent)
+
+        from qtpy.QtWebEngineWidgets import QWebEnginePage
+        from spyder.widgets.browser import FrameWebView
 
         self.webview = FrameWebView(self)
         self.webview.setup()

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -25,7 +25,6 @@ from qtconsole.svg import save_svg, svg_to_clipboard
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtGui import QColor, QKeySequence
 from qtpy.QtPrintSupport import QPrintDialog, QPrinter
-from qtpy.QtWebEngineWidgets import WEBENGINE
 from qtpy.QtWidgets import (
     QApplication, QHBoxLayout, QLabel, QMessageBox, QVBoxLayout, QWidget)
 from traitlets.config.loader import Config, load_pyconfig_files
@@ -58,10 +57,15 @@ from spyder.utils.misc import get_error_match, remove_backslashes
 from spyder.utils.palette import SpyderPalette
 from spyder.utils.stylesheet import AppStyle
 from spyder.utils.workers import WorkerManager
-from spyder.widgets.browser import FrameWebView
 from spyder.widgets.findreplace import FindReplace
 from spyder.widgets.tabs import Tabs
 from spyder.widgets.printer import SpyderPrinter
+
+# In case WebEngine is not available (e.g. in Conda-forge)
+try:
+    from qtpy.QtWebEngineWidgets import WEBENGINE
+except ImportError:
+    WEBENGINE = False
 
 
 # Logging
@@ -252,7 +256,7 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
         self.enable_infowidget = True
         if plugin:
             cli_options = plugin.get_command_line_options()
-            if cli_options.no_web_widgets:
+            if cli_options.no_web_widgets or not WEBENGINE:
                 self.enable_infowidget = False
 
         # Attrs for testing
@@ -288,6 +292,8 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
 
         # Info widget
         if self.enable_infowidget:
+            from spyder.widgets.browser import FrameWebView
+
             self.infowidget = FrameWebView(self)
             if WEBENGINE:
                 self.infowidget.page().setBackgroundColor(

--- a/spyder/plugins/onlinehelp/plugin.py
+++ b/spyder/plugins/onlinehelp/plugin.py
@@ -32,6 +32,7 @@ class OnlineHelp(SpyderDockablePlugin):
     CONF_FILE = False
     WIDGET_CLASS = PydocBrowser
     LOG_PATH = get_conf_path(NAME)
+    REQUIRE_WEB_WIDGETS = True
 
     # --- Signals
     # ------------------------------------------------------------------------

--- a/spyder/plugins/onlinehelp/widgets.py
+++ b/spyder/plugins/onlinehelp/widgets.py
@@ -17,16 +17,20 @@ import sys
 # Third party imports
 from qtpy.QtCore import Qt, QThread, QUrl, Signal, Slot
 from qtpy.QtGui import QCursor
-from qtpy.QtWebEngineWidgets import WEBENGINE
 from qtpy.QtWidgets import QApplication, QLabel, QVBoxLayout
 
 # Local imports
 from spyder.api.translations import _
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.plugins.onlinehelp.pydoc_patch import _start_server, _url_handler
-from spyder.widgets.browser import FrameWebView, WebViewActions
 from spyder.widgets.comboboxes import UrlComboBox
 from spyder.widgets.findreplace import FindReplace
+
+# In case WebEngine is not available (e.g. in Conda-forge)
+try:
+    from qtpy.QtWebEngineWidgets import WEBENGINE
+except ImportError:
+    WEBENGINE = False
 
 
 # --- Constants
@@ -139,6 +143,8 @@ class PydocBrowser(PluginMainWidget):
     """
 
     def __init__(self, name=None, plugin=None, parent=None):
+        from spyder.widgets.browser import FrameWebView
+
         super().__init__(name, plugin, parent=parent)
 
         self._is_running = False
@@ -193,6 +199,8 @@ class PydocBrowser(PluginMainWidget):
         return self.url_combo
 
     def setup(self):
+        from spyder.widgets.browser import WebViewActions
+
         # Actions
         home_action = self.create_action(
             PydocBrowserActions.Home,
@@ -243,6 +251,8 @@ class PydocBrowser(PluginMainWidget):
         self.sig_toggle_view_changed.connect(self.initialize)
 
     def update_actions(self):
+        from spyder.widgets.browser import WebViewActions
+
         stop_action = self.get_action(WebViewActions.Stop)
         refresh_action = self.get_action(WebViewActions.Refresh)
 
@@ -271,6 +281,8 @@ class PydocBrowser(PluginMainWidget):
 
     def _handle_url_combo_activation(self):
         """Load URL from combo box first item."""
+        from spyder.widgets.browser import WebViewActions
+
         if not self._is_running:
             text = str(self.url_combo.currentText())
             self.go_to(self.text_to_url(text))


### PR DESCRIPTION
## Description of Changes

I've been involved with packaging on conda-forge for the last few years and unfortunately the situation for packaging QtWebEngine hasn't really improved.

I think Spyder is a REALLY important tool for those starting off with python and being able to co-install it in modern environments is also a really great asset.

However, ensuring that qt-webengine is updated is a constant challenge and we are having a hard time keeping up especially on windows and OSX.

I would really like to continue to recommend Spyder to users, but if there isn't a clear path toward compatibility with qt6 (for which we don't have the webengine plugin) it makes it a really hard sell.

The following patch would effectively silently disable the plugins that require WebEngine.

One modification I would like to propose is the addition of a flag for each plugin like:
```
REQUIRES_WEBENGINE
```

That way, plugins beyond `help` could declare themselves as requiring webengine and the main application would be able to disable them intelligently 

* [ ] ~Wrote at least one-line docstrings (for any new functions)~
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

The main visual difference is that by default the help tab no longer shows up:
![image](https://github.com/spyder-ide/spyder/assets/90008/d05b2768-87a0-4c02-ac72-edd9e34eff5f)

Example showing matplotlib still working:
![image](https://github.com/spyder-ide/spyder/assets/90008/bba8fd46-a3d8-4859-a539-dc1fc460b2a5)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Xref: https://github.com/conda-forge/qt-main-feedstock/issues/49#issuecomment-2148423663


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Mark Harfouche

<!--- Thanks for your help making Spyder better for everyone! --->
