### PR TITLE
PR: Fix issue where macOS installer update fails to launch Spyder

### DIFF
--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -304,6 +304,7 @@ def _definitions():
             "menuinst >=2.0.2",
             "mamba",
         ],
+        "exclude": ["pip"],
         "installer_filename": OUTPUT_FILE.name,
         "installer_type": args.install_type,
         "initialize_by_default": False,

--- a/spyder/plugins/updatemanager/scripts/install.sh
+++ b/spyder/plugins/updatemanager/scripts/install.sh
@@ -24,7 +24,7 @@ launch_spyder(){
     shortcut_path=$($pythonexe $menuinst shortcut --mode=$mode)
 
     if [[ "$OSTYPE" = "darwin"* ]]; then
-        open -a $shortcut
+        open -a "$shortcut_path"
     elif [[ -n "$(which gtk-launch)" ]]; then
         gtk-launch $(basename ${shortcut_path%.*})
     else


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* Fixed typo that prevented launching Spyder after completing update in runtime environment.
* Exclude `pip` from installer base environment.