### PR TITLE
PR: Fix issues with installers discovered after 6.0.0b2 was released

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -175,6 +175,10 @@ jobs:
             conda_build:
               pkg_format: '2'
               zstd_compression_level: '19'
+            channels:
+              - conda-forge/label/spyder_dev
+              - conda-forge/label/spyder_kernels_rc
+              - conda-forge
           environment-file: installers-conda/build-environment.yml
           environment-name: spy-inst
           create-args: >-
@@ -192,6 +196,10 @@ jobs:
             conda_build:
               pkg_format: '2'
               zstd_compression_level: '19'
+            channels:
+              - conda-forge/label/spyder_dev
+              - conda-forge/label/spyder_kernels_rc
+              - conda-forge
           environment-file: installers-conda/build-environment.yml
           environment-name: spy-inst
           create-args: >-

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Setup Remote SSH Connection
         if: env.ENABLE_SSH == 'true'
         uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 10
+        timeout-minutes: 60
         with:
           detached: true
 

--- a/installers-conda/build-environment.yml
+++ b/installers-conda/build-environment.yml
@@ -2,13 +2,13 @@ name: spy-inst
 channels:
   - conda-forge
 dependencies:
-  - boa <0.17.0  # See https://github.com/conda-forge/boa-feedstock/issues/81
-  - conda >=23.11.0
+  - conda >=24.5.0
+  - conda-build >=24.5.0
   - conda-lock >=2.5.7
-  - conda-standalone >=23.11.0
+  - conda-standalone >=24.5.0
   - constructor >=3.6.0
   - gitpython
   - mamba
-  - menuinst >=2.0.2
+  - menuinst >=2.1.0
   - ruamel.yaml.jinja2
   - setuptools_scm

--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -124,6 +124,7 @@ class BuildCondaPkg:
         pass
 
     def _patch_conda_build_config(self):
+        self.logger.info("Patching 'conda_build_config.yaml'...")
         yaml = YAML()
         yaml.indent(mapping=2, sequence=4, offset=2)
 
@@ -135,6 +136,10 @@ class BuildCondaPkg:
 
         file.rename(file.parent / ("_" + file.name))  # keep copy of original
         yaml.dump(contents, file)
+
+        self.logger.info(
+            f"Patched 'conda_build_config.yaml' contents:\n{file.read_text()}"
+        )
 
     def _patch_meta(self):
         self.logger.info("Patching 'meta.yaml'...")
@@ -223,6 +228,7 @@ class SpyderCondaPkg(BuildCondaPkg):
 
     def _patch_source(self):
         self.logger.info("Patching Spyder source...")
+
         file = self._bld_src / "spyder/__init__.py"
         file_text = file.read_text()
         ver_str = tuple(self.version.split('.'))
@@ -236,10 +242,13 @@ class SpyderCondaPkg(BuildCondaPkg):
 
         # Only write patch if necessary
         if self.repo.git.diff():
+            self.logger.info(f"Creating {self.patchfile.name}...")
             self.repo.git.diff(output=self.patchfile.as_posix())
             self.repo.git.stash()
 
     def _add_recipe_clobber(self):
+        self.logger.info("Creating 'recipe_clobber.yaml'...")
+
         yaml = YAML()
         yaml.indent(mapping=2, sequence=4, offset=2)
 
@@ -274,10 +283,17 @@ class SpyderCondaPkg(BuildCondaPkg):
         file = self._fdstk_path / "recipe" / "recipe_clobber.yaml"
         yaml.dump(clobber_contents, file)
 
+        self.logger.info(
+            f"'recipe_clobber.yaml' contents:\n{file.read_text()}"
+        )
+
     def _add_recipe_append(self):
         if not self.patchfile.exists():
             # No need to append list of patches
+            self.logger.info("Skipping 'recipe_append.yaml'")
             return
+        else:
+            self.logger.info("Creating 'recipe_append.yaml'...")
 
         yaml = YAML()
         yaml.indent(mapping=2, sequence=4, offset=2)
@@ -286,6 +302,8 @@ class SpyderCondaPkg(BuildCondaPkg):
 
         file = self._fdstk_path / "recipe" / "recipe_append.yaml"
         yaml.dump(append_contents, file)
+
+        self.logger.info(f"'recipe_append.yaml' contents:\n{file.read_text()}")
 
 
 class PylspCondaPkg(BuildCondaPkg):

--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -43,6 +43,9 @@ REQ_LINUX = REQUIREMENTS / 'linux.yml'
 BUILD.mkdir(exist_ok=True)
 SPYPATCHFILE = BUILD / "installers-conda.patch"
 
+yaml = YAML()
+yaml.indent(mapping=2, sequence=4, offset=2)
+
 
 class BuildCondaPkg:
     """Base class for building a conda package for conda-based installer"""
@@ -125,8 +128,6 @@ class BuildCondaPkg:
 
     def _patch_conda_build_config(self):
         self.logger.info("Patching 'conda_build_config.yaml'...")
-        yaml = YAML()
-        yaml.indent(mapping=2, sequence=4, offset=2)
 
         file = self._fdstk_path / "recipe" / "conda_build_config.yaml"
         contents = yaml.load(file.read_text())
@@ -249,9 +250,6 @@ class SpyderCondaPkg(BuildCondaPkg):
     def _add_recipe_clobber(self):
         self.logger.info("Creating 'recipe_clobber.yaml'...")
 
-        yaml = YAML()
-        yaml.indent(mapping=2, sequence=4, offset=2)
-
         # Get current Spyder requirements
         current_requirements = ['python']
         current_requirements += yaml.load(
@@ -294,9 +292,6 @@ class SpyderCondaPkg(BuildCondaPkg):
             return
         else:
             self.logger.info("Creating 'recipe_append.yaml'...")
-
-        yaml = YAML()
-        yaml.indent(mapping=2, sequence=4, offset=2)
 
         append_contents = {"source": {"patches": [self.patchfile.name]}}
 
@@ -387,9 +382,6 @@ if __name__ == "__main__":
 
     logger.info(f"Building local conda packages {list(args.build)}...")
     t0 = time()
-
-    yaml = YAML()
-    yaml.indent(mapping=2, sequence=4, offset=2)
 
     if SPECS.exists():
         specs = yaml.load(SPECS.read_text())

--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -130,12 +130,14 @@ class BuildCondaPkg:
         self.logger.info("Patching 'conda_build_config.yaml'...")
 
         file = self._fdstk_path / "recipe" / "conda_build_config.yaml"
-        contents = yaml.load(file.read_text())
+        if file.exists():
+            contents = yaml.load(file.read_text())
+            file.rename(file.parent / ("_" + file.name))  # copy of original
+        else:
+            contents = {}
 
         pyver = sys.version_info
         contents['python'] = [f"{pyver.major}.{pyver.minor}.* *_cpython"]
-
-        file.rename(file.parent / ("_" + file.name))  # keep copy of original
         yaml.dump(contents, file)
 
         self.logger.info(

--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -227,7 +227,7 @@ class BuildCondaPkg:
             self.logger.info("Building conda package "
                              f"{self.name}={self.version}...")
             check_call([
-                "conda", "mambabuild",
+                "conda", "build",
                 "--skip-existing", "--build-id-pat={n}",
                 "--no-test", "--no-anaconda-upload",
                 str(self._fdstk_path / "recipe")


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* Patch recipe `conda_build_config.yaml` on CI in order to replicate the build string hash on conda-forge.
* Use `recipe_clobber.yaml` and `recipe_append.yaml` mechanisms to patch `meta.yaml` instead of find/replace.
* Include `label/spyder_dev` in the url for Spyder in the conda-lock file, if non-stable distribution
* Fix an issue where the shortcut was not found after macOS update, preventing post-update launching of Spyder.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22201 
