### PR TITLE
PR: Fix errors when getting Matplotlib backend in the kernel (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1923,7 +1923,6 @@ def test_pdb_comprehension_namespace(ipyconsole, qtbot, tmpdir):
 
 @flaky(max_runs=10)
 @pytest.mark.auto_backend
-@pytest.mark.skipif(os.name == 'nt', reason="Fails on windows")
 def test_restart_interactive_backend(ipyconsole, qtbot):
     """
     Test that we ask for a restart or not after switching to different
@@ -1936,7 +1935,8 @@ def test_restart_interactive_backend(ipyconsole, qtbot):
 
     # This is necessary to test no spurious messages are printed to the console
     shell.clear_console()
-    qtbot.waitUntil(lambda: '\nIn [2]: ' == shell._control.toPlainText())
+    empty_console_text = '\n\nIn [2]: ' if os.name == "nt" else '\nIn [2]: '
+    qtbot.waitUntil(lambda: empty_console_text == shell._control.toPlainText())
 
     # Switch to the tk backend
     ipyconsole.set_conf('pylab/backend', 'tk')
@@ -1967,7 +1967,7 @@ def test_restart_interactive_backend(ipyconsole, qtbot):
     assert bool(os.environ.get('BACKEND_REQUIRE_RESTART'))
 
     # Check we no spurious messages are shown before the restart below
-    assert "\nIn [2]: " == shell._control.toPlainText()
+    assert empty_console_text == shell._control.toPlainText()
 
     # Restart kernel to check if the new interactive backend is set
     ipyconsole.restart_kernel()

--- a/spyder/plugins/ipythonconsole/utils/kernel_handler.py
+++ b/spyder/plugins/ipythonconsole/utils/kernel_handler.py
@@ -201,8 +201,14 @@ class KernelHandler(QObject):
         self._shellwidget_connected = True
         # Emit signal in case the connection is already made
         if self.connection_state in [
-                KernelConnectionState.IpykernelReady,
-                KernelConnectionState.SpyderKernelReady]:
+            KernelConnectionState.IpykernelReady,
+            KernelConnectionState.SpyderKernelReady
+        ]:
+            # This is necessary for systems in which the kernel takes too much
+            # time to start because in that case its heartbeat is not detected
+            # as beating at this point.
+            # Fixes spyder-ide/spyder#22179
+            self.kernel_client.hb_channel._beating = True
             self.sig_kernel_is_ready.emit()
         elif self.connection_state == KernelConnectionState.Error:
             self.sig_kernel_connection_error.emit()
@@ -274,6 +280,11 @@ class KernelHandler(QObject):
             KernelConnectionState.SpyderKernelWaitComm,
             KernelConnectionState.Crashed
         ]:
+            # This is necessary for systems in which the kernel takes too much
+            # time to start because in that case its heartbeat is not detected
+            # as beating at this point.
+            # Fixes spyder-ide/spyder#22179
+            self.kernel_client.hb_channel._beating = True
             self.connection_state = KernelConnectionState.SpyderKernelReady
             self.sig_kernel_is_ready.emit()
 

--- a/spyder/plugins/ipythonconsole/widgets/status.py
+++ b/spyder/plugins/ipythonconsole/widgets/status.py
@@ -11,6 +11,9 @@ import functools
 import sys
 import textwrap
 
+# Third-party imports
+from spyder_kernels.comms.frontendcomm import CommError
+
 # Local imports
 from spyder.api.shellconnect.mixins import ShellConnectMixin
 from spyder.api.translations import _
@@ -137,7 +140,12 @@ class MatplotlibStatus(StatusBarWidget, ShellConnectMixin):
         if running_in_ci() and not sys.platform.startswith("linux"):
             mpl_backend = "inline"
         else:
-            mpl_backend = shellwidget.get_matplotlib_backend()
+            # Needed when the comm is not connected.
+            # Fixes spyder-ide/spyder#22194
+            try:
+                mpl_backend = shellwidget.get_matplotlib_backend()
+            except CommError:
+                mpl_backend = None
 
         # Hide widget if Matplotlib is not available or failed to import
         if mpl_backend is None:


### PR DESCRIPTION
## Description of Changes

- Issue #22179 was caused because the kernel was not detected as alive after it starts in slow systems (i.e. those in which the kernel takes too long to start).
- Issue #22194 was a simple CommError when getting when the backend if the comm is not connected.
- Fix `test_restart_interactive_backend` on Windows. That allows to check if the `MatplotlibStatus` widget is working fine on it.
- Use `functools.partial` instead of `lambda` for the anonymous slots used in `MatplotlibStatus`. That's necessary because `lambda` slots prevent garbage collecting PyQt objects when `self` is used in them. However, `functools.partial` ones don't have that problem.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22194.
Fixes #22179.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
