### PR TITLE
PR: Tabify Outline next to Projects in default layout and other layout improvements and fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,7 @@ To run Spyder from your clone in its development mode, with extra checks and opt
 ```bash
 $ python bootstrap.py
 ```
+
 Note that if you are running on macOS 10.15 or earlier, you will need to call `pythonw` instead of `python`.
 
 To start Spyder in debug mode, useful for tracking down an issue, you can run:
@@ -80,6 +81,24 @@ $ python bootstrap.py --debug
 ```
 
 **Important Note**: To test any changes you've made to the Spyder source code, you need to restart Spyder or start a fresh instance (you can run multiple copies simultaneously by unchecking the Preferences option <kbd>Use a single instance</kbd> under <kbd>General</kbd> > <kbd>Advanced Settings</kbd> .
+
+To start Spyder with different Qt bindings (e.g. PySide2 or PyQt6), you can run:
+
+```bash
+$ python bootstrap.py --gui pyqt6
+```
+
+To access Spyder command line options from `bootstrap.py`, you need to run:
+
+```bash
+$ python bootstrap.py -- --help
+```
+
+Note that `bootstrap.py` has its own command line options, which can be listed by running:
+
+```bash
+$ python bootstrap.py --help
+```
 
 
 ###  Running tests

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -52,8 +52,7 @@ symbol (example: `python bootstrap.py -- --hide-console`).
 Type `python bootstrap.py -- --help` to read about Spyder
 options.""")
 parser.add_argument('--gui', default=None,
-                    help="GUI toolkit: pyqt5 (for PyQt5) or pyside2 "
-                    "(for PySide2)")
+                    help="GUI toolkit: pyqt5, pyside2, pyqt6 or pyside6")
 parser.add_argument('--hide-console', action='store_true', default=False,
                     help="Hide parent console window (Windows only)")
 parser.add_argument('--safe-mode', dest="safe_mode",
@@ -71,8 +70,9 @@ parser.add_argument('spyder_options', nargs='*')
 
 args = parser.parse_args()
 
-assert args.gui in (None, 'pyqt5', 'pyside2'), \
-       "Invalid GUI toolkit option '%s'" % args.gui
+assert args.gui in (None, "pyqt5", "pyside2", "pyqt6", "pyside6"), (
+    "Invalid GUI toolkit option '%s'" % args.gui
+)
 
 
 # =============================================================================

--- a/spyder/api/plugin_registration/registry.py
+++ b/spyder/api/plugin_registration/registry.py
@@ -628,9 +628,6 @@ class SpyderPluginRegistry(QObject, PreferencesAdapter):
         if not can_close and not close_immediately:
             return False
 
-        # Dock undocked plugins
-        self.dock_all_undocked_plugins(save_undocked=True)
-
         # Delete Spyder 4 external plugins
         for plugin_name in set(self.external_plugins):
             if plugin_name not in excluding:

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -10,6 +10,8 @@ New API for plugins.
 All plugins in Spyder 5+ must inherit from the classes present in this file.
 """
 
+from __future__ import annotations
+
 # Standard library imports
 from collections import OrderedDict
 import inspect
@@ -23,7 +25,7 @@ import warnings
 # Third party imports
 from qtpy.QtCore import QObject, Qt, Signal, Slot
 from qtpy.QtGui import QCursor
-from qtpy.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication, QMainWindow
 
 # Local imports
 from spyder.api.config.mixins import SpyderConfigurationObserver
@@ -320,7 +322,7 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
         self._actions = {}
         self.is_compatible = None
         self.is_registered = None
-        self.main = parent
+        self.main: QMainWindow = parent
 
         # Attribute used to access the action, toolbar, toolbutton and menu
         # registries
@@ -421,7 +423,7 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
         """
         return self._main
 
-    def get_plugin(self, plugin_name, error=True):
+    def get_plugin(self, plugin_name, error=True) -> SpyderPluginV2:
         """
         Get a plugin instance by providing its name.
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -381,8 +381,8 @@ class MainWindow(
 
         # Center message
         screen_geometry = self.screen().geometry()
-        x = (screen_geometry.width() - messageBox.width()) / 2
-        y = (screen_geometry.height() - messageBox.height()) / 2
+        x = (screen_geometry.width() - messageBox.width()) // 2
+        y = (screen_geometry.height() - messageBox.height()) // 2
         messageBox.move(x, y)
 
     def register_plugin(self, plugin_name, external=False, omit_conf=False):

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -855,15 +855,6 @@ class MainWindow(
         if self.layouts is not None:
             self.layouts.register_custom_layouts()
 
-        # Needed to ensure dockwidgets/panes layout size distribution
-        # when a layout state is already present.
-        # See spyder-ide/spyder#17945
-        if (
-            self.layouts is not None
-            and self.get_conf('window/state', default=None)
-        ):
-            self.layouts.before_mainwindow_visible()
-
         # Tabify new plugins which were installed or created after Spyder ran
         # for the first time.
         # NOTE: **DO NOT** make layout changes after this point or new plugins
@@ -1150,16 +1141,13 @@ class MainWindow(
                     ]
                 )
 
-        can_close = self.plugin_registry.delete_all_plugins(
-            excluding={Plugins.Layout},
-            close_immediately=close_immediately)
-
-        if not can_close and not close_immediately:
-            return False
-
-        # Save window settings *after* closing all plugin windows, in order
-        # to show them in their previous locations in the next session.
+        # Dock undocked plugins before saving the layout.
         # Fixes spyder-ide/spyder#12139
+        self.plugin_registry.dock_all_undocked_plugins(save_undocked=True)
+
+        # Save layout before closing all plugins. This ensures its restored
+        # correctly in the next session when there are many IPython consoles
+        # open in the current one.
         prefix = 'window' + '/'
         if self.layouts is not None:
             self.layouts.save_current_window_settings(prefix)
@@ -1173,6 +1161,14 @@ class MainWindow(
                     Plugins.Layout, teardown=False)
             except RuntimeError:
                 pass
+
+        # Close all plugins
+        can_close = self.plugin_registry.delete_all_plugins(
+            excluding={Plugins.Layout}, close_immediately=close_immediately
+        )
+
+        if not can_close and not close_immediately:
+            return False
 
         self.already_closed = True
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -6069,8 +6069,9 @@ def test_visible_plugins(main_window, qtbot):
         lambda: shell.spyder_kernel_ready and shell._prompt_html is not None,
         timeout=SHELL_TIMEOUT)
 
-    # Load default layout
+    # Load default layout and wait for a bit because it's applied immediately
     main_window.layouts.quick_layout_switch(DefaultLayouts.SpyderLayout)
+    qtbot.wait(200)
 
     # Make some non-default plugins visible
     selected = [Plugins.Plots, Plugins.History]

--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -196,6 +196,8 @@ def qt_message_handler(msg_type, msg_log_context, msg_string):
         "QFont::setPixelSize: Pixel size <= 0 (-3)",
         "QPainter::setFont: Painter not active",
         "QPainter::restore: Unbalanced save/restore",
+        # This warning is shown at startup when using PyQt6
+        "<use> element image0 in wrong context!",
     ]
     if msg_string not in BLACKLIST:
         print(msg_string)  # spyder: test-skip

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -1720,8 +1720,12 @@ class EditorMainWidget(PluginMainWidget):
             outline_plugin=self.outline_plugin
         )
 
-        window.resize(self.size())
+        # Give a default size to new windows so they're shown with a nice size
+        # regardless of the current one of this widget (we were using self.size
+        # here before).
+        window.resize(800, 800)
         window.show()
+
         window.editorwidget.editorsplitter.editorstack.new_window = True
         self.register_editorwindow(window)
         window.destroyed.connect(lambda: self.unregister_editorwindow(window))

--- a/spyder/plugins/editor/widgets/window.py
+++ b/spyder/plugins/editor/widgets/window.py
@@ -176,12 +176,12 @@ class EditorWidget(QSplitter, SpyderConfigurationObserver):
         # ---- Splitter
         self.splitter = QSplitter(self)
         self.splitter.setContentsMargins(0, 0, 0, 0)
-        self.splitter.addWidget(editor_widgets)
         if self.outlineexplorer is not None:
             self.splitter.addWidget(self.outlineexplorer)
+        self.splitter.addWidget(editor_widgets)
 
-        self.splitter.setStretchFactor(0, 3)
-        self.splitter.setStretchFactor(1, 1)
+        self.splitter.setStretchFactor(0, 1)
+        self.splitter.setStretchFactor(1, 4)
 
         # This sets the same UX as the one users encounter when the editor is
         # maximized.
@@ -301,7 +301,7 @@ class EditorWidget(QSplitter, SpyderConfigurationObserver):
             self.splitter.setChildrenCollapsible(True)
 
             # Collapse Outline
-            self.splitter.moveSplitter(self.size().width(), 0)
+            self.splitter.moveSplitter(0, 1)
 
             # Hide and disable splitter handle
             self._splitter_css['QSplitter::handle'].setValues(

--- a/spyder/plugins/layout/api.py
+++ b/spyder/plugins/layout/api.py
@@ -509,6 +509,10 @@ class BaseGridLayoutType:
             for plugin in base_plugins_to_hide:
                 plugin.toggle_view(False)
 
+        # We need to wait for a little bit before hiding the not visible base
+        # plugins to correctly set the proportions declared in the layout for
+        # rows and columns. Otherwise the calls to resizeDocks above won't have
+        # the expected effect.
         QTimer.singleShot(50, hide_not_visible_base_plugins)
 
         # Restore displayed external plugins

--- a/spyder/plugins/layout/layouts.py
+++ b/spyder/plugins/layout/layouts.py
@@ -68,7 +68,7 @@ class SpyderLayout(BaseGridLayoutType):
         self.set_column_stretch(2, 3)
 
     def get_name(self):
-        return _("Spyder Default Layout")
+        return _("Default layout")
 
 
 class HorizontalSplitLayout(BaseGridLayoutType):

--- a/spyder/plugins/layout/layouts.py
+++ b/spyder/plugins/layout/layouts.py
@@ -29,7 +29,7 @@ class SpyderLayout(BaseGridLayoutType):
         super().__init__(parent_plugin)
 
         self.add_area(
-            [Plugins.Projects],
+            [Plugins.Projects, Plugins.OutlineExplorer],
             row=0,
             column=0,
             row_span=2,
@@ -42,32 +42,30 @@ class SpyderLayout(BaseGridLayoutType):
             row_span=2,
         )
         self.add_area(
-            [Plugins.OutlineExplorer],
+            [
+                Plugins.Help,
+                Plugins.VariableExplorer,
+                Plugins.Debugger,
+                Plugins.Plots,
+                Plugins.OnlineHelp,
+                Plugins.Explorer,
+                Plugins.Find,
+            ],
             row=0,
             column=2,
-            row_span=2,
-            visible=False,
-        )
-        self.add_area(
-            [Plugins.Help, Plugins.VariableExplorer,
-             Plugins.Debugger, Plugins.Plots,
-             Plugins.OnlineHelp, Plugins.Explorer, Plugins.Find],
-            row=0,
-            column=3,
             default=True,
             hidden_plugin_ids=[Plugins.OnlineHelp, Plugins.Find]
         )
         self.add_area(
             [Plugins.IPythonConsole, Plugins.History, Plugins.Console],
             row=1,
-            column=3,
+            column=2,
             hidden_plugin_ids=[Plugins.Console]
         )
 
         self.set_column_stretch(0, 1)
-        self.set_column_stretch(1, 4)
-        self.set_column_stretch(2, 1)
-        self.set_column_stretch(3, 4)
+        self.set_column_stretch(1, 3)
+        self.set_column_stretch(2, 3)
 
     def get_name(self):
         return _("Spyder Default Layout")

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -517,13 +517,17 @@ class Layout(SpyderPluginV2):
 
         pos = get_func(prefix + 'position', section=section)
 
+        # We use `virtualGeometry` instead of `geometry` below because it gives
+        # the shape of all connected screens, which is what we need here (
+        # `geometry` only works for the current one).
+        screen_shape = self.main.screen().virtualGeometry()
+        current_width = screen_shape.width()
+        current_height = screen_shape.height()
+
         # It's necessary to verify if the window/position value is valid
         # with the current screen. See spyder-ide/spyder#3748.
         width = pos[0]
         height = pos[1]
-        screen_shape = self.main.screen().virtualGeometry()
-        current_width = screen_shape.width()
-        current_height = screen_shape.height()
         if current_width < width or current_height < height:
             pos = self.get_conf_default(prefix + 'position', section)
 

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -532,7 +532,7 @@ class Layout(SpyderPluginV2):
         # with the current screen. See spyder-ide/spyder#3748.
         width = pos[0]
         height = pos[1]
-        screen_shape = self.main.screen().geometry()
+        screen_shape = self.main.screen().virtualGeometry()
         current_width = screen_shape.width()
         current_height = screen_shape.height()
         if current_width < width or current_height < height:

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -200,7 +200,11 @@ class Layout(SpyderPluginV2):
     def before_mainwindow_visible(self):
         # Update layout menu
         self.update_layout_menu_actions()
-        # Setup layout
+
+        # The layout needs to be applied twice: before and after the main
+        # window is visible (see below). This call avoids weird issues when the
+        # window was not maximized in the last session. See:
+        # https://github.com/spyder-ide/spyder/pull/22232#issuecomment-2224142496
         self.setup_layout(default=False)
 
     def on_mainwindow_visible(self):
@@ -208,6 +212,12 @@ class Layout(SpyderPluginV2):
         # This **MUST** be done before restoring the last visible plugins, so
         # that works as expected.
         self.create_plugins_menu()
+
+        # Setup layout when the window is visible.
+        # This **MUST** be done after creating the plugins menu to correctly
+        # restore the layout from the previous session.
+        # Fixes spyder-ide/spyder#17945 and spyder-ide/spyder#21596
+        self.setup_layout(default=False)
 
         # Restore last visible plugins.
         # This **MUST** be done before running on_mainwindow_visible for the

--- a/spyder/plugins/outlineexplorer/plugin.py
+++ b/spyder/plugins/outlineexplorer/plugin.py
@@ -149,8 +149,20 @@ class OutlineExplorer(SpyderDockablePlugin):
         """
         self.get_widget().in_maximized_editor = True
         if self.get_conf('show_with_maximized_editor'):
-            self.main.addDockWidget(Qt.RightDockWidgetArea, self.dockwidget)
+            self.main.addDockWidget(Qt.LeftDockWidgetArea, self.dockwidget)
             self.dockwidget.show()
+
+            # This width is enough to show all buttons in the main toolbar
+            max_width = 360
+
+            # Give an appropiate width to the Outline
+            editor = self.get_plugin(Plugins.Editor)
+            self.main.resizeDocks(
+                [editor.dockwidget, self.dockwidget],
+                [self.main.width(), min(self.main.width() // 7, max_width)],
+                Qt.Horizontal
+            )
+
         self._set_toggle_view_action_state()
 
     def hide_from_maximized_editor(self):

--- a/spyder/plugins/outlineexplorer/plugin.py
+++ b/spyder/plugins/outlineexplorer/plugin.py
@@ -159,6 +159,8 @@ class OutlineExplorer(SpyderDockablePlugin):
             editor = self.get_plugin(Plugins.Editor)
             self.main.resizeDocks(
                 [editor.dockwidget, self.dockwidget],
+                # We set main_window.width() // 7 as the min width for the
+                # Outline because it's not too wide for small screens.
                 [self.main.width(), min(self.main.width() // 7, max_width)],
                 Qt.Horizontal
             )

--- a/spyder/plugins/run/widgets.py
+++ b/spyder/plugins/run/widgets.py
@@ -39,7 +39,7 @@ from spyder.api.fonts import SpyderFontType, SpyderFontsMixin
 from spyder.api.translations import _
 from spyder.api.widgets.comboboxes import SpyderComboBox
 from spyder.api.widgets.dialogs import SpyderDialogButtonBox
-from spyder.config.base import running_under_pytest
+from spyder.config.base import running_in_ci, running_under_pytest
 from spyder.plugins.run.api import (
     ExtendedRunExecutionParameters,
     RunExecutorConfigurationGroup,
@@ -937,8 +937,14 @@ class RunDialog(BaseRunConfigDialog, SpyderFontsMixin):
         # on a successive try
         self.name_params_text.status_action.setVisible(False)
 
-        # Detect if the current params are global
+        # Get index of current params
         current_index = self.parameters_combo.currentIndex()
+        if running_in_ci() and current_index == -1:
+            # This error seems to happen only on CIs
+            self.status = RunDialogStatus.Close
+            return
+
+        # Detect if the current params are global
         params = self.parameter_model.get_parameters(current_index)
         global_params = params["file_uuid"] is None
 

--- a/spyder/widgets/dock.py
+++ b/spyder/widgets/dock.py
@@ -251,7 +251,7 @@ class SpyderDockWidget(QDockWidget):
 
         # Attributes
         self.title = title
-        self._is_shown = False
+        self.is_shown = False
 
         # Set features
         self.setFeatures(self.FEATURES)
@@ -287,20 +287,15 @@ class SpyderDockWidget(QDockWidget):
         """Send a signal on close so that the "Panes" menu can be updated."""
         self.sig_plugin_closed.emit()
 
-    def showEvent(self, event):
-        """Adjustments when the widget is shown."""
-        if not self._is_shown:
-            # This installs the tab filter at startup
-            self.install_tab_event_filter()
-            self._is_shown = True
-
-        super().showEvent(event)
-
     def install_tab_event_filter(self):
         """
         Install an event filter to capture mouse events in the tabs of a
         QTabBar holding tabified dockwidgets.
         """
+        # Avoid to run this before the dockwidget is visible
+        if not self.is_shown:
+            return
+
         dock_tabbar = None
 
         # This is necessary to catch an error when closing the app on macOS


### PR DESCRIPTION
## Description of Changes

- While translating our docs to Spanish, @LucyJimenez noted that the Outline is tabified next to Projects, but that's not the case for the default layout. So, this PR changes that, which I think is a good idea.
- For consistency, show Outline to the left when the editor is maximized and in editor windows.
- Fix setting any layout with the correct proportions declared in its definition. That was not working as expected, which made the Outline/Projects column in the default layout appear too thin.
- Fix bug that prevented to restore the previous layout at startup for some user defined layouts (see #21596).
- Fix bug that broke positioning Spyder in the right screen at startup. That was a regression introduced in #21572.
- Allow to run Spyder with PyQt6 or PySide6 from `bootstrap.py`. I did this to test that the fix to position Spyder in the right screen worked for both Qt5 and 6.
- Give editor windows a good size independent from the `EditorMainWidget` one. That's in case the latter is too small.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22178
Fixes #21596

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
