### PR TITLE
PR: Add missing space over masked label text (Variable Explorer - `ArrayEditor`)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -847,7 +847,7 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
             _('<u>Warning</u>: Changes are applied separately')
         )
         self.masked_label.setToolTip(
-            _("For performance reasons, changes applied to masked arrays won't"
+            _("For performance reasons, changes applied to masked arrays won't "
               "be reflected in array's data (and vice-versa).")
           )
         self.btn_layout.addWidget(self.masked_label)

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -847,8 +847,8 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
             _('<u>Warning</u>: Changes are applied separately')
         )
         self.masked_label.setToolTip(
-            _("For performance reasons, changes applied to masked arrays won't "
-              "be reflected in array's data (and vice-versa).")
+            _("For performance reasons, changes applied to masked arrays "
+              "won't be reflected in array's data (and vice-versa).")
           )
         self.btn_layout.addWidget(self.masked_label)
 

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -849,7 +849,7 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
         self.masked_label.setToolTip(
             _("For performance reasons, changes applied to masked arrays "
               "won't be reflected in array's data (and vice-versa).")
-          )
+        )
         self.btn_layout.addWidget(self.masked_label)
 
         self.btn_layout.addStretch()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->
Fix translation string due to missing space (`won'tbe` vs `won't be`) over the masked label tooltip of the `ArrayEditor` widget

Before:

![image](https://github.com/spyder-ide/spyder/assets/16781833/292878ba-f142-485d-8b13-de29a9204dfb)

After:

![image](https://github.com/spyder-ide/spyder/assets/16781833/afe664f5-ff0d-47e0-b5ad-fe3ca48e3463)


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
