### PR TITLE
PR: Remove dependency on `pkg_resources` and use `importlib-metadata` instead

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -12,6 +12,7 @@ dependencies:
 - cloudpickle >=0.5.0
 - cookiecutter >=1.6.0
 - diff-match-patch >=20181111
+- importlib-metadata >=4.6.0
 - intervaltree >=3.0.2
 - ipython >=8.13.0,<9.0.0,!=8.17.1
 - jedi >=0.17.2,<0.20.0

--- a/conftest.py
+++ b/conftest.py
@@ -113,13 +113,18 @@ def reset_conf_before_test():
     from spyder.plugins.completion.api import COMPLETION_ENTRYPOINT
     from spyder.plugins.completion.plugin import CompletionPlugin
 
+    # See compatibility note on `group` keyword:
+    # https://docs.python.org/3/library/importlib.metadata.html#entry-points
+    if sys.version_info < (3, 10):  # pragma: no cover
+        from importlib_metadata import entry_points
+    else:  # pragma: no cover
+        from importlib.metadata import entry_points
+
     # Restore completion clients default settings, since they
     # don't have default values on the configuration.
-    from pkg_resources import iter_entry_points
-
     provider_configurations = {}
-    for entry_point in iter_entry_points(COMPLETION_ENTRYPOINT):
-        Provider = entry_point.resolve()
+    for entry_point in entry_points(group=COMPLETION_ENTRYPOINT):
+        Provider = entry_point.load()
         provider_name = Provider.COMPLETION_PROVIDER_NAME
 
         (provider_conf_version,

--- a/install_dev_repos.py
+++ b/install_dev_repos.py
@@ -15,7 +15,7 @@ from logging import Formatter, StreamHandler, getLogger
 from pathlib import Path
 from subprocess import check_output
 
-from importlib_metadata import PackageNotFoundError, distribution
+from importlib.metadata import PackageNotFoundError, distribution
 from packaging.requirements import Requirement
 
 # Remove current/script directory from sys.path[0] if added by the Python invocation,

--- a/installers/macOS/packages.py
+++ b/installers/macOS/packages.py
@@ -20,10 +20,6 @@ keyring:
     ModuleNotFoundError: No module named 'keyring.backends.chainer'
     ModuleNotFoundError: No module named 'keyring.backends.libsecret'
     ModuleNotFoundError: No module named 'keyring.backends.macOS'
-pkg_resources:
-    ImportError: The 'more_itertools' package is required; normally this is
-    bundled with this package so if you get this warning, consult the
-    packager of your distribution.
 pygments:
     ModuleNotFoundError: No module named 'pygments.formatters.latex'
 pylint_venv:
@@ -45,7 +41,6 @@ spyder_kernels :
 PACKAGES = [
     'blackd',
     'keyring',
-    'pkg_resources',
     'pygments',
     'pylint_venv',
     'pyls_spyder',

--- a/requirements/main.yml
+++ b/requirements/main.yml
@@ -10,6 +10,8 @@ dependencies:
   - cloudpickle >=0.5.0
   - cookiecutter >=1.6.0
   - diff-match-patch >=20181111
+  # Need at least some compatibility with python 3.10 features
+  - importlib-metadata >=4.6.0
   - intervaltree >=3.0.2
   - ipython >=8.13.0,<9.0.0,!=8.17.1
   - jedi >=0.17.2,<0.20.0

--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,9 @@ install_requires = [
     'cloudpickle>=0.5.0',
     'cookiecutter>=1.6.0',
     'diff-match-patch>=20181111',
+    # While this is only required for python <3.10, it is safe enough to
+    # install in all cases and helps the tests to pass.
+    'importlib-metadata>=4.6.0',
     'intervaltree>=3.0.2',
     'ipython>=8.12.2,<8.13.0; python_version=="3.8"',
     'ipython>=8.13.0,<9.0.0,!=8.17.1; python_version>"3.8"',
@@ -246,7 +249,7 @@ install_requires = [
     'spyder-kernels>=2.5.2,<2.6.0',
     'textdistance>=4.2.0',
     'three-merge>=0.1.1',
-    'watchdog>=0.10.3'
+    'watchdog>=0.10.3',
 ]
 
 # Loosen constraints to ensure dev versions still work

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -40,6 +40,7 @@ CHARDET_REQVER = '>=2.0.0'
 CLOUDPICKLE_REQVER = '>=0.5.0'
 COOKIECUTTER_REQVER = '>=1.6.0'
 DIFF_MATCH_PATCH_REQVER = '>=20181111'
+IMPORTLIB_METADATA_REQVER = '>=4.6.0'
 # None for pynsist install for now
 # (check way to add dist.info/egg.info from packages without wheels available)
 INTERVALTREE_REQVER = None if is_pynsist() else '>=3.0.2'
@@ -121,6 +122,10 @@ DESCRIPTIONS = [
      'package_name': "diff-match-patch",
      'features': _("Compute text file diff changes during edition"),
      'required_version': DIFF_MATCH_PATCH_REQVER},
+    {'modname': 'importlib_metadata',
+     'package_name': 'importlib-metadata',
+     'features': _('Access the metadata for a Python package'),
+     'required_version': IMPORTLIB_METADATA_REQVER},
     {'modname': "intervaltree",
      'package_name': "intervaltree",
      'features': _("Compute folding range nesting levels"),

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -8,10 +8,10 @@
 
 # Standard library imports
 from ast import literal_eval
-from getpass import getuser
-from textwrap import dedent
 import glob
+from getpass import getuser
 import importlib
+from importlib.metadata import PackageNotFoundError, version as package_version
 import itertools
 import os
 import os.path as osp
@@ -19,12 +19,12 @@ import re
 import subprocess
 import sys
 import tempfile
+from textwrap import dedent
 import threading
 import time
 
 # Third party imports
 from packaging.version import parse
-import pkg_resources
 import psutil
 
 # Local imports
@@ -845,13 +845,9 @@ def get_module_version(module_name):
 
 def get_package_version(package_name):
     """Return package version or None if version can't be retrieved."""
-
-    # When support for Python 3.7 and below is dropped, this can be replaced
-    # with the built-in importlib.metadata.version
     try:
-        ver = pkg_resources.get_distribution(package_name).version
-        return ver
-    except pkg_resources.DistributionNotFound:
+        return package_version(package_name)
+    except PackageNotFoundError:
         return None
 
 

--- a/spyder/utils/tests/test_programs.py
+++ b/spyder/utils/tests/test_programs.py
@@ -287,7 +287,7 @@ Icon=/blah/blah.xpm
 
 
 def test_get_package_version():
-    # Primarily a test of pkg_resources/setuptools being installed properly
+    # Primarily a test of importlib.metadata being installed properly
     assert get_package_version('IPython')
     assert get_package_version('python_lsp_black')
 


### PR DESCRIPTION
It is deprecated and the note says to move away when Python 3.7 is dropped.

Seems like now ;)

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

![image](https://github.com/spyder-ide/spyder/assets/90008/da024bd7-7a90-477a-a663-45fdf75cf161)
![image](https://github.com/spyder-ide/spyder/assets/90008/68a23827-a145-4027-8d0e-1c832965d52c)


Python 3.8
![image](https://github.com/spyder-ide/spyder/assets/90008/1f6e7b7d-0524-4d39-9767-fe30086a8372)

<!--- Explain what you've done and why --->
Maintenance

### Issue(s) Resolved

Fixes #21545 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

Mark Harfouche hmaarrfk

<!--- Thanks for your help making Spyder better for everyone! --->
