### PR TITLE
PR: Update conda-lock for change in release workflow

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -220,6 +220,7 @@ jobs:
           env | sort
 
       - name: Build ${{ matrix.target-platform }} spyder Conda Package
+        if: env.IS_RELEASE == 'false'
         run: |
           # Copy built packages to new build location because spyder cannot be
           # built in workspace

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -207,24 +207,7 @@ def _create_conda_lock():
     if logger.getEffectiveLevel() <= 20:
         print(TMP_LOCK_FILE.read_text(), flush=True)
 
-
-def _patch_conda_lock():
-    # Replace local channel url with conda-forge and remove checksum
-    dev_channel = ""
-    if SPYVER.is_prerelease:
-        dev_channel = "/label/spyder_dev"
-
-    tmp_text = TMP_LOCK_FILE.read_text()
-    text = re.sub(
-        f"^{_get_conda_bld_path_url()}(.*)#.*$",
-        fr"https://conda.anaconda.org/conda-forge{dev_channel}\1",
-        tmp_text, flags=re.MULTILINE
-    )
-    LOCK_FILE.write_text(text)
-
-    logger.info(f"Contents of {LOCK_FILE}:")
-    if logger.getEffectiveLevel() <= 20:
-        print(LOCK_FILE.read_text(), flush=True)
+    LOCK_FILE.write_text(TMP_LOCK_FILE.read_text())
 
 
 def _generate_background_images(installer_type):
@@ -504,8 +487,6 @@ def main():
         elapse = timedelta(seconds=int(time() - t0))
         logger.info(f"Build time: {elapse}")
 
-    _patch_conda_lock()
-
 
 if __name__ == "__main__":
     if args.arch:
@@ -525,7 +506,6 @@ if __name__ == "__main__":
         sys.exit()
     if args.conda_lock:
         _create_conda_lock()
-        _patch_conda_lock()
         sys.exit()
 
     main()

--- a/spyder/plugins/updatemanager/tests/test_update_manager.py
+++ b/spyder/plugins/updatemanager/tests/test_update_manager.py
@@ -31,7 +31,7 @@ def worker():
 # ---- Test WorkerUpdate
 
 @pytest.mark.parametrize("version", ["1.0.0", "1000.0.0"])
-def test_updates_appenv(qtbot, mocker, version, caplog):
+def test_updates(qtbot, mocker, version, caplog):
     """
     Test whether or not we offer updates for our installers according to the
     current Spyder version.
@@ -44,12 +44,6 @@ def test_updates_appenv(qtbot, mocker, version, caplog):
         UpdateManagerWidget, "start_update", new=lambda x: None
     )
     mocker.patch.object(workers, "__version__", new=version)
-    mocker.patch.object(workers, "is_anaconda", return_value=True)
-    mocker.patch.object(workers, "is_conda_based_app", return_value=True)
-    mocker.patch.object(
-        workers, "get_spyder_conda_channel",
-        return_value=("conda-forge", "https://conda.anaconda.org/conda-forge")
-    )
 
     with caplog.at_level(logging.DEBUG, logger='spyder.plugins.updatemanager'):
         # Capture >=DEBUG logging messages for spyder.plugins.updatemanager
@@ -75,59 +69,6 @@ def test_updates_appenv(qtbot, mocker, version, caplog):
     else:
         assert not update_available
     assert len(um.update_worker.releases) > 1
-
-
-@pytest.mark.parametrize("version", ["1.0.0", "1000.0.0"])
-@pytest.mark.parametrize(
-    "channel", [
-        ("pkgs/main", "https://repo.anaconda.com/pkgs/main"),
-        ("conda-forge", "https://conda.anaconda.org/conda-forge"),
-        ("pypi", "https://conda.anaconda.org/pypi")
-    ]
-)
-def test_updates_condaenv(qtbot, worker, mocker, version, channel):
-    """
-    Test whether or not we offer updates for conda installed Spyder according
-    to the current version.
-    """
-    mocker.patch.object(workers, "__version__", new=version)
-    mocker.patch.object(workers, "is_anaconda", return_value=True)
-    mocker.patch.object(workers, "is_conda_based_app", return_value=False)
-    mocker.patch.object(
-        workers, "get_spyder_conda_channel", return_value=channel
-    )
-
-    with qtbot.waitSignal(worker.sig_ready, timeout=5000):
-        worker.start()
-
-    update_available = worker.update_available
-    if version.split('.')[0] == '1':
-        assert update_available
-    else:
-        assert not update_available
-    assert len(worker.releases) == 1
-
-
-@pytest.mark.parametrize("version", ["1.0.0", "1000.0.0"])
-def test_updates_pipenv(qtbot, worker, mocker, version):
-    """Test updates for pip installed Spyder."""
-    mocker.patch.object(workers, "__version__", new=version)
-    mocker.patch.object(workers, "is_anaconda", return_value=False)
-    mocker.patch.object(workers, "is_conda_based_app", return_value=False)
-    mocker.patch.object(
-        workers, "get_spyder_conda_channel",
-        return_value=("pypi", "https://conda.anaconda.org/pypi")
-    )
-
-    with qtbot.waitSignal(worker.sig_ready, timeout=5000):
-        worker.start()
-
-    update_available = worker.update_available
-    if version.split('.')[0] == '1':
-        assert update_available
-    else:
-        assert not update_available
-    assert len(worker.releases) == 1
 
 
 @pytest.mark.parametrize("release", ["4.0.1", "4.0.1a1"])


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

We agreed to change the release workflow to PyPi -> conda-forge -> Github in order to produce sound conda-lock files on release for updating our conda-based applications. This results in the following changes to the installer CI workflow and update manager.
* The Spyder conda package will only be built on CI for PRs and workflow-dispatch triggers, not releases
* The conda-lock file will not be patched. For non-release events, this produces an accurate conda-lock file which cannot be used outside CI. For release events, this produces the accurate and portable conda-lock file.
* The update manager only looks at Github for releases.

This is a follow-up PR to #22204 