### PR TITLE
Modernize the use of QRegExp to use QRegularExpression

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor.py
@@ -34,8 +34,8 @@ from IPython.core.inputtransformer2 import TransformerManager
 from packaging.version import parse
 from qtpy import QT_VERSION
 from qtpy.compat import to_qvariant
-from qtpy.QtCore import (QEvent, QEventLoop, QRegExp, Qt, QTimer, QThread,
-                         QUrl, Signal, Slot)
+from qtpy.QtCore import (QEvent, QEventLoop, QRegularExpression, Qt, QTimer,
+                         QThread, QUrl, Signal, Slot)
 from qtpy.QtGui import (QColor, QCursor, QFont, QKeySequence, QPaintEvent,
                         QPainter, QMouseEvent, QTextCursor, QDesktopServices,
                         QKeyEvent, QTextDocument, QTextFormat, QTextOption,
@@ -2590,7 +2590,8 @@ class CodeEditor(TextEditBaseWidget):
         cursor = self.textCursor()
         # Scanning whole document
         cursor.movePosition(QTextCursor.Start)
-        regexp = QRegExp(r"\b%s\b" % QRegExp.escape(text), Qt.CaseSensitive)
+        regexp = QRegularExpression(
+            r"\b%s\b" % QRegularExpression.escape(text), Qt.CaseSensitive)
         cursor = self.document().find(regexp, cursor, flags)
         self.__find_first_pos = cursor.position()
         return cursor
@@ -2598,7 +2599,8 @@ class CodeEditor(TextEditBaseWidget):
     def __find_next(self, text, cursor):
         """Find next occurrence"""
         flags = QTextDocument.FindCaseSensitively|QTextDocument.FindWholeWords
-        regexp = QRegExp(r"\b%s\b" % QRegExp.escape(text), Qt.CaseSensitive)
+        regexp = QRegularExpression(
+            r"\b%s\b" % QRegularExpression.escape(text), Qt.CaseSensitive)
         cursor = self.document().find(regexp, cursor, flags)
         if cursor.position() != self.__find_first_pos:
             return cursor

--- a/spyder/plugins/explorer/widgets/fileassociations.py
+++ b/spyder/plugins/explorer/widgets/fileassociations.py
@@ -15,8 +15,8 @@ import sys
 
 # Third party imports
 from qtpy.compat import getopenfilename
-from qtpy.QtCore import QRegExp, QSize, Qt, Signal, Slot
-from qtpy.QtGui import QCursor, QRegExpValidator
+from qtpy.QtCore import QRegularExpression, QSize, Qt, Signal, Slot
+from qtpy.QtGui import QCursor, QRegularExpressionValidator
 from qtpy.QtWidgets import (QApplication, QDialog, QDialogButtonBox,
                             QHBoxLayout, QLabel, QLineEdit,
                             QListWidget, QListWidgetItem, QPushButton,
@@ -83,7 +83,7 @@ class InputTextDialog(QDialog):
         """Set the regular expression to validate content."""
         self._regex = regex
         self._reg = re.compile(regex, re.IGNORECASE)
-        validator = QRegExpValidator(QRegExp(regex))
+        validator = QRegularExpressionValidator(QRegularExpression(regex))
         self.lineedit.setValidator(validator)
 
     def text(self):

--- a/spyder/plugins/preferences/api.py
+++ b/spyder/plugins/preferences/api.py
@@ -16,8 +16,8 @@ import os.path as osp
 from qtpy import API
 from qtpy.compat import (getexistingdirectory, getopenfilename, from_qvariant,
                          to_qvariant)
-from qtpy.QtCore import Qt, Signal, Slot, QRegExp
-from qtpy.QtGui import QColor, QRegExpValidator, QTextOption
+from qtpy.QtCore import Qt, Signal, Slot, QRegularExpression
+from qtpy.QtGui import QColor, QRegularExpressionValidator, QTextOption
 from qtpy.QtWidgets import (QButtonGroup, QCheckBox, QComboBox, QDoubleSpinBox,
                             QFileDialog, QFontComboBox, QGridLayout, QGroupBox,
                             QHBoxLayout, QLabel, QLineEdit, QMessageBox,
@@ -494,7 +494,8 @@ class SpyderConfigPage(ConfigPage, ConfigAccessMixin):
         if tip:
             edit.setToolTip(tip)
         if regex:
-            edit.setValidator(QRegExpValidator(QRegExp(regex)))
+            edit.setValidator(
+                QRegularExpressionValidator(QRegularExpression(regex)))
         if placeholder:
             edit.setPlaceholderText(placeholder)
         self.lineedits[edit] = (section, option, default)

--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -14,9 +14,10 @@ import re
 # Third party imports
 import qstylizer.style
 from qtpy import PYQT5
-from qtpy.QtCore import QPoint, QRegExp, QSize, QSortFilterProxyModel, Qt
+from qtpy.QtCore import (QPoint, QRegularExpression, QSize,
+                         QSortFilterProxyModel, Qt)
 from qtpy.QtGui import (QAbstractTextDocumentLayout, QColor, QFontMetrics,
-                        QPainter, QRegExpValidator, QTextDocument, )
+                        QPainter, QRegularExpressionValidator, QTextDocument)
 from qtpy.QtWidgets import (QApplication, QCheckBox, QLineEdit, QMessageBox,
                             QSpacerItem, QStyle, QStyledItemDelegate,
                             QStyleOptionFrame, QStyleOptionViewItem,
@@ -345,8 +346,8 @@ class FinderLineEdit(QLineEdit):
         self.main = main
 
         # Widget setup
-        regex = QRegExp(regex_base + "{100}")
-        self.setValidator(QRegExpValidator(regex))
+        regex = QRegularExpression(regex_base + "{100}")
+        self.setValidator(QRegularExpressionValidator(regex))
 
         # Signals
         if callback:


### PR DESCRIPTION
Apparently this was available since 5.0

TODO: read this to see if there is any incompatibility: https://doc.qt.io/qt-6/qregexp.html

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


Just trying to help test against Qt6



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

Mark Harfouche hmaarrfk
<!--- Thanks for your help making Spyder better for everyone! --->
