### PR TITLE
PR: Use the correct micromamba for arm64 architecture on macOS (Installers)

### DIFF
--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -103,7 +103,8 @@ jobs:
       - name: Install Micromamba
         working-directory: ${{ github.workspace }}/spyder
         run: |
-          curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+          [[ "${RUNNER_ARCH}" == "ARM64" ]] && um_arch=osx-arm64 || um_arch=osx-64
+          curl -Ls https://micro.mamba.pm/api/micromamba/${um_arch}/latest | tar -xvj bin/micromamba
           install_name_tool -change @rpath/libc++.1.dylib /usr/lib/libc++.1.dylib bin/micromamba
       - name: Build Application Bundle
         run: |


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Use the correct url for arm64 micromamba.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22233

