### PR TITLE
PR: Remove a non-ascii file extension from QFileDialog filter

### DIFF
--- a/spyder/config/utils.py
+++ b/spyder/config/utils.py
@@ -99,7 +99,16 @@ def _get_pygments_extensions():
             lexer_exts = [le for le in lexer_exts if not le.endswith('_*')]
             extensions = extensions + list(lexer_exts) + list(other_exts)
 
-    return sorted(list(set(extensions)))
+    extensions = list(set(extensions))
+
+    # A non-ascii file extension causes issues for macOS
+    # See spyder-ide/spyder#22248
+    try:
+        extensions.remove('.' + chr(128293))
+    except ValueError:
+        pass
+
+    return sorted(extensions)
 
 
 #==============================================================================

--- a/spyder/config/utils.py
+++ b/spyder/config/utils.py
@@ -164,7 +164,7 @@ def get_edit_extensions():
     supported by the Editor
     """
     edit_filetypes = get_edit_filetypes()
-    return _get_extensions(edit_filetypes)+['']
+    return _get_extensions(edit_filetypes)
 
 
 #==============================================================================


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

A non-ascii character in the list of file extensions appears to cause issues for the QFileDialog filter on macOS. This may be a bug in PyQt. Nevertheless, removing the offending extension resolves the issue.

### Before save as

<img width="1115" alt="Screenshot 2024-07-18 at 5 31 41 PM" src="https://github.com/user-attachments/assets/e7260030-b1b2-40c8-879e-72119f95e089">

### Before open

<img width="809" alt="Screenshot 2024-07-18 at 10 48 34 PM" src="https://github.com/user-attachments/assets/c0262d56-0129-4553-9a09-308f3cf1d7e8">

### After save as

<img width="843" alt="Screenshot 2024-07-18 at 10 37 37 PM" src="https://github.com/user-attachments/assets/82060ca7-6d8e-49c7-b62b-33223dd024cc">

### After open

<img width="798" alt="Screenshot 2024-07-18 at 10 38 07 PM" src="https://github.com/user-attachments/assets/c6e368f7-d95f-4a41-995e-491dd18491a9">

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22248
