### PR TITLE
PR: Corrected horsplit.svg and versplit.svg icons

### DIFF
--- a/spyder/images/dark/horsplit.svg
+++ b/spyder/images/dark/horsplit.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M3 6V18H21V6H3ZM5 8H11V16H5V8ZM19 8H13V16H19V8Z" fill="#FAFAFA"/>
+<path d="M3 6V18H21V6H3ZM19 16H5V13H19V16ZM5 11V8H19V11H5Z" fill="#FAFAFA"/>
 </svg>

--- a/spyder/images/dark/versplit.svg
+++ b/spyder/images/dark/versplit.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M3 6V18H21V6H3ZM19 16H5V13H19V16ZM5 11V8H19V11H5Z" fill="#FAFAFA"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M3 6V18H21V6H3ZM5 8H11V16H5V8ZM19 8H13V16H19V8Z" fill="#FAFAFA"/>
 </svg>

--- a/spyder/images/light/horsplit.svg
+++ b/spyder/images/light/horsplit.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M3 6V18H21V6H3ZM5 8H11V16H5V8ZM19 8H13V16H19V8Z" fill="#37414F"/>
+<path d="M3 6V18H21V6H3ZM19 16H5V13H19V16ZM5 11V8H19V11H5Z" fill="#37414F"/>
 </svg>

--- a/spyder/images/light/versplit.svg
+++ b/spyder/images/light/versplit.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M3 6V18H21V6H3ZM19 16H5V13H19V16ZM5 11V8H19V11H5Z" fill="#37414F"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M3 6V18H21V6H3ZM5 8H11V16H5V8ZM19 8H13V16H19V8Z" fill="#37414F"/>
 </svg>


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

I noticed the horsplit.svg and versplit.svg icons (both light and dark) for splitting the dock were the wrong way round, so I renamed them so they're correct. This now manages the shape of the keyboard binds as well. 


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Before
![before](https://github.com/user-attachments/assets/33635165-1d9f-459b-a9ce-b3299e6f7b9d)

After
![after](https://github.com/user-attachments/assets/f167403d-a997-4a9a-b4d1-e67c76a9aa81)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
