### PR TITLE
PR: Fix several errors with missing plugins when setting a layout

### DIFF
--- a/spyder/plugins/layout/api.py
+++ b/spyder/plugins/layout/api.py
@@ -18,7 +18,6 @@ from qtpy.QtWidgets import QGridLayout, QPlainTextEdit, QWidget
 # Local imports
 from spyder.api.exceptions import SpyderAPIError
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
-from spyder.api.translations import _
 
 
 class BaseGridLayoutType:
@@ -194,15 +193,17 @@ class BaseGridLayoutType:
 
     # --- Public API
     # ------------------------------------------------------------------------
-    def add_area(self,
-                 plugin_ids,
-                 row,
-                 column,
-                 row_span=1,
-                 col_span=1,
-                 default=False,
-                 visible=True,
-                 hidden_plugin_ids=[]):
+    def add_area(
+        self,
+        plugin_ids,
+        row,
+        column,
+        row_span=1,
+        col_span=1,
+        default=False,
+        visible=True,
+        hidden_plugin_ids=[],
+    ):
         """
         Add a new area and `plugin_ids` that will populate it to the layout.
 
@@ -381,8 +382,15 @@ class BaseGridLayoutType:
         docks = {}
         for area in patched_areas:
             current_area = area
-            plugin_id = current_area["plugin_ids"][0]
-            plugin = main_window.get_plugin(plugin_id, error=False)
+
+            # Iterate over plugins in current_area until we find one that is
+            # available
+            plugin = None
+            for plugin_id in current_area["plugin_ids"]:
+                plugin = main_window.get_plugin(plugin_id, error=False)
+                if plugin is not None:
+                    break
+
             if plugin:
                 dock = plugin.dockwidget
                 docks[(current_area["row"], current_area["column"])] = dock
@@ -443,10 +451,18 @@ class BaseGridLayoutType:
         plugins_to_tabify = []
         for area in patched_areas:
             area_visible = area["visible"]
-            base_plugin = main_window.get_plugin(
-                area["plugin_ids"][0], error=False)
+
+            # Iterate over plugins in area until we find one that is available
+            base_plugin = None
+            for i, plugin_id in enumerate(area["plugin_ids"]):
+                base_plugin = main_window.get_plugin(
+                    area["plugin_ids"][i], error=False
+                )
+                if base_plugin is not None:
+                    break
+
             if base_plugin:
-                plugin_ids = area["plugin_ids"][1:]
+                plugin_ids = area["plugin_ids"][i + 1 :]
                 hidden_plugin_ids = area["hidden_plugin_ids"]
                 for plugin_id in plugin_ids:
                     current_plugin = main_window.get_plugin(
@@ -474,7 +490,8 @@ class BaseGridLayoutType:
         for plugin, base_plugin in plugins_to_tabify:
             if not self.plugin.tabify_plugin(plugin):
                 self.plugin.tabify_plugins(base_plugin, plugin)
-            current_plugin.toggle_view(False)
+            if current_plugin:
+                current_plugin.toggle_view(False)
 
         column_docks = []
         column_stretches = []

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -993,8 +993,12 @@ class Layout(SpyderPluginV2):
 
         # This should only be necessary the first time this method is run
         if not visible_plugins:
-            visible_plugins = [Plugins.IPythonConsole, Plugins.Help,
-                               Plugins.Editor]
+            visible_plugins = [
+                Plugins.IPythonConsole,
+                Plugins.Help,
+                Plugins.VariableExplorer,  # In case Help is not available
+                Plugins.Editor,
+            ]
 
         # Restore visible plugins
         for plugin in visible_plugins:
@@ -1151,10 +1155,9 @@ class Layout(SpyderPluginV2):
                 if plugin:
                     self.tabify_plugin(plugin, Plugins.Console)
 
-        # Tabify new external plugins
+        # Tabify any new plugin that was not available in the previous session.
+        # This can include internal plugins that were automatically disabled
+        # in the first session (e.g. due to the lack of WebEngine).
         for plugin in self.get_dockable_plugins():
-            if (
-                plugin.NAME in PLUGIN_REGISTRY.external_plugins
-                and plugin.get_conf('first_time', True)
-            ):
+            if plugin.get_conf('first_time', True):
                 self.tabify_plugin(plugin, Plugins.Console)


### PR DESCRIPTION
## Description of Changes

- We were not setting layouts correctly if the first plugin in the layout's area is missing.
- Also, tabify any plugin not available during the previous session (before we were doing that only for external plugins). That will include internal plugins that were automatically disabled in the first session (e.g. Help). 
- I found these problems while testing Spyder without WebEngine.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
