### PR TITLE
PR: Update custom button tab index when removing intermediate tabs without changing current selected tab (Widgets)

### DIFF
--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -408,6 +408,19 @@ class TabBar(QTabBar):
         # Set close button
         self.setTabButton(index, self.close_btn_side, close_button)
 
+    def tabRemoved(self, index):
+        """Actions to take when a tab is removed."""
+        # A tab removal makes the following ones to change their `index` (`-1`)
+        # Following that, there is a need to update the `index` attribute that
+        # the custom close button instances have. Otherwise, for example on the
+        # Editor, an `IndexError` can be raised.
+        # See spyder-ide/spyder#22033
+        for i in range(index, self.count()):
+            close_btn: CloseTabButton = self.tabButton(i, self.close_btn_side)
+
+            if close_btn:
+                close_btn.index = i
+
 
 class BaseTabs(QTabWidget):
     """TabWidget with context menu and corner widgets"""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->
A tab removal makes the following ones to change their `index` (`<new index> = <old index> - 1`). Following that, there is a need to update the `index` attribute that the custom close button instances have. Otherwise, a `IndexError` (in the case of the Editor) can be raised. This fix also prevents raising an `AttributeError` when doing a similar interaction with IPython Console client tabs:

```python-traceback 
Traceback (most recent call last):
  File "E:\Acer\Documentos\Spyder\spyder\spyder\plugins\ipythonconsole\widgets\main_widget.py", line 1970, in close_client
    if not client.can_close:
AttributeError: 'NoneType' object has no attribute 'can_close'
```

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22033 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
