### PR TITLE
PR: Fix resetting layout options (Layout)

### DIFF
--- a/spyder/plugins/layout/container.py
+++ b/spyder/plugins/layout/container.py
@@ -67,7 +67,7 @@ class LayoutContainer(PluginMainContainer):
 
     def setup(self):
         # Basic attributes to handle layouts options and dialogs references
-        self._spyder_layouts = OrderedDict()
+        self.spyder_layouts = OrderedDict()
         self._save_dialog = None
         self._settings_dialog = None
         self._layouts_menu = None
@@ -179,9 +179,9 @@ class LayoutContainer(PluginMainContainer):
         actions = []
         for name in order:
             if name in active:
-                if name in self._spyder_layouts:
+                if name in self.spyder_layouts:
                     index = name
-                    name = self._spyder_layouts[index].get_name()
+                    name = self.spyder_layouts[index].get_name()
                 else:
                     index = names.index(name)
                     name = ui_names[index]
@@ -231,13 +231,13 @@ class LayoutContainer(PluginMainContainer):
                 "A layout must be a subclass is `BaseGridLayoutType`!")
 
         layout_id = layout_type.ID
-        if layout_id in self._spyder_layouts:
+        if layout_id in self.spyder_layouts:
             raise SpyderAPIError(
                 "Layout with id `{}` already registered!".format(layout_id))
 
         layout = layout_type(parent_plugin)
         layout._check_layout_validity()
-        self._spyder_layouts[layout_id] = layout
+        self.spyder_layouts[layout_id] = layout
         names = self.get_conf('names')
         ui_names = self.get_conf('ui_names')
         order = self.get_conf('order')
@@ -272,11 +272,12 @@ class LayoutContainer(PluginMainContainer):
         Instance of a spyder.plugins.layout.api.BaseGridLayoutType subclass
             Layout.
         """
-        if layout_id not in self._spyder_layouts:
+        if layout_id not in self.spyder_layouts:
             raise SpyderAPIError(
-                "Layout with id `{}` is not registered!".format(layout_id))
+                "Layout with id `{}` is not registered!".format(layout_id)
+            )
 
-        return self._spyder_layouts[layout_id]
+        return self.spyder_layouts[layout_id]
 
     @Slot()
     def show_save_layout(self):
@@ -285,13 +286,14 @@ class LayoutContainer(PluginMainContainer):
         ui_names = self.get_conf('ui_names')
         order = self.get_conf('order')
         active = self.get_conf('active')
-        dialog_names = [name for name in names
-                        if name not in self._spyder_layouts.keys()]
+        dialog_names = [
+            name for name in names if name not in self.spyder_layouts.keys()
+        ]
         dlg = self._save_dialog = LayoutSaveDialog(self, dialog_names)
 
         if dlg.exec_():
             name = dlg.combo_box.currentText()
-            if name in self._spyder_layouts:
+            if name in self.spyder_layouts:
                 QMessageBox.critical(
                     self,
                     _("Error"),
@@ -345,7 +347,7 @@ class LayoutContainer(PluginMainContainer):
         ui_names = self.get_conf('ui_names')
         order = self.get_conf('order')
         active = self.get_conf('active')
-        read_only = list(self._spyder_layouts.keys())
+        read_only = list(self.spyder_layouts.keys())
 
         dlg = self._settings_dialog = LayoutSettingsDialog(
             self, names, ui_names, order, active, read_only)
@@ -410,8 +412,7 @@ class LayoutContainer(PluginMainContainer):
 
         new_index = (current_index + dic[direction]) % len(layout_index)
         index_or_layout_id = layout_index[new_index]
-        is_layout_id = (
-            names[index_or_layout_id] in self._spyder_layouts)
+        is_layout_id = names[index_or_layout_id] in self.spyder_layouts
 
         if is_layout_id:
             index_or_layout_id = names[layout_index[new_index]]

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -357,29 +357,34 @@ class Layout(SpyderPluginV2):
             self._first_spyder_run = True
             self.setup_default_layouts(DefaultLayouts.SpyderLayout, settings)
 
-            # Now that the initial setup is done, copy the window settings,
-            # except for the hexstate in the quick layouts sections for the
-            # default layouts.
-            # Order and name of the default layouts is found in config.py
-            section = 'quick_layouts'
-            get_func = self.get_conf_default if default else self.get_conf
-            order = get_func('order', section=section)
-
-            # Restore the original defaults if reset layouts is called
+            # Restore the original defaults. This is necessary, for instance,
+            # when bumping WINDOW_STATE_VERSION because layouts saved with a
+            # previous version can't be applied with the new one
             if default:
-                self.set_conf('active', order, section)
-                self.set_conf('order', order, section)
-                self.set_conf('names', order, section)
-                self.set_conf('ui_names', order, section)
+                order = list(self.get_container().spyder_layouts.keys())
+                self.set_conf('order', order)
+                self.set_conf('active', order)
+                self.set_conf('names', order)
 
+                ui_names = [
+                    l.get_name()
+                    for l in self.get_container().spyder_layouts.values()
+                ]
+                self.set_conf('ui_names', ui_names)
+
+                # This will remove custom layouts from the UI
+                self.get_container().update_layout_menu_actions()
+
+            section = 'quick_layouts'
+            order = self.get_conf('order')
             for index, _name, in enumerate(order):
                 prefix = 'layout_{0}/'.format(index)
-                self.save_current_window_settings(prefix, section,
-                                                  none_state=True)
+                self.save_current_window_settings(
+                    prefix, section, none_state=True
+                )
 
             # Store the initial layout as the default in spyder
             prefix = 'layout_default/'
-            section = 'quick_layouts'
             self.save_current_window_settings(prefix, section, none_state=True)
             self._current_quick_layout = DefaultLayouts.SpyderLayout
 

--- a/spyder/plugins/layout/widgets/dialog.py
+++ b/spyder/plugins/layout/widgets/dialog.py
@@ -194,13 +194,13 @@ class LayoutSettingsDialog(QDialog):
         self.read_only = read_only
 
         # widgets
-        self.button_move_up = QPushButton(_('Move Up'))
-        self.button_move_down = QPushButton(_('Move Down'))
-        self.button_delete = QPushButton(_('Delete Layout'))
+        self.button_move_up = QPushButton(_('Move up'))
+        self.button_move_down = QPushButton(_('Move down'))
+        self.button_delete = QPushButton(_('Delete layout'))
         self.button_box = SpyderDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel, Qt.Horizontal, self
         )
-        self.group_box = QGroupBox(_("Layout Display and Order"))
+        self.group_box = QGroupBox(_("Layout display and order"))
         self.table = QTableView(self)
         self.ok_button = self.button_box.button(QDialogButtonBox.Ok)
         self.cancel_button = self.button_box.button(QDialogButtonBox.Cancel)


### PR DESCRIPTION
## Description of Changes

- The layout options were not reset as expected after a bump in `WINDOWS_STATE_VERSION`, which generated internal errors and missing menu entries in the UI the first time Spyder starts with a new version.
- I discovered these errors while testing that the layout is applied as expected when moving from Spyder 5 to 6.
- Also, remove some odd capitalization in several translation strings. 

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
