### PR TITLE
PR: Disable shortcuts for actions in the `View > Panes` menu when not visible (Layout)

### DIFF
--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -1021,8 +1021,8 @@ class SpyderDockablePlugin(SpyderPluginV2):
         self.CONTAINER_CLASS = self.WIDGET_CLASS
         super().__init__(parent, configuration=configuration)
 
-        # Defined on mainwindow.py
-        self._shortcut = None
+        # Shortcut to switch to the plugin. It's defined on the main window
+        self._switch_to_shortcut = None
 
         # Widget setup
         # --------------------------------------------------------------------

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -458,17 +458,16 @@ class MainWindow(
                 else:
                     self.shortcut_queue.append((action, context, action_name))
 
+        # Register shortcut to switch to plugin
         if isinstance(plugin, SpyderDockablePlugin):
-            try:
-                context = '_'
-                name = 'switch to {}'.format(plugin.CONF_SECTION)
-            except (cp.NoSectionError, cp.NoOptionError):
-                pass
+            context = '_'
+            name = 'switch to {}'.format(plugin.CONF_SECTION)
 
-            sc = QShortcut(QKeySequence(), self,
-                           lambda: self.switch_to_plugin(plugin))
+            sc = QShortcut(
+                QKeySequence(), self, lambda: self.switch_to_plugin(plugin)
+            )
             sc.setContext(Qt.ApplicationShortcut)
-            plugin._shortcut = sc
+            plugin._switch_to_shortcut = sc
 
             if Plugins.Shortcuts in PLUGIN_REGISTRY:
                 self.register_shortcut(sc, context, name)
@@ -520,7 +519,7 @@ class MainWindow(
 
         if shortcut is not None:
             self.shortcuts.unregister_shortcut(
-                plugin._shortcut,
+                plugin._switch_to_shortcut,
                 context,
                 "Switch to {}".format(plugin.CONF_SECTION),
             )

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -611,46 +611,6 @@ class MainWindow(
         if console:
             console.handle_exception(error_data)
 
-    # ---- Window setup
-    # -------------------------------------------------------------------------
-    def _update_shortcuts_in_panes_menu(self, show=True):
-        """
-        Display the shortcut for the "Switch to plugin..." on the toggle view
-        action of the plugins displayed in the Help/Panes menu.
-
-        Notes
-        -----
-        SpyderDockablePlugins provide two actions that function as a single
-        action. The `Switch to Plugin...` action has an assignable shortcut
-        via the shortcut preferences. The `Plugin toggle View` in the `View`
-        application menu, uses a custom `Toggle view action` that displays the
-        shortcut assigned to the `Switch to Plugin...` action, but is not
-        triggered by that shortcut.
-        """
-        for plugin_name in PLUGIN_REGISTRY:
-            plugin = PLUGIN_REGISTRY.get_plugin(plugin_name)
-            if isinstance(plugin, SpyderDockablePlugin):
-                try:
-                    # New API
-                    action = plugin.toggle_view_action
-                except AttributeError:
-                    # Old API
-                    action = plugin._toggle_view_action
-
-                if show:
-                    section = plugin.CONF_SECTION
-                    try:
-                        context = '_'
-                        name = 'switch to {}'.format(section)
-                        shortcut = self.get_shortcut(
-                            name, context, plugin_name=section)
-                    except (cp.NoSectionError, cp.NoOptionError):
-                        shortcut = QKeySequence()
-                else:
-                    shortcut = QKeySequence()
-
-                action.setShortcut(shortcut)
-
     def _prevent_freeze_when_moving_dockwidgets(self):
         """
         This is necessary to prevent an ugly freeze when moving dockwidgets to
@@ -916,9 +876,6 @@ class MainWindow(
             # Connect the window to the signal emitted by the previous server
             # when it gets a client connected to it
             self.sig_open_external_file.connect(self.open_external_file)
-
-        # Update plugins toggle actions to show the "Switch to" plugin shortcut
-        self._update_shortcuts_in_panes_menu()
 
         # Reopen last session if no project is active
         # NOTE: This needs to be after the calls to on_mainwindow_visible


### PR DESCRIPTION
## Description of Changes

- This solves the problem reported in https://github.com/spyder-ide/spyder/issues/22189#issuecomment-2248644546.
- It seems this is broken since Spyder 5.0a3 but it only affects Mac users and no one had reported it in all this time. That's why it slipped under our radar.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
