### PR TITLE
PR: Enable showing calltip widget even with signatures without parameters (Editor/Completion)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
@@ -813,10 +813,7 @@ class LSPMixin:
         try:
             signature_params = params["params"]
 
-            if (
-                signature_params is not None
-                and "activeParameter" in signature_params
-            ):
+            if signature_params is not None:
                 self.sig_signature_invoked.emit(signature_params)
                 signature_data = signature_params["signatures"]
                 documentation = signature_data["documentation"]
@@ -828,12 +825,17 @@ class LSPMixin:
                 # spaces defined as `\xa0`
                 documentation = documentation.replace("\xa0", " ")
 
-                parameter_idx = signature_params["activeParameter"]
-                parameters = signature_data["parameters"]
+                # Enable parsing signature's active parameter if available
+                # while allowing to show calltip for signatures without
+                # parameters.
+                # See spyder-ide/spyder#21660
                 parameter = None
-                if len(parameters) > 0 and parameter_idx < len(parameters):
-                    parameter_data = parameters[parameter_idx]
-                    parameter = parameter_data["label"]
+                if "activeParameter" in signature_params:
+                    parameter_idx = signature_params["activeParameter"]
+                    parameters = signature_data["parameters"]
+                    if len(parameters) > 0 and parameter_idx < len(parameters):
+                        parameter_data = parameters[parameter_idx]
+                        parameter = parameter_data["label"]
 
                 signature = signature_data["label"]
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->
Before:

![calltips_not_showing_without_params](https://github.com/user-attachments/assets/d30ccc6e-99ba-4e5a-83cf-fb6585f806d9)

After:

![calltips_showing_without_params](https://github.com/user-attachments/assets/c2070b73-c72f-4b91-ac55-500a26e9274c)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #21660 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
