### PR TITLE
PR: Add a widget to show connection logs to `ConnectionDialog` (Remote client)

### DIFF
--- a/spyder/api/widgets/dialogs.py
+++ b/spyder/api/widgets/dialogs.py
@@ -13,12 +13,12 @@ from qtpy.QtCore import Qt
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QDialogButtonBox
 
+# Local imports
+from spyder.utils.stylesheet import AppStyle
+
 
 class SpyderDialogButtonBox(QDialogButtonBox):
-    """
-    QDialogButtonBox widget for Spyder that doesn't display icons on its
-    standard buttons.
-    """
+    """QDialogButtonBox widget for Spyder."""
 
     def __init__(self, buttons=None, orientation=Qt.Horizontal, parent=None):
         if buttons:
@@ -28,6 +28,7 @@ class SpyderDialogButtonBox(QDialogButtonBox):
         else:
             super().__init__(parent=parent)
 
+        # Don't display icons on standard buttons. This is a problem on Linux
         button_constants = [
             QDialogButtonBox.Ok,
             QDialogButtonBox.Open,
@@ -53,3 +54,12 @@ class SpyderDialogButtonBox(QDialogButtonBox):
             button = self.button(constant)
             if button is not None:
                 button.setIcon(QIcon())
+
+        # Set a reasonable spacing between buttons. This is a problem on Mac
+        self.layout().setSpacing(2 * AppStyle.MarginSize)
+
+        # Use the Windows buttons layout to have a uniform layout in all
+        # platforms. We selected that layout because Windows is our most
+        # popular platform.
+        # Solution found in https://stackoverflow.com/a/35907926/438386
+        self.setStyleSheet("* {button-layout: 0}")

--- a/spyder/config/appearance.py
+++ b/spyder/config/appearance.py
@@ -11,9 +11,13 @@ Spyder appearance configuration
 import os
 import sys
 
+from qdarkstyle.dark.palette import DarkPalette
+from qdarkstyle.light.palette import LightPalette
+
 from spyder.config.base import running_under_pytest
 from spyder.config.fonts import MEDIUM, MONOSPACE
 from spyder.plugins.help.utils.sphinxify import CSS_PATH
+
 
 WIN = os.name == 'nt'
 LINUX = sys.platform.startswith('linux')
@@ -74,7 +78,7 @@ APPEARANCE = {
     # ---- IDLE ----
     'idle/name':         "IDLE",
     #      Name            Color     Bold  Italic
-    'idle/background':   "#ffffff",
+    'idle/background':   LightPalette.COLOR_BACKGROUND_1,
     'idle/currentline':  "#f2e6f3",
     'idle/currentcell':  "#feefff",
     'idle/occurrence':   "#C2E3FA",
@@ -82,7 +86,7 @@ APPEARANCE = {
     'idle/sideareas':    "#efefef",
     'idle/matched_p':    "#99ff99",
     'idle/unmatched_p':  "#ff9999",
-    'idle/normal':      ('#000000', False, False),
+    'idle/normal':      (LightPalette.COLOR_TEXT_1, False, False),
     'idle/keyword':     ('#ff7700', True, False),
     'idle/magic':       ('#ff7700', True, False),
     'idle/builtin':     ('#900090', False, False),
@@ -114,7 +118,7 @@ APPEARANCE = {
     # ---- Pydev ----
     'pydev/name':        "Pydev",
     #      Name            Color     Bold  Italic
-    'pydev/background':  "#ffffff",
+    'pydev/background':  LightPalette.COLOR_BACKGROUND_1,
     'pydev/currentline': "#e8f2fe",
     'pydev/currentcell': "#eff8fe",
     'pydev/occurrence':  "#C2E3FA",
@@ -122,7 +126,7 @@ APPEARANCE = {
     'pydev/sideareas':   "#efefef",
     'pydev/matched_p':   "#99ff99",
     'pydev/unmatched_p': "#ff99992",
-    'pydev/normal':     ('#000000', False, False),
+    'pydev/normal':     (LightPalette.COLOR_TEXT_1, False, False),
     'pydev/keyword':    ('#0000ff', False, False),
     'pydev/magic':      ('#0000ff', False, False),
     'pydev/builtin':    ('#900090', False, False),
@@ -134,7 +138,7 @@ APPEARANCE = {
     # ---- Scintilla ----
     'scintilla/name':        "Scintilla",
     #         Name             Color     Bold  Italic
-    'scintilla/background':  "#ffffff",
+    'scintilla/background':  LightPalette.COLOR_BACKGROUND_1,
     'scintilla/currentline': "#e1f0d1",
     'scintilla/currentcell': "#edfcdc",
     'scintilla/occurrence':  "#C2E3FA",
@@ -142,7 +146,7 @@ APPEARANCE = {
     'scintilla/sideareas':   "#efefef",
     'scintilla/matched_p':   "#99ff99",
     'scintilla/unmatched_p': "#ff9999",
-    'scintilla/normal':     ('#000000', False, False),
+    'scintilla/normal':     (LightPalette.COLOR_TEXT_1, False, False),
     'scintilla/keyword':    ('#00007f', True, False),
     'scintilla/magic':      ('#00007f', True, False),
     'scintilla/builtin':    ('#000000', False, False),
@@ -154,7 +158,7 @@ APPEARANCE = {
     # ---- Spyder ----
     'spyder/name':        "Spyder",
     #       Name            Color     Bold  Italic
-    'spyder/background':  "#ffffff",
+    'spyder/background':  LightPalette.COLOR_BACKGROUND_1,
     'spyder/currentline': "#f7ecf8",
     'spyder/currentcell': "#fdfdde",
     'spyder/occurrence':  "#C2E3FA",
@@ -162,7 +166,7 @@ APPEARANCE = {
     'spyder/sideareas':   "#efefef",
     'spyder/matched_p':   "#99ff99",
     'spyder/unmatched_p': "#ff9999",
-    'spyder/normal':     ('#000000', False, False),
+    'spyder/normal':     (LightPalette.COLOR_TEXT_1, False, False),
     'spyder/keyword':    ('#0000ff', False, False),
     'spyder/magic':      ('#0000ff', False, False),
     'spyder/builtin':    ('#900090', False, False),
@@ -182,7 +186,7 @@ APPEARANCE = {
     'spyder/dark/sideareas':   "#222b35",
     'spyder/dark/matched_p':   "#0bbe0b",
     'spyder/dark/unmatched_p': "#ff4340",
-    'spyder/dark/normal':     ('#ffffff', False, False),
+    'spyder/dark/normal':     (DarkPalette.COLOR_TEXT_1, False, False),
     'spyder/dark/keyword':    ('#c670e0', False, False),
     'spyder/dark/magic':      ('#c670e0', False, False),
     'spyder/dark/builtin':    ('#fab16c', False, False),
@@ -274,7 +278,7 @@ APPEARANCE = {
     # ---- minimal (Eclipse color theme) ----
     'minimal/name':        "Minimal",
     #      Name              Color     Bold  Italic
-    'minimal/background':  "#ffffff",
+    'minimal/background':  LightPalette.COLOR_BACKGROUND_1,
     'minimal/currentline': "#aaccff",
     'minimal/currentcell': "#E7F1FF",
     'minimal/occurrence':  "#C2E3FA",
@@ -282,7 +286,7 @@ APPEARANCE = {
     'minimal/sideareas':   "#aaccff",
     'minimal/matched_p':   "#000000",
     'minimal/unmatched_p': "#efefff",
-    'minimal/normal':     ('#000000', False, False),
+    'minimal/normal':     (LightPalette.COLOR_TEXT_1, False, False),
     'minimal/keyword':    ('#5c8198', False, False),
     'minimal/magic':      ('#5c8198', False, False),
     'minimal/builtin':    ('#000066', False, False),
@@ -314,7 +318,7 @@ APPEARANCE = {
     # ---- Notepad++ (Eclipse color theme) ----
     'notepad++/name':        "Notepad++",
     #      Name                     Color     Bold  Italic
-    'notepad++/background':  "#ffffff",
+    'notepad++/background':  LightPalette.COLOR_BACKGROUND_1,
     'notepad++/currentline': "#eeeeee",
     'notepad++/currentcell': "#D9D9D9",
     'notepad++/occurrence':  "#C2E3FA",

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -672,4 +672,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '84.0.0'
+CONF_VERSION = '84.1.0'

--- a/spyder/plugins/findinfiles/widgets/main_widget.py
+++ b/spyder/plugins/findinfiles/widgets/main_widget.py
@@ -26,7 +26,7 @@ from spyder.plugins.findinfiles.widgets.combobox import (
     MAX_PATH_HISTORY, SearchInComboBox)
 from spyder.plugins.findinfiles.widgets.search_thread import SearchThread
 from spyder.utils.misc import regexp_error_msg
-from spyder.utils.palette import SpyderPalette, SpyderPalette
+from spyder.utils.palette import SpyderPalette
 from spyder.utils.stylesheet import AppStyle
 from spyder.widgets.comboboxes import PatternComboBox
 from spyder.widgets.helperwidgets import PaneEmptyWidget

--- a/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
+++ b/spyder/plugins/findinfiles/widgets/tests/test_widgets.py
@@ -28,7 +28,7 @@ from spyder.plugins.findinfiles.widgets.combobox import (
     SearchInComboBoxItems
 )
 from spyder.plugins.findinfiles.widgets.search_thread import SearchThread
-from spyder.utils.palette import SpyderPalette, SpyderPalette
+from spyder.utils.palette import SpyderPalette
 from spyder.utils.stylesheet import APP_STYLESHEET
 
 

--- a/spyder/plugins/remoteclient/api/__init__.py
+++ b/spyder/plugins/remoteclient/api/__init__.py
@@ -14,6 +14,11 @@ Remote Client Plugin API.
 
 # ---- Constants
 # -----------------------------------------------------------------------------
+
+# Max number of logged messages from the client that will be saved.
+MAX_CLIENT_MESSAGES = 1000
+
+
 class RemoteClientActions:
     ManageConnections = "manage connections"
 

--- a/spyder/plugins/remoteclient/api/client.py
+++ b/spyder/plugins/remoteclient/api/client.py
@@ -34,7 +34,7 @@ class SpyderRemoteClientLoggerHandler(logging.Handler):
         super().__init__(*args, **kwargs)
 
     def emit(self, record):
-        self._client._plugin.sig_server_log.emit(
+        self._client._plugin.sig_client_message_logged.emit(
             RemoteClientLog(
                 id=self._client.config_id,
                 message=self.format(record),

--- a/spyder/plugins/remoteclient/api/client.py
+++ b/spyder/plugins/remoteclient/api/client.py
@@ -34,6 +34,12 @@ class SpyderRemoteClientLoggerHandler(logging.Handler):
         self._client = client
         super().__init__(*args, **kwargs)
 
+        log_format = "%(message)s &#8212; %(asctime)s"
+        formatter = logging.Formatter(
+            log_format, datefmt="%H:%M:%S %d/%m/%Y"
+        )
+        self.setFormatter(formatter)
+
     def emit(self, record):
         self._client._plugin.sig_client_message_logged.emit(
             RemoteClientLog(

--- a/spyder/plugins/remoteclient/api/client.py
+++ b/spyder/plugins/remoteclient/api/client.py
@@ -13,6 +13,7 @@ import socket
 import asyncssh
 
 from spyder.api.translations import _
+from spyder.config.base import get_debug_level
 from spyder.plugins.remoteclient.api.jupyterhub import JupyterAPI
 from spyder.plugins.remoteclient.api.protocol import (
     ConnectionInfo,
@@ -72,9 +73,14 @@ class SpyderRemoteClient:
         self._port_forwarder: asyncssh.SSHListener = None
         self._server_info = {}
 
+        # For logging
         self._logger = logging.getLogger(
             f"{__name__}.{self.__class__.__name__}({self.config_id})"
         )
+
+        if not get_debug_level():
+            self._logger.setLevel(logging.DEBUG)
+
         if self._plugin is not None:
             self._logger.addHandler(SpyderRemoteClientLoggerHandler(self))
 

--- a/spyder/plugins/remoteclient/plugin.py
+++ b/spyder/plugins/remoteclient/plugin.py
@@ -58,9 +58,9 @@ class RemoteClient(SpyderPluginV2):
     CONF_SECTION_SERVERS = "servers"
 
     # ---- Signals
-    sig_server_log = Signal(dict)
     sig_server_stopped = Signal(str)
     sig_server_renamed = Signal(str)
+    sig_client_message_logged = Signal(dict)
 
     sig_connection_established = Signal(str)
     sig_connection_lost = Signal(str)

--- a/spyder/plugins/remoteclient/plugin.py
+++ b/spyder/plugins/remoteclient/plugin.py
@@ -109,6 +109,9 @@ class RemoteClient(SpyderPluginV2):
         self.sig_connection_status_changed.connect(
             container.sig_connection_status_changed
         )
+        self.sig_client_message_logged.connect(
+            container.sig_client_message_logged
+        )
         self._sig_kernel_started.connect(container.on_kernel_started)
 
     def on_first_registration(self):

--- a/spyder/plugins/remoteclient/widgets/connectiondialog.py
+++ b/spyder/plugins/remoteclient/widgets/connectiondialog.py
@@ -8,6 +8,7 @@
 
 # Standard library imports
 from __future__ import annotations
+from collections.abc import Iterable
 import re
 from typing import TypedDict
 import uuid
@@ -700,6 +701,9 @@ class ConnectionPage(BaseConnectionPage):
         if log["id"] == self.host_id:
             self.status_widget.add_log(log)
 
+    def add_logs(self, logs: Iterable):
+        self.status_widget.add_logs(logs)
+
     def has_new_name(self):
         """Check if users changed the connection name."""
         current_auth_method = self.auth_method(from_gui=True)
@@ -933,16 +937,19 @@ class ConnectionDialog(SidebarDialog):
             self._update_button_save_connection_state
         )
 
+        if new:
+            page.save_server_info()
+
+        self.add_page(page)
+
+        # Add saved logs to the page
+        page.add_logs(self._container.client_logs.get(host_id, []))
+
         # This updates the info shown in the "Connection info" tab of pages
         self._container.sig_connection_status_changed.connect(
             page.update_status
         )
         self._container.sig_client_message_logged.connect(page.add_log)
-
-        if new:
-            page.save_server_info()
-
-        self.add_page(page)
 
     def _add_saved_connection_pages(self):
         """Add a connection page for each server saved in our config system."""

--- a/spyder/plugins/remoteclient/widgets/connectiondialog.py
+++ b/spyder/plugins/remoteclient/widgets/connectiondialog.py
@@ -750,9 +750,10 @@ class ConnectionDialog(SidebarDialog):
             self.set_current_index(2)
 
         # -- Signals
-        self._container.sig_connection_status_changed.connect(
-            self._update_connection_buttons_state
-        )
+        if self._container is not None:
+            self._container.sig_connection_status_changed.connect(
+                self._update_connection_buttons_state
+            )
 
     # ---- SidebarDialog API
     # -------------------------------------------------------------------------
@@ -953,13 +954,14 @@ class ConnectionDialog(SidebarDialog):
         self.add_page(page)
 
         # Add saved logs to the page
-        page.add_logs(self._container.client_logs.get(host_id, []))
+        if self._container is not None:
+            page.add_logs(self._container.client_logs.get(host_id, []))
 
-        # This updates the info shown in the "Connection info" tab of pages
-        self._container.sig_connection_status_changed.connect(
-            page.update_status
-        )
-        self._container.sig_client_message_logged.connect(page.add_log)
+            # This updates the info shown in the "Connection info" tab of pages
+            self._container.sig_connection_status_changed.connect(
+                page.update_status
+            )
+            self._container.sig_client_message_logged.connect(page.add_log)
 
     def _add_saved_connection_pages(self):
         """Add a connection page for each server saved in our config system."""

--- a/spyder/plugins/remoteclient/widgets/connectiondialog.py
+++ b/spyder/plugins/remoteclient/widgets/connectiondialog.py
@@ -189,7 +189,7 @@ class BaseConnectionPage(SpyderConfigPage, SpyderFontsMixin):
             if not widget.textbox.text():
                 # Validate that the required fields are not empty
                 widget.status_action.setVisible(True)
-                widget.status_action.setToolTip("")
+                widget.status_action.setToolTip(_("This field is empty"))
                 reasons["missing_info"] = True
             elif widget == self._name_widgets[auth_method]:
                 # Validate the server name is different from the ones already

--- a/spyder/plugins/remoteclient/widgets/connectiondialog.py
+++ b/spyder/plugins/remoteclient/widgets/connectiondialog.py
@@ -739,7 +739,17 @@ class ConnectionDialog(SidebarDialog):
         super().__init__(parent)
         self._container = parent
 
+        # -- Setup
         self._add_saved_connection_pages()
+
+        # If there's more than one page, give focus to the first server because
+        # users will probably want to interact with servers here rather than
+        # create new connections.
+        if self.number_of_pages() > 1:
+            # Index 1 is the separator added after the new connection page
+            self.set_current_index(2)
+
+        # -- Signals
         self._container.sig_connection_status_changed.connect(
             self._update_connection_buttons_state
         )

--- a/spyder/plugins/remoteclient/widgets/connectionstatus.py
+++ b/spyder/plugins/remoteclient/widgets/connectionstatus.py
@@ -6,6 +6,7 @@
 
 """Connection status widget."""
 
+from collections.abc import Iterable
 import logging
 
 import qstylizer.style
@@ -174,6 +175,10 @@ class ConnectionStatusWidget(
         self._log_widget.moveCursor(QTextCursor.End)
         self._log_widget.appendHtml(formatted_log)
         self._log_widget.moveCursor(QTextCursor.End)
+
+    def add_logs(self, logs: Iterable):
+        for log in logs:
+            self.add_log(log)
 
     # ---- Private API
     # -------------------------------------------------------------------------

--- a/spyder/plugins/remoteclient/widgets/container.py
+++ b/spyder/plugins/remoteclient/widgets/container.py
@@ -278,10 +278,6 @@ class RemoteClientContainer(PluginMainContainer):
         )
         connection_dialog.sig_server_renamed.connect(self.sig_server_renamed)
 
-        self.sig_connection_status_changed.connect(
-            connection_dialog.sig_connection_status_changed
-        )
-
         connection_dialog.show()
 
     def _on_connection_status_changed(self, info: ConnectionInfo):

--- a/spyder/plugins/remoteclient/widgets/container.py
+++ b/spyder/plugins/remoteclient/widgets/container.py
@@ -42,10 +42,10 @@ class RemoteClientContainer(PluginMainContainer):
         to the server is lost.
     """
 
-    _sig_kernel_info = Signal(object, dict)
+    _sig_kernel_info_replied = Signal(object, dict)
     """
-    This private signal is used to inform that a kernel info request took place
-    in the server.
+    This private signal is used to inform that a kernel info request to the
+    server was replied.
 
     Parameters
     ----------
@@ -153,7 +153,7 @@ class RemoteClientContainer(PluginMainContainer):
             self._on_connection_status_changed
         )
         self._sig_kernel_restarted.connect(self._on_kernel_restarted)
-        self._sig_kernel_info.connect(self._on_kernel_info_reply)
+        self._sig_kernel_info_replied.connect(self._on_kernel_info_reply)
 
         self.__requested_restart = False
         self.__requested_info = False
@@ -328,7 +328,7 @@ class RemoteClientContainer(PluginMainContainer):
         self.__requested_info = True
 
         future.add_done_callback(
-            lambda future: self._sig_kernel_info.emit(
+            lambda future: self._sig_kernel_info_replied.emit(
                 ipyclient, future.result()
             )
         )

--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -47,6 +47,9 @@ class AppStyle(SpyderFontsMixin):
     # Icon size in config pages
     ConfigPageIconSize = 20
 
+    # Padding for QPushButton's
+    QPushButtonPadding = f'{MarginSize + 1}px {4 * MarginSize}px'
+
     @classproperty
     def _fs(cls):
         """Interface font size in points."""
@@ -207,15 +210,20 @@ class AppStylesheet(SpyderStyleSheet, SpyderConfigurationAccessor):
             image="none"
         )
 
-        # Increase padding for QPushButton's
-        css.QPushButton.setValues(
-            padding='3px',
-        )
+        # Increase padding and fix disabled color for QPushButton's
+        css.QPushButton.setValues(padding=AppStyle.QPushButtonPadding)
 
         for state in ['disabled', 'checked', 'checked:disabled']:
             css[f'QPushButton:{state}'].setValues(
-                padding='3px',
+                padding=AppStyle.QPushButtonPadding,
             )
+
+            # This is especially necessary in the light theme because the
+            # contrast between the background and text colors is too small
+            if state in ['disabled', 'checked:disabled']:
+                css[f"QPushButton:{state}"].setValues(
+                    color=SpyderPalette.COLOR_TEXT_3,
+                )
 
         # Adjust QToolButton style to our needs.
         # This affects not only the pane toolbars but also the
@@ -237,14 +245,26 @@ class AppStylesheet(SpyderStyleSheet, SpyderConfigurationAccessor):
 
         # Adjust padding of QPushButton's in QDialog's
         for widget in ["QPushButton", "QPushButton:disabled"]:
-            css[f"QDialog {widget}"].setValues(
+            css[f"QDialogButtonBox {widget}"].setValues(
                 padding=(
+                    AppStyle.QPushButtonPadding
+                    if (MAC or WIN)
+                    else
                     f"{AppStyle.MarginSize + 1}px {AppStyle.MarginSize}px"
                 ),
+                # This width comes from QDarkstyle but it's too big on Mac
+                minWidth="50px" if WIN else ("60px" if MAC else "80px"),
             )
 
         css["QDialogButtonBox QPushButton:!default"].setValues(
-            padding=f"{AppStyle.MarginSize + 1}px {AppStyle.MarginSize}px",
+            padding=(
+                AppStyle.QPushButtonPadding
+                if (MAC or WIN)
+                else
+                f"{AppStyle.MarginSize + 1}px {AppStyle.MarginSize}px"
+            ),
+            # This width comes from QDarkstyle but it's too big on Mac
+            minWidth="50px" if WIN else ("60px" if MAC else "80px"),
         )
 
         # Remove icons in QMessageBoxes
@@ -863,7 +883,6 @@ class DialogStyle(SpyderFontsMixin):
     """Style constants for tour and about dialogs."""
 
     IconScaleFactor = 0.5
-    ButtonsPadding = '6px' if MAC else '4px 6px'
     BackgroundColor = SpyderPalette.COLOR_BACKGROUND_2
     BorderColor = SpyderPalette.COLOR_BACKGROUND_5
 
@@ -897,3 +916,12 @@ class DialogStyle(SpyderFontsMixin):
             return f"{cls._fs + 2}pt"
         else:
             return f"{cls._fs + 3}pt"
+
+    @classproperty
+    def ButtonsPadding(cls):
+        if WIN:
+            return f"{AppStyle.MarginSize + 1}px {5 * AppStyle.MarginSize}px"
+        elif MAC:
+            return f"{2 * AppStyle.MarginSize}px {4 * AppStyle.MarginSize}px"
+        else:
+            return f"{AppStyle.MarginSize + 1}px {AppStyle.MarginSize}px"

--- a/spyder/widgets/sidebardialog.py
+++ b/spyder/widgets/sidebardialog.py
@@ -492,6 +492,16 @@ class SidebarDialog(QDialog, SpyderFontsMixin):
             padding="-2px -3px",
         )
 
+        # This is necessary to correctly show disabled buttons in this kind of
+        # dialogs (oddly QDarkstyle doesn't set this color as expected).
+        css["QPushButton:disabled"].setValues(
+            backgroundColor=SpyderPalette.COLOR_BACKGROUND_4,
+        )
+
+        css["QPushButton:checked:disabled"].setValues(
+            backgroundColor=SpyderPalette.COLOR_BACKGROUND_6,
+        )
+
         return css.toString()
 
     def _generate_contents_stylesheet(self):

--- a/spyder/widgets/simplecodeeditor.py
+++ b/spyder/widgets/simplecodeeditor.py
@@ -14,9 +14,16 @@ https://doc.qt.io/qt-5/qtwidgets-widgets-codeeditor-example.html
 """
 
 # Third party imports
+import qstylizer.style
 from qtpy.QtCore import QPoint, QRect, QSize, Qt, Signal
 from qtpy.QtGui import (
-    QColor, QFont, QPainter, QTextCursor, QTextFormat, QTextOption)
+    QColor,
+    QFont,
+    QPainter,
+    QTextCursor,
+    QTextFormat,
+    QTextOption,
+)
 from qtpy.QtWidgets import QPlainTextEdit, QTextEdit, QWidget
 
 # Local imports
@@ -115,9 +122,11 @@ class SimpleCodeEditor(QPlainTextEdit, BaseEditMixin):
         self.linenumberarea = LineNumberArea(self)
 
         # Widget setup
-        self.setObjectName(self.__class__.__name__ + str(id(self)))
         self.update_linenumberarea_width(0)
         self._apply_current_line_highlight()
+
+        # Style
+        self.css = qstylizer.style.StyleSheet()
 
         # Signals
         self.blockCountChanged.connect(self.update_linenumberarea_width)
@@ -137,9 +146,11 @@ class SimpleCodeEditor(QPlainTextEdit, BaseEditMixin):
                               foreground=hl.get_foreground_color())
 
     def _set_palette(self, background, foreground):
-        style = ("QPlainTextEdit#%s {background: %s; color: %s;}" %
-                 (self.objectName(), background.name(), foreground.name()))
-        self.setStyleSheet(style)
+        self.css.QPlainTextEdit.setValues(
+            background=background.name(),
+            color=foreground.name(),
+        )
+        self.setStyleSheet(self.css.toString())
         self.rehighlight()
 
     def _apply_current_line_highlight(self):
@@ -182,15 +193,17 @@ class SimpleCodeEditor(QPlainTextEdit, BaseEditMixin):
 
     # --- Public API
     # ------------------------------------------------------------------------
-    def setup_editor(self,
-                     linenumbers=True,
-                     color_scheme="spyder/dark",
-                     language="py",
-                     font=None,
-                     show_blanks=False,
-                     wrap=False,
-                     highlight_current_line=True,
-                     scroll_past_end=False):
+    def setup_editor(
+        self,
+        linenumbers=True,
+        color_scheme="spyder/dark",
+        language="py",
+        font=None,
+        show_blanks=False,
+        wrap=False,
+        highlight_current_line=True,
+        scroll_past_end=False,
+    ):
         """
         Setup editor options.
 


### PR DESCRIPTION
## Description of Changes

- It would be really hard for users to debug connection problems without this info. So, we want to have it easily available for them in 6.0.

Besides that, I also fixed other minor issues that were required to provide a good UI for this: 

-  Fix style of QPushButton's in all OSes. Previous fixes only worked on Linux.
- Use a uniform layout in SpyderDialogButtonBox for all OSes (otherwise buttons are placed in odd positions on Mac) and fix some style issues with it.
- Use background and text palette colors in several syntax highlighting themes. This was a major oversight in Spyder 5 that led to have different colors between the syntax highlighting and interface themes.

### Visual changes

**Before**

![imagen](https://github.com/user-attachments/assets/48671ded-4190-477c-9576-0fd69bc65b10)

**After**

![imagen](https://github.com/user-attachments/assets/d2dd711b-5801-491b-b16e-b1475ab416e2)

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
