### PR TITLE
PR: Ensure "Update Assets" job runs when "Build Subrepos" is skipped

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -313,6 +313,7 @@ jobs:
 
   upload-assets:
     name: Upload Assets
+    if: ${{ ! failure() && ! cancelled() }}
     runs-on: ubuntu-latest
     needs:
       - build-installers


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

I believe that "Upload Assets" was skipped because "Build Subrepos" was skipped, and by default jobs require all previous jobs to "succeed", not just the immediately previous one.

Conditioning the job with `${{ ! failure() && ! cancelled() }}` resolves the issue.

Successful run: https://github.com/mrclary/spyder/actions/runs/10327346131