### PR TITLE
PR: Recreate Spyder runtime environment on minor updates (Installers)

### DIFF
--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -135,10 +135,10 @@ yaml.indent(mapping=2, sequence=4, offset=2)
 indent4 = partial(indent, prefix="    ")
 
 base_specs = {
-    "python": f"={PY_VER}",
+    "python": "=3.11.9",
     "conda": "=24.5.0",
     "menuinst": "=2.1.0",
-    "mamba": "",
+    "mamba": "=1.5.8",
 }
 rt_specs = {
     "python": f"={PY_VER}",

--- a/spyder/plugins/updatemanager/scripts/install.bat
+++ b/spyder/plugins/updatemanager/scripts/install.bat
@@ -7,6 +7,7 @@ IF "%~1"=="" GOTO endparse
 IF "%~1"=="-i" set install_file=%~2& SHIFT
 IF "%~1"=="-c" set conda=%~2& SHIFT
 IF "%~1"=="-p" set prefix=%~2& SHIFT
+If "%~1"=="-r" set rebuild=true
 SHIFT
 GOTO parse
 :endparse
@@ -56,15 +57,19 @@ exit %ERRORLEVEL%
     pushd %installer_dir%
 
     echo Updating Spyder base environment...
-    %conda% update -n base -y --file conda-base-win-64.lock
+    %conda% update --name base --yes --file conda-base-win-64.lock
 
-    echo Updating Spyder runtime environment...
-    rem Unnecessary dependencies are not removed when updating with lock file,
-    rem so the environment must be removed and re-created.
-    %conda% remove -p %prefix% --all -y
-    mkdir %prefix%\Menu
-    echo. > "%prefix%\Menu\conda-based-app"
-    %conda% create -p %prefix% -y --file conda-runtime-win-64.lock
+    if "%rebuild%"=="true" (
+        echo Rebuilding Spyder runtime environment...
+        %conda% remove --prefix %prefix% --all --yes
+        mkdir %prefix%\Menu
+        echo. > "%prefix%\Menu\conda-based-app"
+        set conda_cmd=create
+    ) else (
+        echo Updating Spyder runtime environment...
+        set conda_cmd=update
+    )
+    %conda% %conda_cmd% --prefix %prefix% --yes --file conda-runtime-win-64.lock
 
     echo Cleaning packages and temporary files...
     %conda% clean --yes --packages --tempfiles %prefix%

--- a/spyder/plugins/updatemanager/scripts/install.bat
+++ b/spyder/plugins/updatemanager/scripts/install.bat
@@ -8,6 +8,7 @@ IF "%~1"=="-i" set install_file=%~2& SHIFT
 IF "%~1"=="-c" set conda=%~2& SHIFT
 IF "%~1"=="-p" set prefix=%~2& SHIFT
 If "%~1"=="-r" set rebuild=true
+
 SHIFT
 GOTO parse
 :endparse

--- a/spyder/plugins/updatemanager/scripts/install.bat
+++ b/spyder/plugins/updatemanager/scripts/install.bat
@@ -59,7 +59,12 @@ exit %ERRORLEVEL%
     %conda% update -n base -y --file conda-base-win-64.lock
 
     echo Updating Spyder runtime environment...
-    %conda% update -p %prefix% -y --file conda-runtime-win-64.lock
+    rem Unnecessary dependencies are not removed when updating with lock file,
+    rem so the environment must be removed and re-created.
+    %conda% remove -p %prefix% --all -y
+    mkdir %prefix%\Menu
+    echo. > "%prefix%\Menu\conda-based-app"
+    %conda% create -p %prefix% -y --file conda-runtime-win-64.lock
 
     echo Cleaning packages and temporary files...
     %conda% clean --yes --packages --tempfiles %prefix%

--- a/spyder/plugins/updatemanager/scripts/install.sh
+++ b/spyder/plugins/updatemanager/scripts/install.sh
@@ -23,7 +23,12 @@ update_spyder(){
     $conda update -n base -y --file "conda-base-${os}.lock"
 
     echo "Updating Spyder runtime environment..."
-    $conda update -p $prefix -y --file "conda-runtime-${os}.lock"
+    # Unnecessary dependencies are not removed when updating with lock file,
+    # so the environment must be removed and re-created.
+    $conda remove -p $prefix --all -y
+    mkdir -p $prefix/Menu
+    touch $prefix/Menu/conda-based-app
+    $conda create -p $prefix -y --file "conda-runtime-${os}.lock"
 
     echo "Cleaning packages and temporary files..."
     $conda clean --yes --packages --tempfiles $prefix

--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -133,6 +133,7 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         self.installer_path = None
         self.installer_size_path = None
 
+        # Type of Spyder update. It can be "major", "minor" or "micro"
         self.update_type = None
 
     # ---- General
@@ -267,12 +268,14 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         ):
             with open(self.installer_size_path, "r") as f:
                 size = int(f.read().strip())
-            downloaded = size == osp.getsize(self.installer_path)
-        else:
-            downloaded = False
-        logger.debug(f"Update already downloaded: {downloaded}")
 
-        return downloaded
+            update_downloaded = size == osp.getsize(self.installer_path)
+        else:
+            update_downloaded = False
+
+        logger.debug(f"Update already downloaded: {update_downloaded}")
+
+        return update_downloaded
 
     def start_update(self):
         """
@@ -470,6 +473,7 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
                 if is_program_installed(program['cmd']):
                     cmd = [program['cmd'], program['exe-opt']] + sub_cmd
                     break
+
         logger.debug(f"""Update command: "{' '.join(cmd)}" """)
 
         subprocess.Popen(' '.join(cmd), shell=True)

--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -256,6 +256,8 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         self.installer_path = osp.join(dirname, fname)
         self.installer_size_path = osp.join(dirname, "size")
 
+        logger.info(f"Update type: {self.update_type}")
+
     # ---- Download Update
 
     def _verify_installer_path(self):
@@ -265,9 +267,12 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         ):
             with open(self.installer_size_path, "r") as f:
                 size = int(f.read().strip())
-            return size == osp.getsize(self.installer_path)
+            downloaded = size == osp.getsize(self.installer_path)
         else:
-            return False
+            downloaded = False
+        logger.debug(f"Update already downloaded: {downloaded}")
+
+        return downloaded
 
     def start_update(self):
         """
@@ -465,6 +470,7 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
                 if is_program_installed(program['cmd']):
                     cmd = [program['cmd'], program['exe-opt']] + sub_cmd
                     break
+        logger.debug(f"""Update command: "{' '.join(cmd)}" """)
 
         subprocess.Popen(' '.join(cmd), shell=True)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Currently, major updates require downloading new installers and minor/micro updates use conda-lock files to update the Spyder runtime environment using `conda update`. This breaks the environment if the conda-lock file provides a minor update to Python. In order to permit Python minor updates, the runtime environment must be recreated.

This PR has the Update Manager plugin use `conda update` for micro releases of Spyder, and `conda remove` and `conda create` for minor releases of Spyder. This permits Python minor updates to be included with Spyder minor updates. This also has the advantage of removing obsolete packages from the runtime environment on minor updates.
