### PR TITLE
PR: Fix redirection flag for micromamba (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -117,12 +117,12 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
                 self.set_conf('default', True, section='main_interpreter')
                 self.set_conf('custom', False, section='main_interpreter')
 
+        # Command used to start kernels
         kernel_cmd = []
 
         if is_conda_env(pyexec=pyexec):
-            # If executable is a conda environment and different from Spyder's
-            # runtime environment, use conda's "run" subcommand in order to
-            # activate the environment and run spyder-kernels.
+            # If executable is a conda environment, use "run" subcommand to
+            # activate it and run spyder-kernels.
             conda_exe = find_conda()
 
             kernel_cmd.extend([
@@ -137,7 +137,6 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
             else:
                 kernel_cmd.append('--live-stream')
 
-        # Command used to start kernels
         kernel_cmd.extend([
             pyexec,
             # This is necessary to avoid a spurious message on Windows.


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

`micromamba` does not recognize the redirection flag `--live-stream` (`--no-capture-output`). However, its equivalent flag is `--attach ""`


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22240


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
