### PR TITLE
PR: Fix buttons style of the start tour dialog (Tours)

### DIFF
--- a/spyder/api/widgets/dialogs.py
+++ b/spyder/api/widgets/dialogs.py
@@ -11,10 +11,24 @@ Spyder dialog widgets.
 # Third-party imports
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QDialogButtonBox
+from qtpy.QtWidgets import QDialogButtonBox, QProxyStyle, QStyle
 
 # Local imports
 from spyder.utils.stylesheet import AppStyle
+
+
+class _SpyderButtonsProxyStyle(QProxyStyle):
+    """Style adjustments for SpyderDialogButtonBox."""
+
+    def styleHint(self, hint, option=None, widget=None, return_data=None):
+        if hint == QStyle.SH_DialogButtonLayout:
+            # Use the Windows buttons layout to have a uniform layout in all
+            # platforms. We selected that layout because Windows is our most
+            # popular platform.
+            # Solution found in https://stackoverflow.com/a/35907926/438386
+            return QDialogButtonBox.WinLayout
+
+        return super().styleHint(hint, option, widget, return_data)
 
 
 class SpyderDialogButtonBox(QDialogButtonBox):
@@ -58,8 +72,7 @@ class SpyderDialogButtonBox(QDialogButtonBox):
         # Set a reasonable spacing between buttons. This is a problem on Mac
         self.layout().setSpacing(2 * AppStyle.MarginSize)
 
-        # Use the Windows buttons layout to have a uniform layout in all
-        # platforms. We selected that layout because Windows is our most
-        # popular platform.
-        # Solution found in https://stackoverflow.com/a/35907926/438386
-        self.setStyleSheet("* {button-layout: 0}")
+        # Set style
+        style = _SpyderButtonsProxyStyle(None)
+        style.setParent(self)
+        self.setStyle(style)

--- a/spyder/plugins/tours/widgets.py
+++ b/spyder/plugins/tours/widgets.py
@@ -42,6 +42,7 @@ from qtpy.QtWidgets import (
 # Local imports
 from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.api.widgets.menus import SpyderMenu
+from spyder.api.widgets.mixins import SvgToScaledPixmap
 from spyder.api.translations import _
 from spyder.api.widgets.comboboxes import SpyderComboBox
 from spyder.plugins.layout.layouts import DefaultLayouts
@@ -1063,7 +1064,7 @@ class AnimatedTour(QWidget):
         return f
 
 
-class OpenTourDialog(QDialog):
+class OpenTourDialog(QDialog, SvgToScaledPixmap):
     """Initial widget with tour."""
 
     def __init__(self, parent, tour_function):
@@ -1074,20 +1075,18 @@ class OpenTourDialog(QDialog):
         else:
             flags = self.windowFlags() & ~Qt.WindowContextHelpButtonHint
         self.setWindowFlags(flags)
+        self.setWindowTitle(_("Spyder tour"))
         self.tour_function = tour_function
 
         # Image
-        images_layout = QHBoxLayout()
-        icon_filename = 'tour-spyder-logo'
-        image_path = get_image_path(icon_filename)
-        image = QPixmap(image_path)
-        image_label = QLabel()
-        image_height = int(image.height() * DialogStyle.IconScaleFactor)
-        image_width = int(image.width() * DialogStyle.IconScaleFactor)
-        image = image.scaled(image_width, image_height, Qt.KeepAspectRatio,
-                             Qt.SmoothTransformation)
-        image_label.setPixmap(image)
+        image_label = QLabel(self)
+        image_label.setPixmap(
+            self.svg_to_scaled_pixmap(
+                "tour-spyder-logo", rescale=DialogStyle.IconScaleFactor
+            )
+        )
 
+        images_layout = QHBoxLayout()
         images_layout.addStretch()
         images_layout.addWidget(image_label)
         images_layout.addStretch()


### PR DESCRIPTION
## Description of Changes

That style was incorrect due to several changes to dialogs in the Spyder 6 cycle.

### Visual changes

Before

![imagen](https://github.com/user-attachments/assets/c7e03f10-0ddd-408f-a5dd-47eb14449fad)

After

![imagen](https://github.com/user-attachments/assets/9f2d03c3-95c5-4c1b-b2e4-5d51f0c072fd)

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
