### PR TITLE
PR: Sync the IPython console current env with the one used in the Editor for completions

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -1,5 +1,21 @@
 #!/bin/bash -ex
 
+# Auxiliary functions
+install_spyder_kernels() {
+    echo "Installing subrepo version of spyder-kernels in "$1"..."
+
+    pushd external-deps/spyder-kernels
+
+    if [ "$OS" = "win" ]; then
+        # `conda run` fails on Windows without a clear reason
+        /c/Miniconda/envs/"$1"/python -m pip install -q .
+    else
+        conda run -n "$1" python -m pip install -q .
+    fi
+
+    popd
+}
+
 # Install gdb
 if [ "$USE_GDB" = "true" ]; then
     micromamba install gdb -c conda-forge -q -y
@@ -65,23 +81,12 @@ fi
 
 # Create environment for Jedi environment tests
 conda create -n jedi-test-env -q -y python=3.9 flask
+install_spyder_kernels jedi-test-env
 conda list -n jedi-test-env
 
 # Create environment to test conda env activation before launching a kernel
 conda create -n spytest-ž -q -y -c conda-forge python=3.9
-
-# Install subrepo version of Spyder-kernels in that env
-pushd external-deps/spyder-kernels
-
-if [ "$OS" = "win" ]; then
-    # `conda run` fails on Windows without a clear reason
-    /c/Miniconda/envs/spytest-ž/python -m pip install .
-else
-    conda run -n spytest-ž python -m pip install .
-fi
-
-popd
-
+install_spyder_kernels spytest-ž
 conda list -n spytest-ž
 
 # Install pyenv on Linux systems

--- a/spyder/api/shellconnect/status.py
+++ b/spyder/api/shellconnect/status.py
@@ -62,8 +62,8 @@ class ShellConnectStatusBarWidget(StatusBarWidget, ShellConnectMixin):
                 self.hide()
             else:
                 self.show()
-                self.update_status(status)
                 self.current_shellwidget = shellwidget
+                self.update_status(status)
 
     def add_shellwidget(self, shellwidget):
         """Actions to take when adding a shellwidget."""

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -3359,7 +3359,7 @@ def test_preferences_change_interpreter(qtbot, main_window):
     lsp = main_window.completions.get_provider('lsp')
     config = lsp.generate_python_config()
     jedi = config['configurations']['pylsp']['plugins']['jedi']
-    assert jedi['environment'] is sys.executable
+    assert jedi['environment'] == sys.executable
     assert jedi['extra_paths'] == []
 
     # Get conda env to use
@@ -3372,9 +3372,9 @@ def test_preferences_change_interpreter(qtbot, main_window):
     page.cus_exec_radio.radiobutton.setChecked(True)
     page.cus_exec_combo.combobox.setCurrentText(conda_env)
 
-    mi_container = main_window.main_interpreter.get_container()
+    main_interpreter = main_window.main_interpreter
     with qtbot.waitSignal(
-        mi_container.sig_interpreter_changed, timeout=5000, raising=True
+        main_interpreter.sig_interpreter_changed, timeout=5000, raising=True
     ):
         dlg.ok_btn.animateClick()
 

--- a/spyder/plugins/completion/api.py
+++ b/spyder/plugins/completion/api.py
@@ -1073,9 +1073,9 @@ class SpyderCompletionProvider(QObject, CompletionConfigurationObserver):
         """
         pass
 
-    @Slot()
-    def main_interpreter_changed(self):
-        """Handle changes on the main Python interpreter of Spyder."""
+    @Slot(str)
+    def interpreter_changed(self, interpreter):
+        """Handle changes to the Python interpreter used for completions."""
         pass
 
     def file_opened_closed_or_updated(self, filename: str, language: str):

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -135,9 +135,15 @@ class CompletionPlugin(SpyderPluginV2):
         New PythonPath settings.
     """
 
-    sig_interpreter_changed = Signal()
+    sig_interpreter_changed = Signal(str)
     """
-    This signal is used to report changes on the main Python interpreter.
+    This signal is used to handle changes in the Python interpreter done by
+    other plugins.
+
+    Parameters
+    ----------
+    path: str
+        Path to the new interpreter.
     """
 
     sig_language_completions_available = Signal(dict, str)
@@ -275,10 +281,9 @@ class CompletionPlugin(SpyderPluginV2):
     @on_plugin_available(plugin=Plugins.MainInterpreter)
     def on_maininterpreter_available(self):
         maininterpreter = self.get_plugin(Plugins.MainInterpreter)
-        mi_container = maininterpreter.get_container()
-
-        mi_container.sig_interpreter_changed.connect(
-            self.sig_interpreter_changed)
+        maininterpreter.sig_interpreter_changed.connect(
+            self.sig_interpreter_changed
+        )
 
     @on_plugin_available(plugin=Plugins.StatusBar)
     def on_statusbar_available(self):
@@ -313,10 +318,9 @@ class CompletionPlugin(SpyderPluginV2):
     @on_plugin_teardown(plugin=Plugins.MainInterpreter)
     def on_maininterpreter_teardown(self):
         maininterpreter = self.get_plugin(Plugins.MainInterpreter)
-        mi_container = maininterpreter.get_container()
-
-        mi_container.sig_interpreter_changed.disconnect(
-            self.sig_interpreter_changed)
+        maininterpreter.sig_interpreter_changed.disconnect(
+            self.sig_interpreter_changed
+        )
 
     @on_plugin_teardown(plugin=Plugins.StatusBar)
     def on_statusbar_teardown(self):
@@ -780,7 +784,8 @@ class CompletionPlugin(SpyderPluginV2):
         self.sig_pythonpath_changed.connect(
             provider_instance.python_path_update)
         self.sig_interpreter_changed.connect(
-            provider_instance.main_interpreter_changed)
+            provider_instance.interpreter_changed
+        )
 
     def _instantiate_and_register_provider(
             self, Provider: SpyderCompletionProvider):

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -78,10 +78,11 @@ class CompletionPlugin(SpyderPluginV2):
     CONF_SECTION = 'completions'
     REQUIRES = [Plugins.Preferences]
     OPTIONAL = [
+        Plugins.MainInterpreter,
         Plugins.MainMenu,
+        Plugins.IPythonConsole,
         Plugins.PythonpathManager,
         Plugins.StatusBar,
-        Plugins.MainInterpreter,
     ]
 
     CONF_FILE = False
@@ -135,10 +136,10 @@ class CompletionPlugin(SpyderPluginV2):
         New PythonPath settings.
     """
 
-    sig_interpreter_changed = Signal(str)
+    _sig_interpreter_changed = Signal(str)
     """
-    This signal is used to handle changes in the Python interpreter done by
-    other plugins.
+    This private signal is used to handle changes in the Python interpreter
+    done by other plugins.
 
     Parameters
     ----------
@@ -281,9 +282,13 @@ class CompletionPlugin(SpyderPluginV2):
     @on_plugin_available(plugin=Plugins.MainInterpreter)
     def on_maininterpreter_available(self):
         maininterpreter = self.get_plugin(Plugins.MainInterpreter)
-        maininterpreter.sig_interpreter_changed.connect(
-            self.sig_interpreter_changed
-        )
+
+        # This will allow people to change the interpreter used for completions
+        # if they disable the IPython console.
+        if not self.is_plugin_enabled(Plugins.IPythonConsole):
+            maininterpreter.sig_interpreter_changed.connect(
+                self._sig_interpreter_changed
+            )
 
     @on_plugin_available(plugin=Plugins.StatusBar)
     def on_statusbar_available(self):
@@ -310,6 +315,13 @@ class CompletionPlugin(SpyderPluginV2):
         pythonpath_manager.sig_pythonpath_changed.connect(
             self.sig_pythonpath_changed)
 
+    @on_plugin_available(plugin=Plugins.IPythonConsole)
+    def on_ipython_console_available(self):
+        ipyconsole = self.get_plugin(Plugins.IPythonConsole)
+        ipyconsole.sig_interpreter_changed.connect(
+            self._sig_interpreter_changed
+        )
+
     @on_plugin_teardown(plugin=Plugins.Preferences)
     def on_preferences_teardown(self):
         preferences = self.get_plugin(Plugins.Preferences)
@@ -318,9 +330,12 @@ class CompletionPlugin(SpyderPluginV2):
     @on_plugin_teardown(plugin=Plugins.MainInterpreter)
     def on_maininterpreter_teardown(self):
         maininterpreter = self.get_plugin(Plugins.MainInterpreter)
-        maininterpreter.sig_interpreter_changed.disconnect(
-            self.sig_interpreter_changed
-        )
+
+        # We only connect to this signal if the IPython console is not enabled
+        if not self.is_plugin_enabled(Plugins.IPythonConsole):
+            maininterpreter.sig_interpreter_changed.disconnect(
+                self._sig_interpreter_changed
+            )
 
     @on_plugin_teardown(plugin=Plugins.StatusBar)
     def on_statusbar_teardown(self):
@@ -358,6 +373,13 @@ class CompletionPlugin(SpyderPluginV2):
         pythonpath_manager = self.get_plugin(Plugins.PythonpathManager)
         pythonpath_manager.sig_pythonpath_changed.disconnect(
             self.sig_pythonpath_changed)
+
+    @on_plugin_teardown(plugin=Plugins.IPythonConsole)
+    def on_ipython_console_teardowm(self):
+        ipyconsole = self.get_plugin(Plugins.IPythonConsole)
+        ipyconsole.sig_interpreter_changed.disconnect(
+            self._sig_interpreter_changed
+        )
 
     # ---- Public API
     def stop_all_providers(self):
@@ -783,7 +805,7 @@ class CompletionPlugin(SpyderPluginV2):
 
         self.sig_pythonpath_changed.connect(
             provider_instance.python_path_update)
-        self.sig_interpreter_changed.connect(
+        self._sig_interpreter_changed.connect(
             provider_instance.interpreter_changed
         )
 

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_introspection.py
@@ -35,16 +35,11 @@ from spyder.utils.conda import get_list_conda_envs
 LOCATION = osp.realpath(osp.join(os.getcwd(), osp.dirname(__file__)))
 
 
-def set_executable_config_helper(completion_plugin, executable=None):
+def set_executable_helper(completion_plugin, executable=None):
     if executable is None:
-        completion_plugin.set_conf('executable', sys.executable,
-                                   'main_interpreter')
-        completion_plugin.set_conf('default', True, 'main_interpreter')
-        completion_plugin.set_conf('custom', False, 'main_interpreter')
+        completion_plugin._sig_interpreter_changed.emit(sys.executable)
     else:
-        completion_plugin.set_conf('executable', executable,
-                                   'main_interpreter')
-        completion_plugin.set_conf('default', False, 'main_interpreter')
+        completion_plugin._sig_interpreter_changed.emit(executable)
 
 
 @pytest.mark.order(1)
@@ -1019,8 +1014,9 @@ def spam():
 @flaky(max_runs=20)
 @pytest.mark.skipif(not is_anaconda(), reason='Requires conda to work')
 @pytest.mark.skipif(not running_in_ci(), reason="Only meant for CIs")
-@pytest.mark.skipif(not sys.platform.startswith('linux'),
-                    reason="Works reliably on Linux")
+@pytest.mark.skipif(
+    not sys.platform.startswith('linux'), reason="Works reliably on Linux"
+)
 def test_completions_environment(completions_codeeditor, qtbot, tmpdir):
     """
     Exercise code completions when using another Jedi environment, i.e. a
@@ -1045,7 +1041,7 @@ def test_completions_environment(completions_codeeditor, qtbot, tmpdir):
     # Set interpreter that has Flask and check we can provide completions for
     # it
     code_editor.set_text('')
-    set_executable_config_helper(completion_plugin, py_exe)
+    set_executable_helper(completion_plugin, py_exe)
     completion_plugin.after_configuration_update([])
     qtbot.wait(5000)
 
@@ -1059,7 +1055,7 @@ def test_completions_environment(completions_codeeditor, qtbot, tmpdir):
     assert "flask" in [x['label'] for x in sig.args[0]]
     assert code_editor.toPlainText() == 'import flask'
 
-    set_executable_config_helper(completion_plugin)
+    set_executable_helper(completion_plugin)
     completion_plugin.after_configuration_update([])
     qtbot.wait(5000)
 

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -53,12 +53,12 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
         Plugins.History,
         Plugins.MainInterpreter,
         Plugins.MainMenu,
-        Plugins.Run,
         Plugins.Projects,
         Plugins.PythonpathManager,
         Plugins.RemoteClient,
-        Plugins.WorkingDirectory,
+        Plugins.Run,
         Plugins.StatusBar,
+        Plugins.WorkingDirectory,
     ]
     TABIFY = [Plugins.History]
     WIDGET_CLASS = IPythonConsoleWidget
@@ -209,6 +209,17 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
         The new working directory path.
     """
 
+    sig_interpreter_changed = Signal(str)
+    """
+    This signal is emitted when the interpreter of the active shell widget has
+    changed.
+
+    Parameters
+    ----------
+    path: str
+        Path to the new interpreter.
+    """
+
     # ---- SpyderDockablePlugin API
     # -------------------------------------------------------------------------
     @staticmethod
@@ -227,6 +238,8 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
 
     def on_initialize(self):
         widget = self.get_widget()
+
+        # Main widget signals
         widget.sig_append_to_history_requested.connect(
             self.sig_append_to_history_requested)
         widget.sig_switch_to_plugin_requested.connect(self.switch_to_plugin)
@@ -244,6 +257,9 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
         widget.sig_help_requested.connect(self.sig_help_requested)
         widget.sig_current_directory_changed.connect(
             self.sig_current_directory_changed)
+        widget.sig_interpreter_changed.connect(
+            self.sig_interpreter_changed
+        )
 
         # Run configurations
         self.cython_editor_run_configuration = {

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1210,7 +1210,8 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
                         path_to_interpreter
                     )
                 ),
-                overwrite=True
+                overwrite=True,
+                register_action=False,
             )
 
             # Add default env as the first entry in the menu

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -250,6 +250,17 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
         The new working directory path.
     """
 
+    sig_interpreter_changed = Signal(str)
+    """
+    This signal is emitted when the interpreter of the active shell widget has
+    changed.
+
+    Parameters
+    ----------
+    path: str
+        Path to the new interpreter.
+    """
+
     def __init__(self, name=None, plugin=None, parent=None):
         super().__init__(name, plugin, parent)
 
@@ -373,6 +384,9 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
         # Create status widgets
         self.matplotlib_status = MatplotlibStatus(self)
         self.pythonenv_status = PythonEnvironmentStatus(self)
+        self.pythonenv_status.sig_interpreter_changed.connect(
+            self.sig_interpreter_changed
+        )
 
         # Initial value for the current working directory
         self._current_working_directory = get_home_dir()

--- a/spyder/plugins/maininterpreter/container.py
+++ b/spyder/plugins/maininterpreter/container.py
@@ -29,9 +29,14 @@ from spyder.utils.workers import WorkerManager
 
 class MainInterpreterContainer(PluginMainContainer):
 
-    sig_interpreter_changed = Signal()
+    sig_interpreter_changed = Signal(str)
     """
-    Signal to report that the interpreter has changed.
+    Signal to report that the main interpreter has changed.
+
+    Parameters
+    ----------
+    path: str
+        Path to the new interpreter.
     """
 
     sig_environments_updated = Signal(dict)
@@ -115,8 +120,9 @@ class MainInterpreterContainer(PluginMainContainer):
     @on_conf_change(option=['executable'])
     def on_executable_changed(self, value):
         # announce update
-        self._update_interpreter(self.get_main_interpreter())
-        self.sig_interpreter_changed.emit()
+        interpreter = self.get_main_interpreter()
+        self._update_interpreter(interpreter)
+        self.sig_interpreter_changed.emit(interpreter)
 
     def on_close(self):
         self._get_envs_timer.stop()

--- a/spyder/plugins/maininterpreter/container.py
+++ b/spyder/plugins/maininterpreter/container.py
@@ -8,6 +8,7 @@
 """Main interpreter container."""
 
 # Standard library imports
+import logging
 import os
 import os.path as osp
 import sys
@@ -25,6 +26,9 @@ from spyder.utils.envs import get_list_envs
 from spyder.utils.misc import get_python_executable
 from spyder.utils.programs import get_interpreter_info
 from spyder.utils.workers import WorkerManager
+
+
+logger = logging.getLogger(__name__)
 
 
 class MainInterpreterContainer(PluginMainContainer):
@@ -217,6 +221,7 @@ class MainInterpreterContainer(PluginMainContainer):
     def _update_interpreter(self, interpreter=None):
         """Set main interpreter and update information."""
         if interpreter:
+            logger.debug(f"Main interpreter changed to {interpreter}")
             self._interpreter = interpreter
 
         if self._interpreter not in self.path_to_env:

--- a/spyder/plugins/maininterpreter/plugin.py
+++ b/spyder/plugins/maininterpreter/plugin.py
@@ -52,6 +52,16 @@ class MainInterpreter(SpyderPluginV2):
         :py:meth:`spyder.utils.envs.get_list_envs`.
     """
 
+    sig_interpreter_changed = Signal(str)
+    """
+    Signal to report that the main interpreter has changed.
+
+    Parameters
+    ----------
+    path: str
+        Path to the new interpreter.
+    """
+
     # ---- SpyderPluginV2 API
     # -------------------------------------------------------------------------
     @staticmethod
@@ -76,6 +86,7 @@ class MainInterpreter(SpyderPluginV2):
         container.sig_environments_updated.connect(
             self.sig_environments_updated
         )
+        container.sig_interpreter_changed.connect(self.sig_interpreter_changed)
 
         # Validate that the custom interpreter from the previous session
         # still exists


### PR DESCRIPTION
## Description of Changes

- Given that now users will be able to work on multiple Pyenv/Conda envs at the same time, this will (most probably) be the expected UX for completions in the Editor: that they follow those of the the current console env.
- Expose `sig_interpreter_changed` as a plugin signal for Main interpreter (before it was at the container level but used by other plugins).
- This completes the work started in PR #22350.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
