### PR TITLE
PR: Fix starting kernels for old Conda versions (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -135,7 +135,9 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
             if conda_exe.endswith('micromamba'):
                 kernel_cmd.extend(['--attach', '""'])
             else:
-                kernel_cmd.append('--live-stream')
+                # Note: We use --no-capture-output instead of --live-stream
+                # here because it works for very old Conda versions.
+                kernel_cmd.append('--no-capture-output')
 
         kernel_cmd.extend([
             pyexec,


### PR DESCRIPTION
## Description of Changes

- This was a regression introduced by #22360.
- I noticed this because I have a very old Conda in one of my VMs

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
