### PR TITLE
PR: Don't expose `SpyderPlugin` and `SpyderPluginWidget` as part of the public API

### DIFF
--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -39,12 +39,14 @@
 * Add a new button to the Variable Explorer to indicate when variables are being
   filtered.
 
-### New API features
+### New API and plugin features
 
 * `SpyderPluginV2.get_description` must be a static method now and
   `SpyderPluginV2.get_icon` a class or static method. This is necessary to
   display the list of available plugins in Preferences in a more user-friendly
   way (see PR spyder-ide/spyder#21101).
+* `SpyderPlugin` and `SpyderPluginWidget` are no longer exposed in the public
+  API. They will be removed in Spyder 6.1.
 * Generalize the Run plugin to support generic inputs and executors. This allows
   plugins to declare what kind of inputs (i.e. file, cell or selection) they
   can execute and how they will display the result.

--- a/spyder/api/_version.py
+++ b/spyder/api/_version.py
@@ -22,5 +22,5 @@ The API version should be modified according to the following rules:
    updated.
 """
 
-VERSION_INFO = (0, 10, 0)
+VERSION_INFO = (1, 0, 0)
 __version__ = '.'.join(map(str, VERSION_INFO))

--- a/spyder/api/plugin_registration/registry.py
+++ b/spyder/api/plugin_registration/registry.py
@@ -20,9 +20,8 @@ from spyder.config.manager import CONF
 from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.api.plugin_registration._confpage import PluginsConfigPage
 from spyder.api.exceptions import SpyderAPIError
-from spyder.api.plugins import (
-    Plugins, SpyderPluginV2, SpyderDockablePlugin, SpyderPluginWidget,
-    SpyderPlugin)
+from spyder.api.plugins import Plugins, SpyderDockablePlugin, SpyderPluginV2
+from spyder.api.plugins._old_api import SpyderPlugin, SpyderPluginWidget
 from spyder.utils.icon_manager import ima
 
 

--- a/spyder/api/plugins/__init__.py
+++ b/spyder/api/plugins/__init__.py
@@ -9,7 +9,7 @@ spyder.api.plugins
 ==================
 
 Here, 'plugins' are Qt objects that can make changes to Spyder's main window
-and call other plugins directly.
+and call/connect to other plugins directly.
 
 There are two types of plugins available:
 
@@ -22,5 +22,4 @@ There are two types of plugins available:
 """
 
 from .enum import Plugins, DockablePlugins  # noqa
-from .old_api import SpyderPlugin, SpyderPluginWidget  # noqa
 from .new_api import SpyderDockablePlugin, SpyderPluginV2  # noqa

--- a/spyder/api/plugins/_old_api.py
+++ b/spyder/api/plugins/_old_api.py
@@ -7,9 +7,9 @@
 """
 Old API for plugins.
 
-These plugins were supported until Spyder 4, but they will be deprecated in
-the future. Please don't rely on them for new plugins and use instead the
-classes present in new_api.py
+These plugins were supported until Spyder 5, but that's no longer the case.
+Please don't rely on them for new plugins and use instead the classes present
+in new_api.py
 """
 
 # Third-party imports

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -43,7 +43,7 @@ from spyder.utils.image_path_manager import IMAGE_PATH_MANAGER
 
 # Package imports
 from .enum import Plugins
-from .old_api import SpyderPluginWidget
+from ._old_api import SpyderPluginWidget
 
 
 # Logging

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -94,9 +94,8 @@ from spyder.utils.stylesheet import APP_STYLESHEET
 
 # Spyder API Imports
 from spyder.api.exceptions import SpyderAPIError
-from spyder.api.plugins import (
-    Plugins, SpyderPlugin, SpyderPluginV2, SpyderDockablePlugin,
-    SpyderPluginWidget)
+from spyder.api.plugins import Plugins, SpyderDockablePlugin, SpyderPluginV2
+from spyder.api.plugins._old_api import SpyderPlugin, SpyderPluginWidget
 
 #==============================================================================
 # Windows only local imports

--- a/spyder/plugins/preferences/plugin.py
+++ b/spyder/plugins/preferences/plugin.py
@@ -24,7 +24,8 @@ from qtpy.QtCore import Slot
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports
-from spyder.api.plugins import Plugins, SpyderPluginV2, SpyderPlugin
+from spyder.api.plugins import Plugins, SpyderPluginV2
+from spyder.api.plugins._old_api import SpyderPlugin
 from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
 from spyder.api.plugin_registration.registry import PreferencesAdapter


### PR DESCRIPTION
## Description of Changes

- Since the migration to the new API is now complete, there are no internal plugins that rely on those classes anymore. So it's better not to support them for Spyder 6 (otherwise we wouldn't notice when we break them).
- Also, bump API version to `1.0.0` to try to keep it stable.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
