### PR TITLE
PR: Fix issue where single-instance mode was not enforced (Installers)

### DIFF
--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -1162,7 +1162,8 @@ def is_spyder_process(pid):
 
         # Valid names for main script
         names = set(['spyder', 'spyder3', 'spyder.exe', 'spyder3.exe',
-                     'bootstrap.py', 'spyder-script.py', 'Spyder.launch.pyw'])
+                     'bootstrap.py', 'spyder-script.py', 'spyder-script.pyw',
+                     'Spyder.launch.pyw'])
         if running_under_pytest():
             names.add('runtests.py')
 


### PR DESCRIPTION
Fix issue where single-instance was not enforced due to incorrectly not identifying a Spyder process.

