### PR TITLE
PR: Prioritize conda-forge channel so that stable releases are pulled above unstable ones (Installers)

### DIFF
--- a/.github/scripts/installer_test.sh
+++ b/.github/scripts/installer_test.sh
@@ -66,10 +66,22 @@ check_shortcut() {
     fi
 }
 
+check_spyder_version() {
+    runtime_python=${base_prefix}/envs/spyder-runtime/bin/python
+    actual_version=$(${runtime_python} -c "import spyder; print(spyder.__version__)")
+    echo "Expected version = ${SPYVER}"
+    echo "Actual version   = ${actual_version}"
+    if [[ "${SPYVER}" != "${actual_version}" ]]; then
+        echo "Error: installed Spyder version is incorrect!"
+        exit_status=1
+    fi
+}
+
 install || exit 1
 echo "Install info:"
 check_prefix
 check_uninstall
 check_shortcut
+check_spyder_version
 
 exit $exit_status

--- a/.github/scripts/installer_test.sh
+++ b/.github/scripts/installer_test.sh
@@ -25,7 +25,7 @@ check_prefix() {
     fi
 
     if [[ -d "$base_prefix" ]]; then
-        echo "\nContents of ${base_prefix}:"
+        echo -e "\nContents of ${base_prefix}:"
         ls -al $base_prefix
     else
         echo "Base prefix does not exist!"
@@ -49,15 +49,16 @@ check_shortcut() {
     shortcut=$($pythonexe $menuinst shortcut --mode=user)
     if [[ -e "${shortcut}" ]]; then
         if [[ "$OSTYPE" == "darwin"* ]]; then
-            echo "\n${shortcut}/Contents/MacOS contents:"
+            echo -e "\nContents of ${shortcut}/Contents/MacOS:"
             ls -al "${shortcut}/Contents/MacOS"
-            echo -e "\n$shortcut/Contents/Info.plist contents:"
+            echo -e "\nContents of $shortcut/Contents/Info.plist:"
             cat "${shortcut}/Contents/Info.plist"
             script=$(compgen -G "${shortcut}/Contents/MacOS/spyder"*-script)
-            echo -e "\n${script} contents:"
+            echo -e "\nContents of ${script}:"
             cat "${script}"
+            echo ""
         elif [[ "$OSTYPE" == "linux"* ]]; then
-            echo -e "\n${shortcut} contents:"
+            echo -e "\nContents of ${shortcut}:"
             cat $shortcut
         fi
     else
@@ -69,7 +70,7 @@ check_shortcut() {
 check_spyder_version() {
     runtime_python=${base_prefix}/envs/spyder-runtime/bin/python
     actual_version=$(${runtime_python} -c "import spyder; print(spyder.__version__)")
-    echo "Expected version = ${SPYVER}"
+    echo -e "\nExpected version = ${SPYVER}"
     echo "Actual version   = ${actual_version}"
     if [[ "${SPYVER}" != "${actual_version}" ]]; then
         echo "Error: installed Spyder version is incorrect!"
@@ -78,6 +79,7 @@ check_spyder_version() {
 }
 
 install || exit 1
+echo -e "\n#############"
 echo "Install info:"
 check_prefix
 check_uninstall

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -264,7 +264,9 @@ jobs:
           [[ -n $CNAME ]] && args=("--cert-id" "$CNAME") || args=()
           python build_installers.py ${args[@]}
 
+          SPYVER=$(python build_installers.py --version)
           PKG_NAME=$(ls $DISTDIR | grep Spyder-)
+          echo "SPYVER=$SPYVER" >> $GITHUB_ENV
           echo "PKG_NAME=$PKG_NAME" >> $GITHUB_ENV
           echo "ARTIFACT_NAME=${PKG_NAME%.*}" >> $GITHUB_ENV
           echo "PKG_PATH=$DISTDIR/$PKG_NAME" >> $GITHUB_ENV
@@ -293,6 +295,20 @@ jobs:
               echo "Spyder NOT installed successfully"
               EXIT /B 1
           )
+
+          set runtime_python=%base_prefix%\envs\spyder-runtime\python
+          for /F "tokens=*" %%i in (
+              '%runtime_python% -c "import spyder; print(spyder.__version__)"'
+          ) do (
+              set actual_version=%%~i
+          )
+          echo Expected version = %SPYVER%
+          echo Actual version   = %actual_version%
+          if %SPYVER% neq %actual_version% (
+              echo Error: installed Spyder version is incorrect!
+              EXIT /B 1
+          )
+
           EXIT /B %ERRORLEVEL%
 
       - name: Notarize or Compute Checksum

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -281,7 +281,14 @@ jobs:
         run: |
           set base_prefix=%USERPROFILE%\AppData\Local\spyder-6
           start /wait %PKG_PATH% /InstallationType=JustMe /NoRegistry=1 /S
-          if exist %base_prefix%\install.log type %base_prefix%\install.log
+
+          echo.
+          if exist %base_prefix%\install.log (
+              echo Log output:
+              type %base_prefix%\install.log
+          ) else (
+              echo No log found at %base_prefix%\install.log
+          )
 
           set mode=system
           for /F "tokens=*" %%i in (
@@ -289,10 +296,11 @@ jobs:
           ) do (
               set shortcut=%%~fi
           )
+          echo.
           if exist "%shortcut%" (
-              echo "Spyder installed successfully"
+              echo Spyder installed successfully
           ) else (
-              echo "Spyder NOT installed successfully"
+              echo Spyder NOT installed successfully
               EXIT /B 1
           )
 
@@ -302,6 +310,7 @@ jobs:
           ) do (
               set actual_version=%%~i
           )
+          echo.
           echo Expected version = %SPYVER%
           echo Actual version   = %actual_version%
           if %SPYVER% neq %actual_version% (

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -186,10 +186,10 @@ def _create_conda_lock(env_type='base'):
 
     definitions = {
         "channels": [
-            CONDA_BLD_PATH,
+            "conda-forge",
             "conda-forge/label/spyder_dev",
             "conda-forge/label/spyder_kernels_rc",
-            "conda-forge"
+            CONDA_BLD_PATH,
         ],
         "dependencies": [k + v for k, v in specs.items()],
         "platforms": [TARGET_PLATFORM]

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -128,6 +128,10 @@ p.add_argument(
     "--conda-lock", action="store_true",
     help="Create conda-lock file and exit."
 )
+p.add_argument(
+    "--version", action="store_true",
+    help="Print Spyder version and exit."
+)
 args = p.parse_args()
 
 yaml = YAML()
@@ -510,6 +514,9 @@ if __name__ == "__main__":
     if args.conda_lock:
         _create_conda_lock(env_type='base')
         _create_conda_lock(env_type='runtime')
+        sys.exit()
+    if args.version:
+        print(SPYVER)
         sys.exit()
 
     main()


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Release of 6.0.0 revealed an issue where the conda solver would take `6.0.0rc2` as satisfying the specification `6.0.0`. I did not realize that `6.0.0` lacked the specificity required to distinguish it from `6.0.0rc2`, but not the other way around.

By setting the `conda-forge` channel first, it will take priority over `label/spyder_dev` and take the `6.0.0` package first. On developer and release candidate builds, the version specificity, e.g. `6.0.1.dev0` or `6.0.1rc1`, will ensure that stable versions are overlooked in the higher priority `conda-forge` channel and the specified version will be obtained from the appropriate channel.

Fixes #22416 