### PR TITLE
PR: Fix bug when calling `update_edit_menu` at startup (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -1250,7 +1250,11 @@ class EditorMainWidget(PluginMainWidget):
         editor = self.get_current_editor()
         readwrite_editor = possible_text_widget == editor
 
-        if readwrite_editor and not editor.isReadOnly():
+        # We need the first validation to avoid a bug at startup. That probably
+        # happens when the menu is tried to be rendered automatically in some
+        # Linux distros.
+        # Fixes spyder-ide/spyder#22432
+        if editor is not None and readwrite_editor and not editor.isReadOnly():
             # Case where the current editor has the focus
             if not self.is_file_opened():
                 return


### PR DESCRIPTION
## Description of Changes

It seems in some Linux distros the `Edit` menu is tried to be rendered at startup, which was giving this problem. 

### Issue(s) Resolved

Fixes #22432

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
