### PR TITLE
PR: Enable `autoreload` magic on all operating systems (Config)

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -162,7 +162,7 @@ DEFAULTS = [
               'greedy_completer': False,
               'jedi_completer': False,
               'autocall': 0,
-              'autoreload': not WIN,
+              'autoreload': True,
               'symbolic_math': False,
               'in_prompt': '',
               'out_prompt': '',
@@ -672,4 +672,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '84.1.0'
+CONF_VERSION = '84.2.0'


### PR DESCRIPTION
## Description of Changes

- That magic was disabled for Windows and users that rely on it noticed it after Spyder 6.0 was released.
- This was a regression introduced in PR #21320.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22433

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
