### PR TITLE
PR: Update dev version to correctly reflect what `master` is pointing at

### DIFF
--- a/spyder/__init__.py
+++ b/spyder/__init__.py
@@ -31,7 +31,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 from packaging.version import parse
 
-version_info = (7, 0, 0, "dev0")
+version_info = (6, 1, 0, "a1", "dev0")
 
 __version__ = str(parse('.'.join(map(str, version_info))))
 __installer_version__ = __version__


### PR DESCRIPTION
## Description of Changes

In our new backporting workflow, `master` doesn't really point to version `7.0` but to `6.1` instead.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
