### PR TITLE
PR: Prevent error when updating `sys.path` in consoles (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -705,10 +705,14 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
         )
 
     def update_syspath(self, path_dict, new_path_dict):
-        """Update sys.path contents on kernel."""
-        self.call_kernel(
-            interrupt=True,
-            blocking=False).update_syspath(path_dict, new_path_dict)
+        """Update sys.path contents in the kernel."""
+        # Prevent error when the kernel is not available and users open/close
+        # projects or use the Python path manager.
+        # Fixes spyder-ide/spyder#21563
+        if self.kernel_handler is not None:
+            self.call_kernel(interrupt=True, blocking=False).update_syspath(
+                path_dict, new_path_dict
+            )
 
     def request_syspath(self):
         """Ask the kernel for sys.path contents."""


### PR DESCRIPTION
## Description of Changes

This happened when the kernel was not available and users opened/closed projects or used the Python path manager.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21563.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
