### PR TITLE
PR: Show banner when the kernel is ready (IPython console) 

### DIFF
--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -72,7 +72,7 @@ def running_in_ci_with_conda():
 def running_in_binder():
     """Return True if currently running in Binder."""
     return (
-        os.environ.get("BINDER_REPO_URL")
+        bool(os.environ.get("BINDER_REPO_URL"))
         and "spyder-ide/binder-environments" in os.environ["BINDER_REPO_URL"]
     )
 

--- a/spyder/plugins/ipythonconsole/comms/kernelcomm.py
+++ b/spyder/plugins/ipythonconsole/comms/kernelcomm.py
@@ -104,6 +104,11 @@ class KernelComm(CommBase, QObject):
         """Open comm through the kernel client."""
         self.kernel_client = kernel_client
         try:
+            logger.debug(
+                f"Opening kernel comm for "
+                f"{'<' + repr(kernel_client).split('.')[-1]}"
+            )
+
             self._register_comm(
                 # Create new comm and send the highest protocol
                 kernel_client.comm_manager.new_comm(self._comm_name)

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -52,23 +52,28 @@ def test_banners(ipyconsole, qtbot):
     shell = ipyconsole.get_current_shellwidget()
     control = shell._control
 
-    # Long banner
+    # Check long banner (the default)
     text = control.toPlainText().splitlines()
-    if "Update LANGUAGE_CODES" in text[0]:
-        text = text[1:]
-        while not text[0].strip():
-            text = text[1:]
     py_ver = sys.version.splitlines()[0].strip()
     assert py_ver in text[0]  # Python version in first line
     assert 'license' in text[1]  # 'license' mention in second line
     assert '' == text[2]  # Third line is empty
     assert ipy_release.version in text[3]  # Fourth line is IPython
 
-    # Short banner
-    short_banner = shell.short_banner()
+    # Check short banner for a new console
+    ipyconsole.set_conf("show_banner", False)
+    ipyconsole.create_new_client()
+    shell = ipyconsole.get_current_shellwidget()
+    qtbot.waitUntil(
+        lambda: shell.spyder_kernel_ready and shell._prompt_html is not None,
+        timeout=SHELL_TIMEOUT
+    )
+
     py_ver = sys.version.split(' ')[0]
-    expected = 'Python %s -- IPython %s' % (py_ver, ipy_release.version)
-    assert expected == short_banner
+    expected = (
+        f"Python {py_ver} -- IPython {ipy_release.version}\n\n" + "In [1]: "
+    )
+    assert expected == shell._control.toPlainText()
 
 
 @flaky(max_runs=3)

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -9,6 +9,7 @@ Shell Widget for the IPython Console
 """
 
 # Standard library imports
+import logging
 import os
 import os.path as osp
 import time
@@ -45,8 +46,11 @@ from spyder.utils.clipboard_helper import CLIPBOARD_HELPER
 from spyder.widgets.helperwidgets import MessageCheckBox
 
 
+logger = logging.getLogger(__name__)
+
 MODULES_FAQ_URL = (
-    "https://docs.spyder-ide.org/5/faq.html#using-packages-installer")
+    "https://docs.spyder-ide.org/5/faq.html#using-packages-installer"
+)
 
 
 class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
@@ -1186,6 +1190,8 @@ overrided by the Sympy module (e.g. plot)
         if self.is_external_kernel and not self.is_remote():
             return ""
 
+        logger.debug(f"Showing banner for {self}")
+
         # Detect what kind of banner we want to show
         show_banner_o = self.additional_options['show_banner']
         if show_banner_o:
@@ -1465,3 +1471,11 @@ overrided by the Sympy module (e.g. plot)
         """Reimplement Qt method to send focus change notification"""
         self.sig_focus_changed.emit()
         return super(ShellWidget, self).focusOutEvent(event)
+
+    # ---- Python methods
+    def __repr__(self):
+        # Handy repr for logging.
+        # Solution from https://stackoverflow.com/a/121508/438386
+        return (
+            "<" + self.__class__.__name__ + " object at " + hex(id(self)) + ">"
+        )

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -799,7 +799,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
             )
 
             banner = ''.join(banner_parts)
-        except CommError:
+        except (CommError, TimeoutError):
             banner = ""
 
         # Pylab additions
@@ -837,8 +837,8 @@ overrided by the Sympy module (e.g. plot)
             env_info = self.get_pythonenv_info()
             py_ver = env_info['python_version']
             ipy_ver = env_info['ipython_version']
-            banner = f'Python {py_ver} -- IPython {ipy_ver}'
-        except CommError:
+            banner = f'Python {py_ver} -- IPython {ipy_ver}\n'
+        except (CommError, TimeoutError):
             banner = ""
 
         return banner

--- a/spyder/plugins/ipythonconsole/widgets/status.py
+++ b/spyder/plugins/ipythonconsole/widgets/status.py
@@ -100,6 +100,8 @@ class MatplotlibStatus(ShellConnectStatusBarWidget):
     # -------------------------------------------------------------------------
     def update_status(self, gui):
         """Update interactive state."""
+        logger.debug(f"Setting Matplotlib backend to {gui}")
+
         if self._interactive_gui is None and gui != "inline":
             self._interactive_gui = gui
         self._gui = gui


### PR DESCRIPTION
## Description of Changes

- The previous approach didn't work all the time because when the first prompt is shown, the kernel comm is not necessarily connected (and we need that to get the banner info).
- Also add some logging messages to better understand how actions are performed in the console.

### Issue(s) Resolved

Fixes #22440.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
