### PR TITLE
PR: Reset `undocked before hiding` state of all plugins before applying layout

### DIFF
--- a/spyder/plugins/layout/api.py
+++ b/spyder/plugins/layout/api.py
@@ -356,7 +356,7 @@ class BaseGridLayoutType:
         # is applied
         base_plugins_to_hide = []
 
-        # Before applying a new layout all plugins need to be hidden
+        # Actions to be performed before applying the layout
         for plugin in dockable_plugins:
             all_plugin_ids.append(plugin.NAME)
 
@@ -367,6 +367,14 @@ class BaseGridLayoutType:
             ):
                 external_plugins_to_show.append(plugin.NAME)
 
+            # Restore undocked_before_hiding state so that the layout is
+            # applied as expected, i.e. all plugins are shown in their expected
+            # positions. It also avoids an error that leaves the main window in
+            # an inconsistent state.
+            # Fixes spyder-ide/spyder#22494
+            plugin.set_conf('window_was_undocked_before_hiding', False)
+
+            # Hide all plugins
             plugin.toggle_view(False)
 
         # Add plugins without an area assigned to the default area and made


### PR DESCRIPTION
## Description of Changes

- This is necessary to apply the layout as expected, i.e. that all plugins are shown in their expected positions.
- It also avoids an error that leaves the main window in an inconsistent state.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22494

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
