### PR TITLE
PR: Prevent storing a negative position when saving the main window settings (Layout)

### DIFF
--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -668,7 +668,10 @@ class Layout(SpyderPluginV2, SpyderShortcutsMixin):
         )
         self.set_conf(
             prefix + 'position',
-            (pos.x(), pos.y()),
+            # We need to do these validations to avoid an error that breaks
+            # doing mouse clicks in WSL.
+            # Fixes spyder-ide/spyder#20851
+            (pos.x() if pos.x() > 0 else 0, pos.y() if pos.y() > 0 else 0),
             section=section,
         )
 


### PR DESCRIPTION
## Description of Changes

- This is necessary to avoid breaking mouse clicks the next time Spyder starts on WSL.

### Issue(s) Resolved

Fixes #20851.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
