### PR TITLE
PR: Avoid crashes at startup due to faulty/outdated external plugins

### DIFF
--- a/spyder/app/find_plugins.py
+++ b/spyder/app/find_plugins.py
@@ -82,7 +82,9 @@ def find_external_plugins():
                         "Entry point name '{0}' and plugin.NAME '{1}' "
                         "do not match!".format(name, plugin_class.NAME)
                     )
-            except (ModuleNotFoundError, ImportError) as error:
+            except Exception as error:
+                # We catch any error here to avoid Spyder to crash at startup
+                # due to faulty or outdated plugins.
                 print("%s: %s" % (name, str(error)), file=STDERR)
                 traceback.print_exc(file=STDERR)
 


### PR DESCRIPTION
## Description of Changes

- Before we were loading external plugins in a try/except that caught only a handful of errors.
- Now we catch any exception, which is more robust.

### Issue(s) Resolved

I think this is important after seeing what was reported on issue #22419.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
