### PR TITLE
PR: Allow plugins to hook into file actions (API)

### DIFF
--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -17,7 +17,7 @@
 
 #### Remote Client
 
-* **Breaking** The `create_ipyclient_for_server` and `get_kernels` methods were removed.
+* **Breaking** - The `create_ipyclient_for_server` and `get_kernels` methods were removed.
 * Add `sig_server_changed` signal to report when a server was added or removed.
 * Add `get_server_name` method to get a server name given its id.
 * Add `register_api` and `get_api` methods in order to get and register new rest API modules for the remote client.
@@ -45,6 +45,22 @@
 * **Breaking** - Remove `dispatch` method to use it directly as decorator.
 * Add class `DispatcherFuture` to `spyder.api.asyncdispatcher` and `QtSlot` method to `AsyncDispatcher` so that connected methods can be run inside the main Qt event loop.
 * Add `early_return` and `return_awaitable` kwargs its constructor.
+
+#### Application plugin
+
+* Add `create_new_file`, `open_file_using_dialog`, `open_file_in_plugin`, `open_last_closed_file`, `add_recent_file`, `save_file`, `save_file_as`, `save_copy_as`, `revert_file`, `close_file`, `close_all` and `enable_file_action` methods to perform file operations in the appropriate plugin.
+* Add `focused_plugin` attribute.
+
+#### Editor
+
+* **Breaking** - The `NewFile`, `OpenFile`, `OpenLastClosed`, `MaxRecentFiles`, `ClearRecentFiles`, `SaveFile`, `SaveAll`, `SaveAs`, `SaveCopyAs`, `RevertFile`, `CloseFile` and `CloseAll` actions were moved to the `ApplicationActions` class in the `Application` plugin.
+* **Breaking** - The shortcuts "new file", "open file", "open last closed", "save file", "save all", "save as", "close file 1", "close file 2" and "close all" were moved to the "main" section.
+* Add `open_last_closed`, `current_file_is_temporary`, `save_all`, `save_as`, `save_copy_as` and `revert_file` methods.
+
+#### SpyderPluginV2 
+
+* Add `CAN_HANDLE_FILE_ACTIONS` and `FILE_EXTENSIONS` attributes and `create_new_file`, `open_file`, `get_current_filename`, `current_file_is_temporary`, `open_last_closed_file`, `save_file`, `save_all`, `save_file_as`, `save_copy_as`, `revert_file`, `close_file` and `close all` methods to allow other plugins to hook into file actions.
+* Add `sig_focused_plugin_changed` signal to signal that the plugin with focus has changed.
 
 ----
 

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -19,7 +19,7 @@ import logging
 import os
 import os.path as osp
 import sys
-from typing import List, Union
+from typing import List, Optional, Union
 import warnings
 
 # Third party imports
@@ -1104,6 +1104,28 @@ class SpyderDockablePlugin(SpyderPluginV2):
             The name of the file to be opened.
         """
         raise NotImplementedError
+
+    def get_current_filename(self) -> Optional[str]:
+        """
+        Return file name of the file that is currently displayed.
+
+        This is meant for plugins like the Editor or Notebook plugin which
+        editor display files. Return `None` if no file is displayed or if this
+        does not display files.
+
+        This function is used in the `Open file` action to initialize the
+        "Open file" dialog.
+        """
+        return None
+
+    def current_file_is_temporary(self) -> bool:
+        """
+        Return whether currently displayed file is a temporary file.
+
+        This function should only be called if a file is displayed, that is,
+        if `self.get_current_filename()` does not return `None`.
+        """
+        return False
 
     def open_last_closed_file(self) -> None:
         """

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -983,6 +983,13 @@ class SpyderDockablePlugin(SpyderPluginV2):
     # the action to switch is called a second time.
     RAISE_AND_FOCUS = False
 
+    # Whether the plugin can handle file actions.
+    # If set to true, then the `create_new_file`, `open_last_closed_file`,
+    # `save_file`, `save_file_as`, `save_copy_as`, `save_all`, `revert_file`,
+    # `close_file` and `close_all` functions will be called to handle the
+    # corresponding actions.
+    CAN_HANDLE_FILE_ACTIONS = False
+
     # ---- API: Available signals
     # -------------------------------------------------------------------------
     sig_focus_changed = Signal()
@@ -1063,6 +1070,98 @@ class SpyderDockablePlugin(SpyderPluginV2):
         widget.sig_toggle_view_changed.connect(self.sig_toggle_view_changed)
         widget.sig_update_ancestor_requested.connect(
             self.sig_update_ancestor_requested)
+
+    # ---- API: Optional methods to override
+    # -------------------------------------------------------------------------
+    def create_new_file(self) -> None:
+        """
+        Create a new file inside the plugin.
+
+        This function will be called if the user create a new file using
+        the `File > New` menu item or the "New file" button in the toolbar,
+        and `CAN_HANDLE_FILE_ACTIONS` is set to `True`.
+        """
+        raise NotImplementedError
+
+    def open_last_closed_file(self) -> None:
+        """
+        Open the last closed file again.
+
+        This function will be called if the `File > Open last closed` menu item
+        is selected while the plugin has focus and `CAN_HANDLE_FILE_ACTIONS`
+        is set to `True`.
+        """
+        raise NotImplementedError
+
+    def save_file(self) -> None:
+        """
+        Save the current file.
+
+        This function will be called if the user saves the current file using
+        the `File > Save` menu item or the "Save file" button in the toolbar,
+        the plugin has focus, and `CAN_HANDLE_FILE_ACTIONS` is set to `True`.
+        """
+        raise NotImplementedError
+
+    def save_file_as(self) -> None:
+        """
+        Save the current file under a different name.
+
+        This function will be called if the `File > Save as` menu item is
+        selected while the plugin has focus and `CAN_HANDLE_FILE_ACTIONS` is
+        set to `True`.
+        """
+        raise NotImplementedError
+
+    def save_copy_as(self) -> None:
+        """
+        Save a copy of the current file under a different name.
+
+        This function will be called if the `File > Save copy as` menu item is
+        selected while the plugin has focus and `CAN_HANDLE_FILE_ACTIONS` is
+        set to `True`.
+        """
+        raise NotImplementedError
+
+    def save_all(self) -> None:
+        """
+        Save all files that are opened in the plugin.
+
+        This function will be called if the user saves all files using the
+        `File > Save all` menu item or the "Save all" button in the toolbar,
+        the plugin has focus, and `CAN_HANDLE_FILE_ACTIONS` is set to `True`.
+        """
+        raise NotImplementedError
+
+    def revert_file(self) -> None:
+        """
+        Revert the current file to the version stored on disk.
+
+        This function will be called if the `File > Revert` menu item is
+        selected while the plugin has focus and `CAN_HANDLE_FILE_ACTIONS` is
+        set to `True`.
+        """
+        raise NotImplementedError
+
+    def close_file(self) -> None:
+        """
+        Close the current file.
+
+        This function will be called if the `File > Close` menu item is
+        selected while the plugin has focus and `CAN_HANDLE_FILE_ACTIONS` is
+        set to `True`.
+        """
+        raise NotImplementedError
+
+    def close_all(self) -> None:
+        """
+        Close all opened files.
+
+        This function will be called if the `File > Close all` menu item is
+        selected while the plugin has focus and `CAN_HANDLE_FILE_ACTIONS` is
+        set to `True`.
+        """
+        raise NotImplementedError
 
     # ---- API: available methods
     # -------------------------------------------------------------------------

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -987,7 +987,8 @@ class SpyderDockablePlugin(SpyderPluginV2):
     # If set to true, then the `create_new_file`, `open_last_closed_file`,
     # `save_file`, `save_file_as`, `save_copy_as`, `save_all`, `revert_file`,
     # `close_file` and `close_all` functions will be called to handle the
-    # corresponding actions.
+    # corresponding actions. Individual actions can be disabled with
+    # `enable_file_action` in the Applications plugin.
     CAN_HANDLE_FILE_ACTIONS = False
 
     # ---- API: Available signals

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -991,6 +991,12 @@ class SpyderDockablePlugin(SpyderPluginV2):
     # `enable_file_action` in the Applications plugin.
     CAN_HANDLE_FILE_ACTIONS = False
 
+    # List of file extensions which the plugin can open.
+    # If the user opens a file with one of these extensions, then the file
+    # will open in this plugin using the `open_file` function.
+    # Example: ['.ipynb'] for spyder-notebook
+    FILE_EXTENSIONS = []
+
     # ---- API: Available signals
     # -------------------------------------------------------------------------
     sig_focus_changed = Signal()
@@ -1081,6 +1087,21 @@ class SpyderDockablePlugin(SpyderPluginV2):
         This function will be called if the user create a new file using
         the `File > New` menu item or the "New file" button in the toolbar,
         and `CAN_HANDLE_FILE_ACTIONS` is set to `True`.
+        """
+        raise NotImplementedError
+
+    def open_file(self, filename: str):
+        """
+        Open file inside plugin.
+
+        This method will be called if the user wants to open a file with one
+        of the file name extensions listed in `FILE_EXTENSIONS`, so you need
+        to define that variable too.
+
+        Parameters
+        ----------
+        filename: str
+            The name of the file to be opened.
         """
         raise NotImplementedError
 

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -1084,9 +1084,9 @@ class SpyderDockablePlugin(SpyderPluginV2):
         """
         Create a new file inside the plugin.
 
-        This function will be called if the user create a new file using
-        the `File > New` menu item or the "New file" button in the toolbar,
-        and `CAN_HANDLE_FILE_ACTIONS` is set to `True`.
+        This function will be called if the user creates a new file using
+        the `File > New` menu item or the "New file" button in the main
+        toolbar, and `CAN_HANDLE_FILE_ACTIONS` is set to `True`.
         """
         raise NotImplementedError
 
@@ -1110,8 +1110,8 @@ class SpyderDockablePlugin(SpyderPluginV2):
         Return file name of the file that is currently displayed.
 
         This is meant for plugins like the Editor or Notebook plugin which
-        editor display files. Return `None` if no file is displayed or if this
-        does not display files.
+        can edit or display files. Return `None` if no file is displayed or if
+        this does not display files.
 
         This function is used in the `Open file` action to initialize the
         "Open file" dialog.
@@ -1120,7 +1120,7 @@ class SpyderDockablePlugin(SpyderPluginV2):
 
     def current_file_is_temporary(self) -> bool:
         """
-        Return whether currently displayed file is a temporary file.
+        Return whether the currently displayed file is a temporary file.
 
         This function should only be called if a file is displayed, that is,
         if `self.get_current_filename()` does not return `None`.
@@ -1142,8 +1142,9 @@ class SpyderDockablePlugin(SpyderPluginV2):
         Save the current file.
 
         This function will be called if the user saves the current file using
-        the `File > Save` menu item or the "Save file" button in the toolbar,
-        the plugin has focus, and `CAN_HANDLE_FILE_ACTIONS` is set to `True`.
+        the `File > Save` menu item or the "Save file" button in the main
+        toolbar, the plugin has focus, and `CAN_HANDLE_FILE_ACTIONS` is set to
+        `True`.
         """
         raise NotImplementedError
 
@@ -1172,8 +1173,9 @@ class SpyderDockablePlugin(SpyderPluginV2):
         Save all files that are opened in the plugin.
 
         This function will be called if the user saves all files using the
-        `File > Save all` menu item or the "Save all" button in the toolbar,
-        the plugin has focus, and `CAN_HANDLE_FILE_ACTIONS` is set to `True`.
+        `File > Save all` menu item or the "Save all" button in the main
+        toolbar, the plugin has focus, and `CAN_HANDLE_FILE_ACTIONS` is set to
+        `True`.
         """
         raise NotImplementedError
 

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -298,6 +298,17 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
         The window state.
     """
 
+    sig_focused_plugin_changed = Signal(object)
+    """
+    This signal is emitted when the plugin with keyboard focus changes.
+
+    Parameters
+    ----------
+    plugin: Optional[SpyderDockablePlugin]
+        The plugin that currently has keyboard focus, or None if no dockable
+        plugin has focus.
+    """
+
     # ---- Private attributes
     # -------------------------------------------------------------------------
     # Define configuration name map for plugin to split configuration

--- a/spyder/api/widgets/menus.py
+++ b/spyder/api/widgets/menus.py
@@ -370,7 +370,6 @@ class SpyderMenu(QMenu, SpyderFontsMixin):
                     self._sections.remove(after_section)
 
                 idx = self._sections.index(section)
-                idx = idx if (idx == 0) else (idx - 1)
                 self._sections.insert(idx, after_section)
 
     def _set_icons(self):

--- a/spyder/api/widgets/tests/test_menus.py
+++ b/spyder/api/widgets/tests/test_menus.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+# -----------------------------------------------------------------------------
+
+"""
+Tests for menus.py .
+"""
+
+from spyder.api.widgets.menus import MENU_SEPARATOR, SpyderAction, SpyderMenu
+
+
+def test_add_action_with_before_section(qtbot):
+    """
+    Check that the actions in a menu are in the right order if
+    before_section is used.
+    """
+    action1 = SpyderAction('action1', action_id='action1')
+    action2 = SpyderAction('action2', action_id='action2')
+    action3 = SpyderAction('action3', action_id='action3')
+    action4 = SpyderAction('action4', action_id='action4')
+
+    menu = SpyderMenu()
+    menu.add_action(action1, section='section1', before_section='section2')
+    menu.add_action(action4, section='section4')
+    menu.add_action(action2, section='section2', before_section='section3')
+    menu.add_action(action3, section='section3', before_section='section4')
+
+    result = menu.get_actions()
+    expected = [action1, MENU_SEPARATOR, action2, MENU_SEPARATOR,
+                action3, MENU_SEPARATOR, action4, MENU_SEPARATOR]
+    assert result == expected

--- a/spyder/api/widgets/tests/test_menus.py
+++ b/spyder/api/widgets/tests/test_menus.py
@@ -30,6 +30,14 @@ def test_add_action_with_before_section(qtbot):
     menu.add_action(action3, section='section3', before_section='section4')
 
     result = menu.get_actions()
-    expected = [action1, MENU_SEPARATOR, action2, MENU_SEPARATOR,
-                action3, MENU_SEPARATOR, action4, MENU_SEPARATOR]
+    expected = [
+        action1,
+        MENU_SEPARATOR,
+        action2,
+        MENU_SEPARATOR,
+        action3,
+        MENU_SEPARATOR,
+        action4,
+        MENU_SEPARATOR
+    ]
     assert result == expected

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1207,27 +1207,6 @@ class MainWindow(QMainWindow, SpyderMainWindowMixin, SpyderShortcutsMixin):
             else:
                 console.restore_stds()
 
-    def open_file(self, fname, external=False):
-        """
-        Open filename with the appropriate application
-        Redirect to the right widget (txt -> editor, spydata -> workspace, ...)
-        or open file outside Spyder (if extension is not supported)
-        """
-        fname = to_text_string(fname)
-        ext = osp.splitext(fname)[1]
-        editor = self.get_plugin(Plugins.Editor, error=False)
-        variableexplorer = self.get_plugin(
-            Plugins.VariableExplorer, error=False)
-
-        if encoding.is_text_file(fname):
-            if editor:
-                editor.load(fname)
-        elif variableexplorer is not None and ext in IMPORT_EXT:
-            variableexplorer.get_widget().import_data(fname)
-        elif not external:
-            fname = file_uri(fname)
-            start_file(fname)
-
     def get_initial_working_directory(self):
         """Return the initial working directory."""
         return self.INITIAL_CWD
@@ -1252,8 +1231,9 @@ class MainWindow(QMainWindow, SpyderMainWindowMixin, SpyderShortcutsMixin):
         if sys.platform == 'darwin' and 'bin/spyder' in fname:
             return
 
-        if osp.isfile(fpath):
-            self.open_file(fpath, external=True)
+        application = self.get_plugin(Plugins.Application, error=False)
+        if osp.isfile(fpath) and application:
+            application.open_file_in_plugin(fpath)
         elif osp.isdir(fpath):
             QMessageBox.warning(
                 self, _("Error"),

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -154,7 +154,7 @@ class MainWindow(QMainWindow, SpyderMainWindowMixin, SpyderShortcutsMixin):
 
     sig_focused_plugin_changed = Signal(object)
     """
-    This signal is emitted when the another plugin received keyboard focus.
+    This signal is emitted when another plugin received keyboard focus.
 
     Parameters
     ----------
@@ -433,7 +433,8 @@ class MainWindow(QMainWindow, SpyderMainWindowMixin, SpyderShortcutsMixin):
         self.sig_window_state_changed.connect(
             plugin.sig_mainwindow_state_changed)
         self.sig_focused_plugin_changed.connect(
-            plugin.sig_focused_plugin_changed)
+            plugin.sig_focused_plugin_changed
+        )
 
         # Register plugin
         plugin._register(omit_conf=omit_conf)
@@ -1080,7 +1081,7 @@ class MainWindow(QMainWindow, SpyderMainWindowMixin, SpyderShortcutsMixin):
         """
         Keep track of widget and plugin that has keyboard focus.
 
-        This function is connected to the `focusChanged` signal. It keeps
+        This function is connected to the app `focusChanged` signal. It keeps
         track of the widget and plugin that currently has keyboard focus, so
         that we can give focus to the last focused widget when restoring it
         after minimization. It also emits `sig_focused_plugin_changed` if the

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -3055,6 +3055,7 @@ def test_pylint_follows_file(qtbot, tmpdir, main_window):
         timeout=SHELL_TIMEOUT)
 
     pylint_plugin = main_window.get_plugin(Plugins.Pylint)
+    application_plugin = main_window.get_plugin(Plugins.Application)
 
     # Show pylint plugin
     pylint_plugin.dockwidget.show()
@@ -3068,7 +3069,7 @@ def test_pylint_follows_file(qtbot, tmpdir, main_window):
         fh = basedir.join('{}.py'.format(idx))
         fname = str(fh)
         fh.write('print("Hello world!")')
-        main_window.open_file(fh)
+        application_plugin.open_file_in_plugin(fname)
         qtbot.wait(200)
         assert fname == pylint_plugin.get_filename()
 
@@ -3083,7 +3084,7 @@ def test_pylint_follows_file(qtbot, tmpdir, main_window):
         fh = basedir.join('{}.py'.format(idx))
         fh.write('print("Hello world!")')
         fname = str(fh)
-        main_window.open_file(fh)
+        application_plugin.open_file_in_plugin(fname)
         qtbot.wait(200)
         assert fname == pylint_plugin.get_filename()
 

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -424,6 +424,7 @@ DEFAULTS = [
               'main/open last closed': "Ctrl+Shift+T",
               'main/save file': "Ctrl+S",
               'main/save all': "Ctrl+Alt+S",
+              'main/save as': 'Ctrl+Shift+S',
               # -- Switch to plugin --
               '_/switch to help': "Ctrl+Shift+H",
               '_/switch to outline_explorer': "Ctrl+Shift+O",
@@ -492,7 +493,6 @@ DEFAULTS = [
               'editor/go to next file': CTRL + '+Tab',
               'editor/cycle to previous file': 'Ctrl+PgUp',
               'editor/cycle to next file': 'Ctrl+PgDown',
-              'editor/save as': 'Ctrl+Shift+S',
               'editor/close all': "Ctrl+Shift+W",
               'editor/last edit location': "Ctrl+Alt+Shift+Left",
               'editor/previous cursor position': "Alt+Left",

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -85,6 +85,7 @@ DEFAULTS = [
               'report_error/remember_token': False,
               'show_dpi_message': True,
               'show_message_when_panes_are_empty': True,
+              'max_recent_files': 20,
               }),
             ('update_manager',
              {
@@ -266,7 +267,6 @@ DEFAULTS = [
               'always_remove_trailing_newlines': False,
               'show_tab_bar': True,
               'show_class_func_dropdown': False,
-              'max_recent_files': 20,
               'onsave_analysis': False,
               'autosave_enabled': True,
               'autosave_interval': 60,
@@ -605,6 +605,7 @@ NAME_MAP = {
             'crash',
             'current_version',
             'historylog_filename',
+            'recent_files',
             'window/position',
             'window/size',
             'window/state',
@@ -615,7 +616,6 @@ NAME_MAP = {
             'bookmarks',
             'filenames',
             'layout_settings',
-            'recent_files',
             'splitter_state',
             'file_uuids'
             ]

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -417,6 +417,9 @@ DEFAULTS = [
               '_/run': "F5",
               '_/configure': "Ctrl+F6",
               '_/re-run last script': "F6",
+              # -- File menu --
+              # (intended context for these is plugins that support them)
+              'main/new file': "Ctrl+N",
               # -- Switch to plugin --
               '_/switch to help': "Ctrl+Shift+H",
               '_/switch to outline_explorer': "Ctrl+Shift+O",
@@ -485,7 +488,6 @@ DEFAULTS = [
               'editor/go to next file': CTRL + '+Tab',
               'editor/cycle to previous file': 'Ctrl+PgUp',
               'editor/cycle to next file': 'Ctrl+PgDown',
-              'editor/new file': "Ctrl+N",
               'editor/open last closed':"Ctrl+Shift+T",
               'editor/open file': "Ctrl+O",
               'editor/save file': "Ctrl+S",
@@ -691,4 +693,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '86.0.0'
+CONF_VERSION = '87.0.0'

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -420,6 +420,7 @@ DEFAULTS = [
               # -- File menu --
               # (intended context for these is plugins that support them)
               'main/new file': "Ctrl+N",
+              'main/open file': "Ctrl+O",
               # -- Switch to plugin --
               '_/switch to help': "Ctrl+Shift+H",
               '_/switch to outline_explorer': "Ctrl+Shift+O",
@@ -489,7 +490,6 @@ DEFAULTS = [
               'editor/cycle to previous file': 'Ctrl+PgUp',
               'editor/cycle to next file': 'Ctrl+PgDown',
               'editor/open last closed':"Ctrl+Shift+T",
-              'editor/open file': "Ctrl+O",
               'editor/save file': "Ctrl+S",
               'editor/save all': "Ctrl+Alt+S",
               'editor/save as': 'Ctrl+Shift+S',

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -423,6 +423,7 @@ DEFAULTS = [
               'main/open file': "Ctrl+O",
               'main/open last closed': "Ctrl+Shift+T",
               'main/save file': "Ctrl+S",
+              'main/save all': "Ctrl+Alt+S",
               # -- Switch to plugin --
               '_/switch to help': "Ctrl+Shift+H",
               '_/switch to outline_explorer': "Ctrl+Shift+O",
@@ -491,7 +492,6 @@ DEFAULTS = [
               'editor/go to next file': CTRL + '+Tab',
               'editor/cycle to previous file': 'Ctrl+PgUp',
               'editor/cycle to next file': 'Ctrl+PgDown',
-              'editor/save all': "Ctrl+Alt+S",
               'editor/save as': 'Ctrl+Shift+S',
               'editor/close all': "Ctrl+Shift+W",
               'editor/last edit location': "Ctrl+Alt+Shift+Left",

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -421,6 +421,7 @@ DEFAULTS = [
               # (intended context for these is plugins that support them)
               'main/new file': "Ctrl+N",
               'main/open file': "Ctrl+O",
+              'main/open last closed': "Ctrl+Shift+T",
               # -- Switch to plugin --
               '_/switch to help': "Ctrl+Shift+H",
               '_/switch to outline_explorer': "Ctrl+Shift+O",
@@ -489,7 +490,6 @@ DEFAULTS = [
               'editor/go to next file': CTRL + '+Tab',
               'editor/cycle to previous file': 'Ctrl+PgUp',
               'editor/cycle to next file': 'Ctrl+PgDown',
-              'editor/open last closed':"Ctrl+Shift+T",
               'editor/save file': "Ctrl+S",
               'editor/save all': "Ctrl+Alt+S",
               'editor/save as': 'Ctrl+Shift+S',

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -427,6 +427,7 @@ DEFAULTS = [
               'main/save as': 'Ctrl+Shift+S',
               'main/close file 1': "Ctrl+W",
               'main/close file 2': "Ctrl+F4",
+              'main/close all': "Ctrl+Shift+W",
               # -- Switch to plugin --
               '_/switch to help': "Ctrl+Shift+H",
               '_/switch to outline_explorer': "Ctrl+Shift+O",
@@ -495,7 +496,6 @@ DEFAULTS = [
               'editor/go to next file': CTRL + '+Tab',
               'editor/cycle to previous file': 'Ctrl+PgUp',
               'editor/cycle to next file': 'Ctrl+PgDown',
-              'editor/close all': "Ctrl+Shift+W",
               'editor/last edit location': "Ctrl+Alt+Shift+Left",
               'editor/previous cursor position': "Alt+Left",
               'editor/next cursor position': "Alt+Right",

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -425,6 +425,8 @@ DEFAULTS = [
               'main/save file': "Ctrl+S",
               'main/save all': "Ctrl+Alt+S",
               'main/save as': 'Ctrl+Shift+S',
+              'main/close file 1': "Ctrl+W",
+              'main/close file 2': "Ctrl+F4",
               # -- Switch to plugin --
               '_/switch to help': "Ctrl+Shift+H",
               '_/switch to outline_explorer': "Ctrl+Shift+O",
@@ -503,8 +505,6 @@ DEFAULTS = [
               'editor/zoom in 2': "Ctrl+=",
               'editor/zoom out': "Ctrl+-",
               'editor/zoom reset': "Ctrl+0",
-              'editor/close file 1': "Ctrl+W",
-              'editor/close file 2': "Ctrl+F4",
               'editor/run cell': CTRL + '+Return',
               'editor/run cell and advance': 'Shift+Return',
               'editor/run selection and advance': "F9",

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -422,6 +422,7 @@ DEFAULTS = [
               'main/new file': "Ctrl+N",
               'main/open file': "Ctrl+O",
               'main/open last closed': "Ctrl+Shift+T",
+              'main/save file': "Ctrl+S",
               # -- Switch to plugin --
               '_/switch to help': "Ctrl+Shift+H",
               '_/switch to outline_explorer': "Ctrl+Shift+O",
@@ -490,7 +491,6 @@ DEFAULTS = [
               'editor/go to next file': CTRL + '+Tab',
               'editor/cycle to previous file': 'Ctrl+PgUp',
               'editor/cycle to next file': 'Ctrl+PgDown',
-              'editor/save file': "Ctrl+S",
               'editor/save all': "Ctrl+Alt+S",
               'editor/save as': 'Ctrl+Shift+S',
               'editor/close all': "Ctrl+Shift+W",

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -81,6 +81,7 @@ class ApplicationActions:
     SaveFile = "Save file"
     SaveAll = "Save all"
     SaveAs = "Save as"
+    SaveCopyAs = "save_copy_as_action"
     SpyderRestart = "Restart"
     SpyderRestartDebug = "Restart in debug mode"
 
@@ -134,6 +135,11 @@ class ApplicationContainer(PluginMainContainer):
     sig_save_file_as_requested = Signal()
     """
     Signal to request that the current file be saved under a different name.
+    """
+
+    sig_save_copy_as_requested = Signal()
+    """
+    Signal to request that copy of current file be saved under a new name.
     """
 
     def __init__(self, name, plugin, parent=None):
@@ -318,6 +324,13 @@ class ApplicationContainer(PluginMainContainer):
             triggered=self.sig_save_file_as_requested.emit,
             shortcut_context="main",
             register_shortcut=True
+        )
+        self.save_copy_as_action = self.create_action(
+            ApplicationActions.SaveCopyAs,
+            text=_("Save copy as..."),
+            icon=self.create_icon('filesaveas'),
+            tip=_("Save copy of current file as..."),
+            triggered=self.sig_save_copy_as_requested.emit
         )
 
         # Debug logs

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -82,6 +82,7 @@ class ApplicationActions:
     SaveAll = "Save all"
     SaveAs = "Save as"
     SaveCopyAs = "save_copy_as_action"
+    RevertFile = "Revert file"
     SpyderRestart = "Restart"
     SpyderRestartDebug = "Restart in debug mode"
 
@@ -140,6 +141,11 @@ class ApplicationContainer(PluginMainContainer):
     sig_save_copy_as_requested = Signal()
     """
     Signal to request that copy of current file be saved under a new name.
+    """
+
+    sig_revert_file_requested = Signal()
+    """
+    Signal to request that the current file be reverted from disk.
     """
 
     def __init__(self, name, plugin, parent=None):
@@ -331,6 +337,13 @@ class ApplicationContainer(PluginMainContainer):
             icon=self.create_icon('filesaveas'),
             tip=_("Save copy of current file as..."),
             triggered=self.sig_save_copy_as_requested.emit
+        )
+        self.revert_action = self.create_action(
+            ApplicationActions.RevertFile,
+            text=_("&Revert"),
+            icon=self.create_icon('revert'),
+            tip=_("Revert file from disk"),
+            triggered=self.sig_revert_file_requested.emit
         )
 
         # Debug logs

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -23,7 +23,12 @@ from qtpy.compat import getopenfilenames
 from qtpy.QtCore import QDir, Qt, QThread, QTimer, Signal, Slot
 from qtpy.QtGui import QGuiApplication
 from qtpy.QtWidgets import (
-    QAction, QFileDialog, QInputDialog, QMessageBox, QPushButton)
+    QAction,
+    QFileDialog,
+    QInputDialog,
+    QMessageBox,
+    QPushButton,
+)
 
 # Local imports
 from spyder import __docs_url__, __forum_url__, __trouble_url__
@@ -31,9 +36,15 @@ from spyder import dependencies
 from spyder.api.translations import _
 from spyder.api.widgets.main_container import PluginMainContainer
 from spyder.config.base import (
-    get_conf_path, get_debug_level, running_under_pytest)
+    get_conf_path,
+    get_debug_level,
+    running_under_pytest,
+)
 from spyder.config.utils import (
-    get_edit_filetypes, get_edit_filters, get_filter)
+    get_edit_filetypes,
+    get_edit_filters,
+    get_filter,
+)
 from spyder.plugins.application.widgets import AboutDialog, InAppAppealStatus
 from spyder.plugins.console.api import ConsoleActions
 from spyder.utils.icon_manager import ima
@@ -280,7 +291,6 @@ class ApplicationContainer(PluginMainContainer):
             shortcut_context="main",
             register_shortcut=True
         )
-
         self.open_action = self.create_action(
             ApplicationActions.OpenFile,
             text=_("&Open..."),
@@ -544,8 +554,9 @@ class ApplicationContainer(PluginMainContainer):
 
         self.sig_redirect_stdio_requested.emit(False)
         if filename is not None:
-            selectedfilter = get_filter(self.edit_filetypes,
-                                        osp.splitext(filename)[1])
+            selectedfilter = get_filter(
+                self.edit_filetypes, osp.splitext(filename)[1]
+            )
         else:
             selectedfilter = ''
 
@@ -559,8 +570,9 @@ class ApplicationContainer(PluginMainContainer):
                 )
                 dialog.setNameFilters(self.edit_filters.split(';;'))
                 dialog.setOption(QFileDialog.HideNameFilterDetails, True)
-                dialog.setFilter(QDir.AllDirs | QDir.Files | QDir.Drives
-                                 | QDir.Hidden)
+                dialog.setFilter(
+                    QDir.AllDirs | QDir.Files | QDir.Drives | QDir.Hidden
+                )
                 dialog.setFileMode(QFileDialog.ExistingFiles)
 
                 if dialog.exec_():
@@ -576,8 +588,9 @@ class ApplicationContainer(PluginMainContainer):
                 )
         else:
             # Use a Qt (i.e. scriptable) dialog for pytest
-            dialog = QFileDialog(self, _("Open file"),
-                                 options=QFileDialog.DontUseNativeDialog)
+            dialog = QFileDialog(
+                self, _("Open file"), options=QFileDialog.DontUseNativeDialog
+            )
             if dialog.exec_():
                 filenames = dialog.selectedFiles()
 
@@ -589,7 +602,7 @@ class ApplicationContainer(PluginMainContainer):
 
     def add_recent_file(self, fname: str) -> None:
         """
-        Add file to list of recent files.
+        Add file to the list of recent files.
 
         This function adds the given file name to the list of recent files,
         which is used in the `File > Open recent` menu. The function ensures
@@ -618,8 +631,10 @@ class ApplicationContainer(PluginMainContainer):
         This function is called before the menu is about to be shown.
         """
         self.recent_files_menu.clear_actions()
-        recent_files = [fname for fname in self.recent_files
-                        if osp.isfile(fname)]
+        recent_files = [
+            fname for fname in self.recent_files
+            if osp.isfile(fname)
+        ]
         for fname in recent_files:
             icon = ima.get_icon_by_extension_or_type(fname, scale_factor=1.0)
             action = self.create_action(

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -79,6 +79,7 @@ class ApplicationActions:
     MaxRecentFiles = "max_recent_files_action"
     ClearRecentFiles = "clear_recent_files_action"
     SaveFile = "Save file"
+    SaveAll = "Save all"
     SpyderRestart = "Restart"
     SpyderRestartDebug = "Restart in debug mode"
 
@@ -122,6 +123,11 @@ class ApplicationContainer(PluginMainContainer):
     sig_save_file_requested = Signal()
     """
     Signal to request that the current file be saved.
+    """
+
+    sig_save_all_requested = Signal()
+    """
+    Signal to request that all files in the current plugin be saved.
     """
 
     def __init__(self, name, plugin, parent=None):
@@ -286,6 +292,15 @@ class ApplicationContainer(PluginMainContainer):
             icon=self.create_icon('filesave'),
             tip=_("Save file"),
             triggered=self.sig_save_file_requested.emit,
+            shortcut_context="main",
+            register_shortcut=True
+        )
+        self.save_all_action = self.create_action(
+            ApplicationActions.SaveAll,
+            text=_("Sav&e all"),
+            icon=self.create_icon('save_all'),
+            tip=_("Save all files"),
+            triggered=self.sig_save_all_requested.emit,
             shortcut_context="main",
             register_shortcut=True
         )

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -78,6 +78,7 @@ class ApplicationActions:
     OpenLastClosed = "Open last closed"
     MaxRecentFiles = "max_recent_files_action"
     ClearRecentFiles = "clear_recent_files_action"
+    SaveFile = "Save file"
     SpyderRestart = "Restart"
     SpyderRestartDebug = "Restart in debug mode"
 
@@ -116,6 +117,11 @@ class ApplicationContainer(PluginMainContainer):
     sig_open_last_closed_requested = Signal()
     """
     Signal to request that the last closed file be opened again.
+    """
+
+    sig_save_file_requested = Signal()
+    """
+    Signal to request that the current file be saved.
     """
 
     def __init__(self, name, plugin, parent=None):
@@ -270,8 +276,18 @@ class ApplicationContainer(PluginMainContainer):
         )
         self.clear_recent_action = self.create_action(
             ApplicationActions.ClearRecentFiles,
-            text=_("Clear this list"), tip=_("Clear recent files list"),
+            text=_("Clear this list"),
+            tip=_("Clear recent files list"),
             triggered=self.clear_recent_files
+        )
+        self.save_action = self.create_action(
+            ApplicationActions.SaveFile,
+            text=_("&Save"),
+            icon=self.create_icon('filesave'),
+            tip=_("Save file"),
+            triggered=self.sig_save_file_requested.emit,
+            shortcut_context="main",
+            register_shortcut=True
         )
 
         # Debug logs

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -62,6 +62,7 @@ class ApplicationActions:
     SpyderUserEnvVariables = "spyder_user_env_variables_action"
 
     # File
+    NewFile = "New file"
     # The name of the action needs to match the name of the shortcut
     # so 'Restart' is used instead of something like 'restart_action'
     SpyderRestart = "Restart"
@@ -78,6 +79,11 @@ class ApplicationContainer(PluginMainContainer):
     sig_load_log_file = Signal(str)
     """
     Signal to load a log file
+    """
+
+    sig_new_file_requested = Signal()
+    """
+    Signal to request that a new file be created in a suitable plugin.
     """
 
     def __init__(self, name, plugin, parent=None):
@@ -186,6 +192,17 @@ class ApplicationContainer(PluginMainContainer):
             context=Qt.ApplicationShortcut,
             shortcut_context="_",
             register_shortcut=True)
+
+        # File actions
+        self.new_action = self.create_action(
+            ApplicationActions.NewFile,
+            text=_("&New file..."),
+            icon=self.create_icon('filenew'),
+            tip=_("New file"),
+            triggered=self.sig_new_file_requested.emit,
+            shortcut_context="main",
+            register_shortcut=True
+        )
 
         # Debug logs
         if get_debug_level() >= 2:

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -70,6 +70,7 @@ class ApplicationActions:
     # File
     NewFile = "New file"
     OpenFile = "Open file"
+    OpenLastClosed = "Open last closed"
     # The name of the action needs to match the name of the shortcut
     # so 'Restart' is used instead of something like 'restart_action'
     SpyderRestart = "Restart"
@@ -105,6 +106,11 @@ class ApplicationContainer(PluginMainContainer):
     sig_open_file_using_dialog_requested = Signal()
     """
     Signal to request that the Open File dialog is shown to open a file.
+    """
+
+    sig_open_last_closed_requested = Signal()
+    """
+    Signal to request that the last closed file be opened again.
     """
 
     def __init__(self, name, plugin, parent=None):
@@ -231,6 +237,14 @@ class ApplicationContainer(PluginMainContainer):
             icon=self.create_icon('fileopen'),
             tip=_("Open file"),
             triggered=self.sig_open_file_using_dialog_requested.emit,
+            shortcut_context="main",
+            register_shortcut=True
+        )
+        self.open_last_closed_action = self.create_action(
+            ApplicationActions.OpenLastClosed,
+            text=_("O&pen last closed"),
+            tip=_("Open last closed"),
+            triggered=self.sig_open_last_closed_requested.emit,
             shortcut_context="main",
             register_shortcut=True
         )

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -80,6 +80,7 @@ class ApplicationActions:
     ClearRecentFiles = "clear_recent_files_action"
     SaveFile = "Save file"
     SaveAll = "Save all"
+    SaveAs = "Save as"
     SpyderRestart = "Restart"
     SpyderRestartDebug = "Restart in debug mode"
 
@@ -128,6 +129,11 @@ class ApplicationContainer(PluginMainContainer):
     sig_save_all_requested = Signal()
     """
     Signal to request that all files in the current plugin be saved.
+    """
+
+    sig_save_file_as_requested = Signal()
+    """
+    Signal to request that the current file be saved under a different name.
     """
 
     def __init__(self, name, plugin, parent=None):
@@ -301,6 +307,15 @@ class ApplicationContainer(PluginMainContainer):
             icon=self.create_icon('save_all'),
             tip=_("Save all files"),
             triggered=self.sig_save_all_requested.emit,
+            shortcut_context="main",
+            register_shortcut=True
+        )
+        self.save_as_action = self.create_action(
+            ApplicationActions.SaveAs,
+            text=_("Save &as"),
+            icon=self.create_icon('filesaveas'),
+            tip=_("Save current file as..."),
+            triggered=self.sig_save_file_as_requested.emit,
             shortcut_context="main",
             register_shortcut=True
         )

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -83,6 +83,7 @@ class ApplicationActions:
     SaveAs = "Save as"
     SaveCopyAs = "save_copy_as_action"
     RevertFile = "Revert file"
+    CloseFile = "Close file"
     SpyderRestart = "Restart"
     SpyderRestartDebug = "Restart in debug mode"
 
@@ -146,6 +147,11 @@ class ApplicationContainer(PluginMainContainer):
     sig_revert_file_requested = Signal()
     """
     Signal to request that the current file be reverted from disk.
+    """
+
+    sig_close_file_requested = Signal()
+    """
+    Signal to request that the current file be closed.
     """
 
     def __init__(self, name, plugin, parent=None):
@@ -344,6 +350,13 @@ class ApplicationContainer(PluginMainContainer):
             icon=self.create_icon('revert'),
             tip=_("Revert file from disk"),
             triggered=self.sig_revert_file_requested.emit
+        )
+        self.close_file_action = self.create_action(
+            ApplicationActions.CloseFile,
+            text=_("&Close"),
+            icon=self.create_icon('fileclose'),
+            tip=_("Close current file"),
+            triggered=self.sig_close_file_requested.emit
         )
 
         # Debug logs

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -84,6 +84,7 @@ class ApplicationActions:
     SaveCopyAs = "save_copy_as_action"
     RevertFile = "Revert file"
     CloseFile = "Close file"
+    CloseAll = "Close all"
     SpyderRestart = "Restart"
     SpyderRestartDebug = "Restart in debug mode"
 
@@ -152,6 +153,11 @@ class ApplicationContainer(PluginMainContainer):
     sig_close_file_requested = Signal()
     """
     Signal to request that the current file be closed.
+    """
+
+    sig_close_all_requested = Signal()
+    """
+    Signal to request that all open files be closed.
     """
 
     def __init__(self, name, plugin, parent=None):
@@ -357,6 +363,15 @@ class ApplicationContainer(PluginMainContainer):
             icon=self.create_icon('fileclose'),
             tip=_("Close current file"),
             triggered=self.sig_close_file_requested.emit
+        )
+        self.close_all_action = self.create_action(
+            ApplicationActions.CloseAll,
+            text=_("C&lose all"),
+            icon=ima.icon('filecloseall'),
+            tip=_("Close all opened files"),
+            triggered=self.sig_close_all_requested.emit,
+            shortcut_context="main",
+            register_shortcut=True
         )
 
         # Debug logs

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -70,6 +70,9 @@ class Application(SpyderPluginV2):
         container.sig_open_file_using_dialog_requested.connect(
             self.open_file_using_dialog
         )
+        container.sig_open_last_closed_requested.connect(
+            self.open_last_closed_file
+        )
         container.set_window(self._window)
 
     # --------------------- PLUGIN INITIALIZATION -----------------------------
@@ -224,6 +227,11 @@ class Application(SpyderPluginV2):
             section=FileMenuSections.Open,
             before_section=FileMenuSections.Save
         )
+        mainmenu.add_item_to_application_menu(
+            container.open_last_closed_action,
+            menu_id=ApplicationMenus.File,
+            section=FileMenuSections.Open
+        )
 
         # Restart section
         mainmenu.add_item_to_application_menu(
@@ -341,6 +349,7 @@ class Application(SpyderPluginV2):
         for action_id in [
             ApplicationActions.NewFile,
             ApplicationActions.OpenFile,
+            ApplicationActions.OpenLastClosed,
             ApplicationActions.SpyderRestart,
             ApplicationActions.SpyderRestartDebug
         ]:
@@ -498,6 +507,16 @@ class Application(SpyderPluginV2):
         if self.is_plugin_available(Plugins.Editor):
             editor = self.get_plugin(Plugins.Editor)
             editor.load(filename)
+
+    def open_last_closed_file(self) -> None:
+        """
+        Open the last closed file again.
+
+        For the moment, forward the request to the Editor plugin.
+        """
+        if self.is_plugin_available(Plugins.Editor):
+            editor = self.get_plugin(Plugins.Editor)
+            editor.open_last_closed()
 
     @property
     def documentation_action(self):

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -76,6 +76,7 @@ class Application(SpyderPluginV2):
         container.sig_save_file_requested.connect(self.save_file)
         container.sig_save_all_requested.connect(self.save_all)
         container.sig_save_file_as_requested.connect(self.save_file_as)
+        container.sig_save_copy_as_requested.connect(self.save_copy_as)
         container.set_window(self._window)
 
     # --------------------- PLUGIN INITIALIZATION -----------------------------
@@ -245,7 +246,8 @@ class Application(SpyderPluginV2):
         save_actions = [
             container.save_action,
             container.save_all_action,
-            container.save_as_action
+            container.save_as_action,
+            container.save_copy_as_action,
         ]
         for save_action in save_actions:
             mainmenu.add_item_to_application_menu(
@@ -377,6 +379,7 @@ class Application(SpyderPluginV2):
             ApplicationActions.SaveFile,
             ApplicationActions.SaveAll,
             ApplicationActions.SaveAs,
+            ApplicationActions.SaveCopyAs,
             ApplicationActions.SpyderRestart,
             ApplicationActions.SpyderRestartDebug
         ]:
@@ -573,6 +576,14 @@ class Application(SpyderPluginV2):
         if self.is_plugin_available(Plugins.Editor):
             editor = self.get_plugin(Plugins.Editor)
             editor.save_as()
+
+    def save_copy_as(self) -> None:
+        """
+        Save copy of current file in Editor plugin under a different name.
+        """
+        if self.is_plugin_available(Plugins.Editor):
+            editor = self.get_plugin(Plugins.Editor)
+            editor.save_copy_as()
 
     def save_all(self) -> None:
         """

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -74,6 +74,7 @@ class Application(SpyderPluginV2):
             self.open_last_closed_file
         )
         container.sig_save_file_requested.connect(self.save_file)
+        container.sig_save_all_requested.connect(self.save_all)
         container.set_window(self._window)
 
     # --------------------- PLUGIN INITIALIZATION -----------------------------
@@ -125,7 +126,8 @@ class Application(SpyderPluginV2):
         for action in [
             container.new_action,
             container.open_action,
-            container.save_action
+            container.save_action,
+            container.save_all_action
         ]:
             toolbar.add_item_to_application_toolbar(
                 action,
@@ -167,7 +169,8 @@ class Application(SpyderPluginV2):
         for action in [
             ApplicationActions.NewFile,
             ApplicationActions.OpenFile,
-            ApplicationActions.SaveFile
+            ApplicationActions.SaveFile,
+            ApplicationActions.SaveAll
         ]:
             toolbar.remove_item_from_application_toolbar(
                 action,
@@ -239,7 +242,8 @@ class Application(SpyderPluginV2):
 
         # Save section
         save_actions = [
-            container.save_action
+            container.save_action,
+            container.save_all_action
         ]
         for save_action in save_actions:
             mainmenu.add_item_to_application_menu(
@@ -369,6 +373,7 @@ class Application(SpyderPluginV2):
             ApplicationActions.OpenLastClosed,
             container.recent_file_menu,
             ApplicationActions.SaveFile,
+            ApplicationActions.SaveAll,
             ApplicationActions.SpyderRestart,
             ApplicationActions.SpyderRestartDebug
         ]:
@@ -558,6 +563,16 @@ class Application(SpyderPluginV2):
         editor = self.get_plugin(Plugins.Editor)
         editor.save()
 
+    def save_all(self) -> None:
+        """
+        Save all files.
+
+        Save all files in the Editor plugin.
+        """
+        if self.is_plugin_available(Plugins.Editor):
+            editor = self.get_plugin(Plugins.Editor)
+            editor.save_all()
+
     def enable_save_action(self, state: bool) -> None:
         """
         Enable or disable save action.
@@ -568,6 +583,17 @@ class Application(SpyderPluginV2):
             True to enable save action, False to disable it.
         """
         self.get_container().save_action.setEnabled(state)
+
+    def enable_save_all_action(self, state: bool) -> None:
+        """
+        Enable or disable "Save All" action.
+
+        Parameters
+        ----------
+        state : bool
+            True to enable "Save All" action, False to disable it.
+        """
+        self.get_container().save_all_action.setEnabled(state)
 
     @property
     def documentation_action(self):

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -540,10 +540,16 @@ class Application(SpyderPluginV2):
         """
         Create new file in a suitable plugin.
 
-        For the moment, this creates a new file in the Editor plugin.
+        If the plugin that currently has focus, has its
+        `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then create a new
+        file in that plugin. Otherwise, create a new file in the Editor plugin.
         """
-        plugin = self.get_plugin(Plugins.Editor)
-        plugin.new()
+        plugin = self.focused_plugin
+        if plugin and getattr(plugin, 'CAN_HANDLE_FILE_ACTIONS', False):
+            plugin.create_new_file()
+        elif self.is_plugin_available(Plugins.Editor):
+            editor = self.get_plugin(Plugins.Editor)
+            editor.new()
 
     def open_file_using_dialog(self) -> None:
         """
@@ -578,9 +584,15 @@ class Application(SpyderPluginV2):
         """
         Open the last closed file again.
 
-        For the moment, forward the request to the Editor plugin.
+        If the plugin that currently has focus, has its
+        `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then open the
+        last closed file in that plugin. Otherwise, open the last closed file
+        in the Editor plugin.
         """
-        if self.is_plugin_available(Plugins.Editor):
+        plugin = self.focused_plugin
+        if plugin and getattr(plugin, 'CAN_HANDLE_FILE_ACTIONS', False):
+            plugin.open_last_closed_file()
+        elif self.is_plugin_available(Plugins.Editor):
             editor = self.get_plugin(Plugins.Editor)
             editor.open_last_closed()
 
@@ -599,25 +611,47 @@ class Application(SpyderPluginV2):
         """
         Save current file.
 
-        For the moment, this instructs the Editor plugin to save the current
-        file.
+        If the plugin that currently has focus, has its
+        `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then save the
+        current file in that plugin. Otherwise, save the current file in the
+        Editor plugin.
         """
-        editor = self.get_plugin(Plugins.Editor)
-        editor.save()
+        plugin = self.focused_plugin
+        if plugin and getattr(plugin, 'CAN_HANDLE_FILE_ACTIONS', False):
+            plugin.save_file()
+        elif self.is_plugin_available(Plugins.Editor):
+            editor = self.get_plugin(Plugins.Editor)
+            editor.save()
 
     def save_file_as(self) -> None:
         """
-        Save current file in Editor plugin under a different name.
+        Save current file under a different name.
+
+        If the plugin that currently has focus, has its
+        `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then save the
+        current file in that plugin under a different name. Otherwise, save
+        the current file in the Editor plugin under a different name.
         """
-        if self.is_plugin_available(Plugins.Editor):
+        plugin = self.focused_plugin
+        if plugin and getattr(plugin, 'CAN_HANDLE_FILE_ACTIONS', False):
+            plugin.save_file_as()
+        elif self.is_plugin_available(Plugins.Editor):
             editor = self.get_plugin(Plugins.Editor)
             editor.save_as()
 
     def save_copy_as(self) -> None:
         """
-        Save copy of current file in Editor plugin under a different name.
+        Save copy of current file under a different name.
+
+        If the plugin that currently has focus, has its
+        `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then save a copy of
+        the current file in that plugin under a different name. Otherwise, save
+        a copy of the current file in the Editor plugin under a different name.
         """
-        if self.is_plugin_available(Plugins.Editor):
+        plugin = self.focused_plugin
+        if plugin and getattr(plugin, 'CAN_HANDLE_FILE_ACTIONS', False):
+            plugin.save_copy_as()
+        elif self.is_plugin_available(Plugins.Editor):
             editor = self.get_plugin(Plugins.Editor)
             editor.save_copy_as()
 
@@ -625,34 +659,64 @@ class Application(SpyderPluginV2):
         """
         Save all files.
 
-        Save all files in the Editor plugin.
+        If the plugin that currently has focus, has its
+        `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then save all files
+        in that plugin. Otherwise, save all files in the Editor plugin.
         """
-        if self.is_plugin_available(Plugins.Editor):
+        plugin = self.focused_plugin
+        if plugin and getattr(plugin, 'CAN_HANDLE_FILE_ACTIONS', False):
+            plugin.save_all()
+        elif self.is_plugin_available(Plugins.Editor):
             editor = self.get_plugin(Plugins.Editor)
             editor.save_all()
 
     def revert_file(self) -> None:
         """
-        Revert current file in Editor plugin to version on disk.
+        Revert current file to version on disk.
+
+        If the plugin that currently has focus, has its
+        `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then revert the
+        current file in that plugin to the version stored on disk. Otherwise,
+        revert the current file in the Editor plugin.
         """
-        if self.is_plugin_available(Plugins.Editor):
+        plugin = self.focused_plugin
+        if plugin and getattr(plugin, 'CAN_HANDLE_FILE_ACTIONS', False):
+            plugin.revert_file()
+        elif self.is_plugin_available(Plugins.Editor):
             editor = self.get_plugin(Plugins.Editor)
             editor.revert_file()
 
     def close_file(self) -> None:
         """
-        Close current file in Editor plugin to version on disk.
+        Close the current file.
+
+        If the plugin that currently has focus, has its
+        `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then revert the
+        current file in that plugin to the version stored on disk. Otherwise,
+        revert the current file in the Editor plugin.
         """
-        if self.is_plugin_available(Plugins.Editor):
+        plugin = self.focused_plugin
+        if plugin and getattr(plugin, 'CAN_HANDLE_FILE_ACTIONS', False):
+            plugin.close_file()
+        elif self.is_plugin_available(Plugins.Editor):
             editor = self.get_plugin(Plugins.Editor)
             editor.close_file()
 
     def close_all(self) -> None:
         """
-        Close all opened files in the Editor plugin.
+        Close all opened files in the current plugin.
+
+        If the plugin that currently has focus, has its
+        `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then revert the
+        current file in that plugin to the version stored on disk. Otherwise,
+        revert the current file in the Editor plugin.
         """
-        editor = self.get_plugin(Plugins.Editor)
-        editor.close_all_files()
+        plugin = self.focused_plugin
+        if plugin and getattr(plugin, 'CAN_HANDLE_FILE_ACTIONS', False):
+            plugin.close_all()
+        elif self.is_plugin_available(Plugins.Editor):
+            editor = self.get_plugin(Plugins.Editor)
+            editor.close_all_files()
 
     def enable_save_action(self, state: bool) -> None:
         """

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -54,9 +54,7 @@ class Application(SpyderPluginV2):
     def __init__(self, parent, configuration=None):
         super().__init__(parent, configuration)
         self.focused_plugin: Optional[SpyderDockablePlugin] = None
-
-        FileActionEnabledKey = Tuple[SpyderDockablePlugin, str]
-        self.file_action_enabled: Dict[FileActionEnabledKey, bool] = {}
+        self.file_action_enabled: Dict[Tuple[str, str], bool] = {}
 
     @staticmethod
     def get_name():
@@ -465,7 +463,7 @@ class Application(SpyderPluginV2):
                 ApplicationActions.CloseAll,
             ]:
                 action = self.get_action(action_name)
-                key = (plugin, action_name)
+                key = (plugin.NAME, action_name)
                 state = self.file_action_enabled.get(key, True)
                 action.setEnabled(state)
 
@@ -775,7 +773,7 @@ class Application(SpyderPluginV2):
         self,
         action_name: str,
         enabled: bool,
-        plugin: SpyderDockablePlugin
+        plugin: str
     ) -> None:
         """
         Enable or disable file actions for a given plugin.
@@ -787,8 +785,9 @@ class Application(SpyderPluginV2):
             are listed in ApplicationActions, for instance "New file"
         enabled : bool
             True to enable the action, False to disable it.
-        plugin : SpyderDockablePlugin
-            The plugin for which the save action is enabled or disabled.
+        plugin : str
+            The name of the plugin for which the save action needs to be
+            enabled or disabled.
         """
         self.file_action_enabled[(plugin, action_name)] = enabled
         self._update_file_actions()

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -73,6 +73,7 @@ class Application(SpyderPluginV2):
         container.sig_open_last_closed_requested.connect(
             self.open_last_closed_file
         )
+        container.sig_save_file_requested.connect(self.save_file)
         container.set_window(self._window)
 
     # --------------------- PLUGIN INITIALIZATION -----------------------------
@@ -123,7 +124,8 @@ class Application(SpyderPluginV2):
         toolbar = self.get_plugin(Plugins.Toolbar)
         for action in [
             container.new_action,
-            container.open_action
+            container.open_action,
+            container.save_action
         ]:
             toolbar.add_item_to_application_toolbar(
                 action,
@@ -164,7 +166,8 @@ class Application(SpyderPluginV2):
         toolbar = self.get_plugin(Plugins.Toolbar)
         for action in [
             ApplicationActions.NewFile,
-            ApplicationActions.OpenFile
+            ApplicationActions.OpenFile,
+            ApplicationActions.SaveFile
         ]:
             toolbar.remove_item_from_application_toolbar(
                 action,
@@ -232,6 +235,18 @@ class Application(SpyderPluginV2):
                 menu_id=ApplicationMenus.File,
                 section=FileMenuSections.Open,
                 before_section=FileMenuSections.Save
+            )
+
+        # Save section
+        save_actions = [
+            container.save_action
+        ]
+        for save_action in save_actions:
+            mainmenu.add_item_to_application_menu(
+                save_action,
+                menu_id=ApplicationMenus.File,
+                section=FileMenuSections.Save,
+                before_section=FileMenuSections.Print
             )
 
         # Restart section
@@ -353,6 +368,7 @@ class Application(SpyderPluginV2):
             ApplicationActions.OpenFile,
             ApplicationActions.OpenLastClosed,
             container.recent_file_menu,
+            ApplicationActions.SaveFile,
             ApplicationActions.SpyderRestart,
             ApplicationActions.SpyderRestartDebug
         ]:
@@ -531,6 +547,27 @@ class Application(SpyderPluginV2):
         length.
         """
         self.get_container().add_recent_file(fname)
+
+    def save_file(self) -> None:
+        """
+        Save current file.
+
+        For the moment, this instructs the Editor plugin to save the current
+        file.
+        """
+        editor = self.get_plugin(Plugins.Editor)
+        editor.save()
+
+    def enable_save_action(self, state: bool) -> None:
+        """
+        Enable or disable save action.
+
+        Parameters
+        ----------
+        state : bool
+            True to enable save action, False to disable it.
+        """
+        self.get_container().save_action.setEnabled(state)
 
     @property
     def documentation_action(self):

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -587,18 +587,25 @@ class Application(SpyderPluginV2):
         """
         Show Open File dialog and open the selected file.
 
-        Ask Editor plugin for the name of the currently displayed file and
-        whether it is a temporary file, and then call the function with the
-        same name in the container widget to do the actual work.
+        Try asking the plugin that currently has focus for the name of the
+        displayed file and whether it is a temporary file. If that does not
+        work, ask the Editor plugin. Finally, call the function with the same
+        name in the container widget to do the actual work.
         """
-        filename = None
-        basedir = getcwd_or_home()
+        plugin = self.focused_plugin
+        if plugin:
+            filename = plugin.get_current_filename()
+        else:
+            filename = None
 
-        if self.is_plugin_available(Plugins.Editor):
-            editor = self.get_plugin(Plugins.Editor)
-            filename = editor.get_current_filename()
-            if not editor.current_file_is_temporary():
-                basedir = osp.dirname(filename)
+        if filename is None and self.is_plugin_available(Plugins.Editor):
+            plugin = self.get_plugin(Plugins.Editor)
+            filename = plugin.get_current_filename()
+
+        if filename is not None and not plugin.current_file_is_temporary():
+            basedir = osp.dirname(filename)
+        else:
+            basedir = getcwd_or_home()
 
         self.get_container().open_file_using_dialog(filename, basedir)
 

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -77,6 +77,7 @@ class Application(SpyderPluginV2):
         container.sig_save_all_requested.connect(self.save_all)
         container.sig_save_file_as_requested.connect(self.save_file_as)
         container.sig_save_copy_as_requested.connect(self.save_copy_as)
+        container.sig_revert_file_requested.connect(self.revert_file)
         container.set_window(self._window)
 
     # --------------------- PLUGIN INITIALIZATION -----------------------------
@@ -248,6 +249,7 @@ class Application(SpyderPluginV2):
             container.save_all_action,
             container.save_as_action,
             container.save_copy_as_action,
+            container.revert_action
         ]
         for save_action in save_actions:
             mainmenu.add_item_to_application_menu(
@@ -380,6 +382,7 @@ class Application(SpyderPluginV2):
             ApplicationActions.SaveAll,
             ApplicationActions.SaveAs,
             ApplicationActions.SaveCopyAs,
+            ApplicationActions.RevertFile,
             ApplicationActions.SpyderRestart,
             ApplicationActions.SpyderRestartDebug
         ]:
@@ -594,6 +597,14 @@ class Application(SpyderPluginV2):
         if self.is_plugin_available(Plugins.Editor):
             editor = self.get_plugin(Plugins.Editor)
             editor.save_all()
+
+    def revert_file(self) -> None:
+        """
+        Revert current file in Editor plugin to version on disk.
+        """
+        if self.is_plugin_available(Plugins.Editor):
+            editor = self.get_plugin(Plugins.Editor)
+            editor.revert_file()
 
     def enable_save_action(self, state: bool) -> None:
         """

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -31,6 +31,7 @@ from spyder.plugins.application.confpage import ApplicationConfigPage
 from spyder.plugins.application.container import (
     ApplicationActions, ApplicationContainer, ApplicationPluginMenus)
 from spyder.plugins.console.api import ConsoleActions
+from spyder.plugins.editor.api.actions import EditorWidgetActions
 from spyder.plugins.mainmenu.api import (
     ApplicationMenus, FileMenuSections, HelpMenuSections, ToolsMenuSections)
 from spyder.plugins.toolbar.api import ApplicationToolbars
@@ -146,7 +147,8 @@ class Application(SpyderPluginV2):
         ]:
             toolbar.add_item_to_application_toolbar(
                 action,
-                toolbar_id=ApplicationToolbars.File
+                toolbar_id=ApplicationToolbars.File,
+                before=EditorWidgetActions.NewCell
             )
 
     # -------------------------- PLUGIN TEARDOWN ------------------------------
@@ -589,8 +591,7 @@ class Application(SpyderPluginV2):
 
         Try asking the plugin that currently has focus for the name of the
         displayed file and whether it is a temporary file. If that does not
-        work, ask the Editor plugin. Finally, call the function with the same
-        name in the container widget to do the actual work.
+        work, ask the Editor plugin.
         """
         plugin = self.focused_plugin
         if plugin:
@@ -725,7 +726,7 @@ class Application(SpyderPluginV2):
 
     def revert_file(self) -> None:
         """
-        Revert current file to version on disk.
+        Revert current file to the version on disk.
 
         If the plugin that currently has focus, has its
         `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then revert the
@@ -744,9 +745,9 @@ class Application(SpyderPluginV2):
         Close the current file.
 
         If the plugin that currently has focus, has its
-        `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then revert the
-        current file in that plugin to the version stored on disk. Otherwise,
-        revert the current file in the Editor plugin.
+        `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then close the
+        current file in that plugin. Otherwise, close the current file in the
+        Editor plugin.
         """
         plugin = self.focused_plugin
         if plugin and getattr(plugin, 'CAN_HANDLE_FILE_ACTIONS', False):
@@ -760,9 +761,8 @@ class Application(SpyderPluginV2):
         Close all opened files in the current plugin.
 
         If the plugin that currently has focus, has its
-        `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then revert the
-        current file in that plugin to the version stored on disk. Otherwise,
-        revert the current file in the Editor plugin.
+        `CAN_HANDLE_FILE_ACTIONS` attribute set to `True`, then close all
+        files in that plugin. Otherwise, close all files in the Editor plugin.
         """
         plugin = self.focused_plugin
         if plugin and getattr(plugin, 'CAN_HANDLE_FILE_ACTIONS', False):
@@ -778,7 +778,7 @@ class Application(SpyderPluginV2):
         plugin: SpyderDockablePlugin
     ) -> None:
         """
-        Enable or disable file actions for given plugin.
+        Enable or disable file actions for a given plugin.
 
         Parameters
         ----------

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -221,17 +221,18 @@ class Application(SpyderPluginV2):
         )
 
         # Open section
-        mainmenu.add_item_to_application_menu(
+        open_actions = [
             container.open_action,
-            menu_id=ApplicationMenus.File,
-            section=FileMenuSections.Open,
-            before_section=FileMenuSections.Save
-        )
-        mainmenu.add_item_to_application_menu(
             container.open_last_closed_action,
-            menu_id=ApplicationMenus.File,
-            section=FileMenuSections.Open
-        )
+            container.recent_files_menu,
+        ]
+        for open_action in open_actions:
+            mainmenu.add_item_to_application_menu(
+                open_action,
+                menu_id=ApplicationMenus.File,
+                section=FileMenuSections.Open,
+                before_section=FileMenuSections.Save
+            )
 
         # Restart section
         mainmenu.add_item_to_application_menu(
@@ -345,11 +346,13 @@ class Application(SpyderPluginV2):
             menu_id=ApplicationMenus.Help)
 
     def _depopulate_file_menu(self):
+        container = self.get_container()
         mainmenu = self.get_plugin(Plugins.MainMenu)
         for action_id in [
             ApplicationActions.NewFile,
             ApplicationActions.OpenFile,
             ApplicationActions.OpenLastClosed,
+            container.recent_file_menu,
             ApplicationActions.SpyderRestart,
             ApplicationActions.SpyderRestartDebug
         ]:
@@ -517,6 +520,17 @@ class Application(SpyderPluginV2):
         if self.is_plugin_available(Plugins.Editor):
             editor = self.get_plugin(Plugins.Editor)
             editor.open_last_closed()
+
+    def add_recent_file(self, fname: str) -> None:
+        """
+        Add file to list of recent files.
+
+        This function adds the given file name to the list of recent files,
+        which is used in the `File > Open recent` menu. The function ensures
+        that the list has no duplicates and it is no longer than the maximum
+        length.
+        """
+        self.get_container().add_recent_file(fname)
 
     @property
     def documentation_action(self):

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -79,6 +79,7 @@ class Application(SpyderPluginV2):
         container.sig_save_copy_as_requested.connect(self.save_copy_as)
         container.sig_revert_file_requested.connect(self.revert_file)
         container.sig_close_file_requested.connect(self.close_file)
+        container.sig_close_all_requested.connect(self.close_all)
         container.set_window(self._window)
 
     # --------------------- PLUGIN INITIALIZATION -----------------------------
@@ -262,7 +263,8 @@ class Application(SpyderPluginV2):
 
         # Close section
         close_actions = [
-            container.close_file_action
+            container.close_file_action,
+            container.close_all_action
         ]
         for close_action in close_actions:
             mainmenu.add_item_to_application_menu(
@@ -397,6 +399,7 @@ class Application(SpyderPluginV2):
             ApplicationActions.SaveCopyAs,
             ApplicationActions.RevertFile,
             ApplicationActions.CloseFile,
+            ApplicationActions.CloseAll,
             ApplicationActions.SpyderRestart,
             ApplicationActions.SpyderRestartDebug
         ]:
@@ -627,6 +630,13 @@ class Application(SpyderPluginV2):
         if self.is_plugin_available(Plugins.Editor):
             editor = self.get_plugin(Plugins.Editor)
             editor.close_file()
+
+    def close_all(self) -> None:
+        """
+        Close all opened files in the Editor plugin.
+        """
+        editor = self.get_plugin(Plugins.Editor)
+        editor.close_all_files()
 
     def enable_save_action(self, state: bool) -> None:
         """

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -75,6 +75,7 @@ class Application(SpyderPluginV2):
         )
         container.sig_save_file_requested.connect(self.save_file)
         container.sig_save_all_requested.connect(self.save_all)
+        container.sig_save_file_as_requested.connect(self.save_file_as)
         container.set_window(self._window)
 
     # --------------------- PLUGIN INITIALIZATION -----------------------------
@@ -243,7 +244,8 @@ class Application(SpyderPluginV2):
         # Save section
         save_actions = [
             container.save_action,
-            container.save_all_action
+            container.save_all_action,
+            container.save_as_action
         ]
         for save_action in save_actions:
             mainmenu.add_item_to_application_menu(
@@ -374,6 +376,7 @@ class Application(SpyderPluginV2):
             container.recent_file_menu,
             ApplicationActions.SaveFile,
             ApplicationActions.SaveAll,
+            ApplicationActions.SaveAs,
             ApplicationActions.SpyderRestart,
             ApplicationActions.SpyderRestartDebug
         ]:
@@ -562,6 +565,14 @@ class Application(SpyderPluginV2):
         """
         editor = self.get_plugin(Plugins.Editor)
         editor.save()
+
+    def save_file_as(self) -> None:
+        """
+        Save current file in Editor plugin under a different name.
+        """
+        if self.is_plugin_available(Plugins.Editor):
+            editor = self.get_plugin(Plugins.Editor)
+            editor.save_as()
 
     def save_all(self) -> None:
         """

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -78,6 +78,7 @@ class Application(SpyderPluginV2):
         container.sig_save_file_as_requested.connect(self.save_file_as)
         container.sig_save_copy_as_requested.connect(self.save_copy_as)
         container.sig_revert_file_requested.connect(self.revert_file)
+        container.sig_close_file_requested.connect(self.close_file)
         container.set_window(self._window)
 
     # --------------------- PLUGIN INITIALIZATION -----------------------------
@@ -259,6 +260,18 @@ class Application(SpyderPluginV2):
                 before_section=FileMenuSections.Print
             )
 
+        # Close section
+        close_actions = [
+            container.close_file_action
+        ]
+        for close_action in close_actions:
+            mainmenu.add_item_to_application_menu(
+                close_action,
+                menu_id=ApplicationMenus.File,
+                section=FileMenuSections.Close,
+                before_section=FileMenuSections.Restart
+            )
+
         # Restart section
         mainmenu.add_item_to_application_menu(
             self.restart_action,
@@ -383,6 +396,7 @@ class Application(SpyderPluginV2):
             ApplicationActions.SaveAs,
             ApplicationActions.SaveCopyAs,
             ApplicationActions.RevertFile,
+            ApplicationActions.CloseFile,
             ApplicationActions.SpyderRestart,
             ApplicationActions.SpyderRestartDebug
         ]:
@@ -605,6 +619,14 @@ class Application(SpyderPluginV2):
         if self.is_plugin_available(Plugins.Editor):
             editor = self.get_plugin(Plugins.Editor)
             editor.revert_file()
+
+    def close_file(self) -> None:
+        """
+        Close current file in Editor plugin to version on disk.
+        """
+        if self.is_plugin_available(Plugins.Editor):
+            editor = self.get_plugin(Plugins.Editor)
+            editor.close_file()
 
     def enable_save_action(self, state: bool) -> None:
         """

--- a/spyder/plugins/application/tests/conftest.py
+++ b/spyder/plugins/application/tests/conftest.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2009- Spyder Project Contributors
+#
+# Distributed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+# -----------------------------------------------------------------------------
+
+"""Fixtures for the Application plugin tests."""
+
+# Standard library imports
+from unittest.mock import Mock, patch
+
+# Third party imports
+import pytest
+
+# Local imports
+from spyder.config.base import running_in_ci
+from spyder.config.manager import CONF
+from spyder.plugins.application.plugin import Application
+from spyder.utils.stylesheet import APP_STYLESHEET
+
+
+@pytest.fixture
+def application_plugin(qapp, qtbot):
+    main_window = Mock()
+    CONF.set('main', 'recent_files', [])
+    application = Application(None, configuration=CONF)
+    application.main = application._main = main_window
+    application.on_initialize()
+    container = application.get_container()
+    container.setMinimumSize(700, 500)
+    qtbot.addWidget(container)
+    if not running_in_ci():
+        qapp.setStyleSheet(str(APP_STYLESHEET))
+    with qtbot.waitExposed(container):
+        container.show()
+
+    with patch.object(application, 'get_plugin'):
+        yield application

--- a/spyder/plugins/application/tests/test_container.py
+++ b/spyder/plugins/application/tests/test_container.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Tests for ApplicationContainer.
+"""
+
+# Standard library imports
+from unittest.mock import patch
+
+
+def test_add_recent_file(application_plugin):
+    """
+    Test that add_recent_file adds the given file to the front of recent_files
+    and ensures that the list has no duplicates.
+    """
+    container = application_plugin.get_container()
+    assert container.recent_files == []
+
+    container.add_recent_file('file1')
+    assert container.recent_files == ['file1']
+
+    container.add_recent_file('file2')
+    assert container.recent_files == ['file2', 'file1']
+
+    container.add_recent_file('file1')
+    assert container.recent_files == ['file1', 'file2']
+
+
+def test_clear_recent_files(application_plugin):
+    """
+    Test that clear_recent_files clears the list in recent_files.
+    """
+    container = application_plugin.get_container()
+    container.add_recent_file('file1')
+    assert container.recent_files == ['file1']
+
+    container.clear_recent_files()
+    assert container.recent_files == []
+
+
+def test_update_recent_files_menu(application_plugin):
+    """
+    Test that update_recent_files_menu() puts the files in recent_files in
+    the recent_files_menu (skipping those that do not exist), followed by a
+    separator and then other items.
+    """
+
+    def mock_isfile(filename):
+        return filename in ['file1', 'file2']
+
+    container = application_plugin.get_container()
+    container.add_recent_file('file1')
+    container.add_recent_file('file2')
+    container.add_recent_file('non-existing-file')
+    with patch('spyder.plugins.application.container.osp.isfile', mock_isfile):
+        container.update_recent_files_menu()
+
+    menu = container.recent_files_menu
+    menuitems = [action.text() for action in menu.actions()]
+    expected = [
+        'file2',
+        'file1',
+        '',
+        'Maximum number of recent files...',
+        'Clear this list',
+        '',
+    ]
+    assert menuitems == expected
+
+
+def test_change_max_recent_files(application_plugin):
+    """
+    Test that change_max_recent_files changes the value of max_recent_files
+    in the config to the number given by the user.
+    """
+    container = application_plugin.get_container()
+    old_value = container.get_conf('max_recent_files')
+    with patch(
+        'spyder.plugins.application.container.QInputDialog.getInt',
+        return_value=(old_value + 1, True),
+    ):
+        container.change_max_recent_files()
+
+    assert container.get_conf('max_recent_files') == old_value + 1
+
+    container.set_conf('max_recent_files', old_value)

--- a/spyder/plugins/application/tests/test_plugin.py
+++ b/spyder/plugins/application/tests/test_plugin.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Tests for the Application plugin.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from spyder.api.plugins import Plugins
+from spyder.config.base import running_in_ci
+from spyder.config.manager import CONF
+from spyder.plugins.application.plugin import Application
+from spyder.utils.stylesheet import APP_STYLESHEET
+
+
+@pytest.fixture
+def application_plugin(qapp, qtbot):
+    main_window = Mock()
+    application = Application(None, configuration=CONF)
+    application.main = application._main = main_window
+    application.on_initialize()
+    container = application.get_container()
+    container.setMinimumSize(700, 500)
+    qtbot.addWidget(container)
+    if not running_in_ci():
+        qapp.setStyleSheet(str(APP_STYLESHEET))
+    with qtbot.waitExposed(container):
+        container.show()
+
+    with patch.object(application, 'get_plugin'):
+        yield application
+
+
+def test_new_file(application_plugin):
+    """
+    Test that triggering the "New file" action calls the new() function in
+    the Editor plugin.
+    """
+    container = application_plugin.get_container()
+    container.new_action.trigger()
+
+    application_plugin.get_plugin.assert_called_with(Plugins.Editor)
+    editor_plugin = application_plugin.get_plugin.return_value
+    editor_plugin.new.assert_called()

--- a/spyder/plugins/application/tests/test_plugin.py
+++ b/spyder/plugins/application/tests/test_plugin.py
@@ -37,17 +37,26 @@ def application_plugin(qapp, qtbot):
         yield application
 
 
-def test_new_file(application_plugin):
+@pytest.mark.parametrize(
+    'action_name, editor_function_name',
+    [
+        ('new_action', 'new'),
+        ('open_last_closed_action', 'open_last_closed'),
+    ],
+)
+def test_file_actions(application_plugin, action_name, editor_function_name):
     """
-    Test that triggering the "New file" action calls the new() function in
-    the Editor plugin.
+    Test that triggering file actions calls the corresponding function in the
+    Editor plugin.
     """
     container = application_plugin.get_container()
-    container.new_action.trigger()
+    action = getattr(container, action_name)
+    action.trigger()
 
     application_plugin.get_plugin.assert_called_with(Plugins.Editor)
     editor_plugin = application_plugin.get_plugin.return_value
-    editor_plugin.new.assert_called()
+    editor_function = getattr(editor_plugin, editor_function_name)
+    editor_function.assert_called()
 
 
 def test_open_file(application_plugin):

--- a/spyder/plugins/application/tests/test_plugin.py
+++ b/spyder/plugins/application/tests/test_plugin.py
@@ -25,6 +25,7 @@ from spyder.api.plugins import Plugins
         ('open_last_closed_action', 'open_last_closed'),
         ('save_action', 'save'),
         ('save_all_action', 'save_all'),
+        ('save_as_action', 'save_as'),
     ],
 )
 def test_file_actions(application_plugin, action_name, editor_function_name):

--- a/spyder/plugins/application/tests/test_plugin.py
+++ b/spyder/plugins/application/tests/test_plugin.py
@@ -154,7 +154,7 @@ def test_enable_file_action(application_plugin):
 
     # Disabling the Save action in the active plugin works
     application_plugin.enable_file_action(
-        ApplicationActions.SaveFile, False, mock_plugin1
+        ApplicationActions.SaveFile, False, mock_plugin1.NAME
     )
     assert container.save_action.isEnabled() is False
 
@@ -164,13 +164,13 @@ def test_enable_file_action(application_plugin):
 
     # Disabling the Save action in the second plugin (which has focus) works
     application_plugin.enable_file_action(
-        ApplicationActions.SaveFile, False, mock_plugin2
+        ApplicationActions.SaveFile, False, mock_plugin2.NAME
     )
     assert container.save_action.isEnabled() is False
 
     # Enabling the Save action in the first plugin has no immediate effect
     application_plugin.enable_file_action(
-        ApplicationActions.SaveFile, True, mock_plugin1
+        ApplicationActions.SaveFile, True, mock_plugin1.NAME
     )
     assert container.save_action.isEnabled() is False
 

--- a/spyder/plugins/application/tests/test_plugin.py
+++ b/spyder/plugins/application/tests/test_plugin.py
@@ -23,6 +23,7 @@ from spyder.api.plugins import Plugins
     [
         ('new_action', 'new'),
         ('open_last_closed_action', 'open_last_closed'),
+        ('save_action', 'save'),
     ],
 )
 def test_file_actions(application_plugin, action_name, editor_function_name):
@@ -60,3 +61,16 @@ def test_open_file(application_plugin):
     editor_plugin = application_plugin.get_plugin.return_value
     editor_plugin.load.assert_any_call('/home/file1')
     editor_plugin.load.assert_any_call('/home/file2')
+
+
+def test_enable_save_action(application_plugin):
+    """
+    Test that enable_save_action does indeed enable or disable the "Save"
+    action.
+    """
+    container = application_plugin.get_container()
+    application_plugin.enable_save_action(True)
+    assert container.save_action.isEnabled() == True
+
+    application_plugin.enable_save_action(False)
+    assert container.save_action.isEnabled() == False

--- a/spyder/plugins/application/tests/test_plugin.py
+++ b/spyder/plugins/application/tests/test_plugin.py
@@ -24,6 +24,7 @@ from spyder.api.plugins import Plugins
         ('new_action', 'new'),
         ('open_last_closed_action', 'open_last_closed'),
         ('save_action', 'save'),
+        ('save_all_action', 'save_all'),
     ],
 )
 def test_file_actions(application_plugin, action_name, editor_function_name):
@@ -74,3 +75,16 @@ def test_enable_save_action(application_plugin):
 
     application_plugin.enable_save_action(False)
     assert container.save_action.isEnabled() == False
+
+
+def test_enable_save_all_action(application_plugin):
+    """
+    Test that enable_save_all_action does indeed enable or disable the
+    "Save All" action.
+    """
+    container = application_plugin.get_container()
+    application_plugin.enable_save_all_action(True)
+    assert container.save_all_action.isEnabled() == True
+
+    application_plugin.enable_save_all_action(False)
+    assert container.save_all_action.isEnabled() == False

--- a/spyder/plugins/application/tests/test_plugin.py
+++ b/spyder/plugins/application/tests/test_plugin.py
@@ -27,6 +27,9 @@ from spyder.api.plugins import Plugins
         ('save_all_action', 'save_all'),
         ('save_as_action', 'save_as'),
         ('save_copy_as_action', 'save_copy_as'),
+        ('revert_action', 'revert_file'),
+        ('close_file_action', 'close_file'),
+        ('close_all_action', 'close_all_files'),
     ],
 )
 def test_file_actions(application_plugin, action_name, editor_function_name):

--- a/spyder/plugins/application/tests/test_plugin.py
+++ b/spyder/plugins/application/tests/test_plugin.py
@@ -18,6 +18,17 @@ import pytest
 from spyder.api.plugins import Plugins
 
 
+def test_focused_plugin(application_plugin):
+    """
+    Test that focused_plugin is initially None and that it is set after
+    receiving sig_focused_plugin_changed.
+    """
+    assert application_plugin.focused_plugin is None
+    mock_plugin = Mock()
+    application_plugin.sig_focused_plugin_changed.emit(mock_plugin)
+    assert application_plugin.focused_plugin == mock_plugin
+
+
 @pytest.mark.parametrize(
     'action_name, editor_function_name',
     [

--- a/spyder/plugins/application/tests/test_plugin.py
+++ b/spyder/plugins/application/tests/test_plugin.py
@@ -8,33 +8,14 @@
 Tests for the Application plugin.
 """
 
+# Standard library imports
 from unittest.mock import Mock, patch
 
+# Third party imports
 import pytest
 
+# Local imports
 from spyder.api.plugins import Plugins
-from spyder.config.base import running_in_ci
-from spyder.config.manager import CONF
-from spyder.plugins.application.plugin import Application
-from spyder.utils.stylesheet import APP_STYLESHEET
-
-
-@pytest.fixture
-def application_plugin(qapp, qtbot):
-    main_window = Mock()
-    application = Application(None, configuration=CONF)
-    application.main = application._main = main_window
-    application.on_initialize()
-    container = application.get_container()
-    container.setMinimumSize(700, 500)
-    qtbot.addWidget(container)
-    if not running_in_ci():
-        qapp.setStyleSheet(str(APP_STYLESHEET))
-    with qtbot.waitExposed(container):
-        container.show()
-
-    with patch.object(application, 'get_plugin'):
-        yield application
 
 
 @pytest.mark.parametrize(

--- a/spyder/plugins/application/tests/test_plugin.py
+++ b/spyder/plugins/application/tests/test_plugin.py
@@ -26,6 +26,7 @@ from spyder.api.plugins import Plugins
         ('save_action', 'save'),
         ('save_all_action', 'save_all'),
         ('save_as_action', 'save_as'),
+        ('save_copy_as_action', 'save_copy_as'),
     ],
 )
 def test_file_actions(application_plugin, action_name, editor_function_name):

--- a/spyder/plugins/application/tests/test_plugin.py
+++ b/spyder/plugins/application/tests/test_plugin.py
@@ -48,3 +48,25 @@ def test_new_file(application_plugin):
     application_plugin.get_plugin.assert_called_with(Plugins.Editor)
     editor_plugin = application_plugin.get_plugin.return_value
     editor_plugin.new.assert_called()
+
+
+def test_open_file(application_plugin):
+    """
+    Test that triggering the "Open file" action calls the load() function in
+    the Editor plugin with the file names selected in the QFileDialog.
+    """
+    container = application_plugin.get_container()
+    mock_QFileDialog = Mock(name='mock QFileDialog')
+    mock_QFileDialog.return_value.selectedFiles.return_value = [
+        '/home/file1',
+        '/home/file2',
+    ]
+
+    # Note: container.open_file_using_dialog() behaves differently under pytest
+    with patch('spyder.plugins.application.container.QFileDialog', mock_QFileDialog):
+        container.open_action.trigger()
+
+    application_plugin.get_plugin.assert_called_with(Plugins.Editor)
+    editor_plugin = application_plugin.get_plugin.return_value
+    editor_plugin.load.assert_any_call('/home/file1')
+    editor_plugin.load.assert_any_call('/home/file2')

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -10,7 +10,6 @@ Actions defined in the Spyder editor plugin.
 
 class EditorWidgetActions:
     # File operations
-    NewFile = "New file"
     OpenLastClosed = "Open last closed"
     OpenFile = "Open file"
     RevertFileFromDisk = "Revert file from disk"

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -70,4 +70,3 @@ class EditorWidgetActions:
     Paste = "Paste"
     SelectAll = "Select All"
 
-

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Actions defined in the Spyder editor plugin.
+"""
+
+class EditorWidgetActions:
+    # File operations
+    NewFile = "New file"
+    OpenLastClosed = "Open last closed"
+    OpenFile = "Open file"
+    RevertFileFromDisk = "Revert file from disk"
+    SaveFile = "Save file"
+    SaveAll = "Save all"
+    SaveAs = "Save As"
+    SaveCopyAs = "save_copy_as_action"
+    PrintPreview = "print_preview_action"
+    Print = "print_action"
+    CloseFile = "Close current file"
+    CloseAll = "Close all"
+    MaxRecentFiles = "max_recent_files_action"
+    ClearRecentFiles = "clear_recent_files_action"
+
+    # Navigation
+    GoToNextFile = "Go to next file"
+    GoToPreviousFile = "Go to previous file"
+
+    # Find/Search operations
+    FindText = "Find text"
+    FindNext = "Find next"
+    FindPrevious = "Find previous"
+    ReplaceText = "Replace text"
+
+    # Source code operations
+    ShowTodoList = "show_todo_list_action"
+    ShowCodeAnalysisList = "show_code_analaysis_action"
+    GoToPreviousWarning = "Previous warning"
+    GoToNextWarning = "Next warning"
+    GoToLastEditLocation = "Last edit location"
+    GoToPreviousCursorPosition = "Previous cursor position"
+    GoToNextCursorPosition = "Next cursor position"
+    WinEOL = "win_eol_action"
+    LinuxEOL = "linux_eol_action"
+    MacEOL = "mac_eol_action"
+    RemoveTrailingSpaces = "remove_trailing_spaces_action"
+    FormatCode = "autoformating"
+    FixIndentation = "fix_indentation_action"
+
+    # Checkable operations
+    ShowBlanks = "blank_spaces_action"
+    ScrollPastEnd = "scroll_past_end_action"
+    ShowIndentGuides = "show_indent_guides_action"
+    ShowCodeFolding = "show_code_folding_action"
+    ShowClassFuncDropdown = "show_class_func_dropdown_action"
+    ShowCodeStyleWarnings = "pycodestyle_action"
+    ShowDoctringWarnings = "pydocstyle_action"
+    UnderlineErrors = "underline_errors_action"
+
+    # Stack menu
+    GoToLine = "Go to line"
+    SetWorkingDirectory = "set_working_directory_action"
+
+    # Edit operations
+    NewCell = "create_new_cell"
+    ToggleComment = "Toggle comment"
+    Blockcomment = "Blockcomment"
+    Unblockcomment = "Unblockcomment"
+
+    Indent = "indent_action"
+    Unindent = "unindent_action"
+    TransformToUppercase = "transform to uppercase"
+    TransformToLowercase = "transform to lowercase"
+
+    Undo = "Undo"
+    Redo = "Redo"
+    Copy = "Copy"
+    Cut = "Cut"
+    Paste = "Paste"
+    SelectAll = "Select All"
+
+

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -11,7 +11,6 @@ Actions defined in the Spyder editor plugin.
 class EditorWidgetActions:
     # File operations
     OpenLastClosed = "Open last closed"
-    OpenFile = "Open file"
     RevertFileFromDisk = "Revert file from disk"
     SaveFile = "Save file"
     SaveAll = "Save all"

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -12,7 +12,6 @@ class EditorWidgetActions:
     # File operations
     PrintPreview = "print_preview_action"
     Print = "print_action"
-    CloseFile = "Close current file"
     CloseAll = "Close all"
 
     # Navigation

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -11,7 +11,6 @@ Actions defined in the Spyder editor plugin.
 class EditorWidgetActions:
     # File operations
     RevertFileFromDisk = "Revert file from disk"
-    SaveAll = "Save all"
     SaveAs = "Save As"
     SaveCopyAs = "save_copy_as_action"
     PrintPreview = "print_preview_action"

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -11,7 +11,6 @@ Actions defined in the Spyder editor plugin.
 class EditorWidgetActions:
     # File operations
     RevertFileFromDisk = "Revert file from disk"
-    SaveCopyAs = "save_copy_as_action"
     PrintPreview = "print_preview_action"
     Print = "print_action"
     CloseFile = "Close current file"

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -10,7 +10,6 @@ Actions defined in the Spyder editor plugin.
 
 class EditorWidgetActions:
     # File operations
-    RevertFileFromDisk = "Revert file from disk"
     PrintPreview = "print_preview_action"
     Print = "print_action"
     CloseFile = "Close current file"

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -11,7 +11,6 @@ Actions defined in the Spyder editor plugin.
 class EditorWidgetActions:
     # File operations
     RevertFileFromDisk = "Revert file from disk"
-    SaveFile = "Save file"
     SaveAll = "Save all"
     SaveAs = "Save As"
     SaveCopyAs = "save_copy_as_action"

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -10,7 +10,6 @@ Actions defined in the Spyder editor plugin.
 
 class EditorWidgetActions:
     # File operations
-    OpenLastClosed = "Open last closed"
     RevertFileFromDisk = "Revert file from disk"
     SaveFile = "Save file"
     SaveAll = "Save all"

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -12,7 +12,6 @@ class EditorWidgetActions:
     # File operations
     PrintPreview = "print_preview_action"
     Print = "print_action"
-    CloseAll = "Close all"
 
     # Navigation
     GoToNextFile = "Go to next file"

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -19,8 +19,6 @@ class EditorWidgetActions:
     Print = "print_action"
     CloseFile = "Close current file"
     CloseAll = "Close all"
-    MaxRecentFiles = "max_recent_files_action"
-    ClearRecentFiles = "clear_recent_files_action"
 
     # Navigation
     GoToNextFile = "Go to next file"

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -11,7 +11,6 @@ Actions defined in the Spyder editor plugin.
 class EditorWidgetActions:
     # File operations
     RevertFileFromDisk = "Revert file from disk"
-    SaveAs = "Save As"
     SaveCopyAs = "save_copy_as_action"
     PrintPreview = "print_preview_action"
     Print = "print_action"

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -393,7 +393,6 @@ class Editor(SpyderDockablePlugin):
 
         # Save section
         save_actions = [
-            widget.save_copy_as_action,
             widget.revert_action,
         ]
         for save_action in save_actions:
@@ -549,7 +548,6 @@ class Editor(SpyderDockablePlugin):
 
         # Save section
         save_actions = [
-            widget.save_copy_as_action,
             widget.revert_action,
         ]
         for save_action in save_actions:
@@ -1116,6 +1114,12 @@ class Editor(SpyderDockablePlugin):
         Save all files.
         """
         self.get_widget().save_as()
+
+    def save_copy_as(self) -> None:
+        """
+        Save copy of file under a different name.
+        """
+        self.get_widget().save_copy_as()
 
     def save_bookmark(self, slot_num):
         """

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -366,7 +366,6 @@ class Editor(SpyderDockablePlugin):
 
         # Close
         close_actions = [
-            widget.close_action,
             widget.close_all_action
         ]
         for close_action in close_actions:
@@ -513,7 +512,6 @@ class Editor(SpyderDockablePlugin):
 
         # Close
         close_actions = [
-            widget.close_action,
             widget.close_all_action
         ]
         for close_action in close_actions:

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -364,18 +364,6 @@ class Editor(SpyderDockablePlugin):
                 before_section=FileMenuSections.Close
             )
 
-        # Close
-        close_actions = [
-            widget.close_all_action
-        ]
-        for close_action in close_actions:
-            mainmenu.add_item_to_application_menu(
-                close_action,
-                menu_id=ApplicationMenus.File,
-                section=FileMenuSections.Close,
-                before_section=FileMenuSections.Restart
-            )
-
         # Navigation
         if sys.platform == 'darwin':
             tab_navigation_actions = [
@@ -507,16 +495,6 @@ class Editor(SpyderDockablePlugin):
         for print_action in print_actions:
             mainmenu.remove_item_from_application_menu(
                 print_action,
-                menu_id=ApplicationMenus.File
-            )
-
-        # Close
-        close_actions = [
-            widget.close_all_action
-        ]
-        for close_action in close_actions:
-            mainmenu.remove_item_from_application_menu(
-                close_action,
                 menu_id=ApplicationMenus.File
             )
 

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1254,4 +1254,4 @@ class Editor(SpyderDockablePlugin):
         """
         application = self.get_plugin(Plugins.Application, error=False)
         if application:
-            application.enable_file_action(action_name, enabled, self)
+            application.enable_file_action(action_name, enabled, self.NAME)

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -391,18 +391,6 @@ class Editor(SpyderDockablePlugin):
                     before_section=FileMenuSections.Restart
                 )
 
-        # Save section
-        save_actions = [
-            widget.revert_action,
-        ]
-        for save_action in save_actions:
-            mainmenu.add_item_to_application_menu(
-                save_action,
-                menu_id=ApplicationMenus.File,
-                section=FileMenuSections.Save,
-                before_section=FileMenuSections.Print
-            )
-
         # ---- Edit menu ----
         edit_menu = mainmenu.get_application_menu(ApplicationMenus.Edit)
         edit_menu.aboutToShow.connect(widget.update_edit_menu)
@@ -545,16 +533,6 @@ class Editor(SpyderDockablePlugin):
                     tab_navigation_action,
                     menu_id=ApplicationMenus.File
                 )
-
-        # Save section
-        save_actions = [
-            widget.revert_action,
-        ]
-        for save_action in save_actions:
-            mainmenu.remove_item_from_application_menu(
-                save_action,
-                menu_id=ApplicationMenus.File
-            )
 
         # ---- Edit menu ----
         edit_menu = mainmenu.get_application_menu(ApplicationMenus.Edit)
@@ -1120,6 +1098,12 @@ class Editor(SpyderDockablePlugin):
         Save copy of file under a different name.
         """
         self.get_widget().save_copy_as()
+
+    def revert_file(self) -> None:
+        """
+        Revert the currently edited file from disk.
+        """
+        self.get_widget().revert()
 
     def save_bookmark(self, slot_num):
         """

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -18,15 +18,13 @@ from spyder.api.plugin_registration.decorators import (
     on_plugin_teardown,
 )
 from spyder.api.translations import _
+from spyder.plugins.editor.api.actions import EditorWidgetActions
 from spyder.plugins.editor.api.run import (
     SelectionContextModificator,
     ExtraAction
 )
 from spyder.plugins.editor.confpage import EditorConfigPage
-from spyder.plugins.editor.widgets.main_widget import (
-    EditorMainWidget,
-    EditorWidgetActions
-)
+from spyder.plugins.editor.widgets.main_widget import EditorMainWidget
 from spyder.plugins.mainmenu.api import (
     ApplicationMenus,
     EditMenuSections,

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -1246,7 +1246,8 @@ class Editor(SpyderDockablePlugin):
             return True
         return debugger.can_close_file(filename)
 
-    # ---- Methods related to Application plugin
+    # ---- Methods related to the Application plugin
+    # ------------------------------------------------------------------------
     def _enable_file_action(self, action_name: str, enabled: bool) -> None:
         """
         Enable or disable file action for this plugin.

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -393,7 +393,6 @@ class Editor(SpyderDockablePlugin):
 
         # Save section
         save_actions = [
-            widget.save_as_action,
             widget.save_copy_as_action,
             widget.revert_action,
         ]
@@ -550,7 +549,6 @@ class Editor(SpyderDockablePlugin):
 
         # Save section
         save_actions = [
-            widget.save_as_action,
             widget.save_copy_as_action,
             widget.revert_action,
         ]
@@ -1112,6 +1110,12 @@ class Editor(SpyderDockablePlugin):
         Save all files.
         """
         return self.get_widget().save_all()
+
+    def save_as(self) -> None:
+        """
+        Save all files.
+        """
+        self.get_widget().save_as()
 
     def save_bookmark(self, slot_num):
         """

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -45,7 +45,7 @@ class Editor(SpyderDockablePlugin):
     """
 
     NAME = 'editor'
-    REQUIRES = [Plugins.Console, Plugins.Preferences]
+    REQUIRES = [Plugins.Application, Plugins.Console, Plugins.Preferences]
     OPTIONAL = [
         Plugins.Completions,
         Plugins.Debugger,
@@ -393,7 +393,6 @@ class Editor(SpyderDockablePlugin):
 
         # Open section
         open_actions = [
-            widget.open_action,
             widget.open_last_closed_action,
             widget.recent_file_menu,
         ]
@@ -566,7 +565,6 @@ class Editor(SpyderDockablePlugin):
 
         # Open section
         open_actions = [
-            widget.open_action,
             widget.open_last_closed_action,
             widget.recent_file_menu,
         ]
@@ -684,7 +682,6 @@ class Editor(SpyderDockablePlugin):
         widget = self.get_widget()
         toolbar = self.get_plugin(Plugins.Toolbar)
         file_toolbar_actions = [
-            widget.open_action,
             widget.save_action,
             widget.save_all_action,
             widget.create_new_cell
@@ -699,7 +696,6 @@ class Editor(SpyderDockablePlugin):
     def on_toolbar_teardown(self):
         toolbar = self.get_plugin(Plugins.Toolbar)
         file_toolbar_actions = [
-            EditorWidgetActions.OpenFile,
             EditorWidgetActions.SaveFile,
             EditorWidgetActions.SaveAll,
             EditorWidgetActions.NewCell
@@ -1150,6 +1146,10 @@ class Editor(SpyderDockablePlugin):
     def get_current_filename(self):
         """Get current editor 'filename'."""
         return self.get_widget().get_current_filename()
+
+    def current_file_is_temporary(self) -> bool:
+        """Return whether file in current editor is a temporary file."""
+        return self.get_current_editor() == self.get_widget().TEMPFILE_PATH
 
     def get_filenames(self):
         """

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -421,14 +421,6 @@ class Editor(SpyderDockablePlugin):
                 before_section=FileMenuSections.Print
             )
 
-        # New Section
-        mainmenu.add_item_to_application_menu(
-            widget.new_action,
-            menu_id=ApplicationMenus.File,
-            section=FileMenuSections.New,
-            before_section=FileMenuSections.Open
-        )
-
         # ---- Edit menu ----
         edit_menu = mainmenu.get_application_menu(ApplicationMenus.Edit)
         edit_menu.aboutToShow.connect(widget.update_edit_menu)
@@ -598,12 +590,6 @@ class Editor(SpyderDockablePlugin):
                 menu_id=ApplicationMenus.File
             )
 
-        # New Section
-        mainmenu.remove_item_from_application_menu(
-            widget.new_action,
-            menu_id=ApplicationMenus.File
-        )
-
         # ---- Edit menu ----
         edit_menu = mainmenu.get_application_menu(ApplicationMenus.Edit)
         edit_menu.aboutToShow.disconnect(widget.update_edit_menu)
@@ -698,7 +684,6 @@ class Editor(SpyderDockablePlugin):
         widget = self.get_widget()
         toolbar = self.get_plugin(Plugins.Toolbar)
         file_toolbar_actions = [
-            widget.new_action,
             widget.open_action,
             widget.save_action,
             widget.save_all_action,
@@ -714,7 +699,6 @@ class Editor(SpyderDockablePlugin):
     def on_toolbar_teardown(self):
         toolbar = self.get_plugin(Plugins.Toolbar)
         file_toolbar_actions = [
-            EditorWidgetActions.NewFile,
             EditorWidgetActions.OpenFile,
             EditorWidgetActions.SaveFile,
             EditorWidgetActions.SaveAll,

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -393,7 +393,6 @@ class Editor(SpyderDockablePlugin):
 
         # Open section
         open_actions = [
-            widget.open_last_closed_action,
             widget.recent_file_menu,
         ]
         for open_action in open_actions:
@@ -565,7 +564,6 @@ class Editor(SpyderDockablePlugin):
 
         # Open section
         open_actions = [
-            widget.open_last_closed_action,
             widget.recent_file_menu,
         ]
         for open_action in open_actions:
@@ -922,6 +920,12 @@ class Editor(SpyderDockablePlugin):
         return widget.load(
             filenames=filename, goto=goto, word=word, editorwindow=widget
         )
+
+    def open_last_closed(self) -> None:
+        """
+        Open the last closed tab again.
+        """
+        return self.get_widget().open_last_closed()
 
     def new(self, *args, **kwargs):
         """

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -393,7 +393,6 @@ class Editor(SpyderDockablePlugin):
 
         # Save section
         save_actions = [
-            widget.save_action,
             widget.save_all_action,
             widget.save_as_action,
             widget.save_copy_as_action,
@@ -552,7 +551,6 @@ class Editor(SpyderDockablePlugin):
 
         # Save section
         save_actions = [
-            widget.save_action,
             widget.save_all_action,
             widget.save_as_action,
             widget.save_copy_as_action,
@@ -658,7 +656,6 @@ class Editor(SpyderDockablePlugin):
         widget = self.get_widget()
         toolbar = self.get_plugin(Plugins.Toolbar)
         file_toolbar_actions = [
-            widget.save_action,
             widget.save_all_action,
             widget.create_new_cell
         ]
@@ -672,7 +669,6 @@ class Editor(SpyderDockablePlugin):
     def on_toolbar_teardown(self):
         toolbar = self.get_plugin(Plugins.Toolbar)
         file_toolbar_actions = [
-            EditorWidgetActions.SaveFile,
             EditorWidgetActions.SaveAll,
             EditorWidgetActions.NewCell
         ]
@@ -783,12 +779,16 @@ class Editor(SpyderDockablePlugin):
         application = self.get_plugin(Plugins.Application)
         widget = self.get_widget()
         widget.sig_new_recent_file.connect(application.add_recent_file)
+        widget.sig_save_action_enabled.connect(application.enable_save_action)
 
     @on_plugin_teardown(plugin=Plugins.Application)
     def on_application_teardown(self):
         application = self.get_plugin(Plugins.Application)
         widget = self.get_widget()
         widget.sig_new_recent_file.disconnect(application.add_recent_file)
+        widget.sig_save_action_enabled.disconnect(
+            application.enable_save_action
+        )
 
     def update_font(self):
         """Update font from Preferences"""

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -391,18 +391,6 @@ class Editor(SpyderDockablePlugin):
                     before_section=FileMenuSections.Restart
                 )
 
-        # Open section
-        open_actions = [
-            widget.recent_file_menu,
-        ]
-        for open_action in open_actions:
-            mainmenu.add_item_to_application_menu(
-                open_action,
-                menu_id=ApplicationMenus.File,
-                section=FileMenuSections.Open,
-                before_section=FileMenuSections.Save
-            )
-
         # Save section
         save_actions = [
             widget.save_action,
@@ -561,16 +549,6 @@ class Editor(SpyderDockablePlugin):
                     tab_navigation_action,
                     menu_id=ApplicationMenus.File
                 )
-
-        # Open section
-        open_actions = [
-            widget.recent_file_menu,
-        ]
-        for open_action in open_actions:
-            mainmenu.remove_item_from_application_menu(
-                open_action,
-                menu_id=ApplicationMenus.File
-            )
 
         # Save section
         save_actions = [
@@ -799,6 +777,18 @@ class Editor(SpyderDockablePlugin):
         projects = self.get_plugin(Plugins.Projects)
         projects.sig_project_loaded.disconnect(self._on_project_loaded)
         projects.sig_project_closed.disconnect(self._on_project_closed)
+
+    @on_plugin_available(plugin=Plugins.Application)
+    def on_application_available(self):
+        application = self.get_plugin(Plugins.Application)
+        widget = self.get_widget()
+        widget.sig_new_recent_file.connect(application.add_recent_file)
+
+    @on_plugin_teardown(plugin=Plugins.Application)
+    def on_application_teardown(self):
+        application = self.get_plugin(Plugins.Application)
+        widget = self.get_widget()
+        widget.sig_new_recent_file.disconnect(application.add_recent_file)
 
     def update_font(self):
         """Update font from Preferences"""

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -393,7 +393,6 @@ class Editor(SpyderDockablePlugin):
 
         # Save section
         save_actions = [
-            widget.save_all_action,
             widget.save_as_action,
             widget.save_copy_as_action,
             widget.revert_action,
@@ -551,7 +550,6 @@ class Editor(SpyderDockablePlugin):
 
         # Save section
         save_actions = [
-            widget.save_all_action,
             widget.save_as_action,
             widget.save_copy_as_action,
             widget.revert_action,
@@ -655,28 +653,18 @@ class Editor(SpyderDockablePlugin):
     def on_toolbar_available(self):
         widget = self.get_widget()
         toolbar = self.get_plugin(Plugins.Toolbar)
-        file_toolbar_actions = [
-            widget.save_all_action,
-            widget.create_new_cell
-        ]
-        for file_toolbar_action in file_toolbar_actions:
-            toolbar.add_item_to_application_toolbar(
-                file_toolbar_action,
-                toolbar_id=ApplicationToolbars.File,
-            )
+        toolbar.add_item_to_application_toolbar(
+            widget.create_new_cell,
+            toolbar_id=ApplicationToolbars.File,
+        )
 
     @on_plugin_teardown(plugin=Plugins.Toolbar)
     def on_toolbar_teardown(self):
         toolbar = self.get_plugin(Plugins.Toolbar)
-        file_toolbar_actions = [
-            EditorWidgetActions.SaveAll,
-            EditorWidgetActions.NewCell
-        ]
-        for file_toolbar_action_id in file_toolbar_actions:
-            toolbar.remove_item_from_application_toolbar(
-                file_toolbar_action_id,
-                toolbar_id=ApplicationToolbars.File,
-            )
+        toolbar.remove_item_from_application_toolbar(
+            EditorWidgetActions.NewCell,
+            toolbar_id=ApplicationToolbars.File,
+        )
 
     @on_plugin_available(plugin=Plugins.Completions)
     def on_completions_available(self):
@@ -780,6 +768,9 @@ class Editor(SpyderDockablePlugin):
         widget = self.get_widget()
         widget.sig_new_recent_file.connect(application.add_recent_file)
         widget.sig_save_action_enabled.connect(application.enable_save_action)
+        widget.sig_save_all_action_enabled.connect(
+            application.enable_save_all_action
+        )
 
     @on_plugin_teardown(plugin=Plugins.Application)
     def on_application_teardown(self):
@@ -788,6 +779,9 @@ class Editor(SpyderDockablePlugin):
         widget.sig_new_recent_file.disconnect(application.add_recent_file)
         widget.sig_save_action_enabled.disconnect(
             application.enable_save_action
+        )
+        widget.sig_save_all_action_enabled.disconnect(
+            application.enable_save_all_action
         )
 
     def update_font(self):
@@ -1112,6 +1106,12 @@ class Editor(SpyderDockablePlugin):
             `True` if the save operation was sucessfull. `False` otherwise.
         """
         return self.get_widget().save(index=None, force=False)
+
+    def save_all(self) -> None:
+        """
+        Save all files.
+        """
+        return self.get_widget().save_all()
 
     def save_bookmark(self, slot_num):
         """

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -717,22 +717,14 @@ class Editor(SpyderDockablePlugin):
         application = self.get_plugin(Plugins.Application)
         widget = self.get_widget()
         widget.sig_new_recent_file.connect(application.add_recent_file)
-        widget.sig_save_action_enabled.connect(application.enable_save_action)
-        widget.sig_save_all_action_enabled.connect(
-            application.enable_save_all_action
-        )
+        widget.sig_file_action_enabled.connect(self._enable_file_action)
 
     @on_plugin_teardown(plugin=Plugins.Application)
     def on_application_teardown(self):
         application = self.get_plugin(Plugins.Application)
         widget = self.get_widget()
         widget.sig_new_recent_file.disconnect(application.add_recent_file)
-        widget.sig_save_action_enabled.disconnect(
-            application.enable_save_action
-        )
-        widget.sig_save_all_action_enabled.disconnect(
-            application.enable_save_all_action
-        )
+        widget.sig_file_action_enabled.disconnect(self._enable_file_action)
 
     def update_font(self):
         """Update font from Preferences"""
@@ -1253,3 +1245,12 @@ class Editor(SpyderDockablePlugin):
         if debugger is None:
             return True
         return debugger.can_close_file(filename)
+
+    # ---- Methods related to Application plugin
+    def _enable_file_action(self, action_name: str, enabled: bool) -> None:
+        """
+        Enable or disable file action for this plugin.
+        """
+        application = self.get_plugin(Plugins.Application, error=False)
+        if application:
+            application.enable_file_action(action_name, enabled, self)

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -401,7 +401,7 @@ class CompletionWidget(QListWidget, SpyderConfigurationAccessor):
                 # Ask to save file if the user pressed the sequence for that.
                 # Fixes spyder-ide/spyder#14806
                 save_shortcut = self.get_conf(
-                    'editor/save file', section='shortcuts')
+                    'main/save file', section='shortcuts')
                 if key_sequence == save_shortcut:
                     self.textedit.sig_save_requested.emit()
 

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -40,7 +40,6 @@ from spyder.config.utils import (
     get_edit_filetypes, get_edit_filters, get_filter, is_kde_desktop
 )
 from spyder.plugins.application.api import ApplicationActions
-from spyder.plugins.editor.api.actions import EditorWidgetActions
 from spyder.plugins.editor.api.panel import Panel
 from spyder.plugins.editor.utils.autosave import AutosaveForStack
 from spyder.plugins.editor.utils.editor import get_file_language
@@ -125,7 +124,7 @@ class EditorStack(QWidget, SpyderWidgetMixin):
     todo_results_changed = Signal()
     sig_update_code_analysis_actions = Signal()
     refresh_file_dependent_actions = Signal()
-    refresh_save_all_action = Signal()
+    refresh_save_actions = Signal()
     text_changed_at = Signal(str, tuple)
     current_file_changed = Signal(str, int, int, int)
     plugin_load = Signal((str,), ())
@@ -467,7 +466,6 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             ('Go to next file', self.tab_navigation_mru),
             ('Cycle to previous file', lambda: self.tabs.tab_navigate(-1)),
             ('Cycle to next file', lambda: self.tabs.tab_navigate(1)),
-            ('Save file', self.save),
             ('Save all', self.save_all),
             ('Save As', self.sig_save_as),
             ('Close all', self.close_all_files),
@@ -536,6 +534,7 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             "New file",
             "Open file",
             "Open last closed",
+            "Save file",
         ]:
             self.register_shortcut_for_widget(
                 name=action_id,
@@ -2489,15 +2488,7 @@ class EditorStack(QWidget, SpyderWidgetMixin):
         self.set_stack_title(index, state)
 
         # Toggle save/save all actions state
-        try:
-            save_action = self.get_action(
-                EditorWidgetActions.SaveFile,
-                plugin=Plugins.Editor
-            )
-            save_action.setEnabled(state)
-        except KeyError:  # if no main_widget, as happens in tests
-            pass
-        self.refresh_save_all_action.emit()
+        self.refresh_save_actions.emit()
 
         # Refreshing eol mode
         eol_chars = finfo.editor.get_line_separator()

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -465,7 +465,6 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             ('Go to next file', self.tab_navigation_mru),
             ('Cycle to previous file', lambda: self.tabs.tab_navigate(-1)),
             ('Cycle to next file', lambda: self.tabs.tab_navigate(1)),
-            ('Close all', self.close_all_files),
             ("Last edit location", self.sig_prev_edit_pos),
             ("Previous cursor position", self.sig_prev_cursor),
             ("Next cursor position", self.sig_next_cursor),
@@ -533,7 +532,8 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             "Save all",
             "Save as",
             "Close file 1",
-            "Close file 2"
+            "Close file 2",
+            "Close all"
         ]:
             # The shortcut has the same name as the action, except for
             # "Close file" which has two shortcuts associated to it

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -473,8 +473,6 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             ("zoom in 2", self.zoom_in),
             ("zoom out", self.zoom_out),
             ("zoom reset", self.zoom_reset),
-            ("close file 1", self.close_file),
-            ("close file 2", self.close_file),
             ("go to next cell", self.advance_cell),
             ("go to previous cell", lambda: self.advance_cell(reverse=True)),
             ("Previous warning", self.sig_prev_warning),
@@ -527,16 +525,25 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             )
 
         # Register shortcuts for file actions defined in Applications plugin
-        for action_id in [
+        for shortcut_name in [
             "New file",
             "Open file",
             "Open last closed",
             "Save file",
             "Save all",
-            "Save as"
+            "Save as",
+            "Close file 1",
+            "Close file 2"
         ]:
+            # The shortcut has the same name as the action, except for
+            # "Close file" which has two shortcuts associated to it
+            if shortcut_name.startswith('Close file'):
+                action_id = 'Close file'
+            else:
+                action_id = shortcut_name
+
             self.register_shortcut_for_widget(
-                name=action_id,
+                name=shortcut_name,
                 triggered=functools.partial(
                     self.sig_trigger_action.emit,
                     action_id,

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -142,6 +142,7 @@ class EditorStack(QWidget, SpyderWidgetMixin):
     sig_save_bookmark = Signal(int)
     sig_load_bookmark = Signal(int)
     sig_save_bookmarks = Signal(str, str)
+
     sig_trigger_action = Signal(str, str)
     """
     This signal is emitted to request that an action be triggered.
@@ -523,7 +524,7 @@ class EditorStack(QWidget, SpyderWidgetMixin):
                 context=Plugins.Debugger,
             )
 
-        # Register shortcuts for file actions defined in Applications plugin
+        # Register shortcuts for file actions defined in the Application plugin
         for shortcut_name in [
             "New file",
             "Open file",

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -132,7 +132,6 @@ class EditorStack(QWidget, SpyderWidgetMixin):
     sig_split_vertically = Signal()
     sig_split_horizontally = Signal()
     sig_new_file = Signal((str,), ())
-    sig_save_as = Signal()
     sig_prev_edit_pos = Signal()
     sig_prev_cursor = Signal()
     sig_next_cursor = Signal()
@@ -466,7 +465,6 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             ('Go to next file', self.tab_navigation_mru),
             ('Cycle to previous file', lambda: self.tabs.tab_navigate(-1)),
             ('Cycle to next file', lambda: self.tabs.tab_navigate(1)),
-            ('Save As', self.sig_save_as),
             ('Close all', self.close_all_files),
             ("Last edit location", self.sig_prev_edit_pos),
             ("Previous cursor position", self.sig_prev_cursor),
@@ -534,7 +532,8 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             "Open file",
             "Open last closed",
             "Save file",
-            "Save all"
+            "Save all",
+            "Save as"
         ]:
             self.register_shortcut_for_widget(
                 name=action_id,

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -39,6 +39,7 @@ from spyder.config.gui import is_dark_interface
 from spyder.config.utils import (
     get_edit_filetypes, get_edit_filters, get_filter, is_kde_desktop
 )
+from spyder.plugins.application.api import ApplicationActions
 from spyder.plugins.editor.api.actions import EditorWidgetActions
 from spyder.plugins.editor.api.panel import Panel
 from spyder.plugins.editor.utils.autosave import AutosaveForStack
@@ -466,7 +467,6 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             ('Go to next file', self.tab_navigation_mru),
             ('Cycle to previous file', lambda: self.tabs.tab_navigate(-1)),
             ('Cycle to next file', lambda: self.tabs.tab_navigate(1)),
-            ('New file', self.sig_new_file[()]),
             ('Open file', self.plugin_load[()]),
             ('Open last closed', self.sig_open_last_closed),
             ('Save file', self.save),
@@ -531,6 +531,20 @@ class EditorStack(QWidget, SpyderWidgetMixin):
                     Plugins.Debugger
                 ),
                 context=Plugins.Debugger,
+            )
+
+        # Register shortcuts for file actions defined in Applications plugin
+        for action_id in [
+            "New file",
+        ]:
+            self.register_shortcut_for_widget(
+                name=action_id,
+                triggered=functools.partial(
+                    self.sig_trigger_action.emit,
+                    action_id,
+                    Plugins.Application
+                ),
+                context='main',
             )
 
     def update_switcher_actions(self, switcher_available):
@@ -1313,7 +1327,10 @@ class EditorStack(QWidget, SpyderWidgetMixin):
                 )
         else:
             self.setFocus()  # --> Editor.__get_focus_editortabwidget
-            new_action = self.get_action(EditorWidgetActions.NewFile)
+            new_action = self.get_action(
+                ApplicationActions.NewFile,
+                plugin=Plugins.Application
+            )
             open_action = self.get_action(EditorWidgetActions.OpenFile)
             for menu_action in (new_action, open_action):
                 self.menu.add_action(menu_action)

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -467,7 +467,6 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             ('Go to next file', self.tab_navigation_mru),
             ('Cycle to previous file', lambda: self.tabs.tab_navigate(-1)),
             ('Cycle to next file', lambda: self.tabs.tab_navigate(1)),
-            ('Open last closed', self.sig_open_last_closed),
             ('Save file', self.save),
             ('Save all', self.save_all),
             ('Save As', self.sig_save_as),
@@ -536,6 +535,7 @@ class EditorStack(QWidget, SpyderWidgetMixin):
         for action_id in [
             "New file",
             "Open file",
+            "Open last closed",
         ]:
             self.register_shortcut_for_widget(
                 name=action_id,

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -466,7 +466,6 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             ('Go to next file', self.tab_navigation_mru),
             ('Cycle to previous file', lambda: self.tabs.tab_navigate(-1)),
             ('Cycle to next file', lambda: self.tabs.tab_navigate(1)),
-            ('Save all', self.save_all),
             ('Save As', self.sig_save_as),
             ('Close all', self.close_all_files),
             ("Last edit location", self.sig_prev_edit_pos),
@@ -535,6 +534,7 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             "Open file",
             "Open last closed",
             "Save file",
+            "Save all"
         ]:
             self.register_shortcut_for_widget(
                 name=action_id,

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -143,8 +143,17 @@ class EditorStack(QWidget, SpyderWidgetMixin):
     sig_save_bookmark = Signal(int)
     sig_load_bookmark = Signal(int)
     sig_save_bookmarks = Signal(str, str)
-    sig_trigger_run_action = Signal(str)
-    sig_trigger_debugger_action = Signal(str)
+    sig_trigger_action = Signal(str, str)
+    """
+    This signal is emitted to request that an action be triggered.
+
+    Parameters
+    ----------
+    id: str
+        The id of the action.
+    plugin: str
+        The plugin in which the action is registered.
+    """
 
     sig_open_last_closed = Signal()
     """
@@ -503,8 +512,9 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             self.register_shortcut_for_widget(
                 name=action_id,
                 triggered=functools.partial(
-                    self.sig_trigger_run_action.emit,
+                    self.sig_trigger_action.emit,
                     action_id,
+                    Plugins.Run
                 ),
             )
 
@@ -516,8 +526,9 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             self.register_shortcut_for_widget(
                 name=action_id,
                 triggered=functools.partial(
-                    self.sig_trigger_debugger_action.emit,
+                    self.sig_trigger_action.emit,
                     action_id,
+                    Plugins.Debugger
                 ),
                 context=Plugins.Debugger,
             )

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -467,7 +467,6 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             ('Go to next file', self.tab_navigation_mru),
             ('Cycle to previous file', lambda: self.tabs.tab_navigate(-1)),
             ('Cycle to next file', lambda: self.tabs.tab_navigate(1)),
-            ('Open file', self.plugin_load[()]),
             ('Open last closed', self.sig_open_last_closed),
             ('Save file', self.save),
             ('Save all', self.save_all),
@@ -536,6 +535,7 @@ class EditorStack(QWidget, SpyderWidgetMixin):
         # Register shortcuts for file actions defined in Applications plugin
         for action_id in [
             "New file",
+            "Open file",
         ]:
             self.register_shortcut_for_widget(
                 name=action_id,
@@ -1331,7 +1331,10 @@ class EditorStack(QWidget, SpyderWidgetMixin):
                 ApplicationActions.NewFile,
                 plugin=Plugins.Application
             )
-            open_action = self.get_action(EditorWidgetActions.OpenFile)
+            open_action = self.get_action(
+                ApplicationActions.OpenFile,
+                plugin=Plugins.Application
+            )
             for menu_action in (new_action, open_action):
                 self.menu.add_action(menu_action)
 

--- a/spyder/plugins/editor/widgets/editorstack/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/conftest.py
@@ -36,7 +36,6 @@ from spyder.widgets.findreplace import FindReplace
 def editor_factory(new_file=True, text=None):
     editorstack = EditorStack(None, [], False)
     editorstack.set_find_widget(FindReplace(editorstack))
-    editorstack.set_io_actions(Mock(), Mock(), Mock(), Mock())
     if new_file:
         if not text:
             text = (

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_editorstack.py
@@ -38,7 +38,6 @@ HERE = osp.abspath(osp.dirname(__file__))
 def base_editor_bot(qtbot):
     editor_stack = EditorStack(None, [], False)
     editor_stack.set_find_widget(Mock())
-    editor_stack.set_io_actions(Mock(), Mock(), Mock(), Mock())
     return editor_stack
 
 

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_editorstack_and_outline.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_editorstack_and_outline.py
@@ -71,7 +71,6 @@ def editorstack(qtbot, outlineexplorer):
     def _create_editorstack(files):
         editorstack = EditorStack(None, [], False)
         editorstack.set_find_widget(Mock())
-        editorstack.set_io_actions(Mock(), Mock(), Mock(), Mock())
         editorstack.analysis_timer = Mock()
         editorstack.save_dialog_on_tests = True
         editorstack.set_outlineexplorer(outlineexplorer)

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_save.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_save.py
@@ -515,13 +515,14 @@ def test_save_when_completions_are_visible(completions_editor, qtbot):
     assert "some" in [x['label'] for x in sig.args[0]]
     assert "something" in [x['label'] for x in sig.args[0]]
 
-    # Check that pressing Ctrl-S emits the signal for saving the file
+    # Check that pressing Ctrl+S emits the signal for saving the file
     with qtbot.waitSignal(
         editorstack.sig_trigger_action, timeout=5_000
     ) as blocker:
         # Press keyboard shortcut corresponding to save
         qtbot.keyPress(
-            completion, Qt.Key_S, modifier=Qt.ControlModifier, delay=300)
+            completion, Qt.Key_S, modifier=Qt.ControlModifier, delay=300
+        )
 
     # Assert the signal had the correct arguments
     assert blocker.args == ['Save file', Plugins.Application]

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_save.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_save.py
@@ -38,7 +38,6 @@ from spyder.plugins.debugger.utils.breakpointsmanager import BreakpointsManager
 def add_files(editorstack):
     editorstack.close_split_action.setEnabled(False)
     editorstack.set_find_widget(Mock())
-    editorstack.set_io_actions(Mock(), Mock(), Mock(), Mock())
     editorstack.new('foo.py', 'utf-8', 'a = 1\n'
                                        'print(a)\n'
                                        '\n'
@@ -54,7 +53,6 @@ def add_files(editorstack):
 def base_editor_bot(qtbot):
     editor_stack = EditorStack(None, [], False)
     editor_stack.set_find_widget(Mock())
-    editor_stack.set_io_actions(Mock(), Mock(), Mock(), Mock())
     return editor_stack, qtbot
 
 

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
@@ -79,6 +79,7 @@ def test_default_keybinding_values():
     assert CONF.get_shortcut('main', 'open last closed') == 'Ctrl+Shift+T'
     assert CONF.get_shortcut('main', 'save file') == 'Ctrl+S'
     assert CONF.get_shortcut('main', 'save all') == 'Ctrl+Alt+S'
+    assert CONF.get_shortcut('main', 'save as') == 'Ctrl+Shift+S'
 
 
 @pytest.mark.skipif(
@@ -381,6 +382,7 @@ def test_shortcuts_for_new_editors(editorstack, qtbot):
         (Qt.Key_T, Qt.ControlModifier | Qt.ShiftModifier, 'Open last closed'),
         (Qt.Key_S, Qt.ControlModifier, 'Save file'),
         (Qt.Key_S, Qt.ControlModifier | Qt.AltModifier, 'Save all'),
+        (Qt.Key_S, Qt.ControlModifier | Qt.ShiftModifier, 'Save as'),
 ])
 def test_file_shortcut(editorstack, qtbot, key, modifier, action):
     """

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
@@ -19,6 +19,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication
 
 # Local imports
+from spyder.api.plugins import Plugins
 from spyder.config.base import running_in_ci
 from spyder.config.manager import CONF
 from spyder.plugins.editor.widgets.gotoline import GoToLineDialog
@@ -73,6 +74,7 @@ def test_default_keybinding_values():
     assert CONF.get_shortcut('editor', 'go to line') == 'Ctrl+L'
     assert CONF.get_shortcut('editor', 'next word') == 'Ctrl+Right'
     assert CONF.get_shortcut('editor', 'previous word') == 'Ctrl+Left'
+    assert CONF.get_shortcut('main', 'new file') == 'Ctrl+N'
 
 
 @pytest.mark.skipif(
@@ -361,6 +363,17 @@ def test_shortcuts_for_new_editors(editorstack, qtbot):
     editor = editorstack.get_current_editor()
     qtbot.keyClick(editor, Qt.Key_1, modifier=Qt.ControlModifier)
     assert editor.toPlainText() == '# Line5\nLine6\nLine7\nLine8\n'
+
+
+def test_new_file_shortcut(editorstack, qtbot):
+    """
+    Test that typing "New File" shortcut raises the signal requesting that a
+    new file be created.
+    """
+    editor = editorstack.get_current_editor()
+    with qtbot.waitSignal(editorstack.sig_trigger_action) as blocker:
+        qtbot.keyClick(editor, Qt.Key_N, modifier=Qt.ControlModifier)
+    assert blocker.args == ['New file', Plugins.Application]
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
@@ -34,7 +34,6 @@ def editorstack(qtbot):
     """
     editorstack = EditorStack(None, [], False)
     editorstack.set_find_widget(Mock())
-    editorstack.set_io_actions(Mock(), Mock(), Mock(), Mock())
     editorstack.close_split_action.setEnabled(False)
     editorstack.new('foo.py', 'utf-8', 'Line1\nLine2\nLine3\nLine4')
 

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
@@ -76,6 +76,7 @@ def test_default_keybinding_values():
     assert CONF.get_shortcut('editor', 'previous word') == 'Ctrl+Left'
     assert CONF.get_shortcut('main', 'new file') == 'Ctrl+N'
     assert CONF.get_shortcut('main', 'open file') == 'Ctrl+O'
+    assert CONF.get_shortcut('main', 'open last closed') == 'Ctrl+Shift+T'
 
 
 @pytest.mark.skipif(
@@ -375,6 +376,7 @@ def test_shortcuts_for_new_editors(editorstack, qtbot):
     [
         (Qt.Key_N, Qt.ControlModifier, 'New file'),
         (Qt.Key_O, Qt.ControlModifier, 'Open file'),
+        (Qt.Key_T, Qt.ControlModifier | Qt.ShiftModifier, 'Open last closed'),
 ])
 def test_file_shortcut(editorstack, qtbot, key, modifier, action):
     """

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
@@ -77,6 +77,7 @@ def test_default_keybinding_values():
     assert CONF.get_shortcut('main', 'new file') == 'Ctrl+N'
     assert CONF.get_shortcut('main', 'open file') == 'Ctrl+O'
     assert CONF.get_shortcut('main', 'open last closed') == 'Ctrl+Shift+T'
+    assert CONF.get_shortcut('main', 'save file') == 'Ctrl+S'
 
 
 @pytest.mark.skipif(
@@ -377,6 +378,7 @@ def test_shortcuts_for_new_editors(editorstack, qtbot):
         (Qt.Key_N, Qt.ControlModifier, 'New file'),
         (Qt.Key_O, Qt.ControlModifier, 'Open file'),
         (Qt.Key_T, Qt.ControlModifier | Qt.ShiftModifier, 'Open last closed'),
+        (Qt.Key_S, Qt.ControlModifier, 'Save file'),
 ])
 def test_file_shortcut(editorstack, qtbot, key, modifier, action):
     """

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
@@ -78,6 +78,7 @@ def test_default_keybinding_values():
     assert CONF.get_shortcut('main', 'open file') == 'Ctrl+O'
     assert CONF.get_shortcut('main', 'open last closed') == 'Ctrl+Shift+T'
     assert CONF.get_shortcut('main', 'save file') == 'Ctrl+S'
+    assert CONF.get_shortcut('main', 'save all') == 'Ctrl+Alt+S'
 
 
 @pytest.mark.skipif(
@@ -379,6 +380,7 @@ def test_shortcuts_for_new_editors(editorstack, qtbot):
         (Qt.Key_O, Qt.ControlModifier, 'Open file'),
         (Qt.Key_T, Qt.ControlModifier | Qt.ShiftModifier, 'Open last closed'),
         (Qt.Key_S, Qt.ControlModifier, 'Save file'),
+        (Qt.Key_S, Qt.ControlModifier | Qt.AltModifier, 'Save all'),
 ])
 def test_file_shortcut(editorstack, qtbot, key, modifier, action):
     """

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
@@ -80,6 +80,9 @@ def test_default_keybinding_values():
     assert CONF.get_shortcut('main', 'save file') == 'Ctrl+S'
     assert CONF.get_shortcut('main', 'save all') == 'Ctrl+Alt+S'
     assert CONF.get_shortcut('main', 'save as') == 'Ctrl+Shift+S'
+    assert CONF.get_shortcut('main', 'close file 1') == 'Ctrl+W'
+    assert CONF.get_shortcut('main', 'close file 2') == 'Ctrl+F4'
+    assert CONF.get_shortcut('main', 'close all') == 'Ctrl+Shift+W'
 
 
 @pytest.mark.skipif(
@@ -383,6 +386,9 @@ def test_shortcuts_for_new_editors(editorstack, qtbot):
         (Qt.Key_S, Qt.ControlModifier, 'Save file'),
         (Qt.Key_S, Qt.ControlModifier | Qt.AltModifier, 'Save all'),
         (Qt.Key_S, Qt.ControlModifier | Qt.ShiftModifier, 'Save as'),
+        (Qt.Key_W, Qt.ControlModifier, 'Close file'),
+        (Qt.Key_F4, Qt.ControlModifier, 'Close file'),
+        (Qt.Key_W, Qt.ControlModifier | Qt.ShiftModifier, 'Close all'),
 ])
 def test_file_shortcut(editorstack, qtbot, key, modifier, action):
     """

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -331,15 +331,6 @@ class EditorMainWidget(PluginMainWidget):
             tip=_("Revert file from disk"),
             triggered=self.revert
         )
-        self.save_as_action = self.create_action(
-            EditorWidgetActions.SaveAs,
-            text=_("Save &as..."),
-            icon=self.create_icon('filesaveas'),
-            tip=_("Save current file as..."),
-            triggered=self.save_as,
-            context=Qt.WidgetShortcut,
-            register_shortcut=True
-        )
         self.save_copy_as_action = self.create_action(
             EditorWidgetActions.SaveCopyAs,
             text=_("Save copy as..."),
@@ -781,7 +772,6 @@ class EditorMainWidget(PluginMainWidget):
         self.file_dependent_actions = (
             self.pythonfile_dependent_actions +
             [
-                self.save_as_action,
                 self.save_copy_as_action,
                 self.print_preview_action,
                 self.print_action,
@@ -1508,7 +1498,6 @@ class EditorMainWidget(PluginMainWidget):
         editorstack.plugin_load.connect(self.load)
         editorstack.plugin_load[()].connect(self.load)
         editorstack.edit_goto.connect(self.load)
-        editorstack.sig_save_as.connect(self.save_as)
         editorstack.sig_prev_edit_pos.connect(self.go_to_last_edit_location)
         editorstack.sig_prev_cursor.connect(
             self.go_to_previous_cursor_position

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -204,26 +204,16 @@ class EditorMainWidget(PluginMainWidget):
         be the new name.
     """
 
-    sig_save_action_enabled = Signal(bool)
+    sig_file_action_enabled = Signal(str, bool)
     """
-    This signal is emitted to enable or disable the 'Save' action.
+    This signal is emitted to enable or disable a file action.
 
     Parameters
     ----------
-    state: bool
-        True if the 'Save' action should be enabled, False if it should
-        disabled.
-    """
-
-    sig_save_all_action_enabled = Signal(bool)
-    """
-    This signal is emitted to enable or disable the 'Save All' action.
-
-    Parameters
-    ----------
-    state: bool
-        True if the 'Save All' action should be enabled, False if it should
-        disabled.
+    action_name: str
+        Name of the file action to be enabled or disabled.
+    enabled: bool
+        True if the action should be enabled, False if it should disabled.
     """
 
     def __init__(self, name, plugin, parent, ignore_last_opened_files=False):
@@ -1654,13 +1644,15 @@ class EditorMainWidget(PluginMainWidget):
         finfo = editorstack.get_current_finfo()
         if finfo:
             state = finfo.editor.document().isModified() or finfo.newly_created
-            self.sig_save_action_enabled.emit(state)
+        else:
+            state = False
+        self.sig_file_action_enabled.emit(ApplicationActions.SaveFile, state)
 
         state = any(
             finfo.editor.document().isModified() or finfo.newly_created
             for finfo in editorstack.data
         )
-        self.sig_save_all_action_enabled.emit(state)
+        self.sig_file_action_enabled.emit(ApplicationActions.SaveAll, state)
 
     def update_warning_menu(self):
         """Update warning list menu"""

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -215,6 +215,17 @@ class EditorMainWidget(PluginMainWidget):
         disabled.
     """
 
+    sig_save_all_action_enabled = Signal(bool)
+    """
+    This signal is emitted to enable or disable the 'Save All' action.
+
+    Parameters
+    ----------
+    state: bool
+        True if the 'Save All' action should be enabled, False if it should
+        disabled.
+    """
+
     def __init__(self, name, plugin, parent, ignore_last_opened_files=False):
         super().__init__(name, plugin, parent)
 
@@ -319,15 +330,6 @@ class EditorMainWidget(PluginMainWidget):
             icon=self.create_icon('revert'),
             tip=_("Revert file from disk"),
             triggered=self.revert
-        )
-        self.save_all_action = self.create_action(
-            EditorWidgetActions.SaveAll,
-            text=_("Sav&e all"),
-            icon=self.create_icon('save_all'),
-            tip=_("Save all files"),
-            triggered=self.save_all,
-            context=Qt.WidgetShortcut,
-            register_shortcut=True
         )
         self.save_as_action = self.create_action(
             EditorWidgetActions.SaveAs,
@@ -783,7 +785,6 @@ class EditorMainWidget(PluginMainWidget):
                 self.save_copy_as_action,
                 self.print_preview_action,
                 self.print_action,
-                self.save_all_action,
                 self.gotoline_action,
                 self.workdir_action,
                 self.close_file_action,
@@ -1704,7 +1705,7 @@ class EditorMainWidget(PluginMainWidget):
             finfo.editor.document().isModified() or finfo.newly_created
             for finfo in editorstack.data
         )
-        self.save_all_action.setEnabled(state)
+        self.sig_save_all_action_enabled.emit(state)
 
     def update_warning_menu(self):
         """Update warning list menu"""

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -34,7 +34,6 @@ from qtpy.QtWidgets import (QAction, QActionGroup, QApplication, QDialog,
 
 # Local imports
 from spyder.api.config.decorators import on_conf_change
-from spyder.api.plugins import Plugins
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.config.base import _, get_conf_path, running_under_pytest
 from spyder.config.utils import (get_edit_filetypes, get_edit_filters,
@@ -1560,10 +1559,7 @@ class EditorMainWidget(PluginMainWidget):
         editorstack.sig_codeeditor_created.connect(self.sig_codeeditor_created)
         editorstack.sig_codeeditor_changed.connect(self.sig_codeeditor_changed)
         editorstack.sig_codeeditor_deleted.connect(self.sig_codeeditor_deleted)
-        editorstack.sig_trigger_run_action.connect(self.trigger_run_action)
-        editorstack.sig_trigger_debugger_action.connect(
-            self.trigger_debugger_action
-        )
+        editorstack.sig_trigger_action.connect(self.trigger_action)
 
         # Register editorstack's autosave component with plugin's autosave
         # component
@@ -3127,14 +3123,9 @@ class EditorMainWidget(PluginMainWidget):
         if current_fname != fname:
             editorstack.set_current_filename(fname)
 
-    def trigger_run_action(self, action_id):
-        """Trigger a run action according to its id."""
-        action = self.get_action(action_id, plugin=Plugins.Run)
-        action.trigger()
-
-    def trigger_debugger_action(self, action_id):
-        """Trigger a run action according to its id."""
-        action = self.get_action(action_id, plugin=Plugins.Debugger)
+    def trigger_action(self, action_id, plugin):
+        """Trigger an action according to its id and plugin."""
+        action = self.get_action(action_id, plugin=plugin)
         action.trigger()
 
     # ---- Code bookmarks

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -292,13 +292,6 @@ class EditorMainWidget(PluginMainWidget):
 
     def setup(self):
         # ---- File operations ----
-        self.open_last_closed_action = self.create_action(
-            EditorWidgetActions.OpenLastClosed,
-            text=_("O&pen last closed"),
-            tip=_("Open last closed"),
-            triggered=self.open_last_closed,
-            register_shortcut=True
-        )
         self.revert_action = self.create_action(
             EditorWidgetActions.RevertFileFromDisk,
             text=_("&Revert"),

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -337,15 +337,6 @@ class EditorMainWidget(PluginMainWidget):
             tip=_("Print current file..."),
             triggered=self.print_file
         )
-        self.close_all_action = self.create_action(
-            EditorWidgetActions.CloseAll,
-            text=_("C&lose all"),
-            icon=ima.icon('filecloseall'),
-            tip=_("Close all opened files"),
-            triggered=self.close_all_files,
-            context=Qt.WidgetShortcut,
-            register_shortcut=True
-        )
         self.workdir_action = self.create_action(
             EditorWidgetActions.SetWorkingDirectory,
             text=_("Set console working directory"),
@@ -755,7 +746,6 @@ class EditorMainWidget(PluginMainWidget):
                 self.print_action,
                 self.gotoline_action,
                 self.workdir_action,
-                self.close_all_action,
                 self.toggle_comment_action,
                 self.indent_action,
                 self.unindent_action

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -337,13 +337,6 @@ class EditorMainWidget(PluginMainWidget):
             tip=_("Print current file..."),
             triggered=self.print_file
         )
-        self.close_file_action = self.create_action(
-            EditorWidgetActions.CloseFile,
-            text=_("&Close"),
-            icon=self.create_icon('fileclose'),
-            tip=_("Close current file"),
-            triggered=self.close_file
-        )
         self.close_all_action = self.create_action(
             EditorWidgetActions.CloseAll,
             text=_("C&lose all"),
@@ -762,7 +755,6 @@ class EditorMainWidget(PluginMainWidget):
                 self.print_action,
                 self.gotoline_action,
                 self.workdir_action,
-                self.close_file_action,
                 self.close_all_action,
                 self.toggle_comment_action,
                 self.indent_action,

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -1418,8 +1418,6 @@ class EditorMainWidget(PluginMainWidget):
                 self.vcs_status.update_vcs_state)
 
         editorstack.update_switcher_actions(self.switcher_manager is not None)
-        editorstack.set_io_actions(self.new_action, self.open_action,
-                                   self.save_action, self.revert_action)
         editorstack.set_tempfile_path(self.TEMPFILE_PATH)
 
         # *********************************************************************

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -294,15 +294,6 @@ class EditorMainWidget(PluginMainWidget):
 
     def setup(self):
         # ---- File operations ----
-        self.new_action = self.create_action(
-            EditorWidgetActions.NewFile,
-            text=_("&New file..."),
-            icon=self.create_icon('filenew'),
-            tip=_("New file"),
-            triggered=self.new,
-            context=Qt.WidgetShortcut,
-            register_shortcut=True
-        )
         self.open_last_closed_action = self.create_action(
             EditorWidgetActions.OpenLastClosed,
             text=_("O&pen last closed"),

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -46,6 +46,7 @@ from spyder.utils.icon_manager import ima
 from spyder.utils.qthelpers import create_action
 from spyder.utils.misc import getcwd_or_home
 from spyder.widgets.findreplace import FindReplace
+from spyder.plugins.editor.api.actions import EditorWidgetActions
 from spyder.plugins.editor.api.run import (
     EditorRunConfiguration, FileRun, SelectionRun, CellRun,
     SelectionContextModificator, ExtraAction)
@@ -69,81 +70,6 @@ from spyder.widgets.simplecodeeditor import SimpleCodeEditor
 
 
 logger = logging.getLogger(__name__)
-
-
-class EditorWidgetActions:
-    # File operations
-    NewFile = "New file"
-    OpenLastClosed = "Open last closed"
-    OpenFile = "Open file"
-    RevertFileFromDisk = "Revert file from disk"
-    SaveFile = "Save file"
-    SaveAll = "Save all"
-    SaveAs = "Save As"
-    SaveCopyAs = "save_copy_as_action"
-    PrintPreview = "print_preview_action"
-    Print = "print_action"
-    CloseFile = "Close current file"
-    CloseAll = "Close all"
-    MaxRecentFiles = "max_recent_files_action"
-    ClearRecentFiles = "clear_recent_files_action"
-
-    # Navigation
-    GoToNextFile = "Go to next file"
-    GoToPreviousFile = "Go to previous file"
-
-    # Find/Search operations
-    FindText = "Find text"
-    FindNext = "Find next"
-    FindPrevious = "Find previous"
-    ReplaceText = "Replace text"
-
-    # Source code operations
-    ShowTodoList = "show_todo_list_action"
-    ShowCodeAnalysisList = "show_code_analaysis_action"
-    GoToPreviousWarning = "Previous warning"
-    GoToNextWarning = "Next warning"
-    GoToLastEditLocation = "Last edit location"
-    GoToPreviousCursorPosition = "Previous cursor position"
-    GoToNextCursorPosition = "Next cursor position"
-    WinEOL = "win_eol_action"
-    LinuxEOL = "linux_eol_action"
-    MacEOL = "mac_eol_action"
-    RemoveTrailingSpaces = "remove_trailing_spaces_action"
-    FormatCode = "autoformating"
-    FixIndentation = "fix_indentation_action"
-
-    # Checkable operations
-    ShowBlanks = "blank_spaces_action"
-    ScrollPastEnd = "scroll_past_end_action"
-    ShowIndentGuides = "show_indent_guides_action"
-    ShowCodeFolding = "show_code_folding_action"
-    ShowClassFuncDropdown = "show_class_func_dropdown_action"
-    ShowCodeStyleWarnings = "pycodestyle_action"
-    ShowDoctringWarnings = "pydocstyle_action"
-    UnderlineErrors = "underline_errors_action"
-
-    # Stack menu
-    GoToLine = "Go to line"
-    SetWorkingDirectory = "set_working_directory_action"
-
-    # Edit operations
-    NewCell = "create_new_cell"
-    ToggleComment = "Toggle comment"
-    Blockcomment = "Blockcomment"
-    Unblockcomment = "Unblockcomment"
-
-    Indent = "indent_action"
-    Unindent = "unindent_action"
-    TransformToUppercase = "transform to uppercase"
-    TransformToLowercase = "transform to lowercase"
-
-    Undo = "Undo"
-    Redo = "Redo"
-    Copy = "Copy"
-    Cut = "Cut"
-    Paste = "Paste"
-    SelectAll = "Select All"
 
 
 class EditorWidgetMenus:

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -331,13 +331,6 @@ class EditorMainWidget(PluginMainWidget):
             tip=_("Revert file from disk"),
             triggered=self.revert
         )
-        self.save_copy_as_action = self.create_action(
-            EditorWidgetActions.SaveCopyAs,
-            text=_("Save copy as..."),
-            icon=self.create_icon('filesaveas'),
-            tip=_("Save copy of current file as..."),
-            triggered=self.save_copy_as
-        )
         self.print_preview_action = self.create_action(
             EditorWidgetActions.PrintPreview,
             text=_("Print preview..."),
@@ -772,7 +765,6 @@ class EditorMainWidget(PluginMainWidget):
         self.file_dependent_actions = (
             self.pythonfile_dependent_actions +
             [
-                self.save_copy_as_action,
                 self.print_preview_action,
                 self.print_action,
                 self.gotoline_action,

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -324,13 +324,6 @@ class EditorMainWidget(PluginMainWidget):
 
     def setup(self):
         # ---- File operations ----
-        self.revert_action = self.create_action(
-            EditorWidgetActions.RevertFileFromDisk,
-            text=_("&Revert"),
-            icon=self.create_icon('revert'),
-            tip=_("Revert file from disk"),
-            triggered=self.revert
-        )
         self.print_preview_action = self.create_action(
             EditorWidgetActions.PrintPreview,
             text=_("Print preview..."),
@@ -772,7 +765,6 @@ class EditorMainWidget(PluginMainWidget):
                 self.close_file_action,
                 self.close_all_action,
                 self.toggle_comment_action,
-                self.revert_action,
                 self.indent_action,
                 self.unindent_action
             ]

--- a/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
+++ b/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
@@ -31,7 +31,6 @@ from spyder.plugins.editor.widgets.window import EditorMainWidgetExample
 def editor_stack():
     editor_stack = EditorStack(None, [], False)
     editor_stack.set_find_widget(Mock())
-    editor_stack.set_io_actions(Mock(), Mock(), Mock(), Mock())
     return editor_stack
 
 
@@ -76,7 +75,6 @@ def editor_splitter_lsp(qtbot_module, completion_plugin_all_started, request):
 
     def clone(editorstack, template=None):
         editorstack.set_find_widget(Mock())
-        editorstack.set_io_actions(Mock(), Mock(), Mock(), Mock())
         # Emulate "cloning"
         editorstack.new('test.py', 'utf-8', text)
 
@@ -90,7 +88,6 @@ def editor_splitter_lsp(qtbot_module, completion_plugin_all_started, request):
     )
 
     editorsplitter.editorstack.set_find_widget(Mock())
-    editorsplitter.editorstack.set_io_actions(Mock(), Mock(), Mock(), Mock())
     editorsplitter.editorstack.new('test.py', 'utf-8', text)
 
     mock_main_widget.clone_editorstack.side_effect = partial(
@@ -117,7 +114,6 @@ def editor_splitter_layout_bot(editor_splitter_bot):
     def clone(editorstack):
         editorstack.close_split_action.setEnabled(False)
         editorstack.set_find_widget(Mock())
-        editorstack.set_io_actions(Mock(), Mock(), Mock(), Mock())
         editorstack.new('foo.py', 'utf-8', 'a = 1\nprint(a)\n\nx = 2')
         editorstack.new('layout_test.py', 'utf-8', 'print(spam)')
         with open(__file__) as f:

--- a/spyder/plugins/editor/widgets/window.py
+++ b/spyder/plugins/editor/widgets/window.py
@@ -618,8 +618,6 @@ class EditorMainWidgetExample(QSplitter):
             oe_btn = create_toolbutton(self)
             editorstack.add_corner_widgets_to_tabbar([5, oe_btn])
 
-        action = QAction(self)
-        editorstack.set_io_actions(action, action, action, action)
         font = QFont("Courier New")
         font.setPointSize(10)
         editorstack.set_default_font(font, color_scheme='Spyder')

--- a/spyder/plugins/explorer/plugin.py
+++ b/spyder/plugins/explorer/plugin.py
@@ -36,6 +36,7 @@ class Explorer(SpyderDockablePlugin):
         Plugins.IPythonConsole,
         Plugins.Editor,
         Plugins.WorkingDirectory,
+        Plugins.Application,
     ]
     TABIFY = Plugins.VariableExplorer
     WIDGET_CLASS = ExplorerWidget
@@ -199,7 +200,6 @@ class Explorer(SpyderDockablePlugin):
         self.sig_folder_removed.connect(editor.removed_tree)
         self.sig_folder_renamed.connect(editor.renamed_tree)
         self.sig_module_created.connect(editor.new)
-        self.sig_open_file_requested.connect(editor.load)
 
     @on_plugin_available(plugin=Plugins.Preferences)
     def on_preferences_available(self):
@@ -229,6 +229,11 @@ class Explorer(SpyderDockablePlugin):
             self._chdir_from_working_directory
         )
 
+    @on_plugin_available(plugin=Plugins.Application)
+    def on_application_available(self):
+        application = self.get_plugin(Plugins.Application)
+        self.sig_open_file_requested.connect(application.open_file_in_plugin)
+
     @on_plugin_teardown(plugin=Plugins.Editor)
     def on_editor_teardown(self):
         editor = self.get_plugin(Plugins.Editor)
@@ -240,7 +245,6 @@ class Explorer(SpyderDockablePlugin):
         self.sig_folder_removed.disconnect(editor.removed_tree)
         self.sig_folder_renamed.disconnect(editor.renamed_tree)
         self.sig_module_created.disconnect(editor.new)
-        self.sig_open_file_requested.disconnect(editor.load)
 
     @on_plugin_teardown(plugin=Plugins.Preferences)
     def on_preferences_teardown(self):
@@ -259,6 +263,13 @@ class Explorer(SpyderDockablePlugin):
         working_directory = self.get_plugin(Plugins.WorkingDirectory)
         working_directory.sig_current_directory_changed.disconnect(
             self._chdir_from_working_directory
+        )
+
+    @on_plugin_teardown(plugin=Plugins.Application)
+    def on_application_teardown(self):
+        application = self.get_plugin(Plugins.Application)
+        self.sig_open_file_requested.disconnect(
+            application.open_file_in_plugin
         )
 
     # ---- Public API

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -43,7 +43,7 @@ class Projects(SpyderDockablePlugin):
     CONF_FILE = False
     REQUIRES = []
     OPTIONAL = [Plugins.Completions, Plugins.IPythonConsole, Plugins.Editor,
-                Plugins.MainMenu, Plugins.Switcher]
+                Plugins.MainMenu, Plugins.Switcher, Plugins.Application]
     WIDGET_CLASS = ProjectExplorerWidget
 
     # Signals
@@ -116,7 +116,6 @@ class Projects(SpyderDockablePlugin):
             lambda plugin, check: self._show_main_widget())
 
         if self.main:
-            widget.sig_open_file_requested.connect(self.main.open_file)
             widget.sig_project_loaded.connect(
                 lambda v: self.main.set_window_title())
             widget.sig_project_closed.connect(
@@ -132,7 +131,6 @@ class Projects(SpyderDockablePlugin):
         widget = self.get_widget()
         treewidget = widget.treewidget
 
-        treewidget.sig_open_file_requested.connect(editor.load)
         treewidget.sig_removed.connect(editor.removed)
         treewidget.sig_tree_removed.connect(editor.removed_tree)
         treewidget.sig_renamed.connect(editor.renamed)
@@ -145,8 +143,6 @@ class Projects(SpyderDockablePlugin):
         widget.sig_project_closed[bool].connect(self._setup_editor_files)
         widget.sig_project_loaded.connect(self._set_path_in_editor)
         widget.sig_project_closed.connect(self._unset_path_in_editor)
-        # To handle switcher open request
-        widget.sig_open_file_requested.connect(editor.load)
 
     @on_plugin_available(plugin=Plugins.Completions)
     def on_completions_available(self):
@@ -215,13 +211,18 @@ class Projects(SpyderDockablePlugin):
         self._switcher.sig_search_text_available.connect(
             self._handle_switcher_search)
 
+    @on_plugin_available(plugin=Plugins.Application)
+    def on_application_available(self):
+        application = self.get_plugin(Plugins.Application)
+        widget = self.get_widget()
+        widget.sig_open_file_requested.connect(application.open_file_in_plugin)
+
     @on_plugin_teardown(plugin=Plugins.Editor)
     def on_editor_teardown(self):
         editor = self.get_plugin(Plugins.Editor)
         widget = self.get_widget()
         treewidget = widget.treewidget
 
-        treewidget.sig_open_file_requested.disconnect(editor.load)
         treewidget.sig_removed.disconnect(editor.removed)
         treewidget.sig_tree_removed.disconnect(editor.removed_tree)
         treewidget.sig_renamed.disconnect(editor.renamed)
@@ -234,8 +235,6 @@ class Projects(SpyderDockablePlugin):
         widget.sig_project_closed[bool].disconnect(self._setup_editor_files)
         widget.sig_project_loaded.disconnect(self._set_path_in_editor)
         widget.sig_project_closed.disconnect(self._unset_path_in_editor)
-        # To handle switcher open request
-        widget.sig_open_file_requested.disconnect(editor.load)
 
     @on_plugin_teardown(plugin=Plugins.Completions)
     def on_completions_teardown(self):
@@ -279,6 +278,14 @@ class Projects(SpyderDockablePlugin):
         self._switcher.sig_search_text_available.disconnect(
             self._handle_switcher_search)
         self._switcher = None
+
+    @on_plugin_teardown(plugin=Plugins.Application)
+    def on_application_teardown(self):
+        application = self.get_plugin(Plugins.Application)
+        widget = self.get_widget()
+        widget.sig_open_file_requested.disconnect(
+            application.open_file_in_plugin
+        )
 
     def on_close(self, cancelable=False):
         """Perform actions before parent main window is closed"""

--- a/spyder/plugins/variableexplorer/plugin.py
+++ b/spyder/plugins/variableexplorer/plugin.py
@@ -38,8 +38,10 @@ class VariableExplorer(SpyderDockablePlugin, ShellConnectPluginMixin):
     DISABLE_ACTIONS_WHEN_HIDDEN = False
 
     # Open binary data files in this plugin
-    FILE_EXTENSIONS = [ext for ext in iofunctions.load_funcs
-                       if ext not in ['.csv', '.txt', '.json']]
+    FILE_EXTENSIONS = [
+        ext for ext in iofunctions.load_funcs
+        if ext not in ['.csv', '.txt', '.json']
+    ]
 
     # ---- SpyderDockablePlugin API
     # ------------------------------------------------------------------------

--- a/spyder/plugins/variableexplorer/plugin.py
+++ b/spyder/plugins/variableexplorer/plugin.py
@@ -8,6 +8,9 @@
 Variable Explorer Plugin.
 """
 
+# Third-party imports
+from spyder_kernels.utils.iofuncs import iofunctions
+
 # Local imports
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.plugin_registration.decorators import (
@@ -33,6 +36,10 @@ class VariableExplorer(SpyderDockablePlugin, ShellConnectPluginMixin):
     CONF_FILE = False
     CONF_WIDGET_CLASS = VariableExplorerConfigPage
     DISABLE_ACTIONS_WHEN_HIDDEN = False
+
+    # Open binary data files in this plugin
+    FILE_EXTENSIONS = [ext for ext in iofunctions.load_funcs
+                       if ext not in ['.csv', '.txt', '.json']]
 
     # ---- SpyderDockablePlugin API
     # ------------------------------------------------------------------------
@@ -71,6 +78,12 @@ class VariableExplorer(SpyderDockablePlugin, ShellConnectPluginMixin):
     def on_preferences_teardown(self):
         preferences = self.get_plugin(Plugins.Preferences)
         preferences.deregister_plugin_preferences(self)
+
+    def open_file(self, filename: str):
+        """
+        Load data file in variable explorer.
+        """
+        self.get_widget().import_data([filename])
 
     # ---- Private API
     # -------------------------------------------------------------------------

--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -687,12 +687,12 @@ class Tabs(BaseTabs, SpyderShortcutsMixin):
             (
                 "close file 1",
                 lambda: self.sig_close_tab.emit(self.currentIndex()),
-                "editor",
+                "main",
             ),
             (
                 "close file 2",
                 lambda: self.sig_close_tab.emit(self.currentIndex()),
-                "editor",
+                "main",
             ),
         )
 


### PR DESCRIPTION
## Description of Changes

In short, this PR allows plugins to hook into Spyder's new / open / save / close file operations. I have the Notebook plugin in mind for this but the functionality is more widely useful. There are only a few user-visible changes, unless the user installs a plugin that uses the new functionality. Thanks to PR #8798 for a first iteration on this idea.

Changes in more detail (there are videos at the end):
* The PR moves the actions associated to the following items in the `File` menu from the `Editor` plugin to the `Application` plugin, because the actions are no longer specific to the `Editor` plugin:
    * `New file` (also a toolbar button)
    * `Open` (also a toolbar button)
    * `Open last closed`
    * `Open recent` submenu
    * `Save` (also a toolbar button)
    * `Save all` (also a toolbar button)
    * `Save as`
    * `Save copy as`
    * `Revert`
    * `Close`
    * `Close all`
* As a consequence of this move, shortcut associated with these actions (e.g., Ctrl-N for "new file") move from the "editor" section to the "main" menu. This is one user-visible change.
* The plugin API gets a new attribute named `FILE_EXTENSIONS` in which plugins can list file extensions that they can open. If the user opens a file, then Spyder will call the `open_file` function in the plugin that has the extension of the opened file listed in `FILE_EXTENSIONS`. If no such plugin is found, then the file is opened in the editor, so we default to the existing behaviour. This works for files opened with the `File > Open` menu item, the "Open" toolbar button, the File Explorer, the Project Explorer, or from the command line.
* The Variable Explorer lists all binary file extensions that it can import in `FILE_EXTENSIONS`. This is another user-visible change: if a binary data file is opened, then it will be imported in the Variable Explorer. The existing behaviour is that they are opened in the editor if opened using `File > Open`, but imported in the Variable Explorer as given as a command-line argument.
* The plugin API gets a new attribute named `CAN_HANDLE_FILE_ACTIONS` which defaults to `False`.
* If the plugin with focus has this attribute set to `True`, then the file actions listed in the first bullet point (except for `Open`) will call the associated functions in that plugin; otherwise, functions in the `Editor` plugin will be called. For example, if the user clicks on `New file` and the plugin with focus has `CAN_HANDLE_FILE_ACTIONS` set to `True`, then the `create_new_file` function in the plugin will be called.
* The main window now emits the `sig_focused_plugin_changed` to all plugins if the plugin with focus has changed. The `Application` plugin uses this signal to keep track of the plugin that has focus, so that file actions can be routed to the appropriate plugin.
* Plugins can enable and disable file actions for themselves using the new `enable_file_action` function in the `Application` plugin. File actions in the Spyder IDE are enabled or disabled depending on whether the plugin that would handle the file action has enabled the action.

Below are some videos to show what this all looks like. Firstly, opening `.npy` files now imports the data in the Variable Explorer. No variables are defined at the beginning, but after the file is opened, the variable `eivecs` appears.

https://github.com/user-attachments/assets/05af1519-3a77-4b87-a863-7da724027622

The other videos require the `plugin-open` branch in `spyder-notebook`, which still needs some polishing.

Creating a new file in the Editor works as before. However, if the notebook plugin has focus, then creating a new file opens a new notebook in the notebook plugin.

https://github.com/user-attachments/assets/1a86b758-b5dd-4008-a8e2-3ee8c0269410

At the beginning, the `File > Open recent` submenu has no files in it. We then use the File Explorer to open a notebook, `File > Close` to close it, `File > Open last closed` to open it again, `File > Close` to close it again, and the `File > Open recent` submenu to open it a third time.

https://github.com/user-attachments/assets/e5f5c5c4-75e8-4f79-a442-74b4a42c0847

The `File > Save as` and `File > Save copy as` actions in the Notebook pane:

https://github.com/user-attachments/assets/59202b36-5fad-48db-b7ca-bd17595ec1ae

Finally, a video to illustrate enabling and disabling file actions. The Editor plugin uses `enable_file_action` to enable the `Save` and `Save all` actions when there is something to save and disable them if there is nothing to save. The Notebook plugin uses `enable_file_action` at startup to disable the `Revert` action because it is not implemented. The video shows what this looks like for the user. The Editor plugin has nothing to save in the beginning, so `Save` and `Save all` are disabled and `Revert` is enabled (look at the `File` menu and the "Save" and "Save all" buttons in the toolbar). Then we give focus to the Notebook plugin has focus; now `Save` and `Save all` are enabled and `Revert` is disabled. Then we give focus to the File Explorer plugin. This plugin has `CAN_HANDLE_FILE_ACTIONS` set to `False` so file actions are routed to the Editor and thus `Save` and `Save all` are disabled and `Revert` is enabled. After typing something in the editor, the `Save` and `Save all` actions are also enabled in the editor.

https://github.com/user-attachments/assets/b1306ca2-7c11-4660-8bb1-4cbccce09efb

### Issue(s) Resolved

Fixes #22354
Fixes #7794

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
