### PR TITLE
PR: Add harmless OpenCL warning to bening errors (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -533,6 +533,9 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):
             # dependency of IPykernel.
             # See spyder-ide/spyder#21900
             "debugpy_stream undefined, debugging will not be enabled",
+            # Harmless warning from OpenCL on Windows.
+            # See spyder-ide/spyder#22551
+            "The system cannot find the path specified",
         ]
 
         return any([err in error for err in benign_errors])


### PR DESCRIPTION
## Description of Changes

That warning happens during env activation and prevents the console from starting. But it's not an error that doesn't allow the kernel to work.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22551

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
