### PR TITLE
PR: Pin micromamba to the last version before 2.0 to prevent hangs (CI)

### DIFF
--- a/.github/workflows/test-files.yml
+++ b/.github/workflows/test-files.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Create conda test environment
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.10-0'
           environment-file: requirements/main.yml
           environment-name: test
           cache-downloads: true

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -116,6 +116,7 @@ jobs:
         if: env.USE_CONDA == 'true'
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.10-0'
           environment-file: requirements/main.yml
           environment-name: test
           cache-downloads: true
@@ -124,6 +125,7 @@ jobs:
         if: env.USE_CONDA != 'true'
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.10-0'
           environment-name: test
           cache-downloads: true
           create-args: python=${{ matrix.PYTHON_VERSION }}

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -105,6 +105,7 @@ jobs:
       - name: Create conda test environment
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.10-0'
           environment-file: requirements/main.yml
           environment-name: test
           cache-downloads: true

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -106,6 +106,7 @@ jobs:
         if: env.USE_CONDA == 'true'
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.10-0'
           environment-file: requirements/main.yml
           environment-name: test
           cache-downloads: true
@@ -114,6 +115,7 @@ jobs:
         if: env.USE_CONDA != 'true'
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.10-0'
           environment-name: test
           cache-downloads: true
           create-args: python=${{ matrix.PYTHON_VERSION }}


### PR DESCRIPTION
## Description of Changes

- Micromamba 2.0 was released a few hours ago and it's causing hangs when running our test suite on CIs (it seems it can't solve our env file).
- The fix is to pin its version to the last stable one before 2.0 (i.e. 1.5.10).

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
