### PR TITLE
PR: Set shell banner attribute to be the one computed by us (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -1207,6 +1207,11 @@ overrided by the Sympy module (e.g. plot)
         cursor.setPosition(0)
         self._insert_plain_text(cursor, banner)
 
+        # We need to do this so the banner is available to other QtConsole
+        # methods (e.g. console resets).
+        # Fixes spyder-ide/spyder#22593
+        self.banner = banner
+
         # Only do this once
         self._is_banner_shown = True
 


### PR DESCRIPTION
## Description of Changes

That will make the banner available to other QtConsole methods, e.g. resets.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22593.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
