### PR TITLE
PR: Fix `test_copy_paste_autoindent` forcing text over the clipboard to work (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_autoindent.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_autoindent.py
@@ -469,10 +469,8 @@ def test_copy_paste_autoindent(codeeditor):
     # Copy
     cursor = editor.textCursor()
     cursor.setPosition(30)
-    cursor.setPosition(59, QTextCursor.KeepAnchor)
+    cursor.setPosition(51, QTextCursor.KeepAnchor)
     editor.setTextCursor(cursor)
-    cb = QApplication.clipboard()
-    cb.setText("d\n    if e:\n        f", mode=cb.Clipboard)
     editor.copy()
 
     d = {
@@ -495,10 +493,8 @@ def test_copy_paste_autoindent(codeeditor):
     # Copy
     cursor = editor.textCursor()
     cursor.setPosition(30-4)
-    cursor.setPosition(59, QTextCursor.KeepAnchor)
+    cursor.setPosition(51, QTextCursor.KeepAnchor)
     editor.setTextCursor(cursor)
-    cb = QApplication.clipboard()
-    cb.setText("    d\n    if e:\n        f", mode=cb.Clipboard)
     editor.copy()
 
     d = {


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
<!--- Explain what you've done and why --->

Checking PR #22480 I was able to confirm that the test `spyder\plugins\editor\widgets\codeeditor\tests\test_autoindent.py::test_copy_paste_autoindent` had an error and it was being able to pass by forcing some text to be over the clipboard. The need to use the clipboard directly was due to an incorrect position definition (59 instead of 51) to select text. Also, this position definition was causing a warning (`QtWarningMsg: QTextCursor::setPosition: Position '59' out of range`) since the text used over the test doesn't have such position. This warning can be seen in the PR #22480 failed test `Captured Qt messages` section: https://github.com/spyder-ide/spyder/actions/runs/10797623921/job/30226163168?pr=22480#step:14:6338

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
