### PR TITLE
PR: Some small fixes to the Maintenance instructions

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -9,15 +9,15 @@ These are some instructions meant for maintainers of this repo.
 * If `meeseeksdev` fails to do the backport, you need to manually open a PR against the stable branch to do it with the following actions:
 
     - `git checkout 6.x`
-    - `git checkout -b backport-of-pr-<number>`
-    - `git cherry-pick <commit that was merged to master for that PR>`
+    - `git checkout -b backport-pr-<number>`
+    - `git cherry-pick -m 1 <commit that was merged to master for that PR>`
     - Solve conflicts
 
 * If a PR that involved updating our spyder-kernels subrepo and needs to be included in the stable branch (e.g. `6.x`), you need to manually create a PR against it with the following actions:
 
     - `git checkout 6.x`
-    - `git checkout -b backport-of-pr-<number>`
-    - `git cherry-pick <commit that was merged to master>`
+    - `git checkout -b backport-pr-<number>`
+    - `git cherry-pick -m 1 <commit that was merged to master for that PR>`
     - `git reset -- external-deps/spyder-kernels`
     - `git checkout -- external-deps/spyder-kernels`
     - `git commit` with the files left


### PR DESCRIPTION
## Description of Changes

- `git cherry-pick` was missing an option without which it was not working.
- Simplify name of branches created when doing manual backports.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
