### PR TITLE
PR: Always use `utf-8` when handling QByteArray data in `ProcessWorker` (Utils)

### DIFF
--- a/spyder/utils/workers.py
+++ b/spyder/utils/workers.py
@@ -13,7 +13,6 @@ blocking threads.
 # Standard library imports
 from collections import deque
 import logging
-import os
 import sys
 
 # Third party imports
@@ -124,17 +123,11 @@ class ProcessWorker(QObject):
         self._process.readyReadStandardOutput.connect(self._partial)
 
     def _get_encoding(self):
-        """Return the encoding/codepage to use."""
-        enco = 'utf-8'
-
-        #  Currently only cp1252 is allowed?
-        if os.name == 'nt':
-            import ctypes
-            codepage = to_text_string(ctypes.cdll.kernel32.GetACP())
-            # import locale
-            # locale.getpreferredencoding()  # Differences?
-            enco = 'cp' + codepage
-        return enco
+        """Return the encoding to use."""
+        # It seems that in Python 3 we only need this encoding to correctly
+        # decode bytes on all operating systems.
+        # See spyder-ide/spyder#22546
+        return 'utf-8'
 
     def _set_environment(self, environ):
         """Set the environment on the QProcess."""


### PR DESCRIPTION
## Description of Changes

- It seems the previous approach (using the Windows code page) was necessary to have compatibility with Python 2.
- That was affecting opening project files in our switcher with the help of `fzf`.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22546.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
