### PR TITLE
PR: Manually register the Matplotlib inline backend in case it hasn't

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/ccordoba12/spyder-kernels.git
-	branch = fix-registering-inline-backend
-	commit = d8855d4fc26f511352795fc520a62e0afefe767d
-	parent = 565e9b3fd14a2e7d22d205cc4d13ec2ba428c7ed
+	remote = https://github.com/spyder-ide/spyder-kernels.git
+	branch = master
+	commit = f9fc2f62179a98cf582b44306a9f9225506ec532
+	parent = 3d037175c3ae4bb20f1366a6e5446ae064ed6306
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = master
-	commit = 705618596160a1d65a7a0fc71cec1cfc41fbcaeb
-	parent = 3852ec47717cd061a2b9719501a5b5e1f9571f18
+	remote = https://github.com/ccordoba12/spyder-kernels.git
+	branch = fix-registering-inline-backend
+	commit = d8855d4fc26f511352795fc520a62e0afefe767d
+	parent = 565e9b3fd14a2e7d22d205cc4d13ec2ba428c7ed
 	method = merge
 	cmdver = 0.4.9


### PR DESCRIPTION
## Description of Changes

- This can be necessary when there's a mismatch between the installed versions of IPython, matplotlib and matplotlib-inline.
- I don't know how to add a test for this, but I can confirm it solves the problem for me locally.
- Depends on https://github.com/spyder-ide/spyder-kernels/pull/517

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22420 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
