### PR TITLE
PR: Don't use hard-coded path to Python in script shebang used to launch Spyder

### DIFF
--- a/scripts/spyder
+++ b/scripts/spyder
@@ -1,3 +1,3 @@
-#! /usr/bin/python3
+#!/usr/bin/env python3
 from spyder.app import start
 start.main()


### PR DESCRIPTION
Don't use hard-coded path to python in shebang.

This allows spyder to work in other environments which have python installed in a different directory.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Flamefire