### PR TITLE
PR: Allow errors when getting the Layout plugin to be raised (Main Window)

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -780,12 +780,22 @@ class MainWindow(
         as before, e.g self.console or self.main.console, preserving the
         same accessor as before.
         """
+        # It seems the Layout plugin is failing to be loaded under some
+        # circumstances, so we need errors for it to be raised. That way,
+        # they'll be reported by users on Github.
+        # See spyder-ide/spyder#22639
+        if attr == "layouts":
+            return self.get_plugin(
+                self._INTERNAL_PLUGINS_MAPPING[attr], error=True
+            )
+
         # Mapping of new plugin identifiers vs old attributtes
         # names given for plugins
         try:
             if attr in self._INTERNAL_PLUGINS_MAPPING.keys():
                 return self.get_plugin(
-                    self._INTERNAL_PLUGINS_MAPPING[attr], error=False)
+                    self._INTERNAL_PLUGINS_MAPPING[attr], error=False
+                )
             return self.get_plugin(attr)
         except SpyderAPIError:
             pass


### PR DESCRIPTION
## Description of Changes

- It seems the Layout plugin is failing to be loaded under some circumstances, which is really bad.
- So, if errors for it are raised, they'll be reported by users on Github and we'll be able to solve them.

### Issue(s) Resolved

Part of #22639

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
