### PR TITLE
PR: Add `Help Spyder` entry to the Help menu (Application)

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -101,11 +101,14 @@ if not args.no_install:
         REPOS[DEVPATH.name]["editable"] = False
 
     for name in REPOS.keys():
-        if not REPOS[name]['editable']:
-            install_repo(name)
-            installed_dev_repo = True
-        else:
-            logger.info("%s installed in editable mode", name)
+        # Don't install the spyder-remote-services subrepo because it's not
+        # necessary on the Spyder side.
+        if name != "spyder-remote-services":
+            if not REPOS[name]['editable']:
+                install_repo(name)
+                installed_dev_repo = True
+            else:
+                logger.info("%s installed in editable mode", name)
 
 if installed_dev_repo:
     logger.info("Restarting bootstrap to pick up installed subrepos")

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -55,6 +55,7 @@ class ApplicationActions:
     SpyderTroubleshootingAction = "spyder_troubleshooting_action"
     SpyderDependenciesAction = "spyder_dependencies_action"
     SpyderSupportAction = "spyder_support_action"
+    HelpSpyderAction = "help_spyder_action"
     SpyderAbout = "spyder_about_action"
 
     # Tools
@@ -136,6 +137,13 @@ class ApplicationContainer(PluginMainContainer):
             ApplicationActions.SpyderSupportAction,
             _("Spyder support..."),
             triggered=lambda: start_file(__forum_url__))
+
+        self.create_action(
+            ApplicationActions.HelpSpyderAction,
+            _("Help Spyder..."),
+            icon=self.create_icon("inapp_appeal"),
+            triggered=self.inapp_appeal_status.show_appeal
+        )
 
         # About action
         self.about_action = self.create_action(

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -223,13 +223,18 @@ class Application(SpyderPluginV2):
         """Add Spyder base support actions to the Help main menu."""
         mainmenu = self.get_plugin(Plugins.MainMenu)
         for support_action in [
-                self.trouble_action, self.report_action,
-                self.dependencies_action, self.support_group_action]:
+            self.trouble_action,
+            self.report_action,
+            self.dependencies_action,
+            self.support_group_action,
+            self.get_action(ApplicationActions.HelpSpyderAction),
+        ]:
             mainmenu.add_item_to_application_menu(
                 support_action,
                 menu_id=ApplicationMenus.Help,
                 section=HelpMenuSections.Support,
-                before_section=HelpMenuSections.ExternalDocumentation)
+                before_section=HelpMenuSections.ExternalDocumentation
+            )
 
     def _populate_help_menu_about_section(self):
         """Create Spyder base about actions."""

--- a/spyder/plugins/application/widgets/status.py
+++ b/spyder/plugins/application/widgets/status.py
@@ -118,6 +118,8 @@ class InAppAppealStatus(BaseTimerStatus):
     def show_appeal(self):
         if self._appeal_dialog is None:
             self._appeal_dialog = InAppAppealDialog(self)
+
+        if not self._appeal_dialog.isVisible():
             self._appeal_dialog.show()
 
     # ---- StatusBarWidget API


### PR DESCRIPTION
## Description of Changes

- This will help users to find where to donate to the project in our interface in case they miss the heart hint we show in the status bar.
- Also, don't install `spyder-remote-services` when running Spyder from `bootstrap.py` because it's not necessary.

### Visual changes

![help-spyder-menu-entry](https://github.com/user-attachments/assets/ae85ff48-d98f-47aa-b8b9-87a2e1e423f6)

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
