### PR TITLE
PR: Restore buttons that control the debugger to the main toolbar

### DIFF
--- a/spyder/api/_version.py
+++ b/spyder/api/_version.py
@@ -9,10 +9,10 @@ Spyder API Version.
 
 The API version should be modified according to the following rules:
 
-1. If a module/class/method/function is added, then the minor version
+1. If a module/class/method/function/signal is added, then the minor version
    must be increased.
 
-2. If a module/class/method/function is removed, renamed or changes its
+2. If a module/class/method/function/signal is removed, renamed or changes its
    signature, then the major version must be increased.
 
 3. Whenever possible, deprecation marks and alerts should be employed in
@@ -22,5 +22,5 @@ The API version should be modified according to the following rules:
    updated.
 """
 
-VERSION_INFO = (1, 0, 0)
+VERSION_INFO = (1, 1, 0)
 __version__ = '.'.join(map(str, VERSION_INFO))

--- a/spyder/api/widgets/toolbars.py
+++ b/spyder/api/widgets/toolbars.py
@@ -303,6 +303,12 @@ class ApplicationToolbar(SpyderToolbar):
 
         self.setStyleSheet(str(APP_TOOLBAR_STYLESHEET))
 
+    def __str__(self):
+        return f"ApplicationToolbar('{self.ID}')"
+
+    def __repr__(self):
+        return f"ApplicationToolbar('{self.ID}')"
+
 
 class MainWidgetToolbar(SpyderToolbar):
     """

--- a/spyder/api/widgets/toolbars.py
+++ b/spyder/api/widgets/toolbars.py
@@ -16,7 +16,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import uuid
 
 # Third part imports
-from qtpy.QtCore import QEvent, QObject, QSize, Qt
+from qtpy.QtCore import QEvent, QObject, QSize, Qt, Signal
 from qtpy.QtWidgets import (
     QAction, QProxyStyle, QStyle, QToolBar, QToolButton, QWidget)
 
@@ -102,6 +102,12 @@ class SpyderToolbar(QToolBar):
     Spyder Toolbar.
 
     This class provides toolbars with some predefined functionality.
+    """
+
+    sig_is_rendered = Signal()
+    """
+    This signal is emitted to let other objects know that the toolbar is now
+    rendered.
     """
 
     def __init__(self, parent, title):
@@ -278,6 +284,8 @@ class SpyderToolbar(QToolBar):
 
                 if item.isCheckable():
                     widget.setCheckable(True)
+
+        self.sig_is_rendered.emit()
 
 
 class ApplicationToolbar(SpyderToolbar):

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -101,6 +101,7 @@ DEFAULTS = [
                   ApplicationToolbars.Main,
                   ApplicationToolbars.WorkingDirectory,
               ],
+              'toolbars_order': [],
              }),
             ('statusbar',
              {

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -101,7 +101,7 @@ DEFAULTS = [
                   ApplicationToolbars.Main,
                   ApplicationToolbars.WorkingDirectory,
               ],
-              'toolbars_order': [],
+              'last_toolbars': [],
              }),
             ('statusbar',
              {

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -16,6 +16,7 @@ import os
 import sys
 
 # Local import
+from spyder.plugins.toolbar.api import ApplicationToolbars
 from spyder.config.base import CHECK_ALL, EXCLUDED_NAMES
 from spyder.config.utils import IMPORT_EXT
 from spyder.config.appearance import APPEARANCE
@@ -93,7 +94,13 @@ DEFAULTS = [
              {
               'enable': True,
               'toolbars_visible': True,
-              'last_visible_toolbars': [],
+              'last_visible_toolbars': [
+                  ApplicationToolbars.File,
+                  ApplicationToolbars.Run,
+                  ApplicationToolbars.Debug,
+                  ApplicationToolbars.Main,
+                  ApplicationToolbars.WorkingDirectory,
+              ],
              }),
             ('statusbar',
              {
@@ -587,10 +594,6 @@ NAME_MAP = {
             'window/state',
             ]
          ),
-        ('toolbar', [
-            'last_visible_toolbars',
-            ]
-         ),
         ('editor', [
             'autosave_mapping',
             'bookmarks',
@@ -672,4 +675,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '84.2.0'
+CONF_VERSION = '84.3.0'

--- a/spyder/plugins/debugger/plugin.py
+++ b/spyder/plugins/debugger/plugin.py
@@ -41,7 +41,7 @@ class Debugger(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
 
     NAME = 'debugger'
     REQUIRES = [Plugins.IPythonConsole, Plugins.Preferences, Plugins.Run]
-    OPTIONAL = [Plugins.Editor, Plugins.MainMenu]
+    OPTIONAL = [Plugins.Editor, Plugins.MainMenu, Plugins.Toolbar]
     TABIFY = [Plugins.VariableExplorer, Plugins.Help]
     WIDGET_CLASS = DebuggerWidget
     CONF_SECTION = NAME
@@ -324,6 +324,38 @@ class Debugger(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
             mainmenu.remove_item_from_application_menu(
                 name,
                 menu_id=ApplicationMenus.Debug
+            )
+
+    @on_plugin_available(plugin=Plugins.Toolbar)
+    def on_toolbar_available(self):
+        toolbar = self.get_plugin(Plugins.Toolbar)
+
+        for action_id in [
+            DebuggerWidgetActions.Next,
+            DebuggerWidgetActions.Step,
+            DebuggerWidgetActions.Return,
+            DebuggerWidgetActions.Continue,
+            DebuggerWidgetActions.Stop,
+        ]:
+            toolbar.add_item_to_application_toolbar(
+                self.get_action(action_id),
+                toolbar_id=ApplicationToolbars.ControlDebugger,
+            )
+
+    @on_plugin_teardown(plugin=Plugins.Toolbar)
+    def on_toolbar_teardonw(self):
+        toolbar = self.get_plugin(Plugins.Toolbar)
+
+        for action_id in [
+            DebuggerWidgetActions.Next,
+            DebuggerWidgetActions.Step,
+            DebuggerWidgetActions.Return,
+            DebuggerWidgetActions.Continue,
+            DebuggerWidgetActions.Stop,
+        ]:
+            toolbar.remove_item_from_application_toolbar(
+                action_id,
+                toolbar_id=ApplicationToolbars.ControlDebugger,
             )
 
     # ---- Private API

--- a/spyder/plugins/debugger/plugin.py
+++ b/spyder/plugins/debugger/plugin.py
@@ -351,6 +351,13 @@ class Debugger(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
                 toolbar_id=ApplicationToolbars.Debug,
             )
 
+        debug_toolbar = toolbar.get_application_toolbar(
+            ApplicationToolbars.Debug
+        )
+        debug_toolbar.sig_is_rendered.connect(
+            self.get_widget().on_debug_toolbar_rendered
+        )
+
     @on_plugin_teardown(plugin=Plugins.Toolbar)
     def on_toolbar_teardown(self):
         toolbar = self.get_plugin(Plugins.Toolbar)

--- a/spyder/plugins/debugger/plugin.py
+++ b/spyder/plugins/debugger/plugin.py
@@ -167,7 +167,10 @@ class Debugger(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
                 "section": DebugMenuSections.StartDebug,
                 "before_section": DebugMenuSections.ControlDebug
             },
-            add_to_toolbar=ApplicationToolbars.Debug,
+            add_to_toolbar={
+                "toolbar": ApplicationToolbars.Debug,
+                "before": DebuggerWidgetActions.Next,
+            },
             shortcut_widget_context=Qt.ApplicationShortcut,
         )
 
@@ -184,7 +187,10 @@ class Debugger(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
                 "section": DebugMenuSections.StartDebug,
                 "before_section": DebugMenuSections.ControlDebug
             },
-            add_to_toolbar=ApplicationToolbars.Debug
+            add_to_toolbar={
+                "toolbar": ApplicationToolbars.Debug,
+                "before": DebuggerWidgetActions.Next,
+            },
         )
 
         run.create_run_in_executor_button(
@@ -200,7 +206,10 @@ class Debugger(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
                 "section": DebugMenuSections.StartDebug,
                 "before_section": DebugMenuSections.ControlDebug
             },
-            add_to_toolbar=ApplicationToolbars.Debug
+            add_to_toolbar={
+                "toolbar": ApplicationToolbars.Debug,
+                "before": DebuggerWidgetActions.Next,
+            },
         )
 
     @on_plugin_teardown(plugin=Plugins.Run)
@@ -339,11 +348,11 @@ class Debugger(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
         ]:
             toolbar.add_item_to_application_toolbar(
                 self.get_action(action_id),
-                toolbar_id=ApplicationToolbars.ControlDebugger,
+                toolbar_id=ApplicationToolbars.Debug,
             )
 
     @on_plugin_teardown(plugin=Plugins.Toolbar)
-    def on_toolbar_teardonw(self):
+    def on_toolbar_teardown(self):
         toolbar = self.get_plugin(Plugins.Toolbar)
 
         for action_id in [
@@ -355,7 +364,7 @@ class Debugger(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
         ]:
             toolbar.remove_item_from_application_toolbar(
                 action_id,
-                toolbar_id=ApplicationToolbars.ControlDebugger,
+                toolbar_id=ApplicationToolbars.Debug,
             )
 
     # ---- Private API

--- a/spyder/plugins/run/plugin.py
+++ b/spyder/plugins/run/plugin.py
@@ -139,12 +139,25 @@ class Run(SpyderPluginV2):
     def on_toolbar_available(self):
         toolbar = self.get_plugin(Plugins.Toolbar)
         toolbar.add_item_to_application_toolbar(
-            self.get_action(RunActions.Run), ApplicationToolbars.Run)
+            self.get_action(RunActions.Run), ApplicationToolbars.Run
+        )
 
         while self.pending_toolbar_actions != []:
-            action, toolbar_id = self.pending_toolbar_actions.pop(0)
+            (
+                action,
+                toolbar_id,
+                section,
+                before,
+                before_section,
+            ) = self.pending_toolbar_actions.pop(0)
+
             toolbar.add_item_to_application_toolbar(
-                action, toolbar_id)
+                action,
+                toolbar_id,
+                section,
+                before,
+                before_section,
+            )
 
     @on_plugin_available(plugin=Plugins.Shortcuts)
     def on_shortcuts_available(self):
@@ -407,7 +420,7 @@ class Run(SpyderPluginV2):
         register_shortcut: bool = False,
         extra_action_name: Optional[str] = None,
         context_modificator: Optional[str] = None,
-        add_to_toolbar: bool | str = False,
+        add_to_toolbar: bool | str | dict = False,
         add_to_menu: bool | dict = False,
         re_run: bool = False
     ) -> QAction:
@@ -438,7 +451,10 @@ class Run(SpyderPluginV2):
             selection <up to line>.
         add_to_toolbar: bool or str
             If True, then the action will be added to the Run section of the
-            main toolbar. If a string, it must be a toolbar_id
+            main toolbar. If a string, it must be a toolbar_id. If dictionary,
+            it corresponds to
+            {'toolbar': ..., 'section': ..., 'before': ...,
+             'before_section': ...}
         add_to_menu: bool or dict
             If True, then the action will be added to the Run menu.
             If a dictionnary, it corresponds to 
@@ -488,16 +504,39 @@ class Run(SpyderPluginV2):
         )
 
         if add_to_toolbar:
-            toolbar_id = ApplicationToolbars.Run
+            toolbar_id, section, before, before_section = (
+                ApplicationToolbars.Run,
+                None,
+                None,
+                None
+            )
             if isinstance(add_to_toolbar, str):
                 toolbar_id = add_to_toolbar
+            if isinstance(add_to_toolbar, dict):
+                toolbar_id = add_to_toolbar['toolbar']
+                section = add_to_toolbar.get('section')
+                before = add_to_toolbar.get('before')
+                before_section = add_to_menu.get('before_section')
 
             toolbar = self.get_plugin(Plugins.Toolbar)
             if toolbar:
                 toolbar.add_item_to_application_toolbar(
-                    action, toolbar_id)
+                    action,
+                    toolbar_id,
+                    section,
+                    before,
+                    before_section,
+                )
             else:
-                self.pending_toolbar_actions.append((action, toolbar_id))
+                self.pending_toolbar_actions.append(
+                    (
+                        action,
+                        toolbar_id,
+                        section,
+                        before,
+                        before_section,
+                    )
+                )
 
             self.toolbar_actions |= {key}
 
@@ -614,7 +653,7 @@ class Run(SpyderPluginV2):
         tip: Optional[str] = None,
         shortcut_context: Optional[str] = None,
         register_shortcut: bool = False,
-        add_to_toolbar: bool | str = False,
+        add_to_toolbar: bool | str | dict = False,
         add_to_menu: bool | dict = False,
         shortcut_widget_context: Qt.ShortcutContext = Qt.WidgetShortcut,
     ) -> QAction:
@@ -639,9 +678,12 @@ class Run(SpyderPluginV2):
         register_shortcut: bool
             If True, main window will expose the shortcut in Preferences.
             The default value is `False`.
-        add_to_toolbar: bool or str
+        add_to_toolbar: bool or str or dict
             If True, then the action will be added to the Run section of the
-            main toolbar. If a string, it will be a toolbat id
+            main toolbar. If a string, it must be a toolbar_id. If dictionary,
+            it corresponds to
+            {'toolbar': ..., 'section': ..., 'before': ...,
+             'before_section': ...}
         add_to_menu: bool or dict
             If True, then the action will be added to the Run menu.
             If a dictionnary, it corresponds to 
@@ -685,16 +727,39 @@ class Run(SpyderPluginV2):
         )
 
         if add_to_toolbar:
-            toolbar_id = ApplicationToolbars.Run
+            toolbar_id, section, before, before_section = (
+                ApplicationToolbars.Run,
+                None,
+                None,
+                None
+            )
             if isinstance(add_to_toolbar, str):
                 toolbar_id = add_to_toolbar
+            if isinstance(add_to_toolbar, dict):
+                toolbar_id = add_to_toolbar['toolbar']
+                section = add_to_toolbar.get('section')
+                before = add_to_toolbar.get('before')
+                before_section = add_to_menu.get('before_section')
 
             toolbar = self.get_plugin(Plugins.Toolbar)
             if toolbar:
                 toolbar.add_item_to_application_toolbar(
-                    action, toolbar_id)
+                    action,
+                    toolbar_id,
+                    section,
+                    before,
+                    before_section,
+                )
             else:
-                self.pending_toolbar_actions.append((action, toolbar_id))
+                self.pending_toolbar_actions.append(
+                    (
+                        action,
+                        toolbar_id,
+                        section,
+                        before,
+                        before_section,
+                    )
+                )
 
             self.toolbar_actions |= {key}
 

--- a/spyder/plugins/toolbar/api.py
+++ b/spyder/plugins/toolbar/api.py
@@ -15,6 +15,7 @@ class ApplicationToolbars:
     File = 'file_toolbar'
     Run = 'run_toolbar'
     Debug = 'debug_toolbar'
+    ControlDebugger = "control_debugger_toolbar"
     Main = 'main_toolbar'
     WorkingDirectory = 'working_directory_toolbar'
 

--- a/spyder/plugins/toolbar/api.py
+++ b/spyder/plugins/toolbar/api.py
@@ -15,7 +15,6 @@ class ApplicationToolbars:
     File = 'file_toolbar'
     Run = 'run_toolbar'
     Debug = 'debug_toolbar'
-    ControlDebugger = "control_debugger_toolbar"
     Main = 'main_toolbar'
     WorkingDirectory = 'working_directory_toolbar'
 

--- a/spyder/plugins/toolbar/container.py
+++ b/spyder/plugins/toolbar/container.py
@@ -64,8 +64,8 @@ class ToolbarContainer(PluginMainContainer):
 
         self._APPLICATION_TOOLBARS = OrderedDict()
         self._ADDED_TOOLBARS = OrderedDict()
-        self._toolbarslist = []
-        self._visible_toolbars = []
+        self._toolbarslist: list[ApplicationToolbar] = []
+        self._visible_toolbars: list[ApplicationToolbar] = []
         self._ITEMS_QUEUE: Dict[str, List[ItemInfo]] = {}
 
     # ---- Private Methods
@@ -397,28 +397,28 @@ class ToolbarContainer(PluginMainContainer):
         self._save_visible_toolbars()
 
     def load_last_visible_toolbars(self):
-        """Load the last visible toolbars from our preferences."""
+        """Load the last visible toolbars saved in our config system."""
         toolbars_names = self.get_conf('last_visible_toolbars')
         toolbars_visible = self.get_conf("toolbars_visible")
 
-        if toolbars_names:
-            toolbars_dict = {}
-            for toolbar in self._toolbarslist:
-                toolbars_dict[toolbar.objectName()] = toolbar
+        # This is necessary to discard toolbars that were available in the last
+        # session but are not on this one.
+        visible_toolbars = []
+        for name in toolbars_names:
+            if name in self._APPLICATION_TOOLBARS:
+                visible_toolbars.append(self._APPLICATION_TOOLBARS[name])
 
-            toolbars = []
-            for name in toolbars_names:
-                if name in toolbars_dict:
-                    toolbars.append(toolbars_dict[name])
+        # Update visible toolbars
+        self._visible_toolbars = visible_toolbars
 
-            self._visible_toolbars = toolbars
-        else:
-            # This is necessary to set the toolbars in EditorMainWindow the
-            # first time Spyder starts.
-            self.save_last_visible_toolbars()
-
-        for toolbar in self._visible_toolbars:
-            toolbar.setVisible(toolbars_visible)
+        # Show visible/hidden toolbars
+        for toolbar in self._toolbarslist:
+            if toolbar in self._visible_toolbars:
+                toolbar.setVisible(toolbars_visible)
+                toolbar.toggleViewAction().setChecked(toolbars_visible)
+            else:
+                toolbar.setVisible(False)
+                toolbar.toggleViewAction().setChecked(False)
 
         self.update_actions()
 

--- a/spyder/plugins/toolbar/container.py
+++ b/spyder/plugins/toolbar/container.py
@@ -78,8 +78,8 @@ class ToolbarContainer(PluginMainContainer):
 
         self.set_conf('last_visible_toolbars', toolbars)
 
-    def _get_visible_toolbars(self):
-        """Collect the visible toolbars."""
+    def _set_visible_toolbars(self):
+        """Set the current visible toolbars in an attribute."""
         toolbars = []
         for toolbar in self._toolbarslist:
             if (
@@ -98,7 +98,7 @@ class ToolbarContainer(PluginMainContainer):
         if value:
             self._save_visible_toolbars()
         else:
-            self._get_visible_toolbars()
+            self._set_visible_toolbars()
 
         for toolbar in self._visible_toolbars:
             toolbar.setVisible(value)
@@ -393,7 +393,7 @@ class ToolbarContainer(PluginMainContainer):
     def save_last_visible_toolbars(self):
         """Save the last visible toolbars state in our preferences."""
         if self.get_conf("toolbars_visible"):
-            self._get_visible_toolbars()
+            self._set_visible_toolbars()
         self._save_visible_toolbars()
 
     def load_last_visible_toolbars(self):

--- a/spyder/plugins/toolbar/container.py
+++ b/spyder/plugins/toolbar/container.py
@@ -355,6 +355,7 @@ class ToolbarContainer(PluginMainContainer):
             ApplicationToolbars.File,
             ApplicationToolbars.Run,
             ApplicationToolbars.Debug,
+            ApplicationToolbars.ControlDebugger,
             ApplicationToolbars.Main,
         ]
 

--- a/spyder/plugins/toolbar/container.py
+++ b/spyder/plugins/toolbar/container.py
@@ -325,16 +325,16 @@ class ToolbarContainer(PluginMainContainer):
 
         return self._APPLICATION_TOOLBARS[toolbar_id]
 
-    def get_application_toolbars(self) -> List[ApplicationToolbar]:
+    def get_application_toolbars(self) -> Dict[str, ApplicationToolbar]:
         """
         Return all created application toolbars.
 
         Returns
         -------
-        list
-            The list of all the added application toolbars.
+        dict
+            The dict of all the added application toolbars.
         """
-        return self._toolbarslist
+        return self._APPLICATION_TOOLBARS
 
     def save_last_visible_toolbars(self):
         """Save the last visible toolbars state in our preferences."""

--- a/spyder/plugins/toolbar/container.py
+++ b/spyder/plugins/toolbar/container.py
@@ -359,7 +359,6 @@ class ToolbarContainer(PluginMainContainer):
             ApplicationToolbars.File,
             ApplicationToolbars.Run,
             ApplicationToolbars.Debug,
-            ApplicationToolbars.ControlDebugger,
             ApplicationToolbars.Main,
         ]
 

--- a/spyder/plugins/toolbar/container.py
+++ b/spyder/plugins/toolbar/container.py
@@ -166,13 +166,6 @@ class ToolbarContainer(PluginMainContainer):
             )
 
         toolbar = ApplicationToolbar(self, toolbar_id, title)
-        toolbar.setObjectName(toolbar_id)
-
-        TOOLBAR_REGISTRY.register_reference(
-            toolbar, toolbar_id, self.PLUGIN_NAME, self.CONTEXT_NAME
-        )
-        self._APPLICATION_TOOLBARS[toolbar_id] = toolbar
-
         self._add_missing_toolbar_elements(toolbar, toolbar_id)
         return toolbar
 
@@ -203,6 +196,12 @@ class ToolbarContainer(PluginMainContainer):
         if toolbar_id in self._ADDED_TOOLBARS:
             raise SpyderAPIError(
                 'Toolbar with ID "{}" already added!'.format(toolbar_id))
+
+        # Add toolbar to registry and add it to the app toolbars dict
+        TOOLBAR_REGISTRY.register_reference(
+            toolbar, toolbar_id, self.PLUGIN_NAME, self.CONTEXT_NAME
+        )
+        self._APPLICATION_TOOLBARS[toolbar_id] = toolbar
 
         # TODO: Make the icon size adjustable in Preferences later on.
         iconsize = 24

--- a/spyder/plugins/toolbar/plugin.py
+++ b/spyder/plugins/toolbar/plugin.py
@@ -38,8 +38,8 @@ class Toolbar(SpyderPluginV2):
     CONTAINER_CLASS = ToolbarContainer
     CAN_BE_DISABLED = False
 
-    # --- SpyderDocakblePlugin API
-    #  -----------------------------------------------------------------------
+    # ---- SpyderPluginV2 API
+    # -------------------------------------------------------------------------
     @staticmethod
     def get_name():
         return _('Toolbar')
@@ -100,11 +100,14 @@ class Toolbar(SpyderPluginV2):
 
     def on_close(self, _unused):
         container = self.get_container()
+
+        # NOTE: DO NOT change the order in which these methods are called!
         container.save_last_visible_toolbars()
+        container.save_toolbars_order()
         for toolbar in container._visible_toolbars:
             toolbar.setVisible(False)
 
-    # --- Public API
+    # ---- Public API
     # ------------------------------------------------------------------------
     def create_application_toolbar(self, toolbar_id, title):
         """
@@ -234,7 +237,8 @@ class Toolbar(SpyderPluginV2):
         for toolbar in self.toolbarslist:
             toolbar.setMovable(not value)
 
-    # --- Convenience properties, while all plugins migrate.
+    # ---- Convenience properties
+    # -------------------------------------------------------------------------
     @property
     def toolbars_menu(self):
         return self.get_container().get_menu("toolbars_menu")

--- a/spyder/plugins/toolbar/plugin.py
+++ b/spyder/plugins/toolbar/plugin.py
@@ -88,9 +88,10 @@ class Toolbar(SpyderPluginV2):
     def on_mainwindow_visible(self):
         container = self.get_container()
 
-        for toolbar in self.toolbarslist:
-            toolbar.render()
+        # Load all toolbars
+        container.load_application_toolbars()
 
+        # Create toolbars menu and show last visible toolbars
         container.create_toolbars_menu()
         container.load_last_visible_toolbars()
 

--- a/spyder/plugins/toolbar/plugin.py
+++ b/spyder/plugins/toolbar/plugin.py
@@ -88,7 +88,7 @@ class Toolbar(SpyderPluginV2):
     def on_mainwindow_visible(self):
         container = self.get_container()
 
-        for toolbar in container.get_application_toolbars():
+        for toolbar in self.toolbarslist:
             toolbar.render()
 
         container.create_toolbars_menu()

--- a/spyder/plugins/toolbar/plugin.py
+++ b/spyder/plugins/toolbar/plugin.py
@@ -57,9 +57,6 @@ class Toolbar(SpyderPluginV2):
         create_app_toolbar(ApplicationToolbars.File, _("File toolbar"))
         create_app_toolbar(ApplicationToolbars.Run, _("Run toolbar"))
         create_app_toolbar(ApplicationToolbars.Debug, _("Debug toolbar"))
-        create_app_toolbar(
-            ApplicationToolbars.ControlDebugger, _("Control debugger toolbar")
-        )
         create_app_toolbar(ApplicationToolbars.Main, _("Main toolbar"))
 
     @on_plugin_available(plugin=Plugins.MainMenu)

--- a/spyder/plugins/toolbar/plugin.py
+++ b/spyder/plugins/toolbar/plugin.py
@@ -100,10 +100,8 @@ class Toolbar(SpyderPluginV2):
 
     def on_close(self, _unused):
         container = self.get_container()
-
-        # NOTE: DO NOT change the order in which these methods are called!
         container.save_last_visible_toolbars()
-        container.save_toolbars_order()
+        container.save_last_toolbars()
         for toolbar in container._visible_toolbars:
             toolbar.setVisible(False)
 

--- a/spyder/plugins/toolbar/plugin.py
+++ b/spyder/plugins/toolbar/plugin.py
@@ -57,6 +57,9 @@ class Toolbar(SpyderPluginV2):
         create_app_toolbar(ApplicationToolbars.File, _("File toolbar"))
         create_app_toolbar(ApplicationToolbars.Run, _("Run toolbar"))
         create_app_toolbar(ApplicationToolbars.Debug, _("Debug toolbar"))
+        create_app_toolbar(
+            ApplicationToolbars.ControlDebugger, _("Control debugger toolbar")
+        )
         create_app_toolbar(ApplicationToolbars.Main, _("Main toolbar"))
 
     @on_plugin_available(plugin=Plugins.MainMenu)

--- a/spyder/plugins/toolbar/tests/__init__.py
+++ b/spyder/plugins/toolbar/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""
+Tests for the Toolbar Plugin.
+"""

--- a/spyder/plugins/toolbar/tests/test_toolbar.py
+++ b/spyder/plugins/toolbar/tests/test_toolbar.py
@@ -93,16 +93,15 @@ def test_default_order(toolbar):
     assert current_order == sorted(current_order)
 
 
-def test_restore_toolbar_order(toolbar, qtbot):
+def test_restore_toolbars_order(toolbar, qtbot):
     """
     Check that if a toolbar is moved by users to a different position, then the
-    new order is saved on close and restored during the next startup.
+    new order is restored during the next startup.
     """
     new_order = [
         ApplicationToolbars.Debug,
         ApplicationToolbars.File,
         ApplicationToolbars.Run,
-        ApplicationToolbars.ControlDebugger,
         ApplicationToolbars.Main,
     ]
 
@@ -118,8 +117,8 @@ def test_restore_toolbar_order(toolbar, qtbot):
     # Close toolbar plugin (which is called when the main window is closed)
     toolbar.on_close(False)
 
-    # Check the order was saved as expected to our config system
-    assert toolbar.get_conf("toolbars_order") == new_order
+    # Check the list of available toolbars was saved to our config system
+    assert toolbar.get_conf("last_toolbars")
 
     # Reload toolbars as if a new Spyder session was started
     toolbar.on_mainwindow_visible()
@@ -133,10 +132,10 @@ def test_restore_toolbar_order(toolbar, qtbot):
     assert current_order == sorted(current_order)
 
 
-def test_no_toolbar_after_working_directory(toolbar, qtbot):
+def test_reorder_toolbars(toolbar, qtbot):
     """
-    Check that any toolbar that is placed to the right of the working directory
-    is repositioned to its left during the next startup.
+    Check that if a toolbar is removed, then toolbars are reordered the next
+    time with the working directory being shown to the right.
     """
     # Select the toolbars we are going to move
     cwd_toolbar = toolbar.get_application_toolbar(
@@ -152,6 +151,10 @@ def test_no_toolbar_after_working_directory(toolbar, qtbot):
     # Close toolbar plugin (which is called when the main window is closed)
     toolbar.on_close(False)
     qtbot.wait(500)
+
+    # Simulate that a toolbar was present in the last sesstion and then removed
+    last_toolbars = toolbar.get_conf("last_toolbars")
+    toolbar.set_conf("last_toolbars", last_toolbars + ["foo_toolbar"])
 
     # Reload toolbars as if a new Spyder session was started
     toolbar.on_mainwindow_visible()

--- a/spyder/plugins/toolbar/tests/test_toolbar.py
+++ b/spyder/plugins/toolbar/tests/test_toolbar.py
@@ -40,7 +40,6 @@ def toolbar(qtbot):
         (ApplicationToolbars.File, "filenew"),
         (ApplicationToolbars.Run, "run"),
         (ApplicationToolbars.Debug, "debug"),
-        (ApplicationToolbars.ControlDebugger, "arrow-step-over"),
         (ApplicationToolbars.Main, "python"),
     ]
 
@@ -70,19 +69,9 @@ def test_default_order(toolbar):
         ApplicationToolbars.File,
         ApplicationToolbars.Run,
         ApplicationToolbars.Debug,
-        ApplicationToolbars.ControlDebugger,
         ApplicationToolbars.Main,
         ApplicationToolbars.WorkingDirectory,
     ]
-
-    # Check the control debugger toolbar is hidden by default
-    control_debugger = toolbar.get_application_toolbar(
-        ApplicationToolbars.ControlDebugger
-    )
-    assert not control_debugger.isVisible()
-
-    # Make control debugger visible so Qt can correctly get its x position
-    control_debugger.setVisible(True)
 
     # Check the horizontal order obtained the displayed toolbar doesn't change
     # after sorting it.

--- a/spyder/plugins/toolbar/tests/test_toolbar.py
+++ b/spyder/plugins/toolbar/tests/test_toolbar.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+from unittest.mock import MagicMock
+
+from qtpy.QtWidgets import QMainWindow
+import pytest
+
+from spyder.config.manager import CONF
+from spyder.plugins.toolbar.api import ApplicationToolbars
+from spyder.plugins.toolbar.plugin import Toolbar
+from spyder.plugins.workingdirectory.plugin import WorkingDirectory
+
+
+class MainWindow(QMainWindow):
+
+    _cli_options = MagicMock()
+
+    def get_plugin(self, name, error=True):
+        return MagicMock()
+
+
+@pytest.fixture
+def toolbar(qtbot):
+    # Create toolbar plugin
+    main_window = MainWindow()
+    toolbar = Toolbar(main_window, configuration=CONF)
+    toolbar.on_initialize()
+
+    # Add working directory toolbar
+    cwd = WorkingDirectory(main_window, None)
+    cwd.on_initialize()
+    toolbar.add_application_toolbar(cwd.get_container().toolbar)
+
+    # Add buttons to the other toolbars
+    actions = [
+        (ApplicationToolbars.File, "filenew"),
+        (ApplicationToolbars.Run, "run"),
+        (ApplicationToolbars.Debug, "debug"),
+        (ApplicationToolbars.ControlDebugger, "arrow-step-over"),
+        (ApplicationToolbars.Main, "python"),
+    ]
+
+    for i, item in enumerate(actions):
+        toolbar.create_action(
+            f"action_{i}",
+            text="Action {i}",
+            icon=toolbar.create_icon(item[1]),
+            triggered=lambda: True,
+        )
+
+        toolbar.add_item_to_application_toolbar(
+            toolbar.get_action(f"action_{i}"),
+            toolbar_id=item[0],
+        )
+
+    # Show toolbars and main window
+    toolbar.on_mainwindow_visible()
+    toolbar.toggle_lock(True)
+    main_window.show()
+    return toolbar
+
+
+def test_default_order(toolbar):
+    """Check toolbars are displayed in their default order."""
+    expected_order = [
+        ApplicationToolbars.File,
+        ApplicationToolbars.Run,
+        ApplicationToolbars.Debug,
+        ApplicationToolbars.ControlDebugger,
+        ApplicationToolbars.Main,
+        ApplicationToolbars.WorkingDirectory,
+    ]
+
+    # Check the control debugger toolbar is hidden by default
+    control_debugger = toolbar.get_application_toolbar(
+        ApplicationToolbars.ControlDebugger
+    )
+    assert not control_debugger.isVisible()
+
+    # Make control debugger visible so Qt can correctly get its x position
+    control_debugger.setVisible(True)
+
+    # Check the horizontal order obtained the displayed toolbar doesn't change
+    # after sorting it.
+    current_order = [
+        toolbar.get_application_toolbar(id_).x()
+        for id_ in expected_order
+    ]
+    assert current_order == sorted(current_order)
+
+
+def test_restore_toolbar_order(toolbar, qtbot):
+    """
+    Check that if a toolbar is moved by users to a different position, then the
+    new order is saved on close and restored during the next startup.
+    """
+    new_order = [
+        ApplicationToolbars.Debug,
+        ApplicationToolbars.File,
+        ApplicationToolbars.Run,
+        ApplicationToolbars.ControlDebugger,
+        ApplicationToolbars.Main,
+    ]
+
+    # Select two toolbars to change their order
+    file_toolbar = toolbar.get_application_toolbar(ApplicationToolbars.File)
+    debug_toolbar = toolbar.get_application_toolbar(ApplicationToolbars.Debug)
+
+    # Move the debug toolbar to be before the file one
+    toolbar.get_main().insertToolBar(file_toolbar, debug_toolbar)
+    qtbot.wait(500)
+    assert debug_toolbar.x() < file_toolbar.x()
+
+    # Close toolbar plugin (which is called when the main window is closed)
+    toolbar.on_close(False)
+
+    # Check the order was saved as expected to our config system
+    assert toolbar.get_conf("toolbars_order") == new_order
+
+    # Reload toolbars as if a new Spyder session was started
+    toolbar.on_mainwindow_visible()
+    qtbot.wait(500)
+
+    # Check the order of displayed toolbars is the expected one
+    current_order = [
+        toolbar.get_application_toolbar(id_).pos().x()
+        for id_ in new_order
+    ]
+    assert current_order == sorted(current_order)
+
+
+def test_no_toolbar_after_working_directory(toolbar, qtbot):
+    """
+    Check that any toolbar that is placed to the right of the working directory
+    is repositioned to its left during the next startup.
+    """
+    # Select the toolbars we are going to move
+    cwd_toolbar = toolbar.get_application_toolbar(
+        ApplicationToolbars.WorkingDirectory
+    )
+    debug_toolbar = toolbar.get_application_toolbar(ApplicationToolbars.Debug)
+
+    # Move the working directory toolbar to be before the debug one
+    toolbar.get_main().insertToolBar(debug_toolbar, cwd_toolbar)
+    qtbot.wait(500)
+    assert cwd_toolbar.x() < debug_toolbar.x()
+
+    # Close toolbar plugin (which is called when the main window is closed)
+    toolbar.on_close(False)
+    qtbot.wait(500)
+
+    # Reload toolbars as if a new Spyder session was started
+    toolbar.on_mainwindow_visible()
+
+    # Check the working directory toolbar is to the right of the rest
+    current_order = [app_toolbar.x() for app_toolbar in toolbar.toolbarslist]
+    assert all([cwd_toolbar.x() >= pos for pos in current_order])


### PR DESCRIPTION
## Description of Changes

- That's necessary because many people are accustomed to the Spyder 5 workflow, where they could control the debugger and see the Variable Explorer and IPython console at the same time.
- Those buttons will be placed next to the current ones in the Debug toolbar, but they'll be shown only if there's an active debugging session in the current console.
- Changes to the Toolbar plugin:
    * Declare a default order for toolbars.
    * If a toolbar is added or removed, toolbars will be reordered with the default order and the Working Directory will be placed to the right of all others. That's because it's not easy to visually see where that toolbar ends, so it's better to not place other toolbars to its right.
    * Fix loading last visible toolbars.
    * Rename/improve a couple of methods for clarity.
- Changes to the Run plugin:
    * Allow to place items in toolbars using the full Toolbar API. That's necessary to place the debug file/cell/selection buttons before the ones that control the debugger.
- API changes:
    * Add a new signal to `SpyderToolbar` to inform when it's rendered. That's necessary to get the widgets corresponding to the control debugger actions in the Debug toolbar, so we can hide/show them. 

### Visual changes

New buttons shown when a debugging session is started and hidden when it's stopped

![control-debugger-buttons-show-and-hide](https://github.com/user-attachments/assets/85439ea3-f1f2-490e-ac6c-77a06bdde052)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22434 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
