### PR TITLE
PR: Remove unnecessary `return` in a `try/finally` statement (Files)

### DIFF
--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -1307,7 +1307,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
             dirname = osp.join(current_path, str(name))
             try:
                 os.mkdir(dirname)
-            except EnvironmentError as error:
+            except OSError as error:
                 QMessageBox.critical(
                     self, title,
                     _("<b>Unable to create folder <i>%s</i></b>"
@@ -1319,8 +1319,7 @@ class DirView(QTreeView, SpyderWidgetMixin):
                     try:
                         with open(fname, 'wb') as f:
                             f.write(to_binary_string('#'))
-                        return dirname
-                    except EnvironmentError as error:
+                    except OSError as error:
                         QMessageBox.critical(
                             self, title,
                             _("<b>Unable to create file <i>%s</i></b>"

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -1301,18 +1301,24 @@ class DirView(QTreeView, SpyderWidgetMixin):
             current_path = ''
         if osp.isfile(current_path):
             current_path = osp.dirname(current_path)
-        name, valid = QInputDialog.getText(self, title, subtitle,
-                                           QLineEdit.Normal, "")
+        name, valid = QInputDialog.getText(
+            self, title, subtitle, QLineEdit.Normal, ""
+        )
+
         if valid:
             dirname = osp.join(current_path, str(name))
             try:
                 os.mkdir(dirname)
             except OSError as error:
                 QMessageBox.critical(
-                    self, title,
-                    _("<b>Unable to create folder <i>%s</i></b>"
-                      "<br><br>Error message:<br>%s"
-                      ) % (dirname, str(error)))
+                    self,
+                    title,
+                    _(
+                        "<b>Unable to create folder <i>%s</i></b>"
+                        "<br><br>Error message:<br>%s"
+                    )
+                    % (dirname, str(error)),
+                )
             finally:
                 if is_package:
                     fname = osp.join(dirname, '__init__.py')
@@ -1321,10 +1327,14 @@ class DirView(QTreeView, SpyderWidgetMixin):
                             f.write(to_binary_string('#'))
                     except OSError as error:
                         QMessageBox.critical(
-                            self, title,
-                            _("<b>Unable to create file <i>%s</i></b>"
-                              "<br><br>Error message:<br>%s"
-                              ) % (fname, str(error)))
+                            self,
+                            title,
+                            _(
+                                "<b>Unable to create file <i>%s</i></b>"
+                                "<br><br>Error message:<br>%s"
+                            )
+                            % (fname, str(error)),
+                        )
 
     def get_selected_dir(self):
         """ Get selected dir


### PR DESCRIPTION
## Description of Changes

- That was preventing other errors generated there to be raised.
- Also, replace old EnvironmentError by OSError and make some code style improvements.

### Issue(s) Resolved

Fixes #22732

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
