### PR TITLE
PR: Run installer build workflow on both master and 6.x weekly (CI)

### DIFF
--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -2,11 +2,16 @@ on:
   push:
     branches:
       - 'master'
+      - '6.x'
     paths:
       - '**.gitrepo'
       - '.github/workflows/build-subrepos.yml'
 
   workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
 
   workflow_dispatch:
 
@@ -47,6 +52,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.branch || github.ref_name }}
 
       - name: Cache ${{ matrix.pkg }} ${{ matrix.cache-arch }} Conda Build
         id: cache

--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: build-subrepos-${{ github.ref }}
+  group: build-subrepos-${{ inputs.branch || github.ref_name }}
   cancel-in-progress: true
 
 name: Create Subrepo Conda Packages

--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.branch || github.ref_name }}
+          ref: ${{ inputs.branch }}
 
       - name: Cache ${{ matrix.pkg }} ${{ matrix.cache-arch }} Conda Build
         id: cache

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -119,7 +119,7 @@ jobs:
       branch: ${{ matrix.branch }}
 
   build-installers:
-    name: Build installer for ${{ matrix.target-platform }} Python-${{ matrix.python-version }}
+    name: Build installer
     if: ${{ ! failure() && ! cancelled() }}
     runs-on: ${{ matrix.os }}
     needs:

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -1,6 +1,7 @@
 on:
   schedule:
-    - cron: '30 6 * * *'
+    # 6:30 UTC Sunday
+    - cron: '30 6 * * 0'
 
   pull_request:
     paths:
@@ -50,7 +51,7 @@ concurrency:
   group: installers-conda-${{ github.ref }}
   cancel-in-progress: true
 
-name: Nightly conda-based installers
+name: Weekly conda-based installers
 
 env:
   IS_RELEASE: ${{ github.event_name == 'release' }}
@@ -69,6 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       target_platform: ${{ steps.build-matrix.outputs.target_platform }}
+      branch: ${{ steps.build-matrix.outputs.branch }}
       include: ${{ steps.build-matrix.outputs.include }}
       python_version: ${{ steps.build-matrix.outputs.python_version }}
 
@@ -93,14 +95,28 @@ jobs:
             include=${include:+"$include, "}"{'os': 'windows-latest', 'target-platform': 'win-64', 'spyk-arch': 'win-64'}"
         fi
 
+        if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
+            branch="'master', '6.x'"
+        else
+            branch="'$GITHUB_REF_NAME'"
+        fi
+
         echo "target_platform=[$target_platform]" >> $GITHUB_OUTPUT
+        echo "branch=[$branch]" >> $GITHUB_OUTPUT
         echo "include=[$include]" >> $GITHUB_OUTPUT
 
   build-subrepos:
     name: Build Subrepos
     # env.USE_SUBREPOS is not available at job level; must copy-paste here
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ! inputs.pre)
+    needs:
+      - build-matrix
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.build-matrix.outputs.branch) }}
     uses: ./.github/workflows/build-subrepos.yml
+    with:
+      branch: ${{ matrix.branch }}
 
   build-installers:
     name: Build installer for ${{ matrix.target-platform }} Python-${{ matrix.python-version }}
@@ -112,9 +128,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-platform: ${{fromJson(needs.build-matrix.outputs.target_platform)}}
+        target-platform: ${{ fromJson(needs.build-matrix.outputs.target_platform) }}
         python-version: ['3.11']
-        include: ${{fromJson(needs.build-matrix.outputs.include)}}
+        branch: ${{ fromJson(needs.build-matrix.outputs.branch) }}
+        include: ${{ fromJson(needs.build-matrix.outputs.include) }}
     defaults:
       run:
         shell: bash -le {0}
@@ -132,6 +149,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ matrix.branch }}
 
       - name: Setup Remote SSH Connection
         if: env.ENABLE_SSH == 'true'

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -112,6 +112,7 @@ jobs:
     needs:
       - build-matrix
     strategy:
+      fail-fast: false
       matrix:
         branch: ${{ fromJson(needs.build-matrix.outputs.branch) }}
     uses: ./.github/workflows/build-subrepos.yml
@@ -143,6 +144,7 @@ jobs:
       MACOS_INSTALLER_CERTIFICATE: ${{ secrets.MACOS_INSTALLER_CERTIFICATE }}
       APPLICATION_PWD: ${{ secrets.APPLICATION_PWD }}
       CONSTRUCTOR_TARGET_PLATFORM: ${{ matrix.target-platform }}
+      MATRIX_BRANCH: ${{ matrix.branch }}
 
     steps:
       - name: Checkout Code
@@ -290,11 +292,15 @@ jobs:
           python build_installers.py ${args[@]}
 
           SPYVER=$(python build_installers.py --version)
-          PKG_NAME=$(ls $DISTDIR | grep Spyder-)
+          PKG_PATH=$(python build_installers.py --artifact-name)
+          PKG_NAME=$(basename $PKG_PATH)
+          ARTIFACT_NAME=${PKG_NAME%.*}
+          [[ "$GITHUB_EVENT_NAME" == "schedule" ]] && ARTIFACT_NAME=$ARTIFACT_NAME-$MATRIX_BRANCH
+
           echo "SPYVER=$SPYVER" >> $GITHUB_ENV
           echo "PKG_NAME=$PKG_NAME" >> $GITHUB_ENV
-          echo "ARTIFACT_NAME=${PKG_NAME%.*}" >> $GITHUB_ENV
-          echo "PKG_PATH=$DISTDIR/$PKG_NAME" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+          echo "PKG_PATH=$PKG_PATH" >> $GITHUB_ENV
 
       - name: Test macOS or Linux Installer
         if: runner.os != 'Windows'

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -98,7 +98,7 @@ jobs:
         if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
             branch="'master', '6.x'"
         else
-            branch="'$GITHUB_REF_NAME'"
+            branch="''"
         fi
 
         echo "target_platform=[$target_platform]" >> $GITHUB_OUTPUT

--- a/.github/workflows/purge-cache.yml
+++ b/.github/workflows/purge-cache.yml
@@ -27,6 +27,12 @@ jobs:
           # Last command must be successful so that workflow step does not fail
           echo Purging cache is complete.
 
+  build-subrepos:
+    name: Build subrepos
+    needs:
+      - cleanup
+    uses: ./.github/workflows/build-subrepos.yml
+
   run-test-files:
     name: Run test-files
     needs:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

This PR changes the schedule and context in which the installer workflow is run.
* The schedule is changed to run weekly on Sunday at 6:30 UTC instead of daily.
* The scheduled workflow will also create installers from both the master and 6.x branches.
* `workflow_dispatch` and `release` triggers will remain unchanged, i.e. they will only create installers for the currently selected branch or ref.