### PR TITLE
PR: Restore run actions to the context menu of `CodeEditor` (Editor) 

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -4407,6 +4407,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
         self.ipynb_convert_action.setVisible(self.is_json() and
                                              nbformat is not None)
         self.gotodef_action.setVisible(self.go_to_definition_enabled)
+        self.inspect_current_object_action.setVisible(self.enable_hover)
 
         formatter = self.get_conf(
             ('provider_configuration', 'lsp', 'values', 'formatting'),

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -41,6 +41,7 @@ from qtpy.QtWidgets import QApplication, QMessageBox, QSplitter, QScrollBar
 from spyder_kernels.utils.dochelpers import getobj
 
 # Local imports
+from spyder.api.plugins import Plugins
 from spyder.config.base import _, running_under_pytest
 from spyder.plugins.editor.api.decoration import TextDecoration
 from spyder.plugins.editor.api.panel import Panel
@@ -108,6 +109,7 @@ class CodeEditorMenus:
 
 
 class CodeEditorContextMenuSections:
+    RunSection = "run_section"
     InspectSection = "inspect_section"
     UndoRedoSection = "undo_redo_section"
     EditSection = "edit_section"
@@ -3412,6 +3414,18 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
             triggered=self.sig_show_object_info
         )
 
+        # Run actions
+        run_cell_action = self.get_action("run cell", plugin=Plugins.Run)
+        run_cell_and_advance_action = self.get_action(
+            "run cell and advance", plugin=Plugins.Run
+        )
+        rerun_cell_action = self.get_action(
+            "re-run cell", plugin=Plugins.Run
+        )
+        run_selection_action = self.get_action(
+            "run selection and advance", plugin=Plugins.Run
+        )
+
         # Zoom actions
         zoom_in_action = self.create_action(
             CodeEditorActions.ZoomIn,
@@ -3468,6 +3482,19 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
         self.menu = self.create_menu(
             CodeEditorMenus.ContextMenu, register=False
         )
+
+        # Run section
+        for menu_action in [
+            run_cell_action,
+            run_cell_and_advance_action,
+            rerun_cell_action,
+            run_selection_action,
+        ]:
+            self.add_item_to_menu(
+                menu_action,
+                self.menu,
+                section=CodeEditorContextMenuSections.RunSection
+            )
 
         # Inspect section
         inspect_actions = [

--- a/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
@@ -39,7 +39,6 @@ from spyder.plugins.completion.decorators import (
     handles,
     class_register,
 )
-from spyder.plugins.editor.panels import FoldingPanel
 from spyder.plugins.editor.panels.utils import (
     merge_folding,
     collect_folding_regions,
@@ -181,7 +180,7 @@ class LSPMixin:
         self.sync_mode = TextDocumentSyncKind.FULL
         self.will_save_notify = False
         self.will_save_until_notify = False
-        self.enable_hover = True
+        self.enable_hover = False
         self.auto_completion_characters = []
         self.resolve_completions_enabled = False
         self.signature_completion_characters = []


### PR DESCRIPTION
## Description of Changes

- This is a regression with respect to Spyder 5, which had those actions available, so we need to address it.
- Also, fix visibility of the Inspect action in that menu for files with an LSP server that doesn't provide hover or without an LSP.

### Visual changes

| Before | After |
| - | - |
| ![imagen](https://github.com/user-attachments/assets/cd5d2b21-70af-40fa-a67c-60ed172910df) | ![imagen](https://github.com/user-attachments/assets/5197d91e-c824-4f80-93d9-adf6f67efc4f) |

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22637

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
