### PR TITLE
PR: Fix enabled state of Run plugin actions when a file type doesn't have an associated configuration

### DIFF
--- a/spyder/plugins/run/container.py
+++ b/spyder/plugins/run/container.py
@@ -313,7 +313,11 @@ class RunContainer(PluginMainContainer):
 
     def switch_focused_run_configuration(self, uuid: Optional[str]):
         uuid = uuid or None
-        if uuid == self.currently_selected_configuration:
+
+        # We need the first check to correctly update the run and context
+        # actions when the config is None.
+        # Fixes spyder-ide/spyder#22607
+        if uuid is not None and uuid == self.currently_selected_configuration:
             return
 
         self.metadata_model.set_current_run_configuration(uuid)

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -1455,7 +1455,7 @@ class BaseEditMixin(object):
                                                word=word)
         return match_number
 
-    # ---- Array builder helper / See 'spyder/widgets/arraybuilder.py'
+    # ---- Array builder helper methods
     # -------------------------------------------------------------------------
     def enter_array_inline(self):
         """Enter array builder inline mode."""
@@ -1503,6 +1503,7 @@ class BaseEditMixin(object):
                 cursor.endEditBlock()
 
     # ---- Qt methods
+    # -------------------------------------------------------------------------
     def mouseDoubleClickEvent(self, event):
         """Select NUMBER tokens to select numeric literals on double click."""
         cursor = self.cursorForPosition(event.pos())


### PR DESCRIPTION
## Description of Changes

- This problem occurred, for instance, when the last file to receive focus after Spyder started was a Markdown one. And that's because those files don't have a run configuration associated to them by default.
- Also, improve a couple of block comments in `BaseEditMixin`.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22607

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
