### PR TITLE
PR: Register run metadata on renames for supported file extensions (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -1093,12 +1093,21 @@ class EditorMainWidget(PluginMainWidget):
 
         self.deregister_file_run_metadata(old_filename)
 
-        # This avoids to register the run metadata of new_filename twice, which
-        # can happen for some rename operations.
-        if not self.id_per_file.get(new_filename):
+        # Get file extension (without the dot)
+        filename_ext = osp.splitext(new_filename)[1][1:]
+
+        # Check if we can actually register the new file
+        if (
+            # This avoids to register new_filename twice, which can happen for
+            # some rename operations.
+            not self.id_per_file.get(new_filename)
+            # Check if the new file extension is supported.
+            # Fixes spyder-ide/spyder#22630
+            and filename_ext in self.supported_run_configurations
+        ):
             self.register_file_run_metadata(new_filename)
 
-        if is_selected:
+        if is_selected and self.id_per_file.get(new_filename):
             self._plugin._switch_focused_run_configuration(
                 self.id_per_file[new_filename]
             )


### PR DESCRIPTION
## Description of Changes

- This error happened, for instance, when renaming a Python file to a Markdown one. Since we were not checking if there's a run configuration for that file type, the new file was marked as available for running. And that led to errors when trying to run the entire file or a selection in it. 
- Add a test to prevent regressions about this in the future.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22630.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
