### PR TITLE
PR: Try to set the monospace font size up to six times in `SpyderApplication` (Utils)

### DIFF
--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -788,6 +788,8 @@ class SpyderApplication(QApplication, SpyderConfigurationAccessor,
         # This is filled at startup in spyder.app.utils.create_window
         self._main_window: QMainWindow = None
 
+    # ---- Qt methods
+    # -------------------------------------------------------------------------
     def event(self, event):
 
         if sys.platform == 'darwin' and event.type() == QEvent.FileOpen:
@@ -803,6 +805,8 @@ class SpyderApplication(QApplication, SpyderConfigurationAccessor,
 
         return QApplication.event(self, event)
 
+    # ---- Public API
+    # -------------------------------------------------------------------------
     def set_font(self):
         """Set font for the entire application."""
         # This selects the system font by default
@@ -821,10 +825,24 @@ class SpyderApplication(QApplication, SpyderConfigurationAccessor,
         if size > 0:
             app_font.setPointSize(size)
 
-        self.set_monospace_interface_font(app_font)
+        self._set_monospace_interface_font(app_font)
         self.setFont(app_font)
 
-    def set_monospace_interface_font(self, app_font):
+    def get_mainwindow_position(self) -> QPoint:
+        """Get main window position."""
+        return self._main_window.pos()
+
+    def get_mainwindow_width(self) -> int:
+        """Get main window width."""
+        return self._main_window.width()
+
+    def get_mainwindow_height(self) -> int:
+        """Get main window height."""
+        return self._main_window.height()
+
+    # ---- Private API
+    # -------------------------------------------------------------------------
+    def _set_monospace_interface_font(self, app_font):
         """
         Set monospace interface font in our config system according to the app
         one.
@@ -867,18 +885,6 @@ class SpyderApplication(QApplication, SpyderConfigurationAccessor,
                       section='appearance')
         self.set_conf('monospace_app_font/size', monospace_size,
                       section='appearance')
-
-    def get_mainwindow_position(self) -> QPoint:
-        """Get main window position."""
-        return self._main_window.pos()
-
-    def get_mainwindow_width(self) -> int:
-        """Get main window width."""
-        return self._main_window.width()
-
-    def get_mainwindow_height(self) -> int:
-        """Get main window height."""
-        return self._main_window.height()
 
 
 def restore_launchservices():

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -835,18 +835,25 @@ class SpyderApplication(QApplication, SpyderConfigurationAccessor,
         plain_font.setPointSize(size)
 
         # Select a size that matches the app font one, so that the UI looks
-        # consistent. We only check three point sizes above and below the app
-        # font to avoid getting stuck in an infinite loop.
+        # consistent.
+        attempts = 0
         monospace_size = size
         while (
+            # Keep going until the xHeight's of both fonts match
             QFontMetrics(plain_font).xHeight() != x_height
+            # We only check three point sizes above and below the app font to
+            # avoid getting stuck in an infinite loop.
             and ((size - 4) < monospace_size < (size + 4))
+            # Do this up to six times to not get stuck in an infinite loop.
+            # Fixes spyder-ide/spyder#22661
+            and attempts < 6
         ):
             if QFontMetrics(plain_font).xHeight() > x_height:
                 monospace_size -= 1
             else:
                 monospace_size += 1
             plain_font.setPointSize(monospace_size)
+            attempts += 1
 
         # There are some fonts (e.g. MS Serif) for which it seems that Qt
         # can't detect their xHeight's as expected. So, we check below


### PR DESCRIPTION
## Description of Changes

- This prevents Spyder to get stuck in an infinite loop for monospace fonts that don't have an xHeight that matches the app font one in a close range of sizes around the app font size.
- Also, add block comments to that class to make the code more readable and make the method used to set the monospace font private.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22661.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
