### PR TITLE
PR: Do not launch Spyder if installing in CI or batch/silent mode (Installers)

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'installers-conda/**'
       - '.github/workflows/installers-conda.yml'
+      - '.github/scripts/installer_test.sh'
       - 'requirements/*.yml'
       - 'MANIFEST.in'
 

--- a/.github/workflows/test-files.yml
+++ b/.github/workflows/test-files.yml
@@ -18,6 +18,7 @@ on:
       - '!.github/workflows/installers-conda.yml'
       - '!.github/workflows/build-subrepos.yml'
       - '!.github/workflows/purge-cache.yml'
+      - '!.github/scripts/installer_test.sh'
 
   pull_request:
     branches:
@@ -36,6 +37,7 @@ on:
       - '!.github/workflows/installers-conda.yml'
       - '!.github/workflows/build-subrepos.yml'
       - '!.github/workflows/purge-cache.yml'
+      - '!.github/scripts/installer_test.sh'
 
   workflow_call:
 

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -18,6 +18,7 @@ on:
       - '!.github/workflows/installers-conda.yml'
       - '!.github/workflows/build-subrepos.yml'
       - '!.github/workflows/purge-cache.yml'
+      - '!.github/scripts/installer_test.sh'
 
   pull_request:
     branches:
@@ -36,6 +37,7 @@ on:
       - '!.github/workflows/installers-conda.yml'
       - '!.github/workflows/build-subrepos.yml'
       - '!.github/workflows/purge-cache.yml'
+      - '!.github/scripts/installer_test.sh'
 
   workflow_call:
 

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -18,6 +18,7 @@ on:
       - '!.github/workflows/installers-conda.yml'
       - '!.github/workflows/build-subrepos.yml'
       - '!.github/workflows/purge-cache.yml'
+      - '!.github/scripts/installer_test.sh'
 
   pull_request:
     branches:
@@ -36,6 +37,7 @@ on:
       - '!.github/workflows/installers-conda.yml'
       - '!.github/workflows/build-subrepos.yml'
       - '!.github/workflows/purge-cache.yml'
+      - '!.github/scripts/installer_test.sh'
 
   workflow_call:
 

--- a/.github/workflows/test-remoteclient.yml
+++ b/.github/workflows/test-remoteclient.yml
@@ -16,6 +16,7 @@ on:
       - '!.github/workflows/installers-conda.yml'
       - '!.github/workflows/build-subrepos.yml'
       - '!.github/workflows/purge-cache.yml'
+      - '!.github/scripts/installer_test.sh'
 
   pull_request:
     branches:
@@ -32,6 +33,7 @@ on:
       - '!.github/workflows/installers-conda.yml'
       - '!.github/workflows/build-subrepos.yml'
       - '!.github/workflows/purge-cache.yml'
+      - '!.github/scripts/installer_test.sh'
 
   workflow_call:
 

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -18,6 +18,7 @@ on:
       - '!.github/workflows/installers-conda.yml'
       - '!.github/workflows/build-subrepos.yml'
       - '!.github/workflows/purge-cache.yml'
+      - '!.github/scripts/installer_test.sh'
 
   pull_request:
     branches:
@@ -36,6 +37,7 @@ on:
       - '!.github/workflows/installers-conda.yml'
       - '!.github/workflows/build-subrepos.yml'
       - '!.github/workflows/purge-cache.yml'
+      - '!.github/scripts/installer_test.sh'
 
   workflow_call:
 

--- a/installers-conda/resources/post-install.bat
+++ b/installers-conda/resources/post-install.bat
@@ -1,11 +1,22 @@
 @rem  This script launches Spyder after install
 @echo off
 
-if "%CI%"=="1" set no_launch_spyder=true
+call :redirect 2>&1 >> %PREFIX%\install.log
+
+:redirect
+@echo Environment Variables:
+set
+
+if defined CI set no_launch_spyder=true
 if "%INSTALLER_UNATTENDED%"=="1" set no_launch_spyder=true
+@echo CI = %CI%
+@echo INSTALLER_UNATTENDED = %INSTALLER_UNATTENDED%
+@echo no_launch_spyder = %no_launch_spyder%
 if defined no_launch_spyder (
     @echo Installing in CI or silent mode, do not launch Spyder
     exit /b %errorlevel%
+) else (
+    @echo Launching Spyder after install completed.
 )
 
 set mode=system
@@ -17,6 +28,7 @@ for /F "tokens=*" %%i in (
 ) do (
     set shortcut=%%~fi
 )
+@echo shortcut = %shortcut%
 
 @rem  Launch Spyder
 set tmpdir=%TMP%\spyder

--- a/installers-conda/resources/post-install.bat
+++ b/installers-conda/resources/post-install.bat
@@ -13,7 +13,7 @@ if "%INSTALLER_UNATTENDED%"=="1" set no_launch_spyder=true
 @echo INSTALLER_UNATTENDED = %INSTALLER_UNATTENDED%
 @echo no_launch_spyder = %no_launch_spyder%
 if defined no_launch_spyder (
-    @echo Installing in CI or silent mode, do not launch Spyder
+    @echo Installing in silent mode, do not launch Spyder
     exit /b %errorlevel%
 ) else (
     @echo Launching Spyder after install completed.

--- a/installers-conda/resources/post-install.bat
+++ b/installers-conda/resources/post-install.bat
@@ -1,17 +1,24 @@
-rem This script launches Spyder after install
+@rem  This script launches Spyder after install
 @echo off
+
+if "%CI%"=="1" set no_launch_spyder=true
+if "%INSTALLER_UNATTENDED%"=="1" set no_launch_spyder=true
+if defined no_launch_spyder (
+    @echo Installing in CI or silent mode, do not launch Spyder
+    exit /b %errorlevel%
+)
 
 set mode=system
 if exist "%PREFIX%\.nonadmin" set mode=user
 
-rem Get shortcut path
+@rem  Get shortcut path
 for /F "tokens=*" %%i in (
     '%PREFIX%\python %PREFIX%\Scripts\menuinst_cli.py shortcut --mode=%mode%'
 ) do (
     set shortcut=%%~fi
 )
 
-rem Launch Spyder
+@rem  Launch Spyder
 set tmpdir=%TMP%\spyder
 set launch_script=%tmpdir%\launch_script.bat
 
@@ -21,6 +28,7 @@ echo @echo off
 echo :loop
 echo tasklist /fi "ImageName eq Spyder-*" /fo csv 2^>NUL ^| findstr /r "Spyder-.*Windows-x86_64.exe"^>NUL
 echo if "%%errorlevel%%"=="0" ^(
+echo     @rem  Installer is still running
 echo     timeout /t 1 /nobreak ^> nul
 echo     goto loop
 echo ^) else ^(

--- a/installers-conda/resources/post-install.sh
+++ b/installers-conda/resources/post-install.sh
@@ -187,7 +187,7 @@ echo "*** Post install script for ${INSTALLER_NAME} complete"
 
 # ---- Launch Spyder
 if [[ -n "$CI" || "$INSTALLER_UNATTENDED" == "1" || "$COMMAND_LINE_INSTALL" == "1" ]]; then
-    echo Installing in CI or batch mode, do not launch Spyder
+    echo Installing in batch mode, do not launch Spyder
     exit 0
 fi
 

--- a/installers-conda/resources/post-install.sh
+++ b/installers-conda/resources/post-install.sh
@@ -186,7 +186,7 @@ fi
 echo "*** Post install script for ${INSTALLER_NAME} complete"
 
 # ---- Launch Spyder
-if [[ -n "$CI" || "$INSTALLER_UNATTENDED" == "1" ]]; then
+if [[ -n "$CI" || "$INSTALLER_UNATTENDED" == "1" || "$COMMAND_LINE_INSTALL" == "1" ]]; then
     echo Installing in CI or batch mode, do not launch Spyder
     exit 0
 fi

--- a/installers-conda/resources/post-install.sh
+++ b/installers-conda/resources/post-install.sh
@@ -186,7 +186,10 @@ fi
 echo "*** Post install script for ${INSTALLER_NAME} complete"
 
 # ---- Launch Spyder
-[[ -n "$CI" ]] && exit 0  # Running in CI, don't launch Spyder
+if [[ -n "$CI" || "$INSTALLER_UNATTENDED" == "1" ]]; then
+    echo Installing in CI or batch mode, do not launch Spyder
+    exit 0
+fi
 
 echo "Launching Spyder now..."
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/installers-conda/resources/pre-install.bat
+++ b/installers-conda/resources/pre-install.bat
@@ -1,4 +1,4 @@
-rem Mark as conda-based-app
+@rem  Mark as conda-based-app
 set menudir=%PREFIX%\envs\spyder-runtime\Menu
 if not exist "%menudir%" mkdir "%menudir%"
 echo. > "%menudir%\conda-based-app"


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Installing Spyder using our conda-based installers from the command-line will now recognize two environment variables: `CI` or `INSTALLER_UNATTENDED`. If either are set to 1, Spyder will not be launched upon completing the installation.

macOS `.pkg` installers do not receive command-line environment variables, so `CI` and `INSTALLER_UNATTENDED` will not have any affect. However, `COMMAND_LINE_INSTALL` is unique to macOS `.pkg` installers and set when launched from the command-line, so this variable is leveraged to refrain from launching Spyder in this circumstance.

Note that for the next `constructor` release (>3.9.3, see conda/constructor#885), `INSTALLER_UNATTENDED` is automatically set to 1 if `.sh` or `.exe` installers are run in batch mode (`-b` for `.sh` installers) or silent mode (`/S` for `.exe` installers).

### Examples
```bash
INSTALLER_UNATTENDED=1 bash Spyder-Linux-x86_64.sh -b
```
```bat
INSTALLER_UNATTENDED=1 start /wait Spyder-Windows-x86_64.exe /InstallationType=JustMe /S
```
```bash
installer -pkg Spyder-macOS-x86_64.pkg -target CurrentUserHomeDirectory
```

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22730

