### PR TITLE
PR: Activate `Open last closed` shortcut in `EditorStack` (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -139,6 +139,11 @@ class EditorStack(QWidget, SpyderWidgetMixin):
     sig_trigger_run_action = Signal(str)
     sig_trigger_debugger_action = Signal(str)
 
+    sig_open_last_closed = Signal()
+    """
+    This signal requests that the last closed tab be re-opened.
+    """
+
     sig_codeeditor_created = Signal(object)
     """
     This signal is emitted when a codeeditor is created.
@@ -444,7 +449,7 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             ('Cycle to next file', lambda: self.tabs.tab_navigate(1)),
             ('New file', self.sig_new_file[()]),
             ('Open file', self.plugin_load[()]),
-            ('Open last closed', self.get_main_widget().open_last_closed),
+            ('Open last closed', self.sig_open_last_closed),
             ('Save file', self.save),
             ('Save all', self.save_all),
             ('Save As', self.sig_save_as),

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -444,6 +444,7 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             ('Cycle to next file', lambda: self.tabs.tab_navigate(1)),
             ('New file', self.sig_new_file[()]),
             ('Open file', self.plugin_load[()]),
+            ('Open last closed', self.get_main_widget().open_last_closed),
             ('Save file', self.save),
             ('Save all', self.save_all),
             ('Save As', self.sig_save_as),

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -1595,6 +1595,7 @@ class EditorMainWidget(PluginMainWidget):
         editorstack.sig_open_file.connect(self.report_open_file)
         editorstack.sig_new_file.connect(lambda s: self.new(text=s))
         editorstack.sig_new_file[()].connect(self.new)
+        editorstack.sig_open_last_closed.connect(self.open_last_closed)
         editorstack.sig_close_file.connect(self.close_file_in_all_editorstacks)
         editorstack.sig_close_file.connect(self.remove_file_cursor_history)
         editorstack.file_saved.connect(self.file_saved_in_editorstack)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

This fixes the "Open last closed" shortcut in the editor, which stopped working in Spyder 6. 

<s>The proper way to implement this is perhaps via a signal instead of using get_main_widget(). However, I intend to replace this code in Spyder 6.1 as part of the fix for issue #22354, which will move all the shortcuts and actions for New/Open/Close/Save from the Editor plugin to the Application plugin, so that other plugins can also open and edit files. A minimal change seems better in this case.</s>

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22912


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
