### PR TITLE
PR: Improve the way users can select the interface font in Preferences (Appearance)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,6 +237,18 @@ Due to that, a clone of those projects is placed in the `external-deps` director
     ```
 
 
+## Guidelines for Spyder API changes
+
+If your work makes changes to public classes, methods or Qt signals in `spyder.api`, or to the public interface of any plugin (e.g. `plugins/editor/plugin.py`), you must add a note about it in the current Changelog (e.g. `changelogs/Spyder-6.md`).
+If an entry for the version where your PR will be included doesn't exist yet, create one (with `Unreleased` as its date) and a subsection called `API changes`.
+
+Please note that the Spyder API must be changed according to the following guidelines:
+
+* For bugfix versions (e.g. `6.0.3`), you can only add new Qt signals or methods, or kwargs to current methods.
+* For minor versions (e.g. `6.1.0`), you should try to do the same as for bugfix versions, unless it's **strictly** necessary to break the API by removing or changing certain Qt signals, classes or methods in a backwards incompatible way.
+* For major versions (e.g. `7.0.0`), there are no restrictions on API changes.
+
+
 ## Adding Third-Party Content
 
 All files or groups of files, including source code, images, icons, and other assets, that originate from projects outside of the Spyder organization (regardless of the license), must be first approved by the Spyder team. Always check with us (on Github, Gitter, Google Group, etc) before attempting to add content from an external project, and only do so when necessary.

--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -4,6 +4,8 @@
 
 ### API changes
 
+* Add `items_elide_mode` kwarg to the constructors of `SpyderComboBox` and
+  `SpyderComboBoxWithIcons`.
 * The `sig_item_in_popup_changed` and `sig_popup_is_hidden` signals were added
   to `SpyderComboBox` and `SpyderFontComboBox`.
 

--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -7,7 +7,7 @@
 * Add `items_elide_mode` kwarg to the constructors of `SpyderComboBox` and
   `SpyderComboBoxWithIcons`.
 * The `sig_item_in_popup_changed` and `sig_popup_is_hidden` signals were added
-  to `SpyderComboBox` and `SpyderFontComboBox`.
+  to `SpyderComboBox`, `SpyderComboBoxWithIcons` and `SpyderFontComboBox`.
 
 ----
 

--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -1,5 +1,14 @@
 # History of changes for Spyder 6
 
+## Version 6.0.3 (Unreleased)
+
+### API changes
+
+* The `sig_item_in_popup_changed` and `sig_popup_is_hidden` signals were added
+  to `SpyderComboBox` and `SpyderFontComboBox`.
+
+----
+
 ## Version 6.0.2 (2024/10/31)
 
 ### Important fixes
@@ -10,6 +19,12 @@
 * Fix SSH tunneling info handling for remote kernels connection and add remote client tests.
 * Handle kernel fault file not being available.
 * Update QtConsole constraint to 5.6.1 to support ANSI codes that move the cursor.
+
+### API changes
+
+* The `sig_is_rendered` signal was added to `SpyderToolbar`.
+* The `add_toolbar` kwarg of the `create_run_button` and `create_run_in_executor_button`
+  methods of the Run plugin can now accept a dictionary.
 
 ### Issues Closed
 

--- a/spyder/api/_version.py
+++ b/spyder/api/_version.py
@@ -22,5 +22,5 @@ The API version should be modified according to the following rules:
    updated.
 """
 
-VERSION_INFO = (1, 1, 0)
+VERSION_INFO = (1, 2, 0)
 __version__ = '.'.join(map(str, VERSION_INFO))

--- a/spyder/api/widgets/comboboxes.py
+++ b/spyder/api/widgets/comboboxes.py
@@ -241,9 +241,19 @@ class _SpyderComboBoxMixin:
 
 
 class SpyderComboBox(QComboBox, _SpyderComboBoxMixin):
-    """Combobox widget for Spyder when its items don't have icons."""
+    """Default combobox widget for Spyder."""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, items_elide_mode=None):
+        """
+        Default combobox widget for Spyder.
+
+        Parameters
+        ----------
+        parent: QWidget, optional
+            The combobox parent.
+        items_elide_mode: Qt.TextElideMode, optional
+            Elide mode for the combobox items.
+        """
         if PYQT5 or PYQT6:
             super().__init__(parent)
         else:
@@ -254,11 +264,12 @@ class SpyderComboBox(QComboBox, _SpyderComboBoxMixin):
         self._is_shown = False
         self._is_popup_shown = False
 
-        # This is also necessary to have more fine-grained control over the
-        # style of our comboboxes with css, e.g. to add more padding between
-        # its items.
+        # This is necessary to have more fine-grained control over the style of
+        # our comboboxes with css, e.g. to add more padding between its items.
         # See https://stackoverflow.com/a/33464045/438386 for the details.
-        self.setItemDelegate(_SpyderComboBoxDelegate(self))
+        self.setItemDelegate(
+            _SpyderComboBoxDelegate(self, elide_mode=items_elide_mode)
+        )
 
     def showEvent(self, event):
         """Adjustments when the widget is shown."""
@@ -327,8 +338,18 @@ class SpyderComboBox(QComboBox, _SpyderComboBoxMixin):
 class SpyderComboBoxWithIcons(SpyderComboBox):
     """"Combobox widget for Spyder when its items have icons."""
 
-    def __init__(self, parent=None):
-        super().__init__(parent)
+    def __init__(self, parent=None, items_elide_mode=None):
+        """"
+        Combobox widget for Spyder when its items have icons.
+
+        Parameters
+        ----------
+        parent: QWidget, optional
+            The combobox parent.
+        items_elide_mode: Qt.TextElideMode, optional
+            Elide mode for the combobox items.
+        """
+        super().__init__(parent, items_elide_mode)
 
         # Padding is not necessary because icons give items enough of it.
         self._css["QComboBox QAbstractItemView::item"].setValues(

--- a/spyder/api/widgets/menus.py
+++ b/spyder/api/widgets/menus.py
@@ -402,7 +402,7 @@ class SpyderMenu(QMenu, SpyderFontsMixin):
             border=f"1px solid {SpyderPalette.COLOR_BACKGROUND_6}"
         )
 
-        # Set the right background color This is the only way to do it!
+        # Set the right background color. This is the only way to do it!
         css['QWidget:disabled QMenu'].setValues(
             backgroundColor=SpyderPalette.COLOR_BACKGROUND_3,
         )

--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -98,7 +98,8 @@ def set_opengl_implementation(option):
     if hasattr(QQuickWindow, "setGraphicsApi"):
         set_api = QQuickWindow.setGraphicsApi  # Qt 6
     else:
-        set_api = QQuickWindow.setSceneGraphBackend  # Qt 5
+        if QQuickWindow is not None:
+            set_api = QQuickWindow.setSceneGraphBackend  # Qt 5
 
     if option == 'software':
         QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)

--- a/spyder/plugins/appearance/confpage.py
+++ b/spyder/plugins/appearance/confpage.py
@@ -161,10 +161,13 @@ class AppearanceConfigPage(PluginConfigPage):
         self.preview_editor.set_scrollpastend_enabled(False)
 
         preview_interface_label = QLabel(_("Interface font"))
-        self.preview_interface = QLabel("Happy Spydering!")
+        self.preview_interface = QLabel("Sample text")
         self.preview_interface.setFixedWidth(260)
         self.preview_interface.setFixedHeight(45)
         self.preview_interface.setWordWrap(True)
+        self.preview_interface.setTextInteractionFlags(
+            Qt.TextEditorInteraction
+        )
         self.preview_interface.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
 
         preview_interface_label_css = qstylizer.style.StyleSheet()

--- a/spyder/plugins/appearance/confpage.py
+++ b/spyder/plugins/appearance/confpage.py
@@ -162,7 +162,7 @@ class AppearanceConfigPage(PluginConfigPage):
         preview_interface_label = QLabel(_("Interface font"))
         self.preview_interface = QLabel("Happy Spydering!")
         self.preview_interface.setFixedWidth(260)
-        self.preview_interface.setFixedHeight(50)
+        self.preview_interface.setFixedHeight(45)
         self.preview_interface.setWordWrap(True)
         self.preview_interface.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
 
@@ -230,14 +230,30 @@ class AppearanceConfigPage(PluginConfigPage):
         self.reset_button.clicked.connect(self.reset_to_default)
         self.delete_button.clicked.connect(self.delete_scheme)
         self.schemes_combobox.currentIndexChanged.connect(
-            lambda index: self.update_preview()
+            lambda index: self.update_editor_preview()
+        )
+        self.schemes_combobox.sig_popup_is_hidden.connect(
+            self.update_editor_preview
+        )
+        self.schemes_combobox.sig_item_in_popup_changed.connect(
+            lambda scheme_name: self.update_editor_preview(
+                scheme_name=scheme_name
+            )
         )
         self.schemes_combobox.currentIndexChanged.connect(self.update_buttons)
         self.plain_text_font.fontbox.currentFontChanged.connect(
-            lambda font: self.update_preview()
+            lambda font: self.update_editor_preview()
+        )
+        self.plain_text_font.fontbox.sig_popup_is_hidden.connect(
+            self.update_editor_preview
+        )
+        self.plain_text_font.fontbox.sig_item_in_popup_changed.connect(
+            lambda font_family: self.update_editor_preview(
+                scheme_name=None, font_family=font_family
+            )
         )
         self.plain_text_font.sizebox.valueChanged.connect(
-            lambda value: self.update_preview()
+            lambda value: self.update_editor_preview()
         )
         self.app_font.fontbox.currentFontChanged.connect(
             lambda font: self.update_interface_preview()
@@ -266,7 +282,7 @@ class AppearanceConfigPage(PluginConfigPage):
             system_font_checkbox.checkbox.setEnabled(False)
         self.update_app_font_group(system_font_checkbox.checkbox.isChecked())
         self.update_combobox()
-        self.update_preview()
+        self.update_editor_preview()
 
     def get_font(self, option):
         """Return global font used in Spyder."""
@@ -312,7 +328,7 @@ class AppearanceConfigPage(PluginConfigPage):
             CONF.restore_notifications(section='appearance', option=option)
 
         self.update_combobox()
-        self.update_preview()
+        self.update_editor_preview()
 
         return set(self.changed_options)
 
@@ -389,14 +405,19 @@ class AppearanceConfigPage(PluginConfigPage):
         self.delete_button.setEnabled(delete_enabled)
         self.reset_button.setEnabled(not delete_enabled)
 
-    def update_preview(self, scheme_name=None):
+    def update_editor_preview(self, scheme_name=None, font_family=None):
         """Update the color scheme of the preview editor and adds text."""
         if scheme_name is None:
             scheme_name = self.current_scheme
+        else:
+            scheme_name = self.scheme_choices_dict[scheme_name]
 
-        plain_text_font = self.plain_text_font.fontbox.currentFont()
+        if font_family is None:
+            plain_text_font = self.plain_text_font.fontbox.currentFont()
+        else:
+            plain_text_font = QFont(font_family)
+
         plain_text_font.setPointSize(self.plain_text_font.sizebox.value())
-
         self.preview_editor.setup_editor(
             font=plain_text_font,
             color_scheme=scheme_name
@@ -482,7 +503,7 @@ class AppearanceConfigPage(PluginConfigPage):
                 option = "temp/{0}".format(key)
                 value = temporal_color_scheme[key]
                 self.set_option(option, value)
-            self.update_preview(scheme_name='temp')
+            self.update_editor_preview(scheme_name='temp')
 
     def delete_scheme(self):
         """Deletes the currently selected custom color scheme."""
@@ -515,7 +536,7 @@ class AppearanceConfigPage(PluginConfigPage):
                                "{0}/name".format(scheme_name))
 
             self.update_combobox()
-            self.update_preview()
+            self.update_editor_preview()
 
     def set_scheme(self, scheme_name):
         """

--- a/spyder/plugins/appearance/confpage.py
+++ b/spyder/plugins/appearance/confpage.py
@@ -504,6 +504,10 @@ class AppearanceConfigPage(PluginConfigPage):
                 option = "temp/{0}".format(key)
                 value = temporal_color_scheme[key]
                 self.set_option(option, value)
+
+            if not self.scheme_choices_dict.get("temp"):
+                self.scheme_choices_dict["temp"] = "temp"
+
             self.update_editor_preview(scheme_name='temp')
 
     def delete_scheme(self):

--- a/spyder/plugins/appearance/confpage.py
+++ b/spyder/plugins/appearance/confpage.py
@@ -104,8 +104,9 @@ class AppearanceConfigPage(PluginConfigPage):
         )
 
         self.scheme_choices_dict = {}
-        schemes_combobox_widget = self.create_combobox('', [('', '')],
-                                                       'selected')
+        schemes_combobox_widget = self.create_combobox(
+            '', [('', '')], 'selected', items_elide_mode=Qt.ElideNone
+        )
         self.schemes_combobox = schemes_combobox_widget.combobox
 
         # Syntax layout

--- a/spyder/widgets/config.py
+++ b/spyder/widgets/config.py
@@ -915,12 +915,13 @@ class SpyderConfigPage(SidebarPage, ConfigAccessMixin):
         return widget
 
     def create_combobox(self, text, choices, option, default=NoDefault,
-                        tip=None, restart=False, section=None):
+                        tip=None, restart=False, section=None,
+                        items_elide_mode=None):
         """choices: couples (name, key)"""
         if section is not None and section != self.CONF_SECTION:
             self.cross_section_options[option] = section
         label = QLabel(text)
-        combobox = SpyderComboBox()
+        combobox = SpyderComboBox(items_elide_mode=items_elide_mode)
         for name, key in choices:
             if not (name is None and key is None):
                 combobox.addItem(name, to_qvariant(key))


### PR DESCRIPTION
## Description of Changes

- This fixes a regression with respect to the same functionality in Spyder 5, introduced by #21555.
- Show a preview of the interface font that is updated automatically when users browse among the available fonts in the system (the last part is important in case users have too many fonts installed). I decided to follow @dalthviz's excellent suggestion in https://github.com/spyder-ide/spyder/pull/21555#issuecomment-1830934497 about it.
- Prevent font names to be elided in the combobox dropdown.
- Automatically update the color scheme and monospace font shown in the editor preview widget when browsing them. This is to have feature parity with the new interface font preview.
- Document API changes in our Changelog and add missing ones for 6.0.2

### Visual changes

**New interface font preview**

![interface-font-preview](https://github.com/user-attachments/assets/cf0406a9-aa1c-4115-aabc-cd827d5b4edd)

**Editor preview is automatically updated**

![editor-preview](https://github.com/user-attachments/assets/e62e8245-45cc-4689-9130-a10a1225904f)


### Issue(s) Resolved

Fixes #22683

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
