### PR TITLE
PR: Fix saving modifications to default run parameters (Run)

### DIFF
--- a/spyder/plugins/run/confpage.py
+++ b/spyder/plugins/run/confpage.py
@@ -507,4 +507,8 @@ class RunConfigPage(PluginConfigPage):
 
         self._params_to_delete = {}
 
+        # This is necessary to prevent giving focus to the executor combobox,
+        # which is odd.
+        self.setFocus()
+
         return {'parameters'}

--- a/spyder/plugins/run/confpage.py
+++ b/spyder/plugins/run/confpage.py
@@ -111,16 +111,16 @@ class RunParametersTableView(HoverRowsTableView):
             (extension, context, params) = model[index]
 
         self.dialog = ExecutionParametersDialog(
-            self,
-            plugin_name,
-            executor_params,
-            self.model().get_parameter_names(),
-            extensions,
-            contexts,
-            params,
-            extension,
-            context,
-            new
+            parent=self,
+            executor_name=plugin_name,
+            executor_params=executor_params,
+            param_names=self.model().get_parameter_names(),
+            extensions=extensions,
+            contexts=contexts,
+            current_params=params,
+            extension=extension,
+            context=context,
+            new_config=new,
         )
 
         self.dialog.setup()

--- a/spyder/plugins/run/widgets.py
+++ b/spyder/plugins/run/widgets.py
@@ -175,7 +175,7 @@ class ExecutionParametersDialog(BaseRunConfigDialog):
         param_names: Dict[Tuple[str, str], List[str]],
         extensions: Optional[List[str]] = None,
         contexts: Optional[Dict[str, List[str]]] = None,
-        default_params: Optional[ExtendedRunExecutionParameters] = None,
+        current_params: Optional[ExtendedRunExecutionParameters] = None,
         extension: Optional[str] = None,
         context: Optional[str] = None,
         new_config: bool = False
@@ -185,7 +185,7 @@ class ExecutionParametersDialog(BaseRunConfigDialog):
         self.executor_name = executor_name
         self.executor_params = executor_params
         self.param_names = param_names
-        self.default_params = default_params
+        self.current_params = current_params
         self.extensions = extensions or []
         self.contexts = contexts or {}
         self.extension = extension
@@ -193,11 +193,11 @@ class ExecutionParametersDialog(BaseRunConfigDialog):
         self.new_config = new_config
 
         self.parameters_name = None
-        if default_params is not None:
+        if current_params is not None:
             self.parameters_name = (
                 _("Default")
-                if default_params["default"]
-                else default_params["name"]
+                if current_params["default"]
+                else current_params["name"]
             )
 
         self.current_widget = None
@@ -342,7 +342,7 @@ class ExecutionParametersDialog(BaseRunConfigDialog):
             self.store_params_text.setText(self.parameters_name)
 
             # Don't allow to change name for default or already saved params.
-            if self.default_params["default"] or not self.new_config:
+            if self.current_params["default"] or not self.new_config:
                 self.store_params_text.setEnabled(False)
 
         # --- Stylesheet
@@ -403,8 +403,8 @@ class ExecutionParametersDialog(BaseRunConfigDialog):
 
         default_params = self.current_widget.get_default_configuration()
 
-        if self.default_params:
-            params = self.default_params['params']
+        if self.current_params:
+            params = self.current_params['params']
             working_dir_params = params['working_dir']
             exec_params = params
 
@@ -490,8 +490,8 @@ class ExecutionParametersDialog(BaseRunConfigDialog):
         exec_params = RunExecutionParameters(
             working_dir=cwd_opts, executor_params=widget_conf)
 
-        if self.default_params:
-            uuid = self.default_params['uuid']
+        if self.current_params:
+            uuid = self.current_params['uuid']
         else:
             uuid = str(uuid4())
 

--- a/spyder/plugins/run/widgets.py
+++ b/spyder/plugins/run/widgets.py
@@ -515,12 +515,26 @@ class ExecutionParametersDialog(BaseRunConfigDialog):
                     )
                     return
 
+        # Check if params are app default ones.
+        # Fixes spyder-ide/spyder#22649
+        if self.current_params is None:
+            # The user is trying to create new params, so this is not a
+            # default.
+            is_default = False
+        else:
+            if self.current_params["default"]:
+                # Default params
+                is_default = True
+            else:
+                # User created params
+                is_default = False
+
         ext_exec_params = ExtendedRunExecutionParameters(
             uuid=uuid,
             name=name,
             params=exec_params,
             file_uuid=None,
-            default=False,
+            default=is_default,
         )
 
         self.saved_conf = (self.selected_extension, self.selected_context,


### PR DESCRIPTION
## Description of Changes

- This was failing because we were not correctly saving the default state of parameters.
- Do a bit of refactoring to make it easier to change that code in the future.
- Set focus to Run config page after applying its changes. Before the focus was given to the runners combobox, which was odd.

### Issue(s) Resolved

Fixes #22649

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
