### PR TITLE
PR: Fix several issues when getting selections to run them (Editor)

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1491,7 +1491,7 @@ def test_run_code(main_window, qtbot, tmpdir):
     assert shell.get_value('li') == [1, 2, 3]
 
     # Test that lines below did not run
-    assert 'arr' not in nsb.editor.source_model._data.keys()
+    assert 'arr' in nsb.editor.source_model._data.keys()
     assert 's' not in nsb.editor.source_model._data.keys()
 
     reset_run_code(qtbot, shell, code_editor, nsb)

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -518,7 +518,9 @@ class TextEditBaseWidget(
         return []
 
     def get_selection_as_executable_code(self, cursor=None):
-        """Get selected text in a way that allows other plugins executed it."""
+        """
+        Get selected text in a way that allows other plugins to execute it.
+        """
         ls = self.get_line_separator()
 
         _indent = lambda line: len(line)-len(line.lstrip())
@@ -535,7 +537,7 @@ class TextEditBaseWidget(
         if len(lines) > 1:
             # Multiline selection -> eventually fixing indentation
             original_indent = _indent(self.get_text_line(line_from))
-            text = (" "*(original_indent-_indent(lines[0])))+text
+            text = (" " * (original_indent - _indent(lines[0]))) + text
 
         # If there is a common indent to all lines, find it.
         # Moving from bottom line to top line ensures that blank
@@ -544,7 +546,7 @@ class TextEditBaseWidget(
         min_indent = 999
         current_indent = 0
         lines = text.split(ls)
-        for i in range(len(lines)-1, -1, -1):
+        for i in range(len(lines) - 1, -1, -1):
             line = lines[i]
             if line.strip():
                 current_indent = _indent(line)
@@ -564,11 +566,6 @@ class TextEditBaseWidget(
                 lines.pop(0)
             else:
                 break
-
-        # Add an EOL character after the last line of code so that it gets
-        # evaluated automatically by the console and any quote characters
-        # are separated from the triple quotes of runcell
-        lines.append(ls)
 
         # Add removed lines back to have correct traceback line numbers
         leading_lines_str = ls * lines_removed

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -2831,15 +2831,16 @@ class EditorStack(QWidget, SpyderWidgetMixin):
         editor = self.get_current_editor()
         finfo = self.get_current_finfo()
         enc = finfo.encoding
-
-        # Move cursor to start of line then move to beginning or end of
-        # document with KeepAnchor
         cursor = editor.textCursor()
-        cursor.movePosition(QTextCursor.StartOfLine)
 
         if direction == 'up':
+            # Select everything from the beginning of the file up to the
+            # current line
+            cursor.movePosition(QTextCursor.EndOfLine)
             cursor.movePosition(QTextCursor.Start, QTextCursor.KeepAnchor)
         elif direction == 'down':
+            # Select everything from the current line to the end of the file
+            cursor.movePosition(QTextCursor.StartOfLine)
             cursor.movePosition(QTextCursor.End, QTextCursor.KeepAnchor)
 
         selection = editor.get_selection_as_executable_code(cursor)

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -3092,14 +3092,9 @@ class EditorMainWidget(PluginMainWidget):
         return run_conf
 
     def get_run_configuration_per_context(
-        self, context, extra_action_name, context_modificator,
-        re_run=False
+        self, context, extra_action_name, context_modificator, re_run=False
     ) -> Optional[RunConfiguration]:
-        # TODO: Should be moved over the plugin?
         editorstack = self.get_current_editorstack()
-        if self.get_conf('save_all_before_run', section="run"):
-            editorstack.save_all(save_new_files=False)
-
         fname = self.get_current_filename()
         __, filename_ext = osp.splitext(fname)
         fname_ext = filename_ext[1:]

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -3121,8 +3121,13 @@ class EditorMainWidget(PluginMainWidget):
             else:
                 text, offsets, line_cols, enc = editorstack.get_selection()
 
-            if extra_action_name == ExtraAction.Advance:
+            # Don't advance line if the selection includes multiple lines. That
+            # was the behavior in Spyder 5 and users are accustomed to it.
+            # Fixes spyder-ide/spyder#22060
+            eol = self.get_current_editor().get_line_separator()
+            if extra_action_name == ExtraAction.Advance and not (eol in text):
                 editorstack.advance_line()
+
             context_name = 'Selection'
             run_input = SelectionRun(
                 path=fname, selection=text, encoding=enc,


### PR DESCRIPTION
## Description of Changes

- Don't advance line for multi-line selections when running them. That keeps the current selection in the editor, which users prefer.
- Don't save files when running cells and selections. This was the behavior in Spyder 5 and it seems users prefer it (e.g. see https://github.com/spyder-ide/spyder/issues/22637#issuecomment-2399707635).
- Remove extra end-of-line when getting selections. That introduced two extra blank lines in the IPython console when running multi-line selections, which was distracting.
- Fix running code up to the current line. Before we were not selecting that line, which was confusing if there are several blank lines before it.

### Issue(s) Resolved

Fixes #22060

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
