### PR TITLE
PR: Catch error when trying to compute the console banner (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -799,7 +799,9 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
             )
 
             banner = ''.join(banner_parts)
-        except (CommError, TimeoutError):
+        except (CommError, TimeoutError, RuntimeError):
+            # RuntimeError happens when the kernel crashes after it starts.
+            # See spyder-ide/spyder#22929
             banner = ""
 
         # Pylab additions


### PR DESCRIPTION
## Description of Changes

It seems this error happens when the kernel crashes after it starts.

### Issue(s) Resolved

Fixes #22929

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
