### PR TITLE
PR: Initial traceback setup to use selected syntax style (IPython Console)

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/dalthviz/spyder-kernels.git
 	branch = spyder_22965
-	commit = d9e7bad059f1acf69de9fef45c0b849aacfebf1e
-	parent = 23928f725ec8e6f44a3ca68ea2b2a4d7a5f8e70d
+	commit = 6939c42dfe1500ce1fa99a079d4fe7bffab90ddb
+	parent = 5baef983b540f87b5b0237f2d4b47ceb5ab6c1f9
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/dalthviz/spyder-kernels.git
 	branch = spyder_22965
-	commit = 589c471ae58a0480a0d670dbccc86d69a46630a7
-	parent = 0927a4b54e7e96808bd3fc926e9dfe8e02b18c1b
+	commit = f3211825d0bdb4970e14b930afffec164d275e26
+	parent = 06fc0033cf021d6f2b1ad910e27029e2afe92e6e
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/dalthviz/spyder-kernels.git
 	branch = spyder_22965
-	commit = 75ebcac30e35d96658c59b70ee9c5f6b0cad8f98
-	parent = 79dcad4c1c910dea5e75e23f7a30a7d585db55ba
+	commit = 589c471ae58a0480a0d670dbccc86d69a46630a7
+	parent = 0927a4b54e7e96808bd3fc926e9dfe8e02b18c1b
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/dalthviz/spyder-kernels.git
 	branch = spyder_22965
-	commit = f3211825d0bdb4970e14b930afffec164d275e26
-	parent = 06fc0033cf021d6f2b1ad910e27029e2afe92e6e
+	commit = d9e7bad059f1acf69de9fef45c0b849aacfebf1e
+	parent = 23928f725ec8e6f44a3ca68ea2b2a4d7a5f8e70d
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/dalthviz/spyder-kernels.git
 	branch = spyder_22965
-	commit = 6939c42dfe1500ce1fa99a079d4fe7bffab90ddb
-	parent = 5baef983b540f87b5b0237f2d4b47ceb5ab6c1f9
+	commit = 753558ad1a63a3a92a15642b730481beb55353a7
+	parent = 0c5e18fa40331ce579e6206aeef5de89bb5dd6e1
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/dalthviz/spyder-kernels.git
 	branch = spyder_22965
-	commit = db71627b92c61142688a12d1148732e5cfafc159
-	parent = a6cb0c2c351cbdddac08e9063d508c16fdfacead
+	commit = 20f181681e4b7fa4c18d6820f6802cdc63d53c32
+	parent = 55d747c958ad4fb8b32ea78a0a39f072e8c01c3b
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/dalthviz/spyder-kernels.git
 	branch = spyder_22965
-	commit = 753558ad1a63a3a92a15642b730481beb55353a7
-	parent = 0c5e18fa40331ce579e6206aeef5de89bb5dd6e1
+	commit = 07b9ca3e8d08f64c95c0c15f79a31183363c294a
+	parent = d0be46014ce9d433dd8fd8f0290de35649e5b5fe
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = master
-	commit = f9fc2f62179a98cf582b44306a9f9225506ec532
-	parent = 3d037175c3ae4bb20f1366a6e5446ae064ed6306
+	remote = https://github.com/dalthviz/spyder-kernels.git
+	branch = spyder_22965
+	commit = 75ebcac30e35d96658c59b70ee9c5f6b0cad8f98
+	parent = 79dcad4c1c910dea5e75e23f7a30a7d585db55ba
 	method = merge
-	cmdver = 0.4.9
+	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/dalthviz/spyder-kernels.git
-	branch = spyder_22965
-	commit = 20f181681e4b7fa4c18d6820f6802cdc63d53c32
-	parent = 55d747c958ad4fb8b32ea78a0a39f072e8c01c3b
+	remote = https://github.com/spyder-ide/spyder-kernels.git
+	branch = master
+	commit = 07f24b6fde55585e64d1802036efba19514dbf0c
+	parent = 41c288acf1c34b7cd9f1175b4f0fa8233692a26c
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/dalthviz/spyder-kernels.git
 	branch = spyder_22965
-	commit = 07b9ca3e8d08f64c95c0c15f79a31183363c294a
-	parent = d0be46014ce9d433dd8fd8f0290de35649e5b5fe
+	commit = db71627b92c61142688a12d1148732e5cfafc159
+	parent = a6cb0c2c351cbdddac08e9063d508c16fdfacead
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -639,6 +639,8 @@ class SpyderKernel(IPythonKernel):
                     ret["special_kernel_error"] = value
             elif key == "color scheme":
                 self.set_color_scheme(value)
+            elif key == "traceback_highlight_style":
+                self.set_traceback_syntax_highlighting(value)
             elif key == "jedi_completer":
                 self.set_jedi_completer(value)
             elif key == "greedy_completer":
@@ -664,6 +666,25 @@ class SpyderKernel(IPythonKernel):
         elif color_scheme == "light":
             self.shell.run_line_magic("colors", "lightbg")
             self.set_sympy_forecolor(background_color='light')
+
+    def set_traceback_syntax_highlighting(self, syntax_style):
+        """Set the traceback syntax highlighting."""
+        try:
+            import IPython.core.ultratb
+            from IPython.core.ultratb import VerboseTB
+
+            from spyder.plugins.ipythonconsole.utils.style import create_style_class
+
+            IPython.core.ultratb.get_style_by_name = create_style_class
+
+            if getattr(VerboseTB, 'tb_highlight_style', None) is not None:
+                VerboseTB.tb_highlight_style = syntax_style
+            elif getattr(VerboseTB, '_tb_highlight_style', None) is not None:
+                VerboseTB._tb_highlight_style = syntax_style
+        except Exception:
+            # Only usable if the kernel has access to Spyder syntax style function logic
+            # i.e spyder-kernels and Spyder are installed in the same environment
+            pass
 
     def get_cwd(self):
         """Get current working directory."""

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -47,6 +47,7 @@ from spyder_kernels.utils.iofuncs import iofunctions
 from spyder_kernels.utils.mpl import automatic_backend, MPL_BACKENDS_TO_SPYDER
 from spyder_kernels.utils.nsview import (
     get_remote_data, make_remote_view, get_size)
+from spyder_kernels.utils.style import create_style_class
 from spyder_kernels.console.shell import SpyderShell
 from spyder_kernels.comms.utils import WriteContext
 
@@ -659,17 +660,13 @@ class SpyderKernel(IPythonKernel):
         return ret
 
     def set_color_scheme(self, color_scheme):
-        if color_scheme == "dark":
-            # Needed to change the colors of tracebacks
-            self.shell.run_line_magic("colors", "linux")
-        elif color_scheme == "light":
-            self.shell.run_line_magic("colors", "lightbg")
+        self.shell.set_spyder_theme(color_scheme)
         self.set_sympy_forecolor(background_color=color_scheme)
         self.set_traceback_highlighting(color_scheme)
 
     def set_traceback_highlighting(self, color_scheme):
         """Set the traceback highlighting color."""
-        color = 'bg:ansigreen' if color_scheme == 'dark' else 'bg:ansiyellow'
+        color = 'bg:ansired' if color_scheme == 'dark' else 'bg:ansiyellow'
         from IPython.core.ultratb import VerboseTB
 
         if getattr(VerboseTB, 'tb_highlight', None) is not None:
@@ -681,8 +678,6 @@ class SpyderKernel(IPythonKernel):
         """Set the traceback syntax highlighting style."""
         import IPython.core.ultratb
         from IPython.core.ultratb import VerboseTB
-
-        from spyder_kernels.utils.style import create_style_class
 
         IPython.core.ultratb.get_style_by_name = create_style_class
 

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -669,7 +669,7 @@ class SpyderKernel(IPythonKernel):
 
     def set_traceback_highlighting(self, color_scheme):
         """Set the traceback highlighting color."""
-        color = 'bg:ansired' if color_scheme == 'dark' else 'bg:ansiyellow'
+        color = 'bg:ansigreen' if color_scheme == 'dark' else 'bg:ansiyellow'
         from IPython.core.ultratb import VerboseTB
 
         if getattr(VerboseTB, 'tb_highlight', None) is not None:

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -662,13 +662,23 @@ class SpyderKernel(IPythonKernel):
         if color_scheme == "dark":
             # Needed to change the colors of tracebacks
             self.shell.run_line_magic("colors", "linux")
-            self.set_sympy_forecolor(background_color='dark')
         elif color_scheme == "light":
             self.shell.run_line_magic("colors", "lightbg")
-            self.set_sympy_forecolor(background_color='light')
+        self.set_sympy_forecolor(background_color=color_scheme)
+        self.set_traceback_highlighting(color_scheme)
+
+    def set_traceback_highlighting(self, color_scheme):
+        """Set the traceback highlighting color."""
+        color = 'bg:ansired' if color_scheme == 'dark' else 'bg:ansiyellow'
+        from IPython.core.ultratb import VerboseTB
+
+        if getattr(VerboseTB, 'tb_highlight', None) is not None:
+            VerboseTB.tb_highlight = color
+        elif getattr(VerboseTB, '_tb_highlight', None) is not None:
+            VerboseTB._tb_highlight = color
 
     def set_traceback_syntax_highlighting(self, syntax_style):
-        """Set the traceback syntax highlighting."""
+        """Set the traceback syntax highlighting style."""
         try:
             import IPython.core.ultratb
             from IPython.core.ultratb import VerboseTB

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -677,7 +677,7 @@ class SpyderKernel(IPythonKernel):
         elif getattr(VerboseTB, '_tb_highlight', None) is not None:
             VerboseTB._tb_highlight = color
 
-    def set_traceback_syntax_highlighting(self, syntax_style, syntax_style_dict):
+    def set_traceback_syntax_highlighting(self, syntax_style):
         """Set the traceback syntax highlighting style."""
         import IPython.core.ultratb
         from IPython.core.ultratb import VerboseTB

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -677,24 +677,19 @@ class SpyderKernel(IPythonKernel):
         elif getattr(VerboseTB, '_tb_highlight', None) is not None:
             VerboseTB._tb_highlight = color
 
-    def set_traceback_syntax_highlighting(self, syntax_style):
+    def set_traceback_syntax_highlighting(self, syntax_style, syntax_style_dict):
         """Set the traceback syntax highlighting style."""
-        try:
-            import IPython.core.ultratb
-            from IPython.core.ultratb import VerboseTB
+        import IPython.core.ultratb
+        from IPython.core.ultratb import VerboseTB
 
-            from spyder.plugins.ipythonconsole.utils.style import create_style_class
+        from spyder_kernels.utils.style import create_style_class
 
-            IPython.core.ultratb.get_style_by_name = create_style_class
+        IPython.core.ultratb.get_style_by_name = create_style_class
 
-            if getattr(VerboseTB, 'tb_highlight_style', None) is not None:
-                VerboseTB.tb_highlight_style = syntax_style
-            elif getattr(VerboseTB, '_tb_highlight_style', None) is not None:
-                VerboseTB._tb_highlight_style = syntax_style
-        except Exception:
-            # Only usable if the kernel has access to Spyder syntax style function logic
-            # i.e spyder-kernels and Spyder are installed in the same environment
-            pass
+        if getattr(VerboseTB, 'tb_highlight_style', None) is not None:
+            VerboseTB.tb_highlight_style = syntax_style
+        elif getattr(VerboseTB, '_tb_highlight_style', None) is not None:
+            VerboseTB._tb_highlight_style = syntax_style
 
     def get_cwd(self):
         """Get current working directory."""

--- a/external-deps/spyder-kernels/spyder_kernels/console/shell.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/shell.py
@@ -56,6 +56,7 @@ class SpyderShell(ZMQInteractiveShell):
         self._allow_kbdint = False
         self.register_debugger_sigint()
         self.update_gui_frontend = False
+        self._spyder_theme = 'dark'
 
         # register post_execute
         self.events.register('post_execute', self.do_post_execute)
@@ -83,6 +84,19 @@ class SpyderShell(ZMQInteractiveShell):
         if etype is bdb.BdbQuit:
             stb = ['']
         super(SpyderShell, self)._showtraceback(etype, evalue, stb)
+
+    def set_spyder_theme(self, theme):
+        """Set the theme for the console."""
+        self._spyder_theme = theme
+        if theme == "dark":
+            # Needed to change the colors of tracebacks
+            self.run_line_magic("colors", "linux")
+        elif theme == "light":
+            self.run_line_magic("colors", "lightbg")
+
+    def get_spyder_theme(self):
+        """Get the theme for the console."""
+        return self._spyder_theme
 
     def enable_matplotlib(self, gui=None):
         """Enable matplotlib."""

--- a/external-deps/spyder-kernels/spyder_kernels/console/start.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/start.py
@@ -69,9 +69,6 @@ def kernel_config():
         # Don't load nor save history in our IPython consoles.
         spy_cfg.HistoryAccessor.enabled = False
 
-    # Until we implement Issue 1052
-    spy_cfg.InteractiveShell.xmode = 'Plain'
-
     # Jedi completer.
     jedi_o = os.environ.get('SPY_JEDI_O') == 'True'
     spy_cfg.IPCompleter.use_jedi = jedi_o

--- a/external-deps/spyder-kernels/spyder_kernels/console/tests/test_console_kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/tests/test_console_kernel.py
@@ -1314,13 +1314,19 @@ def test_interrupt():
         kernel_comm.remote_call().raise_interrupt_signal()
         # Wait for shell message
         while True:
-            assert time.time() - t0 < 5
+            delta = time.time() - t0
+            assert delta < 5
             msg = client.get_shell_msg(timeout=TIMEOUT)
             if msg["parent_header"].get("msg_id") != msg_id:
                 # not from my request
                 continue
             break
-        assert time.time() - t0 < 5
+
+        delta = time.time() - t0
+        assert delta < 5, (
+            "10 seconds long call should have been interrupted, so the "
+            "interrupt signal was likely mishandled"
+        )
 
 
 def test_enter_debug_after_interruption():

--- a/external-deps/spyder-kernels/spyder_kernels/customize/code_runner.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/code_runner.py
@@ -145,10 +145,11 @@ class SpyderCodeRunner(Magics):
     def __init__(self, *args, **kwargs):
         self.show_global_msg = True
         self.show_invalid_syntax_msg = True
-        self.umr = UserModuleReloader(
-            namelist=os.environ.get("SPY_UMR_NAMELIST", None)
-        )
         super().__init__(*args, **kwargs)
+        self.umr = UserModuleReloader(
+            namelist=os.environ.get("SPY_UMR_NAMELIST", None),
+            shell=self.shell,
+        )
 
     @runfile_arguments
     @needs_local_scope

--- a/external-deps/spyder-kernels/spyder_kernels/customize/code_runner.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/code_runner.py
@@ -143,9 +143,10 @@ class SpyderCodeRunner(Magics):
     Functions and magics related to code execution, debugging, profiling, etc.
     """
     def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
         self.show_global_msg = True
         self.show_invalid_syntax_msg = True
-        super().__init__(*args, **kwargs)
         self.umr = UserModuleReloader(
             namelist=os.environ.get("SPY_UMR_NAMELIST", None),
             shell=self.shell,

--- a/external-deps/spyder-kernels/spyder_kernels/customize/umr.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/umr.py
@@ -92,7 +92,7 @@ class UserModuleReloader:
         # Report reloaded modules
         if self.verbose and modnames_to_reload:
             modnames = modnames_to_reload
-            print("\x1b[4;33m%s\x1b[24m%s\x1b[0m"
+            print("\x1b[1;4;31m%s\x1b[24m%s\x1b[0m"
                   % ("Reloaded modules", ": "+", ".join(modnames)))
 
         return modnames_to_reload

--- a/external-deps/spyder-kernels/spyder_kernels/customize/umr.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/umr.py
@@ -20,7 +20,7 @@ class UserModuleReloader:
     namelist [list]: blacklist in terms of module name
     """
 
-    def __init__(self, namelist=None, pathlist=None):
+    def __init__(self, namelist=None, pathlist=None, shell=None):
         if namelist is None:
             namelist = []
         else:
@@ -45,6 +45,7 @@ class UserModuleReloader:
         self.namelist = namelist + spy_modules + mpl_modules + other_modules
 
         self.pathlist = pathlist
+        self._shell = shell
 
         # List of previously loaded modules
         self.previous_modules = list(sys.modules.keys())
@@ -92,7 +93,11 @@ class UserModuleReloader:
         # Report reloaded modules
         if self.verbose and modnames_to_reload:
             modnames = modnames_to_reload
-            print("\x1b[1;4;31m%s\x1b[24m%s\x1b[0m"
-                  % ("Reloaded modules", ": "+", ".join(modnames)))
+            colors = {"dark": "33", "light": "31"}
+            color = colors["dark"]
+            if self._shell:
+                color = colors[self._shell.get_spyder_theme()]
+            print("\x1b[4;%sm%s\x1b[24m%s\x1b[0m"
+                  % (color, "Reloaded modules", ": "+", ".join(modnames)))
 
         return modnames_to_reload

--- a/external-deps/spyder-kernels/spyder_kernels/customize/umr.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/umr.py
@@ -97,7 +97,7 @@ class UserModuleReloader:
             color = colors["dark"]
             if self._shell:
                 color = colors[self._shell.get_spyder_theme()]
-            print("\x1b[4;%sm%s\x1b[24m%s\x1b[0m"
-                  % (color, "Reloaded modules", ": "+", ".join(modnames)))
+            content = ": "+", ".join(modnames)
+            print(f"\x1b[4;{color}mReloaded modules\x1b[24m{content}\x1b[0m")
 
         return modnames_to_reload

--- a/external-deps/spyder-kernels/spyder_kernels/utils/style.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/style.py
@@ -109,6 +109,6 @@ def create_style_class(color_scheme_dict):
 
     class StyleClass(Style):
         default_style = ""
-        styles = create_pygments_dict(color_scheme_dict)
+        styles = create_pygments_dict(dict(color_scheme_dict))
 
     return StyleClass

--- a/external-deps/spyder-kernels/spyder_kernels/utils/style.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/style.py
@@ -12,8 +12,15 @@ Style for IPython Console
 
 # Third party imports
 from pygments.style import Style
-from pygments.token import (Name, Keyword, Comment, String, Number,
-                            Punctuation, Operator)
+from pygments.token import (
+    Name,
+    Keyword,
+    Comment,
+    String,
+    Number,
+    Punctuation,
+    Operator,
+)
 
 
 def create_pygments_dict(color_scheme_dict):
@@ -24,79 +31,99 @@ def create_pygments_dict(color_scheme_dict):
 
     def give_font_weight(is_bold):
         if is_bold:
-            return 'bold'
+            return "bold"
         else:
-            return ''
+            return ""
 
     def give_font_style(is_italic):
         if is_italic:
-            return 'italic'
+            return "italic"
         else:
-            return ''
+            return ""
 
     color_scheme = color_scheme_dict
 
-    fon_c, fon_fw, fon_fs = color_scheme['normal']
-    font_color =  fon_c
+    fon_c, fon_fw, fon_fs = color_scheme["normal"]
+    font_color = fon_c
     font_font_weight = give_font_weight(fon_fw)
     font_font_style = give_font_style(fon_fs)
-    key_c, key_fw, key_fs = color_scheme['keyword']
-    keyword_color =  key_c
+
+    key_c, key_fw, key_fs = color_scheme["keyword"]
+    keyword_color = key_c
     keyword_font_weight = give_font_weight(key_fw)
     keyword_font_style = give_font_style(key_fs)
-    bui_c, bui_fw, bui_fs = color_scheme['builtin']
-    builtin_color =  bui_c
+
+    bui_c, bui_fw, bui_fs = color_scheme["builtin"]
+    builtin_color = bui_c
     builtin_font_weight = give_font_weight(bui_fw)
     builtin_font_style = give_font_style(bui_fs)
-    str_c, str_fw, str_fs = color_scheme['string']
-    string_color =  str_c
+
+    str_c, str_fw, str_fs = color_scheme["string"]
+    string_color = str_c
     string_font_weight = give_font_weight(str_fw)
     string_font_style = give_font_style(str_fs)
-    num_c, num_fw, num_fs = color_scheme['number']
-    number_color =  num_c
+
+    num_c, num_fw, num_fs = color_scheme["number"]
+    number_color = num_c
     number_font_weight = give_font_weight(num_fw)
     number_font_style = give_font_style(num_fs)
-    com_c, com_fw, com_fs = color_scheme['comment']
-    comment_color =  com_c
+
+    com_c, com_fw, com_fs = color_scheme["comment"]
+    comment_color = com_c
     comment_font_weight = give_font_weight(com_fw)
     comment_font_style = give_font_style(com_fs)
-    def_c, def_fw, def_fs = color_scheme['definition']
-    definition_color =  def_c
+
+    def_c, def_fw, def_fs = color_scheme["definition"]
+    definition_color = def_c
     definition_font_weight = give_font_weight(def_fw)
     definition_font_style = give_font_style(def_fs)
-    ins_c, ins_fw, ins_fs = color_scheme['instance']
-    instance_color =  ins_c
+
+    ins_c, ins_fw, ins_fs = color_scheme["instance"]
+    instance_color = ins_c
     instance_font_weight = give_font_weight(ins_fw)
     instance_font_style = give_font_style(ins_fs)
 
-    font_token = font_font_style + ' ' + font_font_weight + ' ' + font_color
-    definition_token = (definition_font_style + ' ' + definition_font_weight +
-                        ' ' + definition_color)
-    builtin_token = (builtin_font_style + ' ' + builtin_font_weight + ' ' +
-                     builtin_color)
-    instance_token = (instance_font_style + ' ' + instance_font_weight + ' ' +
-                      instance_color)
-    keyword_token = (keyword_font_style + ' ' + keyword_font_weight + ' ' +
-                     keyword_color)
-    comment_token = (comment_font_style + ' ' + comment_font_weight + ' ' +
-                     comment_color)
-    string_token = (string_font_style + ' ' + string_font_weight + ' ' +
-                    string_color)
-    number_token = (number_font_style + ' ' + number_font_weight + ' ' +
-                    number_color)
+    font_token = font_font_style + " " + font_font_weight + " " + font_color
+    definition_token = (
+        definition_font_style
+        + " "
+        + definition_font_weight
+        + " "
+        + definition_color
+    )
+    builtin_token = (
+        builtin_font_style + " " + builtin_font_weight + " " + builtin_color
+    )
+    instance_token = (
+        instance_font_style + " " + instance_font_weight + " " + instance_color
+    )
+    keyword_token = (
+        keyword_font_style + " " + keyword_font_weight + " " + keyword_color
+    )
+    comment_token = (
+        comment_font_style + " " + comment_font_weight + " " + comment_color
+    )
+    string_token = (
+        string_font_style + " " + string_font_weight + " " + string_color
+    )
+    number_token = (
+        number_font_style + " " + number_font_weight + " " + number_color
+    )
 
-    syntax_style_dic = {Name: font_token.strip(),
-                        Name.Class: definition_token.strip(),
-                        Name.Function: definition_token.strip(),
-                        Name.Builtin: builtin_token.strip(),
-                        Name.Builtin.Pseudo: instance_token.strip(),
-                        Keyword: keyword_token.strip(),
-                        Keyword.Type: builtin_token.strip(),
-                        Comment: comment_token.strip(),
-                        String: string_token.strip(),
-                        Number: number_token.strip(),
-                        Punctuation: font_token.strip(),
-                        Operator.Word: keyword_token.strip()}
+    syntax_style_dic = {
+        Name: font_token.strip(),
+        Name.Class: definition_token.strip(),
+        Name.Function: definition_token.strip(),
+        Name.Builtin: builtin_token.strip(),
+        Name.Builtin.Pseudo: instance_token.strip(),
+        Keyword: keyword_token.strip(),
+        Keyword.Type: builtin_token.strip(),
+        Comment: comment_token.strip(),
+        String: string_token.strip(),
+        Number: number_token.strip(),
+        Punctuation: font_token.strip(),
+        Operator.Word: keyword_token.strip(),
+    }
 
     return syntax_style_dic
 

--- a/external-deps/spyder-kernels/spyder_kernels/utils/style.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/style.py
@@ -10,9 +10,6 @@
 Style for IPython Console
 """
 
-# Local imports
-from spyder.config.gui import get_color_scheme
-
 # Third party imports
 from pygments.style import Style
 from pygments.token import (Name, Keyword, Comment, String, Number,
@@ -37,7 +34,7 @@ def create_pygments_dict(color_scheme_dict):
         else:
             return ''
 
-    color_scheme = get_color_scheme(color_scheme_dict)
+    color_scheme = color_scheme_dict
 
     fon_c, fon_fw, fon_fs = color_scheme['normal']
     font_color =  fon_c

--- a/external-deps/spyder-kernels/spyder_kernels/utils/style.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/style.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2009- Spyder Kernels Contributors
+#
+# Licensed under the terms of the MIT License
+# (see spyder_kernels/__init__.py for details)
+# -----------------------------------------------------------------------------
+
+"""
+Style for IPython Console
+"""
+
+# Local imports
+from spyder.config.gui import get_color_scheme
+
+# Third party imports
+from pygments.style import Style
+from pygments.token import (Name, Keyword, Comment, String, Number,
+                            Punctuation, Operator)
+
+
+def create_pygments_dict(color_scheme_dict):
+    """
+    Create a dictionary that saves the given color scheme as a
+    Pygments style.
+    """
+
+    def give_font_weight(is_bold):
+        if is_bold:
+            return 'bold'
+        else:
+            return ''
+
+    def give_font_style(is_italic):
+        if is_italic:
+            return 'italic'
+        else:
+            return ''
+
+    color_scheme = get_color_scheme(color_scheme_dict)
+
+    fon_c, fon_fw, fon_fs = color_scheme['normal']
+    font_color =  fon_c
+    font_font_weight = give_font_weight(fon_fw)
+    font_font_style = give_font_style(fon_fs)
+    key_c, key_fw, key_fs = color_scheme['keyword']
+    keyword_color =  key_c
+    keyword_font_weight = give_font_weight(key_fw)
+    keyword_font_style = give_font_style(key_fs)
+    bui_c, bui_fw, bui_fs = color_scheme['builtin']
+    builtin_color =  bui_c
+    builtin_font_weight = give_font_weight(bui_fw)
+    builtin_font_style = give_font_style(bui_fs)
+    str_c, str_fw, str_fs = color_scheme['string']
+    string_color =  str_c
+    string_font_weight = give_font_weight(str_fw)
+    string_font_style = give_font_style(str_fs)
+    num_c, num_fw, num_fs = color_scheme['number']
+    number_color =  num_c
+    number_font_weight = give_font_weight(num_fw)
+    number_font_style = give_font_style(num_fs)
+    com_c, com_fw, com_fs = color_scheme['comment']
+    comment_color =  com_c
+    comment_font_weight = give_font_weight(com_fw)
+    comment_font_style = give_font_style(com_fs)
+    def_c, def_fw, def_fs = color_scheme['definition']
+    definition_color =  def_c
+    definition_font_weight = give_font_weight(def_fw)
+    definition_font_style = give_font_style(def_fs)
+    ins_c, ins_fw, ins_fs = color_scheme['instance']
+    instance_color =  ins_c
+    instance_font_weight = give_font_weight(ins_fw)
+    instance_font_style = give_font_style(ins_fs)
+
+    font_token = font_font_style + ' ' + font_font_weight + ' ' + font_color
+    definition_token = (definition_font_style + ' ' + definition_font_weight +
+                        ' ' + definition_color)
+    builtin_token = (builtin_font_style + ' ' + builtin_font_weight + ' ' +
+                     builtin_color)
+    instance_token = (instance_font_style + ' ' + instance_font_weight + ' ' +
+                      instance_color)
+    keyword_token = (keyword_font_style + ' ' + keyword_font_weight + ' ' +
+                     keyword_color)
+    comment_token = (comment_font_style + ' ' + comment_font_weight + ' ' +
+                     comment_color)
+    string_token = (string_font_style + ' ' + string_font_weight + ' ' +
+                    string_color)
+    number_token = (number_font_style + ' ' + number_font_weight + ' ' +
+                    number_color)
+
+    syntax_style_dic = {Name: font_token.strip(),
+                        Name.Class: definition_token.strip(),
+                        Name.Function: definition_token.strip(),
+                        Name.Builtin: builtin_token.strip(),
+                        Name.Builtin.Pseudo: instance_token.strip(),
+                        Keyword: keyword_token.strip(),
+                        Keyword.Type: builtin_token.strip(),
+                        Comment: comment_token.strip(),
+                        String: string_token.strip(),
+                        Number: number_token.strip(),
+                        Punctuation: font_token.strip(),
+                        Operator.Word: keyword_token.strip()}
+
+    return syntax_style_dic
+
+
+def create_style_class(color_scheme_dict):
+    """Create a Pygments Style class with the given color scheme."""
+
+    class StyleClass(Style):
+        default_style = ""
+        styles = create_pygments_dict(color_scheme_dict)
+
+    return StyleClass

--- a/external-deps/spyder-kernels/spyder_kernels/utils/style.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/style.py
@@ -106,6 +106,6 @@ def create_style_class(color_scheme_dict):
 
     class StyleClass(Style):
         default_style = ""
-        styles = create_pygments_dict(dict(color_scheme_dict))
+        styles = create_pygments_dict(color_scheme_dict)
 
     return StyleClass

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -6461,9 +6461,9 @@ def test_PYTHONPATH_in_consoles(main_window, qtbot, tmp_path,
         assert str(user_dir) not in sys_path
 
 
-# @flaky(max_runs=10)
+@flaky(max_runs=10)
 @pytest.mark.skipif(sys.platform == 'darwin', reason="Fails on Mac")
-# @pytest.mark.order(before='test_shell_execution')
+@pytest.mark.order(before='test_shell_execution')
 def test_clickable_ipython_tracebacks(main_window, qtbot, tmp_path):
     """
     Test that file names in IPython console tracebacks are clickable.

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -6461,9 +6461,9 @@ def test_PYTHONPATH_in_consoles(main_window, qtbot, tmp_path,
         assert str(user_dir) not in sys_path
 
 
-@flaky(max_runs=10)
+# @flaky(max_runs=10)
 @pytest.mark.skipif(sys.platform == 'darwin', reason="Fails on Mac")
-@pytest.mark.order(before='test_shell_execution')
+# @pytest.mark.order(before='test_shell_execution')
 def test_clickable_ipython_tracebacks(main_window, qtbot, tmp_path):
     """
     Test that file names in IPython console tracebacks are clickable.
@@ -6502,7 +6502,7 @@ def test_clickable_ipython_tracebacks(main_window, qtbot, tmp_path):
     control.setFocus()
     find_widget = main_window.ipyconsole.get_widget().find_widget
     find_widget.show()
-    find_widget.search_text.lineEdit().setText('  File')
+    find_widget.search_text.lineEdit().setText('File')
     find_widget.find_previous()
 
     # Position mouse on top of that line

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -1439,6 +1439,8 @@ overrided by the Sympy module (e.g. plot)
         if self.syntax_style:
             self._highlighter._style = create_style_class(self.syntax_style)
             self._highlighter._clear_caches()
+            if changed is None:
+                return
             self.set_kernel_configuration(
                 "traceback_highlight_style", self.syntax_style
             )

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -700,7 +700,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
         self.style_sheet, dark_color = create_qss_style(color_scheme)
         self.syntax_style = color_scheme
         self._style_sheet_changed()
-        self._syntax_style_changed()
+        self._syntax_style_changed(changed={})
         if reset:
             self.reset(clear=True)
         if not self.spyder_kernel_ready:

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -187,8 +187,9 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
         self.is_kernel_configured = False
         self._init_kernel_setup = False
         self._is_banner_shown = False
-        # Set bright colors instead of bold formating for better traceback
-        # readability
+
+        # Set bright colors instead of bold formatting for better traceback
+        # readability.
         self._ansi_processor.bold_text_enabled = False
 
         if handlers is None:

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -452,8 +452,6 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
             # Enable autoreload_magic
             self.set_kernel_configuration("autoreload_magic", True)
 
-        self.silent_execute("%xmode context")
-
         self.call_kernel(
             interrupt=self.is_debugging(),
             callback=self.kernel_configure_callback
@@ -1441,20 +1439,8 @@ overrided by the Sympy module (e.g. plot)
         if self.syntax_style:
             self._highlighter._style = create_style_class(self.syntax_style)
             self._highlighter._clear_caches()
-            self.silent_execute(
-f"""
-import IPython.core.ultratb
-from IPython.core.ultratb import VerboseTB
-
-from spyder.plugins.ipythonconsole.utils.style import create_style_class
-
-IPython.core.ultratb.get_style_by_name = create_style_class
-
-if getattr(VerboseTB, 'tb_highlight_style', None) is not None:
-    VerboseTB.tb_highlight_style = '{self.syntax_style}'
-elif getattr(VerboseTB, '_tb_highlight_style', None) is not None:
-    VerboseTB._tb_highlight_style = '{self.syntax_style}'
-"""
+            self.set_kernel_configuration(
+                "traceback_highlight_style", self.syntax_style
             )
         else:
             self._highlighter.set_style_sheet(self.style_sheet)

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -1444,7 +1444,8 @@ overrided by the Sympy module (e.g. plot)
             if changed is None:
                 return
             self.set_kernel_configuration(
-                "traceback_highlight_style", get_color_scheme(self.syntax_style)
+                "traceback_highlight_style",
+                get_color_scheme(self.syntax_style),
             )
         else:
             self._highlighter.set_style_sheet(self.style_sheet)

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -1444,7 +1444,7 @@ overrided by the Sympy module (e.g. plot)
             if changed is None:
                 return
             self.set_kernel_configuration(
-                "traceback_highlight_style", self.syntax_style, get_color_scheme(self.syntax_style)
+                "traceback_highlight_style", get_color_scheme(self.syntax_style)
             )
         else:
             self._highlighter.set_style_sheet(self.style_sheet)

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -452,7 +452,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
             # Enable autoreload_magic
             self.set_kernel_configuration("autoreload_magic", True)
 
-        self.silent_execute("%xmode verbose")
+        self.silent_execute("%xmode context")
 
         self.call_kernel(
             interrupt=self.is_debugging(),

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -1444,7 +1444,7 @@ overrided by the Sympy module (e.g. plot)
             if changed is None:
                 return
             self.set_kernel_configuration(
-                "traceback_highlight_style", self.syntax_style
+                "traceback_highlight_style", self.syntax_style, get_color_scheme(self.syntax_style)
             )
         else:
             self._highlighter.set_style_sheet(self.style_sheet)

--- a/spyder/utils/misc.py
+++ b/spyder/utils/misc.py
@@ -154,16 +154,21 @@ def remove_backslashes(path):
 
 def get_error_match(text):
     """Check if text contains a Python error."""
-    # For regular Python tracebacks and IPython 7 or less.
+    # For regular Python tracebacks and IPython 7 or less (xmode plain).
     match_python = re.match(r'  File "(.*)", line (\d*)', text)
     if match_python is not None:
         return match_python
 
-    # For IPython 8+ tracebacks.
+    # For IPython 8+ tracebacks (xmode plain).
     # Fixes spyder-ide/spyder#20407
-    ipython8_match = re.match(r'  File (.*):(\d*)', text)
-    if ipython8_match is not None:
-        return ipython8_match
+    ipython8_plain_match = re.match(r'  File (.*):(\d*)', text)
+    if ipython8_plain_match is not None:
+        return ipython8_plain_match
+
+    # For IPython 8+ tracebacks (xmode context).
+    ipython8_context_match = re.match(r'File (.*):(\d*)', text)
+    if ipython8_context_match is not None:
+        return ipython8_context_match
 
     return False
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->

Enable context mode tracebacks to follow currently selected syntax style. A preview:

![image](https://github.com/user-attachments/assets/cb953e26-4514-44d2-a367-1501c43a4f23)
![image](https://github.com/user-attachments/assets/bdc2b53c-4409-4554-b214-1b2ca978c587)


- Depends on https://github.com/spyder-ide/spyder-kernels/pull/521

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22412
Fixes #1052

### Notes

~Probably the logic here to set the syntax style via the import of the `VerboseTB` class and set the exception handler to `verbose` (`xmode` magic) should go over `spyder-kernels` and be added as a kernel comm handler method? What do you think @ccordoba12 ?~
Requires changes over spyder-kernels: https://github.com/spyder-ide/spyder-kernels/pull/521

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
