### PR TITLE
PR: Restore widget shortcuts to Preferences and allow to change them on the fly (Shortcuts)

### DIFF
--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -4,6 +4,7 @@
 
 ### API changes
 
+* The `add_configuration_observer` method was added to `SpyderConfigurationObserver`.
 * Add `items_elide_mode` kwarg to the constructors of `SpyderComboBox` and
   `SpyderComboBoxWithIcons`.
 * The `sig_item_in_popup_changed` and `sig_popup_is_hidden` signals were added

--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -4,6 +4,8 @@
 
 ### API changes
 
+* Add `plugin_name` kwarg to the `register_shortcut_for_widget` method of
+  `SpyderShortcutsMixin`.
 * The `add_configuration_observer` method was added to `SpyderConfigurationObserver`.
 * Add `items_elide_mode` kwarg to the constructors of `SpyderComboBox` and
   `SpyderComboBoxWithIcons`.

--- a/conftest.py
+++ b/conftest.py
@@ -109,7 +109,12 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture(autouse=True)
-def reset_conf_before_test():
+def reset_conf_before_test(request):
+    # To prevent running this fixture for a specific test, you need to use this
+    # marker.
+    if 'no_reset_conf' in request.keywords:
+        return
+
     from spyder.config.manager import CONF
     CONF.reset_to_defaults(notification=False)
 

--- a/spyder/api/plugins/new_api.py
+++ b/spyder/api/plugins/new_api.py
@@ -298,8 +298,8 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
         The window state.
     """
 
-    # --- Private attributes -------------------------------------------------
-    # ------------------------------------------------------------------------
+    # ---- Private attributes
+    # -------------------------------------------------------------------------
     # Define configuration name map for plugin to split configuration
     # among several files. See spyder/config/main.py
     _CONF_NAME_MAP = None
@@ -361,8 +361,8 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
             plugin_path = osp.join(self.get_path(), self.IMG_PATH)
             IMAGE_PATH_MANAGER.add_image_path(plugin_path)
 
-    # --- Private methods ----------------------------------------------------
-    # ------------------------------------------------------------------------
+    # ---- Private methods
+    # -------------------------------------------------------------------------
     def _register(self, omit_conf=False):
         """
         Setup and register plugin in Spyder's main window and connect it to
@@ -397,8 +397,8 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
         self.is_compatible = None
         self.is_registered = False
 
-    # --- API: available methods ---------------------------------------------
-    # ------------------------------------------------------------------------
+    # ---- API: available methods
+    # -------------------------------------------------------------------------
     def get_path(self):
         """
         Return the plugin's system path.
@@ -765,8 +765,8 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
             sys_argv = [sys.argv[0]]  # Avoid options passed to pytest
             return get_options(sys_argv)[0]
 
-    # --- API: Mandatory methods to define -----------------------------------
-    # ------------------------------------------------------------------------
+    # ---- API: Mandatory methods to define
+    # -------------------------------------------------------------------------
     @staticmethod
     def get_name():
         """
@@ -832,8 +832,8 @@ class SpyderPluginV2(QObject, SpyderActionMixin, SpyderConfigurationObserver,
             f'The plugin {type(self)} is missing an implementation of '
             'on_initialize')
 
-    # --- API: Optional methods to override ----------------------------------
-    # ------------------------------------------------------------------------
+    # ---- API: Optional methods to override
+    # -------------------------------------------------------------------------
     @staticmethod
     def check_compatibility():
         """
@@ -952,14 +952,14 @@ class SpyderDockablePlugin(SpyderPluginV2):
     """
     A Spyder plugin to enhance functionality with a dockable widget.
     """
-    # --- API: Mandatory attributes ------------------------------------------
-    # ------------------------------------------------------------------------
+    # ---- API: Mandatory attributes
+    # -------------------------------------------------------------------------
     # This is the main widget of the dockable plugin.
     # It needs to be a subclass of PluginMainWidget.
     WIDGET_CLASS = None
 
-    # --- API: Optional attributes -------------------------------------------
-    # ------------------------------------------------------------------------
+    # ---- API: Optional attributes
+    # -------------------------------------------------------------------------
     # Define a list of plugins next to which we want to to tabify this plugin.
     # Example: ['Plugins.Editor']
     TABIFY = []
@@ -972,8 +972,8 @@ class SpyderDockablePlugin(SpyderPluginV2):
     # the action to switch is called a second time.
     RAISE_AND_FOCUS = False
 
-    # --- API: Available signals ---------------------------------------------
-    # ------------------------------------------------------------------------
+    # ---- API: Available signals
+    # -------------------------------------------------------------------------
     sig_focus_changed = Signal()
     """
     This signal is emitted to inform the focus of this plugin has changed.
@@ -1010,8 +1010,8 @@ class SpyderDockablePlugin(SpyderPluginV2):
     needs its ancestor to be updated.
     """
 
-    # --- Private methods ----------------------------------------------------
-    # ------------------------------------------------------------------------
+    # ---- Private methods
+    # -------------------------------------------------------------------------
     def __init__(self, parent, configuration):
         if not issubclass(self.WIDGET_CLASS, PluginMainWidget):
             raise SpyderAPIError(
@@ -1053,8 +1053,8 @@ class SpyderDockablePlugin(SpyderPluginV2):
         widget.sig_update_ancestor_requested.connect(
             self.sig_update_ancestor_requested)
 
-    # --- API: available methods ---------------------------------------------
-    # ------------------------------------------------------------------------
+    # ---- API: available methods
+    # -------------------------------------------------------------------------
     def before_long_process(self, message):
         """
         Show a message in main window's status bar, change the mouse pointer
@@ -1116,8 +1116,8 @@ class SpyderDockablePlugin(SpyderPluginV2):
         """
         self.get_widget().set_ancestor(ancestor_widget)
 
-    # --- Convenience methods from the widget exposed on the plugin
-    # ------------------------------------------------------------------------
+    # ---- Convenience methods from the widget exposed on the plugin
+    # -------------------------------------------------------------------------
     @property
     def dockwidget(self):
         return self.get_widget().dockwidget

--- a/spyder/api/shortcuts.py
+++ b/spyder/api/shortcuts.py
@@ -18,6 +18,10 @@ from qtpy.QtWidgets import QShortcut, QWidget
 
 # Local imports
 from spyder.config.manager import CONF
+from spyder.plugins.shortcuts.utils import (
+    ShortcutData,
+    SHORTCUTS_FOR_WIDGETS_DATA,
+)
 
 
 class SpyderShortcutsMixin:
@@ -119,7 +123,14 @@ class SpyderShortcutsMixin:
         context = self.CONF_SECTION if context is None else context
         widget = self if widget is None else widget
 
+        # Register shortcut to widget
         keystr = self.get_shortcut(name, context)
         qsc = QShortcut(QKeySequence(keystr), widget)
         qsc.activated.connect(triggered)
         qsc.setContext(Qt.WidgetWithChildrenShortcut)
+
+        # Keep track of all widget shortcuts. This is necessary to show them in
+        # Preferences.
+        data = ShortcutData(qobject=None, name=name, context=context)
+        if data not in SHORTCUTS_FOR_WIDGETS_DATA:
+            SHORTCUTS_FOR_WIDGETS_DATA.append(data)

--- a/spyder/api/shortcuts.py
+++ b/spyder/api/shortcuts.py
@@ -35,11 +35,15 @@ class SpyderShortcutsMixin:
         Parameters
         ----------
         name: str
-            Key identifier under which the shortcut is stored.
-        context: Optional[str]
-            Name of the shortcut context.
-        plugin: Optional[str]
-            Name of the plugin where the shortcut is defined.
+            The shortcut name (e.g. "run cell").
+        context: str, optional
+            Name of the shortcut context, e.g. "editor" for shortcuts that have
+            effect when the Editor is focused or "_" for global shortcuts. If
+            not set, the widget's CONF_SECTION will be used as context.
+        plugin_name: str, optional
+            Name of the plugin where the shortcut is defined. This is necessary
+            for third-party plugins that have shortcuts with a context
+            different from the plugin name.
 
         Returns
         -------
@@ -49,7 +53,7 @@ class SpyderShortcutsMixin:
         Raises
         ------
         configparser.NoOptionError
-            If the context does not exist in the configuration.
+            If the shortcut does not exist in the configuration.
         """
         context = self.CONF_SECTION if context is None else context
         return CONF.get_shortcut(context, name, plugin_name)
@@ -69,16 +73,20 @@ class SpyderShortcutsMixin:
         shortcut: str
             Key sequence of the shortcut.
         name: str
-            Key identifier under which the shortcut is stored.
-        context: Optional[str]
-            Name of the shortcut context.
-        plugin: Optional[str]
-            Name of the plugin where the shortcut is defined.
+            The shortcut name (e.g. "run cell").
+        context: str, optional
+            Name of the shortcut context, e.g. "editor" for shortcuts that have
+            effect when the Editor is focused or "_" for global shortcuts. If
+            not set, the widget's CONF_SECTION will be used as context.
+        plugin_name: str, optional
+            Name of the plugin where the shortcut is defined. This is necessary
+            for third-party plugins that have shortcuts with a context
+            different from the plugin name.
 
         Raises
         ------
         configparser.NoOptionError
-            If the context does not exist in the configuration.
+            If the shortcut does not exist in the configuration.
         """
         context = self.CONF_SECTION if context is None else context
         return CONF.set_shortcut(context, name, shortcut, plugin_name)
@@ -96,16 +104,17 @@ class SpyderShortcutsMixin:
         Parameters
         ----------
         name: str
-            Key identifier under which the shortcut is stored.
+            The shortcut name (e.g. "run cell").
         triggered: Callable
             Callable (i.e. function or method) that will be triggered by the
             shortcut.
-        widget: Optional[QWidget]
-            Widget to which register this shortcut. By default we register it
-            to the one that calls this method.
-        context: Optional[str]
-            Name of the context (plugin) where the shortcut is defined. By
-            default we use the widget's CONF_SECTION.
+        widget: QWidget, optional
+            Widget to which this shortcut will be registered. If not set, the
+            widget that calls this method will be used.
+        context: str, optional
+            Name of the shortcut context, e.g. "editor" for shortcuts that have
+            effect when the Editor is focused or "_" for global shortcuts. If
+            not set, the widget's CONF_SECTION will be used as context.
         """
         context = self.CONF_SECTION if context is None else context
         widget = self if widget is None else widget

--- a/spyder/api/shortcuts.py
+++ b/spyder/api/shortcuts.py
@@ -136,6 +136,12 @@ class SpyderShortcutsMixin(SpyderConfigurationObserver):
         context = self.CONF_SECTION if context is None else context
         widget = self if widget is None else widget
 
+        # Name and context are saved in lowercase in our config system, so we
+        # need to use them like that here.
+        # Note: That's how the Python ConfigParser class saves options.
+        name = name.lower()
+        context = context.lower()
+
         # Add observer to register shortcut when its associated option is
         # broadcasted by CONF or updated in Preferences.
         config_observer = functools.partial(

--- a/spyder/api/widgets/mixins.py
+++ b/spyder/api/widgets/mixins.py
@@ -653,7 +653,6 @@ class SpyderActionMixin:
 
 class SpyderWidgetMixin(
     SpyderActionMixin,
-    SpyderConfigurationObserver,
     SpyderMenuMixin,
     SpyderToolbarMixin,
     SpyderToolButtonMixin,

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -74,7 +74,6 @@ from spyder.app.utils import (
     delete_debug_log_files, qt_message_handler, set_links_color, setup_logging,
     set_opengl_implementation)
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
-from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.api.shortcuts import SpyderShortcutsMixin
 from spyder.api.widgets.mixins import SpyderMainWindowMixin
 from spyder.config.base import (_, DEV, get_conf_path, get_debug_level,
@@ -122,12 +121,7 @@ qInstallMessageHandler(qt_message_handler)
 #==============================================================================
 # Main Window
 #==============================================================================
-class MainWindow(
-    QMainWindow,
-    SpyderMainWindowMixin,
-    SpyderConfigurationAccessor,
-    SpyderShortcutsMixin,
-):
+class MainWindow(QMainWindow, SpyderMainWindowMixin, SpyderShortcutsMixin):
     """Spyder main window"""
     CONF_SECTION = 'main'
 

--- a/spyder/app/tests/spyder-boilerplate/setup.py
+++ b/spyder/app/tests/spyder-boilerplate/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         "qtpy",
         "qtawesome",
-        "spyder>=5.1.1",
+        "spyder>=6",
     ],
     packages=find_packages(),
     entry_points={

--- a/spyder/app/tests/spyder-boilerplate/spyder_boilerplate/spyder/plugin.py
+++ b/spyder/app/tests/spyder-boilerplate/spyder_boilerplate/spyder/plugin.py
@@ -10,7 +10,7 @@ Spyder Boilerplate Plugin.
 
 # Third party imports
 import qtawesome as qta
-from qtpy.QtWidgets import QHBoxLayout, QLabel
+from qtpy.QtWidgets import QHBoxLayout, QTextEdit
 
 # Spyder imports
 from spyder.api.config.decorators import on_conf_change
@@ -50,12 +50,13 @@ class SpyderBoilerplateWidget(PluginMainWidget):
     def __init__(self, name=None, plugin=None, parent=None):
         super().__init__(name, plugin, parent)
 
-        # Create an example label
-        self._example_label = QLabel("Example Label")
+        # Create example widgets
+        self._example_widget = QTextEdit(self)
+        self._example_widget.setText("Example text")
 
         # Add example label to layout
         layout = QHBoxLayout()
-        layout.addWidget(self._example_label)
+        layout.addWidget(self._example_widget)
         self.setLayout(layout)
 
     # --- PluginMainWidget API
@@ -72,7 +73,7 @@ class SpyderBoilerplateWidget(PluginMainWidget):
             name=SpyderBoilerplateActions.ExampleAction,
             text="Example action",
             tip="Example hover hint",
-            icon=self.create_icon("spyder"),
+            icon=self.create_icon("python"),
             triggered=lambda: print("Example action triggered!"),
         )
 
@@ -92,6 +93,19 @@ class SpyderBoilerplateWidget(PluginMainWidget):
             SpyderBoilerplateOptionsMenuSections.ExampleSection,
         )
 
+        # Shortcuts
+        self.register_shortcut_for_widget(
+            "Change text",
+            self.change_text,
+        )
+
+        self.register_shortcut_for_widget(
+            "new text",
+            self.new_text,
+            context="editor",
+            plugin_name=self._plugin.NAME,
+        )
+
     def update_actions(self):
         pass
 
@@ -101,6 +115,15 @@ class SpyderBoilerplateWidget(PluginMainWidget):
 
     # --- Public API
     # ------------------------------------------------------------------------
+    def change_text(self):
+        if self._example_widget.toPlainText() == "":
+            self._example_widget.setText("Example text")
+        else:
+            self._example_widget.setText("")
+
+    def new_text(self):
+        if self._example_widget.toPlainText() != "Another text":
+            self._example_widget.setText("Another text")
 
 
 class SpyderBoilerplate(SpyderDockablePlugin):
@@ -115,6 +138,15 @@ class SpyderBoilerplate(SpyderDockablePlugin):
     CONF_SECTION = NAME
     CONF_WIDGET_CLASS = SpyderBoilerplateConfigPage
     CUSTOM_LAYOUTS = [VerticalSplitLayout2]
+    CONF_DEFAULTS = [
+        (CONF_SECTION, {}),
+        (
+            "shortcuts",
+            # Note: These shortcut names are capitalized to check we can
+            # set/get/reset them correctly.
+            {f"{NAME}/Change text": "Ctrl+B", "editor/New text": "Ctrl+H"},
+        ),
+    ]
 
     # --- Signals
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -5374,6 +5374,10 @@ def test_copy_paste(main_window, qtbot, tmpdir):
     code_editor = main_window.editor.get_focus_widget()
     code_editor.set_text(code)
 
+    # Register codeeditor shortcuts
+    CONF.notify_section_all_observers("shortcuts")
+    qtbot.wait(300)
+
     # Test copy
     cursor = code_editor.textCursor()
     cursor.setPosition(69)

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -522,8 +522,8 @@ DEFAULTS = [
               # -- Profiler --
               'profiler/run file in profiler': "F10",
               # -- Switcher --
-              'switcher/file switcher': 'Ctrl+P',
-              'switcher/symbol finder': 'Ctrl+Alt+P',
+              '_/file switcher': 'Ctrl+P',
+              '_/symbol finder': 'Ctrl+Alt+P',
               # -- IPython console --
               'ipython_console/new tab': "Ctrl+T",
               'ipython_console/reset namespace': "Ctrl+Alt+R",
@@ -676,4 +676,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '84.3.0'
+CONF_VERSION = '85.0.0'

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -703,7 +703,12 @@ class ConfigurationManager(object):
         Context must be either '_' for global or the name of a plugin.
         """
         config = self._get_shortcut_config(context, plugin_name)
-        config.set('shortcuts', context + '/' + name, keystr)
+        option = context + "/" + name
+        current_shortcut = config.get("shortcuts", option, default="")
+
+        if current_shortcut != keystr:
+            config.set('shortcuts', option, keystr)
+            self.notify_observers("shortcuts", option)
 
     def iter_shortcuts(self):
         """Iterate over keyboard shortcuts."""

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -25,6 +25,7 @@ from spyder.config.base import (
 from spyder.config.main import CONF_VERSION, DEFAULTS, NAME_MAP
 from spyder.config.types import ConfigurationKey, ConfigurationObserver
 from spyder.config.user import UserConfig, MultiUserConfig, NoDefault, cp
+from spyder.plugins.shortcuts.utils import SHORTCUTS_FOR_WIDGETS_DATA
 from spyder.utils.programs import check_version
 
 
@@ -100,24 +101,25 @@ class ConfigurationManager(object):
         # This dict maps from a configuration key (str/tuple) to a set
         # of objects that should be notified on changes to the corresponding
         # subscription key per section. The observer objects must be hashable.
-        #
-        # type: Dict[ConfigurationKey, Dict[str, Set[ConfigurationObserver]]]
-        self._observers = {}
+        self._observers: Dict[
+            ConfigurationKey, Dict[str, Set[ConfigurationObserver]]
+        ] = {}
 
         # Set of suscription keys per observer object
         # This dict maps from a observer object to the set of configuration
         # keys that the object is subscribed to per section.
-        #
-        # type: Dict[ConfigurationObserver, Dict[str, Set[ConfigurationKey]]]
-        self._observer_map_keys = weakref.WeakKeyDictionary()
+        self._observer_map_keys: Dict[
+            ConfigurationObserver, Dict[str, Set[ConfigurationKey]]
+        ] = weakref.WeakKeyDictionary()
 
         # List of options with disabled notifications.
         # This holds a list of (section, option) options that won't be notified
         # to observers. It can be used to temporarily disable notifications for
         # some options.
-        #
-        # type: List[Tuple(str, ConfigurationKey)]
-        self._disabled_options = []
+        self._disabled_options: List[Tuple(str, ConfigurationKey)] = []
+
+        # Mapping for shortcuts that need to be notified
+        self._shortcuts_to_notify: Dict[(str, str), Optional[str]] = {}
 
         # Setup
         self.remove_deprecated_config_locations()
@@ -361,8 +363,11 @@ class ConfigurationManager(object):
             if option == '__section':
                 self._notify_section(section)
             else:
-                value = self.get(section, option, secure=secure)
-                self._notify_option(section, option, value)
+                if section == "shortcuts":
+                    self._notify_shortcut(option)
+                else:
+                    value = self.get(section, option, secure=secure)
+                    self._notify_option(section, option, value)
 
     def _notify_option(self, section: str, option: ConfigurationKey,
                        value: Any):
@@ -391,6 +396,27 @@ class ConfigurationManager(object):
     def _notify_section(self, section: str):
         section_values = dict(self.items(section) or [])
         self._notify_option(section, '__section', section_values)
+
+    def _notify_shortcut(self, option: str):
+        # We need this mapping for two reasons:
+        # 1. We don't need to notify changes for all shortcuts, only for
+        #    widget shortcuts, which are the ones with associated observers
+        #    (see SpyderShortcutsMixin.register_shortcut_for_widget).
+        # 2. Besides context and name, we need the plugin_name to correctly get
+        #    the shortcut value to notify. That's not saved in our config
+        #    system, but it is in SHORTCUTS_FOR_WIDGETS_DATA.
+        if not self._shortcuts_to_notify:
+            # Populate mapping only once
+            self._shortcuts_to_notify = {
+                (data.context, data.name): data.plugin_name
+                for data in SHORTCUTS_FOR_WIDGETS_DATA
+            }
+
+        context, name = option.split("/")
+        if (context, name) in self._shortcuts_to_notify:
+            plugin_name = self._shortcuts_to_notify[(context, name)]
+            value = self.get_shortcut(context, name, plugin_name)
+            self._notify_option("shortcuts", option, value)
 
     def notify_section_all_observers(self, section: str):
         """Notify all the observers subscribed to any option of a section."""
@@ -733,6 +759,9 @@ class ConfigurationManager(object):
         for __, (__, plugin_config) in self._plugin_configs.items():
             # TODO: check if the section exists?
             plugin_config.reset_to_defaults(section='shortcuts')
+
+        # This necessary to notify the observers of widget shortcuts
+        self.notify_section_all_observers(section="shortcuts")
 
 
 try:

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -12,6 +12,7 @@ Configuration manager providing access to user/site/project configuration.
 import logging
 import os
 import os.path as osp
+import traceback
 from typing import Any, Dict, List, Optional, Set, Tuple
 import weakref
 
@@ -723,7 +724,7 @@ class ConfigurationManager(object):
         Context must be either '_' for global or the name of a plugin.
         """
         config = self._get_shortcut_config(context, plugin_name)
-        option = context + "/" + name
+        option = f"{context}/{name}"
         current_shortcut = config.get("shortcuts", option, default="")
 
         if current_shortcut != keystr:
@@ -762,6 +763,9 @@ try:
     CONF = ConfigurationManager()
 except Exception:
     from qtpy.QtWidgets import QApplication, QMessageBox
+
+    # Print traceback to show error in the terminal in case it's needed
+    print(traceback.format_exc())  # spyder: test-skip
 
     # Check if there's an app already running
     app = QApplication.instance()

--- a/spyder/config/manager.py
+++ b/spyder/config/manager.py
@@ -31,13 +31,7 @@ from spyder.utils.programs import check_version
 
 logger = logging.getLogger(__name__)
 
-EXTRA_VALID_SHORTCUT_CONTEXTS = [
-    '_',
-    'array_builder',
-    'console',
-    'find_replace',
-    'switcher'
-]
+EXTRA_VALID_SHORTCUT_CONTEXTS = ['_', 'find_replace']
 
 
 class ConfigurationManager(object):

--- a/spyder/config/tests/test_user.py
+++ b/spyder/config/tests/test_user.py
@@ -377,6 +377,30 @@ def test_userconfig_cleanup(userconfig):
     assert not os.path.isfile(configpath)
 
 
+@pytest.mark.no_reset_conf
+def test_invalid_shortcuts(tmp_path):
+    name = 'invalid-shortcuts'
+    path = str(tmp_path)
+
+    for defaults in [
+        # Shortcut is not of the form context/name
+        [('shortcuts', {'foo': "Ctrl+I"})],
+        # Shortcut contains more than one slash, which breaks the way we parse
+        # them
+        [('shortcuts', {'editor/foo/bar': "Ctrl+I"})],
+    ]:
+        with pytest.raises(ValueError):
+            UserConfig(
+                name=name,
+                path=path,
+                defaults=defaults,
+                load=False,
+                version="1.0.0",
+                backup=False,
+                raw_mode=True,
+            )
+
+
 # --- SpyderUserConfig tests
 # ============================================================================
 # --- Compatibility API

--- a/spyder/config/user.py
+++ b/spyder/config/user.py
@@ -263,6 +263,17 @@ class UserConfig(DefaultsConfig):
                 assert isinstance(options, dict)
                 for opt, _ in options.items():
                     assert is_text_string(opt)
+
+                    if sec == "shortcuts" and (
+                        "/" not in opt or len(opt.split("/")) > 2
+                    ):
+                        raise ValueError(
+                            f"Error in shortcut option '{opt}'. Shortcut "
+                            f"options need to be of the form context/name, "
+                            f"e.g. editor/run cell (for a shortcut that works "
+                            f"only in the editor) or _/file switcher (for "
+                            f"global shortcuts)"
+                        )
         else:
             raise ValueError('`defaults` must be a dict or a list of tuples!')
 

--- a/spyder/config/user.py
+++ b/spyder/config/user.py
@@ -266,13 +266,23 @@ class UserConfig(DefaultsConfig):
         else:
             raise ValueError('`defaults` must be a dict or a list of tuples!')
 
-        # This attribute is overriding a method from cp.ConfigParser
-        self.defaults = defaults
+        # We need to transform default options to lowercase because
+        # ConfigParser saves options like that (see its optionxform method).
+        # Otherwise, resetting to defaults fails when option names are
+        # capitalized.
+        defaults_with_lowercase_options = []
+        for sec, options in defaults:
+            defaults_with_lowercase_options.append(
+                (sec, {k.lower(): v for k, v in options.items()})
+            )
+
+        # This attribute is overriding a method from ConfigParser
+        self.defaults = defaults_with_lowercase_options
 
         if defaults is not None:
             self.reset_to_defaults(save=False)
 
-        return defaults
+        return self.defaults
 
     @classmethod
     def _check_section_option(cls, section, option):

--- a/spyder/plugins/console/widgets/shell.py
+++ b/spyder/plugins/console/widgets/shell.py
@@ -679,6 +679,7 @@ class PythonShellWidget(
         )
         TracebackLinksMixin.__init__(self)
         GetHelpMixin.__init__(self)
+        SpyderShortcutsMixin.__init__(self)
 
         # Local shortcuts
         self.register_shortcuts()

--- a/spyder/plugins/editor/widgets/codeeditor/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/conftest.py
@@ -248,6 +248,11 @@ def codeeditor(qtbot):
     widget.setup_editor(language='Python')
     widget.resize(640, 480)
     widget.show()
+
+    # Register shortcuts for CodeEditor
+    CONF.notify_section_all_observers("shortcuts")
+    qtbot.wait(300)
+
     yield widget
     widget.close()
 

--- a/spyder/plugins/editor/widgets/codeeditor/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/conftest.py
@@ -149,6 +149,10 @@ def mock_completions_codeeditor(qtbot_module, request):
     qtbot_module.addWidget(editor)
     editor.show()
 
+    # Register shortcuts for CodeEditor
+    CONF.notify_section_all_observers("shortcuts")
+    qtbot_module.wait(300)
+
     mock_response = Mock()
 
     def perform_request(lang, method, params):
@@ -181,6 +185,10 @@ def completions_codeeditor(completion_plugin_all_started, qtbot_module,
 
     completion_plugin, capabilities = completion_plugin_all_started
     completion_plugin.wait_for_ms = 2000
+
+    # Register shortcuts for CodeEditor
+    CONF.notify_section_all_observers("shortcuts")
+    qtbot_module.wait(300)
 
     CONF.set('completions', 'enable_code_snippets', False)
     completion_plugin.after_configuration_update([])

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -95,6 +95,12 @@ class EditorStackMenuSections:
 
 
 class EditorStack(QWidget, SpyderWidgetMixin):
+
+    # This is necessary for the EditorStack tests to run independently of the
+    # Editor plugin.
+    CONF_SECTION = "editor"
+
+    # Signals
     reset_statusbar = Signal()
     readonly_changed = Signal(bool)
     encoding_changed = Signal(str)

--- a/spyder/plugins/editor/widgets/editorstack/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/conftest.py
@@ -34,7 +34,6 @@ from spyder.widgets.findreplace import FindReplace
 
 
 def editor_factory(new_file=True, text=None):
-    EditorStack.CONF_SECTION = "Editor"
     editorstack = EditorStack(None, [], False)
     editorstack.set_find_widget(FindReplace(editorstack))
     editorstack.set_io_actions(Mock(), Mock(), Mock(), Mock())

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_editorstack.py
@@ -36,7 +36,6 @@ HERE = osp.abspath(osp.dirname(__file__))
 # =============================================================================
 @pytest.fixture
 def base_editor_bot(qtbot):
-    EditorStack.CONF_SECTION = "Editor"
     editor_stack = EditorStack(None, [], False)
     editor_stack.set_find_widget(Mock())
     editor_stack.set_io_actions(Mock(), Mock(), Mock(), Mock())

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_editorstack_and_outline.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_editorstack_and_outline.py
@@ -68,7 +68,6 @@ def test_files(tmpdir_factory):
 @pytest.fixture
 def editorstack(qtbot, outlineexplorer):
     def _create_editorstack(files):
-        EditorStack.CONF_SECTION = "Editor"
         editorstack = EditorStack(None, [], False)
         editorstack.set_find_widget(Mock())
         editorstack.set_io_actions(Mock(), Mock(), Mock(), Mock())

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_save.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_save.py
@@ -51,7 +51,6 @@ def add_files(editorstack):
 # ---- Qt Test Fixtures
 @pytest.fixture
 def base_editor_bot(qtbot):
-    EditorStack.CONF_SECTION = "Editor"
     editor_stack = EditorStack(None, [], False)
     editor_stack.set_find_widget(Mock())
     editor_stack.set_io_actions(Mock(), Mock(), Mock(), Mock())
@@ -78,7 +77,6 @@ def editor_bot(base_editor_bot, request):
 @pytest.fixture
 def editor_splitter_bot(qtbot):
     """Create editor splitter."""
-    EditorSplitter.CONF_SECTION = "Editor"
     main_widget = Mock(wraps=EditorMainWidgetExample())
     es = EditorSplitter(None, main_widget, [], first=True)
     qtbot.addWidget(es)

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
@@ -32,7 +32,6 @@ def editorstack(qtbot):
     Set up EditorStack with CodeEditors containing some Python code.
     The cursor is at the empty line below the code.
     """
-    EditorStack.CONF_SECTION = "Editor"
     editorstack = EditorStack(None, [], False)
     editorstack.set_find_widget(Mock())
     editorstack.set_io_actions(Mock(), Mock(), Mock(), Mock())

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
@@ -20,9 +20,9 @@ from qtpy.QtWidgets import QApplication
 
 # Local imports
 from spyder.config.base import running_in_ci
+from spyder.config.manager import CONF
 from spyder.plugins.editor.widgets.gotoline import GoToLineDialog
 from spyder.plugins.editor.widgets.editorstack import EditorStack
-from spyder.config.manager import CONF
 
 
 # ---- Qt Test Fixtures
@@ -41,6 +41,10 @@ def editorstack(qtbot):
     qtbot.addWidget(editorstack)
     editorstack.show()
     editorstack.go_to_line(1)
+
+    # Register shortcuts
+    CONF.notify_section_all_observers("shortcuts")
+    qtbot.wait(300)
 
     return editorstack
 

--- a/spyder/plugins/editor/widgets/tabswitcher.py
+++ b/spyder/plugins/editor/widgets/tabswitcher.py
@@ -13,13 +13,10 @@ from qtpy.QtWidgets import QListWidget, QListWidgetItem
 
 # Local imports
 from spyder.api.shortcuts import SpyderShortcutsMixin
-from spyder.api.widgets.mixins import SpyderConfigurationAccessor
 from spyder.utils.icon_manager import ima
 
 
-class TabSwitcherWidget(
-    QListWidget, SpyderConfigurationAccessor, SpyderShortcutsMixin
-):
+class TabSwitcherWidget(QListWidget, SpyderShortcutsMixin):
     """Show tabs in mru order and change between them."""
 
     CONF_SECTION = "editor"

--- a/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
+++ b/spyder/plugins/editor/widgets/tests/test_editorsplitter.py
@@ -29,7 +29,6 @@ from spyder.plugins.editor.widgets.window import EditorMainWidgetExample
 # ---- Qt Test Fixtures
 
 def editor_stack():
-    EditorStack.CONF_SECTION = "Editor"
     editor_stack = EditorStack(None, [], False)
     editor_stack.set_find_widget(Mock())
     editor_stack.set_io_actions(Mock(), Mock(), Mock(), Mock())
@@ -39,7 +38,6 @@ def editor_stack():
 @pytest.fixture
 def editor_splitter_bot(qtbot):
     """Create editor splitter."""
-    EditorSplitter.CONF_SECTION = "Editor"
     main_widget = Mock(wraps=EditorMainWidgetExample())
     es = EditorSplitter(None, main_widget, [], first=True)
     qtbot.addWidget(es)
@@ -83,7 +81,6 @@ def editor_splitter_lsp(qtbot_module, completion_plugin_all_started, request):
         editorstack.new('test.py', 'utf-8', text)
 
     mock_main_widget = Mock(wraps=EditorMainWidgetExample())
-    EditorSplitter.CONF_SECTION = "Editor"
     editorsplitter = EditorSplitter(
         None,
         mock_main_widget,

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -172,6 +172,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
 
         # Keyboard shortcuts
         # Registered here to use shellwidget as the parent
+        SpyderWidgetMixin.__init__(self)
         self.regiter_shortcuts()
 
         # Set the color of the matched parentheses here since the qtconsole

--- a/spyder/plugins/shortcuts/plugin.py
+++ b/spyder/plugins/shortcuts/plugin.py
@@ -12,6 +12,7 @@ Shortcuts Plugin.
 
 # Standard library imports
 import configparser
+from typing import List
 
 # Third party imports
 from qtpy.QtCore import Qt, Signal, Slot
@@ -27,6 +28,7 @@ from spyder.api.shortcuts import SpyderShortcutsMixin
 from spyder.api.translations import _
 from spyder.plugins.mainmenu.api import ApplicationMenus, HelpMenuSections
 from spyder.plugins.shortcuts.confpage import ShortcutsConfigPage
+from spyder.plugins.shortcuts.utils import ShortcutData
 from spyder.plugins.shortcuts.widgets.summary import ShortcutsSummaryDialog
 from spyder.utils.qthelpers import add_shortcut_to_tooltip, SpyderAction
 
@@ -73,7 +75,7 @@ class Shortcuts(SpyderPluginV2, SpyderShortcutsMixin):
         return cls.create_icon('keyboard')
 
     def on_initialize(self):
-        self._shortcut_data = []
+        self._shortcut_data: List[ShortcutData] = []
         self._shortcut_sequences = set({})
         self.create_action(
             ShortcutActions.ShortcutSummaryAction,
@@ -143,16 +145,28 @@ class Shortcuts(SpyderPluginV2, SpyderShortcutsMixin):
         Register QAction or QShortcut to Spyder main application,
         with shortcut (context, name, default)
         """
-        self._shortcut_data.append((qaction_or_qshortcut, context,
-                                   name, add_shortcut_to_tip, plugin_name))
+        self._shortcut_data.append(
+            ShortcutData(
+                qobject=qaction_or_qshortcut,
+                name=name,
+                context=context,
+                plugin_name=plugin_name,
+                add_shortcut_to_tip=add_shortcut_to_tip,
+            )
+        )
 
     def unregister_shortcut(self, qaction_or_qshortcut, context, name,
                             add_shortcut_to_tip=True, plugin_name=None):
         """
         Unregister QAction or QShortcut from Spyder main application.
         """
-        data = (qaction_or_qshortcut, context, name, add_shortcut_to_tip,
-                plugin_name)
+        data = ShortcutData(
+            qobject=qaction_or_qshortcut,
+            name=name,
+            context=context,
+            plugin_name=plugin_name,
+            add_shortcut_to_tip=add_shortcut_to_tip,
+        )
 
         if data in self._shortcut_data:
             self._shortcut_data.remove(data)
@@ -166,24 +180,25 @@ class Shortcuts(SpyderPluginV2, SpyderShortcutsMixin):
         # TODO: Check shortcut existence based on action existence, so that we
         # can update shortcut names without showing the old ones on the
         # preferences
-        for index, (qobject, context, name, add_shortcut_to_tip,
-                    plugin_name) in enumerate(self._shortcut_data):
+        for index, data in enumerate(self._shortcut_data):
             try:
                 shortcut_sequence = self.get_shortcut(
-                    name, context, plugin_name
+                    data.name, data.context, data.plugin_name
                 )
             except (configparser.NoSectionError, configparser.NoOptionError):
                 # If shortcut does not exist, save it to CONF. This is an
                 # action for which there is no shortcut assigned (yet) in
                 # the configuration
-                self.set_shortcut('', name, context, plugin_name)
+                self.set_shortcut(
+                    "", data.name, data.context, data.plugin_name
+                )
                 shortcut_sequence = ''
 
             if shortcut_sequence:
                 if shortcut_sequence in self._shortcut_sequences:
                     continue
 
-                self._shortcut_sequences |= {(context, shortcut_sequence)}
+                self._shortcut_sequences |= {(data.context, shortcut_sequence)}
                 keyseq = QKeySequence(shortcut_sequence)
             else:
                 # Needed to remove old sequences that were cleared.
@@ -194,18 +209,21 @@ class Shortcuts(SpyderPluginV2, SpyderShortcutsMixin):
             # The shortcut will be displayed only on the menus and handled by
             # about to show/hide signals.
             if (
-                name.startswith('switch to')
-                and isinstance(qobject, SpyderAction)
+                data.name.startswith('switch to')
+                and isinstance(data.qobject, SpyderAction)
             ):
                 keyseq = QKeySequence()
 
+            # Register shortcut for the associated qobject
             try:
-                if isinstance(qobject, QAction):
-                    qobject.setShortcut(keyseq)
-                    if add_shortcut_to_tip:
-                        add_shortcut_to_tooltip(qobject, context, name)
-                elif isinstance(qobject, QShortcut):
-                    qobject.setKey(keyseq)
+                if isinstance(data.qobject, QAction):
+                    data.qobject.setShortcut(keyseq)
+                    if data.add_shortcut_to_tip:
+                        add_shortcut_to_tooltip(
+                            data.qobject, data.context, data.name
+                        )
+                elif isinstance(data.qobject, QShortcut):
+                    data.qobject.setKey(keyseq)
             except RuntimeError:
                 # Object has been deleted
                 toberemoved.append(index)

--- a/spyder/plugins/shortcuts/plugin.py
+++ b/spyder/plugins/shortcuts/plugin.py
@@ -128,7 +128,8 @@ class Shortcuts(SpyderPluginV2, SpyderShortcutsMixin):
     def get_shortcut_data(self):
         """Return the registered shortcut data."""
         # We need to include the second list here so that those shortcuts are
-        # displayed in Preferences.
+        # displayed in Preferences. But they are updated using a different
+        # mechanism (see SpyderShortcutsMixin.register_shortcut_for_widget).
         return self._shortcut_data + SHORTCUTS_FOR_WIDGETS_DATA
 
     def reset_shortcuts(self):

--- a/spyder/plugins/shortcuts/plugin.py
+++ b/spyder/plugins/shortcuts/plugin.py
@@ -28,7 +28,10 @@ from spyder.api.shortcuts import SpyderShortcutsMixin
 from spyder.api.translations import _
 from spyder.plugins.mainmenu.api import ApplicationMenus, HelpMenuSections
 from spyder.plugins.shortcuts.confpage import ShortcutsConfigPage
-from spyder.plugins.shortcuts.utils import ShortcutData
+from spyder.plugins.shortcuts.utils import (
+    ShortcutData,
+    SHORTCUTS_FOR_WIDGETS_DATA,
+)
 from spyder.plugins.shortcuts.widgets.summary import ShortcutsSummaryDialog
 from spyder.utils.qthelpers import add_shortcut_to_tooltip, SpyderAction
 
@@ -123,10 +126,10 @@ class Shortcuts(SpyderPluginV2, SpyderShortcutsMixin):
     # ---- Public API
     # -------------------------------------------------------------------------
     def get_shortcut_data(self):
-        """
-        Return the registered shortcut data from the main application window.
-        """
-        return self._shortcut_data
+        """Return the registered shortcut data."""
+        # We need to include the second list here so that those shortcuts are
+        # displayed in Preferences.
+        return self._shortcut_data + SHORTCUTS_FOR_WIDGETS_DATA
 
     def reset_shortcuts(self):
         """Reset shrotcuts."""

--- a/spyder/plugins/shortcuts/plugin.py
+++ b/spyder/plugins/shortcuts/plugin.py
@@ -149,6 +149,12 @@ class Shortcuts(SpyderPluginV2, SpyderShortcutsMixin):
         Register QAction or QShortcut to Spyder main application,
         with shortcut (context, name, default)
         """
+        # Name and context are saved in lowercase in our config system, so we
+        # need to use them like that here.
+        # Note: That's how the Python ConfigParser class saves options.
+        name = name.lower()
+        context = context.lower()
+
         self._shortcut_data.append(
             ShortcutData(
                 qobject=qaction_or_qshortcut,
@@ -164,6 +170,12 @@ class Shortcuts(SpyderPluginV2, SpyderShortcutsMixin):
         """
         Unregister QAction or QShortcut from Spyder main application.
         """
+        # Name and context are saved in lowercase in our config system, so we
+        # need to use them like that here.
+        # Note: That's how the Python ConfigParser class saves options.
+        name = name.lower()
+        context = context.lower()
+
         data = ShortcutData(
             qobject=qaction_or_qshortcut,
             name=name,

--- a/spyder/plugins/shortcuts/tests/test_shortcuts.py
+++ b/spyder/plugins/shortcuts/tests/test_shortcuts.py
@@ -19,6 +19,7 @@ from qtpy.QtCore import Qt
 # Local imports
 from spyder.config.base import running_in_ci
 from spyder.config.manager import CONF
+from spyder.plugins.shortcuts.utils import ShortcutData
 from spyder.plugins.shortcuts.widgets.table import (
     INVALID_KEY, NO_WARNING, SEQUENCE_CONFLICT, SEQUENCE_EMPTY,
     ShortcutEditor, ShortcutsTable, load_shortcuts)
@@ -77,8 +78,8 @@ def test_shortcut_in_conf_is_filtered_with_shortcut_data(qtbot):
 
     shortcut_table_empty = ShortcutsTable()
     shortcut_table_empty.set_shortcut_data([
-        (None, '_', 'switch to plots', None, None),
-        (None, '_', 'switch to editor', None, None),
+        ShortcutData(qobject=None, name='switch to plots', context='_'),
+        ShortcutData(qobject=None, name='switch to editor', context='_')
     ])
     shortcut_table_empty.load_shortcuts()
     qtbot.addWidget(shortcut_table_empty)

--- a/spyder/plugins/shortcuts/utils.py
+++ b/spyder/plugins/shortcuts/utils.py
@@ -7,7 +7,7 @@
 """Shortcuts utils."""
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 from qtpy.QtCore import QObject
 
@@ -16,8 +16,15 @@ from qtpy.QtCore import QObject
 class ShortcutData:
     """Dataclass to represent shortcut data."""
 
-    qobject: QObject
-    """QObject to which the shortcut will be associated."""
+    qobject: Optional[QObject]
+    """
+    QObject to which the shortcut will be associated.
+
+    Notes
+    -----
+    This can be None when there's no need to register the shortcut to a
+    specific QObject.
+    """
 
     name: str
     """Shortcut name (e.g. "run cell")."""
@@ -44,3 +51,7 @@ class ShortcutData:
 
     add_shortcut_to_tip: bool = False
     """Whether to add the shortcut to the qobject's tooltip."""
+
+
+# List to save shortcut data registered for all widgets
+SHORTCUTS_FOR_WIDGETS_DATA: List[ShortcutData] = []

--- a/spyder/plugins/shortcuts/utils.py
+++ b/spyder/plugins/shortcuts/utils.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""Shortcuts utils."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from qtpy.QtCore import QObject
+
+
+@dataclass(frozen=True)
+class ShortcutData:
+    """Dataclass to represent shortcut data."""
+
+    qobject: QObject
+    """QObject to which the shortcut will be associated."""
+
+    name: str
+    """Shortcut name (e.g. "run cell")."""
+
+    context: str
+    """
+    Name of the shortcut context.
+
+    Notes
+    -----
+    This can be the plugin name (e.g. "editor" for shortcuts that have
+    effect when the Editor is focused) or "_" for global shortcuts.
+    """
+
+    plugin_name: Optional[str] = None
+    """
+    Name of the plugin where the shortcut is defined.
+
+    Notes
+    -----
+    This is only necessary for third-party plugins that have shortcuts with
+    several contexts.
+    """
+
+    add_shortcut_to_tip: bool = False
+    """Whether to add the shortcut to the qobject's tooltip."""

--- a/spyder/plugins/shortcuts/widgets/table.py
+++ b/spyder/plugins/shortcuts/widgets/table.py
@@ -8,6 +8,7 @@
 
 # Standard library importsimport re
 import re
+from typing import List
 
 # Third party imports
 from qtawesome import IconWidget
@@ -24,6 +25,7 @@ from qtpy.QtWidgets import (QAbstractItemView, QApplication, QDialog,
 from spyder.api.shortcuts import SpyderShortcutsMixin
 from spyder.api.translations import _
 from spyder.config.manager import CONF
+from spyder.plugins.shortcuts.utils import ShortcutData
 from spyder.utils.icon_manager import ima
 from spyder.utils.palette import SpyderPalette
 from spyder.utils.qthelpers import create_toolbutton
@@ -638,7 +640,7 @@ class ShortcutsTable(HoverRowsTableView):
         HoverRowsTableView.__init__(self, parent, custom_delegate=True)
         self._parent = parent
         self.finder = None
-        self.shortcut_data = None
+        self.shortcut_data: List[ShortcutData] = []
         self.source_model = ShortcutsModel(self)
         self.proxy_model = ShortcutsSortFilterProxy(self)
         self.last_regex = ''
@@ -701,11 +703,14 @@ class ShortcutsTable(HoverRowsTableView):
 
     def load_shortcuts(self):
         """Load shortcuts and assign to table model."""
-        # item[1] -> context, item[2] -> name
-        # Data might be capitalized so we user lower()
+        # Data might be capitalized so we use lower() below.
         # See: spyder-ide/spyder/#12415
-        shortcut_data = set([(item[1].lower(), item[2].lower()) for item
-                             in self.shortcut_data])
+        shortcut_data = set(
+            [
+                (data.context.lower(), data.name.lower())
+                for data in self.shortcut_data
+            ]
+        )
         shortcut_data = list(sorted(set(shortcut_data)))
         shortcuts = []
 
@@ -746,8 +751,10 @@ class ShortcutsTable(HoverRowsTableView):
                    and (sh1.context == sh2.context or sh1.context == '_' or
                         sh2.context == '_'):
                     conflicts.append((sh1, sh2))
+
         if conflicts:
-            self.parent().show_this_page.emit()
+            if self.parent() is not None:
+                self.parent().show_this_page.emit()
             cstr = "\n".join(['%s <---> %s' % (sh1, sh2)
                               for sh1, sh2 in conflicts])
             QMessageBox.warning(self, _("Conflicts"),
@@ -901,7 +908,9 @@ def load_shortcuts_data():
     for context, name, __ in CONF.iter_shortcuts():
         context = context.lower()
         name = name.lower()
-        shortcut_data.append((None, context, name, None, None))
+        shortcut_data.append(
+            ShortcutData(qobject=None, name=name, context=context)
+        )
     return shortcut_data
 
 

--- a/spyder/plugins/switcher/container.py
+++ b/spyder/plugins/switcher/container.py
@@ -35,7 +35,8 @@ class SwitcherContainer(PluginMainContainer):
             tip=_('Fast switch between files'),
             triggered=self.open_switcher,
             register_shortcut=True,
-            context=Qt.ApplicationShortcut
+            context=Qt.ApplicationShortcut,
+            shortcut_context="_",
         )
 
         self.create_action(
@@ -45,7 +46,8 @@ class SwitcherContainer(PluginMainContainer):
             tip=_('Fast symbol search in file'),
             triggered=self.open_symbolfinder,
             register_shortcut=True,
-            context=Qt.ApplicationShortcut
+            context=Qt.ApplicationShortcut,
+            shortcut_context="_",
         )
 
     def update_actions(self):

--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -625,6 +625,9 @@ class BaseTabs(QTabWidget):
 
 class Tabs(BaseTabs, SpyderShortcutsMixin):
     """BaseTabs widget with movable tabs and tab navigation shortcuts."""
+    # Dummy CONF_SECTION to avoid a warning
+    CONF_SECTION = ""
+
     # Signals
     move_data = Signal(int, int)
     move_tab_finished = Signal()


### PR DESCRIPTION
## Description of Changes

- Those shortcuts were not shown in Spyder 6, as reported by several users.
- That was a regression introduced by #22230, which unfortunately we overlooked.
- This also fixes an important usability issue: changing those shortcuts didn't have an immediate effect (like all other shortcuts), but required an app restart. That issue was also present in Spyder 5 and it was very counterintuitive. Now those shortcuts will be updated on the fly.
- Introduce a new `ShortcutData` dataclass to represent shortcut data internally and work more easily with it.
- Change context of Switcher plugin shortcuts to be `_`, i.e. global (before their context was `switcher` but that made little sense).

### Issue(s) Resolved

Fixes #23072 
Fixes #22741 
Fixes #22516

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
