### PR TITLE
PR: Pin Jedi to 0.19.1 for now on Linux (CI)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -42,6 +42,12 @@ if [ "$USE_CONDA" = "true" ]; then
     # Remove pylsp before installing its subrepo below
     micromamba remove --force python-lsp-server python-lsp-server-base -y
 
+    # Pin Jedi to 0.19.1 because test_update_outline fails frequently with
+    # 0.19.2, although it passes locally
+    if [ "$OS" = "linux" ]; then
+        micromamba install jedi=0.19.1
+    fi
+
 else
     # Update pip and setuptools
     python -m pip install -U pip setuptools wheel build
@@ -58,6 +64,11 @@ else
     # To check our manifest
     pip install -q check-manifest
 
+    # Pin Jedi to 0.19.1 because test_update_outline fails frequently with
+    # 0.19.2, although it passes locally
+    if [ "$OS" = "linux" ]; then
+        pip install jedi==0.19.1
+    fi
 
 fi
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -4750,7 +4750,7 @@ def test_tour_message(main_window, qtbot):
     qtbot.wait(2000)
 
 
-@flaky(max_runs=3)
+@flaky(max_runs=20)
 @pytest.mark.use_introspection
 @pytest.mark.order(after="test_debug_unsaved_function")
 @pytest.mark.preload_complex_project


### PR DESCRIPTION
## Description of Changes

- After the release of Jedi 0.19.2 some days ago, `test_update_outline` (which only runs on Linux) started to fail frequently. But I tested it locally and it works fine.
- So, in order to have a stable CI for now, I prefer to pin Jedi to 0.19.1, which has been working fine for a long time.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
