### PR TITLE
PR: Fix `FoldingPanel._expand_selection` to not select text an extra line below a folded region (Editor)

### DIFF
--- a/spyder/plugins/editor/panels/codefolding.py
+++ b/spyder/plugins/editor/panels/codefolding.py
@@ -709,11 +709,13 @@ class FoldingPanel(Panel):
                 start_line in self.folding_regions
                 and self.folding_status[start_line]
             ):
-                end_line = self.folding_regions[start_line] + 1
+                end_line = self.folding_regions[start_line]
 
                 if cursor.hasSelection():
                     tc = TextHelper(self.editor).select_lines(
                         start_line, end_line)
+                    tc.movePosition(tc.MoveOperation.NextBlock,
+                                    tc.MoveMode.KeepAnchor)
 
                     if tc.selectionStart() > cursor.selectionStart():
                         start = cursor.selectionStart()

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_folding.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_folding.py
@@ -181,7 +181,7 @@ def test_delete_folded_line(completions_codeeditor, qtbot):
     assert "myfunc2" not in editor.toPlainText()
     assert "print" not in editor.toPlainText()
     assert editor.blockCount() == 31
-    
+
     # Check line after folded region was not removed
     assert "# don't delete this comment" in editor.toPlainText()
 
@@ -195,7 +195,7 @@ def test_delete_folded_line(completions_codeeditor, qtbot):
     assert "myfunc2" not in editor.toPlainText()
     assert "print" not in editor.toPlainText()
     assert editor.blockCount() == 31
-    
+
     # Check line after folded region was not removed
     assert "# don't delete this comment" in editor.toPlainText()
 

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_folding.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_folding.py
@@ -28,7 +28,7 @@ def myfunc2():
         3 , 4] # Arbitary Code
     x[0] = 2 # Desired break
     print(x[1]) # Arbitary Code
-
+# don't delete this comment
 responses = {
     100: ('Continue', 'Request received, please continue'),
     101: ('Switching Protocols','Switching to new protocol'),
@@ -181,6 +181,9 @@ def test_delete_folded_line(completions_codeeditor, qtbot):
     assert "myfunc2" not in editor.toPlainText()
     assert "print" not in editor.toPlainText()
     assert editor.blockCount() == 31
+    
+    # Check line after folded region was not removed
+    assert "# don't delete this comment" in editor.toPlainText()
 
     # Press Ctrl+Z
     qtbot.keyClick(editor, Qt.Key_Z, Qt.ControlModifier)
@@ -192,6 +195,9 @@ def test_delete_folded_line(completions_codeeditor, qtbot):
     assert "myfunc2" not in editor.toPlainText()
     assert "print" not in editor.toPlainText()
     assert editor.blockCount() == 31
+    
+    # Check line after folded region was not removed
+    assert "# don't delete this comment" in editor.toPlainText()
 
     # Press Ctrl+Z again
     qtbot.keyClick(editor, Qt.Key_Z, Qt.ControlModifier)


### PR DESCRIPTION
## Description of Changes

Edited `FoldingPanel._expand_selection`
 - don't select a entire extra line with TextHelper.select_lines (eliminated `+1` from `end_line`)
 - select the leftover newline using `MoveOperation.NextBlock` so blank line is not left after deleting folded portion


* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (see linked issue)


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23042 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: athompson673

<!--- Thanks for your help making Spyder better for everyone! --->
