### PR TITLE
PR: Choose Qt binding to install from `SPYDER_QT_BINDING` environment variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,9 +146,9 @@ def get_qt_requirements(qt_requirements, default='pyqt5'):
 
     if install_requires is None:
         raise ValueError(
-                f"Unsupported Qt binding: {env_qt_binding}. "
-                "Supported: "  + ", ".join(qt_requirements.keys())
-            )
+            f"Unsupported Qt binding: {env_qt_binding}. "
+            f"Supported: "  + ", ".join(qt_requirements.keys())
+        )
 
     return install_requires
 

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ def get_qt_requirements(qt_requirements, default='pyqt5'):
     # Check if a Qt binding is set in the environment and normalizes
     env_qt_binding = os.environ.get('SPYDER_QT_BINDING', default)
     env_qt_binding = env_qt_binding.lower()
-    install_requires = env_qt_binding.get(env_qt_binding, qt_requirements[default])
+    install_requires = qt_requirements.get(env_qt_binding, qt_requirements[default])
 
     return install_requires
 

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ def get_packages():
     packages = get_subpackages(LIBNAME)
     return packages
 
+
 def get_qt_requirements(qt_requirements, default='pyqt5'):
     """
     Return a list of requirements for the Qt binding according to the
@@ -122,23 +123,32 @@ def get_qt_requirements(qt_requirements, default='pyqt5'):
     qt_requirements : dict
         A dictionary whose keys are supported Qt bindings and whose values are
         lists of required packages to install for each binding.
-
     default : str
-        Default Qt binding to use if the environment variable is not
-        in qt_requirements. Default is 'pyqt5'.
+        Default Qt binding to use if the environment variable is not set.
+        Defaults to 'pyqt5'.
+
+    Raises
+    ------
+    ValueError
+        If the environment variable SPYDER_QT_BINDING has an unsupported value.
 
     Returns
     -------
     install_requires : list
         A list of required packages to install for the given Qt binding.
     """
-
     install_requires = []
 
     # Check if a Qt binding is set in the environment and normalizes
     env_qt_binding = os.environ.get('SPYDER_QT_BINDING', default)
     env_qt_binding = env_qt_binding.lower()
-    install_requires = qt_requirements.get(env_qt_binding, qt_requirements[default])
+    install_requires = qt_requirements.get(env_qt_binding, None)
+
+    if install_requires is None:
+        raise ValueError(
+                f"Unsupported Qt binding: {env_qt_binding}. "
+                "Supported: "  + ", ".join(qt_requirements.keys())
+            )
 
     return install_requires
 
@@ -234,8 +244,8 @@ setup_args = dict(
 
 # Qt bindings requirements
 qt_requirements = {
-    'pyqt5' : ['pyqt5>=5.15,<5.16', 'pyqtwebengine>=5.15,<5.16'],
-    'pyqt6' : ['pyqt6>=6,<7', 'pyqt6-webengine>=6,<7'],
+    'pyqt5': ['pyqt5>=5.15,<5.16', 'pyqtwebengine>=5.15,<5.16'],
+    'pyqt6': ['pyqt6>=6.5,<7', 'pyqt6-webengine>=6.5,<7'],
 }
 
 # Get the proper requirements for the selected Qt binding

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,37 @@ def get_packages():
     packages = get_subpackages(LIBNAME)
     return packages
 
+def get_qt_requirements(qt_requirements, default='pyqt5'):
+    """
+    Return a list of requirements for the Qt binding according to the
+    environment variable SPYDER_QT_BINDING. If this variable is not set
+    or has an unsupported value it defaults to 'pyqt5'.
+
+    Parameters
+    ----------
+    qt_requirements : dict
+        A dictionary whose keys are supported Qt bindings and whose values are
+        lists of required packages to install for each binding.
+
+    default : str
+        Default Qt binding to use if the environment variable is not
+        in qt_requirements. Default is 'pyqt5'.
+
+    Returns
+    -------
+    install_requires : list
+        A list of required packages to install for the given Qt binding.
+    """
+
+    install_requires = []
+
+    # Check if a Qt binding is set in the environment and normalizes
+    env_qt_binding = os.environ.get('SPYDER_QT_BINDING', default)
+    env_qt_binding = env_qt_binding.lower()
+    install_requires = env_qt_binding.get(env_qt_binding, qt_requirements[default])
+
+    return install_requires
+
 
 # =============================================================================
 # Make Linux detect Spyder desktop file (will not work with wheels)
@@ -201,8 +232,16 @@ setup_args = dict(
     cmdclass=CMDCLASS,
 )
 
+# Qt bindings requirements
+qt_requirements = {
+    'pyqt5' : ['pyqt5>=5.15,<5.16', 'pyqtwebengine>=5.15,<5.16'],
+    'pyqt6' : ['pyqt6>=6,<7', 'pyqt6-webengine>=6,<7'],
+}
 
-install_requires = [
+# Get the proper requirements for the selected Qt binding
+install_requires = get_qt_requirements(qt_requirements, default='pyqt5')
+
+install_requires += [
     'aiohttp>=3.9.3',
     'applaunchservices>=0.3.0;platform_system=="Darwin"',
     'asyncssh>=2.14.0,<3.0.0',
@@ -232,8 +271,6 @@ install_requires = [
     'pylint>=3.1,<4',
     'pylint-venv>=3.0.2',
     'pyls-spyder>=0.4.0',
-    'pyqt5>=5.15,<5.16',
-    'pyqtwebengine>=5.15,<5.16',
     'python-lsp-black>=2.0.0,<3.0.0',
     'python-lsp-server[all]>=1.12.0,<1.13.0',
     'pyuca>=1.2',

--- a/spyder/tests/test_dependencies_in_sync.py
+++ b/spyder/tests/test_dependencies_in_sync.py
@@ -88,16 +88,22 @@ def parse_setup_install_requires(fpath):
     start = None
     end = None
     for idx, line in enumerate(lines):
-        if line.startswith('install_requires = '):
+        if "'pyqt5': " in line:
+            idx_qt = idx
+
+        if line.startswith('install_requires += '):
             start = idx + 1
 
         if start is not None and line.startswith(']'):
             end = idx
             break
 
+    qt_deps = lines[idx_qt].split("'pyqt5': ")[1]
+    qt_deps = literal_eval(qt_deps[:qt_deps.index("]") + 1])
     dep_list = literal_eval('[' + '\n'.join(lines[start:end + 1]))
     dep_list = [item for item in dep_list if item[0] != '#']
-    for dep in dep_list:
+
+    for dep in dep_list + qt_deps:
         dep = dep.split(';')[0]
         name, ver = None, None
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [X] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

This is a proposal  to allow the user to choose the Qt binding to be installed when installing with PIP.

for example using PyQt6 (or PySide6 in the future).

[Since the we could not rely on having other imports other than` stdlib `available on `setup.py` ](https://peps.python.org/pep-0517/#build-environment) when building and installing, we could not test if there is a binding already installed. For example, we could use `QtPy` to identify which one was installed, including it to `setup_requires`, and asking for `qtpy.QT_API. But, also without success. 
`
After testing some other ways to do that, I have implemented this version that checks the SPYDER_QT_BINDING environment variable to proper set the requirement during installation. 

We can use like this:

`SPYDER_QT_BINDING='pyqt6' pip install spyder`

This is also compatible with test environments, where you can set the variable. 

Not sure if this useful for `conda` also, I'm not familiar with it. 

I want to hear from you guys, let me know your thoughts.

Links related to setup imports:
- https://github.com/pypa/setuptools/issues/3939
- https://peps.python.org/pep-0517/
- https://github.com/pypa/pip/issues/12030

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #20201


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dpizetta

<!--- Thanks for your help making Spyder better for everyone! --->
