### PR TITLE
PR: Fix `DeprecationWarning: module 'sre_constants' is deprecated`

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -22,7 +22,6 @@ import logging
 import os
 import os.path as osp
 import re
-import sre_constants
 import sys
 import textwrap
 
@@ -1515,7 +1514,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
         re_flags = re.MULTILINE if case else re.IGNORECASE | re.MULTILINE
         try:
             regobj = re.compile(pattern, flags=re_flags)
-        except sre_constants.error:
+        except re.error:
             return
 
         extra_selections = []

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -8,7 +8,6 @@
 
 # Standard library imports
 import re
-import sre_constants
 import sys
 
 # Third party imports
@@ -287,7 +286,7 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
                 regobj = re.compile(pattern, re.MULTILINE)
             else:
                 regobj = re.compile(pattern, re.MULTILINE | re.IGNORECASE)
-        except sre_constants.error:
+        except re.error:
             return
 
         number_matches = 0

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -16,7 +16,6 @@ from io import StringIO
 import os
 import os.path as osp
 import re
-import sre_constants
 import sys
 import textwrap
 from token import NUMBER
@@ -1327,7 +1326,7 @@ class BaseEditMixin(object):
         text = to_text_string(self.toPlainText())
         try:
             regobj = re.compile(pattern)
-        except sre_constants.error:
+        except re.error:
             return
         if findflag & QTextDocument.FindBackward:
             # Find backward
@@ -1436,7 +1435,7 @@ class BaseEditMixin(object):
         try:
             re_flags = re.MULTILINE if case else re.IGNORECASE | re.MULTILINE
             regobj = re.compile(pattern, flags=re_flags)
-        except sre_constants.error:
+        except re.error:
             return None
 
         number_matches = 0


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
changed instances of `sre_constants.error` to `re.error`

<!--- Explain what you've done and why --->
`re.error` has been available since 3.0.0 and is considered the public interface. `sre_constants`, `sre_compile`, and `sre_parse` are considered [depreciated as of 3.11](https://github.com/python/cpython/issues/105456). [As of 3.13](https://docs.python.org/3.13/library/re.html#re.PatternError) `re.PatternError` replaces `re.error` (which is still kept for backward compatibility).



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: athompson673

<!--- Thanks for your help making Spyder better for everyone! --->
