### PR TITLE
PR: Don't register shortcuts for find/replace related actions that go in the Search menu (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -514,7 +514,6 @@ class EditorMainWidget(PluginMainWidget):
             triggered=self.find,
             context=Qt.WidgetShortcut,
             shortcut_context="find_replace",
-            register_shortcut=True
         )
         self.find_next_action = self.create_action(
             EditorWidgetActions.FindNext,
@@ -523,7 +522,6 @@ class EditorMainWidget(PluginMainWidget):
             triggered=self.find_next,
             context=Qt.WidgetShortcut,
             shortcut_context="find_replace",
-            register_shortcut=True
         )
         self.find_previous_action = self.create_action(
             EditorWidgetActions.FindPrevious,
@@ -532,7 +530,6 @@ class EditorMainWidget(PluginMainWidget):
             triggered=self.find_previous,
             context=Qt.WidgetShortcut,
             shortcut_context="find_replace",
-            register_shortcut=True
         )
         self.replace_action = self.create_action(
             EditorWidgetActions.ReplaceText,
@@ -542,7 +539,6 @@ class EditorMainWidget(PluginMainWidget):
             triggered=self.replace,
             context=Qt.WidgetShortcut,
             shortcut_context="find_replace",
-            register_shortcut=True
         )
         self.gotoline_action = self.create_action(
             EditorWidgetActions.GoToLine,


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->
Prevent actions from the Search menu (that come from the Editor) to interfere with local find/replace shortcuts from other plugins

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22453


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
