### PR TITLE
PR: Register shortcuts for widgets directly (API)

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -5375,10 +5375,6 @@ def test_copy_paste(main_window, qtbot, tmpdir):
     code_editor = main_window.editor.get_focus_widget()
     code_editor.set_text(code)
 
-    # Register codeeditor shortcuts
-    CONF.notify_section_all_observers("shortcuts")
-    qtbot.wait(300)
-
     # Test copy
     cursor = code_editor.textCursor()
     cursor.setPosition(69)

--- a/spyder/plugins/editor/widgets/codeeditor/tests/conftest.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/conftest.py
@@ -149,10 +149,6 @@ def mock_completions_codeeditor(qtbot_module, request):
     qtbot_module.addWidget(editor)
     editor.show()
 
-    # Register shortcuts for CodeEditor
-    CONF.notify_section_all_observers("shortcuts")
-    qtbot_module.wait(300)
-
     mock_response = Mock()
 
     def perform_request(lang, method, params):
@@ -185,10 +181,6 @@ def completions_codeeditor(completion_plugin_all_started, qtbot_module,
 
     completion_plugin, capabilities = completion_plugin_all_started
     completion_plugin.wait_for_ms = 2000
-
-    # Register shortcuts for CodeEditor
-    CONF.notify_section_all_observers("shortcuts")
-    qtbot_module.wait(300)
 
     CONF.set('completions', 'enable_code_snippets', False)
     completion_plugin.after_configuration_update([])
@@ -256,10 +248,6 @@ def codeeditor(qtbot):
     widget.setup_editor(language='Python')
     widget.resize(640, 480)
     widget.show()
-
-    # Register shortcuts for CodeEditor
-    CONF.notify_section_all_observers("shortcuts")
-    qtbot.wait(300)
 
     yield widget
     widget.close()

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_codeeditor.py
@@ -721,6 +721,9 @@ def test_shortcut_for_widget_is_updated(config_dialog, codeeditor, qtbot):
     text = ('aa\nbb\ncc\ndd\n')
     editor.set_text(text)
 
+    # We need to wait for a bit so shortcuts are registered correctly
+    qtbot.wait(300)
+
     # Check shortcuts were registered
     assert editor._shortcuts != {}
 

--- a/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
+++ b/spyder/plugins/editor/widgets/editorstack/tests/test_shortcuts.py
@@ -42,8 +42,7 @@ def editorstack(qtbot):
     editorstack.show()
     editorstack.go_to_line(1)
 
-    # Register shortcuts
-    CONF.notify_section_all_observers("shortcuts")
+    # We need to wait for a bit so shortcuts are registered correctly
     qtbot.wait(300)
 
     return editorstack
@@ -342,6 +341,27 @@ def test_builtin_undo_redo(editorstack, qtbot):
     # Redo the last action with Ctrl+Y.
     qtbot.keyClick(editor, Qt.Key_Y, modifier=Qt.ControlModifier)
     assert editor.toPlainText() == 'Something\nLine1\nLine2\nLine3\nLine4\n'
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("linux") and running_in_ci(),
+    reason='Fails on Linux and CI'
+)
+def test_shortcuts_for_new_editors(editorstack, qtbot):
+    """
+    Test that widget shortcuts are working for new editors.
+
+    This is a regression test for spyder-ide/spyder#23151.
+    """
+    # Create new file and give it focus
+    editorstack.new('bar.py', 'utf-8', 'Line5\nLine6\nLine7\nLine8')
+    editorstack.tabs.setCurrentIndex(1)
+
+    # Go to its first line, click the shortcut to comment it and check it was
+    editorstack.go_to_line(1)
+    editor = editorstack.get_current_editor()
+    qtbot.keyClick(editor, Qt.Key_1, modifier=Qt.ControlModifier)
+    assert editor.toPlainText() == '# Line5\nLine6\nLine7\nLine8\n'
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of Changes

- Shorcuts for widgets were not registered for new widget instances (e.g. new CodeEditor's) because they required a notification from `CONF`.
- This is a regression introduced by #23024, which we overlooked.
- Add a test to catch possible regressions about this.

### Issue(s) Resolved

Fixes #23151.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
