### PR TITLE
PR: UI fixes for the Appearance config page and find/replace widget on Mac 

### DIFF
--- a/spyder/plugins/appearance/confpage.py
+++ b/spyder/plugins/appearance/confpage.py
@@ -112,6 +112,10 @@ class AppearanceConfigPage(PluginConfigPage):
 
         # Syntax layout
         syntax_layout = QGridLayout(syntax_group)
+        if sys.platform == "darwin":
+            # Default spacing is too big on Mac
+            syntax_layout.setVerticalSpacing(2 * AppStyle. MarginSize)
+
         btns = [self.schemes_combobox, edit_button, self.reset_button,
                 create_button, self.delete_button]
         for i, btn in enumerate(btns):

--- a/spyder/plugins/appearance/confpage.py
+++ b/spyder/plugins/appearance/confpage.py
@@ -49,6 +49,7 @@ class AppearanceConfigPage(PluginConfigPage):
 
     def __init__(self, plugin, parent):
         super().__init__(plugin, parent)
+        self._is_shown = False
         self.pre_apply_callback = self.check_color_scheme_notification
 
         # Notifications for this option are disabled when the plugin is
@@ -352,7 +353,7 @@ class AppearanceConfigPage(PluginConfigPage):
 
         return set(self.changed_options)
 
-    # Helpers
+    # ---- Helpers
     # -------------------------------------------------------------------------
     @property
     def current_scheme_name(self):
@@ -370,6 +371,24 @@ class AppearanceConfigPage(PluginConfigPage):
     def current_ui_theme_index(self):
         return self.ui_combobox.currentIndex()
 
+    # ---- Qt methods
+    # -------------------------------------------------------------------------
+    def showEvent(self, event):
+        """Adjustments when the page is shown."""
+        super().showEvent(event)
+
+        if not self._is_shown:
+            # Set the right interface font for Mac in the respective combobox,
+            # so that preview_interface shows it appropriately.
+            if sys.platform == "darwin":
+                index = self.app_font.fontbox.findText("SF Pro")
+                if index != -1:
+                    self.app_font.fontbox.setCurrentIndex(index)
+
+        self._is_shown = True
+
+    # ---- Update contents
+    # -------------------------------------------------------------------------
     def update_combobox(self):
         """Recreates the combobox contents."""
         index = self.current_scheme_index
@@ -464,7 +483,7 @@ class AppearanceConfigPage(PluginConfigPage):
             for widget in subwidgets:
                 getattr(self.app_font, widget).setEnabled(True)
 
-    # Actions
+    # ---- Actions
     # -------------------------------------------------------------------------
     def create_new_scheme(self):
         """Creates a new color scheme with a custom name."""

--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -13,6 +13,7 @@
 
 # Standard library imports
 import re
+import sys
 
 # Third party imports
 from qtpy.QtCore import QEvent, QSize, Qt, QTimer, Signal, Slot
@@ -82,6 +83,9 @@ class FindReplace(QWidget, SpyderShortcutsMixin):
             2 * AppStyle.MarginSize,
             0
         )
+        if sys.platform == "darwin":
+            # Spacing is too big on Mac, which makes the widget look bad
+            glayout.setSpacing(2 * AppStyle.MarginSize)
         self.setLayout(glayout)
 
         self.close_button = create_toolbutton(


### PR DESCRIPTION
## Description of Changes

- We were not showing the right interface font in the preview added in #22927, which was incorrect.
- Fix vertical spacing of some buttons in that page because it was too big.
- Fix horizontal and vertical spacing of find/replace widget on Mac because it was not good.

### Visual changes

**Preferences page**

| Before | After |
| - | - |
|![imagen](https://github.com/user-attachments/assets/f41d0a05-1e89-4cbb-a7ae-3f11d250072f) | ![imagen](https://github.com/user-attachments/assets/c1090a17-4e01-4bda-ac47-afe40fa1720d)

**Find/replace widget**

| Before | After |
| - | - |
| ![imagen](https://github.com/user-attachments/assets/6acff2bb-e33e-4cd8-9a65-cd4288cba686) | ![imagen](https://github.com/user-attachments/assets/53151e8f-1b1d-48e0-a1f7-bcd71e6f2254)



### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
