### PR TITLE
PR: Enable/disable the `Configuration per file` action according to the current file run configuration (Run)

### DIFF
--- a/spyder/plugins/run/container.py
+++ b/spyder/plugins/run/container.py
@@ -324,6 +324,7 @@ class RunContainer(PluginMainContainer):
 
         if uuid is not None:
             self.run_action.setEnabled(True)
+            self.configure_action.setEnabled(True)
 
             metadata = self.metadata_model[uuid]
             self.current_input_provider = metadata['source']
@@ -336,7 +337,8 @@ class RunContainer(PluginMainContainer):
             return
 
         self.run_action.setEnabled(False)
-        
+        self.configure_action.setEnabled(False)
+
         for context, act, mod in self.context_actions:
             action, __ = self.context_actions[(context, act, mod)]
             action.setEnabled(False)


### PR DESCRIPTION
## Description of Changes

That action was enabled for files without a run configuration, which was giving the same error as the one reported on issue #22607 when clicking on it.

### Issue(s) Resolved

Part of #22607.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
