### PR TITLE
PR: Add constraint for `pyqt5-sip` on Python 3.8 (Dependencies)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -244,7 +244,7 @@ setup_args = dict(
 
 # Qt bindings requirements
 qt_requirements = {
-    'pyqt5': ['pyqt5>=5.15,<5.16', 'pyqtwebengine>=5.15,<5.16'],
+    'pyqt5': ['pyqt5>=5.15,<5.16', 'pyqtwebengine>=5.15,<5.16', 'pyqt5-sip<12.16; python_version=="3.8"'],
     'pyqt6': ['pyqt6>=6.5,<7', 'pyqt6-webengine>=6.5,<7'],
 }
 

--- a/spyder/tests/test_dependencies_in_sync.py
+++ b/spyder/tests/test_dependencies_in_sync.py
@@ -237,6 +237,8 @@ def test_dependencies_for_spyder_setup_install_requires_in_sync():
     # We can't declare these as dependencies in setup.py
     for dep in ['python.app', 'fzf', 'fcitx-qt5']:
         full_reqs.pop(dep)
+    # Ignored `pyqt5-sip` constraint on conda
+    spyder_setup.pop('pyqt5-sip')
 
     assert spyder_setup == full_reqs
 


### PR DESCRIPTION
## Description of Changes

- A new version of that package was released yesterday which broke compatibility with Python 3.8, even when the other PyQt5 packages still support it.
- Without this constraint Spyder fails to be installed in that Python version.
- This commit was already included in #23201 for the `6.x` branch, but we also need to have it in master until we drop support for that Python version.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
