### PR TITLE
PR: A couple of fixes for the Internal console

### DIFF
--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -134,6 +134,7 @@ class ConsoleWidget(PluginMainWidget):
         self.dialog_manager = DialogManager()
         self.error_dlg = None
         self.shell = InternalShell(  # TODO: Move to use SpyderWidgetMixin?
+            parent=parent,
             commands=[],
             message=message,
             max_line_count=self.get_conf('max_line_count'),

--- a/spyder/plugins/console/widgets/shell.py
+++ b/spyder/plugins/console/widgets/shell.py
@@ -46,8 +46,12 @@ from spyder.plugins.console.widgets.console import ConsoleBaseWidget
 MAX_LINES = 1000
 
 
-class ShellBaseWidget(ConsoleBaseWidget, SaveHistoryMixin,
-                      BrowseHistoryMixin):
+class ShellBaseWidget(
+    ConsoleBaseWidget,
+    SpyderShortcutsMixin,
+    SaveHistoryMixin,
+    BrowseHistoryMixin
+):
     """
     Shell base widget
     """
@@ -65,6 +69,7 @@ class ShellBaseWidget(ConsoleBaseWidget, SaveHistoryMixin,
         parent : specifies the parent widget
         """
         ConsoleBaseWidget.__init__(self, parent)
+        SpyderShortcutsMixin.__init__(self)
         SaveHistoryMixin.__init__(self, history_filename)
         BrowseHistoryMixin.__init__(self)
 
@@ -642,9 +647,7 @@ class ShellBaseWidget(ConsoleBaseWidget, SaveHistoryMixin,
 # from spyder.utils.debug import log_methods_calls
 # log_methods_calls('log.log', ShellBaseWidget)
 
-class PythonShellWidget(
-    TracebackLinksMixin, ShellBaseWidget, GetHelpMixin, SpyderShortcutsMixin
-):
+class PythonShellWidget(ShellBaseWidget, TracebackLinksMixin, GetHelpMixin):
     """Python shell widget"""
     QT_CLASS = ShellBaseWidget
     INITHISTORY = ['# -*- coding: utf-8 -*-',
@@ -679,7 +682,6 @@ class PythonShellWidget(
         )
         TracebackLinksMixin.__init__(self)
         GetHelpMixin.__init__(self)
-        SpyderShortcutsMixin.__init__(self)
 
         # Local shortcuts
         self.register_shortcuts()


### PR DESCRIPTION
## Description of Changes

- Restore parent for `InternalShell`. This sets the right parent and style for the completion widget in the console (regression introduced in #17657).
- Fix saving command history, which was not working due to the incorrect initialization of some mixins (regression introduced in #23024).

### Issue(s) Resolved

Fixes #23196.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
