### PR TITLE
PR: Improve displaying several kernel error messages (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/__init__.py
+++ b/spyder/plugins/ipythonconsole/__init__.py
@@ -44,5 +44,12 @@ else:
 
 
 class SpyderKernelError(RuntimeError):
-    """Error to be shown in client."""
-    pass
+    """
+    Error to be shown in the IPython console.
+
+    Notes
+    -----
+    * Use this exception if you want to show a nice formatted error in the
+      current console instead of a long and hard-to-read traceback.
+    * This should only be used for errors whose cause we are certain of.
+    """

--- a/spyder/plugins/ipythonconsole/utils/client.py
+++ b/spyder/plugins/ipythonconsole/utils/client.py
@@ -20,6 +20,7 @@ from traitlets import Type
 # Local imports
 from spyder.api.asyncdispatcher import AsyncDispatcher
 from spyder.api.translations import _
+from spyder.plugins.ipythonconsole import SpyderKernelError
 
 
 class KernelClientTunneler:
@@ -63,10 +64,10 @@ class KernelClientTunneler:
                 )
             )
         except asyncssh.Error as err:
-            raise RuntimeError(
+            raise SpyderKernelError(
                 _(
-                    "It was not possible to open an SSH tunnel for the "
-                    "remote kernel. Please check your credentials and the "
+                    "It was not possible to open an SSH tunnel to connect to "
+                    "the remote kernel. Please check your credentials and the "
                     "server connection status."
                 )
             ) from err

--- a/spyder/plugins/ipythonconsole/utils/kernel_handler.py
+++ b/spyder/plugins/ipythonconsole/utils/kernel_handler.py
@@ -378,7 +378,7 @@ class KernelHandler(QObject):
         """
         connection_file = cls.new_connection_file()
         if connection_file is None:
-            raise RuntimeError(
+            raise SpyderKernelError(
                 PERMISSION_ERROR_MSG.format(jupyter_runtime_dir())
             )
 
@@ -483,13 +483,13 @@ class KernelHandler(QObject):
         try:
             kernel_client.load_connection_file()
         except Exception as e:
-            raise RuntimeError(
+            raise SpyderKernelError(
                 _(
                     "An error occurred while trying to load "
                     "the kernel connection file. The error "
                     "was:\n\n"
                 )
-                + str(e)
+                + f"<tt>{str(e)}</tt>"
             )
 
         if hostname is not None or ssh_connection is not None:


### PR DESCRIPTION
## Description of Changes

- Use `SpyderKernelError` for errors whose cause we are certain of. That displays just the error message, nicely formatted in the console, instead of a long traceback.
- Improve `SpyderKernelError` docstring to describe its proper usage.

### Visual changes 

Message when `jupyter_runtime_dir()` is not writable

| Before | After |
| - | - |
| ![imagen](https://github.com/user-attachments/assets/91ac4509-d45b-4074-9b43-d803a3c5e9e6) | ![imagen](https://github.com/user-attachments/assets/3a6bc45b-16ef-4a5b-a5e4-364babf94842) |

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23124 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
