### PR TITLE
PR: Fix error when inserting items in DataFrameEditor (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -1143,7 +1143,7 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
                     new_name = self.next_index_name(indexes, new_name)
 
             item_value = eval(eval_type)
-            if item_value == ():
+            if isinstance(item_value, tuple) and item_value == ():
                 item_value = ('')
 
             df.insert(


### PR DESCRIPTION
## Description of Changes

- This error was due to a comparison for the item's value that was not specific enough.
- It started to appear with Numpy 2.2.0 (released yesterday), which raises a `ValueError` for comparisons with empty arrays.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
