### PR TITLE
PR: Set python_min environment variable for subrepo conda package builds

### DIFF
--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -79,4 +79,5 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         env:
           CONDA_BLD_PATH: ${{ github.workspace }}/installers-conda/build/conda-bld
+          python_min: '3.9'
         run: python build_conda_pkgs.py --build $pkg


### PR DESCRIPTION
Building a subrepo conda package will fail if `python_min` is not defined either as an environment variable or in `meta.yaml`, e.g. `qtconsole` (see conda-forge/qtconsole-feedstock#61).
