### PR TITLE
PR: Fix invalid workflow issue with `purge_cache.yml`

### DIFF
--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
     inputs:
       branch:
-        required: true
+        required: false
         type: string
 
   workflow_dispatch:


### PR DESCRIPTION
The called reusable workflow requires specifying the git ref.

Merge after #23254.