### PR TITLE
PR: Don't hide control debugger buttons from main toolbar while executing

### DIFF
--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -416,6 +416,7 @@ class DebuggerWidget(ShellConnectMainWidget):
                 post_mortem = False
                 executing = False
                 pdb_prompt = False
+                is_debugging = False
             else:
                 search_action.setEnabled(True)
                 search_action.setChecked(widget.finder_is_visible())
@@ -423,6 +424,7 @@ class DebuggerWidget(ShellConnectMainWidget):
                 sw = widget.shellwidget
                 executing = sw._executing
                 pdb_prompt = sw.is_waiting_pdb_input()
+                is_debugging = sw.is_debugging()
 
             enter_debug_action.setEnabled(post_mortem and not executing)
             interrupt_and_debug_action.setEnabled(executing)
@@ -438,7 +440,8 @@ class DebuggerWidget(ShellConnectMainWidget):
                 action = self.get_action(action_name)
                 action.setEnabled(pdb_prompt)
 
-            self._set_visible_control_debugger_buttons(pdb_prompt or executing)
+            self._set_visible_control_debugger_buttons(pdb_prompt or
+                                                       is_debugging)
 
             rows = self.breakpoints_table.selectionModel().selectedRows()
             initial_row = rows[0] if rows else None

--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -440,8 +440,9 @@ class DebuggerWidget(ShellConnectMainWidget):
                 action = self.get_action(action_name)
                 action.setEnabled(pdb_prompt)
 
-            self._set_visible_control_debugger_buttons(pdb_prompt or
-                                                       is_debugging)
+            self._set_visible_control_debugger_buttons(
+                pdb_prompt or is_debugging
+            )
 
             rows = self.breakpoints_table.selectionModel().selectedRows()
             initial_row = rows[0] if rows else None

--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -438,7 +438,7 @@ class DebuggerWidget(ShellConnectMainWidget):
                 action = self.get_action(action_name)
                 action.setEnabled(pdb_prompt)
 
-            self._set_visible_control_debugger_buttons(pdb_prompt)
+            self._set_visible_control_debugger_buttons(pdb_prompt or executing)
 
             rows = self.breakpoints_table.selectionModel().selectedRows()
             initial_row = rows[0] if rows else None


### PR DESCRIPTION
<!--- Explain what you've done and why --->
while debugging, clicking run (step in/out, etc) causes the debug actions on the toolbar to briefly hide until the current line has completed. This looks visually glitchy, and can cause mis-clicks. Instead continue to show the buttons if currently executing.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23208


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: athompson673

<!--- Thanks for your help making Spyder better for everyone! --->
