### PR TITLE
PR: Reduce calls to get environment variables in `SpyderKernelSpec` and raise timeout threshold to do that 

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -860,7 +860,10 @@ def test_dedicated_consoles(main_window, qtbot):
         == "script.py/A"
     )
 
-    qtbot.waitUntil(lambda: nsb.editor.source_model.rowCount() == 4, timeout=SHELL_TIMEOUT)
+    qtbot.waitUntil(
+        lambda: nsb.editor.source_model.rowCount() == 4,
+        timeout=SHELL_TIMEOUT
+    )
     assert nsb.editor.source_model.rowCount() == 4
 
     # --- Assert runfile text is present and we show the banner ---

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -860,7 +860,7 @@ def test_dedicated_consoles(main_window, qtbot):
         == "script.py/A"
     )
 
-    qtbot.waitUntil(lambda: nsb.editor.source_model.rowCount() == 4)
+    qtbot.waitUntil(lambda: nsb.editor.source_model.rowCount() == 4, timeout=SHELL_TIMEOUT)
     assert nsb.editor.source_model.rowCount() == 4
 
     # --- Assert runfile text is present and we show the banner ---
@@ -868,11 +868,11 @@ def test_dedicated_consoles(main_window, qtbot):
     assert ('runfile' in text) and ('Python' in text and 'IPython' in text)
 
     # --- Check namespace retention after re-execution ---
-    with qtbot.waitSignal(shell.executed):
+    with qtbot.waitSignal(shell.executed, timeout=SHELL_TIMEOUT):
         shell.execute('zz = -1')
 
     qtbot.keyClick(code_editor, Qt.Key_F5)
-    qtbot.waitUntil(lambda: shell.is_defined('zz'))
+    qtbot.waitUntil(lambda: shell.is_defined('zz'), timeout=SHELL_TIMEOUT)
     assert shell.is_defined('zz')
 
     # --- Assert runfile text is present after reruns and there's no banner
@@ -886,7 +886,7 @@ def test_dedicated_consoles(main_window, qtbot):
 
     qtbot.wait(500)
     qtbot.keyClick(code_editor, Qt.Key_F5)
-    qtbot.waitUntil(lambda: not shell.is_defined('zz'))
+    qtbot.waitUntil(lambda: not shell.is_defined('zz'), timeout=SHELL_TIMEOUT)
     assert not shell.is_defined('zz')
 
     # --- Assert runfile text is present after reruns ---

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -90,6 +90,8 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
         self.language = 'python3'
         self.resource_dir = ''
 
+        self.env = get_user_environment_variables()
+
     @property
     def argv(self):
         """Command to start kernels"""
@@ -201,7 +203,7 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
 
         # Ensure that user environment variables are included, but don't
         # override existing environ values
-        env_vars = get_user_environment_variables()
+        env_vars = self._env_vars.copy()
         env_vars.update(os.environ)
 
         # Avoid IPython adding the virtualenv on which Spyder is running
@@ -257,3 +259,8 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
         clean_env_vars = clean_env(env_vars)
 
         return clean_env_vars
+
+    @env.setter
+    def env(self, env_vars):
+        self._env_vars = dict(env_vars)
+        self._env_vars.pop('PYTEST_CURRENT_TEST', None)

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -117,7 +117,7 @@ def get_user_environment_variables():
                 proc = run_shell_command(user_env_script, env={}, text=True)
 
                 # Use timeout to fix spyder-ide/spyder#21172
-                stdout, stderr = proc.communicate(timeout=5)
+                stdout, stderr = proc.communicate(timeout=3)
 
                 if stderr:
                     logger.info(stderr.strip())

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -27,9 +27,7 @@ import psutil
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports
-from spyder.config.base import (
-    _, running_in_ci, get_conf_path, running_under_pytest
-)
+from spyder.config.base import _, running_in_ci, get_conf_path
 from spyder.widgets.collectionseditor import CollectionsEditor
 from spyder.utils.icon_manager import ima
 from spyder.utils.programs import run_shell_command
@@ -113,7 +111,7 @@ def get_user_environment_variables():
         # We only need to do this if Spyder was **not** launched from a
         # terminal. Otherwise, it'll inherit the env vars present in it.
         # Fixes spyder-ide/spyder#22415
-        if not launched_from_terminal or running_under_pytest():
+        if not launched_from_terminal or running_in_ci():
             try:
                 user_env_script = _get_user_env_script()
                 proc = run_shell_command(user_env_script, env={}, text=True)

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -117,9 +117,7 @@ def get_user_environment_variables():
                 proc = run_shell_command(user_env_script, env={}, text=True)
 
                 # Use timeout to fix spyder-ide/spyder#21172
-                stdout, stderr = proc.communicate(
-                    timeout=3 if running_in_ci() else 0.5
-                )
+                stdout, stderr = proc.communicate(timeout=5)
 
                 if stderr:
                     logger.info(stderr.strip())


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
I propose raising the timeout to 5s for all scenarios.
This PR raises the timeout for the subprocess for getting user environment variables from 0.5s to 5s, and reduces superfulous calls to `get_user_environment_variables` by moving it to the instantiation of `SpyderKernelSpec` from `SpyderKernelSpec.env`.

I've run into a scenario where `get_user_environment_variables` can take up to ~1s or more. This triggers the timeout and renders the function useless, leaving users with incorrect environment variables sent to the console and language server.

Currently, `get_user_environment_variables` is called in `SpyderKernelSpec.env`, which is not appropriate since this is decorated with `@property`. `SpyderKernelSpec.env` can be referenced many times, resulting in superfluous exectution of `get_user_environment_variables` (8 times during Spyder startup!).

