### PR TITLE
PR: Remove mutable defaults for keyword arguments

### DIFF
--- a/external-deps/qtconsole/qtconsole/ansi_code_processor.py
+++ b/external-deps/qtconsole/qtconsole/ansi_code_processor.py
@@ -146,7 +146,7 @@ class AnsiCodeProcessor(object):
             self.actions.append(NewLineAction('newline'))
             yield None
 
-    def set_csi_code(self, command, params=[]):
+    def set_csi_code(self, command, params=None):
         """ Set attributes based on CSI (Control Sequence Introducer) code.
 
         Parameters
@@ -157,6 +157,7 @@ class AnsiCodeProcessor(object):
         params : sequence of integers, optional
             The parameter codes for the command.
         """
+        params = [] if params is None else params
         if command == 'm':   # SGR - Select Graphic Rendition
             if params:
                 self.set_sgr_code(params)
@@ -196,7 +197,7 @@ class AnsiCodeProcessor(object):
             dir = 'leftup'
             count = params[0] if params else 1
             self.actions.append(MoveAction('move', dir, 'line', count))
-        
+
 
     def set_osc_code(self, params):
         """ Set attributes based on OSC (Operating System Command) parameters.

--- a/external-deps/qtconsole/qtconsole/ansi_code_processor.py
+++ b/external-deps/qtconsole/qtconsole/ansi_code_processor.py
@@ -146,7 +146,7 @@ class AnsiCodeProcessor(object):
             self.actions.append(NewLineAction('newline'))
             yield None
 
-    def set_csi_code(self, command, params=None):
+    def set_csi_code(self, command, params=[]):
         """ Set attributes based on CSI (Control Sequence Introducer) code.
 
         Parameters
@@ -157,7 +157,6 @@ class AnsiCodeProcessor(object):
         params : sequence of integers, optional
             The parameter codes for the command.
         """
-        params = [] if params is None else params
         if command == 'm':   # SGR - Select Graphic Rendition
             if params:
                 self.set_sgr_code(params)
@@ -197,7 +196,7 @@ class AnsiCodeProcessor(object):
             dir = 'leftup'
             count = params[0] if params else 1
             self.actions.append(MoveAction('move', dir, 'line', count))
-
+        
 
     def set_osc_code(self, params):
         """ Set attributes based on OSC (Operating System Command) parameters.

--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -56,7 +56,8 @@ class BuildCondaPkg:
     feedstock_branch = None
     shallow_ver = None
 
-    def __init__(self, data={}, debug=False, shallow=False):
+    def __init__(self, data=None, debug=False, shallow=False):
+        data = {} if data is None else data
         self.logger = getLogger(self.__class__.__name__)
         if not self.logger.handlers:
             self.logger.addHandler(h)

--- a/spyder/plugins/completion/confpage.py
+++ b/spyder/plugins/completion/confpage.py
@@ -15,7 +15,8 @@ from spyder.api.preferences import PluginConfigPage
 
 
 class CompletionConfigPage(PluginConfigPage):
-    def __init__(self, plugin, parent, providers=[]):
+    def __init__(self, plugin, parent, providers=None):
+        providers = [] if providers is None else providers
         super().__init__(plugin, parent)
         self.providers = providers
 

--- a/spyder/plugins/completion/providers/snippets/widgets/snippetsconfig.py
+++ b/spyder/plugins/completion/providers/snippets/widgets/snippetsconfig.py
@@ -498,7 +498,8 @@ class SnippetModelsProxy:
             model.delete_queue = list(model.snippets)
             self.load_snippets(language, model, defaults)
 
-    def load_snippets(self, language, model, snippets=None, to_add=[]):
+    def load_snippets(self, language, model, snippets=None, to_add=None):
+        to_add = [] if to_add is None else to_add
         snippets = iter_snippets(language, self.parent.get_option,
                                  self.parent.set_option,
                                  snippets=snippets)

--- a/spyder/plugins/console/widgets/internalshell.py
+++ b/spyder/plugins/console/widgets/internalshell.py
@@ -145,9 +145,10 @@ class InternalShell(PythonShellWidget):
     # TODO: I think this is not being used now?
     sig_focus_changed = Signal()
 
-    def __init__(self, parent=None, commands=[], message=None,
+    def __init__(self, parent=None, commands=None, message=None,
                  max_line_count=300, exitfunc=None, profile=False,
                  multithreaded=True):
+        commands = [] if commands is None else commands
         super().__init__(parent, get_conf_path('history_internal.py'),
                          profile=profile)
 

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -2476,7 +2476,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
         if len(spaces) - 1 >= group:
             return len(spaces[group])
 
-    def __get_brackets(self, line_text, closing_brackets=[]):
+    def __get_brackets(self, line_text, closing_brackets=None):
         """
         Return unmatched opening brackets and left-over closing brackets.
 
@@ -2493,6 +2493,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
             be matched with previously unmatched opening brackets in this line.
         3) Pos at which a # comment begins. -1 if it doesn't.'
         """
+        closing_brackets = [] if closing_brackets is None else closing_brackets
         # Remove inline comment and check brackets
         bracket_stack = []  # list containing this lines unmatched opening
         # same deal, for closing though. Ignore if bracket stack not empty,

--- a/spyder/plugins/explorer/widgets/main_widget.py
+++ b/spyder/plugins/explorer/widgets/main_widget.py
@@ -306,7 +306,10 @@ class ExplorerWidget(PluginMainWidget):
 # Tests
 # =============================================================================
 class FileExplorerTest(QWidget):
-    def __init__(self, directory=None, file_associations={}):
+    def __init__(self, directory=None, file_associations=None):
+        file_associations = (
+            {} if file_associations is None else file_associations
+        )
         self.CONF_SECTION = 'explorer'
         super().__init__()
 

--- a/spyder/plugins/findinfiles/widgets/combobox.py
+++ b/spyder/plugins/findinfiles/widgets/combobox.py
@@ -44,7 +44,10 @@ class SearchInComboBox(SpyderComboBox):
     # Signals
     sig_redirect_stdio_requested = Signal(bool)
 
-    def __init__(self, external_path_history=[], parent=None, id_=None):
+    def __init__(self, external_path_history=None, parent=None, id_=None):
+        external_path_history = (
+            [] if external_path_history is None else external_path_history
+        )
         super().__init__(parent)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.setEditable(False)

--- a/spyder/plugins/onlinehelp/pydoc_patch.py
+++ b/spyder/plugins/onlinehelp/pydoc_patch.py
@@ -164,7 +164,9 @@ class CustomHTMLDoc(Doc, SpyderFontsMixin):
         """Make a link to source file."""
         return '<a href="file:%s">%s</a>' % (url, path)
 
-    def markup(self, text, escape=None, funcs=None, classes=None, methods=None):
+    def markup(
+        self, text, escape=None, funcs=None, classes=None, methods=None
+    ):
         """
         Mark up some plain text, given a context of symbols to look for.
 

--- a/spyder/plugins/onlinehelp/pydoc_patch.py
+++ b/spyder/plugins/onlinehelp/pydoc_patch.py
@@ -164,12 +164,15 @@ class CustomHTMLDoc(Doc, SpyderFontsMixin):
         """Make a link to source file."""
         return '<a href="file:%s">%s</a>' % (url, path)
 
-    def markup(self, text, escape=None, funcs={}, classes={}, methods={}):
+    def markup(self, text, escape=None, funcs=None, classes=None, methods=None):
         """
         Mark up some plain text, given a context of symbols to look for.
 
         Each context dictionary maps object names to anchor names.
         """
+        funcs = {} if funcs is None else funcs
+        classes = {} if classes is None else classes
+        methods = {} if methods is None else methods
         escape = escape or self.escape
         results = []
         here = 0
@@ -370,9 +373,11 @@ class CustomHTMLDoc(Doc, SpyderFontsMixin):
 
         return result
 
-    def docclass(self, object, name=None, mod=None, funcs={}, classes={},
+    def docclass(self, object, name=None, mod=None, funcs=None, classes=None,
                  *ignored):
         """Produce HTML documentation for a class object."""
+        funcs = {} if funcs is None else funcs
+        classes = {} if classes is None else classes
         realname = object.__name__
         name = name or realname
         bases = object.__bases__

--- a/spyder/plugins/onlinehelp/widgets.py
+++ b/spyder/plugins/onlinehelp/widgets.py
@@ -63,7 +63,8 @@ DIRECT_PYDOC_IMPORT_MODULES = ['numpy', 'numpy.core']
 try:
     from pydoc import safeimport
 
-    def spyder_safeimport(path, forceload=0, cache={}):
+    def spyder_safeimport(path, forceload=0, cache=None):
+        cache = {} if cache is None else cache
         if path in DIRECT_PYDOC_IMPORT_MODULES:
             forceload = 0
         return safeimport(path, forceload=forceload, cache=cache)

--- a/spyder/plugins/variableexplorer/widgets/importwizard.py
+++ b/spyder/plugins/variableexplorer/widgets/importwizard.py
@@ -267,7 +267,8 @@ class ContentsWidget(QWidget):
 
 class PreviewTableModel(QAbstractTableModel):
     """Import wizard preview table model"""
-    def __init__(self, data=[], parent=None):
+    def __init__(self, data=None, parent=None):
+        data = [] if data is None else data
         QAbstractTableModel.__init__(self, parent)
         self._data = data
 

--- a/spyder/utils/bsdsocket.py
+++ b/spyder/utils/bsdsocket.py
@@ -98,8 +98,9 @@ COMMUNICATE_LOCK = threading.Lock()
 
 # * Old com implementation *
 # See solution (1) in spyder-ide/spyder#434, comment 13:
-def communicate(sock, command, settings=[]):
+def communicate(sock, command, settings=None):
     """Communicate with monitor"""
+    settings = [] if settings is None else settings
     try:
         COMMUNICATE_LOCK.acquire()
         write_packet(sock, command)

--- a/spyder/utils/bsdsocket.py
+++ b/spyder/utils/bsdsocket.py
@@ -96,6 +96,7 @@ def read_packet(sock, timeout=None):
 # spyder-ide/spyder#857.
 COMMUNICATE_LOCK = threading.Lock()
 
+
 # * Old com implementation *
 # See solution (1) in spyder-ide/spyder#434, comment 13:
 def communicate(sock, command, settings=None):

--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -71,7 +71,7 @@ def get_temp_dir(suffix=None):
     return tempdir
 
 
-def is_program_installed(basename, extra_paths=[]):
+def is_program_installed(basename, extra_paths=None):
     """
     Return program absolute path if installed in PATH.
     Otherwise, return None.
@@ -83,6 +83,7 @@ def is_program_installed(basename, extra_paths=[]):
 
     On macOS systems, a .app is considered installed if it exists.
     """
+    extra_paths = [] if extra_paths is None else extra_paths
     home = get_home_dir()
     req_paths = []
     if (
@@ -118,13 +119,14 @@ def is_program_installed(basename, extra_paths=[]):
             return abspath
 
 
-def find_program(basename, extra_paths=[]):
+def find_program(basename, extra_paths=None):
     """
     Find program in PATH and return absolute path
 
     Try adding .exe or .bat to basename on Windows platforms
     (return None if not found)
     """
+    extra_paths = [] if extra_paths is None else extra_paths
     names = [basename]
     if os.name == 'nt':
         # Windows platforms
@@ -657,11 +659,13 @@ def python_script_exists(package=None, module=None):
             return path
 
 
-def run_python_script(package=None, module=None, args=[], p_args=[]):
+def run_python_script(package=None, module=None, args=None, p_args=None):
     """
     Run Python script in a separate process
     package=None -> module is in sys.path (standard library modules)
     """
+    args = [] if args is None else args
+    p_args = [] if p_args is None else p_args
     assert module is not None
     assert isinstance(args, (tuple, list)) and isinstance(p_args, (tuple, list))
     path = python_script_exists(package, module)

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -548,8 +548,9 @@ def create_program_action(parent, text, name, icon=None, nt_name=None):
                              triggered=lambda: programs.run_program(name))
 
 
-def create_python_script_action(parent, text, icon, package, module, args=[]):
+def create_python_script_action(parent, text, icon, package, module, args=None):
     """Create action to run a GUI based Python script"""
+    args = [] if args else args
     if is_text_string(icon):
         icon = ima.get_icon(icon)
     if programs.python_script_exists(package, module):

--- a/spyder/utils/qthelpers.py
+++ b/spyder/utils/qthelpers.py
@@ -548,7 +548,9 @@ def create_program_action(parent, text, name, icon=None, nt_name=None):
                              triggered=lambda: programs.run_program(name))
 
 
-def create_python_script_action(parent, text, icon, package, module, args=None):
+def create_python_script_action(
+    parent, text, icon, package, module, args=None
+):
     """Create action to run a GUI based Python script"""
     args = [] if args else args
     if is_text_string(icon):

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -420,8 +420,14 @@ class GenericSH(BaseSH):
 #==============================================================================
 # Python syntax highlighter
 #==============================================================================
-def make_python_patterns(additional_keywords=[], additional_builtins=[]):
+def make_python_patterns(additional_keywords=None, additional_builtins=None):
     "Strongly inspired from idlelib.ColorDelegator.make_pat"
+    additional_keywords = (
+        [] if additional_keywords is None else additional_keywords
+    )
+    additional_builtins = (
+        [] if additional_builtins is None else additional_builtins
+    )
     kwlist = keyword.kwlist + additional_keywords
     builtinlist = [str(name) for name in dir(builtins)
                    if not name.startswith('_')] + additional_builtins

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -116,7 +116,8 @@ class WebView(QWebEngineView, SpyderWidgetMixin):
             self.setPage(web_page)
             self.source_text = ''
 
-    def setup(self, options={}):
+    def setup(self, options=None):
+        options = {} if options is None else options
         # Actions
         original_back_action = self.pageAction(QWebEnginePage.WebAction.Back)
         back_action = self.create_action(


### PR DESCRIPTION
## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


Whilst tracking down an odd race condition in locating conda, I spotted several instances where a mutable type
was being used as a default for a keyword argument. This PR simple replaces the mutable constant (typically [] and {})
with a `None` and then does an `x = [] if x is None else x` or equivalent on the first line of each affected function.

It is possible that functionality was depending on the default mutable value being changed by a function call, but
I'd argue that it is sufficiently non-obvious that doing that should be considered a bug :-)

### Issue(s) Resolved

Partially Fixes #23061


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: gb119 (https://github.com/gb119)


