### PR TITLE
PR: Prevent Chinese input method to block edit input area

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/control.py
+++ b/spyder/plugins/ipythonconsole/widgets/control.py
@@ -50,7 +50,8 @@ class ControlWidget(TracebackLinksMixin, GetHelpMixin,
         # To not use Spyder calltips obtained through the monitor
         self.calltips = False
 
-    # ---- Public methods ----------------------------------------------------
+    # ---- Public methods
+    # -------------------------------------------------------------------------
     def insert_horizontal_ruler(self):
         """
         Insert a horizontal ruler with the appropriate color according
@@ -69,7 +70,8 @@ class ControlWidget(TracebackLinksMixin, GetHelpMixin,
         cursor.movePosition(cursor.End)
         cursor.insertFrame(ruler)
 
-    # ---- Private methods ---------------------------------------------------
+    # ---- Private methods
+    # -------------------------------------------------------------------------
     def _key_paren_left(self, text):
         """ Action for '(' """
         self.current_prompt_pos = self.parentWidget()._prompt_pos
@@ -79,7 +81,8 @@ class ControlWidget(TracebackLinksMixin, GetHelpMixin,
                 self.show_object_info(last_obj)
         self.insert_text(text)
 
-    # ---- Qt methods --------------------------------------------------------
+    # ---- Qt methods
+    # -------------------------------------------------------------------------
     def showEvent(self, event):
         """Reimplement Qt Method"""
         self.sig_visibility_changed.emit(True)

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -1539,6 +1539,28 @@ class BaseEditMixin(object):
         elif isinstance(self, QTextEdit):
             QTextEdit.mouseDoubleClickEvent(self, event)
 
+    def inputMethodQuery(self, query):
+        """
+        Prevent Chinese input method to block edit input area.
+
+        Notes
+        -----
+        This was suggested by a user in spyder-ide/spyder#23313. So, it's not
+        tested by us.
+        """
+        if query == Qt.ImInputItemClipRectangle:
+            cursor_rect = self.cursorRect()
+            margins = self.viewportMargins()
+            cursor_rect.moveTopLeft(
+                cursor_rect.topLeft() + QPoint(margins.left(), margins.top())
+            )
+            return cursor_rect
+
+        if isinstance(self, QPlainTextEdit):
+            QPlainTextEdit.inputMethodQuery(self, query)
+        elif isinstance(self, QTextEdit):
+            QTextEdit.inputMethodQuery(self, query)
+
 
 class TracebackLinksMixin(object):
     """Mixin to make file names in tracebacks and anchors clickable."""


### PR DESCRIPTION
## Description of Changes

- This fix was suggested by a user in #23313 but only for the editor. I decided to apply to `BaseEditMixin` so it also takes effect in the IPython console and other areas where users can edit text.
- Fix some block comments so they appear better in the Outline pane.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23313

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
