### PR TITLE
PR: Make `TextEditBaseWidget.__move_line_or_selection` public

### DIFF
--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -806,7 +806,7 @@ class TextEditBaseWidget(
         """
         self.__duplicate_line_or_selection(after_current_line=True)
 
-    def __move_line_or_selection(self, after_current_line=True):
+    def move_line_or_selection(self, after_current_line=True):
         """Move current line or selected text"""
         cursor = self.textCursor()
         cursor.beginEditBlock()
@@ -883,11 +883,11 @@ class TextEditBaseWidget(
 
     def move_line_up(self):
         """Move up current line or selected text"""
-        self.__move_line_or_selection(after_current_line=False)
+        self.move_line_or_selection(after_current_line=False)
 
     def move_line_down(self):
         """Move down current line or selected text"""
-        self.__move_line_or_selection(after_current_line=True)
+        self.move_line_or_selection(after_current_line=True)
 
     def go_to_new_line(self):
         """Go to the end of the current line and create a new line"""

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -881,14 +881,6 @@ class TextEditBaseWidget(
         self.setTextCursor(cursor)
         self.__restore_selection(start_pos, end_pos)
 
-    def move_line_up(self):
-        """Move up current line or selected text"""
-        self.move_line_or_selection(after_current_line=False)
-
-    def move_line_down(self):
-        """Move down current line or selected text"""
-        self.move_line_or_selection(after_current_line=True)
-
     def go_to_new_line(self):
         """Go to the end of the current line and create a new line"""
         self.stdkey_end(False, False)

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -4303,7 +4303,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
                         if fold_status:
                             self.folding_panel.toggle_fold_trigger(block)
 
-        self._TextEditBaseWidget__move_line_or_selection(
+        self.move_line_or_selection(
             after_current_line=after_current_line
         )
 


### PR DESCRIPTION
## Description of Changes
codeeditor.CodeEditor calls name mangled private function of parent class. That function should instead be made public if it needs to be called from the child.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: athompson673

<!--- Thanks for your help making Spyder better for everyone! --->
