### PR TITLE
PR: Add missing `__init__()` calls

### DIFF
--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -72,6 +72,7 @@ class FindReplace(QWidget, SpyderShortcutsMixin):
 
     def __init__(self, parent, enable_replace=False):
         QWidget.__init__(self, parent)
+        SpyderShortcutsMixin.__init__(self)
         self.enable_replace = enable_replace
         self.editor = None
         self.is_code_editor = None

--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -639,6 +639,7 @@ class Tabs(BaseTabs, SpyderShortcutsMixin):
                  split_index=0):
         BaseTabs.__init__(self, parent, actions, menu,
                           corner_widgets, menu_use_tooltips)
+        SpyderShortcutsMixin.__init__(self)
         tab_bar = TabBar(self, parent,
                          rename_tabs=rename_tabs,
                          split_char=split_char,


### PR DESCRIPTION
## Description of Changes

Add missing `__init__()` calls detected with PySide2. I have no idea why it works with PyQt5 and PyQt6. 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

rear1019

<!--- Thanks for your help making Spyder better for everyone! --->
