### PR TITLE
PR: Replace set with list when searching for installed program

### DIFF
--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -84,7 +84,6 @@ def is_program_installed(basename, extra_paths=[]):
     On macOS systems, a .app is considered installed if it exists.
     """
     home = get_home_dir()
-    req_paths = []
     if (
         sys.platform == 'darwin'
         and basename.endswith('.app')
@@ -110,9 +109,10 @@ def is_program_installed(basename, extra_paths=[]):
              'Miniconda3', 'Anaconda3', 'Miniconda', 'Anaconda']
 
     conda = [osp.join(*p, 'condabin') for p in itertools.product(a, b)]
-    req_paths.extend(pyenv + conda + extra_paths)
 
-    for path in set(os.environ['PATH'].split(os.pathsep) + req_paths):
+    for path in (
+        extra_paths + conda + pyenv + os.getenv('PATH', []).split(os.pathsep)
+    ):
         abspath = osp.join(path, basename)
         if osp.isfile(abspath):
             return abspath


### PR DESCRIPTION
`set` does not guarantee order, so could be non-deterministic. Also, it is desirable for the priority to be `extra_paths`, `conda`, `pyenv`, then system paths

Part of #23061