### PR TITLE
PR: Fix detecting Micromamba on Windows for kernel activation (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -133,11 +133,14 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
                 get_conda_env_path(pyexec)
             ])
 
-            if conda_exe.endswith('micromamba'):
+            # We need to use this flag to prevent conda_exe from capturing the
+            # kernel process stdout/stderr streams. That way we are able to
+            # show them in Spyder.
+            if conda_exe.endswith(('micromamba', 'micromamba.exe')):
                 kernel_cmd.extend(['--attach', '""'])
             else:
                 # Note: We use --no-capture-output instead of --live-stream
-                # here because it works for very old Conda versions.
+                # here because it works for older Conda versions.
                 kernel_cmd.append('--no-capture-output')
 
         kernel_cmd.extend([


### PR DESCRIPTION
## Description of Changes

- Due to this error we were not activating kernels correctly on Windows.
- This error was reported in https://github.com/spyder-ide/spyder/issues/22614#issuecomment-2542820448.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #22614 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
