### PR TITLE
Uneditable boilerplate installation

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -85,7 +85,7 @@ else
 
     # Install boilerplate plugin
     pushd spyder/app/tests/spyder-boilerplate
-    pip install --no-deps -q -e .
+    pip install --no-deps .
     popd
 
     # Adjust PATH on Windows so that we can use conda below. This needs to be done


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Pip is reporting that installing a module as editable is deprecated: from the test logs on GitHub (Linux-Py3.10, pip, slow in this case), line breaks added for clarity:

```
DEPRECATION: Legacy editable install of spyder-boilerplate==0.0.1 from
file:///home/runner/work/spyder/spyder/spyder/app/tests/spyder-boilerplate
(setup.py develop) is deprecated. pip 25.0 will enforce this behaviour change.
A possible replacement is to add a pyproject.toml or
enable --use-pep517, and use setuptools >= 64. If the resulting installation is
not behaving as expected, try using --config-settings editable_mode=compat.
Please consult the setuptools documentation for more information.
Discussion can be found at https://github.com/pypa/pip/issues/11457
```

This patch simply removes the `-q -e` flags, meaning that the installation is verbose and not editable.  (Verbose means that the action of pip is visible in the logs.)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @juliangilbey 

<!--- Thanks for your help making Spyder better for everyone! --->
