### PR TITLE
PR: Display a button to select the entire row when hovering it in `CollectionsEditor` (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -499,8 +499,11 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
         if (
             # Do this only for the last column
             index.column() == 3
-            # Do this when the row is hovered.
-            and index.row() == self.parent().hovered_row
+            # Do this when the row is hovered or if it's selected
+            and (
+                index.row() == self.parent().hovered_row
+                or index.row() in self.parent().selected_rows()
+            )
         ):
             # Paint regular contents
             super().paint(painter, option, index)

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -16,10 +16,28 @@ from typing import Any, Callable, Optional
 
 # Third party imports
 from qtpy.compat import to_qvariant
-from qtpy.QtCore import QDateTime, QModelIndex, Qt, Signal
+from qtpy.QtCore import (
+    QDateTime,
+    QEvent,
+    QModelIndex,
+    QRect,
+    QSize,
+    Qt,
+    Signal,
+)
+from qtpy.QtGui import QMouseEvent
 from qtpy.QtWidgets import (
-    QAbstractItemDelegate, QDateEdit, QDateTimeEdit, QItemDelegate, QLineEdit,
-    QMessageBox, QTableView)
+    QAbstractItemDelegate,
+    QApplication,
+    QDateEdit,
+    QDateTimeEdit,
+    QItemDelegate,
+    QLineEdit,
+    QMessageBox,
+    QStyle,
+    QStyleOptionButton,
+    QTableView,
+)
 from spyder_kernels.utils.lazymodules import (
     FakeObject, numpy as np, pandas as pd, PIL)
 from spyder_kernels.utils.nsview import (display_to_value, is_editable_type,
@@ -33,10 +51,12 @@ from spyder.plugins.variableexplorer.widgets.arrayeditor import ArrayEditor
 from spyder.plugins.variableexplorer.widgets.dataframeeditor import (
     DataFrameEditor)
 from spyder.plugins.variableexplorer.widgets.texteditor import TextEditor
+from spyder.utils.icon_manager import ima
 
 
 LARGE_COLLECTION = 1e5
 LARGE_ARRAY = 5e6
+SELECT_ROW_BUTTON_SIZE = 22
 
 
 class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
@@ -471,6 +491,69 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
         else:
             super(CollectionsDelegate, self).updateEditorGeometry(
                 editor, option, index)
+
+    def paint(self, painter, option, index):
+        """Actions to take when painting a cell."""
+        if (
+            # Do this only for the last column
+            index.column() == 3
+            # Do this when the row is hovered.
+            and index.row() == self.parent().hovered_row
+        ):
+            # Paint regular contents
+            super().paint(painter, option, index)
+
+            # Paint an extra button to select the entire row. This is necessary
+            # because in Spyder 6 is not intuitive how to do that since we use
+            # a single click to open the editor associated to the cell.
+            # Fixes spyder-ide/spyder#22524
+            # Solution adapted from https://stackoverflow.com/a/11778012/438386
+
+            # Getting the cell's rectangle
+            rect = option.rect
+
+            # Button left/top coordinates
+            x = rect.left() + rect.width() - SELECT_ROW_BUTTON_SIZE
+            y = rect.top() + rect.height() // 2 - SELECT_ROW_BUTTON_SIZE // 2
+
+            # Create and paint button
+            button = QStyleOptionButton()
+            button.rect = QRect(
+                x, y, SELECT_ROW_BUTTON_SIZE, SELECT_ROW_BUTTON_SIZE
+            )
+            button.text = ""
+            button.icon = ima.icon("select_row")
+            button.iconSize = QSize(20, 20)
+            button.state = QStyle.State_Enabled
+            QApplication.style().drawControl(
+                QStyle.CE_PushButtonLabel, button, painter
+            )
+        else:
+            super().paint(painter, option, index)
+
+    def editorEvent(self, event, model, option, index):
+        """Actions to take when interacting with a cell."""
+        if event.type() == QEvent.MouseButtonRelease and index.column() == 3:
+            # Getting the position of the mouse click
+            click_x = QMouseEvent(event).x()
+            click_y = QMouseEvent(event).y()
+
+            # Getting the cell's rectangle
+            rect = option.rect
+
+            # Region for the select row button
+            x = rect.left() + rect.width() - SELECT_ROW_BUTTON_SIZE
+            y = rect.top()
+
+            # Select row when clicking on the button
+            if click_x > x and (y < click_y < (y + SELECT_ROW_BUTTON_SIZE)):
+                self.parent().selectRow(index.row())
+            else:
+                super().editorEvent(event, model, option, index)
+        else:
+            super().editorEvent(event, model, option, index)
+
+        return False
 
 
 class ToggleColumnDelegate(CollectionsDelegate):

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
@@ -9,6 +9,7 @@
 # -----------------------------------------------------------------------------
 
 # Standard library imports
+from functools import lru_cache
 import logging
 from typing import Any, Callable, Optional
 
@@ -190,6 +191,7 @@ class ToggleColumnTreeView(QTreeView, ToggleColumnMixIn):
         """Resize all the columns to its contents."""
         self._horizontal_header().resizeSections(QHeaderView.ResizeToContents)
 
+    @lru_cache(maxsize=1)
     def selected_rows(self):
         """Dummy method to be compatible with BaseTableView."""
         return set()

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
@@ -190,6 +190,10 @@ class ToggleColumnTreeView(QTreeView, ToggleColumnMixIn):
         """Resize all the columns to its contents."""
         self._horizontal_header().resizeSections(QHeaderView.ResizeToContents)
 
+    def selected_rows(self):
+        """Dummy method to be compatible with BaseTableView."""
+        return set()
+
     def _horizontal_header(self):
         """
         Returns the horizontal header (of type QHeaderView).

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/toggle_column_mixin.py
@@ -161,6 +161,8 @@ class ToggleColumnTreeView(QTreeView, ToggleColumnMixIn):
     A QTreeView where right clicking on the header allows the user to
     show/hide columns.
     """
+    # Dummy conf section to avoid a warning
+    CONF_SECTION = ""
 
     def __init__(
         self,
@@ -179,6 +181,9 @@ class ToggleColumnTreeView(QTreeView, ToggleColumnMixIn):
         self.setEditTriggers(QAbstractItemView.DoubleClicked)
         self.expanded.connect(self.resize_columns_to_contents)
         self.collapsed.connect(self.resize_columns_to_contents)
+
+        # Dummy attribute to be compatible with BaseTableView
+        self.hovered_row = -1
 
     @Slot()
     def resize_columns_to_contents(self):

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -215,6 +215,7 @@ class IconManager():
             'move':                    [('mdi.file-move',), {'color': self.MAIN_FG_COLOR}],
             'edit_add':                [('mdi.plus-box',), {'color': self.MAIN_FG_COLOR}],
             'select_row':              [('mdi.plus-box-outline',), {'color': self.MAIN_FG_COLOR}],
+            'deselect_row':            [('mdi.minus-box-outline',), {'color': self.MAIN_FG_COLOR}],
             'duplicate_row':           [('ph.rows',), {'color': self.MAIN_FG_COLOR}],
             'duplicate_column':        [('ph.columns',), {'color': self.MAIN_FG_COLOR}],
             'collapse_column':         [('mdi.arrow-collapse-horizontal',), {'color': self.MAIN_FG_COLOR}],

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -214,6 +214,7 @@ class IconManager():
             'rename':                  [('mdi.rename-box',), {'color': self.MAIN_FG_COLOR}],
             'move':                    [('mdi.file-move',), {'color': self.MAIN_FG_COLOR}],
             'edit_add':                [('mdi.plus-box',), {'color': self.MAIN_FG_COLOR}],
+            'select_row':              [('mdi.plus-box-outline',), {'color': self.MAIN_FG_COLOR}],
             'duplicate_row':           [('ph.rows',), {'color': self.MAIN_FG_COLOR}],
             'duplicate_column':        [('ph.columns',), {'color': self.MAIN_FG_COLOR}],
             'collapse_column':         [('mdi.arrow-collapse-horizontal',), {'color': self.MAIN_FG_COLOR}],

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -483,10 +483,13 @@ class ReadOnlyCollectionsModel(QAbstractTableModel, SpyderFontsMixin):
                 display = value
         if role == Qt.ToolTipRole:
             if self.parent().over_select_row_button:
-                tooltip = _(
-                    "Click to select this row. Maintain pressed Ctrl (Cmd on "
-                    "macOS) for multiple rows"
-                )
+                if index.row() in self.parent().selected_rows():
+                    tooltip = _("Click to deselect this row")
+                else:
+                    tooltip = _(
+                        "Click to select this row. Maintain pressed Ctrl (Cmd "
+                        "on macOS) for multiple rows"
+                    )
                 return '\n'.join(textwrap.wrap(tooltip, 50))
             return display
         if role == Qt.UserRole:
@@ -1558,6 +1561,12 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
         else:
             QMessageBox.warning(self, _( "Empty clipboard"),
                                 _("Nothing to be imported from clipboard."))
+
+    def selected_rows(self):
+        """Get the rows currently selected."""
+        return {
+            index.row() for index in self.selectionModel().selectedRows()
+        }
 
 
 class CollectionsEditorTableView(BaseTableView):

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -33,6 +33,9 @@ from spyder.widgets.collectionseditor import (
     CollectionsEditor, CollectionsEditorTableView, CollectionsEditorWidget,
     CollectionsModel, LARGE_NROWS, natsort, RemoteCollectionsEditorTableView,
     ROWS_TO_LOAD)
+from spyder.plugins.variableexplorer.widgets.collectionsdelegate import (
+    SELECT_ROW_BUTTON_SIZE
+)
 from spyder.plugins.variableexplorer.widgets.tests.test_dataframeeditor import (
     generate_pandas_indexes)
 from spyder_kernels.utils.nsview import get_size
@@ -1080,6 +1083,46 @@ def test_collectioneditor_plot(qtbot):
 
     cew.editor.plot('list', 'plot')
     mock_namespacebrowser.plot.assert_called_once_with(my_list, 'plot')
+
+
+def test_collectionseditor_select_row_button(qtbot):
+    """Test that the button to select rows is working as expected."""
+    data = {"a": 10, "b": "This is a string"}
+    editor = CollectionsEditor()
+    editor.setup(data)
+    editor.show()
+
+    # This is necessary so that Qt paints
+    qtbot.wait(300)
+
+    # Coordinates to position the cursor on top of the select row button for
+    # the first row
+    table_view = editor.widget.editor
+    x = (
+        # Left x ccordinate for the first row
+        + table_view.columnViewportPosition(0)
+        + table_view.width()
+        - SELECT_ROW_BUTTON_SIZE // 2
+    )
+
+    y = (
+        # Top y ccordinate for the first row
+        + table_view.rowViewportPosition(0)
+        + table_view.rowHeight(0) // 2
+    )
+
+    # Move cursor
+    qtbot.mouseMove(table_view.viewport(), QPoint(x, y), delay=100)
+
+    # Click on that posiiton and check the first row was selected.
+    # Note: We can't use LeftButton here because it edits the row. However, it
+    # works as exoected in regular usage.
+    qtbot.mouseClick(table_view.viewport(), Qt.MiddleButton, pos=QPoint(x, y))
+    assert table_view.selected_rows() == {0}
+
+    # Click again and check the row was deselected
+    qtbot.mouseClick(table_view.viewport(), Qt.MiddleButton, pos=QPoint(x, y))
+    assert table_view.selected_rows() == set()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of Changes

- This is necessary because in Spyder 6 is not intuitive how to do that since we use a single click to open the editor associated to the cell.
- Add a test to cover this new UX.

### Visual changes

![select-row-button](https://github.com/user-attachments/assets/7d49d610-fd13-4346-bdf0-718ef65f050e)

### Issue(s) Resolved

Fixes #22524.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
