### PR TITLE
PR: Don't install `spyder-boilerplate` testing plugin in editable mode (CI)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -85,7 +85,7 @@ else
 
     # Install boilerplate plugin
     pushd spyder/app/tests/spyder-boilerplate
-    pip install --no-deps -q -e .
+    pip install --no-deps .
     popd
 
     # Adjust PATH on Windows so that we can use conda below. This needs to be done


### PR DESCRIPTION
## Description of Changes

Resubmitting #23366 but now based against master.

There is another occurrence in the same script:

https://github.com/spyder-ide/spyder/blob/5d3c74cc5a588ff875b685ac3fa4c231feeb36be/.github/scripts/install.sh#L56

which could be handled similarly; I could add this to the patch if you'd like.

There are also two occurrences of this pattern in `spyder-unittest` and `spyder-line-profiler` in `.github/workflows/run-tests.yml` which could have the `-e` removed.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @juliangilbey 

<!--- Thanks for your help making Spyder better for everyone! --->
