### PR TITLE
PR: Avoid error in `PathComboBox` (Widgets)

### DIFF
--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -266,7 +266,16 @@ class PathComboBox(EditableComboBox):
         # https://groups.google.com/group/spyderlib/browse_thread/thread/2257abf530e210bd
         if not self.is_valid():
             lineedit = self.lineEdit()
-            QTimer.singleShot(50, lambda: lineedit.setText(self.selected_text))
+
+            # Avoid error when lineedit is no longer available (probably
+            # because this widget's parent was garbage collected).
+            # Fixes spyder-ide/spyder#23361
+            try:
+                QTimer.singleShot(
+                    50, lambda: lineedit.setText(self.selected_text)
+                )
+            except RuntimeError:
+                pass
 
         hide_status = getattr(self.lineEdit(), 'hide_status_icon', None)
         if hide_status:


### PR DESCRIPTION
## Description of Changes

This error might happen when Preferences is closed too quickly, so the widget which we're trying to interact with doesn't exist anymore.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23361.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
