### PR TITLE
PR: Recreate thumbnails list after dropping one in a new position (Plots)

### DIFF
--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -847,6 +847,12 @@ class ThumbnailScrollBar(QFrame):
                     self.scene.insertWidget(i - 1, dropped_thumbnail)
                     break
 
+        # Recreate thumbnails list to take into account the new order
+        # Fixes spyder-ide/spyder#22458
+        self._thumbnails = []
+        for i in range(n_thumbnails):
+            self._thumbnails.append(self.scene.itemAt(i).widget())
+
         event.accept()
 
     # ---- Save Figure
@@ -1041,7 +1047,7 @@ class ThumbnailScrollBar(QFrame):
         if thumbnail in self._thumbnails:
             self._thumbnails.remove(thumbnail)
 
-        # Select a new thumbnail if any :
+        # Select a new thumbnail, if any
         if thumbnail == self.current_thumbnail:
             if len(self._thumbnails) > 0:
                 self.set_current_index(


### PR DESCRIPTION
## Description of Changes

This fixes going to the next/previous thumbnail with the Down/Up arrow keys.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22458.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
