### PR TITLE
PR: Filter frames that come from Spyder-kernels in tracebacks and fix tracebacks in Python 3.8 (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.github/workflows/linux-pip-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/linux-pip-tests.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   linux:
     name: Linux (pip) - Py${{ matrix.PYTHON_VERSION }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CI: True
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}

--- a/external-deps/spyder-kernels/.github/workflows/linux-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/linux-tests.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   linux:
     name: Linux - Py${{ matrix.PYTHON_VERSION }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CI: True
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/ccordoba12/spyder-kernels.git
-	branch = filter-traceback-frames
-	commit = 8b9c4f0c8375318c88e21c44cacbb2b5bf5515f5
-	parent = 5106b0f412b4c1e1af621c26f303f8b711618012
+	remote = https://github.com/spyder-ide/spyder-kernels.git
+	branch = master
+	commit = fa909029b8f371b985d75422b503e222968a2ac0
+	parent = 95e1e15db7245e981a2ce981bfd788a007c5251c
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = master
-	commit = 07f24b6fde55585e64d1802036efba19514dbf0c
-	parent = 41c288acf1c34b7cd9f1175b4f0fa8233692a26c
+	remote = https://github.com/ccordoba12/spyder-kernels.git
+	branch = filter-traceback-frames
+	commit = 92bcb3061c3afeda76c7a83f1315971d8f5e966e
+	parent = 1e20d173762e6236e037bfa6d299002a9590d872
 	method = merge
-	cmdver = 0.4.3
+	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ccordoba12/spyder-kernels.git
 	branch = filter-traceback-frames
-	commit = 92bcb3061c3afeda76c7a83f1315971d8f5e966e
-	parent = 1e20d173762e6236e037bfa6d299002a9590d872
+	commit = 8b9c4f0c8375318c88e21c44cacbb2b5bf5515f5
+	parent = 5106b0f412b4c1e1af621c26f303f8b711618012
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/RELEASE.md
+++ b/external-deps/spyder-kernels/RELEASE.md
@@ -6,9 +6,9 @@ To release a new version of spyder-kernels on PyPI:
 
 * git fetch upstream && get merge upstream/3.x
 
-* git clean -xfdi
-
 * Update CHANGELOG.md with `loghub spyder-ide/spyder-kernels -m vX.X.X`
+
+* git clean -xfdi
 
 * Update `_version.py` (set release version, remove 'dev0')
 
@@ -24,15 +24,9 @@ To release a new version of spyder-kernels on PyPI:
 
 * git tag -a vX.X.X -m 'Release X.X.X'
 
-* Update `_version.py` (add 'dev0' and increment minor)
+* Update `_version.py` (add 'dev0' and increment patch)
 
 * git add . && git commit -m 'Back to work'
-
-* git checkout master
-
-* git merge 3.x
-
-* git push upstream master
 
 * git push upstream 3.x
 

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -641,7 +641,12 @@ class SpyderKernel(IPythonKernel):
             elif key == "color scheme":
                 self.set_color_scheme(value)
             elif key == "traceback_highlight_style":
-                self.set_traceback_syntax_highlighting(value)
+                # This doesn't work in Python 3.8 because the last IPython
+                # version compatible with it doesn't allow to customize the
+                # syntax highlighting scheme used for tracebacks.
+                # Fixes spyder-ide/spyder#23484
+                if sys.version_info >= (3, 9):
+                    self.set_traceback_syntax_highlighting(value)
             elif key == "jedi_completer":
                 self.set_jedi_completer(value)
             elif key == "greedy_completer":


### PR DESCRIPTION
## Description of Changes

- We don't need to show those frames to users because they contain no relevant info that they need to look at.
- This is more necessary now that we use  verbose tracebacks because those frames make them much longer.
- Add test that checks the new behavior.
- This also fixes showing tracebacks in Python 3.8, which was broken in #22965.
- Depends on https://github.com/spyder-ide/spyder-kernels/pull/526

### Visual changes (TODO)

**Before**

![imagen](https://github.com/user-attachments/assets/c06d3b8a-89a2-42d3-9dc1-413c809e43a7)

**After**

![imagen](https://github.com/user-attachments/assets/546dd35b-622c-4dae-9ac7-6fe26d665859)

### Issue(s) Resolved

Fixes #23484 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
