### PR TITLE
PR: Add `ipython_pygments_lexers` as a new dependency

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -20,6 +20,7 @@ dependencies:
 - importlib-metadata >=4.6.0
 - intervaltree >=3.0.2
 - ipython >=8.13.0,<9.0.0,!=8.17.1
+- ipython_pygments_lexers
 - jedi >=0.17.2,<0.20.0
 - jellyfish >=0.7
 - jsonschema >=3.2.0

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -20,7 +20,7 @@ dependencies:
 - importlib-metadata >=4.6.0
 - intervaltree >=3.0.2
 - ipython >=8.13.0,<9.0.0,!=8.17.1
-- ipython_pygments_lexers
+- ipython_pygments_lexers >=1.0
 - jedi >=0.17.2,<0.20.0
 - jellyfish >=0.7
 - jsonschema >=3.2.0

--- a/requirements/main.yml
+++ b/requirements/main.yml
@@ -18,7 +18,7 @@ dependencies:
   - importlib-metadata >=4.6.0
   - intervaltree >=3.0.2
   - ipython >=8.13.0,<9.0.0,!=8.17.1
-  - ipython_pygments_lexers
+  - ipython_pygments_lexers >=1.0
   - jedi >=0.17.2,<0.20.0
   - jellyfish >=0.7
   - jsonschema >=3.2.0

--- a/requirements/main.yml
+++ b/requirements/main.yml
@@ -18,6 +18,7 @@ dependencies:
   - importlib-metadata >=4.6.0
   - intervaltree >=3.0.2
   - ipython >=8.13.0,<9.0.0,!=8.17.1
+  - ipython_pygments_lexers
   - jedi >=0.17.2,<0.20.0
   - jellyfish >=0.7
   - jsonschema >=3.2.0

--- a/setup.py
+++ b/setup.py
@@ -278,6 +278,7 @@ install_requires += [
     'intervaltree>=3.0.2',
     'ipython>=8.12.2,<8.13.0; python_version=="3.8"',
     'ipython>=8.13.0,<9.0.0,!=8.17.1; python_version>"3.8"',
+    'ipython_pygments_lexers',
     'jedi>=0.17.2,<0.20.0',
     'jellyfish>=0.7',
     'jsonschema>=3.2.0',

--- a/setup.py
+++ b/setup.py
@@ -278,7 +278,7 @@ install_requires += [
     'intervaltree>=3.0.2',
     'ipython>=8.12.2,<8.13.0; python_version=="3.8"',
     'ipython>=8.13.0,<9.0.0,!=8.17.1; python_version>"3.8"',
-    'ipython_pygments_lexers',
+    'ipython_pygments_lexers>=1.0',
     'jedi>=0.17.2,<0.20.0',
     'jellyfish>=0.7',
     'jsonschema>=3.2.0',

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -45,6 +45,7 @@ DIFF_MATCH_PATCH_REQVER = '>=20181111'
 IMPORTLIB_METADATA_REQVER = '>=4.6.0'
 INTERVALTREE_REQVER = '>=3.0.2'
 IPYTHON_REQVER = ">=8.12.2,<8.13.0" if PY38 else ">=8.13.0,<9.0.0,!=8.17.1"
+IPYTHON_PYGMENTS_LEXERS_REQVER = ">=1.0"
 JEDI_REQVER = '>=0.17.2,<0.20.0'
 JELLYFISH_REQVER = '>=0.7'
 JSONSCHEMA_REQVER = '>=3.2.0'
@@ -142,6 +143,10 @@ DESCRIPTIONS = [
      'package_name': "IPython",
      'features': _("IPython interactive python environment"),
      'required_version': IPYTHON_REQVER},
+    {'modname': "ipython_pygments_lexers",
+     'package_name': "ipython_pygments_lexers",
+     'features': _("IPython lexers for syntax highlighting"),
+     'required_version': IPYTHON_PYGMENTS_LEXERS_REQVER},
     {'modname': "jedi",
      'package_name': "jedi",
      'features': _("Main backend for the Python Language Server"),

--- a/spyder/plugins/ipythonconsole/widgets/debugging.py
+++ b/spyder/plugins/ipythonconsole/widgets/debugging.py
@@ -17,9 +17,9 @@ import re
 # Third-party imports
 from IPython.core.history import HistoryManager
 from IPython.core.inputtransformer2 import TransformerManager
-from IPython.lib.lexers import (
-    IPython3Lexer, Python3Lexer, bygroups, using
-)
+from ipython_pygments_lexers import IPython3Lexer
+from pygments.lexer import bygroups, using
+from pygments.lexers import Python3Lexer
 from pygments.token import Keyword, Operator
 from pygments.util import ClassNotFound
 from qtconsole.rich_jupyter_widget import RichJupyterWidget


### PR DESCRIPTION
## Description of Changes

The IPython Pygments lexers are moving to a separate package (https://github.com/ipython/ipython/issues/14520). Importing the IPython classes from `IPython.lib.lexers` will still work for a while, but importing the incidental things which that module imported from pygments won't, so I've switched those imports to point to pygments.


### Issue(s) Resolved


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @takluyver 

<!--- Thanks for your help making Spyder better for everyone! --->
