### PR TITLE
PR: Give more descriptive names to the shortcuts that control the Debugger

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -540,14 +540,14 @@ DEFAULTS = [
               'variable_explorer/search': 'Ctrl+F',
               'variable_explorer/refresh': 'Ctrl+R',
               # -- Debugger --
+              '_/run file in debugger': "Ctrl+F5",
+              '_/debug current line': "Ctrl+F10",
+              '_/debug continue': "Ctrl+F12",
+              '_/debug step into': "Ctrl+F11",
+              '_/debug step return': "Ctrl+Shift+F11",
+              '_/debug stop': "Ctrl+Shift+F12",
               'debugger/refresh': 'Ctrl+R',
               'debugger/search': 'Ctrl+F',
-              'debugger/run file in debugger': "Ctrl+F5",
-              '_/next': "Ctrl+F10",
-              '_/continue': "Ctrl+F12",
-              '_/step': "Ctrl+F11",
-              '_/return': "Ctrl+Shift+F11",
-              '_/stop': "Ctrl+Shift+F12",
               'debugger/toggle breakpoint': 'F12',
               'debugger/toggle conditional breakpoint': 'Shift+F12',
               'debugger/show breakpoint table': "",
@@ -678,4 +678,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '85.1.0'
+CONF_VERSION = '86.0.0'

--- a/spyder/plugins/debugger/plugin.py
+++ b/spyder/plugins/debugger/plugin.py
@@ -160,7 +160,7 @@ class Debugger(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
             text=_("&Debug file"),
             tip=_("Debug file"),
             icon=self.create_icon('debug'),
-            shortcut_context=self.NAME,
+            shortcut_context="_",
             register_shortcut=True,
             add_to_menu={
                 "menu": ApplicationMenus.Debug,

--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -39,11 +39,11 @@ class DebuggerWidgetActions:
     Inspect = 'inspect'
     EnterDebug = 'enter_debug'
     InterrupAndDebug = "interrupt_and_debug"
-    Next = "next"
-    Continue = "continue"
-    Step = "step"
-    Return = "return"
-    Stop = "stop"
+    Next = "debug current line"
+    Continue = "debug continue"
+    Step = "debug step into"
+    Return = "debug step return"
+    Stop = "debug stop"
     GotoCursor = "go to editor"
 
     # Toggles
@@ -257,7 +257,7 @@ class DebuggerWidget(ShellConnectMainWidget):
 
         next_action = self.create_action(
             DebuggerWidgetActions.Next,
-            text=_("Execute current line"),
+            text=_("Debug current line"),
             icon=self.create_icon('arrow-step-over'),
             triggered=lambda: self.debug_command("next"),
             register_shortcut=True,

--- a/spyder/plugins/shortcuts/tests/test_shortcuts.py
+++ b/spyder/plugins/shortcuts/tests/test_shortcuts.py
@@ -98,7 +98,7 @@ def test_shortcuts_filtering(shortcut_table):
     assert not shortcut_table.isSortingEnabled()
     # Six hits (causes a bit of an issue to hardcode it like this if new
     # shortcuts are added...)
-    assert shortcut_table.model().rowCount() == 9
+    assert shortcut_table.model().rowCount() == 14
     # Remove filter text
     shortcut_table.finder = FilterTextMock('')
     shortcut_table.set_regex()


### PR DESCRIPTION
## Description of Changes

- This is necessary since now that those shortcuts are global (i.e. not prefixed by "debugger"), it was difficult to understand what a shortcut about "next" or "continue" referred to in Preferences.
- Also, make shortcut to debug a file global because that's how things worked in Spyder 5 and fix a test related to filtering shortcuts with the word "debug".

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Follow-up of PR #23452.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
