### PR TITLE
PR: Fix setting custom run configurations for multiple executors (Run)

### DIFF
--- a/spyder/app/tests/conftest.py
+++ b/spyder/app/tests/conftest.py
@@ -252,7 +252,7 @@ def generate_run_parameters(mainwindow, filename, selected=None,
         selected=selected,
     )
 
-    return {file_uuid: file_run_params}
+    return {file_uuid: [file_run_params]}
 
 
 def get_random_dockable_plugin(main_window, exclude=None):

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -39,7 +39,13 @@ import pytest
 from qtpy import PYQT_VERSION, PYQT5
 from qtpy.QtCore import QPoint, Qt, QTimer, QUrl
 from qtpy.QtGui import QImage, QTextCursor
-from qtpy.QtWidgets import QAction, QApplication, QInputDialog, QWidget
+from qtpy.QtWidgets import (
+    QAction,
+    QApplication,
+    QDialogButtonBox,
+    QInputDialog,
+    QWidget,
+)
 from qtpy.QtWebEngineWidgets import WEBENGINE
 from spyder_kernels.utils.pythonenv import is_conda_env
 
@@ -81,8 +87,13 @@ from spyder.plugins.mainmenu.api import ApplicationMenus
 from spyder.plugins.layout.layouts import DefaultLayouts
 from spyder.plugins.toolbar.api import ApplicationToolbars
 from spyder.plugins.run.api import (
-    RunExecutionParameters, ExtendedRunExecutionParameters, WorkingDirOpts,
-    WorkingDirSource, RunContext)
+    ExtendedRunExecutionParameters,
+    RunActions,
+    RunContext,
+    RunExecutionParameters,
+    WorkingDirOpts,
+    WorkingDirSource,
+)
 from spyder.plugins.shortcuts.widgets.table import SEQUENCE
 from spyder.py3compat import qbytearray_to_str, to_text_string
 from spyder.utils.environ import set_user_env
@@ -7107,6 +7118,112 @@ def test_editor_window_outline_and_toolbars(main_window, qtbot):
 
     # Restore debug toolbar
     debug_toolbar_action.trigger()
+
+
+@flaky(max_runs=3)
+def test_custom_run_config_for_multiple_executors(
+    main_window, qtbot, tmp_path
+):
+    """
+    Check that we correctly use custom run configurations for multiple
+    executors.
+
+    This is a regression test for issue spyder-ide/spyder#22496
+    """
+    # Auxiliary function
+    def change_run_options(
+        executor: str, change_cwd: bool, dedicated_console: bool
+    ):
+        # Select executor
+        dialog = main_window.run.get_container().dialog
+        dialog.select_executor(executor)
+
+        # Use a fixed path for cwd
+        if change_cwd:
+            dialog.fixed_dir_radio.setChecked(True)
+            dialog.wd_edit.setText(str(tmp_path))
+
+        if dedicated_console:
+            dialog.current_widget.dedicated_radio.setChecked(True)
+
+        # Accept changes
+        ok_btn = dialog.bbox.button(QDialogButtonBox.Ok)
+        ok_btn.animateClick()
+
+        # Wait for a bit until changes are saved to disk
+        qtbot.wait(500)
+
+    # Wait until the window is fully up
+    shell = main_window.ipyconsole.get_current_shellwidget()
+    control = shell._control
+    qtbot.waitUntil(
+        lambda: shell.spyder_kernel_ready and shell._prompt_html is not None,
+        timeout=SHELL_TIMEOUT
+    )
+
+    # Open test file
+    main_window.editor.load(osp.join(LOCATION, 'script.py'))
+
+    # Configure debugger with custom options
+    run_config_action = main_window.run.get_action(RunActions.Configure)
+    run_config_action.trigger()
+    change_run_options(
+        executor=Plugins.Debugger,
+        change_cwd=True,
+        dedicated_console=False,
+    )
+
+    # Run test file
+    run_action = main_window.run.get_action(RunActions.Run)
+    with qtbot.waitSignal(shell.executed):
+        run_action.trigger()
+
+    # Check we used the default executor, i.e. we ran the file instead of
+    # debugging it (the run config per file dialog must be used for
+    # configuration only, not to decide what plugin gets associated to the
+    # Run file, cell, selection actions).
+    assert "runfile" in control.toPlainText()
+
+    # Check we didn't change the cwd
+    cwd = (
+        str(tmp_path).replace("\\", "/") if os.name == "nt" else str(tmp_path)
+    )
+    assert cwd not in control.toPlainText()
+
+    # Configure IPython console with custom options
+    run_config_action.trigger()
+    change_run_options(
+        executor=Plugins.IPythonConsole,
+        change_cwd=False,
+        dedicated_console=True,
+    )
+
+    # Debug file
+    debug_action = main_window.run.get_action(
+        "run file in debugger"
+    )
+    with qtbot.waitSignal(shell.executed):
+        debug_action.trigger()
+
+    # Check debugging happened in the same console and not in a new one
+    assert (
+        "debugfile" in control.toPlainText()
+        and "runfile" in control.toPlainText()
+    )
+
+    # Check we used the selected cwd for debugging
+    assert cwd in control.toPlainText()
+
+    # Run file again
+    run_action.trigger()
+
+    # Check a new console was created
+    ipyconsole_widget = main_window.ipyconsole.get_widget()
+    qtbot.waitUntil(lambda: len(ipyconsole_widget.clients) == 2)
+
+    # Check it's a dedicated console for the file we're running
+    client = main_window.ipyconsole.get_current_client()
+    assert "script.py" in client.get_name()
 
 
 if __name__ == "__main__":

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -737,7 +737,7 @@ def test_runconfig_workdir(main_window, qtbot, tmpdir):
 
     # --- Set run options for this file ---
     run_parameters = generate_run_parameters(main_window, test_file, exec_uuid)
-    CONF.set('run', 'last_used_parameters', run_parameters)
+    CONF.set('run', 'last_used_parameters_per_executor', run_parameters)
 
     # --- Run test file ---
     shell = main_window.ipyconsole.get_current_shellwidget()
@@ -787,8 +787,8 @@ def test_runconfig_workdir(main_window, qtbot, tmpdir):
 @pytest.mark.order(1)
 @pytest.mark.no_new_console
 @pytest.mark.skipif(
-    sys.platform.startswith("linux"),
-    reason='Fails sometimes on Linux'
+    sys.platform.startswith("linux") and running_in_ci(),
+    reason='Fails sometimes on Linux and CIs'
 )
 def test_dedicated_consoles(main_window, qtbot):
     """Test running code in dedicated consoles."""
@@ -826,7 +826,7 @@ def test_dedicated_consoles(main_window, qtbot):
 
     # --- Set run options for this file ---
     run_parameters = generate_run_parameters(main_window, test_file, exec_uuid)
-    CONF.set('run', 'last_used_parameters', run_parameters)
+    CONF.set('run', 'last_used_parameters_per_executor', run_parameters)
 
     # --- Run test file and assert that we get a dedicated console ---
     qtbot.keyClick(code_editor, Qt.Key_F5)
@@ -882,7 +882,7 @@ def test_dedicated_consoles(main_window, qtbot):
     # ---- Closing test file and resetting config ----
     main_window.editor.close_file()
     CONF.set('run', 'configurations', {})
-    CONF.set('run', 'last_used_parameters', {})
+    CONF.set('run', 'last_used_parameters_per_executor', {})
 
 
 @flaky(max_runs=3)
@@ -946,7 +946,7 @@ def test_shell_execution(main_window, qtbot, tmpdir):
     # --- Set run options for this file ---
     run_parameters = generate_run_parameters(
         main_window, test_file, exec_uuid, external_terminal.NAME)
-    CONF.set('run', 'last_used_parameters', run_parameters)
+    CONF.set('run', 'last_used_parameters_per_executor', run_parameters)
 
     # --- Run test file and assert that the script gets executed ---
     qtbot.keyClick(code_editor, Qt.Key_F5)

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -651,8 +651,10 @@ NAME_MAP = {
             'breakpoints',
             'configurations',
             'default/wdir/fixed_directory',
-            'last_used_parameters',
-            'parameters'
+            'parameters',
+            'last_used_parameters', # Needed for Spyder 6.0.0 to 6.0.3
+            'last_used_parameters_per_executor',
+            'last_configured_executor',
           ]
          ),
         ('workingdir', [

--- a/spyder/plugins/externalterminal/plugin.py
+++ b/spyder/plugins/externalterminal/plugin.py
@@ -27,6 +27,7 @@ from spyder.plugins.externalterminal.api import (
     ExtTerminalPyConfiguration, ExtTerminalShConfiguration)
 from spyder.plugins.externalterminal.widgets.run_conf import (
     ExternalTerminalPyConfiguration, ExternalTerminalShConfiguration)
+from spyder.plugins.mainmenu.api import ApplicationMenus, RunMenuSections
 from spyder.plugins.run.api import (
     RunContext, run_execute, RunConfiguration, ExtendedRunExecutionParameters,
     RunResult, RunExecutor)
@@ -175,6 +176,19 @@ class ExternalTerminal(SpyderPluginV2, RunExecutor):
         run = self.get_plugin(Plugins.Run)
         run.register_executor_configuration(self, self.executor_configuration)
 
+        run.create_run_in_executor_button(
+            RunContext.File,
+            self.NAME,
+            text=_("Run in external terminal"),
+            tip=_("Run in an operating system terminal"),
+            icon=self.get_icon(),
+            register_shortcut=False,
+            add_to_menu={
+                "menu": ApplicationMenus.Run,
+                "section": RunMenuSections.RunInExecutors
+            },
+        )
+
     @on_plugin_available(plugin=Plugins.Editor)
     def on_editor_available(self):
         editor = self.get_plugin(Plugins.Editor)
@@ -185,7 +199,9 @@ class ExternalTerminal(SpyderPluginV2, RunExecutor):
     def on_run_teardown(self):
         run = self.get_plugin(Plugins.Run)
         run.deregister_executor_configuration(
-            self, self.executor_configuration)
+            self, self.executor_configuration
+        )
+        run.destroy_run_in_executor_button(RunContext.File, self.NAME)
 
     @on_plugin_teardown(plugin=Plugins.Editor)
     def on_editor_teardown(self):

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1661,6 +1661,9 @@ def test_recursive_pdb(ipyconsole, qtbot):
     assert control.toPlainText().split()[-2:] == ["In", "[3]:"]
 
 
+@pytest.mark.skipif(
+    sys.version_info[:2] == (3, 8), reason="Fails in Python 3.8"
+)
 def test_pdb_magics_are_recursive(ipyconsole, qtbot, tmp_path):
     """
     Check that calls to Pdb magics start a recursive debugger when called in

--- a/spyder/plugins/run/container.py
+++ b/spyder/plugins/run/container.py
@@ -165,8 +165,11 @@ class RunContainer(PluginMainContainer):
                 run_conf = input_provider.get_run_configuration(uuid)
             else:
                 run_conf = input_provider.get_run_configuration_per_context(
-                    context, extra_action_name, context_modificator,
-                    re_run=re_run)
+                    context,
+                    extra_action_name,
+                    context_modificator,
+                    re_run=re_run,
+                )
 
             if run_conf is None:
                 return
@@ -183,11 +186,15 @@ class RunContainer(PluginMainContainer):
                 last_executor = last_executor['executor']
 
             run_comb = (extension, context)
-            if (last_executor is None or
-                    not self.executor_model.executor_supports_configuration(
-                        last_executor, run_comb)):
+            if (
+                last_executor is None
+                or not self.executor_model.executor_supports_configuration(
+                    last_executor, run_comb
+                )
+            ):
                 last_executor = self.executor_model.get_default_executor(
                     run_comb)
+
             executor_metadata = self.executor_model[
                 ((extension, context), last_executor)]
             ConfWidget = executor_metadata['configuration_widget']

--- a/spyder/plugins/run/widgets.py
+++ b/spyder/plugins/run/widgets.py
@@ -591,14 +591,11 @@ class RunDialog(BaseRunConfigDialog, SpyderFontsMixin):
         self.configuration_combo.hide()
 
         # --- Executor and parameters widgets
-        executor_label = QLabel(_("Run this file in:"))
+        executor_label = QLabel(_("Runner:"))
         self.executor_combo = SpyderComboBox(self)
         self.executor_combo.setMinimumWidth(250)
         executor_tip = TipWidget(
-            _(
-                "This is the runner that will be used for execution when you "
-                "click on the Run button"
-            ),
+            _("Configure the selected runner for this file"),
             icon=ima.icon('question_tip'),
             hover_icon=ima.icon('question_tip_hover'),
             size=23,


### PR DESCRIPTION
## Description of Changes

- Before it was not possible to use a custom run config for the debugger unless it was selected as executor in the `Configuration per file` dialog. Now, we save the last run config per executor and use it for the one users choose in the main toolbar or menus. This way, each executor will use its own config regardless of what's selected in that dialog.
- This also declares a default executor for Python-like files to use it for the Run file, cell and selection actions regardless of the one selected in `Configuration per file`. That was a serious UX bug because if users had selected the Debugger in `Configuration per file`, then the Run actions were tied to that plugin instead of simply running the file (as in Spyder 5).
- Add a new action to the Run menu to run a Python file in an external terminal. This is necessary now due to the change described in the previous point and because there was no UI element to do that. 

### Visual changes

New action tom run a file in an external, system terminal

![imagen](https://github.com/user-attachments/assets/c1f161cc-1379-4bf9-93f4-a1e129aac8e3)

### Issue(s) Resolved

Fixes #22496

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
