### PR TITLE
PR: Fix error in debugger with Python 3.12.5+ 

### DIFF
--- a/.github/workflows/test-files.yml
+++ b/.github/workflows/test-files.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.10']
+        PYTHON_VERSION: ['3.9', '3.12']
     timeout-minutes: 30
     steps:
       - name: Checkout Pull Requests

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -76,12 +76,21 @@ jobs:
       fail-fast: false
       matrix:
         INSTALL_TYPE: ['pip', 'conda']
-        PYTHON_VERSION: ['3.8', '3.10']
+        PYTHON_VERSION: ['3.8', '3.10', '3.12']
         TEST_TYPE: ['fast', 'slow']
         exclude:
-          # Only test Python 3.8 with pip because Conda-forge will drop it soon
+          # Only test Python 3.8 with pip because Conda-forge drop support for
+          # it
           - INSTALL_TYPE: 'conda'
             PYTHON_VERSION: '3.8'
+          # We can't test with pip in Python 3.11+ due to an error, so we use
+          # 3.10 instead.
+          - INSTALL_TYPE: 'pip'
+            PYTHON_VERSION: '3.12'
+          # Some slow tests are failing in Python 3.12, so we skip them for now
+          - INSTALL_TYPE: 'conda'
+            PYTHON_VERSION: '3.12'
+            TEST_TYPE: 'slow'
     timeout-minutes: 90
     steps:
       - name: Setup Remote SSH Connection

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/ccordoba12/spyder-kernels.git
-	branch = process-cmdqueue
-	commit = 5b9a60dddf89e75ac0e3e324e2b8435128053385
-	parent = 9de131cd40a4c832fcb4bb5da5813b81258c7c8f
+	remote = https://github.com/spyder-ide/spyder-kernels.git
+	branch = master
+	commit = 67259709972e39c6d13b463076670a62dc9e832e
+	parent = 00f4b6630c6846ebd51514b8bc63f49c4821b38b
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = master
-	commit = fa909029b8f371b985d75422b503e222968a2ac0
-	parent = 95e1e15db7245e981a2ce981bfd788a007c5251c
+	remote = https://github.com/ccordoba12/spyder-kernels.git
+	branch = process-cmdqueue
+	commit = 5b9a60dddf89e75ac0e3e324e2b8435128053385
+	parent = 9de131cd40a4c832fcb4bb5da5813b81258c7c8f
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/spyder_kernels/customize/spyderpdb.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/spyderpdb.py
@@ -687,7 +687,12 @@ class SpyderPdb(ipyPdb):
         stop = None
         while not stop:
             if self.cmdqueue:
-                line = self.cmdqueue.pop(0)
+                # Anything available in cmdqueue is a Pdb command, so we need
+                # to process it as such.
+                # Fixes spyder-ide/spyder#22500
+                line = (
+                    "!" if self.pdb_use_exclamation_mark else ""
+                ) + self.cmdqueue.pop(0)
             else:
                 try:
                     line = self.cmd_input(self.prompt)


### PR DESCRIPTION
## Description of Changes

- This error happened because we were not processing Pdb commands present in the debugger's command queue as expected (a command was added to it in Python 3.12.5, specifically in PR https://github.com/python/cpython/pull/120928).
- Use Python 3.12 on Linux CI's to verify that the bug was correctly fixed in our fast tests (some of the slow ones are failing but not due to this, so I skipped them for now).
- Depends on https://github.com/spyder-ide/spyder-kernels/pull/530

### Issue(s) Resolved

Fixes #22500

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
