### PR TITLE
PR: Disable shell history for both zsh and bash when installing update for macOS (Installers)

### DIFF
--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -463,7 +463,7 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
             cmd = [
                 "osascript", "-e",
                 ("""'tell application "Terminal" to do script"""
-                 f""" "set +o history; {sub_cmd_str}; exit;"'"""),
+                 f""" "unset HISTFILE; {sub_cmd_str}; exit;"'"""),
             ]
         else:
             programs = [


### PR DESCRIPTION
### Description of Changes

zsh does not have the `history` option, but `unset HISTFILE` achieves the same result as `set +o history` in bash but works for both zsh and bash.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23650

### Verification

1. Installed Spyder 6.0.2 using the package installer
3. Changed my default shell to `zsh`
   ```
   > chsh -s /bin/zsh
   ```
2. Attempted to update to 6.0.3 and reproduced #23650
4. Modified `~/Library/spyder-6/envs/spyder-runtime/lib/python3.11/site-packages/spyder/plugins/updatemanager/widgets/update.py` to match this PR.
5. Re-attempted update to 6.0.3 and was successfull.
6. Verified that update/install commands were not saved to history.