### PR TITLE
PR: Set icon in constructor for `ConfigDialog` (Widgets)

### DIFF
--- a/spyder/plugins/preferences/widgets/configdialog.py
+++ b/spyder/plugins/preferences/widgets/configdialog.py
@@ -28,11 +28,11 @@ class ConfigDialog(SidebarDialog):
 
     # Constants
     TITLE = _("Preferences")
-    ICON = ima.icon('configure')
     MIN_WIDTH = 940 if MAC else (875 if WIN else 920)
     MIN_HEIGHT = 700 if MAC else (660 if WIN else 670)
 
     def __init__(self, parent=None):
+        self.ICON = ima.icon('configure')
         SidebarDialog.__init__(self, parent)
 
         # Attributes


### PR DESCRIPTION
## Description of Changes

- This allows to import it without a running QApplication, which is necessary for testing.
- For instance, tests in https://github.com/spyder-ide/spyder-env-manager/pull/20 are failing due to that.

### Issue(s) Resolved

Fixes #23074

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
