### PR TITLE
Fix bug with qtwebengine being optional

### DIFF
--- a/.github/scripts/remove_check_qtwebengine.sh
+++ b/.github/scripts/remove_check_qtwebengine.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+echo "which spyder: $(which spyder)"
+pip show pyqtwebengine
+TO=10s
+for i in 1 2; do
+    echo "::group::Iteration $i"
+    if [[ "$i" == "2" ]]; then
+        echo "Removing pyqtwebengine"
+        pip uninstall -y pyqtwebengine
+        echo
+    fi
+    echo "Running Spyder with a timeout of $TO:"
+    set +e
+    timeout $TO spyder
+    RESULT=$?
+    set -e
+    if [[ $RESULT -eq 124 ]]; then
+        echo "Spyder succeeded with timeout"
+        echo
+    else
+        echo "Spyder failed with error code $RESULT (should be 124 for timeout)"
+        exit 1
+    fi
+    echo "::endgroup::"
+done

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -187,3 +187,8 @@ jobs:
         with:
           fail_ci_if_error: false
           verbose: true
+      # Note: This will remove qtwebengine so make sure it's done last!
+      - name: Ensure QtWebEngine is optional
+        run: xvfb-run --auto-servernum .github/scripts/remove_check_qtwebengine.sh
+        shell: bash -l {0}
+        if: matrix.INSTALL_TYPE == 'pip' && matrix.TEST_TYPE == 'fast'


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

This is mostly an issue-as-PR, it sounds like https://github.com/spyder-ide/spyder/pull/22196 removed the dependency on QtWebEngine but then it came back in https://github.com/spyder-ide/spyder/pull/22387. So the goals of this PR are:

- [x] Add a regression test that shows the problem (ideally same traceback as https://github.com/conda-forge/spyder-feedstock/issues/175#issuecomment-2648950636) at the top to check quickly
- [x] Fix the problem
- [x] Remove workflow cruft (move without-pyqtwebengine test to bottom of test file and remove `if: false` statements)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

Eric Larson

<!--- Thanks for your help making Spyder better for everyone! --->
