### PR TITLE
PR: Use `AsyncDispatcher` as class decorator (API)

### DIFF
--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -5,8 +5,8 @@
 ### API changes
 
 * **Breaking** - The `sig_pythonpath_changed` signal of the Python path manager plugin now emits a list of strings and a bool, instead of two dictionaries.
-* Add class `DispatcherFuture` and `QtSlot` method to `AsyncDispatcher` so connected methods can be run inside main qt event loop.
-* **Breaking** Remove `dispatch` method from `spyder.api.asyncdispatcher.AsyncDispatcher` to use it directly as decorator.
+* **Breaking** - Remove `dispatch` method from `spyder.api.asyncdispatcher.AsyncDispatcher` to use it directly as decorator.
+* Add class `DispatcherFuture` to `spyder/api/asyncdispatcher` and `QtSlot` method to `AsyncDispatcher` so that connected methods can be run inside the main Qt event loop.
 * Add `early_return` and `return_awaitable` kwargs to `AsyncDispatcher` constructor.
 * Add `register_api` and `get_api` methods to `RemoteClient` plugin in order to
   get and register new rest API modules for the remote client.

--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -5,6 +5,8 @@
 ### API changes
 
 * **Breaking** - The `sig_pythonpath_changed` signal of the Python path manager plugin now emits a list of strings and a bool, instead of two dictionaries.
+* Add class `DispatcherFuture` and `QtSlot` method to `AsyncDispatcher` so connected methods can be run inside main qt event loop.
+* **Breaking** Remove `dispatch` method from `spyder.api.asyncdispatcher.AsyncDispatcher` to use it directly as decorator.
 * Add `early_return` and `return_awaitable` kwargs to `AsyncDispatcher` constructor.
 * Add `register_api` and `get_api` methods to `RemoteClient` plugin in order to
   get and register new rest API modules for the remote client.

--- a/spyder/api/asyncdispatcher.py
+++ b/spyder/api/asyncdispatcher.py
@@ -2,6 +2,7 @@
 # Copyright © 2025 Spyder Project Contributors
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
+
 """
 Spyder AsyncDispatcher API.
 

--- a/spyder/plugins/ipythonconsole/utils/client.py
+++ b/spyder/plugins/ipythonconsole/utils/client.py
@@ -40,7 +40,7 @@ class KernelClientTunneler:
             self.ssh_connection.close()
 
     @classmethod
-    @AsyncDispatcher.dispatch(loop="asyncssh", early_return=False)
+    @AsyncDispatcher(loop="asyncssh", early_return=False)
     async def new_connection(cls, *args, **kwargs):
         """Create a new SSH connection."""
         return cls(
@@ -53,7 +53,7 @@ class KernelClientTunneler:
         """Create a new KernelTunnelHandler from an existing connection."""
         return cls(ssh_connection)
 
-    @AsyncDispatcher.dispatch(loop="asyncssh", early_return=False)
+    @AsyncDispatcher(loop="asyncssh", early_return=False)
     async def forward_port(self, remote_host, remote_port):
         """Forward a port through the SSH connection."""
         local = self._get_free_port()

--- a/spyder/plugins/remoteclient/api/modules/base.py
+++ b/spyder/plugins/remoteclient/api/modules/base.py
@@ -567,10 +567,9 @@ class SpyderBaseJupyterAPI(metaclass=ABCMeta):
 
     async def connect(self):
         if not await AsyncDispatcher(
-            self.manager.ensure_connection_and_server,
             loop="asyncssh",
             return_awaitable=True,
-        )():
+        )(self.manager.ensure_connection_and_server)():
             raise RuntimeError("Failed to connect to Jupyter server")
 
         if self.session is not None and not self.session.closed:

--- a/spyder/plugins/remoteclient/plugin.py
+++ b/spyder/plugins/remoteclient/plugin.py
@@ -301,9 +301,8 @@ class RemoteClient(SpyderPluginV2):
         container = self.get_container()
         future = self._start_new_kernel(config_id)
         future.connect(
-            AsyncDispatcher.QtSlot(lambda kernel_info: container.on_kernel_started(ipyclient, kernel_info))
+            AsyncDispatcher.QtSlot(lambda future: container.on_kernel_started(ipyclient, future.result()))
         )
-
 
     @staticmethod
     def register_api(kclass: typing.Type[SpyderBaseJupyterAPIType]):

--- a/spyder/plugins/remoteclient/plugin.py
+++ b/spyder/plugins/remoteclient/plugin.py
@@ -301,7 +301,11 @@ class RemoteClient(SpyderPluginV2):
         container = self.get_container()
         future = self._start_new_kernel(config_id)
         future.connect(
-            AsyncDispatcher.QtSlot(lambda future: container.on_kernel_started(ipyclient, future.result()))
+            AsyncDispatcher.QtSlot(
+                lambda future: container.on_kernel_started(
+                    ipyclient, future.result()
+                )
+            )
         )
 
     @staticmethod

--- a/spyder/plugins/remoteclient/plugin.py
+++ b/spyder/plugins/remoteclient/plugin.py
@@ -135,8 +135,9 @@ class RemoteClient(SpyderPluginV2):
         """Stops remote server and close any opened connection."""
         for client in self._remote_clients.values():
             AsyncDispatcher(
-                client.close, loop="asyncssh", early_return=False
-            )()
+                loop="asyncssh",
+                early_return=False
+            )(client.close)()
 
     @on_plugin_available(plugin=Plugins.MainMenu)
     def on_mainmenu_available(self):
@@ -187,14 +188,14 @@ class RemoteClient(SpyderPluginV2):
         if config_id in self._remote_clients:
             return self._remote_clients[config_id]
 
-    @AsyncDispatcher.dispatch(loop="asyncssh")
+    @AsyncDispatcher(loop="asyncssh")
     async def _install_remote_server(self, config_id):
         """Install remote server."""
         if config_id in self._remote_clients:
             client = self._remote_clients[config_id]
             await client.connect_and_install_remote_server()
 
-    @AsyncDispatcher.dispatch(loop="asyncssh")
+    @AsyncDispatcher(loop="asyncssh")
     async def start_remote_server(self, config_id):
         """Start remote server."""
         if config_id not in self._remote_clients:
@@ -203,14 +204,14 @@ class RemoteClient(SpyderPluginV2):
         client = self._remote_clients[config_id]
         await client.connect_and_ensure_server()
 
-    @AsyncDispatcher.dispatch(loop="asyncssh")
+    @AsyncDispatcher(loop="asyncssh")
     async def stop_remote_server(self, config_id):
         """Stop remote server."""
         if config_id in self._remote_clients:
             client = self._remote_clients[config_id]
             await client.close()
 
-    @AsyncDispatcher.dispatch(loop="asyncssh")
+    @AsyncDispatcher(loop="asyncssh")
     async def ensure_remote_server(self, config_id):
         """Ensure remote server is running and installed."""
         if config_id in self._remote_clients:
@@ -360,7 +361,7 @@ class RemoteClient(SpyderPluginV2):
     # -------------------------------------------------------------------------
     # --- Remote Server Kernel Methods
     @Slot(str)
-    @AsyncDispatcher.dispatch(loop="asyncssh")
+    @AsyncDispatcher(loop="asyncssh")
     async def get_kernels(self, config_id) -> list:
         """Get opened kernels."""
         if config_id in self._remote_clients:
@@ -368,7 +369,7 @@ class RemoteClient(SpyderPluginV2):
             return await client.list_kernels()
         return []
 
-    @AsyncDispatcher.dispatch(loop="asyncssh")
+    @AsyncDispatcher(loop="asyncssh")
     async def _get_kernel_info(self, config_id, kernel_id) -> dict:
         """Get kernel info."""
         if config_id in self._remote_clients:
@@ -376,7 +377,7 @@ class RemoteClient(SpyderPluginV2):
             return await client.get_kernel_info_ensure_server(kernel_id)
         return {}
 
-    @AsyncDispatcher.dispatch(loop="asyncssh")
+    @AsyncDispatcher(loop="asyncssh")
     async def _shutdown_kernel(self, config_id, kernel_id):
         """Shutdown a running kernel."""
         if config_id in self._remote_clients:
@@ -384,7 +385,7 @@ class RemoteClient(SpyderPluginV2):
             with contextlib.suppress(Exception):
                 await client.terminate_kernel(kernel_id)
 
-    @AsyncDispatcher.dispatch(loop="asyncssh")
+    @AsyncDispatcher(loop="asyncssh")
     async def _start_new_kernel(self, config_id):
         """Start new kernel."""
         if config_id not in self._remote_clients:
@@ -393,7 +394,7 @@ class RemoteClient(SpyderPluginV2):
         client = self._remote_clients[config_id]
         return await client.start_new_kernel_ensure_server()
 
-    @AsyncDispatcher.dispatch(loop="asyncssh")
+    @AsyncDispatcher(loop="asyncssh")
     async def _restart_kernel(self, config_id, kernel_id) -> bool:
         """Restart kernel."""
         if config_id in self._remote_clients:
@@ -403,7 +404,7 @@ class RemoteClient(SpyderPluginV2):
 
         return False
 
-    @AsyncDispatcher.dispatch(loop="asyncssh")
+    @AsyncDispatcher(loop="asyncssh")
     async def _interrupt_kernel(self, config_id, kernel_id):
         """Interrupt kernel."""
         if config_id in self._remote_clients:

--- a/spyder/plugins/remoteclient/tests/test_files.py
+++ b/spyder/plugins/remoteclient/tests/test_files.py
@@ -18,7 +18,7 @@ from spyder.plugins.remoteclient.api.modules.file_services import RemoteOSError
 class TestRemoteFilesAPI:
     remote_temp_dir = "/tmp/spyder-remote-tests"
 
-    @AsyncDispatcher.dispatch(early_return=False)
+    @AsyncDispatcher(early_return=False)
     async def test_create_dir(
         self,
         remote_client: RemoteClient,
@@ -33,7 +33,7 @@ class TestRemoteFilesAPI:
                 "success": True
             }
 
-    @AsyncDispatcher.dispatch(early_return=False)
+    @AsyncDispatcher(early_return=False)
     async def test_write_file(
         self,
         remote_client: RemoteClient,
@@ -52,7 +52,7 @@ class TestRemoteFilesAPI:
                 await f.seek(0)
                 assert await f.read() == "Hello, world!"
 
-    @AsyncDispatcher.dispatch(early_return=False)
+    @AsyncDispatcher(early_return=False)
     async def test_list_directories(
         self,
         remote_client: RemoteClient,
@@ -77,7 +77,7 @@ class TestRemoteFilesAPI:
             assert ls_content[0]["ino"] > 0
             assert ls_content[0]["nlink"] == 1
 
-    @AsyncDispatcher.dispatch(early_return=False)
+    @AsyncDispatcher(early_return=False)
     async def test_copy_file(
         self,
         remote_client: RemoteClient,
@@ -105,7 +105,7 @@ class TestRemoteFilesAPI:
             )
             assert ls_content[0]["size"] == ls_content[1]["size"]
 
-    @AsyncDispatcher.dispatch(early_return=False)
+    @AsyncDispatcher(early_return=False)
     async def test_rm_file(
         self,
         remote_client: RemoteClient,
@@ -123,7 +123,7 @@ class TestRemoteFilesAPI:
                 self.remote_temp_dir + "/test2.txt"
             ) == {"success": True}
 
-    @AsyncDispatcher.dispatch(early_return=False)
+    @AsyncDispatcher(early_return=False)
     async def test_rm_dir(
         self,
         remote_client: RemoteClient,
@@ -138,7 +138,7 @@ class TestRemoteFilesAPI:
                 "success": True
             }
 
-    @AsyncDispatcher.dispatch(early_return=False)
+    @AsyncDispatcher(early_return=False)
     async def test_ls_nonexistent_dir(
         self,
         remote_client: RemoteClient,

--- a/spyder/plugins/remoteclient/widgets/container.py
+++ b/spyder/plugins/remoteclient/widgets/container.py
@@ -321,8 +321,8 @@ class RemoteClientContainer(PluginMainContainer):
         self.__requested_restart = True
 
         future.connect(
-            AsyncDispatcher.QtSlot(lambda restarted: self._on_kernel_restarted(
-                ipyclient, restarted
+            AsyncDispatcher.QtSlot(lambda future: self._on_kernel_restarted(
+                ipyclient, future.result()
             ))
         )
 
@@ -341,8 +341,8 @@ class RemoteClientContainer(PluginMainContainer):
         self.__requested_info = True
 
         future.connect(
-            AsyncDispatcher.QtSlot(lambda kernel_info: self._on_kernel_info_reply(
-                ipyclient, kernel_info
+            AsyncDispatcher.QtSlot(lambda future: self._on_kernel_info_reply(
+                ipyclient, future.result()
             ))
         )
 

--- a/spyder/plugins/remoteclient/widgets/container.py
+++ b/spyder/plugins/remoteclient/widgets/container.py
@@ -17,6 +17,7 @@ from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports
+from spyder.api.asyncdispatcher import AsyncDispatcher
 from spyder.api.translations import _
 from spyder.api.widgets.main_container import PluginMainContainer
 from spyder.plugins.ipythonconsole.utils.kernel_handler import KernelHandler
@@ -34,37 +35,6 @@ from spyder.plugins.remoteclient.widgets.connectiondialog import (
 
 
 class RemoteClientContainer(PluginMainContainer):
-
-    _sig_kernel_restarted = Signal(object, bool)
-    """
-    This private signal is used to inform that a kernel restart took place in
-    the server.
-
-    Parameters
-    ----------
-    ipyclient: ClientWidget
-        An IPython console client widget (the first parameter in both
-        signatures).
-    response: bool or None
-        Response returned by the server. `None` can happen when the connection
-        to the server is lost.
-    """
-
-    _sig_kernel_info_replied = Signal(object, dict)
-    """
-    This private signal is used to inform that a kernel info request to the
-    server was replied.
-
-    Parameters
-    ----------
-    ipyclient: ClientWidget
-        An IPython console client widget (the first parameter in both
-        signatures).
-    response: dict or None
-        Response returned by the server. `None` can happen when the connection
-        to the server is lost.
-    """
-
     sig_start_server_requested = Signal(str)
     """
     This signal is used to request starting a remote server.
@@ -175,8 +145,6 @@ class RemoteClientContainer(PluginMainContainer):
             self._on_connection_status_changed
         )
         self.sig_client_message_logged.connect(self._on_client_message_logged)
-        self._sig_kernel_restarted.connect(self._on_kernel_restarted)
-        self._sig_kernel_info_replied.connect(self._on_kernel_info_reply)
 
         self.__requested_restart = False
         self.__requested_info = False
@@ -352,10 +320,10 @@ class RemoteClientContainer(PluginMainContainer):
 
         self.__requested_restart = True
 
-        future.add_done_callback(
-            lambda future: self._sig_kernel_restarted.emit(
-                ipyclient, future.result()
-            )
+        future.connect(
+            AsyncDispatcher.QtSlot(lambda restarted: self._on_kernel_restarted(
+                ipyclient, restarted
+            ))
         )
 
     def _request_kernel_info(self, ipyclient):
@@ -372,10 +340,10 @@ class RemoteClientContainer(PluginMainContainer):
 
         self.__requested_info = True
 
-        future.add_done_callback(
-            lambda future: self._sig_kernel_info_replied.emit(
-                ipyclient, future.result()
-            )
+        future.connect(
+            AsyncDispatcher.QtSlot(lambda kernel_info: self._on_kernel_info_reply(
+                ipyclient, kernel_info
+            ))
         )
 
     def _on_kernel_restarted(self, ipyclient, restarted: bool):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Fix typings issue with AsyncDispatcher, refactor to use as decorator and add minor improvements on logic for performace.
Allow to execute callbacks inside the main qt loops.

### New Usage:

Non-Blocking usage (returns a concurrent Future):
```
@AsyncDispatcher()
async def my_coroutine(...):
    ...

future = my_coroutine(...)  # Non-blocking call

result = future.result()  # Blocking call
```

Blocking usage (returns the result):
```
@AsyncDispatcher(early_return=False)
async def my_coroutine(...):
    ...

result = my_coroutine(...)  # Blocking call
```

Coroutine usage (returns an awaitable Future):
```
@AsyncDispatcher(return_awaitable=True)
async def my_coroutine(...):
    ...

result = await my_coroutine(...)  # Wait for the result to be ready
```

Calling qt function:
```
@AsyncDispatcher()
async def my_coroutine(...):
    ...

@AsyncDispatcher.QtSlot()  # Mark to execute inside main qt event loop
def qt_function(future):
    result = future.result()   # raises any error raised in my_coroutine

future = my_coroutine(...)
future.connect(qt_function)  # add callback to execute upon done (non-blocking)
```

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @hlouzada

<!--- Thanks for your help making Spyder better for everyone! --->
