### PR TITLE
PR: Don't show move, undock and close actions in the Options menu of new editor windows

### DIFF
--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -1399,11 +1399,12 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             else:
                 if self.new_window_action:
                     actions += [self.new_window_action]
-                actions += [
-                    main_widget.lock_unlock_action,
-                    main_widget.undock_action,
-                    main_widget.close_action
-                ]
+                if not self.new_window:
+                    actions += [
+                        main_widget.lock_unlock_action,
+                        main_widget.undock_action,                    
+                        main_widget.close_action
+                    ]
 
         return actions
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Don't show Move, Undock and Close actions in new editor window


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23665 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@jsbautista 
<!--- Thanks for your help making Spyder better for everyone! --->
