### PR TITLE
PR: Try to recover files from autosave before the main window is visible (Editor)

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1053,13 +1053,12 @@ class MainWindow(QMainWindow, SpyderMainWindowMixin, SpyderShortcutsMixin):
         """Set splash message"""
         if self.splash is None:
             return
-        if message:
-            logger.info(message)
         self.splash.show()
-        self.splash.showMessage(message,
-                                int(Qt.AlignBottom | Qt.AlignCenter |
-                                    Qt.AlignAbsolute),
-                                QColor(Qt.white))
+        self.splash.showMessage(
+            message,
+            int(Qt.AlignBottom | Qt.AlignCenter | Qt.AlignAbsolute),
+            QColor(Qt.white),
+        )
         QApplication.processEvents()
 
     def change_last_focused_widget(self, old, now):

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -829,6 +829,11 @@ class Editor(SpyderDockablePlugin):
         font = self.get_font(SpyderFontType.Monospace)
         self.get_widget().update_font(font)
 
+    def before_mainwindow_visible(self):
+        # Don't move this to on_mainwindow_visible because the window appears
+        # empty while the recovery dialog is shown.
+        self.get_widget().autosave.try_recover_from_autosave()
+
     def on_mainwindow_visible(self):
         widget = self.get_widget()
         widget.restore_scrollbar_position()

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -226,8 +226,13 @@ def test_editorstacks_share_autosave_data(editor_plugin, qtbot):
 # The mock_RecoveryDialog fixture needs to be called before setup_editor, so
 # it needs to be mentioned first
 def test_editor_calls_recoverydialog_exec_if_nonempty(
-        mock_RecoveryDialog, editor_plugin):
-    """Check that editor tries to exec a recovery dialog on construction."""
+    mock_RecoveryDialog, editor_plugin
+):
+    """
+    Check that the editor tries to exec a recovery dialog before the main
+    window is visible.
+    """
+    editor_plugin.before_mainwindow_visible()
     assert mock_RecoveryDialog.return_value.exec_if_nonempty.called
 
 

--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -72,9 +72,12 @@ class AutosaveForPlugin(object):
         self.editor = editor
         self.name_mapping = {}
         self.file_hashes = {}
+        self.recover_files_to_open = []
+
         self.timer = QTimer(self.editor)
         self.timer.setSingleShot(True)
         self.timer.timeout.connect(self.do_autosave)
+
         self._enabled = False  # Can't use setter here
         self._interval = self.DEFAULT_AUTOSAVE_INTERVAL
 

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -342,7 +342,6 @@ class EditorMainWidget(PluginMainWidget):
         # Start autosave component
         # (needs to be done before EditorSplitter)
         self.autosave = AutosaveForPlugin(self)
-        self.autosave.try_recover_from_autosave()
 
         # Multiply by 1000 to convert seconds to milliseconds
         self.autosave.interval = self.get_conf('autosave_interval') * 1000


### PR DESCRIPTION
## Description of Changes

- Before we were running that when `EditorMainWidget` was instantiated, which caused a noticeable delay at startup and the splash screen to be hidden while it was taking place.
- Also, remove unnecessary log messages when setting splash screen messages.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
