### PR TITLE
PR: User environment variables to take precedence for IPython Console kernel

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -162,10 +162,9 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
         default_interpreter = self.get_conf(
             'default', section='main_interpreter')
 
-        # Ensure that user environment variables are included, but don't
-        # override existing environ values
-        env_vars = get_user_environment_variables()
-        env_vars.update(os.environ)
+        # Ensure that user environment variables supersede existing variables
+        env_vars = os.environ.copy()
+        env_vars.update(get_user_environment_variables())
 
         # Avoid IPython adding the virtualenv on which Spyder is running
         # to the kernel sys.path


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Ensure that user environment variables supersede Spyder runtime environment variables when starting the IPython Console kernel.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23711
