### PR TITLE
PR: Fix indent guides at startup and for cloned editors (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -932,10 +932,6 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
             # This is required for the line number area
             self.setFont(font)
 
-            # Needed to show indent guides for splited editor panels
-            # See spyder-ide/spyder#10900
-            self.patch = cloned_from.patch
-
             # Needed to show code folding in cloned editors.
             # Fixes spyder-ide/spyder#23622
             cloned_from.sig_update_code_folding.connect(

--- a/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
@@ -1299,6 +1299,7 @@ class LSPMixin:
 
             # This is necessary to repaint guides in cloned editors and the
             # original one after making edits in any one of them.
+            # See spyder-ide/spyder#23297
             self.update()
 
         self.folding_in_sync = True

--- a/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
@@ -1283,7 +1283,7 @@ class LSPMixin:
         self.apply_code_folding(self._folding_info)
 
     def apply_code_folding(self, folding_info):
-
+        """Apply code folding info."""
         # Check if we actually have folding info to update before trying to do
         # it.
         # Fixes spyder-ide/spyder#19514
@@ -1293,9 +1293,13 @@ class LSPMixin:
         self.highlight_folded_regions()
 
         # Update indent guides, which depend on folding
-        if self.indent_guides._enabled and len(self.patch) > 0:
+        if self.indent_guides._enabled:
             line, column = self.get_cursor_line_column()
             self.update_whitespace_count(line, column)
+
+            # This is necessary to repaint guides in cloned editors and the
+            # original one after making edits in any one of them.
+            self.update()
 
         self.folding_in_sync = True
 


### PR DESCRIPTION
## Description of Changes

- Guides were not shown at startup for some files, when multiple files were open in the previous session, and for any cloned editor.
- I basically applied the changes related to guides in #21033 (with the proper attribution) because they contained the right fixes for those problems. And I improved them a bit by calling `update` to repaint them after they are applied.

### Issue(s) Resolved

Fixes #23297

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
