### PR TITLE
PR: Handle `TypeError` when loading a `.spydata` file (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -382,13 +382,14 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
                         extensions=', '.join(IMPORT_EXT))
             return msg
         except TypeError:
-            msg = _("Spyder is unable to open the file "
-                    "you're trying to load. This could be caused due to a "
-                    "difference between the packages versions used to create "
-                    "the data and the versions installed with the currently "
-                    "selected interpreter. Please check the packages versions "
-                    "used to create the data and their compatibility with the "
-                    "packages versions installed.<br>")
+            msg = _(
+                "Spyder is unable to open the file you're trying to load. "
+                "This could be caused due to a difference between the package "
+                "versions used when you saved this spydata file and the ones "
+                "installed in the current environment. Please check the "
+                "compatibility between them (e.g. that you're using Numpy 2.x "
+                "in both environments).<br>"
+            )
         except (UnpicklingError, RuntimeError, CommError):
             return None
 

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -381,6 +381,14 @@ class NamespaceBrowser(QWidget, SpyderWidgetMixin):
                     "<br><br><tt>{extensions}</tt>").format(
                         extensions=', '.join(IMPORT_EXT))
             return msg
+        except TypeError:
+            msg = _("Spyder is unable to open the file "
+                    "you're trying to load. This could be caused due to a "
+                    "difference between the packages versions used to create "
+                    "the data and the versions installed with the currently "
+                    "selected interpreter. Please check the packages versions "
+                    "used to create the data and their compatibility with the "
+                    "packages versions installed.<br>")
         except (UnpicklingError, RuntimeError, CommError):
             return None
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Catch `TypeError` errors when trying to load a } .spydata}  file and leave as message a possible reason for the error (having incompatible versions for the packages used to create and load the data/variables)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22972


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
