### PR TITLE
PR: Fix running `test_update_outline` on CI

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -11,6 +11,13 @@ else
     export CONDA_EXE=$CONDA/bin/conda
 fi
 
+# To know what's the current run (some tests don't pass on the first one)
+while getopts "n:" option; do
+    case "$option" in
+        (n) export CI_RUN_NUMBER=$OPTARG ;;
+    esac
+done
+
 # Run tests
 if [ "$SPYDER_TEST_REMOTE_CLIENT" = "true" ]; then
     xvfb-run --auto-servernum python runtests.py --color=yes --remote-client | tee -a pytest_log.txt

--- a/.github/workflows/test-linux-qt6.yml
+++ b/.github/workflows/test-linux-qt6.yml
@@ -168,10 +168,10 @@ jobs:
           PYTEST_QT_API: ${{ matrix.SPYDER_QT_BINDING }}
         run: |
           rm -f pytest_log.txt  # Must remove any log file from a previous run
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh
+          .github/scripts/run_tests.sh -n 0 || \
+          .github/scripts/run_tests.sh -n 1 || \
+          .github/scripts/run_tests.sh -n 2 || \
+          .github/scripts/run_tests.sh -n 3
       - name: Coverage
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -178,10 +178,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           rm -f pytest_log.txt  # Must remove any log file from a previous run
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh
+          .github/scripts/run_tests.sh -n 0 || \
+          .github/scripts/run_tests.sh -n 1 || \
+          .github/scripts/run_tests.sh -n 2 || \
+          .github/scripts/run_tests.sh -n 3
       - name: Coverage
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -138,10 +138,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           rm -f pytest_log.txt  # Must remove any log file from a previous run
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh
+          .github/scripts/run_tests.sh -n 0 || \
+          .github/scripts/run_tests.sh -n 1 || \
+          .github/scripts/run_tests.sh -n 2 || \
+          .github/scripts/run_tests.sh -n 3
       - name: Coverage
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/test-remoteclient.yml
+++ b/.github/workflows/test-remoteclient.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           rm -f pytest_log.txt
           rm -f pytest_log.txt  # Must remove any log file from a previous run
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh
+          .github/scripts/run_tests.sh -n 0 || \
+          .github/scripts/run_tests.sh -n 1 || \
+          .github/scripts/run_tests.sh -n 2 || \
+          .github/scripts/run_tests.sh -n 3

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -153,10 +153,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           rm -f pytest_log.txt  # Must remove any log file from a previous run
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh || \
-          .github/scripts/run_tests.sh
+          .github/scripts/run_tests.sh -n 0 || \
+          .github/scripts/run_tests.sh -n 1 || \
+          .github/scripts/run_tests.sh -n 2 || \
+          .github/scripts/run_tests.sh -n 3
       - name: Coverage
         uses: codecov/codecov-action@v4
         with:

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -4810,7 +4810,7 @@ def test_tour_message(main_window, qtbot):
     qtbot.wait(2000)
 
 
-@flaky(max_runs=8)
+@flaky(max_runs=20)
 @pytest.mark.use_introspection
 @pytest.mark.order(after="test_debug_unsaved_function")
 @pytest.mark.preload_complex_project


### PR DESCRIPTION
## Description of Changes

- That test fails frequently on the first CI run but passes on the next ones. So, I added a way to skip it for that run.
- I also increased again the number of runs required for that test to reduce the flakiness observed lately on CIs.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
