### PR TITLE
PR: Declare `File` as super context when Run plugin is created

### DIFF
--- a/spyder/plugins/run/container.py
+++ b/spyder/plugins/run/container.py
@@ -120,8 +120,12 @@ class RunContainer(PluginMainContainer):
         self.run_executor_actions: Dict[
             Tuple[str, str], Tuple[QAction, Callable]] = {}
 
+        # 'File' is the only super context we support for now. It needs to be
+        # set here so that run actions for files in different plugins (e.g.
+        # 'Debug file') are declared correctly at startup.
+        # Fixes spyder-ide/spyder#23694
+        self.super_contexts: Set[str] = {RunContext.File}
         self.supported_extension_contexts: Dict[str, Set[Tuple[str, str]]] = {}
-        self.super_contexts: Set[str] = set({})
 
         self.last_executed_file: Optional[str] = None
         self.last_executed_per_context: Set[Tuple[str, str]] = set()


### PR DESCRIPTION
## Description of Changes

- This is needed so that run actions for files in different plugins (e.g. 'Debug file') are declared correctly at startup.
- With this small change, Run can also correctly get all options declared in the `Configuration per file` dialog.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23694

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
