### PR TITLE
PR: Set the current working directory used by the Run plugin directly in the Working directory plugin

### DIFF
--- a/spyder/plugins/workingdirectory/plugin.py
+++ b/spyder/plugins/workingdirectory/plugin.py
@@ -35,7 +35,7 @@ class WorkingDirectory(SpyderPluginV2):
     NAME = 'workingdir'
     REQUIRES = [Plugins.Preferences, Plugins.Console, Plugins.Toolbar]
     OPTIONAL = [Plugins.Editor, Plugins.Explorer, Plugins.IPythonConsole,
-                Plugins.Find, Plugins.Projects]
+                Plugins.Find, Plugins.Projects, Plugins.Run]
     CONTAINER_CLASS = WorkingDirectoryContainer
     CONF_SECTION = NAME
     CONF_WIDGET_CLASS = WorkingDirectoryConfigPage
@@ -175,6 +175,7 @@ class WorkingDirectory(SpyderPluginV2):
         explorer = self.get_plugin(Plugins.Explorer)
         ipyconsole = self.get_plugin(Plugins.IPythonConsole)
         find = self.get_plugin(Plugins.Find)
+        run = self.get_plugin(Plugins.Run)
 
         if explorer and sender_plugin != explorer:
             explorer.chdir(directory, emit=False)
@@ -185,6 +186,14 @@ class WorkingDirectory(SpyderPluginV2):
 
         if find:
             find.refresh_search_directory()
+
+        # This is a quick hack to make the Run plugin use the current working
+        # directory when the option for it is set by users. In 6.1 we'll
+        # improve how other plugins receive changes to the cwd from this one
+        # to avoid things like this.
+        # Fixes spyder-ide/spyder#23866
+        if run:
+            run._switch_working_dir(directory)
 
         if sender_plugin is not None:
             container = self.get_container()


### PR DESCRIPTION
## Description of Changes

- The Run plugin is correctly connected to the signal provided by the Working directory one to receive updates about the cwd set there. But that plugin is actually not emitting that signal and instead is calling directly the methods related to the cwd for plugins that use or can set it.
- That's very convoluted and not something external plugins can work with. But we can't address it in a bugfix release, so for now I followed the same approach for Run.
- I also added a test to catch future regressions for this problem.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23866.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
