### PR TITLE
PR: Prevent collapsing splitter widgets in the Plots plugin

### DIFF
--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -194,7 +194,6 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
               "like Bokeh, Plotly or Altair.")
         )
 
-
         # Create the layout.
         self.splitter = splitter = QSplitter(parent=self)
         splitter.addWidget(self.figviewer)
@@ -205,7 +204,7 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
             f"border-radius: {SpyderPalette.SIZE_BORDER_RADIUS}"
         )
         self.splitter.setChildrenCollapsible(False)
-        self.splitter.splitterMoved.connect(self.on_splitter_moved)
+        self.splitter.splitterMoved.connect(self._on_splitter_moved)
 
         self.stack_layout = QStackedLayout()
         self.stack_layout.addWidget(splitter)
@@ -215,13 +214,10 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
         self.stack_layout.setSpacing(0)
         self.setContentsMargins(0, 0, 0, 0)
 
-    def on_splitter_moved(self):
+    def _on_splitter_moved(self):
         total_width = self.splitter.width()
-
-        min_width_percentage = 0.5
-
-        min_width = total_width * min_width_percentage
-
+        min_width_percentage = 0.55
+        min_width = int(total_width * min_width_percentage)
         self.figviewer.setMinimumWidth(min_width)
 
     def _update_zoom_value(self, value):

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -194,6 +194,7 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
               "like Bokeh, Plotly or Altair.")
         )
 
+
         # Create the layout.
         self.splitter = splitter = QSplitter(parent=self)
         splitter.addWidget(self.figviewer)
@@ -203,6 +204,8 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
         splitter.setStyleSheet(
             f"border-radius: {SpyderPalette.SIZE_BORDER_RADIUS}"
         )
+        self.splitter.setChildrenCollapsible(False)
+        self.splitter.splitterMoved.connect(self.on_splitter_moved)
 
         self.stack_layout = QStackedLayout()
         self.stack_layout.addWidget(splitter)
@@ -211,6 +214,15 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
         self.stack_layout.setContentsMargins(0, 0, 0, 0)
         self.stack_layout.setSpacing(0)
         self.setContentsMargins(0, 0, 0, 0)
+
+    def on_splitter_moved(self):
+        total_width = self.splitter.width()
+
+        min_width_percentage = 0.5
+
+        min_width = total_width * min_width_percentage
+
+        self.figviewer.setMinimumWidth(min_width)
 
     def _update_zoom_value(self, value):
         """


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

This fixes a `ValueError: math domain error` reported by a user when the figure viewer had zero width.


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23677 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@jsbautista 
<!--- Thanks for your help making Spyder better for everyone! --->
