### PR TITLE
PR: Fix `sig_current_directory_changed` signal of the Working directory plugin

### DIFF
--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -4,16 +4,31 @@
 
 ### API changes
 
-* **Breaking** - The `sig_pythonpath_changed` signal of the Python path manager plugin now emits a list of strings and a bool, instead of two dictionaries.
-* **Breaking** - Remove `dispatch` method from `spyder.api.asyncdispatcher.AsyncDispatcher` to use it directly as decorator.
-* **Breaking** - Remove `set_working_directory` method of the IPython console (you can use `set_current_client_working_directory` instead, which does the same).
-* **Breaking** - The `save_working_directory` method of the IPython console was made private because it's only used internally.
-* Add class `DispatcherFuture` to `spyder/api/asyncdispatcher` and `QtSlot` method to `AsyncDispatcher` so that connected methods can be run inside the main Qt event loop.
-* Add `early_return` and `return_awaitable` kwargs to `AsyncDispatcher` constructor.
-* Add `register_api` and `get_api` methods to `RemoteClient` plugin in order to
-  get and register new rest API modules for the remote client.
-* Add `get_file_api` method to `RemoteClient` to get the
-  `SpyderRemoteFileServicesAPI` rest API module to manage remote file systems.
+#### IPython console
+
+* **Breaking** - Remove `set_working_directory` method. You can use `set_current_client_working_directory` instead, which does the same.
+* **Breaking** - The `save_working_directory` method was made private because it's only used internally.
+* Add `sender_plugin` kwarg to the `set_current_client_working_directory` method.
+
+#### Working Directory
+
+* **Breaking** - The `sig_current_directory_changed` signal now emits two strings instead of a single one.
+* **Breaking** - The `sender_plugin` kwarg of the `chdir` method now expects a string instead of a `SpyderPluginV2` object.
+
+#### Remote Client
+
+* Add `register_api` and `get_api` methods in order to get and register new rest API modules for the remote client.
+* Add `get_file_api` method to get the `SpyderRemoteFileServicesAPI` rest API module to manage remote file systems.
+
+#### Pythonpath manager
+
+* **Breaking** - The `sig_pythonpath_changed` signal now emits a list of strings and a bool, instead of two dictionaries.
+
+#### AsyncDispatcher
+
+* **Breaking** - Remove `dispatch` method to use it directly as decorator.
+* Add class `DispatcherFuture` to `spyder.api.asyncdispatcher` and `QtSlot` method to `AsyncDispatcher` so that connected methods can be run inside the main Qt event loop.
+* Add `early_return` and `return_awaitable` kwargs its constructor.
 
 ----
 

--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -6,6 +6,8 @@
 
 * **Breaking** - The `sig_pythonpath_changed` signal of the Python path manager plugin now emits a list of strings and a bool, instead of two dictionaries.
 * **Breaking** - Remove `dispatch` method from `spyder.api.asyncdispatcher.AsyncDispatcher` to use it directly as decorator.
+* **Breaking** - Remove `set_working_directory` method of the IPython console (you can use `set_current_client_working_directory` instead, which does the same).
+* **Breaking** - The `save_working_directory` method of the IPython console was made private because it's only used internally.
 * Add class `DispatcherFuture` to `spyder/api/asyncdispatcher` and `QtSlot` method to `AsyncDispatcher` so that connected methods can be run inside the main Qt event loop.
 * Add `early_return` and `return_awaitable` kwargs to `AsyncDispatcher` constructor.
 * Add `register_api` and `get_api` methods to `RemoteClient` plugin in order to

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -6300,8 +6300,10 @@ def test_cwd_is_synced_when_switching_consoles(main_window, qtbot, tmpdir):
         ipyconsole.create_new_client()
         shell = ipyconsole.get_current_shellwidget()
         qtbot.waitUntil(
-            lambda: shell.spyder_kernel_ready and shell._prompt_html is not None,
-            timeout=SHELL_TIMEOUT)
+            lambda: shell.spyder_kernel_ready
+            and shell._prompt_html is not None,
+            timeout=SHELL_TIMEOUT,
+        )
         with qtbot.waitSignal(shell.executed):
             shell.execute(f'cd {str(sync_dir)}')
 
@@ -6310,8 +6312,11 @@ def test_cwd_is_synced_when_switching_consoles(main_window, qtbot, tmpdir):
     for i in range(3):
         ipyconsole.get_widget().tabwidget.setCurrentIndex(i)
         shell_cwd = ipyconsole.get_current_shellwidget().get_cwd()
-        assert shell_cwd == workdir.get_workdir() == files.get_current_folder()
-
+        qtbot.waitUntil(
+            lambda: shell_cwd
+            == workdir.get_workdir()
+            == files.get_current_folder()
+        )
 
 @flaky(max_runs=5)
 def test_console_initial_cwd_is_synced(main_window, qtbot, tmpdir):
@@ -6335,9 +6340,12 @@ def test_console_initial_cwd_is_synced(main_window, qtbot, tmpdir):
     qtbot.waitUntil(
         lambda: shell.spyder_kernel_ready and shell._prompt_html is not None,
         timeout=SHELL_TIMEOUT)
-    qtbot.waitUntil(lambda: shell.get_cwd() == str(tmpdir))
-    assert shell.get_cwd() == str(tmpdir) == workdir.get_workdir() == \
-           files.get_current_folder()
+    qtbot.waitUntil(
+        lambda: shell.get_cwd()
+        == str(tmpdir)
+        == workdir.get_workdir()
+        == files.get_current_folder()
+    )
 
     # Check that a new client has the same initial cwd as the current one
     ipyconsole.create_new_client()
@@ -6345,9 +6353,12 @@ def test_console_initial_cwd_is_synced(main_window, qtbot, tmpdir):
     qtbot.waitUntil(
         lambda: shell.spyder_kernel_ready and shell._prompt_html is not None,
         timeout=SHELL_TIMEOUT)
-    qtbot.waitUntil(lambda: shell.get_cwd() == str(tmpdir))
-    assert shell.get_cwd() == str(tmpdir) == workdir.get_workdir() == \
-           files.get_current_folder()
+    qtbot.waitUntil(
+        lambda: shell.get_cwd()
+        == str(tmpdir)
+        == workdir.get_workdir()
+        == files.get_current_folder()
+    )
 
     # Check new clients with a fixed directory
     ipyconsole.set_conf('console/use_cwd', False, section='workingdir')
@@ -6369,9 +6380,12 @@ def test_console_initial_cwd_is_synced(main_window, qtbot, tmpdir):
     qtbot.waitUntil(
         lambda: shell.spyder_kernel_ready and shell._prompt_html is not None,
         timeout=SHELL_TIMEOUT)
-    qtbot.waitUntil(lambda: shell.get_cwd() == fixed_dir)
-    assert shell.get_cwd() == fixed_dir == workdir.get_workdir() == \
-           files.get_current_folder()
+    qtbot.waitUntil(
+        lambda: shell.get_cwd()
+        == fixed_dir
+        == workdir.get_workdir()
+        == files.get_current_folder()
+    )
 
     # Check when opening projects
     project_path = str(tmpdir.mkdir('test_project'))
@@ -6382,9 +6396,12 @@ def test_console_initial_cwd_is_synced(main_window, qtbot, tmpdir):
     qtbot.waitUntil(
         lambda: shell.spyder_kernel_ready and shell._prompt_html is not None,
         timeout=SHELL_TIMEOUT)
-    qtbot.waitUntil(lambda: shell.get_cwd() == project_path)
-    assert shell.get_cwd() == project_path == workdir.get_workdir() == \
-           files.get_current_folder()
+    qtbot.waitUntil(
+        lambda: shell.get_cwd()
+        == project_path
+        == workdir.get_workdir()
+        == files.get_current_folder()
+    )
 
     # Check when closing projects
     main_window.projects.close_project()
@@ -6394,9 +6411,12 @@ def test_console_initial_cwd_is_synced(main_window, qtbot, tmpdir):
     qtbot.waitUntil(
         lambda: shell.spyder_kernel_ready and shell._prompt_html is not None,
         timeout=SHELL_TIMEOUT)
-    qtbot.waitUntil(lambda: shell.get_cwd() == get_home_dir())
-    assert shell.get_cwd() == get_home_dir() == workdir.get_workdir() == \
-           files.get_current_folder()
+    qtbot.waitUntil(
+        lambda: shell.get_cwd()
+        == get_home_dir()
+        == workdir.get_workdir()
+        == files.get_current_folder()
+    )
 
 
 def test_debug_selection(main_window, qtbot):

--- a/spyder/plugins/explorer/plugin.py
+++ b/spyder/plugins/explorer/plugin.py
@@ -31,7 +31,11 @@ class Explorer(SpyderDockablePlugin):
 
     NAME = 'explorer'
     REQUIRES = [Plugins.Preferences]
-    OPTIONAL = [Plugins.IPythonConsole, Plugins.Editor]
+    OPTIONAL = [
+        Plugins.IPythonConsole,
+        Plugins.Editor,
+        Plugins.WorkingDirectory,
+    ]
     TABIFY = Plugins.VariableExplorer
     WIDGET_CLASS = ExplorerWidget
     CONF_SECTION = NAME
@@ -217,6 +221,13 @@ class Explorer(SpyderDockablePlugin):
             )
         )
 
+    @on_plugin_available(plugin=Plugins.WorkingDirectory)
+    def on_working_directory_available(self):
+        working_directory = self.get_plugin(Plugins.WorkingDirectory)
+        working_directory.sig_current_directory_changed.connect(
+            self._chdir_from_working_directory
+        )
+
     @on_plugin_teardown(plugin=Plugins.Editor)
     def on_editor_teardown(self):
         editor = self.get_plugin(Plugins.Editor)
@@ -241,6 +252,13 @@ class Explorer(SpyderDockablePlugin):
         self.sig_open_interpreter_requested.disconnect(
             ipyconsole.create_client_from_path)
         self.sig_run_requested.disconnect()
+
+    @on_plugin_teardown(plugin=Plugins.WorkingDirectory)
+    def on_working_directory_teardown(self):
+        working_directory = self.get_plugin(Plugins.WorkingDirectory)
+        working_directory.sig_current_directory_changed.disconnect(
+            self._chdir_from_working_directory
+        )
 
     # ---- Public API
     # ------------------------------------------------------------------------
@@ -276,3 +294,13 @@ class Explorer(SpyderDockablePlugin):
         widget = self.get_widget()
         widget.update_history(new_path)
         widget.refresh(new_path, force_current=force_current)
+
+    # ---- Private API
+    # -------------------------------------------------------------------------
+    def _chdir_from_working_directory(self, directory):
+        """
+        Change the working directory when requested from the Working Directory
+        plugin.
+        """
+        self.chdir(directory, emit=False)
+        self.refresh(directory)

--- a/spyder/plugins/findinfiles/plugin.py
+++ b/spyder/plugins/findinfiles/plugin.py
@@ -35,7 +35,12 @@ class FindInFiles(SpyderDockablePlugin):
     """
     NAME = 'find_in_files'
     REQUIRES = []
-    OPTIONAL = [Plugins.Editor, Plugins.Projects, Plugins.MainMenu]
+    OPTIONAL = [
+        Plugins.Editor,
+        Plugins.Projects,
+        Plugins.MainMenu,
+        Plugins.WorkingDirectory,
+    ]
     TABIFY = [Plugins.VariableExplorer]
     WIDGET_CLASS = FindInFilesWidget
     CONF_SECTION = NAME
@@ -94,6 +99,13 @@ class FindInFiles(SpyderDockablePlugin):
             section=SearchMenuSections.FindInFiles
         )
 
+    @on_plugin_available(plugin=Plugins.WorkingDirectory)
+    def on_working_directory_available(self):
+        working_directory = self.get_plugin(Plugins.WorkingDirectory)
+        working_directory.sig_current_directory_changed.connect(
+            self.refresh_search_directory
+        )
+
     @on_plugin_teardown(plugin=Plugins.Editor)
     def on_editor_teardown(self):
         widget = self.get_widget()
@@ -115,6 +127,13 @@ class FindInFiles(SpyderDockablePlugin):
         mainmenu.remove_item_from_application_menu(
             FindInFilesActions.FindInFiles,
             menu_id=ApplicationMenus.Search,
+        )
+
+    @on_plugin_teardown(plugin=Plugins.WorkingDirectory)
+    def on_working_directory_teardown(self):
+        working_directory = self.get_plugin(Plugins.WorkingDirectory)
+        working_directory.sig_current_directory_changed.disconnect(
+            self.refresh_search_directory
         )
 
     def on_close(self, cancelable=False):

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -467,7 +467,7 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
     def on_working_directory_available(self):
         working_directory = self.get_plugin(Plugins.WorkingDirectory)
         working_directory.sig_current_directory_changed.connect(
-            self.save_working_directory
+            self._save_working_directory
         )
         working_directory.sig_current_directory_changed.connect(
             self.set_current_client_working_directory
@@ -535,7 +535,7 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
     def on_working_directory_teardown(self):
         working_directory = self.get_plugin(Plugins.WorkingDirectory)
         working_directory.sig_current_directory_changed.disconnect(
-            self.save_working_directory
+            self._save_working_directory
         )
         working_directory.sig_current_directory_changed.disconnect(
             self.set_current_client_working_directory
@@ -617,6 +617,18 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
         dlg = container.dialog
         index = dlg.get_index_by_name("main_interpreter")
         dlg.set_current_index(index)
+
+    @Slot(str)
+    def _save_working_directory(self, dirname):
+        """
+        Save current working directory on the main widget to start new clients.
+
+        Parameters
+        ----------
+        new_dir: str
+            Path to the new current working directory.
+        """
+        self.get_widget().save_working_directory(dirname)
 
     # ---- Public API
     # -------------------------------------------------------------------------
@@ -1004,34 +1016,6 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
         """
         self.get_widget().set_current_client_working_directory(directory)
 
-    def set_working_directory(self, dirname):
-        """
-        Set current working directory in the Working Directory and Files
-        plugins.
-
-        Parameters
-        ----------
-        dirname : str
-            Path to the new current working directory.
-
-        Returns
-        -------
-        None.
-        """
-        self.get_widget().set_working_directory(dirname)
-
-    @Slot(str)
-    def save_working_directory(self, dirname):
-        """
-        Save current working directory on the main widget to start new clients.
-
-        Parameters
-        ----------
-        new_dir: str
-            Path to the new current working directory.
-        """
-        self.get_widget().save_working_directory(dirname)
-
     def update_path(self, new_path, prioritize):
         """
         Update path on consoles.
@@ -1052,6 +1036,7 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
         """
         self.get_widget().update_path(new_path, prioritize)
 
+    # ---- For restarts
     def restart(self):
         """
         Restart the console.

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -467,7 +467,11 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
     def on_working_directory_available(self):
         working_directory = self.get_plugin(Plugins.WorkingDirectory)
         working_directory.sig_current_directory_changed.connect(
-            self.save_working_directory)
+            self.save_working_directory
+        )
+        working_directory.sig_current_directory_changed.connect(
+            self.set_current_client_working_directory
+        )
 
     @on_plugin_available(plugin=Plugins.PythonpathManager)
     def on_pythonpath_manager_available(self):
@@ -531,7 +535,11 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
     def on_working_directory_teardown(self):
         working_directory = self.get_plugin(Plugins.WorkingDirectory)
         working_directory.sig_current_directory_changed.disconnect(
-            self.save_working_directory)
+            self.save_working_directory
+        )
+        working_directory.sig_current_directory_changed.disconnect(
+            self.set_current_client_working_directory
+        )
 
     @on_plugin_teardown(plugin=Plugins.PythonpathManager)
     def on_pythonpath_manager_teardown(self):

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -2439,14 +2439,6 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):
             )
 
     # ---- For working directory and path management
-    def set_working_directory(self, dirname):
-        """
-        Set current working directory in the Working Directory and Files
-        plugins.
-        """
-        if osp.isdir(dirname):
-            self.sig_current_directory_changed.emit(dirname)
-
     def save_working_directory(self, dirname):
         """
         Save current working directory when changed by the Working Directory

--- a/spyder/plugins/workingdirectory/container.py
+++ b/spyder/plugins/workingdirectory/container.py
@@ -159,7 +159,7 @@ class WorkingDirectoryContainer(PluginMainContainer):
     Parameters
     ----------
     new_working_directory: str
-        The new new working directory path.
+        The new working directory path.
     """
 
     edit_goto = Signal(str, int, str)
@@ -200,7 +200,6 @@ class WorkingDirectoryContainer(PluginMainContainer):
         self.pathedit.selected_text = self.pathedit.currentText()
 
         # Signals
-        self.pathedit.open_dir.connect(self.chdir)
         self.pathedit.edit_goto.connect(self.edit_goto)
         self.pathedit.textActivated.connect(self.chdir)
 


### PR DESCRIPTION
## Description of Changes

* That signal was not emitted in all situations when a cwd change happened in Spyder, only when a new directory was selected in the Working directory toolbar.
* Instead, the Working directory was calling directly methods in other plugins to update their cwd. That not only worked against the way our API works (i.e. other plugins should connect to `sig_current_directory_changed` and do what they need to when it's emitted), but also prevented external plugins to react to cwd changes. So, I fixed that signal by making it work like that.
* In order to prevent a plugin to change its cwd if it requested it in the first place and after `sig_current_directory_changed` is emitted, I changed its signature to include the plugin's name. With that, the requesting plugin can avoid changing its own cwd again.
* Methods that react to  `sig_current_directory_changed` in Files and the IPython console are now debounced to avoid calling them multiple times in quick succession.
* Remove `set_working_directory` method of the IPython console because it wasn't used.
* Break API changes section of 6.1 changelog into subsections for plugins and classes so that it's easier to write.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
