### PR TITLE
PR: Allow to set keyboard shortcut for `Run in external terminal` action

### DIFF
--- a/spyder/plugins/externalterminal/plugin.py
+++ b/spyder/plugins/externalterminal/plugin.py
@@ -15,6 +15,7 @@ from typing import List
 
 # Third-party imports
 from packaging.version import parse
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QMessageBox
 
 # Local imports
@@ -182,7 +183,9 @@ class ExternalTerminal(SpyderPluginV2, RunExecutor):
             text=_("Run in external terminal"),
             tip=_("Run in an operating system terminal"),
             icon=self.get_icon(),
-            register_shortcut=False,
+            shortcut_context='_',
+            register_shortcut=True,
+            shortcut_widget_context=Qt.ApplicationShortcut,
             add_to_menu={
                 "menu": ApplicationMenus.Run,
                 "section": RunMenuSections.RunInExecutors

--- a/spyder/plugins/run/container.py
+++ b/spyder/plugins/run/container.py
@@ -275,14 +275,6 @@ class RunContainer(PluginMainContainer):
         if not isinstance(selected_uuid, bool) and selected_uuid is not None:
             self.switch_focused_run_configuration(selected_uuid)
 
-        if selected_executor is None:
-            # If the executor is not provided, check if the file has a default
-            # one.
-            metadata = self.metadata_model.get_selected_metadata()
-            if metadata is not None:
-                extension = metadata["input_extension"]
-                selected_executor = self._get_default_executor(extension)
-
         self.edit_run_configurations(
             display_dialog=False,
             selected_executor=selected_executor
@@ -307,6 +299,14 @@ class RunContainer(PluginMainContainer):
         self.dialog.sig_delete_config_requested.connect(
             self.delete_executor_configuration_parameters
         )
+
+        # If the file is going to be executed (not configured) and the executor
+        # is not provided, check if it has a default one.
+        if not display_dialog and selected_executor is None:
+            metadata = self.metadata_model.get_selected_metadata()
+            if metadata is not None:
+                extension = metadata["input_extension"]
+                selected_executor = self._get_default_executor(extension)
 
         if selected_executor is not None:
             self.dialog.select_executor(selected_executor)


### PR DESCRIPTION
## Description of Changes

Also, fix bug in the Run plugin to select the default executor the first time a file is run

### Visual changes

New shortcut that can be configured

![imagen](https://github.com/user-attachments/assets/451871e4-5813-461b-9ffc-7d4b84ecda79)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #23701.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
