### PR TITLE
PR: Update focused file for Run plugin after a `Save as` operation (Editor)

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -4822,6 +4822,10 @@ def test_tour_message(main_window, qtbot):
     sys.version_info[:2] < (3, 10),
     reason="Too flaky in old Python versions"
 )
+@pytest.mark.skipif(
+    not running_in_ci_with_conda(),
+    reason="Too flaky with pip packages"
+)
 @pytest.mark.known_leak
 def test_update_outline(main_window, qtbot, tmpdir):
     """

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -2464,6 +2464,12 @@ class EditorMainWidget(PluginMainWidget):
             fname = editorstack.get_current_filename()
             self.__add_recent_file(fname)
 
+            # We need to call this directly because at least on Windows
+            # editorstack.editor_focus_changed is not emitted after saving the
+            # file (and it's not harmful to do it for other OSes).
+            # Fixes spyder-ide/spyder#23716
+            self.update_run_focus_file()
+
     @Slot()
     def save_copy_as(self):
         """Save *copy as* the currently edited file"""


### PR DESCRIPTION
## Description of Changes

- We need to do this because on Windows because `editorstack.editor_focus_changed` is not emitted after saving the file.
- Also, skip `test_update_outline` when using pip packages because it fails too much.

### Issue(s) Resolved

Fixes #23716

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
