### PR TITLE
PR: Use Bash to run the `spyder-remote-services` installation script (Remote client)

### DIFF
--- a/spyder/plugins/remoteclient/utils/installation.py
+++ b/spyder/plugins/remoteclient/utils/installation.py
@@ -13,7 +13,7 @@ SERVER_ENV = "spyder-remote"
 PACKAGE_NAME = "spyder-remote-services"
 SCRIPT_URL = (
     f"https://raw.githubusercontent.com/spyder-ide/"
-    f"{PACKAGE_NAME}/master/scripts"
+    f"{PACKAGE_NAME}/main/scripts"
 )
 
 
@@ -27,7 +27,7 @@ def get_installer_command(platform: str) -> str:
         )
 
     return (
-        f'"${{SHELL}}" <(curl -L {SCRIPT_URL}/installer.sh) '
+        f'"`which bash`" <(curl -L {SCRIPT_URL}/installer.sh) '
         f'"{SPYDER_REMOTE_VERSION}" "{SPYDER_KERNELS_VERSION}"'
     )
 


### PR DESCRIPTION
## Description of Changes

- This prevents relying on the `SHELL` env var, which doesn't necessarily support the syntax we need to download the script with curl and run it.
- Also, fix small error with the script URL.

### Issue(s) Resolved

Fixes #22843.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
