### PR TITLE
Backport PR #23968 on branch 6.x (PR: Use Bash to run the `spyder-remote-services` installation script (Remote client))

### DIFF
--- a/spyder/plugins/remoteclient/utils/installation.py
+++ b/spyder/plugins/remoteclient/utils/installation.py
@@ -12,7 +12,7 @@ from spyder.plugins.remoteclient import SPYDER_REMOTE_VERSION
 SERVER_ENV = "spyder-remote"
 PACKAGE_NAME = "spyder-remote-services"
 SCRIPT_URL = (
-    f"https://raw.githubusercontent.com/spyder-ide/{PACKAGE_NAME}/master/scripts"
+    f"https://raw.githubusercontent.com/spyder-ide/{PACKAGE_NAME}/main/scripts"
 )
 
 
@@ -24,7 +24,7 @@ def get_installer_command(platform: str) -> str:
         return '\n'  # server should be aready installed in the test environment
 
     return (
-        f'"${{SHELL}}" <(curl -L {SCRIPT_URL}/installer.sh) '
+        f'"`which bash`" <(curl -L {SCRIPT_URL}/installer.sh) '
         f'"{SPYDER_REMOTE_VERSION}" "{SPYDER_KERNELS_VERSION}"'
     )
 


### PR DESCRIPTION
Manual backport of PR #23968.