### PR TITLE
PR: Improve message we show when getting a variable fails (Variable Explorer)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 # Max time before giving up when making a blocking call to the kernel
 CALL_KERNEL_TIMEOUT = 30
 
+# URL to our Github issues
+GH_ISSUES = "https://github.com/spyder-ide/spyder/issues/new"
+
 
 class NamepaceBrowserWidget(RichJupyterWidget):
     """
@@ -37,11 +40,18 @@ class NamepaceBrowserWidget(RichJupyterWidget):
     def get_value(self, name):
         """Ask kernel for a value"""
         reason_big = _("The variable is too big to be retrieved")
-        reason_not_picklable = _("The variable is not picklable")
+        reason_not_picklable = _(
+            "It was not possible to create a copy of the variable in the "
+            "kernel to pass it to Spyder."
+        )
         reason_dead = _("The kernel is dead")
-        reason_other = _("An unkown error occurred. Check the console because "
-                         "its contents could have been printed there")
-        reason_comm = _("The comm channel is not working")
+        reason_other = _(
+            "An unknown error occurred. Check the console because its contents "
+            "could have been printed there."
+        )
+        reason_comm = _(
+            "The channel used to communicate with the kernel is not working."
+        )
         reason_missing_package_installer = _(
             "The '{}' package is required to open this variable. "
             "Unfortunately, it's not part of our installer, which means your "
@@ -52,9 +62,13 @@ class NamepaceBrowserWidget(RichJupyterWidget):
             "installed alongside Spyder. To fix this problem, please install "
             "it in the same environment that you use to run Spyder."
         )
-        msg = _("<br><i>%s.</i><br><br><br>"
-                "<b>Note</b>: Please don't report this problem on Github, "
-                "there's nothing to do about it.")
+        msg = _(
+            "<br><i>%s.</i><br><br><br>"
+            "<b>Note</b>: If you consider this to be a valid error that needs "
+            "to be fixed by the Spyder team, please report it on "
+            "<a href='{}'>Github</a>."
+        ).format(GH_ISSUES)
+
         try:
             value = self.call_kernel(
                 blocking=True,
@@ -79,9 +93,7 @@ class NamepaceBrowserWidget(RichJupyterWidget):
                     msg % reason_missing_package_installer.format(e.name)
                 )
             else:
-                raise ValueError(
-                    msg % reason_missing_package.format(e.name)
-                )
+                raise ValueError(msg % reason_missing_package.format(e.name))
         except Exception:
             raise ValueError(msg % reason_other)
 

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -27,7 +27,6 @@ from qtpy.QtCore import (
     Qt,
     Signal,
 )
-from qtpy.QtGui import QMouseEvent
 from qtpy.QtWidgets import (
     QAbstractItemDelegate,
     QApplication,
@@ -214,12 +213,18 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
                 return
         except Exception as msg:
             self.sig_editor_shown.emit()
-            QMessageBox.critical(
-                self.parent(), _("Error"),
-                _("Spyder was unable to retrieve the value of "
-                  "this variable from the console.<br><br>"
-                  "The error message was:<br>"
-                  "%s") % to_text_string(msg))
+            msg_box = QMessageBox(self.parent())
+            msg_box.setTextFormat(Qt.RichText)  # Needed to enable links
+            msg_box.critical(
+                self.parent(),
+                _("Error"),
+                _(
+                    "Spyder was unable to retrieve the value of this variable "
+                    "from the console.<br><br>"
+                    "The problem is:<br>"
+                    "%s"
+                ) % str(msg)
+            )
             return
 
         key = index.model().get_key(index)
@@ -666,12 +671,18 @@ class ToggleColumnDelegate(CollectionsDelegate):
             if value is None:
                 return None
         except Exception as msg:
-            QMessageBox.critical(
-                self.parent(), _("Error"),
-                _("Spyder was unable to retrieve the value of "
-                  "this variable from the console.<br><br>"
-                  "The error message was:<br>"
-                  "<i>%s</i>") % to_text_string(msg))
+            msg_box = QMessageBox(self.parent())
+            msg_box.setTextFormat(Qt.RichText)  # Needed to enable links
+            msg_box.critical(
+                self.parent(),
+                _("Error"),
+                _(
+                    "Spyder was unable to retrieve the value of this variable "
+                    "from the console.<br><br>"
+                    "The problem is:<br>"
+                    "<i>%s</i>"
+                ) % str(msg)
+            )
             return
         self.current_index = index
 

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -46,7 +46,7 @@ from spyder_kernels.utils.nsview import (display_to_value, is_editable_type,
 
 # Local imports
 from spyder.api.fonts import SpyderFontsMixin, SpyderFontType
-from spyder.config.base import _, is_conda_based_app
+from spyder.api.translations import _
 from spyder.py3compat import is_binary_string, is_text_string, to_text_string
 from spyder.plugins.variableexplorer.widgets.arrayeditor import ArrayEditor
 from spyder.plugins.variableexplorer.widgets.dataframeeditor import (
@@ -163,7 +163,6 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
 
     def createEditor(self, parent, option, index, object_explorer=False):
         """Overriding method createEditor"""
-        val_type = index.sibling(index.row(), 1).data()
         self.sig_editor_creation_started.emit()
         if index.column() < 3:
             return None
@@ -180,37 +179,6 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
             value = self.get_value(index)
             if value is None:
                 return None
-        except ImportError as msg:
-            self.sig_editor_shown.emit()
-            module = str(msg).split("'")[1]
-            if module in ['pandas', 'numpy']:
-                if module == 'numpy':
-                    val_type = 'array'
-                else:
-                    val_type = 'dataframe or series'
-                message = _("Spyder is unable to show the {val_type} object "
-                            "you're trying to view because <tt>{module}</tt> "
-                            "is missing. Please install that package in your "
-                            "Spyder environment to fix this problem.")
-                QMessageBox.critical(
-                    self.parent(), _("Error"),
-                    message.format(val_type=val_type, module=module))
-                return
-            else:
-                if is_conda_based_app():
-                    message = _("Spyder is unable to show the variable you're"
-                                " trying to view because the module "
-                                "<tt>{module}</tt> is not supported "
-                                "by Spyder's standalone application.<br>")
-                else:
-                    message = _("Spyder is unable to show the variable you're"
-                                " trying to view because the module "
-                                "<tt>{module}</tt> is not found in your "
-                                "Spyder environment. Please install this "
-                                "package in this environment.<br>")
-                QMessageBox.critical(self.parent(), _("Error"),
-                                     message.format(module=module))
-                return
         except Exception as msg:
             self.sig_editor_shown.emit()
             msg_box = QMessageBox(self.parent())


### PR DESCRIPTION
## Description of Changes

- Reword some messages that were too short and cryptic. For example:

    `The variable is not picklable` to `It was not possible to create a copy of the variable in the kernel to pass it to Spyder`

- Ask users to report an issue to Github instead of deterring them from doing it. The previous message was not welcoming and users still have reported some issues despite it.
- Remove some code related to this in `CollectionsDelegate` that is not called anymore (error handling is managed in the IPython console now).
- We should add an FAQ to our docs later (as proposed by @dalthviz) to better explain to users why this problem can happen, and link it to this message. Then I'd say we can could issue #20671.

### Visual changes

| Before | After |
| - | - |
| ![imagen](https://github.com/user-attachments/assets/8375fbba-25c3-409f-941e-708f694cc014) | ![imagen](https://github.com/user-attachments/assets/17ab436c-26b9-49e2-9739-fa0087cd2fe9) |

### Issue(s) Resolved

Part of #20671.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
