### PR TITLE
PR: Remove mamba from Spyder's installer build and base environment (Installers)

### DIFF
--- a/installers-conda/build-environment.yml
+++ b/installers-conda/build-environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - conda-standalone =24.7.1
   - constructor =3.9.2
   - gitpython
-  - mamba
   - menuinst =2.1.2
   - ruamel.yaml.jinja2
   - setuptools_scm

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -142,7 +142,6 @@ base_specs = {
     "python": "=3.11.9",
     "conda": "=24.5.0",
     "menuinst": "=2.1.2",
-    "mamba": "=1.5.8",
 }
 rt_specs = {
     "python": f"={PY_VER}",

--- a/spyder/utils/conda.py
+++ b/spyder/utils/conda.py
@@ -85,7 +85,7 @@ def find_conda(pyexec=None):
     # First try Spyder's conda executable
     if is_conda_based_app():
         root = osp.dirname(os.environ['CONDA_EXE'])
-        conda = osp.join(root, 'mamba.exe' if WINDOWS else 'mamba')
+        conda = osp.join(root, 'conda.exe' if WINDOWS else 'conda')
 
     # Next try the environment variables
     if conda is None:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Spyder now looks for `conda` instead of `mamba` in the conda-based-app (installer) environment. `mamba` is removed from the requirements for both the build and base environment of the installer.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23940
