### PR TITLE
Backport PR #23278 on branch 6.x (PR: Reduce calls to get environment variables in SpyderKernelSpec and raise timeout threshold to do that)

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -859,7 +859,10 @@ def test_dedicated_consoles(main_window, qtbot):
         == "script.py/A"
     )
 
-    qtbot.waitUntil(lambda: nsb.editor.source_model.rowCount() == 4)
+    qtbot.waitUntil(
+        lambda: nsb.editor.source_model.rowCount() == 4,
+        timeout=SHELL_TIMEOUT
+    )
     assert nsb.editor.source_model.rowCount() == 4
 
     # --- Assert runfile text is present and we show the banner ---
@@ -867,11 +870,11 @@ def test_dedicated_consoles(main_window, qtbot):
     assert ('runfile' in text) and ('Python' in text and 'IPython' in text)
 
     # --- Check namespace retention after re-execution ---
-    with qtbot.waitSignal(shell.executed):
+    with qtbot.waitSignal(shell.executed, timeout=SHELL_TIMEOUT):
         shell.execute('zz = -1')
 
     qtbot.keyClick(code_editor, Qt.Key_F5)
-    qtbot.waitUntil(lambda: shell.is_defined('zz'))
+    qtbot.waitUntil(lambda: shell.is_defined('zz'), timeout=SHELL_TIMEOUT)
     assert shell.is_defined('zz')
 
     # --- Assert runfile text is present after reruns and there's no banner
@@ -885,7 +888,7 @@ def test_dedicated_consoles(main_window, qtbot):
 
     qtbot.wait(500)
     qtbot.keyClick(code_editor, Qt.Key_F5)
-    qtbot.waitUntil(lambda: not shell.is_defined('zz'))
+    qtbot.waitUntil(lambda: not shell.is_defined('zz'), timeout=SHELL_TIMEOUT)
     assert not shell.is_defined('zz')
 
     # --- Assert runfile text is present after reruns ---

--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -90,6 +90,8 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
         self.language = 'python3'
         self.resource_dir = ''
 
+        self.env = get_user_environment_variables()
+
     @property
     def argv(self):
         """Command to start kernels"""
@@ -201,7 +203,7 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
 
         # Ensure that user environment variables are included, but don't
         # override existing environ values
-        env_vars = get_user_environment_variables()
+        env_vars = self._env_vars.copy()
         env_vars.update(os.environ)
 
         # Avoid IPython adding the virtualenv on which Spyder is running
@@ -264,3 +266,8 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
         clean_env_vars = clean_env(env_vars)
 
         return clean_env_vars
+
+    @env.setter
+    def env(self, env_vars):
+        self._env_vars = dict(env_vars)
+        self._env_vars.pop('PYTEST_CURRENT_TEST', None)

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -111,15 +111,13 @@ def get_user_environment_variables():
         # We only need to do this if Spyder was **not** launched from a
         # terminal. Otherwise, it'll inherit the env vars present in it.
         # Fixes spyder-ide/spyder#22415
-        if not launched_from_terminal:
+        if not launched_from_terminal or running_in_ci():
             try:
                 user_env_script = _get_user_env_script()
                 proc = run_shell_command(user_env_script, env={}, text=True)
 
                 # Use timeout to fix spyder-ide/spyder#21172
-                stdout, stderr = proc.communicate(
-                    timeout=3 if running_in_ci() else 0.5
-                )
+                stdout, stderr = proc.communicate(timeout=3)
 
                 if stderr:
                     logger.info(stderr.strip())


### PR DESCRIPTION
Manual backport of PR #23278.