### PR TITLE
PR: More improvements to the message shown when a variable can't be displayed (Variable Explorer)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
@@ -53,17 +53,17 @@ class NamepaceBrowserWidget(RichJupyterWidget):
             "The channel used to communicate with the kernel is not working."
         )
         reason_missing_package_installer = _(
-            "The '{}' package is required to open this variable. "
+            "The '<tt>{}</tt>' module is required to open this variable. "
             "Unfortunately, it's not part of our installer, which means your "
             "variable can't be displayed by Spyder."
         )
         reason_missing_package = _(
-            "The '{}' package is required to open this variable and it's not "
-            "installed alongside Spyder. To fix this problem, please install "
-            "it in the same environment that you use to run Spyder."
+            "The '<tt>{}</tt>' module is required to open this variable and "
+            "it's not installed alongside Spyder. To fix this problem, please "
+            "install it in the same environment that you use to run Spyder."
         )
         msg = _(
-            "<br><i>%s.</i><br><br><br>"
+            "<br>%s<br><br>"
             "<b>Note</b>: If you consider this to be a valid error that needs "
             "to be fixed by the Spyder team, please report it on "
             "<a href='{}'>Github</a>."


### PR DESCRIPTION
## Description of Changes

- Refer to "module" instead of "package" when a ModuleNotFoundError is raised. That's because a package is composed of set of modules, but the error is about a single module.
- Use monospace font for the module name to make it different from the rest of the message.
- Remove italics for error messages. That simplifies the UI for the text in that dialog.
- Remove a spurious dot and extra blank line at the end of messages, which are unnecessary.

### Visual changes

| Before | After |
| - | - |
| ![imagen](https://github.com/user-attachments/assets/0009b231-a639-49db-9184-973329180ec8) | ![imagen](https://github.com/user-attachments/assets/20da83b3-0737-4a26-b5ae-192b17992730) |


### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
