### PR TITLE
PR: Fix `Check for updates at startup` checkbox being ignored when an update is declined (Update manager)

### DIFF
--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -497,6 +497,7 @@ class UpdateMessageCheckBox(MessageCheckBox):
         self.set_checkbox_text(_("Check for updates at startup"))
         self.option = 'check_updates_on_startup'
         self.accepted.connect(self.accept)  # ??? Why is the signal necessary?
+        self.rejected.connect(self.accept)
         if self._parent is not None:
             self.set_checked(parent.get_conf(self.option))
 

--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -501,7 +501,7 @@ class UpdateMessageCheckBox(MessageCheckBox):
         if self._parent is not None:
             self.set_checked(parent.get_conf(self.option))
 
-    def accept(self):
+    def on_close(self):
         if self._parent is not None:
             self._parent.set_conf(self.option, self.is_checked())
 

--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -496,8 +496,8 @@ class UpdateMessageCheckBox(MessageCheckBox):
         self._parent = parent
         self.set_checkbox_text(_("Check for updates at startup"))
         self.option = 'check_updates_on_startup'
-        self.accepted.connect(self.accept)  # ??? Why is the signal necessary?
-        self.rejected.connect(self.accept)
+        self.accepted.connect(self.on_close)
+        self.rejected.connect(self.on_close)
         if self._parent is not None:
             self.set_checked(parent.get_conf(self.option))
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes



<!--- Explain what you've done and why --->

Fix check for updates at startup checkbox


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23953


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@jsbautista 
<!--- Thanks for your help making Spyder better for everyone! --->
