### PR TITLE
PR: Return an iterable from `ls` method of `SpyderRemoteFileServicesAPI` (Remote client)

### DIFF
--- a/external-deps/spyder-remote-services/.gitrepo
+++ b/external-deps/spyder-remote-services/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-remote-services
-	branch = main
-	commit = 2b8dcf2aa3da5764136ee842724086aced71cba7
-	parent = 9c058adfa8ef3ed13cf31bc30b8400a36c819491
+	branch = feat-straming-ls
+	commit = fc7095d768f224dc9985760471d54fa36924073c
+	parent = e9154b9a4e0936f2139bc39d401be1ee060c81ad
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-remote-services/.gitrepo
+++ b/external-deps/spyder-remote-services/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-remote-services
-	branch = feat-straming-ls
-	commit = fc7095d768f224dc9985760471d54fa36924073c
-	parent = e9154b9a4e0936f2139bc39d401be1ee060c81ad
+	branch = main
+	commit = b4de4a02107feec976fe6f457278ace842c29ec1
+	parent = 11ab489965089bae137f60d0b73729082e05b3f4
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-remote-services/spyder_remote_services/services/files/base.py
+++ b/external-deps/spyder-remote-services/spyder_remote_services/services/files/base.py
@@ -358,18 +358,17 @@ class FilesRESTMixin:
         if path.is_file():
             # fsspec.ls of a file often returns a single entry
             if detail:
-                return [self._info_for_path(path)]
-
-            return [str(path)]
+                yield self._info_for_path(path)
+            else:
+                yield str(path)
+            return
 
         # Otherwise, it's a directory
-        results = []
         for p in path.glob("*"):
             if detail:
-                results.append(self._info_for_path(p))
+                yield self._info_for_path(p)
             else:
-                results.append(str(p))
-        return results
+                yield str(p)
 
     def fs_info(self, path_str: str):
         """Get info about a single path, like fsspec.info()."""

--- a/spyder/plugins/remoteclient/api/modules/file_services.py
+++ b/spyder/plugins/remoteclient/api/modules/file_services.py
@@ -401,7 +401,11 @@ class SpyderRemoteFileServicesAPI(SpyderBaseJupyterAPI):
             return await response.json()
 
     async def mkdir(
-        self, path: Path, *, create_parents: bool = True, exist_ok: bool = False
+        self,
+        path: Path,
+        *,
+        create_parents: bool = True,
+        exist_ok: bool = False
     ):
         async with self.session.post(
             self.api_url / "mkdir" / f"file://{path}",

--- a/spyder/plugins/remoteclient/api/modules/file_services.py
+++ b/spyder/plugins/remoteclient/api/modules/file_services.py
@@ -368,12 +368,13 @@ class SpyderRemoteFileServicesAPI(SpyderBaseJupyterAPI):
             data.get("tracebacks", []),
         )
 
-    async def ls(self, path: Path, detail: bool = True):
+    async def ls(self, path: Path, *, detail: bool = True):
         async with self.session.get(
             self.api_url / "ls" / f"file://{path}",
             params={"detail": str(detail).lower()},
         ) as response:
-            return await response.json()
+            async for line in response.content:
+                yield json.loads(line)
 
     async def info(self, path: Path):
         async with self.session.get(
@@ -400,7 +401,7 @@ class SpyderRemoteFileServicesAPI(SpyderBaseJupyterAPI):
             return await response.json()
 
     async def mkdir(
-        self, path: Path, create_parents: bool = True, exist_ok: bool = False
+        self, path: Path, *, create_parents: bool = True, exist_ok: bool = False
     ):
         async with self.session.post(
             self.api_url / "mkdir" / f"file://{path}",

--- a/spyder/plugins/remoteclient/tests/test_files.py
+++ b/spyder/plugins/remoteclient/tests/test_files.py
@@ -151,7 +151,8 @@ class TestRemoteFilesAPI:
 
         async with file_api_class() as file_api:
             with pytest.raises(RemoteOSError) as exc_info:
-                await file_api.ls(self.remote_temp_dir)
+                async for ls_file in file_api.ls(self.remote_temp_dir):
+                    ...
 
         assert exc_info.value.errno == 2  # ENOENT: No such file or directory
 

--- a/spyder/plugins/remoteclient/tests/test_files.py
+++ b/spyder/plugins/remoteclient/tests/test_files.py
@@ -65,19 +65,18 @@ class TestRemoteFilesAPI:
         assert file_api_class is not None
 
         async with file_api_class() as file_api:
-            ls_content = await file_api.ls(self.remote_temp_dir)
-            assert len(ls_content) == 1
-            assert ls_content[0]["name"] == self.remote_temp_dir + "/test.txt"
-            assert ls_content[0]["size"] == 13
-            assert ls_content[0]["type"] == "file"
-            assert not ls_content[0]["islink"]
-            assert ls_content[0]["created"] > 0
-            assert ls_content[0]["mode"] == 0o100644
-            assert ls_content[0]["uid"] > 0
-            assert ls_content[0]["gid"] >= 0
-            assert ls_content[0]["mtime"] > 0
-            assert ls_content[0]["ino"] > 0
-            assert ls_content[0]["nlink"] == 1
+            async for ls_content in file_api.ls(self.remote_temp_dir):
+                assert ls_content["name"] == self.remote_temp_dir + "/test.txt"
+                assert ls_content["size"] == 13
+                assert ls_content["type"] == "file"
+                assert not ls_content["islink"]
+                assert ls_content["created"] > 0
+                assert ls_content["mode"] == 0o100644
+                assert ls_content["uid"] > 0
+                assert ls_content["gid"] >= 0
+                assert ls_content["mtime"] > 0
+                assert ls_content["ino"] > 0
+                assert ls_content["nlink"] == 1
 
     @AsyncDispatcher(early_return=False)
     async def test_copy_file(
@@ -96,7 +95,7 @@ class TestRemoteFilesAPI:
             ) == {"success": True}
 
         async with file_api_class() as file_api:
-            ls_content = await file_api.ls(self.remote_temp_dir)
+            ls_content = [ls_file async for ls_file in file_api.ls(self.remote_temp_dir)]
             assert len(ls_content) == 2
             idx = [
                 item["name"] for item in ls_content

--- a/spyder/plugins/remoteclient/tests/test_files.py
+++ b/spyder/plugins/remoteclient/tests/test_files.py
@@ -95,7 +95,9 @@ class TestRemoteFilesAPI:
             ) == {"success": True}
 
         async with file_api_class() as file_api:
-            ls_content = [ls_file async for ls_file in file_api.ls(self.remote_temp_dir)]
+            ls_content = [
+                ls_file async for ls_file in file_api.ls(self.remote_temp_dir)
+            ]
             assert len(ls_content) == 2
             idx = [
                 item["name"] for item in ls_content


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [X] Wrote at least one-line docstrings (for any new functions)
* [X] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [X] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Modified `ls` method from `SpyderRemoteFileServicesAPI` to return an async generator and consume fron the stream of ls generated from the `spyder-remote-services`.

Implements the client-side update for: https://github.com/spyder-ide/spyder-remote-services/pull/12


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @hlouzada

<!--- Thanks for your help making Spyder better for everyone! --->
