### PR TITLE
PR: formatting of generated docstrings according to style-guides

### DIFF
--- a/spyder/plugins/editor/extensions/docstring.py
+++ b/spyder/plugins/editor/extensions/docstring.py
@@ -407,7 +407,7 @@ class DocstringWriterExtension(object):
         indent1 = func_info.func_indent + self.code_editor.indent_chars
         indent2 = func_info.func_indent + self.code_editor.indent_chars * 2
 
-        numpy_doc += '\n{}\n'.format(indent1)
+        numpy_doc += '\n{}SUMMARY.\n'.format(indent1)
 
         if len(arg_names) > 0:
             numpy_doc += '\n{}Parameters'.format(indent1)
@@ -435,14 +435,6 @@ class DocstringWriterExtension(object):
 
         numpy_doc += arg_text
 
-        if func_info.raise_list:
-            numpy_doc += '\n{}Raises'.format(indent1)
-            numpy_doc += '\n{}------'.format(indent1)
-            for raise_type in func_info.raise_list:
-                numpy_doc += '\n{}{}'.format(indent1, raise_type)
-                numpy_doc += '\n{}DESCRIPTION.'.format(indent2)
-            numpy_doc += '\n'
-
         numpy_doc += '\n'
         if func_info.has_yield:
             header = '{0}Yields\n{0}------\n'.format(indent1)
@@ -458,8 +450,12 @@ class DocstringWriterExtension(object):
             return_element_type = indent1 + '{return_type}\n' + indent2 + \
                 'DESCRIPTION.'
             placeholder = return_element_type.format(return_type='TYPE')
-            return_element_name = indent1 + '{return_name} : ' + \
-                placeholder.lstrip()
+            if len([rv for rvs in func_info.return_value_in_body for rv in rvs.split(",")]) == 1:
+                # numpydoc RT02, only include type and not name if it's a single return value
+                return_element_name = indent1 + placeholder.lstrip()
+            else:
+                return_element_name = indent1 + '{return_name} : ' + \
+                    placeholder.lstrip()
 
             try:
                 return_section = self._generate_docstring_return_section(
@@ -470,7 +466,16 @@ class DocstringWriterExtension(object):
                 return_section = '{}{}None.'.format(header, indent1)
 
         numpy_doc += return_section
-        numpy_doc += '\n\n{}{}'.format(indent1, self.quote3)
+
+        if func_info.raise_list:
+            numpy_doc += '\n\n{}Raises'.format(indent1)
+            numpy_doc += '\n{}------'.format(indent1)
+            for raise_type in func_info.raise_list:
+                numpy_doc += '\n{}{}'.format(indent1, raise_type)
+                numpy_doc += '\n{}DESCRIPTION.'.format(indent2)
+
+        numpy_doc = numpy_doc.rstrip('\n')
+        numpy_doc += '\n{}{}'.format(indent1, self.quote3)
 
         return numpy_doc
 
@@ -490,7 +495,7 @@ class DocstringWriterExtension(object):
         indent1 = func_info.func_indent + self.code_editor.indent_chars
         indent2 = func_info.func_indent + self.code_editor.indent_chars * 2
 
-        google_doc += '\n{}\n'.format(indent1)
+        google_doc += 'SUMMARY.\n'
 
         if len(arg_names) > 0:
             google_doc += '\n{0}Args:\n'.format(indent1)
@@ -514,18 +519,11 @@ class DocstringWriterExtension(object):
 
             if arg_value:
                 arg_value = arg_value.replace(self.quote3, self.quote3_other)
-                arg_text += ' Defaults to {}.\n'.format(arg_value)
-            else:
-                arg_text += '\n'
+                arg_text += ' Defaults to {}.'.format(arg_value)
+
+            arg_text += '\n'
 
         google_doc += arg_text
-
-        if func_info.raise_list:
-            google_doc += '\n{0}Raises:'.format(indent1)
-            for raise_type in func_info.raise_list:
-                google_doc += '\n{}{}'.format(indent2, raise_type)
-                google_doc += ': DESCRIPTION.'
-            google_doc += '\n'
 
         google_doc += '\n'
         if func_info.has_yield:
@@ -552,7 +550,15 @@ class DocstringWriterExtension(object):
                 return_section = '{}{}None.'.format(header, indent2)
 
         google_doc += return_section
-        google_doc += '\n\n{}{}'.format(indent1, self.quote3)
+
+        if func_info.raise_list:
+            google_doc += '\n\n{0}Raises:'.format(indent1)
+            for raise_type in func_info.raise_list:
+                google_doc += '\n{}{}'.format(indent2, raise_type)
+                google_doc += ': DESCRIPTION.'
+
+        google_doc = google_doc.rstrip('\n')
+        google_doc += '\n{}{}'.format(indent1, self.quote3)
 
         return google_doc
 
@@ -571,7 +577,7 @@ class DocstringWriterExtension(object):
 
         indent1 = func_info.func_indent + self.code_editor.indent_chars
 
-        sphinx_doc += '\n{}\n'.format(indent1)
+        sphinx_doc += 'SUMMARY.\n\n'
 
         arg_text = ''
         for arg_name, arg_type, arg_value in zip(arg_names, arg_types,
@@ -617,7 +623,9 @@ class DocstringWriterExtension(object):
             return_section += '{}:rtype: TYPE'.format(indent1)
 
         sphinx_doc += return_section
-        sphinx_doc += '\n\n{}{}'.format(indent1, self.quote3)
+
+        sphinx_doc = sphinx_doc.rstrip('\n')
+        sphinx_doc += '\n{}{}'.format(indent1, self.quote3)
 
         return sphinx_doc
 

--- a/spyder/plugins/editor/extensions/docstring.py
+++ b/spyder/plugins/editor/extensions/docstring.py
@@ -463,7 +463,7 @@ class DocstringWriterExtension(object):
                     return_element_name, return_element_type, placeholder,
                     indent1)
             except (ValueError, IndexError):
-                return_section = '{}{}None.'.format(header, indent1)
+                return_section = ''
 
         numpy_doc += return_section
 
@@ -547,7 +547,7 @@ class DocstringWriterExtension(object):
                     return_element_name, return_element_type, placeholder,
                     indent2)
             except (ValueError, IndexError):
-                return_section = '{}{}None.'.format(header, indent2)
+                return_section = ''
 
         google_doc += return_section
 
@@ -614,7 +614,9 @@ class DocstringWriterExtension(object):
             header = '{}:return:'.format(indent1)
 
         return_type_annotated = func_info.return_type_annotated
-        if return_type_annotated:
+        if not func_info.return_value_in_body and not return_type_annotated:
+            return_section = ''
+        elif return_type_annotated:
             return_section = '{} DESCRIPTION\n'.format(header)
             return_section += '{}:rtype: {}'.format(indent1,
                                                     return_type_annotated)
@@ -731,7 +733,7 @@ class DocstringWriterExtension(object):
         non_none_vals = [return_val for return_val in return_vals
                          if return_val and return_val != 'None']
         if not non_none_vals:
-            return header + indent + 'None.'
+            return ''
 
         # Get only values with matching brackets that can be cleaned up
         non_none_vals = [return_val.strip(' ()\t\n').rstrip(',')


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

The aim of this PR is to make the auto-generated docstrings pass numpydoc linting. Some changes also included for the Google and Sphinx docstring style. See #24040 

Specifically, this PR:
- Add "SUMMARY." to the beginning of the docstring, for numpy, google and sphinx docstrings (Fixes numpydoc lint SS01).
- Change order so that "Raises" comes after "Returns" section for numpy and google style (fixes numpydoc lint GL07), following these style guides.
- Strip newline characeters at the end of the docstring (fixes numpydoc lint GL02/GL03). This also closes #22043 (following comment https://github.com/spyder-ide/spyder/issues/22043#issuecomment-2502345238).
- Remove variable name from numpy return section when only a single value is returned (fixes numpydoc lint RT02)
- Remove "Returns" section if function has no return value (i.e. returns None), see notes just below.

How to deal with None return values is a bit unclear.
Currently, this PR has removed the return section if it only returns None. 

Google style-guide: "If the function only returns None, this section is not required."
Numpydoc: not mentioned, but convention appears to be to omit the section: https://stackoverflow.com/a/66176351
Sphinx: unclear

An alternative, in the case of numpy, would be to produce something like this to pass numpydoc linting.
```
Returns
-------
None
	None.
```
Or keep the current behavior on master.


Once the changes to be included in this PR are agreed on I will deal with the tests.

Links and references:
Google docstring style: https://google.github.io/styleguide/pyguide.html#383-functions-and-methods
Sphinx docstring style: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html#the-sphinx-docstring-format , 
Numpydoc: https://numpydoc.readthedocs.io/en/latest/format.html#sections

Additional note:
There are some inconsistencies in how the return section is generated, at least for numpy style, with multiple return values and depending on if the return value is type annotated or not.
These are however still valid docstrings as far as I can tell, so I consider this outside the scope of this PR.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24040 and #22043


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @rhkarls 

<!--- Thanks for your help making Spyder better for everyone! --->
