### PR TITLE
PR: Revert removing mamba from base environment specification

### DIFF
--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -142,6 +142,7 @@ base_specs = {
     "python": "=3.11.9",
     "conda": "=24.5.0",
     "menuinst": "=2.1.2",
+    "mamba": "=1.5.8",
 }
 rt_specs = {
     "python": f"={PY_VER}",

--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -142,7 +142,7 @@ base_specs = {
     "python": "=3.11.9",
     "conda": "=24.5.0",
     "menuinst": "=2.1.2",
-    "mamba": "=1.5.8",
+    "mamba": "=1.5.8",  # Remove for Spyder 7
 }
 rt_specs = {
     "python": f"={PY_VER}",


### PR DESCRIPTION
The conda-based installer base environment should not change primary dependencies for a minor/micro release.

Fixes #24058 