### PR TITLE
PR: Fix connecting to remote host with key file and passphrase (Remote client)

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -12,6 +12,7 @@ dependencies:
 - aiohttp >=3.9.3
 - asyncssh >=2.14.0,<3.0.0
 - atomicwrites >=1.2.0
+- bcrypt >=4.3.0
 - chardet >=2.0.0
 - cloudpickle >=0.5.0
 - cookiecutter >=1.6.0

--- a/requirements/main.yml
+++ b/requirements/main.yml
@@ -10,6 +10,7 @@ dependencies:
   - aiohttp >=3.9.3
   - asyncssh >=2.14.0,<3.0.0
   - atomicwrites >=1.2.0
+  - bcrypt >=4.3.0
   - chardet >=2.0.0
   - cloudpickle >=0.5.0
   - cookiecutter >=1.6.0

--- a/setup.py
+++ b/setup.py
@@ -272,6 +272,7 @@ install_requires += [
     'applaunchservices>=0.3.0;platform_system=="Darwin"',
     'asyncssh>=2.14.0,<3.0.0',
     'atomicwrites>=1.2.0',
+    'bcrypt>=4.3.0',
     'chardet>=2.0.0',
     'cloudpickle>=0.5.0',
     'cookiecutter>=1.6.0',

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -38,6 +38,7 @@ AIOHTTP_REQVER = '>=3.9.3'
 APPLAUNCHSERVICES_REQVER = '>=0.3.0'
 ASYNCSSH_REQVER = '>=2.14.0,<3.0.0'
 ATOMICWRITES_REQVER = '>=1.2.0'
+BCRYPT_REQVER = ">=4.3.0"
 CHARDET_REQVER = '>=2.0.0'
 CLOUDPICKLE_REQVER = '>=0.5.0'
 COOKIECUTTER_REQVER = '>=1.6.0'
@@ -115,6 +116,10 @@ DESCRIPTIONS = [
      'package_name': "atomicwrites",
      'features': _("Atomic file writes in the Editor"),
      'required_version': ATOMICWRITES_REQVER},
+    {'modname': "bcrypt",
+     'package_name': "bcrypt",
+     'features': _("Decrypt passphrase of SSH key files"),
+     'required_version': BCRYPT_REQVER},
     {'modname': "chardet",
      'package_name': "chardet",
      'features': _("Character encoding auto-detection for the Editor"),

--- a/spyder/plugins/remoteclient/plugin.py
+++ b/spyder/plugins/remoteclient/plugin.py
@@ -214,12 +214,12 @@ class RemoteClient(SpyderPluginV2):
             return {}
 
         if options["client_keys"]:
-            passpharse = self.get_conf(f"{config_id}/passpharse", secure=True)
+            passphrase = self.get_conf(f"{config_id}/passphrase", secure=True)
             options["client_keys"] = [options["client_keys"]]
 
             # Passphrase is optional
-            if passpharse:
-                options["passpharse"] = passpharse
+            if passphrase:
+                options["passphrase"] = passphrase
         elif options["config"]:
             # TODO: Check how this needs to be handled
             pass

--- a/spyder/plugins/remoteclient/plugin.py
+++ b/spyder/plugins/remoteclient/plugin.py
@@ -231,6 +231,9 @@ class RemoteClient(SpyderPluginV2):
         # Default for now
         options["platform"] = "linux"
 
+        # Don't require the host to be known to connect to it
+        options["known_hosts"] = None
+
         return SSHClientOptions(**options)
 
     def get_loaded_servers(self):

--- a/spyder/plugins/remoteclient/widgets/connectiondialog.py
+++ b/spyder/plugins/remoteclient/widgets/connectiondialog.py
@@ -439,9 +439,9 @@ class BaseConnectionPage(SpyderConfigPage, SpyderFontsMixin):
             status_icon=ima.icon("error"),
         )
 
-        passpharse = self.create_lineedit(
-            text=_("Passpharse"),
-            option=f"{self.host_id}/passpharse",
+        passphrase = self.create_lineedit(
+            text=_("Passphrase"),
+            option=f"{self.host_id}/passphrase",
             tip=(
                 _("Your passphrase will be saved securely by Spyder")
                 if self.NEW_CONNECTION
@@ -473,7 +473,7 @@ class BaseConnectionPage(SpyderConfigPage, SpyderFontsMixin):
         keyfile_layout.addSpacing(5 * AppStyle.MarginSize)
         keyfile_layout.addWidget(keyfile)
         keyfile_layout.addSpacing(5 * AppStyle.MarginSize)
-        keyfile_layout.addWidget(passpharse)
+        keyfile_layout.addWidget(passphrase)
         keyfile_layout.addSpacing(7 * AppStyle.MarginSize)
         keyfile_layout.addWidget(validation_label)
         keyfile_layout.addStretch()
@@ -687,7 +687,7 @@ class ConnectionPage(BaseConnectionPage):
             self.remove_option(f"{self.host_id}/{option}")
 
         # Remove secure options
-        for secure_option in ["password", "passpharse"]:
+        for secure_option in ["password", "passphrase"]:
             # One of these options was saved securely and other as empty in our
             # config system, so we try to remove them both.
             for secure in [True, False]:


### PR DESCRIPTION
## Description of Changes

- Fix typo in `passphrase` variable used in several places.
- Add `bcrypt` as a new dependency because it's required by `asyncssh` to decrypt the keyfile's passphrase.
- Also, set `known_hosts = None` when creating an SSH connection with `asyncssh`. That way users won't need to confirm first the remote host as known in a terminal.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23375.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
