### PR TITLE
PR: Catch error when computing max of columms in dataframe editor (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -337,9 +337,9 @@ class DataFrameModel(QAbstractTableModel, SpyderFontsMixin):
             return
         self.max_min_col = []
         for __, col in self.df.items():
-            # This is necessary to catch an error in Pandas when computing
+            # This is necessary to catch some errors in Pandas when computing
             # the maximum of a column.
-            # Fixes spyder-ide/spyder#17145
+            # Fixes spyder-ide/spyder#17145 and spyder-ide/spyder#24094
             try:
                 if (
                     is_any_real_numeric_dtype(col.dtype)
@@ -357,8 +357,9 @@ class DataFrameModel(QAbstractTableModel, SpyderFontsMixin):
                         max_min = [vmax, vmin - 1]
                 else:
                     max_min = None
-            except TypeError:
+            except (TypeError, ValueError):
                 max_min = None
+
             self.max_min_col.append(max_min)
 
     def get_format_spec(self) -> str:


### PR DESCRIPTION
## Description of Changes

It's hard to know why this error happens but the best we can do is to catch it and disable the associated functionality because it's an error raised by Pandas.

### Issue(s) Resolved

Fixes #24094.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
