### PR TITLE
PR: Don't advance line when running code if there's selected text (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -3147,11 +3147,11 @@ class EditorMainWidget(PluginMainWidget):
             else:
                 text, offsets, line_cols, enc = editorstack.get_selection()
 
-            # Don't advance line if the selection includes multiple lines. That
+            # Don't advance line if there is text selected in the editor. That
             # was the behavior in Spyder 5 and users are accustomed to it.
-            # Fixes spyder-ide/spyder#22060
-            eol = self.get_current_editor().get_line_separator()
-            if extra_action_name == ExtraAction.Advance and not (eol in text):
+            # Fixes spyder-ide/spyder#22060 and spyder-ide/spyder#24091
+            has_selection = self.get_current_editor().has_selected_text()
+            if extra_action_name == ExtraAction.Advance and not has_selection:
                 editorstack.advance_line()
 
             context_name = 'Selection'


### PR DESCRIPTION
## Description of Changes

- Users expect selections to be preserved even when running a single line.
- I didn't consider that use case in PR #22940, but the fix was simple enough.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24091

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
