### PR TITLE
PR: Use checksum to verify downloaded asset for updating Spyder (Update manager)

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -355,15 +355,10 @@ jobs:
 
           EXIT /B %ERRORLEVEL%
 
-      - name: Notarize or Compute Checksum
-        if: env.NOTARIZE == 'true'
+      - name: Notarize
+        if: runner.os == 'macOS' && env.NOTARIZE == 'true'
         run: |
-          if [[ $RUNNER_OS == "macOS" ]]; then
-              ./notarize.sh -p $APPLICATION_PWD $PKG_PATH
-          else
-              cd $DISTDIR
-              echo $(sha256sum $PKG_NAME) > "${ARTIFACT_NAME}-sha256sum.txt"
-          fi
+          ./notarize.sh -p $APPLICATION_PWD $PKG_PATH
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
@@ -390,11 +385,21 @@ jobs:
       - name: Zip Lock Files
         run: zip -mT spyder-conda-lock *.lock
 
-      - name: Upload Artifact
+      - name: Create Checksums
+        run: |
+          sha256sum *.zip *.pkg *.sh *.exe > Spyder-checksums.txt
+
+      - name: Upload Lock Files
         uses: actions/upload-artifact@v4
         with:
           path: spyder-conda-lock.zip
-          name: spyder-conda-lock
+          name: spyder-conda-lock-artifact
+
+      - name: Upload Checksums
+        uses: actions/upload-artifact@v4
+        with:
+          path: Spyder-checksums.txt
+          name: Spyder-checksums
 
       - name: Get Release
         if: env.IS_RELEASE == 'true'

--- a/spyder/plugins/updatemanager/tests/test_update_manager.py
+++ b/spyder/plugins/updatemanager/tests/test_update_manager.py
@@ -69,7 +69,7 @@ def test_updates(qtbot, mocker, caplog, version, channel):
 
 
 @pytest.mark.parametrize("version", ["4.0.0a1", "4.0.0"])
-@pytest.mark.parametrize("release", ["6.0.0", "6.0.0b3"])
+@pytest.mark.parametrize("release", ["6.0.0", "6.0.0rc1"])
 @pytest.mark.parametrize("stable_only", [True, False])
 def test_update_non_stable(qtbot, mocker, version, release, stable_only):
     """Test we offer unstable updates."""

--- a/spyder/plugins/updatemanager/tests/test_update_manager.py
+++ b/spyder/plugins/updatemanager/tests/test_update_manager.py
@@ -22,6 +22,7 @@ from spyder.plugins.updatemanager.widgets.update import UpdateManagerWidget
 logging.basicConfig()
 
 workers.get_github_releases = lru_cache(workers.get_github_releases)
+workers.get_asset_checksum = lru_cache(workers.get_asset_checksum)
 
 
 @pytest.fixture(autouse=True)
@@ -59,7 +60,7 @@ def test_updates(qtbot, mocker, caplog, version, channel):
 
     um = UpdateManagerWidget(None)
     um.start_check_update()
-    qtbot.waitUntil(um.update_thread.isFinished)
+    qtbot.waitUntil(um.update_thread.isFinished, timeout=10000)
 
     if version.split('.')[0] == '1':
         assert um.update_worker.asset_info is not None

--- a/spyder/plugins/updatemanager/tests/test_update_manager.py
+++ b/spyder/plugins/updatemanager/tests/test_update_manager.py
@@ -23,6 +23,14 @@ logging.basicConfig()
 
 workers.get_github_releases = lru_cache(workers.get_github_releases)
 workers.get_asset_checksum = lru_cache(workers.get_asset_checksum)
+_tags = (
+    "v6.0.5", "v6.0.5rc1", "v6.1.0a1", "v6.0.4",
+    "v6.0.4rc1", "v6.0.3", "v6.0.3rc2", "v6.0.3rc1",
+    "v6.0.2", "v6.0.2rc1", "v6.0.1", "v6.0.0",
+    "v5.5.6", "v6.0.0rc2", "v6.0.0rc1", "v6.0.0b3",
+    "v6.0.0b2", "v5.5.5", "v6.0.0b1", "v6.0.0a5"
+)
+workers.get_github_releases(_tags)  # Run once to cache result for tests
 
 
 @pytest.fixture(autouse=True)

--- a/spyder/plugins/updatemanager/tests/test_update_manager.py
+++ b/spyder/plugins/updatemanager/tests/test_update_manager.py
@@ -85,7 +85,7 @@ def test_update_non_stable(qtbot, mocker, version, release, stable_only):
 
     release = parse(release)
     worker = WorkerUpdate(stable_only)
-    worker._check_asset_available(release)
+    worker._check_update_available(release)
 
     if release.is_prerelease and stable_only:
         assert worker.asset_info is None
@@ -101,7 +101,7 @@ def test_update_no_asset(qtbot, mocker, version, release):
 
     release = parse(release) if release else None
     worker = WorkerUpdate(True)
-    worker._check_asset_available(release)
+    worker._check_update_available(release)
 
     # For both values of version, there should be an update available
     # However, the available version should be 6.0.1, since there is
@@ -126,8 +126,7 @@ def test_get_asset_info(qtbot, mocker, app, version, release, update_type):
     mocker.patch.object(workers, "is_conda_based_app", return_value=app)
 
     worker = WorkerUpdate(False)
-    # import pdb; pdb.set_trace()
-    worker._check_asset_available(parse(release))
+    worker._check_update_available(parse(release))
     info = worker.asset_info
 
     assert info['update_type'] == update_type

--- a/spyder/plugins/updatemanager/tests/test_update_manager.py
+++ b/spyder/plugins/updatemanager/tests/test_update_manager.py
@@ -23,12 +23,9 @@ logging.basicConfig()
 
 @pytest.fixture(autouse=True)
 def capture_logging(caplog):
+    # Capture >=DEBUG logging messages for spyder.plugins.updatemanager.
+    # Messages will be reported at the end of the pytest run for failed tests.
     caplog.set_level(10, "spyder.plugins.updatemanager")
-
-
-@pytest.fixture
-def worker():
-    return WorkerUpdate(None)
 
 
 # ---- Test WorkerUpdate
@@ -57,13 +54,9 @@ def test_updates(qtbot, mocker, caplog, version, channel):
         workers, "get_spyder_conda_channel", return_value=channel
     )
 
-    with caplog.at_level(logging.DEBUG, logger='spyder.plugins.updatemanager'):
-        # Capture >=DEBUG logging messages for spyder.plugins.updatemanager
-        # while checking for updates. Messages will be reported at the end
-        # of the pytest run, and only if this test fails.
-        um = UpdateManagerWidget(None)
-        um.start_check_update()
-        qtbot.waitUntil(um.update_thread.isFinished)
+    um = UpdateManagerWidget(None)
+    um.start_check_update()
+    qtbot.waitUntil(um.update_thread.isFinished)
 
     if um.update_worker.error:
         # Possible 403 error - rate limit error, was encountered while doing
@@ -73,17 +66,14 @@ def test_updates(qtbot, mocker, caplog, version, channel):
         assert um.update_worker.error == HTTP_ERROR_MSG.format(status_code="403")
         return
 
-    assert not um.update_worker.error
-
-    update_available = um.update_worker.update_available
     if version.split('.')[0] == '1':
-        assert update_available
+        assert um.update_worker.asset_info is not None
     else:
-        assert not update_available
+        assert um.update_worker.asset_info is None
 
 
-@pytest.mark.parametrize("release", ["6.0.0", "6.0.0b3"])
 @pytest.mark.parametrize("version", ["4.0.0a1", "4.0.0"])
+@pytest.mark.parametrize("release", ["6.0.0", "6.0.0b3"])
 @pytest.mark.parametrize("stable_only", [True, False])
 def test_update_non_stable(qtbot, mocker, version, release, stable_only):
     """Test we offer unstable updates."""
@@ -91,44 +81,51 @@ def test_update_non_stable(qtbot, mocker, version, release, stable_only):
 
     release = parse(release)
     worker = WorkerUpdate(stable_only)
-    worker._check_update_available([release])
+    worker._check_asset_available(release)
 
     if release.is_prerelease and stable_only:
-        assert not worker.update_available
+        assert worker.asset_info is None
     else:
-        assert worker.update_available
+        assert worker.asset_info is not None
 
 
 @pytest.mark.parametrize("version", ["4.0.0", "6.0.0"])
-def test_update_no_asset(qtbot, mocker, version):
+@pytest.mark.parametrize("release", [None, "6.0.1", "6.100.0"])
+def test_update_no_asset(qtbot, mocker, version, release):
     """Test update availability when asset is not available"""
     mocker.patch.object(workers, "CURRENT_VERSION", new=parse(version))
 
-    releases = [parse("6.0.1"), parse("6.100.0")]
+    release = parse(release) if release else None
     worker = WorkerUpdate(True)
-    worker._check_update_available(releases)
+    worker._check_asset_available(release)
 
     # For both values of version, there should be an update available
     # However, the available version should be 6.0.1, since there is
     # no asset for 6.100.0
-    assert worker.update_available
-    assert worker.latest_release == releases[0]
+    assert worker.asset_info is not None
+    assert worker.asset_info["version"] >= parse("6.0.1")
 
 
 @pytest.mark.parametrize(
-    "release,update_type",
+    "app,version,release,update_type",
     [
-        ("6.0.1", UpdateType.Micro),
-        ("6.1.0", UpdateType.Minor),
-        ("7.0.0", UpdateType.Major)
+        (True, "6.0.0", "6.0.1", UpdateType.Micro),
+        (True, "6.0.0", "6.1.0a1", UpdateType.Minor),
+        (True, "5.0.0", "6.0.0", UpdateType.Major),
+        (False, "6.0.0", "6.0.1", UpdateType.Major),
+        (False, "6.0.0", "6.1.0a1", UpdateType.Major),
+        (False, "5.0.0", "6.0.0", UpdateType.Major)
     ]
 )
-@pytest.mark.parametrize("app", [True, False])
-def test_get_asset_info(qtbot, mocker, release, update_type, app):
-    mocker.patch.object(workers, "CURRENT_VERSION", new=parse("6.0.0"))
+def test_get_asset_info(qtbot, mocker, app, version, release, update_type):
+    mocker.patch.object(workers, "CURRENT_VERSION", new=parse(version))
     mocker.patch.object(workers, "is_conda_based_app", return_value=app)
 
-    info = get_asset_info(release)
+    worker = WorkerUpdate(False)
+    # import pdb; pdb.set_trace()
+    worker._check_asset_available(parse(release))
+    info = worker.asset_info
+
     assert info['update_type'] == update_type
 
     if update_type == "major" or not app:
@@ -149,8 +146,11 @@ def test_download(qtbot, mocker):
 
     Uses UpdateManagerWidget in order to also test QThread.
     """
+    releases = workers.get_github_releases()
+    release_info = releases[parse("6.0.0a2")]
+
     um = UpdateManagerWidget(None)
-    um.latest_release = "6.0.0a2"
+    um.asset_info = get_asset_info(release_info)
     um._set_installer_path()
 
     # Do not execute _start_install after download completes.

--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -26,6 +26,7 @@ from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.api.translations import _
 from spyder.config.base import is_conda_based_app
 from spyder.plugins.updatemanager.workers import (
+    validate_download,
     WorkerUpdate,
     WorkerDownloadInstaller
 )
@@ -258,11 +259,11 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
 
         logger.info(f"Update type: {self.asset_info['update_type']}")
 
-    def _verify_installer_path(self):
+    def _validate_download(self):
         update_downloaded = False
         if osp.exists(self.installer_path):
-            update_downloaded = (
-                self.asset_info["size"] == osp.getsize(self.installer_path)
+            update_downloaded = validate_download(
+                self.installer_path, self.asset_info["checksum"]
             )
 
         logger.debug(f"Update already downloaded: {update_downloaded}")
@@ -282,7 +283,7 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         self._set_installer_path()
         version = self.asset_info["version"]
 
-        if self._verify_installer_path():
+        if self._validate_download():
             self.set_status(DOWNLOAD_FINISHED)
             self._confirm_install()
         elif not is_conda_based_app():

--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -26,7 +26,6 @@ from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.api.translations import _
 from spyder.config.base import is_conda_based_app
 from spyder.plugins.updatemanager.workers import (
-    get_asset_info,
     WorkerUpdate,
     WorkerDownloadInstaller
 )
@@ -133,23 +132,22 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         self.update_thread = None
         self.update_worker = None
         self.update_timer = None
-        self.latest_release = None
+        self.asset_info = None
 
         self.cancelled = False
         self.download_thread = None
         self.download_worker = None
         self.progress_dialog = None
         self.installer_path = None
-        self.installer_size_path = None
-
-        # Type of Spyder update. It can be "major", "minor" or "micro"
-        self.update_type = None
 
     # ---- General
 
     def set_status(self, status=NO_STATUS):
         """Set the update manager status."""
-        self.sig_set_status.emit(status, str(self.latest_release))
+        version = None
+        if self.asset_info is not None:
+            version = self.asset_info["version"]
+        self.sig_set_status.emit(status, str(version))
 
     def cleanup_threads(self):
         """Clean up QThreads"""
@@ -226,7 +224,7 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
     def _process_check_update(self):
         """Process the results of check update."""
         # Get results from worker
-        update_available = self.update_worker.update_available
+        update_available = self.update_worker.asset_info is not None
         error_msg = self.update_worker.error
         checkbox = self.update_worker.checkbox
 
@@ -250,30 +248,22 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         else:
             info_messagebox(self, _("Spyder is up to date."), checkbox=True)
 
-    def _set_installer_path(self):
-        """Set the temp file path for the downloaded installer."""
-        asset_info = get_asset_info(self.latest_release)
-        self.update_type = asset_info['update_type']
-
-        dirname = osp.join(get_temp_dir(), 'updates', str(self.latest_release))
-        self.installer_path = osp.join(dirname, asset_info['filename'])
-        self.installer_size_path = osp.join(dirname, "size")
-
-        logger.info(f"Update type: {self.update_type}")
-
     # ---- Download Update
 
-    def _verify_installer_path(self):
-        if (
-            osp.exists(self.installer_path)
-            and osp.exists(self.installer_size_path)
-        ):
-            with open(self.installer_size_path, "r") as f:
-                size = int(f.read().strip())
+    def _set_installer_path(self):
+        dirname = osp.join(
+            get_temp_dir(), 'updates', str(self.asset_info["version"])
+        )
+        self.installer_path = osp.join(dirname, self.asset_info['filename'])
 
-            update_downloaded = size == osp.getsize(self.installer_path)
-        else:
-            update_downloaded = False
+        logger.info(f"Update type: {self.asset_info['update_type']}")
+
+    def _verify_installer_path(self):
+        update_downloaded = False
+        if osp.exists(self.installer_path):
+            update_downloaded = (
+                self.asset_info["size"] == osp.getsize(self.installer_path)
+            )
 
         logger.debug(f"Update already downloaded: {update_downloaded}")
 
@@ -288,8 +278,9 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
 
         If the installer is already downloaded, proceed to confirm install.
         """
-        self.latest_release = self.update_worker.latest_release
+        self.asset_info = self.update_worker.asset_info
         self._set_installer_path()
+        version = self.asset_info["version"]
 
         if self._verify_installer_path():
             self.set_status(DOWNLOAD_FINISHED)
@@ -306,21 +297,19 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
             ).format(URL_I + "#standalone-installers")
 
             box = confirm_messagebox(
-                self, msg, _('Spyder update'),
-                version=self.latest_release, checkbox=True
+                self, msg, _('Spyder update'), version=version, checkbox=True
             )
             if box.result() == QMessageBox.Yes:
                 self._start_download()
             else:
                 manual_update_messagebox(
-                    self, self.latest_release, self.update_worker.channel
+                    self, version, self.update_worker.channel
                 )
         else:
             msg = _("Would you like to automatically download "
                     "and install it?")
             box = confirm_messagebox(
-                self, msg, _('Spyder update'),
-                version=self.latest_release, checkbox=True
+                self, msg, _('Spyder update'), version=version, checkbox=True
             )
             if box.result() == QMessageBox.Yes:
                 self._start_download()
@@ -334,7 +323,7 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         self.progress_dialog = None
 
         self.download_worker = WorkerDownloadInstaller(
-            self.latest_release, self.installer_path, self.installer_size_path
+            self.asset_info, self.installer_path
         )
 
         self.sig_disable_actions.emit(True)
@@ -343,7 +332,10 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         # Only show progress bar for installers
         if not self.installer_path.endswith('zip'):
             self.progress_dialog = ProgressDialog(
-                self, _("Downloading Spyder {} ...").format(self.latest_release)
+                self,
+                _("Downloading Spyder {} ...").format(
+                    self.asset_info["version"]
+                )
             )
             self.progress_dialog.cancel.clicked.connect(self._cancel_download)
 
@@ -422,7 +414,7 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
             self,
             msg,
             _('Spyder install'),
-            version=self.latest_release,
+            version=self.asset_info["version"],
             on_close=True
         )
         if box.result() == QMessageBox.Yes:
@@ -444,11 +436,11 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
 
         # Sub command
         sub_cmd = [tmpscript_path, '-i', self.installer_path]
-        if self.update_type != 'major':
+        if self.asset_info["update_type"] != 'major':
             # Update with conda
             sub_cmd.extend(['-c', find_conda(), '-p', sys.prefix])
 
-        if self.update_type == 'minor':
+        if self.asset_info["update_type"] == 'minor':
             # Rebuild runtime environment
             sub_cmd.append('-r')
 

--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -6,7 +6,6 @@
 
 # Standard library imports
 from __future__ import annotations  # noqa; required for typing in Python 3.8
-from datetime import datetime as dt
 import logging
 import os
 import os.path as osp
@@ -59,23 +58,6 @@ OS_ERROR_MSG = _(
 )
 
 
-def _rate_limits(page):
-    """Log rate limits for GitHub.com"""
-    if page.headers.get('Server') != 'GitHub.com':
-        return
-
-    xrlr = dt.utcfromtimestamp(int(page.headers['X-RateLimit-Reset']))
-    msg_items = [
-        "Rate Limits:",
-        f"Resource:  {page.headers['X-RateLimit-Resource']}",
-        f"Reset:     {xrlr}",
-        f"Limit:     {page.headers['X-RateLimit-Limit']:>5s}",
-        f"Used:      {page.headers['X-RateLimit-Used']:>5s}",
-        f"Remaining: {page.headers['X-RateLimit-Remaining']:>5s}",
-    ]
-    logger.debug("\n\t".join(msg_items))
-
-
 class UpdateType:
     """Enum with the different update types."""
 
@@ -123,7 +105,6 @@ def get_github_releases() -> dict[Version, dict]:
 
     logger.info(f"Getting release info from {url}")
     page = requests.get(url, headers=headers)
-    _rate_limits(page)
     page.raise_for_status()
     data = page.json()
 


### PR DESCRIPTION
In the course of testing #24072, @ccordoba12 discovered the possibility that a previously downloaded update artifact may not match the current update artifact on Github. This is the result of using the completed download artifact size as the verification tool. This works fine to verify the download immediately upon download completion or if the Github artifact does not change. However, it will be more robust to use the checksum of the artifact to both verify the completed download _and_ to verify an existing local artifact against the current Github artifact.

* The checksum digest for each asset is included in a single `Spyder-checksums.txt` asset. All 6.x release checksum assets are updated to reflect the new paradigm (unit tests will fail until this is completed).
* The `Spyder-checksums.txt` asset is used to obtain the expected checksum for a downloaded asset. Fortunately, this does not need to be downloaded and read from file. A simple url request provides the contents of the file.
* The checksum is then compared to the locally computed one if the download already exists or upon completion of the download.
* The result of `get_github_releases` and `get_asset_checksum` are cached for unit tests. This removes the need to consider rate limit errors.

Notes:
* The `Spyder-checksums.txt` file can be used to verify one or more local assets from the command line as follows.
  ```bash
  $ sha256sum --check Spyder-ckecksums.txt --ignore-missing
  ```
* The `updatemanager` unit tests rely on specific releases for testing and url requests for Github releases return a finite number of releases. This means that at some time in the near future, either the releases referenced in the tests will need to be updated or the number of releases returned by the url request will need to be increased. This issue existed prior to this PR.