### PR TITLE
PR: Use `spyder-updater` to handle updates (Installers)

### DIFF
--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -18,7 +18,6 @@ import os
 import os.path as osp
 import re
 import shutil
-import subprocess as sp
 import sys
 import tempfile
 import uuid
@@ -584,39 +583,6 @@ def is_conda_based_app(pyexec=sys.executable):
         return True
     else:
         return False
-
-
-def get_updater_info() -> (str, str):
-    """
-    Get spyder-updater info
-
-    Returns
-    -------
-    updater_exe : str
-        Full path to the spyder-updater executable. This may not exist.
-    version : str
-        Version of spyder-updater. If not installed, defaults to "0.0.0"
-    """
-    real_pyexec = osp.realpath(sys.executable)
-    if os.name == 'nt':
-        env_dir = osp.dirname(osp.dirname(real_pyexec))
-        updater_exe = osp.join(
-            env_dir, "spyder-updater", "Scripts", "spyder-updater.bat"
-        )
-    else:
-        env_dir = osp.dirname(osp.dirname(osp.dirname(real_pyexec)))
-        updater_exe = osp.join(
-            env_dir, "spyder-updater", "bin", "spyder-updater"
-        )
-
-    version = "0.0.0"  # Not installed
-    if is_conda_based_app() and osp.isfile(updater_exe):
-        cmd = " ".join([updater_exe, "--version"])
-        proc = sp.run(cmd, shell=True, text=True, capture_output=True)
-        if proc.returncode == 0:
-            version = proc.stdout
-
-    return updater_exe, version
 
 
 #==============================================================================

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -18,6 +18,7 @@ import os
 import os.path as osp
 import re
 import shutil
+import subprocess as sp
 import sys
 import tempfile
 import uuid
@@ -583,6 +584,39 @@ def is_conda_based_app(pyexec=sys.executable):
         return True
     else:
         return False
+
+
+def get_updater_info() -> (str, str):
+    """
+    Get spyder-updater info
+
+    Returns
+    -------
+    updater_exe : str
+        Full path to the spyder-updater executable. This may not exist.
+    version : str
+        Version of spyder-updater. If not installed, defaults to "0.0.0"
+    """
+    real_pyexec = osp.realpath(sys.executable)
+    if os.name == 'nt':
+        env_dir = osp.dirname(osp.dirname(real_pyexec))
+        updater_exe = osp.join(
+            env_dir, "spyder-updater", "Scripts", "spyder-updater.bat"
+        )
+    else:
+        env_dir = osp.dirname(osp.dirname(osp.dirname(real_pyexec)))
+        updater_exe = osp.join(
+            env_dir, "spyder-updater", "bin", "spyder-updater"
+        )
+
+    version = "0.0.0"  # Not installed
+    if is_conda_based_app() and osp.isfile(updater_exe):
+        cmd = " ".join([updater_exe, "--version"])
+        proc = sp.run(cmd, shell=True, text=True, capture_output=True)
+        if proc.returncode == 0:
+            version = proc.stdout
+
+    return updater_exe, version
 
 
 #==============================================================================

--- a/spyder/plugins/updatemanager/utils.py
+++ b/spyder/plugins/updatemanager/utils.py
@@ -33,7 +33,7 @@ def get_updater_info() -> (str, str):
         )
     else:
         env_dir = env_dir.parent
-        updater_exe = env_dir, "spyder-updater", "bin", "spyder-updater"
+        updater_exe = env_dir / "spyder-updater" / "bin" / "spyder-updater"
 
     version = "0.0.0"  # Not installed
     if is_conda_based_app() and updater_exe.exists():

--- a/spyder/plugins/updatemanager/utils.py
+++ b/spyder/plugins/updatemanager/utils.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+# Standard library imports
+import os
+from pathlib import Path
+import subprocess as sp
+import sys
+
+# Local imports
+from spyder.config.base import is_conda_based_app
+
+
+def get_updater_info() -> (str, str):
+    """
+    Get spyder-updater info
+
+    Returns
+    -------
+    updater_exe : str
+        Full path to the spyder-updater executable. This may not exist.
+    version : str
+        Version of spyder-updater. If not installed, defaults to "0.0.0"
+    """
+    real_pyexec = Path(sys.executable).resolve()
+    env_dir = real_pyexec.parent.parent
+    if os.name == 'nt':
+        updater_exe = (
+            env_dir / "spyder-updater" / "Scripts" / "spyder-updater.exe"
+        )
+    else:
+        env_dir = env_dir.parent
+        updater_exe = env_dir, "spyder-updater", "bin", "spyder-updater"
+
+    version = "0.0.0"  # Not installed
+    if is_conda_based_app() and updater_exe.exists():
+        cmd = " ".join([updater_exe, "--version"])
+        proc = sp.run(cmd, shell=True, text=True, capture_output=True)
+        if proc.returncode == 0:
+            version = proc.stdout
+
+    return updater_exe, version

--- a/spyder/plugins/updatemanager/utils.py
+++ b/spyder/plugins/updatemanager/utils.py
@@ -37,9 +37,9 @@ def get_updater_info() -> (str, str):
 
     version = "0.0.0"  # Not installed
     if is_conda_based_app() and updater_exe.exists():
-        cmd = " ".join([updater_exe, "--version"])
+        cmd = " ".join([str(updater_exe), "--version"])
         proc = sp.run(cmd, shell=True, text=True, capture_output=True)
         if proc.returncode == 0:
             version = proc.stdout
 
-    return updater_exe, version
+    return str(updater_exe), version

--- a/spyder/plugins/updatemanager/widgets/status.py
+++ b/spyder/plugins/updatemanager/widgets/status.py
@@ -23,6 +23,7 @@ from spyder.plugins.updatemanager.widgets.update import (
     CHECKING,
     DOWNLOAD_FINISHED,
     DOWNLOADING_INSTALLER,
+    UPDATING_UPDATER,
     INSTALL_ON_CLOSE,
     NO_STATUS,
     PENDING
@@ -85,6 +86,10 @@ class UpdateManagerStatus(StatusBarWidget):
             self.custom_widget.hide()
             self.hide()
         elif value == PENDING:
+            self.tooltip = value
+            self.custom_widget.hide()
+            self.show()
+        elif value == UPDATING_UPDATER:
             self.tooltip = value
             self.custom_widget.hide()
             self.show()

--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -568,7 +568,7 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
             osp.dirname(self.installer_path), "update-info.json"
         )
         with open(info_file, "w") as f:
-            json.dump(info, f)
+            json.dump(info, f, indent=4)
 
         # Launch updater
         cmd = [UPDATER_PATH, "--update-info-file", info_file]

--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -6,6 +6,7 @@
 
 # Standard library imports
 from __future__ import annotations  # noqa; required for typing in Python 3.8
+from glob import glob
 from hashlib import sha256
 import logging
 import os
@@ -571,7 +572,7 @@ class WorkerUpdateUpdater(BaseWorker):
         else:
             plat = "linux-64"
         spy_updater_lock = osp.join(dirname, f"conda-updater-{plat}.lock")
-        spy_updater_conda = osp.join(dirname, "spyder-updater*.conda")
+        spy_updater_conda = glob(osp.join(dirname, "spyder-updater*.conda"))[0]
 
         conda_exe = find_conda()
         conda_cmd = "update" if UPDATER_VERSION > parse("0.0.0") else "create"

--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -95,7 +95,8 @@ class AssetInfo(TypedDict):
 
 
 def get_github_releases(
-    tags: str | tuple[str] | None = None
+    tags: str | tuple[str] | None = None,
+    updater: bool = False
 ) -> dict[Version, dict]:
     """
     Get Github release information
@@ -106,13 +107,17 @@ def get_github_releases(
         If tags is provided, only release information for the requested tags
         is retrieved. Otherwise, the most recent 20 releases are retrieved.
         This is only used to retrieve a known set of releases for unit testing.
+    updater : bool (False)
+        Whether to get Updater releases (True) or Spyder releases (False).
 
     Returns
     -------
     releases : dict[packaging.version.Version, dict]
         Dictionary of release information.
     """
-    url = "https://api.github.com/repos/spyder-ide/spyder/releases"
+    url = "https://api.github.com/repos/{}/releases".format(
+        "spyder-ide/spyder-updater" if updater else "spyder-ide/spyder"
+    )
 
     if tags is None:
         # Get 20 most recent releases

--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -566,7 +566,7 @@ class WorkerUpdateUpdater(BaseWorker):
 
         if os.name == "nt":
             plat = "win-64"
-        if sys.platform == "darwin":
+        elif sys.platform == "darwin":
             plat = "osx-arm64" if platform.machine() == "arm64" else "osx-64"
         else:
             plat = "linux-64"
@@ -603,7 +603,10 @@ class WorkerUpdateUpdater(BaseWorker):
         try:
             self._check_asset_available()
             if self.asset_info is None and UPDATER_VERSION == parse("0.0.0"):
-                proc.check_returncode()
+                raise RuntimeError(
+                    "Spyder-updater is not installed and "
+                    "not available for download!"
+                )
             elif self.asset_info is not None:
                 self._download_asset()
                 self._install_update()


### PR DESCRIPTION
Use `spyder-updater` for minor/micro updates to Spyder's conda-based installer.

All update procedures and user interaction remains unchanged for all scenarios _except_ minor/micro updates to Spyder's conda-based installer. All major updates are still handled by Spyder, as well as all downloads. Minor/micro updates are only allowed for the conda-based installer, as before, but now `spyder-updater` is launched to provide the graphical user interface for the conda environment updates.

For minor/micro updates to Spyder:
* The user is first notified about its availability, as before. 
* However, upon affirmatively proceeding with the download (the first message window), rather than proceeding immediately downloading the Spyder lock files, Spyder will first check for and install updates to `spyder-updater`. Upon successful completion (or if no `spyder-updater` updates are available), then Spyder will proceed to download the Spyder lock files.
* Spyder notifies the user upon successful download of the lock files and the user has the option to proceed with the install or install after quitting Spyder; this is as before.
* Upon Spyder quitting, Spyder will launch `spyder-updater`.

### Testing with Spyder Updater

To test integration with Spyder Updater, do the following.
1. Install Spyder 6.1.0a1 using our conda-based installer.
1. Checkout the `spyder-updater-test` branch from mrclary/spyder fork in your local Spyder repository.
1. Install Spyder in editable mode into Spyder's runtime environment.
   ```
   $ conda run --live-stream -p ~/Library/spyder-6/envs/spyder-runtime python path/to/spyder/repo/install_dev_repos.py
   ```
1. Spoof Spyder version to 5.9.9 to test major update, or 6.0.5 to test minor update. Change the Github url to point to the mrclary fork. The latest commit on the `spyder-updater` branch contains these changes (to be reverted before merging). You can modify the version number as desired for testing.
1. Start Spyder, ensure that "Check stable releases only" is deselected in preferences, and check for updates. I recommend deselecting "Check for updates on startup".

If checking for major update:

6. Expect a major update to be available (6.1.0a1) and proceed with the download and expect the .pkg/.sh/.exe installer to be downloaded to `spyder-<user>/updates/6.1.0a1` in a temporary location.
7. When prompted to install, do not proceed because major installs will execute as previously without engaging the Spyder Updater.

If checking for minor/micro update:
  
6. Expect a minor/micro update to be available (6.1.0a1) and proceed with the download.
   * Expect the Spyder Updater zip file to be downloaded and extracted into `spyder-<user>/updates/spyder-updater/0.1.0` in a temporary location. You should see a conda package and conda lock files.
   * Expect the `spyder-updater` environment to be installed alongside the `spyder-runtime` environment.
7. Proceed to install the update when prompted.
   * Expect Spyder to quit and the Spyder Updater to launch and install Spyder 6.1.0a1. Upon completion, Spyder Updater will quit and Spyder should launch.

Return to step 3 to test different scenarios. 
