### PR TITLE
PR: Show contents of Numpy string arrays in the Variable Explorer

### DIFF
--- a/external-deps/spyder-kernels/.github/workflows/linux-pip-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/linux-pip-tests.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   linux:
     name: Linux (pip) - Py${{ matrix.PYTHON_VERSION }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CI: True
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}

--- a/external-deps/spyder-kernels/.github/workflows/linux-tests.yml
+++ b/external-deps/spyder-kernels/.github/workflows/linux-tests.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   linux:
     name: Linux - Py${{ matrix.PYTHON_VERSION }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CI: True
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = master
-	commit = 183a8f0507f46120372f30ff8534b3f01146ce37
-	parent = e2c9c5ec7b1dddc9cb35fa7b50972fadab91cecf
+	commit = 910936ceea310c4e62764e7bb6c54d4fcf88e13d
+	parent = 0ae28768c0fd4ca5f71647c78bd3eb1bbee77241
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
@@ -321,7 +321,7 @@ def value_to_display(value, minmax=False, level=0):
     """Convert value for display purpose"""
     # To save current Numpy printoptions
     np_printoptions = FakeObject
-    numeric_numpy_types = get_numeric_numpy_types()
+    printable_numpy_types = get_numeric_numpy_types() + (np.str_,)
 
     try:
         if np.ndarray is not FakeObject:
@@ -344,11 +344,11 @@ def value_to_display(value, minmax=False, level=0):
                     try:
                         display = 'Min: %r\nMax: %r' % (value.min(), value.max())
                     except (TypeError, ValueError):
-                        if value.dtype.type in numeric_numpy_types:
+                        if value.dtype.type in printable_numpy_types:
                             display = str(value)
                         else:
                             display = default_display(value)
-                elif value.dtype.type in numeric_numpy_types:
+                elif value.dtype.type in printable_numpy_types:
                     display = str(value)
                 else:
                     display = default_display(value)
@@ -410,7 +410,7 @@ def value_to_display(value, minmax=False, level=0):
             display = str(value)
         elif (isinstance(value, (int, float, complex)) or
               isinstance(value, bool) or
-              isinstance(value, numeric_numpy_types)):
+              isinstance(value, printable_numpy_types)):
             display = repr(value)
         else:
             if level == 0:

--- a/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_nsview.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_nsview.py
@@ -284,6 +284,12 @@ def test_str_in_container_display():
     assert value_to_display([b'a', u'b']) == "['a', 'b']"
 
 
+def test_string_array_display():
+    """Test that an array of strings is displayed correctly."""
+    arr = np.array(['a', 'b'])
+    assert value_to_display(arr) == "['a' 'b']"
+
+
 def test_ellipses(tmpdir):
     """
     Test that we're adding a binary ellipses when value_to_display of


### PR DESCRIPTION
## Description of Changes

Show the contents of arrays of strings in the Variable Explorer.

This PR incorporates spyder-ide/spyder-kernels#535 and nothing more. 

![string-array](https://github.com/user-attachments/assets/aaa2537d-5cd8-4a7a-b27a-3ef8399e7eb0)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22570


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
