### PR TITLE
PR: Add API to display an empty message in any dockable plugin (API)

### DIFF
--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -28,6 +28,18 @@
 
 * **Breaking** - The `sig_pythonpath_changed` signal now emits a list of strings and a bool, instead of two dictionaries.
 
+#### PluginMainWidget
+
+* Add `SHOW_MESSAGE_WHEN_EMPTY`, `MESSAGE_WHEN_EMPTY`, `IMAGE_WHEN_EMPTY`, `DESCRIPTION_WHEN_EMPTY` and `SET_LAYOUT_WHEN_EMPTY` class attributes,
+  and `set_content_widget`, `show_content_widget` and `show_empty_message` methods to display a message when it's empty (like the one shown in
+  the Variable Explorer).
+
+#### Shellconnect
+
+* **Breaking** Rename `is_current_widget_empty` to `is_current_widget_error_message` in `ShellConnectMainWidget`.
+* Add `switch_empty_message` to `ShellConnectMainWidget` to switch between the empty message widget and the one with content.
+* Add `ShellConnectWidgetForStackMixin` class for widgets that will be added to the stacked widget part of `ShellConnectMainWidget`.
+
 #### AsyncDispatcher
 
 * **Breaking** - Remove `dispatch` method to use it directly as decorator.

--- a/spyder/api/shellconnect/main_widget.py
+++ b/spyder/api/shellconnect/main_widget.py
@@ -18,6 +18,31 @@ from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.widgets.helperwidgets import PaneEmptyWidget
 
 
+class _ErroredMessageWidget(PaneEmptyWidget):
+    """Widget to show when the kernel's shell failed to start."""
+
+    def __init__(self, parent, shellwidget):
+        # Initialize PaneEmptyWidget with the content we want to show for
+        # errors
+        super().__init__(
+            parent,
+            icon_filename=(
+                "console-remote-off"
+                if shellwidget.is_remote()
+                else "console-off"
+            ),
+            text=_("No connected console"),
+            description=_(
+                "The current console has no active kernel, so there is no "
+                "content to show here"
+            )
+        )
+
+        # This is necessary to show this widget in case ShellConnectMainWidget
+        # shows an empty message.
+        self.is_empty = False
+
+
 class ShellConnectMainWidget(PluginMainWidget):
     """
     Main widget to use in a plugin that shows console-specific content.
@@ -33,14 +58,15 @@ class ShellConnectMainWidget(PluginMainWidget):
         super().__init__(*args, **kwargs)
 
         # Widgets
-        self._stack = QStackedWidget(self)
-        self._shellwidgets = {}
+        if not self.SHOW_MESSAGE_WHEN_EMPTY:
+            self._stack = QStackedWidget(self)
 
-        if set_layout:
-            # Layout
-            layout = QVBoxLayout()
-            layout.addWidget(self._stack)
-            self.setLayout(layout)
+            if set_layout:
+                layout = QVBoxLayout()
+                layout.addWidget(self._stack)
+                self.setLayout(layout)
+
+        self._shellwidgets = {}
 
     # ---- PluginMainWidget API
     # ------------------------------------------------------------------------
@@ -53,10 +79,10 @@ class ShellConnectMainWidget(PluginMainWidget):
         QWidget
             The current widget.
         """
-        return self._stack.currentWidget()
+        return self._content_widget
 
     def get_focus_widget(self):
-        return self.current_widget()
+        return self._stack.currentWidget()
 
     # ---- SpyderWidgetMixin API
     # ------------------------------------------------------------------------
@@ -125,13 +151,17 @@ class ShellConnectMainWidget(PluginMainWidget):
         if widget is None:
             return
 
-        self._stack.setCurrentWidget(widget)
-        self.switch_widget(widget, old_widget)
+        self.set_content_widget(widget, add_to_stack=False)
+        if self.SHOW_MESSAGE_WHEN_EMPTY and widget.is_empty:
+            self.show_empty_message()
+        else:
+            self.show_content_widget()
+            self.switch_widget(widget, old_widget)
         self.update_actions()
 
     def add_errored_shellwidget(self, shellwidget):
         """
-        Create a new PaneEmptyWidget in the stack and associate it to
+        Create a new _ErroredMessageWidget in the stack and associate it to
         shellwidget.
 
         This is necessary to show a meaningful message when switching to
@@ -146,16 +176,8 @@ class ShellConnectMainWidget(PluginMainWidget):
         if shellwidget_id in self._shellwidgets:
             self._shellwidgets.pop(shellwidget_id)
 
-        widget = PaneEmptyWidget(
-            self,
-            "console-remote-off" if shellwidget.is_remote() else "console-off",
-            _("No connected console"),
-            _(
-                "The current console has no active kernel, so there is no "
-                "content to show here"
-            ),
-        )
-        self._stack.addWidget(widget)
+        widget = _ErroredMessageWidget(self, shellwidget)
+        self.set_content_widget(widget)
         self._shellwidgets[shellwidget_id] = widget
         self.set_shellwidget(shellwidget)
 
@@ -178,5 +200,12 @@ class ShellConnectMainWidget(PluginMainWidget):
             widget.refresh()
 
     def is_current_widget_empty(self):
-        """Check if the current widget is a PaneEmptyWidget."""
-        return isinstance(self.current_widget(), PaneEmptyWidget)
+        """Check if the current widget is showing an error message."""
+        return isinstance(self.current_widget(), _ErroredMessageWidget)
+
+    def switch_empty_message(self, value: bool):
+        """Switch between the empty message widget or the one with content."""
+        if value:
+            self.show_empty_message()
+        else:
+            self.show_content_widget()

--- a/spyder/api/shellconnect/main_widget.py
+++ b/spyder/api/shellconnect/main_widget.py
@@ -199,7 +199,7 @@ class ShellConnectMainWidget(PluginMainWidget):
             widget = self.current_widget()
             widget.refresh()
 
-    def is_current_widget_empty(self):
+    def is_current_widget_error_message(self):
         """Check if the current widget is showing an error message."""
         return isinstance(self.current_widget(), _ErroredMessageWidget)
 

--- a/spyder/api/shellconnect/main_widget.py
+++ b/spyder/api/shellconnect/main_widget.py
@@ -35,7 +35,8 @@ class _ErroredMessageWidget(PaneEmptyWidget):
             description=_(
                 "The current console has no active kernel, so there is no "
                 "content to show here"
-            )
+            ),
+            adjust_on_resize=True,
         )
 
         # This is necessary to show this widget in case ShellConnectMainWidget
@@ -177,6 +178,10 @@ class ShellConnectMainWidget(PluginMainWidget):
             self._shellwidgets.pop(shellwidget_id)
 
         widget = _ErroredMessageWidget(self, shellwidget)
+        widget.set_visibility(self.is_visible)
+        if self.dockwidget is not None:
+            self.dockwidget.visibilityChanged.connect(widget.set_visibility)
+
         self.set_content_widget(widget)
         self._shellwidgets[shellwidget_id] = widget
         self.set_shellwidget(shellwidget)

--- a/spyder/api/shellconnect/main_widget.py
+++ b/spyder/api/shellconnect/main_widget.py
@@ -59,7 +59,12 @@ class ShellConnectMainWidget(PluginMainWidget):
         super().__init__(*args, **kwargs)
 
         # Widgets
-        if not self.SHOW_MESSAGE_WHEN_EMPTY:
+        if not (
+            self.SHOW_MESSAGE_WHEN_EMPTY
+            and self.get_conf(
+                "show_message_when_panes_are_empty", section="main"
+            )
+        ):
             self._stack = QStackedWidget(self)
 
             if set_layout:
@@ -153,7 +158,13 @@ class ShellConnectMainWidget(PluginMainWidget):
             return
 
         self.set_content_widget(widget, add_to_stack=False)
-        if self.SHOW_MESSAGE_WHEN_EMPTY and widget.is_empty:
+        if (
+            self.SHOW_MESSAGE_WHEN_EMPTY
+            and self.get_conf(
+                "show_message_when_panes_are_empty", section="main"
+            )
+            and widget.is_empty
+        ):
             self.show_empty_message()
         else:
             self.show_content_widget()

--- a/spyder/api/shellconnect/mixins.py
+++ b/spyder/api/shellconnect/mixins.py
@@ -5,8 +5,10 @@
 # (see spyder/__init__.py for details)
 
 """
-Mixin to connect a plugin to the IPython console.
+Mixins for plugins/widgets that are connected to the IPython console.
 """
+
+from qtpy.QtCore import Signal
 
 from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
@@ -54,6 +56,27 @@ class ShellConnectMixin:
     def add_errored_shellwidget(self, shellwidget):
         """Register a new shellwidget whose kernel failed to start."""
         raise NotImplementedError
+
+
+class ShellConnectWidgetForStackMixin:
+    """
+    Mixin for widgets that will be added to the stacked widget part of
+    ShellConnectMainWidget.
+    """
+
+    sig_show_empty_message_requested = Signal(bool)
+    """
+    Signal to request that the empty message will be shown/hidden.
+
+    Parameters
+    show_empty_message: bool
+        Whether show the empty message or this widget must be shown.
+    """
+
+    def __init__(self):
+        # This attribute is necessary to track if this widget has content to
+        # display or not.
+        self.is_empty = True
 
 
 class ShellConnectPluginMixin(ShellConnectMixin):

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -1013,7 +1013,8 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin):
         elif force_focus is False:
             pass
 
-        self.is_visible = enable
+        # If the widget is undocked, it's always visible
+        self.is_visible = enable or (self.windowwidget is not None)
 
         if (
             self.SHOW_MESSAGE_WHEN_EMPTY

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -395,6 +395,7 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin):
                 self.IMAGE_WHEN_EMPTY,
                 self.MESSAGE_WHEN_EMPTY,
                 self.DESCRIPTION_WHEN_EMPTY,
+                adjust_on_resize=True,
             )
 
             self._stack = QStackedWidget(self)
@@ -1001,6 +1002,9 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin):
             pass
 
         self.is_visible = enable
+
+        if self.SHOW_MESSAGE_WHEN_EMPTY:
+            self._pane_empty.set_visibility(self.is_visible)
 
         # TODO: Pending on plugin migration that uses this
         # if getattr(self, 'DISABLE_ACTIONS_WHEN_HIDDEN', None):

--- a/spyder/api/widgets/main_widget.py
+++ b/spyder/api/widgets/main_widget.py
@@ -158,6 +158,18 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin):
     - The Find in files plugin is an example of a core plugin that uses this.
     """
 
+    SET_LAYOUT_WHEN_EMPTY = True
+    """
+    Whether to automatically set a vertical layout for the stacked widget that
+    holds the empty message widget and the content one.
+
+    Notes
+    -----
+    - You need to set this to False if you need to set a more complex layout in
+      your widget.
+    - The Debugger plugin is an example of a core plugin that uses this.
+    """
+
     # ---- Signals
     # -------------------------------------------------------------------------
     sig_free_memory_requested = Signal()
@@ -388,9 +400,10 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin):
             self._stack = QStackedWidget(self)
             self._stack.addWidget(self._pane_empty)
 
-            layout = QVBoxLayout()
-            layout.addWidget(self._stack)
-            self.setLayout(layout)
+            if self.SET_LAYOUT_WHEN_EMPTY:
+                layout = QVBoxLayout()
+                layout.addWidget(self._stack)
+                self.setLayout(layout)
 
     # ---- Private Methods
     # -------------------------------------------------------------------------
@@ -789,7 +802,7 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin):
 
     # ---- For widgets with an empty message
     # -------------------------------------------------------------------------
-    def set_content_widget(self, widget):
+    def set_content_widget(self, widget, add_to_stack=True):
         """
         Set the widget that actually displays content when there is an empty
         message.
@@ -798,10 +811,14 @@ class PluginMainWidget(QWidget, SpyderWidgetMixin):
         ----------
         widget: QWidget
             Widget to set as the widget with content.
+        add_to_stack: bool
+            Whether to add this widget to stacked widget that holds the empty
+            message.
         """
         if self._stack is not None:
             self._content_widget = widget
-            self._stack.addWidget(self._content_widget)
+            if add_to_stack:
+                self._stack.addWidget(self._content_widget)
 
     def show_content_widget(self):
         """

--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -84,6 +84,7 @@ DEFAULTS = [
               'completion/size': (300, 180),
               'report_error/remember_token': False,
               'show_dpi_message': True,
+              'show_message_when_panes_are_empty': True,
               }),
             ('update_manager',
              {

--- a/spyder/plugins/application/confpage.py
+++ b/spyder/plugins/application/confpage.py
@@ -109,6 +109,11 @@ class ApplicationConfigPage(PluginConfigPage):
         # --- Panes
         interface_group = QGroupBox(_("Panes"))
 
+        empty_messages_box = newcb(
+            _("Show friendly message when some panes are empty"),
+            'show_message_when_panes_are_empty',
+            restart=True
+        )
         verttabs_box = newcb(_("Vertical tabs in panes"),
                              'vertical_tabs', restart=True)
         margin_box = newcb(_("Custom margin for panes:"),
@@ -145,6 +150,7 @@ class ApplicationConfigPage(PluginConfigPage):
 
         # Layout interface
         interface_layout = QVBoxLayout()
+        interface_layout.addWidget(empty_messages_box)
         interface_layout.addWidget(verttabs_box)
         interface_layout.addLayout(margins_cursor_layout)
         interface_group.setLayout(interface_layout)

--- a/spyder/plugins/debugger/widgets/framesbrowser.py
+++ b/spyder/plugins/debugger/widgets/framesbrowser.py
@@ -20,15 +20,16 @@ from qtpy.QtGui import QAbstractTextDocumentLayout, QTextDocument
 from qtpy.QtCore import (QSize, Qt, Slot)
 from qtpy.QtWidgets import (
     QApplication, QStyle, QStyledItemDelegate, QStyleOptionViewItem,
-    QTreeWidgetItem, QVBoxLayout, QWidget, QTreeWidget, QStackedLayout)
+    QTreeWidgetItem, QVBoxLayout, QWidget, QTreeWidget)
 
 # Local imports
 from spyder.api.config.decorators import on_conf_change
 from spyder.api.fonts import SpyderFontsMixin, SpyderFontType
-from spyder.api.widgets.mixins import SpyderWidgetMixin
+from spyder.api.shellconnect.mixins import ShellConnectWidgetForStackMixin
 from spyder.api.translations import _
+from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.utils.palette import SpyderPalette
-from spyder.widgets.helperwidgets import FinderWidget, PaneEmptyWidget
+from spyder.widgets.helperwidgets import FinderWidget
 
 
 class FramesBrowserState:
@@ -38,7 +39,9 @@ class FramesBrowserState:
     Error = 'error'
 
 
-class FramesBrowser(QWidget, SpyderWidgetMixin):
+class FramesBrowser(
+    QWidget, SpyderWidgetMixin, ShellConnectWidgetForStackMixin
+):
     """Frames browser (global debugger widget)"""
     CONF_SECTION = 'debugger'
 
@@ -117,9 +120,11 @@ class FramesBrowser(QWidget, SpyderWidgetMixin):
 
     def set_pane_empty(self, empty):
         if empty:
-            self.stack_layout.setCurrentWidget(self.pane_empty)
+            self.is_empty = True
+            self.sig_show_empty_message_requested.emit(True)
         else:
-            self.stack_layout.setCurrentWidget(self.container)
+            self.is_empty = False
+            self.sig_show_empty_message_requested.emit(False)
 
     def setup(self):
         """
@@ -136,33 +141,14 @@ class FramesBrowser(QWidget, SpyderWidgetMixin):
         self.finder.sig_hide_finder_requested.connect(
             self.sig_hide_finder_requested)
 
-        # Widget empty pane
-        self.pane_empty = PaneEmptyWidget(
-            self,
-            "debugger",
-            _("Debugging is not active"),
-            _("Start a debugging session with the ⏯ button, allowing you to "
-              "step through your code and see the functions here that "
-              "Python has run.")
-        )
-
         # Setup layout.
-        self.stack_layout = QStackedLayout()
-        self.stack_layout.addWidget(self.pane_empty)
-        self.setLayout(self.stack_layout)
-        self.stack_layout.setContentsMargins(0, 0, 0, 0)
-        self.stack_layout.setSpacing(0)
-        self.setContentsMargins(0, 0, 0, 0)
-
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
         layout.addWidget(self.results_browser)
         layout.addWidget(self.finder)
-
-        self.container = QWidget(self)
-        self.container.setLayout(layout)
-        self.stack_layout.addWidget(self.container)
+        self.setLayout(layout)
+        self.setContentsMargins(0, 0, 0, 0)
 
     def _show_frames(self, stack_dict, title, state):
         """Set current frames"""

--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -430,7 +430,7 @@ class DebuggerWidget(ShellConnectMainWidget):
             )
 
             widget = self.current_widget()
-            if self.is_current_widget_empty() or widget is None:
+            if self.is_current_widget_error_message() or widget is None:
                 search_action.setEnabled(False)
                 post_mortem = False
                 executing = False
@@ -534,7 +534,7 @@ class DebuggerWidget(ShellConnectMainWidget):
 
     def switch_widget(self, widget, old_widget):
         """Set the current FramesBrowser."""
-        if not self.is_current_widget_empty():
+        if not self.is_current_widget_error_message():
             sw = widget.shellwidget
             state = sw.is_waiting_pdb_input()
             self.sig_pdb_state_changed.emit(state)
@@ -598,7 +598,7 @@ class DebuggerWidget(ShellConnectMainWidget):
         next call.
         """
         widget = self.current_widget()
-        if widget is None or self.is_current_widget_empty():
+        if widget is None or self.is_current_widget_error_message():
             return False
         widget.shellwidget._pdb_take_focus = take_focus
 
@@ -606,14 +606,14 @@ class DebuggerWidget(ShellConnectMainWidget):
     def toggle_finder(self, checked):
         """Show or hide finder."""
         widget = self.current_widget()
-        if widget is None or self.is_current_widget_empty():
+        if widget is None or self.is_current_widget_error_message():
             return
         widget.toggle_finder(checked)
 
     def get_pdb_state(self):
         """Get debugging state of the current console."""
         widget = self.current_widget()
-        if widget is None or self.is_current_widget_empty():
+        if widget is None or self.is_current_widget_error_message():
             return False
         sw = widget.shellwidget
         if sw is not None:
@@ -623,7 +623,7 @@ class DebuggerWidget(ShellConnectMainWidget):
     def get_pdb_last_step(self):
         """Get last pdb step of the current console."""
         widget = self.current_widget()
-        if widget is None or self.is_current_widget_empty():
+        if widget is None or self.is_current_widget_error_message():
             return None, None
         sw = widget.shellwidget
         if sw is not None:

--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -87,6 +87,16 @@ class DebuggerContextMenuSections:
 # =============================================================================
 class DebuggerWidget(ShellConnectMainWidget):
 
+    # PluginMainWidget class constants
+    SHOW_MESSAGE_WHEN_EMPTY = True
+    IMAGE_WHEN_EMPTY = "debugger"
+    MESSAGE_WHEN_EMPTY = _("Debugging is not active")
+    DESCRIPTION_WHEN_EMPTY = _(
+        "Start a debugging session with the ⏯ button, allowing you to step "
+        "through your code and see the functions here that Python has run."
+    )
+    SET_LAYOUT_WHEN_EMPTY = False
+
     # Signals
     sig_edit_goto = Signal(str, int, str)
     """
@@ -181,7 +191,6 @@ class DebuggerWidget(ShellConnectMainWidget):
         )
 
         # Layout
-        # Create the layout.
         layout = QHBoxLayout()
         layout.setSpacing(0)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -495,6 +504,9 @@ class DebuggerWidget(ShellConnectMainWidget):
         widget.sig_edit_goto.connect(self.sig_edit_goto)
         widget.sig_hide_finder_requested.connect(self.hide_finder)
         widget.sig_update_actions_requested.connect(self.update_actions)
+        widget.sig_show_empty_message_requested.connect(
+            self.switch_empty_message
+        )
 
         shellwidget.sig_prompt_ready.connect(widget.clear_if_needed)
         shellwidget.sig_pdb_prompt_ready.connect(widget.clear_if_needed)

--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -6,9 +6,12 @@
 
 """Editor config page."""
 
-
 from qtpy.QtWidgets import (
-    QGridLayout, QGroupBox, QHBoxLayout, QLabel, QVBoxLayout
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QVBoxLayout,
 )
 
 from spyder.api.config.decorators import on_conf_change

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1932,6 +1932,10 @@ def test_shutdown_kernel(ipyconsole, qtbot):
     assert not shell.get_value('kernel_exists')
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("linux") and running_in_ci(),
+    reason="Fails on Linux and CIs"
+)
 def test_pdb_comprehension_namespace(ipyconsole, qtbot, tmpdir):
     """Check that the debugger handles the namespace of a comprehension."""
     shell = ipyconsole.get_current_shellwidget()

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -1075,6 +1075,13 @@ class Layout(SpyderPluginV2, SpyderShortcutsMixin):
                 Plugins.Editor,
             ]
 
+        # This is necessary because the visible state of dockable plugins is
+        # not set correctly for all of them at startup. So, we make it False
+        # first for all of them to then set it to True only for those that were
+        # visible during the last session.
+        for plugin in self.get_dockable_plugins():
+            plugin.change_visibility(False)
+
         # Restore visible plugins
         for plugin in visible_plugins:
             plugin_class = self.get_plugin(plugin, error=False)
@@ -1084,7 +1091,7 @@ class Layout(SpyderPluginV2, SpyderShortcutsMixin):
                 and plugin_class.dockwidget is not None
                 and plugin_class.dockwidget.isVisible()
             ):
-                plugin_class.dockwidget.raise_()
+                plugin_class.change_visibility(True, force_focus=False)
 
     def save_visible_plugins(self):
         """Save visible plugins."""

--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -34,15 +34,15 @@ from qtpy.QtCore import (
 from qtpy.QtGui import QDrag, QPainter, QPixmap
 from qtpy.QtWidgets import (QApplication, QFrame, QGridLayout, QLayout,
                             QScrollArea, QScrollBar, QSplitter, QStyle,
-                            QVBoxLayout, QWidget, QStackedLayout)
+                            QVBoxLayout, QWidget)
 
 # Local library imports
 from spyder.api.translations import _
+from spyder.api.shellconnect.mixins import ShellConnectWidgetForStackMixin
 from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.utils.misc import getcwd_or_home
 from spyder.utils.palette import SpyderPalette
 from spyder.utils.stylesheet import AppStyle
-from spyder.widgets.helperwidgets import PaneEmptyWidget
 
 
 # TODO:
@@ -82,7 +82,9 @@ def get_unique_figname(dirname, root, ext, start_at_zero=False):
             return osp.join(dirname, figname)
 
 
-class FigureBrowser(QWidget, SpyderWidgetMixin):
+class FigureBrowser(
+    QWidget, SpyderWidgetMixin, ShellConnectWidgetForStackMixin
+):
     """
     Widget to browse the figures that were sent by the kernel to the IPython
     console to be plotted inline.
@@ -183,17 +185,6 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
         self.thumbnails_sb.sig_redirect_stdio_requested.connect(
             self.sig_redirect_stdio_requested)
 
-        # Widget empty pane
-        self.pane_empty = PaneEmptyWidget(
-            self,
-            "plots",
-            _("No plots to show"),
-            _("Run plot-generating code in the Editor or IPython console to "
-              "see your figures appear here. This pane only supports "
-              "static images, so it can't display interactive plots "
-              "like Bokeh, Plotly or Altair.")
-        )
-
         # Create the layout.
         self.splitter = splitter = QSplitter(parent=self)
         splitter.addWidget(self.figviewer)
@@ -206,12 +197,11 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
         self.splitter.setChildrenCollapsible(False)
         self.splitter.splitterMoved.connect(self._on_splitter_moved)
 
-        self.stack_layout = QStackedLayout()
-        self.stack_layout.addWidget(splitter)
-        self.stack_layout.addWidget(self.pane_empty)
-        self.setLayout(self.stack_layout)
-        self.stack_layout.setContentsMargins(0, 0, 0, 0)
-        self.stack_layout.setSpacing(0)
+        layout = QVBoxLayout()
+        layout.addWidget(splitter)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        self.setLayout(layout)
         self.setContentsMargins(0, 0, 0, 0)
 
     def _on_splitter_moved(self):
@@ -241,9 +231,11 @@ class FigureBrowser(QWidget, SpyderWidgetMixin):
 
     def set_pane_empty(self, empty):
         if empty:
-            self.stack_layout.setCurrentWidget(self.pane_empty)
+            self.is_empty = True
+            self.sig_show_empty_message_requested.emit(True)
         else:
-            self.stack_layout.setCurrentWidget(self.splitter)
+            self.is_empty = False
+            self.sig_show_empty_message_requested.emit(False)
 
     def update_splitter_widths(self, base_width):
         """

--- a/spyder/plugins/plots/widgets/main_widget.py
+++ b/spyder/plugins/plots/widgets/main_widget.py
@@ -21,7 +21,6 @@ from spyder.api.shellconnect.main_widget import ShellConnectMainWidget
 from spyder.plugins.plots.widgets.figurebrowser import FigureBrowser
 from spyder.utils.misc import getcwd_or_home
 from spyder.utils.palette import SpyderPalette
-from spyder.widgets.helperwidgets import PaneEmptyWidget
 
 
 MAIN_BG_COLOR = SpyderPalette.COLOR_BACKGROUND_1
@@ -60,6 +59,18 @@ class PlotsWidgetToolbarItems:
 # --- Widgets
 # ----------------------------------------------------------------------------
 class PlotsWidget(ShellConnectMainWidget):
+
+    # PluginMainWidget API
+    SHOW_MESSAGE_WHEN_EMPTY = True
+    IMAGE_WHEN_EMPTY = "plots"
+    MESSAGE_WHEN_EMPTY = _("No plots to show")
+    DESCRIPTION_WHEN_EMPTY = _(
+        "Run plot-generating code in the Editor or IPython console to see "
+        "your figures appear here. This pane only supports static images, so "
+        "it can't display interactive plots like Bokeh, Plotly or Altair."
+    )
+
+    # Signals
     sig_figure_loaded = Signal()
     """This signal is emitted when a figure is loaded succesfully"""
 
@@ -297,9 +308,9 @@ class PlotsWidget(ShellConnectMainWidget):
         fig_browser = FigureBrowser(parent=self,
                                     background_color=MAIN_BG_COLOR)
         fig_browser.set_shellwidget(shellwidget)
+
         fig_browser.sig_redirect_stdio_requested.connect(
             self.sig_redirect_stdio_requested)
-
         fig_browser.sig_figure_menu_requested.connect(
             self.show_figure_menu)
         fig_browser.sig_thumbnail_menu_requested.connect(
@@ -308,6 +319,10 @@ class PlotsWidget(ShellConnectMainWidget):
         fig_browser.sig_save_dir_changed.connect(
             lambda val: self.set_conf('save_dir', val))
         fig_browser.sig_zoom_changed.connect(self.zoom_disp.setValue)
+        fig_browser.sig_show_empty_message_requested.connect(
+            self.switch_empty_message
+        )
+
         return fig_browser
 
     def close_widget(self, fig_browser):
@@ -404,7 +419,7 @@ class PlotsWidget(ShellConnectMainWidget):
         Add a plot to the figure browser with the given shellwidget, if any.
         """
         fig_browser = self.get_widget_for_shellwidget(shellwidget)
-        if fig_browser and not isinstance(fig_browser, PaneEmptyWidget):
+        if fig_browser and not self.is_current_widget_empty():
             fig_browser.add_figure(fig, fmt)
 
     def remove_plot(self):

--- a/spyder/plugins/plots/widgets/main_widget.py
+++ b/spyder/plugins/plots/widgets/main_widget.py
@@ -252,7 +252,7 @@ class PlotsWidget(ShellConnectMainWidget):
         widget = self.current_widget()
         figviewer = None
 
-        if widget and not self.is_current_widget_empty():
+        if widget and not self.is_current_widget_error_message():
             figviewer = widget.figviewer
             value = figviewer.figcanvas.fig is not None
 
@@ -419,7 +419,7 @@ class PlotsWidget(ShellConnectMainWidget):
         Add a plot to the figure browser with the given shellwidget, if any.
         """
         fig_browser = self.get_widget_for_shellwidget(shellwidget)
-        if fig_browser and not self.is_current_widget_empty():
+        if fig_browser and not self.is_current_widget_error_message():
             fig_browser.add_figure(fig, fmt)
 
     def remove_plot(self):

--- a/spyder/plugins/profiler/widgets/main_widget.py
+++ b/spyder/plugins/profiler/widgets/main_widget.py
@@ -27,8 +27,13 @@ from qtpy import PYSIDE2
 from qtpy.compat import getopenfilename, getsavefilename
 from qtpy.QtCore import QByteArray, QProcess, QProcessEnvironment, Qt, Signal
 from qtpy.QtGui import QColor
-from qtpy.QtWidgets import (QApplication, QLabel, QMessageBox, QTreeWidget,
-                            QTreeWidgetItem, QStackedWidget, QVBoxLayout)
+from qtpy.QtWidgets import (
+    QApplication,
+    QLabel,
+    QMessageBox,
+    QTreeWidget,
+    QTreeWidgetItem,
+)
 
 # Local imports
 from spyder.api.config.decorators import on_conf_change
@@ -43,7 +48,6 @@ from spyder.utils.palette import SpyderPalette
 from spyder.utils.programs import shell_split
 from spyder.utils.qthelpers import get_item_user_text, set_item_user_text
 from spyder.widgets.comboboxes import PythonModulesComboBox
-from spyder.widgets.helperwidgets import PaneEmptyWidget
 
 
 # Logging
@@ -130,7 +134,17 @@ class ProfilerWidget(PluginMainWidget):
     """
     Profiler widget.
     """
+    # PluginMainWidget API
     ENABLE_SPINNER = True
+    SHOW_MESSAGE_WHEN_EMPTY = True
+    IMAGE_WHEN_EMPTY = "code-profiler"
+    MESSAGE_WHEN_EMPTY = _("Code not profiled yet")
+    DESCRIPTION_WHEN_EMPTY = _(
+        "Profile your code to explore which functions and methods took the "
+        "longest to run and were called the most, and find out where to "
+        "optimize it."
+    )
+
     DATAPATH = get_conf_path('profiler.results')
 
     # --- Signals
@@ -173,26 +187,12 @@ class ProfilerWidget(PluginMainWidget):
         self.process = None
         self.filecombo = PythonModulesComboBox(
             self, id_=ProfilerWidgetMainToolbarItems.FileCombo)
+
         self.datatree = ProfilerDataTree(self)
-        self.pane_empty = PaneEmptyWidget(
-            self,
-            "code-profiler",
-            _("Code not profiled yet"),
-            _("Profile your code to explore which functions and methods "
-              "took the longest to run and were called the most, "
-              "and find out where to optimize it.")
-        )
+        self.set_content_widget(self.datatree)
+
         self.datelabel = QLabel()
         self.datelabel.ID = ProfilerWidgetInformationToolbarItems.DateLabel
-
-        # Layout
-        self.stacked_widget = QStackedWidget(self)
-        self.stacked_widget.addWidget(self.pane_empty)
-        self.stacked_widget.addWidget(self.datatree)
-
-        layout = QVBoxLayout()
-        layout.addWidget(self.stacked_widget)
-        self.setLayout(layout)
 
         # Signals
         self.datatree.sig_edit_goto_requested.connect(
@@ -618,7 +618,7 @@ class ProfilerWidget(PluginMainWidget):
         self.datelabel.setText(_('Sorting data, please wait...'))
         QApplication.processEvents()
 
-        self.stacked_widget.setCurrentWidget(self.datatree)
+        self.show_content_widget()
         self.datatree.load_data(self.DATAPATH)
         self.datatree.show_tree()
 

--- a/spyder/plugins/projects/plugin.py
+++ b/spyder/plugins/projects/plugin.py
@@ -307,7 +307,7 @@ class Projects(SpyderDockablePlugin):
                 restart_console=restart_console
             )
         else:
-            self.get_widget().set_pane_empty()
+            self.get_widget().show_empty_message()
             logger.debug('Reopening project from last session')
             self.get_widget().reopen_last_project(
                 working_directory=cli_options.working_directory,

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -46,7 +46,6 @@ from spyder.utils import encoding
 from spyder.utils.misc import getcwd_or_home
 from spyder.utils.programs import find_program
 from spyder.utils.workers import WorkerManager
-from spyder.widgets.helperwidgets import PaneEmptyWidget
 
 
 # For logging
@@ -86,6 +85,15 @@ class ProjectsOptionsMenuActions:
 @class_register
 class ProjectExplorerWidget(PluginMainWidget):
     """Project explorer main widget."""
+
+    # ---- PluginMainWidget API
+    # -------------------------------------------------------------------------
+    SHOW_MESSAGE_WHEN_EMPTY = True
+    IMAGE_WHEN_EMPTY = "projects"
+    MESSAGE_WHEN_EMPTY = _("No project opened")
+    DESCRIPTION_WHEN_EMPTY = _(
+        "Create one using the menu entry Projects > New project."
+    )
 
     # ---- Constants
     # -------------------------------------------------------------------------
@@ -186,13 +194,7 @@ class ProjectExplorerWidget(PluginMainWidget):
         self.treewidget.hide()
         self.treewidget.sig_open_file_requested.connect(
             self.sig_open_file_requested)
-
-        self.pane_empty = PaneEmptyWidget(
-            self,
-            "projects",
-            _("No project opened"),
-            _("Create one using the menu entry Projects > New project.")
-        )
+        self.set_content_widget(self.treewidget)
 
         # -- Watcher
         self.watcher = WorkspaceWatcher(self)
@@ -214,10 +216,6 @@ class ProjectExplorerWidget(PluginMainWidget):
         self.sig_project_closed.connect(lambda p: self._clear_switcher_paths())
 
         # -- Layout
-        layout = QVBoxLayout()
-        layout.addWidget(self.pane_empty)
-        layout.addWidget(self.treewidget)
-        self.setLayout(layout)
         self.setMinimumWidth(200)
 
         # Initial setup
@@ -301,10 +299,6 @@ class ProjectExplorerWidget(PluginMainWidget):
                 menu=menu,
                 section=ProjectExplorerOptionsMenuSections.Main
             )
-
-    def set_pane_empty(self):
-        self.treewidget.hide()
-        self.pane_empty.show()
 
     def update_actions(self):
         pass
@@ -866,13 +860,11 @@ class ProjectExplorerWidget(PluginMainWidget):
 
     def _clear(self):
         """Show an empty view"""
-        self.treewidget.hide()
-        self.pane_empty.show()
+        self.show_empty_message()
 
     def _setup_project(self, directory):
         """Setup project"""
-        self.pane_empty.hide()
-        self.treewidget.show()
+        self.show_content_widget()
 
         # Setup the directory shown by the tree
         self._set_project_dir(directory)

--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -191,7 +191,6 @@ class ProjectExplorerWidget(PluginMainWidget):
         self.treewidget = ProjectExplorerTreeWidget(self, self.show_hscrollbar)
         self.treewidget.setup()
         self.treewidget.setup_view()
-        self.treewidget.hide()
         self.treewidget.sig_open_file_requested.connect(
             self.sig_open_file_requested)
         self.set_content_widget(self.treewidget)
@@ -860,11 +859,16 @@ class ProjectExplorerWidget(PluginMainWidget):
 
     def _clear(self):
         """Show an empty view"""
-        self.show_empty_message()
+        if self.get_conf("show_message_when_panes_are_empty", section="main"):
+            super().show_empty_message()
+        else:
+            # This removes the widget's contents to show an empty pane
+            self.treewidget.set_root_path("")
 
     def _setup_project(self, directory):
         """Setup project"""
-        self.show_content_widget()
+        if self.get_conf("show_message_when_panes_are_empty", section="main"):
+            self.show_content_widget()
 
         # Setup the directory shown by the tree
         self._set_project_dir(directory)

--- a/spyder/plugins/pylint/main_widget.py
+++ b/spyder/plugins/pylint/main_widget.py
@@ -24,8 +24,13 @@ import pylint
 from qtpy.compat import getopenfilename
 from qtpy.QtCore import (QByteArray, QProcess, QProcessEnvironment, Signal,
                          Slot)
-from qtpy.QtWidgets import (QComboBox, QInputDialog, QLabel, QMessageBox,
-                            QTreeWidgetItem, QStackedWidget, QVBoxLayout)
+from qtpy.QtWidgets import (
+    QComboBox,
+    QInputDialog,
+    QLabel,
+    QMessageBox,
+    QTreeWidgetItem,
+)
 from spyder_kernels.utils.pythonenv import is_conda_env
 
 # Local imports
@@ -42,7 +47,6 @@ from spyder.utils.palette import SpyderPalette
 from spyder.widgets.comboboxes import (PythonModulesComboBox,
                                        is_module_or_package)
 from spyder.widgets.onecolumntree import OneColumnTree, OneColumnTreeActions
-from spyder.widgets.helperwidgets import PaneEmptyWidget
 
 
 # --- Constants
@@ -264,7 +268,15 @@ class PylintWidget(PluginMainWidget):
     """
     Pylint widget.
     """
+    # PluginMainWidget API
     ENABLE_SPINNER = True
+    SHOW_MESSAGE_WHEN_EMPTY = True
+    IMAGE_WHEN_EMPTY = "code-analysis"
+    MESSAGE_WHEN_EMPTY = _("Code not analyzed yet")
+    DESCRIPTION_WHEN_EMPTY = _(
+        "Run an analysis using Pylint to get feedback on style issues, bad "
+        "practices, potential bugs, and suggested improvements in your code."
+    )
 
     DATAPATH = get_conf_path("pylint.results")
     VERSION = "1.1.0"
@@ -316,14 +328,7 @@ class PylintWidget(PluginMainWidget):
         self.datelabel.ID = PylintWidgetToolbarItems.DateLabel
 
         self.treewidget = ResultsTree(self)
-        self.pane_empty = PaneEmptyWidget(
-            self,
-            "code-analysis",
-            _("Code not analyzed yet"),
-            _("Run an analysis using Pylint to get feedback on "
-              "style issues, bad practices, potential bugs, "
-              "and suggested improvements in your code.")
-        )
+        self.set_content_widget(self.treewidget)
 
         if osp.isfile(self.DATAPATH):
             try:
@@ -339,15 +344,6 @@ class PylintWidget(PluginMainWidget):
         self.filecombo.setInsertPolicy(QComboBox.InsertPolicy.InsertAtTop)
         for fname in self.curr_filenames[::-1]:
             self.set_filename(fname)
-
-        # Layout
-        self.stacked_widget = QStackedWidget(self)
-        self.stacked_widget.addWidget(self.pane_empty)
-        self.stacked_widget.addWidget(self.treewidget)
-
-        layout = QVBoxLayout()
-        layout.addWidget(self.stacked_widget)
-        self.setLayout(layout)
 
         # Signals
         self.filecombo.valid.connect(self._check_new_file)
@@ -784,17 +780,17 @@ class PylintWidget(PluginMainWidget):
             text = _("Source code has not been rated yet.")
             self.treewidget.clear_results()
             date_text = ""
-            self.stacked_widget.setCurrentWidget(self.pane_empty)
+            self.show_empty_message()
         else:
             datetime, rate, previous_rate, results = data
             if rate is None:
-                self.stacked_widget.setCurrentWidget(self.treewidget)
+                self.show_content_widget()
                 text = _("Analysis did not succeed "
                          "(see output for more details).")
                 self.treewidget.clear_results()
                 date_text = ""
             else:
-                self.stacked_widget.setCurrentWidget(self.treewidget)
+                self.show_content_widget()
                 text_style = "<span style=\"color: %s\"><b>%s </b></span>"
                 rate_style = "<span style=\"color: %s\"><b>%s</b></span>"
                 prevrate_style = "<span style=\"color: %s\">%s</span>"

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -95,6 +95,13 @@ class VariableExplorerWidget(ShellConnectMainWidget):
 
     # PluginMainWidget class constants
     ENABLE_SPINNER = True
+    SHOW_MESSAGE_WHEN_EMPTY = True
+    IMAGE_WHEN_EMPTY = "variable-explorer"
+    MESSAGE_WHEN_EMPTY = _("No variables to show")
+    DESCRIPTION_WHEN_EMPTY = _(
+        "Run code in the Editor or IPython console to see any global "
+        "variables listed here for exploration and editing."
+    )
 
     # Other class constants
     INITIAL_FREE_MEMORY_TIME_TRIGGER = 60 * 1000  # ms
@@ -513,11 +520,16 @@ class VariableExplorerWidget(ShellConnectMainWidget):
     def create_new_widget(self, shellwidget):
         """Create new NamespaceBrowser."""
         nsb = NamespaceBrowser(self)
+
         nsb.sig_hide_finder_requested.connect(self.hide_finder)
         nsb.sig_free_memory_requested.connect(self.free_memory)
         nsb.sig_start_spinner_requested.connect(self.start_spinner)
         nsb.sig_stop_spinner_requested.connect(self.stop_spinner)
         nsb.sig_show_figure_requested.connect(self.sig_show_figure_requested)
+        nsb.sig_show_empty_message_requested.connect(
+            self.switch_empty_message
+        )
+
         nsb.set_shellwidget(shellwidget)
         nsb.plots_plugin_enabled = self.plots_plugin_enabled
         nsb.setup()

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -467,7 +467,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
 
     def update_actions(self):
         """Update the actions."""
-        if self.is_current_widget_empty():
+        if self.is_current_widget_error_message():
             self._set_main_toolbar_state(False)
             return
         else:
@@ -562,19 +562,19 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         """
         Import data in current namespace.
         """
-        if not self.is_current_widget_empty():
+        if not self.is_current_widget_error_message():
             nsb = self.current_widget()
             nsb.refresh_table()
             nsb.import_data(filenames=filenames)
 
     def save_data(self):
-        if not self.is_current_widget_empty():
+        if not self.is_current_widget_error_message():
             nsb = self.current_widget()
             nsb.save_data()
             self.update_actions()
 
     def reset_namespace(self):
-        if not self.is_current_widget_empty():
+        if not self.is_current_widget_error_message():
             nsb = self.current_widget()
             nsb.reset_namespace()
 
@@ -582,7 +582,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
     def toggle_finder(self, checked):
         """Hide or show the finder."""
         widget = self.current_widget()
-        if widget is None or self.is_current_widget_empty():
+        if widget is None or self.is_current_widget_error_message():
             return
         widget.toggle_finder(checked)
 
@@ -593,7 +593,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         action.setChecked(False)
 
     def refresh_table(self):
-        if not self.is_current_widget_empty():
+        if not self.is_current_widget_error_message():
             nsb = self.current_widget()
             nsb.refresh_table()
 
@@ -657,7 +657,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
     @property
     def _current_editor(self):
         editor = None
-        if not self.is_current_widget_empty():
+        if not self.is_current_widget_error_message():
             nsb = self.current_widget()
             editor = nsb.editor
         return editor

--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -570,7 +570,7 @@ class PaneEmptyWidget(QFrame, SvgToScaledPixmap, SpyderFontsMixin):
     def __init__(
         self,
         parent,
-        icon_filename,
+        icon_filename=None,
         text=None,
         description=None,
         top_stretch: int = 1,
@@ -588,14 +588,15 @@ class PaneEmptyWidget(QFrame, SvgToScaledPixmap, SpyderFontsMixin):
             SpyderFontType.Interface).pointSize()
 
         # Image (icon)
-        image_label = QLabel(self)
-        image_label.setPixmap(
-            self.svg_to_scaled_pixmap(icon_filename, rescale=0.8)
-        )
-        image_label.setAlignment(Qt.AlignCenter)
-        image_label_qss = qstylizer.style.StyleSheet()
-        image_label_qss.QLabel.setValues(border="0px")
-        image_label.setStyleSheet(image_label_qss.toString())
+        if icon_filename:
+            image_label = QLabel(self)
+            image_label.setPixmap(
+                self.svg_to_scaled_pixmap(icon_filename, rescale=0.8)
+            )
+            image_label.setAlignment(Qt.AlignCenter)
+            image_label_qss = qstylizer.style.StyleSheet()
+            image_label_qss.QLabel.setValues(border="0px")
+            image_label.setStyleSheet(image_label_qss.toString())
 
         # Main text
         if text is not None:
@@ -628,8 +629,9 @@ class PaneEmptyWidget(QFrame, SvgToScaledPixmap, SpyderFontsMixin):
         # Add the top stretch
         pane_empty_layout.addStretch(top_stretch)
 
-        # add the image_lebel (icon)
-        pane_empty_layout.addWidget(image_label)
+        # Add the image_label (icon)
+        if icon_filename is not None:
+            pane_empty_layout.addWidget(image_label)
 
         # Display spinner if requested
         if spinner:


### PR DESCRIPTION
## Description of Changes

- This simplifies the way we were adding and handling empty message widgets to the current plugins that display them.
- By having a public API for this, it'll be possible for external plugins to make use of it too (e.g. `Spyder-env-manager`).
- An additional benefit is that it'll be possible to disable all empty messages by unchecking an option in Preferences (see below).
- Fix restoring visible plugins in the last session (I noticed that bug while working on this PR).
- With this refactoring it'll also be possible to vertically resize dockable plugins below its min size hint.

#### Visual changes

* Option to disable all empty messages

    ![imagen](https://github.com/user-attachments/assets/6f5349ad-f2ce-4265-a736-72a6c4405c06)

* Panes with empty messages can be resized below its min height

    ![resizing-panes-1](https://github.com/user-attachments/assets/90a7f543-f7a8-4cc9-bfe5-2e13f9b57b68)

### Issue(s) Resolved

Fixes #21197

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
