### PR TITLE
TST: Test Pyside6 and Python 3.13

### DIFF
--- a/.github/workflows/test-linux-qt6.yml
+++ b/.github/workflows/test-linux-qt6.yml
@@ -78,7 +78,12 @@ jobs:
         INSTALL_TYPE: ['pip']  # conda has no PyQt6 package
         PYTHON_VERSION: ['3.10']
         TEST_TYPE: ['fast', 'slow']
-        SPYDER_QT_BINDING: ['pyqt6'] # TODO add 'pyside6' once Spyder supports it
+        SPYDER_QT_BINDING: ['pyqt6']
+        include:
+          - INSTALL_TYPE: 'pip'
+            PYTHON_VERSION: '3.13'
+            TEST_TYPE: 'fast'
+            SPYDER_QT_BINDING: 'pyside6'
     timeout-minutes: 90
     steps:
       - name: Setup Remote SSH Connection

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ $ python bootstrap.py --debug
 
 **Important Note**: To test any changes you've made to the Spyder source code, you need to restart Spyder or start a fresh instance (you can run multiple copies simultaneously by unchecking the Preferences option <kbd>Use a single instance</kbd> under <kbd>General</kbd> > <kbd>Advanced Settings</kbd> .
 
-To start Spyder with different Qt bindings (e.g. PySide2 or PyQt6), you can run:
+To start Spyder with different Qt bindings (e.g. PySide6 or PyQt6), you can run:
 
 ```bash
 $ python bootstrap.py --gui pyqt6

--- a/setup.py
+++ b/setup.py
@@ -232,6 +232,7 @@ setup_args = dict(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
I was going to open a PR to conda-forge to add Python 3.13 packages, but realized I should probably create a PR here for 3.13 support here. From a very quick search I didn't find an issue about it (https://github.com/spyder-ide/spyder/issues/22801 was close I guess?), but I did find https://github.com/spyder-ide/spyder/issues/20201. So this PR tries to take care of both by adding a CI job for PySide6 and Python 3.13. Then also updates `setup.py`, and tweaks the README to promote the newer PySide6.