### PR TITLE
PR: Fix several issues in the Layout plugin

### DIFF
--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -1243,3 +1243,8 @@ class Layout(SpyderPluginV2, SpyderShortcutsMixin):
         for plugin in self.get_dockable_plugins():
             if plugin.get_conf('first_time', True):
                 self.tabify_plugin(plugin, Plugins.Console)
+
+                # This is necessary in case the plugin doesn't set its TABIFY
+                # constant
+                plugin.set_conf("enable", True)
+                plugin.set_conf("first_time", False)

--- a/spyder/plugins/layout/plugin.py
+++ b/spyder/plugins/layout/plugin.py
@@ -636,11 +636,12 @@ class Layout(SpyderPluginV2, SpyderShortcutsMixin):
             return
 
         self.main.setUpdatesEnabled(False)
+
+        # Restore window properties
         self.window_size = QSize(
             window_size[0], window_size[1] # width, height
         )
         self.window_position = QPoint(pos[0], pos[1]) # x, y
-        self.main.setWindowState(Qt.WindowNoState)
         self.main.resize(self.window_size)
         self.main.move(self.window_position)
 

--- a/spyder/plugins/layout/widgets/dialog.py
+++ b/spyder/plugins/layout/widgets/dialog.py
@@ -17,6 +17,7 @@ from qtpy.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QHBoxLayout,
+    QMessageBox,
     QLabel,
     QTableView,
     QVBoxLayout,
@@ -320,6 +321,16 @@ class LayoutSettingsDialog(QDialog, SpyderWidgetMixin):
         )
         row = self.table.selectionModel().currentIndex().row()
         ui_name, name, state = self.table.model().row(row)
+
+        answer = QMessageBox.question(
+            self,
+            _("Remove layout"),
+            _("Do you want to remove the layout '<b>{}</b>'?").format(ui_name),
+            QMessageBox.Yes | QMessageBox.No
+        )
+
+        if not answer:
+            return
 
         if name not in read_only:
             if ui_name in ui_names:

--- a/spyder/plugins/layout/widgets/dialog.py
+++ b/spyder/plugins/layout/widgets/dialog.py
@@ -273,29 +273,33 @@ class LayoutSettingsDialog(QDialog):
     def delete_layout(self):
         """Delete layout from the config."""
         names, ui_names, order, active, read_only = (
-            self.names, self.ui_names, self.order, self.active, self.read_only)
+            self.names, self.ui_names, self.order, self.active, self.read_only
+        )
         row = self.table.selectionModel().currentIndex().row()
         ui_name, name, state = self.table.model().row(row)
 
         if name not in read_only:
-            name = from_qvariant(
-                self.table.selectionModel().currentIndex().data(),
-                to_text_string)
             if ui_name in ui_names:
                 index = ui_names.index(ui_name)
             else:
                 # In case nothing has focus in the table
                 return
+
             if index != -1:
-                order.remove(ui_name)
-                names.remove(ui_name)
+                order.remove(name)
+                names.remove(name)
                 ui_names.remove(ui_name)
+
                 if name in active:
-                    active.remove(ui_name)
+                    active.remove(name)
+
                 self.names, self.ui_names, self.order, self.active = (
-                    names, ui_names, order, active)
+                    names, ui_names, order, active
+                )
                 self.table.model().set_data(
-                    names, ui_names, order, active, read_only)
+                    names, ui_names, order, active, read_only
+                )
+
                 index = self.table.model().index(0, 0)
                 self.table.setCurrentIndex(index)
                 self.table.setFocus()

--- a/spyder/plugins/layout/widgets/dialog.py
+++ b/spyder/plugins/layout/widgets/dialog.py
@@ -150,7 +150,8 @@ class LayoutModel(QAbstractTableModel):
 
 
 class LayoutSaveDialog(QDialog):
-    """ """
+    """Dialog to save a custom layout with a given name."""
+
     def __init__(self, parent, order):
         super(LayoutSaveDialog, self).__init__(parent)
 
@@ -162,6 +163,10 @@ class LayoutSaveDialog(QDialog):
         self.combo_box.addItems(order)
         self.combo_box.setEditable(True)
         self.combo_box.clearEditText()
+        self.combo_box.lineEdit().setPlaceholderText(
+            _("Give a name to your layout")
+        )
+
         self.button_box = SpyderDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel, Qt.Horizontal, self
         )
@@ -170,7 +175,7 @@ class LayoutSaveDialog(QDialog):
 
         # widget setup
         self.button_ok.setEnabled(False)
-        self.dialog_size = QSize(300, 100)
+        self.dialog_size = QSize(350, 100)
         self.setWindowTitle(_('Save layout as'))
         self.setModal(True)
         self.setMinimumSize(self.dialog_size)


### PR DESCRIPTION
## Description of Changes

- Improve style of `LayoutSettingsDialog`.
- Prevent flickering the first time Spyder starts on Windows and Mac. Although issue #15074 is closed, it's still happening in Spyder 6.
- Fix flickering on Mac at startup if the main window was maximized in the previous session.
- Fix removing custom layouts from `LayoutSettingsDialog`.
- Ask before removing a custom layout.
- Set placeholder text in `LayoutSaveDialog`.
- Fix tabifying plugins that don't set the TABIFY class constant.

### Visual changes

* Style of `LayoutSettingsDialog`

    | Before | After |
    | - | - |
    | ![image](https://github.com/user-attachments/assets/4bcaef3e-0eb0-494e-8681-9c4d20cd27cc) | ![image](https://github.com/user-attachments/assets/c2831ac4-9c26-430a-9595-d18e5f4370c8) |

* Placeholder text in `LayoutSaveDialog`

    | Before | After |
    | - | - |
    | ![image](https://github.com/user-attachments/assets/4fa9ffe6-9b22-4643-ab23-3aa5e1237013) | ![image](https://github.com/user-attachments/assets/e502d16b-fee5-4970-a746-1d8c83b85bc1) |

### Issue(s) Resolved

Addresses again #15074

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
