### PR TITLE
PR: Update `python-lsp-server` and `qtconsole` subrepos

### DIFF
--- a/external-deps/python-lsp-server/.github/workflows/static.yml
+++ b/external-deps/python-lsp-server/.github/workflows/static.yml
@@ -39,7 +39,7 @@ jobs:
       # This error cannot be resolved by adding a pylint: disable=unused-argument comment ...
       - run: |
           pip install -e .[pylint,pycodestyle]
-          pip install ruff
+          pip install ruff==0.9.4
       - name: ruff linter and code style checks
         run: ruff check pylsp test
       - name: ruff code formatter check

--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/python-lsp/python-lsp-server.git
 	branch = develop
-	commit = eb61ccd97bbe9c58fbde6496a78015ee3c129146
-	parent = 72e992386c3617ecfb957a51e6b910890e931358
+	commit = 04fa3e59e82e05a43759f7d3b5bea2fa7a9b539b
+	parent = 2193e4d0357f31d3eb70ccadfbb4b25e2e176320
 	method = merge
-	cmdver = 0.4.3
+	cmdver = 0.4.9

--- a/external-deps/python-lsp-server/CHANGELOG.md
+++ b/external-deps/python-lsp-server/CHANGELOG.md
@@ -1,5 +1,33 @@
 # History of changes
 
+## Version 1.12.2 (2025/02/07)
+
+### Pull Requests Merged
+
+* [PR 608](https://github.com/python-lsp/python-lsp-server/pull/608) - Fix putting `extra_paths` in front of `sys.path`, by [@cmashinho](https://github.com/cmashinho)
+
+In this release 1 pull request was closed.
+
+----
+
+## Version 1.12.1 (2025/02/06)
+
+### Issues Closed
+
+* [Issue 602](https://github.com/python-lsp/python-lsp-server/issues/602) - `test_jedi_completion_with_fuzzy_enabled` fails with jedi 0.19.2
+
+In this release 1 issue was closed.
+
+### Pull Requests Merged
+
+* [PR 616](https://github.com/python-lsp/python-lsp-server/pull/616) - Fix formatting issues reported by the latest Ruff version, by [@ccordoba12](https://github.com/ccordoba12)
+* [PR 609](https://github.com/python-lsp/python-lsp-server/pull/609) - Fix test for Jedi 0.19.2, by [@cmashinho](https://github.com/cmashinho)
+* [PR 604](https://github.com/python-lsp/python-lsp-server/pull/604) - Correctly handle null value for `ropeFolder` config, by [@osiewicz](https://github.com/osiewicz)
+
+In this release 3 pull requests were closed.
+
+----
+
 ## Version 1.12.0 (2024/08/25)
 
 ### New features

--- a/external-deps/python-lsp-server/pylsp/_utils.py
+++ b/external-deps/python-lsp-server/pylsp/_utils.py
@@ -19,7 +19,7 @@ JEDI_VERSION = jedi.__version__
 # Eol chars accepted by the LSP protocol
 # the ordering affects performance
 EOL_CHARS = ["\r\n", "\r", "\n"]
-EOL_REGEX = re.compile(f'({"|".join(EOL_CHARS)})')
+EOL_REGEX = re.compile(f"({'|'.join(EOL_CHARS)})")
 
 log = logging.getLogger(__name__)
 

--- a/external-deps/python-lsp-server/pylsp/workspace.py
+++ b/external-deps/python-lsp-server/pylsp/workspace.py
@@ -77,7 +77,7 @@ class Workspace:
         # TODO: we could keep track of dirty files and validate only those
         if self.__rope is None or self.__rope_config != rope_config:
             rope_folder = rope_config.get("ropeFolder")
-            if rope_folder:
+            if "ropeFolder" in rope_config:
                 self.__rope = Project(self._root_path, ropefolder=rope_folder)
             else:
                 self.__rope = Project(self._root_path)
@@ -460,7 +460,8 @@ class Document:
         end_col = change_range["end"]["character"]
 
         # Check for an edit occuring at the very end of the file
-        if start_line == len(self.lines):
+        lines = self.lines
+        if start_line == len(lines):
             self._source = self.source + text
             return
 
@@ -469,7 +470,7 @@ class Document:
         # Iterate over the existing document until we hit the edit range,
         # at which point we write the new text, then loop until we hit
         # the end of the range and continue writing.
-        for i, line in enumerate(self.lines):
+        for i, line in enumerate(lines):
             if i < start_line:
                 new.write(line)
                 continue
@@ -493,10 +494,11 @@ class Document:
 
     def word_at_position(self, position):
         """Get the word under the cursor returning the start and end positions."""
-        if position["line"] >= len(self.lines):
+        lines = self.lines
+        if position["line"] >= len(lines):
             return ""
 
-        line = self.lines[position["line"]]
+        line = lines[position["line"]]
         i = position["character"]
         # Split word in two
         start = line[:i]
@@ -599,9 +601,9 @@ class Document:
         )
         path.extend(environment.get_sys_path())
         if prioritize_extra_paths:
-            path += extra_paths + path
+            path = extra_paths + path
         else:
-            path += path + extra_paths
+            path = path + extra_paths
 
         return path
 

--- a/external-deps/python-lsp-server/test/plugins/test_completion.py
+++ b/external-deps/python-lsp-server/test/plugins/test_completion.py
@@ -65,6 +65,7 @@ class TypeCase(NamedTuple):
     expected: lsp.CompletionItemKind
 
 
+# fmt: off
 TYPE_CASES: Dict[str, TypeCase] = {
     "variable": TypeCase(
         document="test = 1\ntes",
@@ -115,6 +116,7 @@ TYPE_CASES: Dict[str, TypeCase] = {
         expected=lsp.CompletionItemKind.Property,
     ),
 }
+# fmt: on
 
 
 @pytest.mark.parametrize("case", list(TYPE_CASES.values()), ids=list(TYPE_CASES.keys()))
@@ -179,9 +181,7 @@ def test_jedi_completion_with_fuzzy_enabled(config, workspace) -> None:
 
     assert items
 
-    expected = "commonprefix(m)"
-    if JEDI_VERSION == "0.18.0":
-        expected = "commonprefix(list)"
+    expected = "isabs(s)"
     assert items[0]["label"] == expected
 
     # Test we don't throw with big character

--- a/external-deps/python-lsp-server/test/test_utils.py
+++ b/external-deps/python-lsp-server/test/test_utils.py
@@ -45,14 +45,14 @@ def notebook_with_python_cells(cells: List[str]):
             "cells": [
                 {
                     "kind": NotebookCellKind.Code,
-                    "document": f"cell_{i+1}_uri",
+                    "document": f"cell_{i + 1}_uri",
                 }
                 for i in range(len(cells))
             ],
         },
         "cellTextDocuments": [
             {
-                "uri": f"cell_{i+1}_uri",
+                "uri": f"cell_{i + 1}_uri",
                 "languageId": "python",
                 "text": cell,
             }

--- a/external-deps/python-lsp-server/test/test_workspace.py
+++ b/external-deps/python-lsp-server/test/test_workspace.py
@@ -238,7 +238,7 @@ def test_workspace_loads_pycodestyle_config(pylsp, tmpdir) -> None:
     # Test that project settings are loaded
     workspace2_dir = tmpdir.mkdir("NewTest456")
     cfg = workspace2_dir.join("pycodestyle.cfg")
-    cfg.write("[pycodestyle]\n" "max-line-length = 1000")
+    cfg.write("[pycodestyle]\nmax-line-length = 1000")
 
     workspace1 = {"uri": str(workspace1_dir)}
     workspace2 = {"uri": str(workspace2_dir)}
@@ -257,7 +257,7 @@ def test_workspace_loads_pycodestyle_config(pylsp, tmpdir) -> None:
     # Test switching to another workspace with different settings
     workspace3_dir = tmpdir.mkdir("NewTest789")
     cfg1 = workspace3_dir.join("pycodestyle.cfg")
-    cfg1.write("[pycodestyle]\n" "max-line-length = 20")
+    cfg1.write("[pycodestyle]\nmax-line-length = 20")
 
     workspace3 = {"uri": str(workspace3_dir)}
 
@@ -310,9 +310,9 @@ def test_progress_simple(workspace, consumer) -> None:
     assert init_call[0][0]["method"] == "window/workDoneProgress/create"
 
     # same method for all calls
-    assert all(
-        call[0][0]["method"] == "$/progress" for call in progress_calls
-    ), consumer.call_args_list
+    assert all(call[0][0]["method"] == "$/progress" for call in progress_calls), (
+        consumer.call_args_list
+    )
 
     # same token used in all calls
     assert (

--- a/external-deps/qtconsole/.github/workflows/linux-tests.yml
+++ b/external-deps/qtconsole/.github/workflows/linux-tests.yml
@@ -27,12 +27,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.8', '3.9', '3.10', '3.11']
+        PYTHON_VERSION: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         INSTALL_TYPE: ['conda', 'pip']
         QT_LIB: ['pyqt5', 'pyqt6']
         exclude:
           - INSTALL_TYPE: 'conda'
             QT_LIB: 'pyqt6'
+          - INSTALL_TYPE: 'conda'
+            PYTHON_VERSION: '3.8'
     timeout-minutes: 15
     steps:
       - name: Checkout branch
@@ -42,22 +44,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libegl1
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
            auto-update-conda: false
            auto-activate-base: false
+           miniforge-version: latest
+           mamba-version: "*"
            channels: conda-forge
-           channel-priority: strict
-           miniforge-variant: Mambaforge
+           channel-priority: true
            python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Install dependencies with conda
         if: matrix.INSTALL_TYPE == 'conda'
-        shell: bash -l {0}
+        shell: bash -el {0}
         run: mamba env update --file requirements/environment.yml
       - name: Install dependencies with pip
         if: matrix.INSTALL_TYPE == 'pip'
-        shell: bash -l {0}
+        shell: bash -el {0}
         run: |
           pip install -e .[test]
           if [ ${{ matrix.QT_LIB }} = "pyqt6" ]; then
@@ -66,18 +69,18 @@ jobs:
             pip install ${{ matrix.QT_LIB }} coveralls pytest-cov
           fi
       - name: Show environment information
-        shell: bash -l {0}
+        shell: bash -el {0}
         run: |
           conda info
           conda list
           pip list
       - name: Run tests
-        shell: bash -l {0}
+        shell: bash -el {0}
         run: xvfb-run --auto-servernum pytest -vv -s --full-trace --color=yes --cov=qtconsole qtconsole
         env:
           QT_API: ${{ matrix.QT_LIB }}
           PYTEST_QT_API: ${{ matrix.QT_LIB }}
       - name: Upload coverage to coveralls
         if: matrix.PYTHON_VERSION == '3.8'
-        shell: bash -l {0}
+        shell: bash -el {0}
         run: coveralls

--- a/external-deps/qtconsole/.github/workflows/macos-tests.yml
+++ b/external-deps/qtconsole/.github/workflows/macos-tests.yml
@@ -24,29 +24,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.8', '3.9', '3.10', '3.11']
+        PYTHON_VERSION: ['3.9', '3.10', '3.11']
     timeout-minutes: 15
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
            auto-update-conda: false
            auto-activate-base: false
-           python-version: ${{ matrix.PYTHON_VERSION }}
-           miniforge-variant: Mambaforge
+           miniforge-version: latest
+           mamba-version: "*"
            channels: conda-forge
-           channel-priority: strict
+           channel-priority: true
+           python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Install package dependencies
-        shell: bash -l {0}
+        shell: bash -el {0}
         run: mamba env update --file requirements/environment.yml
       - name: Show environment information
-        shell: bash -l {0}
+        shell: bash -el {0}
         run: |
           conda info
           conda list
       - name: Run tests
-        shell: bash -l {0}
+        shell: bash -el {0}
         run: pytest -vv --color=yes --cov=qtconsole qtconsole

--- a/external-deps/qtconsole/.github/workflows/windows-tests.yml
+++ b/external-deps/qtconsole/.github/workflows/windows-tests.yml
@@ -24,29 +24,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.8', '3.9', '3.10', '3.11']
+        PYTHON_VERSION: ['3.9', '3.10', '3.11']
     timeout-minutes: 15
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3
-      - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Install Conda and install package dependencies
+        uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
            auto-update-conda: false
            auto-activate-base: false
-           python-version: ${{ matrix.PYTHON_VERSION }}
-           miniforge-variant: Mambaforge
+           miniforge-version: latest
+           mamba-version: "*"
            channels: conda-forge
-           channel-priority: strict
-      - name: Install package dependencies
-        shell: bash -l {0}
-        run: mamba env update --file requirements/environment.yml
+           channel-priority: true
+           python-version: ${{ matrix.PYTHON_VERSION }}
+           environment-file: requirements/environment.yml # Need to set up dependencies in the same step due to https://github.com/conda-incubator/setup-miniconda/issues/371
       - name: Show environment information
-        shell: bash -l {0}
+        shell: bash -el {0}
         run: |
           conda info
           conda list
       - name: Run tests
-        shell: bash -l {0}
+        shell: bash -el {0}
         run: pytest -vv --color=yes --cov=qtconsole qtconsole

--- a/external-deps/qtconsole/.gitrepo
+++ b/external-deps/qtconsole/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/jupyter/qtconsole.git
 	branch = main
-	commit = d527a84b8e7ada16dba847508dafccd1eda542ff
-	parent = 3274e793422497da39940e8ac4dad3ef793acafe
+	commit = f6d3a7ce269f7ba2d244f395de6f1375ae5c0a6a
+	parent = 50b889ab6ed8ee031d8aca75d3df5f507bf1c0fc
 	method = merge
-	cmdver = 0.4.3
+	cmdver = 0.4.9

--- a/external-deps/qtconsole/qtconsole/jupyter_widget.py
+++ b/external-deps/qtconsole/qtconsole/jupyter_widget.py
@@ -14,7 +14,7 @@ from warnings import warn
 
 from qtpy import QtCore, QtGui
 
-from IPython.lib.lexers import IPython3Lexer
+from ipython_pygments_lexers import IPython3Lexer
 from pygments.lexers import get_lexer_by_name
 from pygments.util import ClassNotFound
 from qtconsole import __version__

--- a/external-deps/qtconsole/requirements/environment.yml
+++ b/external-deps/qtconsole/requirements/environment.yml
@@ -9,6 +9,7 @@ dependencies:
 - jupyter_client
 - pygments
 - ipykernel
+- ipython_pygments_lexers
 
 # For testing
 - coveralls

--- a/external-deps/qtconsole/setup.py
+++ b/external-deps/qtconsole/setup.py
@@ -70,12 +70,13 @@ setup_args = dict(
         'jupyter_client>=4.1',
         'pygments',
         'ipykernel>=4.1', # not a real dependency, but require the reference kernel
+        'ipython_pygments_lexers',
         'qtpy>=2.4.0',
         'packaging'
     ],
-    extras_require = {
-        'test': ['flaky', 'pytest', 'pytest-qt'],
-        'doc': 'Sphinx>=1.3',
+    extras_require={
+        "test": ["flaky", "pytest", "pytest-qt", "pytest-asyncio"],
+        "doc": "Sphinx>=1.3",
     },
     entry_points = {
         'gui_scripts': [


### PR DESCRIPTION
Update python-lsp-server and qtconsole external-deps.

Our external-deps cache of conda packages for these repos have been behind and should have caused our weekly installers to fail. However, the weekly installers were erroneously discovering the latest releases of these packages from conda-forge rather than using the cached CI-built ones, allowing the workflow to succeed, i.e. a false-positive.

#23287 fixes this error, but then requires the external-deps specs to be updated so that the correct conda packages can be built and cached.