### PR TITLE
PR: Avoid rounding scaling for figure browser to zero (Plots)

### DIFF
--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -636,7 +636,7 @@ class FigureViewer(QScrollArea, SpyderWidgetMixin):
         width = self.figcanvas.width()
         fwidth = self.figcanvas.fwidth
         if fwidth != 0:
-            return round(width / fwidth * 100)
+            return max(round(width / fwidth * 100), 1)
         else:
             return 100
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [N/A] Wrote at least one-line docstrings (for any new functions)
* [N/A] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [N/A] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
If one creates very large figures, `get_scaling` may result in 0, which then will give a math domain error in https://github.com/spyder-ide/spyder/blob/1baf8d1f6898e431e6ddf2a80788fedc8ec93390/spyder/plugins/plots/widgets/figurebrowser.py#L645

This fix results in get_scaling always returning at least 1. This is maybe not the best choice every time, but at least better than an error.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->



### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: oscargus

<!--- Thanks for your help making Spyder better for everyone! --->
