### PR TITLE
PR: Kill persistent `python.exe` tasks on Windows test workflows (CI)

### DIFF
--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -162,3 +162,9 @@ jobs:
         with:
           fail_ci_if_error: false
           verbose: true
+      - name: Kill Python
+        shell: bash -l {0}
+        run: |
+          # Avoid EPERM: operation not permitted
+          tasklist | grep python
+          taskkill //im python.exe //f || true


### PR DESCRIPTION
Hopefully this will avoid "EPERM: operation not permitted".

The `post-cleanup: none` did not do as we had hoped. The error appears during the caching actions of the teardown, which are not impacted by `post-cleanup`.

Upon ssh into the workflow, I discovered that several python.exe tasks are created and complete throughout the workflow, as might be expected. However, nearing the end of the testing step, the number of python.exe tasks explodes to several tens (20 or 30) and these tasks do not go away even after the code coverage step (the last step). I suspect that these may be holding the file lock on `zlib.dll` (and possibly others), causing the workflow error at setup-micromamba teardown.

If this works, then I think we need to later investigate why these processes are not naturally terminated. 