### PR TITLE
PR: Fix width of the Find pane when searching for long strings

### DIFF
--- a/spyder/plugins/findinfiles/widgets/main_widget.py
+++ b/spyder/plugins/findinfiles/widgets/main_widget.py
@@ -12,7 +12,7 @@ import re
 
 # Third party imports
 from qtpy import PYSIDE2
-from qtpy.QtCore import Signal
+from qtpy.QtCore import Signal, Qt
 from qtpy.QtGui import QFontMetricsF
 from qtpy.QtWidgets import QInputDialog, QLabel
 
@@ -171,7 +171,8 @@ class FindInFilesWidget(PluginMainWidget):
             self,
             items=search_text,
             adjust_to_minimum=False,
-            id_=FindInFilesWidgetToolbarItems.SearchPatternCombo
+            id_=FindInFilesWidgetToolbarItems.SearchPatternCombo,
+            items_elide_mode=Qt.ElideMiddle
         )
         self.search_text_edit.lineEdit().setPlaceholderText(
             _('Write text to search'))

--- a/spyder/plugins/findinfiles/widgets/main_widget.py
+++ b/spyder/plugins/findinfiles/widgets/main_widget.py
@@ -176,6 +176,12 @@ class FindInFilesWidget(PluginMainWidget):
         )
         self.search_text_edit.lineEdit().setPlaceholderText(
             _('Write text to search'))
+        
+        self.search_text_edit.setMinimumSize(
+            MIN_COMBOBOX_WIDTH, AppStyle.FindHeight
+        )        
+        
+        self.search_text_edit.setMaximumWidth(MAX_COMBOBOX_WIDTH)
 
         self.search_in_label = QLabel(_('Search in:'))
         self.search_in_label.ID = FindInFilesWidgetToolbarItems.SearchInLabel

--- a/spyder/plugins/findinfiles/widgets/main_widget.py
+++ b/spyder/plugins/findinfiles/widgets/main_widget.py
@@ -181,6 +181,9 @@ class FindInFilesWidget(PluginMainWidget):
             MIN_COMBOBOX_WIDTH, AppStyle.FindHeight
         )        
         
+        # This is necessary to prevent the width of search_text_edit to control
+        # the width of the pane.
+        # Fixes spyder-ide/spyder#24188
         self.search_text_edit.setMaximumWidth(MAX_COMBOBOX_WIDTH)
 
         self.search_in_label = QLabel(_('Search in:'))
@@ -437,6 +440,9 @@ class FindInFilesWidget(PluginMainWidget):
         """Adjustments when the widget is resized."""
         super().resizeEvent(event)
 
+        # This is necessary to prevent the width of search_text_edit to control
+        # the width of the pane.
+        # Fixes spyder-ide/spyder#24188
         self.search_text_edit.setMaximumWidth(self.width())
 
         # This recomputes the result items width according to this widget's

--- a/spyder/plugins/findinfiles/widgets/main_widget.py
+++ b/spyder/plugins/findinfiles/widgets/main_widget.py
@@ -437,6 +437,8 @@ class FindInFilesWidget(PluginMainWidget):
         """Adjustments when the widget is resized."""
         super().resizeEvent(event)
 
+        self.search_text_edit.setMaximumWidth(self.width())
+
         # This recomputes the result items width according to this widget's
         # width, which makes the UI be rendered as expected.
         # NOTE: Don't debounce or throttle `set_width` because then it wouldn't

--- a/spyder/plugins/findinfiles/widgets/results_browser.py
+++ b/spyder/plugins/findinfiles/widgets/results_browser.py
@@ -264,15 +264,15 @@ class ResultsBrowser(OneColumnTree, SpyderFontsMixin):
         self.set_title(title + text)
 
     def set_title(self, title):
+        # Prevent the title's width to be bigger than the widget's one.
         metrics = QFontMetrics(self.font)
-        searchTextWidth = len(title)* metrics.width('W')
-        maxWidth = self.width()
-        if searchTextWidth >= maxWidth:
-            elided_title = metrics.elidedText(
-                title, Qt.ElideMiddle, maxWidth
-            )
+        search_text_width = len(title) * metrics.width('W')
+        max_width = self.width()
+        if search_text_width >= max_width:
+            elided_title = metrics.elidedText(title, Qt.ElideMiddle, max_width)
         else:
             elided_title = title
+
         self.setHeaderLabels([elided_title])
 
     @Slot(object)

--- a/spyder/plugins/findinfiles/widgets/results_browser.py
+++ b/spyder/plugins/findinfiles/widgets/results_browser.py
@@ -263,6 +263,18 @@ class ResultsBrowser(OneColumnTree, SpyderFontsMixin):
         text = _('String not found')
         self.set_title(title + text)
 
+    def set_title(self, title):
+        metrics = QFontMetrics(self.font)
+        searchTextWidth = len(title)* metrics.width('W')
+        maxWidth = self.width()
+        if searchTextWidth >= maxWidth:
+            elided_title = metrics.elidedText(
+                title, Qt.ElideMiddle, maxWidth
+            )
+        else:
+            elided_title = title
+        self.setHeaderLabels([elided_title])
+
     @Slot(object)
     def append_file_result(self, filename):
         """Real-time update of file items."""
@@ -322,13 +334,6 @@ class ResultsBrowser(OneColumnTree, SpyderFontsMixin):
 
     def set_width(self):
         """Set widget width according to its longest item."""
-        if self.search_text :
-            metrics = QFontMetrics(self.font)
-            searchTextWidth = len(self.search_text)* metrics.width('W')
-            if searchTextWidth >= self.width()-40:
-                maxWidth = int(self.width()/metrics.width('W'))
-                search_text_to_show = self.search_text[:maxWidth] + '...'
-                self.set_title(search_text_to_show)
         if not self.data:
             return
 

--- a/spyder/plugins/findinfiles/widgets/results_browser.py
+++ b/spyder/plugins/findinfiles/widgets/results_browser.py
@@ -322,6 +322,13 @@ class ResultsBrowser(OneColumnTree, SpyderFontsMixin):
 
     def set_width(self):
         """Set widget width according to its longest item."""
+        if self.search_text :
+            metrics = QFontMetrics(self.font)
+            searchTextWidth = len(self.search_text)* metrics.width('W')
+            if searchTextWidth >= self.width()-40:
+                maxWidth = int(self.width()/metrics.width('W'))
+                search_text_to_show = self.search_text[:maxWidth] + '...'
+                self.set_title(search_text_to_show)
         if not self.data:
             return
 

--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -173,7 +173,7 @@ class PatternComboBox(BaseComboBox):
         items_elide_mode=None,
     ):
         if not PYSIDE2:
-            super().__init__(parent)
+            super().__init__(parent, items_elide_mode)
         else:
             BaseComboBox.__init__(self, parent, items_elide_mode)
 

--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -49,8 +49,8 @@ class BaseComboBox(SpyderComboBox):
         The previous size of the widget.
     """
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, parent, items_elide_mode=None):
+        super().__init__(parent, items_elide_mode)
         self.setEditable(True)
         self.setCompleter(QCompleter(self))
         self.selected_text = self.currentText()
@@ -164,11 +164,11 @@ class PatternComboBox(BaseComboBox):
     """Search pattern combo box"""
 
     def __init__(self, parent, items=None, tip=None,
-                 adjust_to_minimum=True, id_=None):
+                 adjust_to_minimum=True, id_=None, items_elide_mode=None):
         if not PYSIDE2:
             super().__init__(parent)
         else:
-            BaseComboBox.__init__(self, parent)
+            BaseComboBox.__init__(self, parent, items_elide_mode)
 
         if adjust_to_minimum:
             self.setSizeAdjustPolicy(

--- a/spyder/widgets/comboboxes.py
+++ b/spyder/widgets/comboboxes.py
@@ -163,8 +163,15 @@ class BaseComboBox(SpyderComboBox):
 class PatternComboBox(BaseComboBox):
     """Search pattern combo box"""
 
-    def __init__(self, parent, items=None, tip=None,
-                 adjust_to_minimum=True, id_=None, items_elide_mode=None):
+    def __init__(
+        self,
+        parent,
+        items=None,
+        tip=None,
+        adjust_to_minimum=True,
+        id_=None,
+        items_elide_mode=None,
+    ):
         if not PYSIDE2:
             super().__init__(parent)
         else:


### PR DESCRIPTION
## Description of Changes

The Find pane width ended up being too large if the user searched for a very long string.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24188.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@jsbautista 
<!--- Thanks for your help making Spyder better for everyone! --->
