### PR TITLE
PR: Update workflow actions to address some warnings (CI)

### DIFF
--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Setup Build Environment
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           condarc: |
             conda_build:

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -190,7 +190,7 @@ jobs:
 
       - name: Setup Build Environment (Windows)
         if: runner.os == 'Windows'
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           condarc: |
             conda_build:
@@ -213,7 +213,7 @@ jobs:
 
       - name: Setup Build Environment (macOS & Linux)
         if: runner.os != 'Windows'
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           condarc: |
             conda_build:

--- a/.github/workflows/test-files.yml
+++ b/.github/workflows/test-files.yml
@@ -86,7 +86,7 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-cachepip-installconda-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
       - name: Create conda test environment
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: '1.5.10-0'
           environment-file: requirements/main.yml

--- a/.github/workflows/test-files.yml
+++ b/.github/workflows/test-files.yml
@@ -72,14 +72,6 @@ jobs:
         run: |
           sudo apt-get update --fix-missing
           sudo apt-get install -qq pyqt5-dev-tools libxcb-xinerama0 xterm --fix-missing
-      - name: Cache conda
-        uses: actions/cache@v4
-        env:
-          # Increase this value to reset cache if requirements/*.yml has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-cacheconda-installconda-${{ matrix.PYTHON_VERSION }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('requirements/*.yml') }}
       - name: Cache pip
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test-linux-qt6.yml
+++ b/.github/workflows/test-linux-qt6.yml
@@ -110,7 +110,7 @@ jobs:
           key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
       - name: Create conda test environment
         if: env.USE_CONDA == 'true'
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: '1.5.10-0'
           environment-file: requirements/main.yml
@@ -119,7 +119,7 @@ jobs:
           create-args: python=${{ matrix.PYTHON_VERSION }}
       - name: Create pip test environment
         if: env.USE_CONDA != 'true'
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: '1.5.10-0'
           environment-name: test

--- a/.github/workflows/test-linux-qt6.yml
+++ b/.github/workflows/test-linux-qt6.yml
@@ -95,14 +95,6 @@ jobs:
         run: |
           sudo apt-get update --fix-missing
           sudo apt-get install -qq pyqt5-dev-tools libxcb-xinerama0 libxcb-cursor0 xterm --fix-missing
-      - name: Cache conda
-        uses: actions/cache@v4
-        env:
-          # Increase this value to reset cache if requirements/*.txt has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-cacheconda-install${{ matrix.INSTALL_TYPE }}-${{ matrix.PYTHON_VERSION }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('requirements/*.yml') }}
       - name: Cache pip
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -108,14 +108,6 @@ jobs:
         run: |
           sudo apt-get update --fix-missing
           sudo apt-get install -qq pyqt5-dev-tools libxcb-xinerama0 xterm --fix-missing
-      - name: Cache conda
-        uses: actions/cache@v4
-        env:
-          # Increase this value to reset cache if requirements/*.txt has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-cacheconda-install${{ matrix.INSTALL_TYPE }}-${{ matrix.PYTHON_VERSION }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('requirements/*.yml') }}
       - name: Cache pip
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -123,7 +123,7 @@ jobs:
           key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
       - name: Create conda test environment
         if: env.USE_CONDA == 'true'
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: '1.5.10-0'
           environment-file: requirements/main.yml
@@ -132,7 +132,7 @@ jobs:
           create-args: python=${{ matrix.PYTHON_VERSION }}
       - name: Create pip test environment
         if: env.USE_CONDA != 'true'
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: '1.5.10-0'
           environment-name: test

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Install Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
+          conda-remove-defaults: "true"
           auto-activate-base: false
           python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Create conda test environment

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -106,7 +106,7 @@ jobs:
           auto-activate-base: false
           python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Create conda test environment
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: '1.5.10-0'
           environment-file: requirements/main.yml

--- a/.github/workflows/test-remoteclient.yml
+++ b/.github/workflows/test-remoteclient.yml
@@ -93,14 +93,6 @@ jobs:
         run: |
           sudo apt-get update --fix-missing
           sudo apt-get install -qq pyqt5-dev-tools libxcb-xinerama0 xterm --fix-missing
-      - name: Cache conda
-        uses: actions/cache@v4
-        env:
-          # Increase this value to reset cache if requirements/*.txt has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-cacheconda-install${{ matrix.INSTALL_TYPE }}-${{ matrix.PYTHON_VERSION }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('requirements/*.yml') }}
       - name: Cache pip
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test-remoteclient.yml
+++ b/.github/workflows/test-remoteclient.yml
@@ -108,7 +108,7 @@ jobs:
           key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
       - name: Create conda test environment
         if: env.USE_CONDA == 'true'
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: '1.5.10-0'
           environment-file: requirements/main.yml
@@ -117,7 +117,7 @@ jobs:
           create-args: python=${{ matrix.PYTHON_VERSION }}
       - name: Create pip test environment
         if: env.USE_CONDA != 'true'
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: '1.5.10-0'
           environment-name: test

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -102,7 +102,7 @@ jobs:
           key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
       - name: Create conda test environment
         if: env.USE_CONDA == 'true'
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: '1.5.10-0'
           environment-file: requirements/main.yml
@@ -111,7 +111,7 @@ jobs:
           create-args: python=${{ matrix.PYTHON_VERSION }}
       - name: Create pip test environment
         if: env.USE_CONDA != 'true'
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: '1.5.10-0'
           environment-name: test

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -87,14 +87,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Fetch branches
         run: git fetch --prune --unshallow
-      - name: Cache conda
-        uses: actions/cache@v4
-        env:
-          # Increase this value to reset cache if requirements/*.txt has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-cacheconda-install${{ matrix.INSTALL_TYPE }}-${{ matrix.PYTHON_VERSION }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('requirements/*.yml') }}
       - name: Cache pip
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
setup-micromamba@v1 uses legacy caching that is no longer in service. Updating to setup-micromamba@v2 resolves the following warnings:
* "Failed to restore: Cache service responded with 422" 
* "This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP"

The "Cache conda" step in Linux and Windows workflows does not serve any purpose. This step remains for the macOS test workflow. Resolves:
* "Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved."

Explicitly remove the defaults channel from setup-miniconda (macOS only). Resolves:
* "The 'defaults' channel might have been added implicitly"