### PR TITLE
PR: Remove `CONF` usage in `MouseShortcutEditor` (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/mouse_shortcuts.py
+++ b/spyder/plugins/editor/widgets/mouse_shortcuts.py
@@ -24,20 +24,22 @@ from qtpy.QtWidgets import (
 )
 
 # Local imports
+from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.config.base import _
-from spyder.config.manager import CONF
 from spyder.utils.icon_manager import ima
 from spyder.widgets.helperwidgets import TipWidget
 
 
-class MouseShortcutEditor(QDialog):
+class MouseShortcutEditor(QDialog, SpyderConfigurationAccessor):
     """A dialog to edit the modifier keys for CodeEditor mouse interactions."""
+
+    CONF_SECTION = "editor"
 
     def __init__(self, parent):
         super().__init__(parent)
         self.editor_config_page = parent
-        mouse_shortcuts = CONF.get('editor', 'mouse_shortcuts')
+        mouse_shortcuts = self.get_conf('mouse_shortcuts')
         self.setWindowFlags(
             self.windowFlags() & ~Qt.WindowContextHelpButtonHint
         )


### PR DESCRIPTION
## Description of Changes

I missed this in my review of PR #23463.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
