### PR TITLE
PR: Catch error when `xdg-open` is missing and show message instead (Files)

### DIFF
--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -415,14 +415,14 @@ class EditorStack(QWidget, SpyderWidgetMixin):
         try:
             show_in_external_file_explorer(fnames)
         except FileNotFoundError as error:
-            file = str(error).split("'")[1]
-            if "xdg-open" in file:
-                msg_title = _("Warning")
+            if "xdg-open" in str(error):
+                msg_title = _("Error")
                 msg = _("Spyder can't show this file in the external file "
                         "explorer because the <tt>xdg-utils</tt> package is "
                         "not available on your system.")
-                QMessageBox.information(self, msg_title, msg,
-                                        QMessageBox.Ok)
+                QMessageBox.critical(
+                    self, msg_title, msg, QMessageBox.Ok
+                )
 
     def copy_absolute_path(self):
         """Copy current filename absolute path to the clipboard."""

--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -1258,7 +1258,20 @@ class DirView(QTreeView, SpyderWidgetMixin):
         """Show file in external file explorer"""
         if fnames is None or isinstance(fnames, bool):
             fnames = self.get_selected_filenames()
-        show_in_external_file_explorer(fnames)
+
+        try:
+            show_in_external_file_explorer(fnames)
+        except FileNotFoundError as error:
+            if "xdg-open" in str(error):
+                msg_title = _("Error")
+                msg = _(
+                    "Spyder can't show this file in the external file "
+                    "explorer because the <tt>xdg-utils</tt> package is not "
+                    "available on your system."
+                )
+                QMessageBox.critical(
+                    self._parent, msg_title, msg, QMessageBox.Ok
+                )
 
     @Slot()
     def rename(self, fnames=None):


### PR DESCRIPTION
## Description of Changes

Also, improve a bit UI of the equivalent message in the Editor.

### Issue(s) Resolved

Reported in https://github.com/spyder-ide/spyder/issues/24205#issuecomment-2807211701

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
