### PR TITLE
PR: Follow-up to removing `CONF` from `mouse_shortcuts` (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/mouse_shortcuts.py
+++ b/spyder/plugins/editor/widgets/mouse_shortcuts.py
@@ -38,7 +38,6 @@ class MouseShortcutEditor(QDialog, SpyderConfigurationAccessor):
 
     def __init__(self, parent):
         super().__init__(parent)
-        self.editor_config_page = parent
         mouse_shortcuts = self.get_conf('mouse_shortcuts')
         self.setWindowFlags(
             self.windowFlags() & ~Qt.WindowContextHelpButtonHint
@@ -108,9 +107,7 @@ class MouseShortcutEditor(QDialog, SpyderConfigurationAccessor):
 
     def apply_mouse_shortcuts(self):
         """Set new config to CONF"""
-        self.editor_config_page.set_option(
-            'mouse_shortcuts', self.mouse_shortcuts
-        )
+        self.set_conf('mouse_shortcuts', self.mouse_shortcuts)
         self.scrollflag_shortcut.apply_modifiers()
         self.goto_def_shortcut.apply_modifiers()
         self.add_cursor_shortcut.apply_modifiers()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
PR: Remove CONF usage in MouseShortcutEditor (Editor)
https://github.com/spyder-ide/spyder/pull/24250#issuecomment-2817239603

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Refactor setting mouse shortcuts CONF to use `SpyderConfigurationAccessor` api


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: athompson673

<!--- Thanks for your help making Spyder better for everyone! --->
