### PR TITLE
PR: Remove qtwebengine patch from feedstock for 6.0.5+ (Installers)

### DIFF
--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -154,6 +154,9 @@ class BuildCondaPkg:
         for k, v in self.data.items():
             meta = re.sub(f".*set {k} =.*", f'{{% set {k} = "{v}" %}}', meta)
 
+        # TODO: Revert for 6.0.6
+        meta = re.sub("\s+- 24095_24156_qtwebengine_optional.patch", "", meta)
+
         file.rename(file.parent / ("_" + file.name))  # keep copy of original
         file.write_text(meta)
 


### PR DESCRIPTION
Remove `24095_24156_qtwebengine_optional.patch` from patches to apply in spyder-feedstock `meta.yaml` when building Spyder conda package in our CI for >6.0.5 and <6.0.6.

This should be reverted for 6.0.6, when the patch is removed from spyder-feedstock repository.