### PR TITLE
PR: Do not scroll to the bottom if last plot is not selected (Plots)

### DIFF
--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -1007,7 +1007,7 @@ class ThumbnailScrollBar(QFrame):
         thumbnail.show()
         self._setup_thumbnail_size(thumbnail)
 
-        if not is_first and not stick_at_end:
+        if not is_first and (not stick_at_end or not select_last):
             self._scroll_to_last_thumbnail = False
 
     def remove_current_thumbnail(self):


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Change the logic in the Plots pane so that when a plot is added, the scrollbar at the right will scroll to the bottom if this is the first plot in the current execution OR (the scrollbar is currently at the bottom AND the last plot is selected).

Before, the scrollbar would scroll to be bottom if it is the first plot OR the scrollbar is currently at the bottom.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21683 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
