### PR TITLE
PR: Skip some tests about warnings on Mac because they became flaky

### DIFF
--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -803,6 +803,7 @@ def test_runconfig_workdir(main_window, qtbot, tmpdir):
     sys.platform.startswith("linux") and running_in_ci(),
     reason='Fails sometimes on Linux and CIs'
 )
+@pytest.mark.skipif(sys.platform == "darwin", reason="Fails sometimes on Mac")
 def test_dedicated_consoles(main_window, qtbot):
     """Test running code in dedicated consoles."""
 

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_warnings.py
@@ -182,6 +182,7 @@ def test_move_warnings(qtbot, completions_codeeditor_linting):
 
 @pytest.mark.order(2)
 @flaky(max_runs=5)
+@pytest.mark.skipif(sys.platform == "darwin", reason="Fails sometimes on Mac")
 def test_get_warnings(qtbot, completions_codeeditor_linting):
     """Test that the editor is returning the right list of warnings."""
     editor, _ = completions_codeeditor_linting
@@ -209,15 +210,12 @@ def test_get_warnings(qtbot, completions_codeeditor_linting):
                 ["""E305 expected 2 blank lines after class or """
                  """function definition, found 0""", 7]]
 
-    # For some odd reason the first warning is not reported on Mac anymore
-    if sys.platform == "darwin":
-        expected = expected[1:]
-
     assert warnings == expected
 
 
 @pytest.mark.order(2)
 @flaky(max_runs=5)
+@pytest.mark.skipif(sys.platform == "darwin", reason="Fails sometimes on Mac")
 def test_update_warnings_after_delete_line(qtbot, completions_codeeditor_linting):
     """
     Test that code style warnings are correctly updated after deleting a line
@@ -252,15 +250,12 @@ def test_update_warnings_after_delete_line(qtbot, completions_codeeditor_linting
                 ["""E305 expected 2 blank lines after class or """
                  """function definition, found 0""", 6]]
 
-    # For some odd reason the first warning is not reported on Mac anymore
-    if sys.platform == "darwin":
-        expected = expected[1:]
-
     assert editor.get_current_warnings() == expected
 
 
 @pytest.mark.order(2)
 @flaky(max_runs=5)
+@pytest.mark.skipif(sys.platform == "darwin", reason="Fails sometimes on Mac")
 def test_update_warnings_after_closequotes(qtbot, completions_codeeditor_linting):
     """
     Test that code errors are correctly updated after activating closequotes
@@ -299,18 +294,13 @@ def test_update_warnings_after_closequotes(qtbot, completions_codeeditor_linting
 
     # Assert that the error is gone.
     qtbot.wait(2000)
-
-    # For some odd reason this warning is not reported on Mac anymore
-    expected = (
-        []
-        if sys.platform == "darwin"
-        else [["D100: Missing docstring in public module", 1]]
-    )
+    expected = [["D100: Missing docstring in public module", 1]]
     assert editor.get_current_warnings() == expected
 
 
 @pytest.mark.order(2)
 @flaky(max_runs=5)
+@pytest.mark.skipif(sys.platform == "darwin", reason="Fails sometimes on Mac")
 def test_update_warnings_after_closebrackets(qtbot, completions_codeeditor_linting):
     """
     Test that code errors are correctly updated after activating closebrackets
@@ -355,13 +345,7 @@ def test_update_warnings_after_closebrackets(qtbot, completions_codeeditor_linti
 
     # Assert that the error is gone.
     qtbot.wait(2000)
-
-    # For some odd reason this warning is not reported on Mac anymore
-    expected = (
-        []
-        if sys.platform == "darwin"
-        else [["D100: Missing docstring in public module", 1]]
-    )
+    expected = [["D100: Missing docstring in public module", 1]]
     assert editor.get_current_warnings() == expected
 
 
@@ -370,6 +354,7 @@ def test_update_warnings_after_closebrackets(qtbot, completions_codeeditor_linti
 @pytest.mark.parametrize(
     'ignore_comment', ['#noqa', '# NOQA', '# analysis:ignore', '# no-work']
 )
+@pytest.mark.skipif(sys.platform == "darwin", reason="Fails sometimes on Mac")
 def test_ignore_warnings_with_comments(
     qtbot, completions_codeeditor_linting, ignore_comment
 ):
@@ -390,10 +375,6 @@ def test_ignore_warnings_with_comments(
             ['E261 at least two spaces before inline comment', 1],
             ["undefined name 'bar'", 2]
         ]
-
-        # For some odd reason the second warning is not reported on Mac anymore
-        if sys.platform == "darwin":
-            expected.pop(1)
     else:
         expected = [["undefined name 'bar'", 2]]
 


### PR DESCRIPTION
## Description of Changes

- I tried to fix those tests in PR #24234 but now it seems they fail sometimes and pass on other occasions. So, I think it's better to simply skip them.
- I also decided to skip `test_dedicated_consoles` on Mac because it fails frequently.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
