### PR TITLE
PR: Fix error when resizing not visible `PaneEmptyWidget`'s

### DIFF
--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -778,10 +778,17 @@ class PaneEmptyWidget(QFrame, SvgToScaledPixmap, SpyderFontsMixin):
         """Actions to take when widget is resized."""
         # Hide/show image label when necessary
         if self._image_label is not None:
-            # We need to do this validation because sometimes minimumSizeHint
-            # doesn't give the right min_height in showEvent (e.g. when adding
-            # an _ErroredMessageWidget to plugins that are not visible).
-            if self._min_height < self.minimumSizeHint().height():
+            if (
+                # This is necessary to prevent and error when the widget hasn't
+                # been made visible yet.
+                # Fixes spyder-ide/spyder#24280
+                self._min_height is None
+                # We need to do this validation because sometimes
+                # minimumSizeHint doesn't give the right min_height in
+                # showEvent (e.g. when adding an _ErroredMessageWidget to
+                # plugins that are not visible).
+                or self._min_height < self.minimumSizeHint().height()
+            ):
                 self._min_height = self.minimumSizeHint().height()
 
             if self.height() <= self._min_height:


### PR DESCRIPTION
## Description of Changes

This error happened when a resize event was triggered in panes that are not visible at startup (e.g. Find in the default layout).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24280

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
