### PR TITLE
PR: Do not skip warnings test on macOS

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_warnings.py
@@ -182,7 +182,6 @@ def test_move_warnings(qtbot, completions_codeeditor_linting):
 
 @pytest.mark.order(2)
 @flaky(max_runs=5)
-@pytest.mark.skipif(sys.platform == "darwin", reason="Fails sometimes on Mac")
 def test_get_warnings(qtbot, completions_codeeditor_linting):
     """Test that the editor is returning the right list of warnings."""
     editor, _ = completions_codeeditor_linting
@@ -215,7 +214,6 @@ def test_get_warnings(qtbot, completions_codeeditor_linting):
 
 @pytest.mark.order(2)
 @flaky(max_runs=5)
-@pytest.mark.skipif(sys.platform == "darwin", reason="Fails sometimes on Mac")
 def test_update_warnings_after_delete_line(qtbot, completions_codeeditor_linting):
     """
     Test that code style warnings are correctly updated after deleting a line
@@ -255,7 +253,6 @@ def test_update_warnings_after_delete_line(qtbot, completions_codeeditor_linting
 
 @pytest.mark.order(2)
 @flaky(max_runs=5)
-@pytest.mark.skipif(sys.platform == "darwin", reason="Fails sometimes on Mac")
 def test_update_warnings_after_closequotes(qtbot, completions_codeeditor_linting):
     """
     Test that code errors are correctly updated after activating closequotes
@@ -300,7 +297,6 @@ def test_update_warnings_after_closequotes(qtbot, completions_codeeditor_linting
 
 @pytest.mark.order(2)
 @flaky(max_runs=5)
-@pytest.mark.skipif(sys.platform == "darwin", reason="Fails sometimes on Mac")
 def test_update_warnings_after_closebrackets(qtbot, completions_codeeditor_linting):
     """
     Test that code errors are correctly updated after activating closebrackets
@@ -354,7 +350,6 @@ def test_update_warnings_after_closebrackets(qtbot, completions_codeeditor_linti
 @pytest.mark.parametrize(
     'ignore_comment', ['#noqa', '# NOQA', '# analysis:ignore', '# no-work']
 )
-@pytest.mark.skipif(sys.platform == "darwin", reason="Fails sometimes on Mac")
 def test_ignore_warnings_with_comments(
     qtbot, completions_codeeditor_linting, ignore_comment
 ):


### PR DESCRIPTION
These tests do not need to be skipped by macOS. PR https://github.com/spyder-ide/spyder/pull/24294 removed the offending code which _removed_ expected warnings for the macOS case. I don't know what changed to make these considerations obsolete.
