### PR TITLE
PR: Treat `frozenset` as `set` in Variable Explorer

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = master
-	commit = 910936ceea310c4e62764e7bb6c54d4fcf88e13d
-	parent = 0ae28768c0fd4ca5f71647c78bd3eb1bbee77241
+	commit = 58ecaf3934d95475a67aa97615e0433b7626bc34
+	parent = 6be77cd03a84506b148d72a897482463c4f86732
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
@@ -203,10 +203,26 @@ def is_editable_type(value):
         return False
     else:
         supported_types = [
-            'bool', 'int', 'long', 'float', 'complex', 'list', 'set', 'dict',
-            'tuple', 'str', 'unicode', 'NDArray', 'MaskedArray', 'Matrix',
-            'DataFrame', 'Series', 'PIL.Image.Image', 'datetime.date',
-            'datetime.timedelta'
+            'bool',
+            'int',
+            'long',
+            'float',
+            'complex',
+            'list',
+            'set',
+            'frozenset',
+            'dict',
+            'tuple',
+            'str',
+            'unicode',
+            'NDArray',
+            'MaskedArray',
+            'Matrix',
+            'DataFrame',
+            'Series',
+            'PIL.Image.Image',
+            'datetime.date',
+            'datetime.timedelta',
         ]
 
         if (get_type_string(value) not in supported_types and
@@ -272,7 +288,7 @@ def default_display(value, with_module=True):
 def collections_display(value, level):
     """Display for collections (i.e. list, set, tuple and dict)."""
     is_dict = isinstance(value, dict)
-    is_set = isinstance(value, set)
+    is_set = isinstance(value, (set, frozenset))
 
     # Get elements
     if is_dict:
@@ -311,6 +327,8 @@ def collections_display(value, level):
         display = '[' + display + ']'
     elif isinstance(value, set):
         display = '{' + display + '}'
+    elif isinstance(value, frozenset):
+        display = 'frozenset({' + display + '})'
     else:
         display = '(' + display + ')'
 
@@ -354,7 +372,7 @@ def value_to_display(value, minmax=False, level=0):
                     display = default_display(value)
             else:
                 display = 'Numpy array'
-        elif any([type(value) == t for t in [list, set, tuple, dict]]):
+        elif type(value) in [list, set, frozenset, tuple, dict]:
             display = collections_display(value, level+1)
         elif isinstance(value, PIL.Image.Image):
             if level == 0:
@@ -558,7 +576,7 @@ def is_supported(value, check_all=False, filters=None, iterate=False):
     elif not isinstance(value, filters):
         return False
     elif iterate:
-        if isinstance(value, (list, tuple, set)):
+        if isinstance(value, (list, tuple, set, frozenset)):
             valid_count = 0
             for val in value:
                 if is_supported(val, filters=filters, iterate=check_all):
@@ -632,8 +650,19 @@ def get_supported_types():
     in spyder-docs
     """
     from datetime import date, timedelta
-    editable_types = [int, float, complex, list, set, dict, tuple, date,
-                      timedelta, str]
+    editable_types = [
+        int,
+        float,
+        complex,
+        list,
+        set,
+        frozenset,
+        dict,
+        tuple,
+        date,
+        timedelta,
+        str,
+    ]
     try:
         from numpy import ndarray, matrix, generic
         editable_types += [ndarray, matrix, generic]

--- a/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_nsview.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_nsview.py
@@ -55,8 +55,14 @@ def test_get_size():
                 return super(object, self).__getattribute__(name)
 
 
-    length = [list([1,2,3]), tuple([1,2,3]), set([1,2,3]), '123',
-              {1:1, 2:2, 3:3}]
+    length = [
+        list([1, 2, 3]),
+        tuple([1, 2, 3]),
+        set([1, 2, 3]),
+        '123',
+        {1:1, 2:2, 3:3},
+        frozenset([1, 2, 3]),
+    ]
     for obj in length:
         assert get_size(obj) == 3
 
@@ -243,6 +249,11 @@ def test_set_display():
     assert value_to_display([long_set] * 10) == disp[:70] + ' ...'
 
 
+def test_frozenset_display():
+    """Test for display of a frozenset."""
+    assert value_to_display(frozenset({1, 2, 3})) == 'frozenset({1, 2, 3})'
+
+
 def test_datetime_display():
     """Simple tests that dates, datetimes and timedeltas display correctly."""
     test_date = datetime.date(2017, 12, 18)
@@ -323,6 +334,9 @@ def test_get_type_string():
     # Sets
     assert get_type_string({1, 2, 3}) == 'set'
 
+    # Frozensets
+    assert get_type_string(frozenset({1, 2, 3})) == 'frozenset'
+
     # Dictionaries
     assert get_type_string({'a': 1, 'b': 2}) == 'dict'
 
@@ -377,6 +391,9 @@ def test_is_editable_type():
 
     # Sets
     assert is_editable_type({1, 2, 3})
+
+    # Frozensets
+    assert is_editable_type(frozenset({1, 2, 3}))
 
     # Dictionaries
     assert is_editable_type({'a': 1, 'b': 2})

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -222,7 +222,10 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
             self.sig_editor_shown.emit()
             return None
         # CollectionsEditor for a list, tuple, dict, etc.
-        elif isinstance(value, (list, set, tuple, dict)) and not object_explorer:
+        elif (
+            isinstance(value, (list, set, frozenset, tuple, dict))
+            and not object_explorer
+        ):
             from spyder.widgets.collectionseditor import CollectionsEditor
             editor = CollectionsEditor(
                 parent=parent,
@@ -688,7 +691,7 @@ class ToggleColumnDelegate(CollectionsDelegate):
                     or not is_known_type(value))
 
         # CollectionsEditor for a list, tuple, dict, etc.
-        if isinstance(value, (list, set, tuple, dict)):
+        if isinstance(value, (list, set, frozenset, tuple, dict)):
             from spyder.widgets.collectionseditor import CollectionsEditor
             editor = CollectionsEditor(
                 parent=parent,

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -220,8 +220,11 @@ class ReadOnlyCollectionsModel(QAbstractTableModel, SpyderFontsMixin):
         """Set model data"""
         self._data = data
 
-        if (coll_filter is not None and not self.remote and
-                isinstance(data, (tuple, list, dict, set, frozenset))):
+        if (
+            coll_filter is not None
+            and not self.remote 
+            and isinstance(data, (tuple, list, dict, set, frozenset))
+        ):
             data = coll_filter(data)
         self.showndata = data
 

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -221,7 +221,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel, SpyderFontsMixin):
         self._data = data
 
         if (coll_filter is not None and not self.remote and
-                isinstance(data, (tuple, list, dict, set))):
+                isinstance(data, (tuple, list, dict, set, frozenset))):
             data = coll_filter(data)
         self.showndata = data
 
@@ -237,6 +237,10 @@ class ReadOnlyCollectionsModel(QAbstractTableModel, SpyderFontsMixin):
         elif isinstance(data, set):
             self.keys = list(range(len(data)))
             self.title += _("Set")
+            self._data = list(data)
+        elif isinstance(data, frozenset):
+            self.keys = list(range(len(data)))
+            self.title += _("Frozenset")
             self._data = list(data)
         elif isinstance(data, dict):
             try:
@@ -576,7 +580,7 @@ class CollectionsModel(ReadOnlyCollectionsModel):
             color = SpyderPalette.GROUP_4
         elif python_type == 'list':
             color = SpyderPalette.GROUP_5
-        elif python_type == 'set':
+        elif python_type in ['set', 'frozenset']:
             color = SpyderPalette.GROUP_6
         elif python_type == 'tuple':
             color = SpyderPalette.GROUP_7
@@ -973,7 +977,7 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
 
         # Enable/disable actions
         condition_edit = (
-            (not isinstance(data, (tuple, set))) and
+            (not isinstance(data, (tuple, set, frozenset))) and
             index.isValid() and
             (len(self.selectedIndexes()) > 0) and
             indexes_in_same_row() and
@@ -998,7 +1002,7 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
         self.copy_action.setEnabled(condition_select)
 
         condition_remove = (
-            (not isinstance(data, (tuple, set))) and
+            (not isinstance(data, (tuple, set, frozenset))) and
             index.isValid() and
             (len(self.selectedIndexes()) > 0) and
             not self.readonly
@@ -1291,7 +1295,7 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
             field_text = _('Variable name:')
 
         data = self.source_model.get_data()
-        if isinstance(data, (list, set)):
+        if isinstance(data, (list, set, frozenset)):
             new_key, valid = len(data), True
         elif new_name is not None:
             new_key, valid = new_name, True
@@ -1595,7 +1599,7 @@ class CollectionsEditorTableView(BaseTableView):
         BaseTableView.__init__(self, parent)
         self.dictfilter = None
         self.namespacebrowser = namespacebrowser
-        self.readonly = readonly or isinstance(data, (tuple, set))
+        self.readonly = readonly or isinstance(data, (tuple, set, frozenset))
         CollectionsModelClass = (ReadOnlyCollectionsModel if self.readonly
                                  else CollectionsModel)
         self.source_model = CollectionsModelClass(
@@ -1613,7 +1617,7 @@ class CollectionsEditorTableView(BaseTableView):
 
         self.setup_table()
         self.menu = self.setup_menu()
-        if isinstance(data, set):
+        if isinstance(data, (set, frozenset)):
             self.horizontalHeader().hideSection(0)
 
     #------ Remote/local API --------------------------------------------------
@@ -1629,7 +1633,7 @@ class CollectionsEditorTableView(BaseTableView):
         data = self.source_model.get_data()
         if isinstance(data, list):
             data.append(data[orig_key])
-        if isinstance(data, set):
+        if isinstance(data, (set, frozenset)):
             data.add(data[orig_key])
         else:
             data[new_key] = data[orig_key]
@@ -1649,9 +1653,9 @@ class CollectionsEditorTableView(BaseTableView):
         return isinstance(data[key], (tuple, list))
 
     def is_set(self, key):
-        """Return True if variable is a set"""
+        """Return True if variable is a set or a frozenset"""
         data = self.source_model.get_data()
-        return isinstance(data[key], set)
+        return isinstance(data[key], (set, frozenset))
 
     def get_len(self, key):
         """Return sequence length"""
@@ -1837,7 +1841,7 @@ class CollectionsEditor(BaseDialog):
     def setup(self, data, title='', readonly=False, remote=False,
               icon=None, parent=None):
         """Setup editor."""
-        if isinstance(data, (dict, set)):
+        if isinstance(data, (dict, set, frozenset)):
             # dictionary, set
             self.data_copy = data.copy()
         elif isinstance(data, (tuple, list)):

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -354,6 +354,17 @@ def test_shows_dataframeeditor_when_editing_index(monkeypatch):
         mockDataFrameEditor_instance.show.assert_called_once_with()
 
 
+def test_shows_collectioneditor_when_editing_frozenset():
+    fs = frozenset('Spyder')
+    editor = CollectionsEditorTableView(None, {'fs': fs})
+    name_to_patch = 'spyder.widgets.collectionseditor.CollectionsEditor'
+    with patch(name_to_patch) as MockCollectionsEditor:
+        editor.delegate.createEditor(
+            None, None, editor.model().index(0, 3)
+        )
+    MockCollectionsEditor.return_value.show.assert_called_once_with()
+
+
 def test_sort_numpy_numeric_collectionsmodel():
     if parse(numpy.__version__) >= parse("2.0.0"):
         np20 = True


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

This PR add supports for variables of type `frozenset` in the Variable Explorer. A `frozenset` will be treated like a `set`. The value is displayed as "frozenset({...})" and clicking on it opens a Collection Editor. Add a test for the latter.

Depends on spyder-ide/spyder-kernels#540.

Video of the new behaviour:

https://github.com/user-attachments/assets/13608bc1-5fa1-4d3c-a0b5-d960760857bf

Video of the old behaviour:

https://github.com/user-attachments/assets/f0623149-728d-49d0-bd49-dc946840d5bc


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24306


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
