### PR TITLE
PR: Remove 6.x branch from weekly scheduled installer build

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -97,7 +97,7 @@ jobs:
         fi
 
         if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then
-            branch="'master', '6.x'"
+            branch="'master'"
         else
             branch="''"
         fi


### PR DESCRIPTION
Remove 6.x branch from weekly scheduled installer build because the workflow on the master branch is incompatible with the installer build modules on 6.x after PR #23287.
