### PR TITLE
PR: Rename resources to Resources in our runtime environment for macOS case-sensitive file systems (Installers)

### DIFF
--- a/installers-conda/build_installers.py
+++ b/installers-conda/build_installers.py
@@ -167,7 +167,7 @@ def _create_conda_lock(env_type, extra_specs=[], no_local=False):
     ]
 
     logger.info(f"Building {lock_file.name}...")
-    logger.info("Conda lock configuration:\n{env_file.read_text()}\n")
+    logger.info(f"Conda lock configuration:\n{env_file.read_text()}\n")
     run(cmd_args, check=True, env=env)
 
     logger.info(f"Contents of {lock_file}:\n{lock_file.read_text()}")

--- a/installers-conda/resources/post-install.sh
+++ b/installers-conda/resources/post-install.sh
@@ -9,6 +9,16 @@ echo "Environment variables:"
 env | sort
 echo ""
 
+# ---- QtWebengine
+# QtWebengine cannot find $prefix/resources directory on a APFS case-sensitive file system.
+# This is not the default macOS file system. To work-around this we rename it to Resources.
+# See https://github.com/spyder-ide/spyder/issues/23415
+runtime_env="${PREFIX}/envs/spyder-runtime"
+if [[ "$OSTYPE" == "darwin"* && ! -e "${runtime_env}/Resources" ]]; then
+    # macOS and case-sensitive
+    mv -f ${runtime_env}/resources ${runtime_env}/Resources || true
+fi
+
 # ---- Shortcut
 pythonexe=${PREFIX}/bin/python
 menuinst=${PREFIX}/bin/menuinst_cli.py


### PR DESCRIPTION
Rename resources->Resources in our runtime environment for macOS case-sensitive file systems.

Fixes #23415