### PR TITLE
PR: Add ability to filter elements in `ElementsTable`

### DIFF
--- a/spyder/api/plugin_registration/_confpage.py
+++ b/spyder/api/plugin_registration/_confpage.py
@@ -14,6 +14,7 @@ from qtpy.QtWidgets import QVBoxLayout, QLabel
 from spyder.api.preferences import PluginConfigPage
 from spyder.config.base import _
 from spyder.widgets.elementstable import ElementsTable
+from spyder.widgets.helperwidgets import FinderWidget
 
 
 class PluginsConfigPage(PluginConfigPage):
@@ -94,15 +95,25 @@ class PluginsConfigPage(PluginConfigPage):
         external_elements.sort(key=lambda e: collator.sort_key(e['title']))
 
         # Build plugins table, showing external plugins first.
-        plugins_table = ElementsTable(
+        self._plugins_table = ElementsTable(
             self, external_elements + internal_elements
         )
+
+        # Finder to filter plugins
+        finder = FinderWidget(
+            self,
+            find_on_change=True,
+            show_close_button=False,
+            set_min_width=False,
+        )
+        finder.sig_find_text.connect(self._do_find)
 
         # Layout
         layout = QVBoxLayout()
         layout.addWidget(header_label)
         layout.addSpacing(15)
-        layout.addWidget(plugins_table)
+        layout.addWidget(self._plugins_table)
+        layout.addWidget(finder)
         layout.addSpacing(15)
         self.setLayout(layout)
 
@@ -133,3 +144,6 @@ class PluginsConfigPage(PluginConfigPage):
                 # self.plugin.delete_plugin(plugin_name)
                 pass
         return set({})
+
+    def _do_find(self, text):
+        self._plugins_table.do_find(text)

--- a/spyder/plugins/debugger/widgets/framesbrowser.py
+++ b/spyder/plugins/debugger/widgets/framesbrowser.py
@@ -137,6 +137,7 @@ class FramesBrowser(
         self.results_browser.sig_edit_goto.connect(self.sig_edit_goto)
 
         self.finder = FinderWidget(self)
+        self.finder.setVisible(False)
         self.finder.sig_find_text.connect(self.do_find)
         self.finder.sig_hide_finder_requested.connect(
             self.sig_hide_finder_requested)

--- a/spyder/plugins/shortcuts/widgets/table.py
+++ b/spyder/plugins/shortcuts/widgets/table.py
@@ -31,6 +31,7 @@ from spyder.utils.palette import SpyderPalette
 from spyder.utils.qthelpers import create_toolbutton
 from spyder.utils.stringmatching import get_search_regex, get_search_scores
 from spyder.widgets.helperwidgets import (
+    ClearLineEdit,
     HTMLDelegate,
     HoverRowsTableView,
     VALID_FINDER_CHARS,
@@ -116,7 +117,7 @@ class ShortcutLineEdit(QLineEdit):
         super(ShortcutLineEdit, self).setText(sequence)
 
 
-class ShortcutFinder(QLineEdit):
+class ShortcutFinder(ClearLineEdit):
     """Textbox for filtering listed shortcuts in the table."""
 
     def __init__(self, parent, callback=None, main=None,

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -142,6 +142,7 @@ class NamespaceBrowser(
                 regex_base=VALID_VARIABLE_CHARS,
                 key_filter_dict=key_filter_dict
             )
+            self.finder.setVisible(False)
 
             # Signals
             self.editor.sig_files_dropped.connect(self.import_data)

--- a/spyder/widgets/elementstable.py
+++ b/spyder/widgets/elementstable.py
@@ -170,6 +170,10 @@ class ElementsTable(HoverRowsTableView):
         # To make adjustments when the widget is shown
         self._is_shown = False
 
+        # To use these widths where necessary
+        self._info_column_width = 0
+        self._widgets_column_width = 0
+
         # This is used to paint the entire row's background color when its
         # hovered.
         self.sig_hover_index_changed.connect(self._on_hover_index_changed)
@@ -192,7 +196,6 @@ class ElementsTable(HoverRowsTableView):
              title_delegate.on_hover_index_changed)
 
         # Adjustments for the additional info column
-        self._info_column_width = 0
         if self._with_addtional_info:
             info_delegate = HTMLDelegate(self, margin=10, align_vcenter=True)
             self.setItemDelegateForColumn(
@@ -207,22 +210,12 @@ class ElementsTable(HoverRowsTableView):
                 self.model.columns['additional_info'])
 
         # Adjustments for the widgets column
-        self._widgets_column_width = 0
         if self._with_widgets:
             widgets_delegate = HTMLDelegate(self, margin=0)
             self.setItemDelegateForColumn(
                 self.model.columns['widgets'], widgets_delegate)
             self.sig_hover_index_changed.connect(
                  widgets_delegate.on_hover_index_changed)
-
-            # This is necessary to get this column's width below
-            self.resizeColumnsToContents()
-
-            # Note: We add 15 pixels to the Qt width so that the widgets are
-            # not so close to the right border of the table, which doesn't look
-            # good.
-            self._widgets_column_width = self.horizontalHeader().sectionSize(
-                self.model.columns['widgets']) + 15
 
             # Add widgets
             for i in range(len(self.elements)):
@@ -350,10 +343,26 @@ class ElementsTable(HoverRowsTableView):
         """Check if it's necessary to build the table with `feature_name`."""
         return len([e for e in self.elements if e.get(feature_name)]) > 0
 
+    def _compute_widgets_column_width(self):
+        if self._with_widgets:
+            # This is necessary to get the right width
+            self.resizeColumnsToContents()
+
+            # We add 10 pixels to the width computed by Qt so that the widgets
+            # are not so close to the right border of the table, which doesn't
+            # look good.
+            self._widgets_column_width = (
+                self.horizontalHeader().sectionSize(
+                    self.model.columns["widgets"]
+                )
+                + 10
+            )
+
     # ---- Qt methods
     # -------------------------------------------------------------------------
     def showEvent(self, event):
         if not self._is_shown:
+            self._compute_widgets_column_width()
             self._set_layout()
 
             # To not run the adjustments above every time the widget is shown

--- a/spyder/widgets/elementstable.py
+++ b/spyder/widgets/elementstable.py
@@ -153,9 +153,15 @@ class ElementsModel(QAbstractTableModel, SpyderFontsMixin):
 
 class ElementsTable(HoverRowsTableView):
 
-    def __init__(self, parent: Optional[QWidget], elements: List[Element]):
+    def __init__(
+        self,
+        parent: Optional[QWidget],
+        elements: List[Element],
+        highlight_hovered_row: bool = True,
+    ):
         HoverRowsTableView.__init__(self, parent, custom_delegate=True)
         self.elements = elements
+        self._highlight_hovered_row = highlight_hovered_row
 
         # Check for additional features
         self._with_icons = self._with_feature('icon')
@@ -176,7 +182,8 @@ class ElementsTable(HoverRowsTableView):
 
         # This is used to paint the entire row's background color when its
         # hovered.
-        self.sig_hover_index_changed.connect(self._on_hover_index_changed)
+        if self._highlight_hovered_row:
+            self.sig_hover_index_changed.connect(self._on_hover_index_changed)
 
         # Set model
         self.model = ElementsModel(
@@ -191,17 +198,23 @@ class ElementsTable(HoverRowsTableView):
         # Adjustments for the title column
         title_delegate = HTMLDelegate(self, margin=9, wrap_text=True)
         self.setItemDelegateForColumn(
-            self.model.columns['title'], title_delegate)
-        self.sig_hover_index_changed.connect(
-             title_delegate.on_hover_index_changed)
+            self.model.columns['title'], title_delegate
+        )
+        if self._highlight_hovered_row:
+            self.sig_hover_index_changed.connect(
+                 title_delegate.on_hover_index_changed
+            )
 
         # Adjustments for the additional info column
         if self._with_addtional_info:
             info_delegate = HTMLDelegate(self, margin=10, align_vcenter=True)
             self.setItemDelegateForColumn(
-                self.model.columns['additional_info'], info_delegate)
-            self.sig_hover_index_changed.connect(
-                 info_delegate.on_hover_index_changed)
+                self.model.columns['additional_info'], info_delegate
+            )
+            if self._highlight_hovered_row:
+                self.sig_hover_index_changed.connect(
+                     info_delegate.on_hover_index_changed
+                )
 
             # This is necessary to get this column's width below
             self.resizeColumnsToContents()
@@ -213,9 +226,12 @@ class ElementsTable(HoverRowsTableView):
         if self._with_widgets:
             widgets_delegate = HTMLDelegate(self, margin=0)
             self.setItemDelegateForColumn(
-                self.model.columns['widgets'], widgets_delegate)
-            self.sig_hover_index_changed.connect(
-                 widgets_delegate.on_hover_index_changed)
+                self.model.columns['widgets'], widgets_delegate
+            )
+            if self._highlight_hovered_row:
+                self.sig_hover_index_changed.connect(
+                     widgets_delegate.on_hover_index_changed
+                )
 
             # Add widgets
             for i in range(len(self.elements)):


### PR DESCRIPTION
## Description of Changes

- The plan is to add a new table, based on `ElementsTable`, to select the default Python interpreter in a follow-up PR. And to facilitate that, in case users have many environments, we need to give them the ability to filter them.
- To check this new functionality, I added a lineedit to filter plugins in the Plugins config page.
- Improve the Shorcuts config page UI to match the new one of the Plugins page.
- Fix computing the width of widgets column and add kwarg to highlight hovered row in `ElementsTable`. These changes are necessary when the table has buttons.
- Make `FinderLineEdit`, `FinderWidget` and `CustomSortFilterProxy` more generic to be able to use them in connection to  `ElementsTable`.

### Visual changes

* Filtering in the Plugins config page:

    ![imagen](https://github.com/user-attachments/assets/a7bf897b-b485-4ea2-b568-630d462f0c70)

* UI improvements to the Shortcuts config page

    | Before | After |
    | - | - |
    | ![imagen](https://github.com/user-attachments/assets/d0ea0187-3f92-4909-9e6e-bd11c0d05f0e) | ![imagen](https://github.com/user-attachments/assets/7cc9b791-3a6b-46ca-bd7b-8b6e4f06b388) |

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
