### PR TITLE
PR: Use modern and more fine-grained error types in autosave module (Editor)

### DIFF
--- a/spyder/plugins/editor/utils/autosave.py
+++ b/spyder/plugins/editor/utils/autosave.py
@@ -311,7 +311,7 @@ class AutosaveForStack(object):
         autosave_filename = self.name_mapping[filename]
         try:
             os.remove(autosave_filename)
-        except EnvironmentError as error:
+        except (FileNotFoundError, OSError) as error:
             action = (_('Error while removing autosave file {}')
                       .format(autosave_filename))
             msgbox = AutosaveErrorDialog(action, error)
@@ -347,7 +347,7 @@ class AutosaveForStack(object):
             if not osp.isdir(autosave_dir):
                 try:
                     os.mkdir(autosave_dir)
-                except EnvironmentError as error:
+                except (PermissionError, OSError) as error:
                     action = _('Error while creating autosave directory')
                     msgbox = AutosaveErrorDialog(action, error)
                     msgbox.exec_if_enabled()
@@ -417,7 +417,7 @@ class AutosaveForStack(object):
             self.stack._write_to_file(finfo, autosave_filename)
             autosave_hash = self.stack.compute_hash(finfo)
             self.file_hashes[autosave_filename] = autosave_hash
-        except EnvironmentError as error:
+        except (PermissionError, OSError) as error:
             action = (_('Error while autosaving {} to {}')
                       .format(finfo.filename, autosave_filename))
             msgbox = AutosaveErrorDialog(action, error)


### PR DESCRIPTION
## Description of Changes

- We were using `EnvironmentError`, which was made equivalent to `OSError` in Python 3.
- We also need to use more fine-grained error types to catch errors such as the one reported on issue #24281.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24281.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
