### PR TITLE
PR: Display `pathlib.Path` variables and `None` in Variable Explorer

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = master
-	commit = 58ecaf3934d95475a67aa97615e0433b7626bc34
-	parent = 6be77cd03a84506b148d72a897482463c4f86732
+	commit = 7b2ef69ea03e535108c77279c2addd0a7fc2196b
+	parent = 12e2bfe78716b149833c0d40a91676dafc5c0b8a
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
@@ -11,6 +11,7 @@ Utilities to build a namespace view.
 """
 from itertools import islice
 import inspect
+import pathlib
 import re
 
 from spyder_kernels.utils.lazymodules import (
@@ -422,13 +423,15 @@ def value_to_display(value, minmax=False, level=0):
                     display = "'" + display + "'"
             else:
                 display = default_display(value)
-
-        elif (isinstance(value, datetime.date) or
-              isinstance(value, datetime.timedelta)):
+        elif isinstance(value, pathlib.PurePath):
             display = str(value)
-        elif (isinstance(value, (int, float, complex)) or
-              isinstance(value, bool) or
-              isinstance(value, printable_numpy_types)):
+        elif isinstance(value, (datetime.date, datetime.timedelta)):
+            display = str(value)
+        elif (
+            isinstance(value, (int, float, complex, bool))
+            or isinstance(value, printable_numpy_types)
+            or value is None
+        ):
             display = repr(value)
         else:
             if level == 0:

--- a/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_nsview.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_nsview.py
@@ -13,6 +13,7 @@ Tests for utils.py
 # Standard library imports
 from collections import defaultdict
 import datetime
+import pathlib
 import sys
 
 # Third party imports
@@ -287,6 +288,17 @@ def test_datetime_display():
                               1: test_datetime,
                               2: test_timedelta_2}) ==
             ("{0:2017-12-18, 1:2017-12-18 13:43:02, 2:1:00:00}"))
+
+
+def test_path_display():
+    """Test for display of a path from pathlib."""
+    path = pathlib.PureWindowsPath('C:/') / 'Program Files'
+    assert value_to_display(path) == r'C:\Program Files'
+
+
+def test_none_display():
+    """Test for display of None."""
+    assert value_to_display(None) == 'None'
 
 
 def test_str_in_container_display():


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

This PR incorporates spyder-ide/spyder-kernels#541 into Spyder so that variables of type `pathlib.Path` and variables containing `None` are displayed in the Variable Explorer. See that PR for screenshots.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22351 
Fixes #6853 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
