### PR TITLE
PR: Disable magics and commands to call Python package managers in the IPython console

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = master
-	commit = 7b2ef69ea03e535108c77279c2addd0a7fc2196b
-	parent = 12e2bfe78716b149833c0d40a91676dafc5c0b8a
+	commit = 5b78c93a31f5b16d188b9718f2095dbf98633bc0
+	parent = 5de52e8ceeed3c620ad37f1671a4e520cbc069ff
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/spyder_kernels/console/tests/test_console_kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/tests/test_console_kernel.py
@@ -12,16 +12,17 @@ Tests for the console kernel.
 # Standard library imports
 import ast
 import asyncio
+from collections import namedtuple
+from contextlib import contextmanager
+import inspect
 import os
 import os.path as osp
-from textwrap import dedent
-from contextlib import contextmanager
-import time
+import random
 from subprocess import Popen, PIPE
 import sys
-import inspect
+from textwrap import dedent
+import time
 import uuid
-from collections import namedtuple
 
 # Test imports
 from flaky import flaky
@@ -1487,6 +1488,15 @@ def test_get_pythonenv_info(kernel):
     assert output["python_version"] == sys.version.split()[0]
     assert output["ipython_version"] == ipython_release.version
     assert output["sys_version"] == sys.version
+
+
+@pytest.mark.parametrize("prefix", ["%", "!"])
+def test_disable_pkg_managers(kernel, capsys, prefix):
+    """Test that we disable Python package manager magics and commands."""
+    pkg_manager = random.choice(kernel.shell._disabled_pkg_managers)
+    asyncio.run(kernel.do_execute(f"{prefix}{pkg_manager}", True))
+    captured = capsys.readouterr()
+    assert kernel.shell._disable_pkg_managers_msg[2:] == captured.out[1:-1]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of Changes

- This refers to magics like `%conda` or commands like `!pip`.
- It's been known for years that they don't work reliably when called in the IPython console. So, it's better to disable them and post a friendly message instead.
- Depends on https://github.com/spyder-ide/spyder-kernels/pull/542.

### Visual changes

![imagen](https://github.com/user-attachments/assets/0ed41856-6f00-4904-9e03-f7e783d46505)

### Issue(s) Resolved

Fixes #21894.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
