### PR TITLE
PR: Don't display errors when calling `get_value` (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
@@ -50,10 +50,7 @@ class NamepaceBrowserWidget(RichJupyterWidget):
             "serialized."
         )
         reason_dead = _("The kernel is dead")
-        reason_other = _(
-            "An unknown error occurred. Check the console because its "
-            "contents could have been printed there."
-        )
+        reason_other = _("An unknown error occurred, sorry.")
         reason_comm = _(
             "The channel used to communicate with the kernel is not working."
         )
@@ -84,7 +81,11 @@ class NamepaceBrowserWidget(RichJupyterWidget):
         try:
             value = self.call_kernel(
                 blocking=True,
-                display_error=True,
+                # We prefer not to display errors because it's not clear that
+                # they are related to what users are doing in the Variable
+                # Explorer. So, it's not user friendly.
+                # See spyder-ide/spyder#22411
+                display_error=False,
                 timeout=CALL_KERNEL_TIMEOUT
             ).get_value(name, encoded=True)
             value = cloudpickle.loads(value)


### PR DESCRIPTION
## Description of Changes

As @jitseniesen said on https://github.com/spyder-ide/spyder/issues/22411#issuecomment-2836587272 (and I agreed):

> I think it is a better user experience to suppress the traceback. It is not clear that the error in the IPython Console is related to what you are doing in the Variable Explorer.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #22411.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
