### PR TITLE
PR: Don't use cached kernels on Windows with Conda 25.3.0+ (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -162,9 +162,12 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
             # We need to use this flag to prevent conda_exe from capturing the
             # kernel process stdout/stderr streams. That way we are able to
             # show them in Spyder.
-            if conda_exe.endswith(('micromamba', 'micromamba.exe')):
+            if "micromamba" in osp.basename(conda_exe):
                 kernel_cmd.extend(['--attach', '""'])
-            elif conda_exe_version >= parse("4.9"):
+            elif "mamba" in osp.basename(conda_exe) or (
+                "conda" in osp.basename(conda_exe)
+                and conda_exe_version >= parse("4.9")
+            ):
                 # Note: We use --no-capture-output instead of --live-stream
                 # here because it works for older Conda versions (conda>=4.9).
                 kernel_cmd.append('--no-capture-output')

--- a/spyder/plugins/ipythonconsole/widgets/mixins.py
+++ b/spyder/plugins/ipythonconsole/widgets/mixins.py
@@ -8,8 +8,16 @@
 IPython Console mixins.
 """
 
+# Standard library imports
+import os
+import os.path as osp
+
+# Third-party imports
+from packaging.version import parse
+
 # Local imports
 from spyder.plugins.ipythonconsole.utils.kernel_handler import KernelHandler
+from spyder.utils.conda import conda_version, find_conda
 
 
 class CachedKernelMixin:
@@ -18,6 +26,7 @@ class CachedKernelMixin:
     def __init__(self):
         super().__init__()
         self._cached_kernel_properties = None
+        self._conda_exec = find_conda()
 
     def close_cached_kernel(self):
         """Close the cached kernel."""
@@ -58,8 +67,18 @@ class CachedKernelMixin:
         # Cache another kernel for next time.
         new_kernel_handler = KernelHandler.new_from_spec(kernel_spec)
 
-        if not cache:
-            # remove/don't use cache if requested
+        # Don't use cache if requested or needed
+        if (
+            not cache
+            # Conda 25.3.0 changed the way env activation works, which makes
+            # activating kernels fail when using cached kernels.
+            # Fixes spyder-ide/spyder#24132
+            or (
+                os.name == "nt"
+                and "conda" in osp.basename(self._conda_exec)
+                and conda_version() >= parse("25.3.0")
+            )
+        ):
             self.close_cached_kernel()
             return new_kernel_handler
 


### PR DESCRIPTION
## Description of Changes

Conda 25.3.0 changed the way env activation works on Windows, which makes activating kernels fail when using cached kernels.

### Issue(s) Resolved

Fixes #24132.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
