### PR TITLE
PR: Fix UnboundLocalError when cancelling the open file dialog

### DIFF
--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -560,6 +560,7 @@ class ApplicationContainer(PluginMainContainer):
         else:
             selectedfilter = ''
 
+        filenames = []
         if not running_under_pytest():
             # See: spyder-ide/spyder#3291
             if sys.platform == 'darwin':
@@ -574,8 +575,9 @@ class ApplicationContainer(PluginMainContainer):
                     QDir.AllDirs | QDir.Files | QDir.Drives | QDir.Hidden
                 )
                 dialog.setFileMode(QFileDialog.ExistingFiles)
-                dialog.exec_()
-                filenames = dialog.selectedFiles()
+
+                if dialog.exec_():
+                    filenames = dialog.selectedFiles()
             else:
                 filenames, _sf = getopenfilenames(
                     self,
@@ -590,8 +592,8 @@ class ApplicationContainer(PluginMainContainer):
             dialog = QFileDialog(
                 self, _("Open file"), options=QFileDialog.DontUseNativeDialog
             )
-            dialog.exec_()
-            filenames = dialog.selectedFiles()
+            if dialog.exec_():
+                filenames = dialog.selectedFiles()
 
         self.sig_redirect_stdio_requested.emit(True)
 

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -574,9 +574,8 @@ class ApplicationContainer(PluginMainContainer):
                     QDir.AllDirs | QDir.Files | QDir.Drives | QDir.Hidden
                 )
                 dialog.setFileMode(QFileDialog.ExistingFiles)
-
-                if dialog.exec_():
-                    filenames = dialog.selectedFiles()
+                dialog.exec_()
+                filenames = dialog.selectedFiles()
             else:
                 filenames, _sf = getopenfilenames(
                     self,
@@ -591,8 +590,8 @@ class ApplicationContainer(PluginMainContainer):
             dialog = QFileDialog(
                 self, _("Open file"), options=QFileDialog.DontUseNativeDialog
             )
-            if dialog.exec_():
-                filenames = dialog.selectedFiles()
+            dialog.exec_()
+            filenames = dialog.selectedFiles()
 
         self.sig_redirect_stdio_requested.emit(True)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

If the dialog window is cancelled, `dialog._exec()` returns falsey, resulting in `filenames` not being defined. Removing the conditional on `dialog._exec()` allows `filenames` to be defined regardless of the exit status of the dialog. If cancelled, `dialog.selectedFiles()` returns an empty list, as expected.

Fixes #24370