### PR TITLE
PR: Fix cached kernels on Windows for CIs

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -8,7 +8,7 @@ install_spyder_kernels() {
 
     if [ "$OS" = "win" ]; then
         # `conda run` fails on Windows without a clear reason
-        /c/Miniconda/envs/"$1"/python -m pip install -q .
+        /c/Users/runneradmin/miniconda3/envs/"$1"/python -m pip install -q .
     else
         conda run -n "$1" python -m pip install -q .
     fi
@@ -91,12 +91,6 @@ else
     pushd spyder/app/tests/spyder-boilerplate
     pip install --no-deps .
     popd
-
-    # Adjust PATH on Windows so that we can use conda below. This needs to be done
-    # at this point or the pip slots fail.
-    if [ "$OS" = "win" ]; then
-        PATH=/c/Miniconda/Scripts/:$PATH
-    fi
 
     # Create environment for Jedi environment tests
     conda create -n jedi-test-env -q -y python=3.9 flask

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -63,6 +63,7 @@ jobs:
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
       RUN_SLOW: ${{ matrix.TEST_TYPE == 'slow' }}
       USE_CONDA: ${{ matrix.INSTALL_TYPE == 'conda' }}
+      CONDA: C:\Users\runneradmin\miniconda3
     strategy:
       fail-fast: false
       matrix:
@@ -92,6 +93,12 @@ jobs:
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
+      - name: Install Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          conda-remove-defaults: "true"
+          auto-activate-base: false
+          installer-url: https://repo.anaconda.com/miniconda/Miniconda3-py312_25.1.1-2-Windows-x86_64.exe
       - name: Create conda test environment
         if: env.USE_CONDA == 'true'
         uses: mamba-org/setup-micromamba@v2
@@ -126,6 +133,7 @@ jobs:
         shell: bash -l {0}
         run: |
           micromamba info
+          conda info
           micromamba list
           pip list
       - name: Run manifest checks


### PR DESCRIPTION
## Description of Changes

Tests on Windows are very flaky right now and the reason seems to be that we're not using cached kernels on CIs due to Conda 25.3 present.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
