### PR TITLE
PR: Fix executable used for restarts on macOS

### DIFF
--- a/spyder/app/__init__.py
+++ b/spyder/app/__init__.py
@@ -10,3 +10,13 @@ spyder.app
 
 Modules related to starting and restarting the Spyder application
 """
+import os
+import sys
+
+# On macOS conda installations, sys.executable may be a symlink in the
+# application bundle, and therefore should be resolved to the executable in the
+# environment. Also store the orignal sys.executable.
+SHORTCUT_EXE = None
+if sys.platform == "darwin" and sys.executable.endswith("MacOS/python"):
+    SHORTCUT_EXE = sys.executable
+    sys.executable = os.readlink(sys.executable)

--- a/spyder/app/restart.py
+++ b/spyder/app/restart.py
@@ -25,6 +25,7 @@ from qtpy.QtGui import QColor, QIcon
 from qtpy.QtWidgets import QApplication, QMessageBox, QWidget
 
 # Local imports
+from spyder.app import SHORTCUT_EXE
 from spyder.app.utils import create_splash_screen
 from spyder.config.base import _
 from spyder.utils.image_path_manager import get_image_path
@@ -232,7 +233,7 @@ def main():
     else:
         script = osp.join(spyder_dir, 'spyder', 'app', 'start.py')
 
-    command = [f'"{sys.executable}"', f'"{script}"']
+    command = [f'"{SHORTCUT_EXE or sys.executable}"', f'"{script}"']
 
     # Adjust the command and/or arguments to subprocess depending on the OS
     shell = not IS_WINDOWS

--- a/spyder/app/start.py
+++ b/spyder/app/start.py
@@ -60,13 +60,6 @@ from spyder.utils.conda import get_conda_root_prefix
 from spyder.utils.external import lockfile
 from spyder.py3compat import is_text_string
 
-
-# On macOS conda installations, sys.executable may be a symlink in the
-# application bundle, and therefore should be resolved to the executable in the
-# environment.
-if sys.platform == "darwin" and sys.executable.endswith("MacOS/python"):
-    sys.executable = os.readlink(sys.executable)
-
 # Enforce correct CONDA_EXE environment variable
 # Do not rely on CONDA_PYTHON_EXE or CONDA_PREFIX in case Spyder is started
 # from the commandline

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -25,6 +25,7 @@ from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
 from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
 from spyder.api.widgets.menus import SpyderMenu, MENU_SEPARATOR
+from spyder.app import SHORTCUT_EXE
 from spyder.config.base import (get_module_path, get_debug_level,
                                 running_under_pytest)
 from spyder.plugins.application.confpage import ApplicationConfigPage
@@ -530,7 +531,7 @@ class Application(SpyderPluginV2):
 
         # Get current process and python running spyder
         pid = os.getpid()
-        python = sys.executable
+        python = SHORTCUT_EXE or sys.executable
 
         # Check if started with bootstrap.py
         if bootstrap_args is not None:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Spyder uses the `sys.executable` to start Spyder when a restart is enacted. For macOS shortcuts this value is resolved to the real location of the Python executable. However, when restarting Spyder the symlink executable should be used in order to retain macOS integration. i.e. macOS will still consider Spyder an application.

* The redefinition of `sys.executable` is moved to `spyder.app.__init__.py` and the original value is stored in the module constant `SHORTCUT_EXE`.
* Upon restart, the original `sys.executable` is used.