### PR TITLE
PR: Fix hard crash when checking conda for cached kernels (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/mixins.py
+++ b/spyder/plugins/ipythonconsole/widgets/mixins.py
@@ -75,6 +75,7 @@ class CachedKernelMixin:
             # Fixes spyder-ide/spyder#24132
             or (
                 os.name == "nt"
+                and self._conda_exec is not None  # See spyder-ide/spyder#24421
                 and "conda" in osp.basename(self._conda_exec)
                 and conda_version() >= parse("25.3.0")
             )


### PR DESCRIPTION
## Description of Changes

- This was an oversight on my side, introduced by #24389.
- It was not caught by our tests because we check a lot of Conda stuff for pip packages.

### Issue(s) Resolved

Fixes #24421.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
