### PR TITLE
PR: Require a minimal version of the `traitlets` package (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = master
-	commit = 957e1fde77d85d915bca6c279dc76007805ac5d0
-	parent = 8435ff59f9cc0b724d4dde4f32f997539f6fbf3d
+	commit = 08e1395f870e3784881e5d1007eb27581738e080
+	parent = 5d879d705e0dc58b65fb19311d5c5523c1e9b94e
 	method = merge
-	cmdver = 0.4.3
+	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/requirements/posix.txt
+++ b/external-deps/spyder-kernels/requirements/posix.txt
@@ -3,6 +3,7 @@ ipykernel>=6.29.3,<7
 ipython>=8.12.2,<9
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
-wurlitzer>=1.0.3
 pyxdg>=0.26
+traitlets>=5.14.3
+wurlitzer>=1.0.3
 setuptools<71.0

--- a/external-deps/spyder-kernels/requirements/windows.txt
+++ b/external-deps/spyder-kernels/requirements/windows.txt
@@ -3,4 +3,5 @@ ipykernel>=6.29.3,<7
 ipython>=8.12.2,<9
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
+traitlets>=5.14.3
 setuptools<71.0

--- a/external-deps/spyder-kernels/setup.py
+++ b/external-deps/spyder-kernels/setup.py
@@ -42,8 +42,12 @@ REQUIREMENTS = [
     'ipython>=8.13.0,<9,!=8.17.1; python_version>"3.8"',
     'jupyter-client>=7.4.9,<9',
     'pyzmq>=24.0.0',
-    'wurlitzer>=1.0.3;platform_system!="Windows"',
     'pyxdg>=0.26;platform_system=="Linux"',
+    # We need at least this version of traitlets to fix an error when setting
+    # the Matplotlib inline backend formats.
+    # Fixes spyder-ide/spyder#24390
+    'traitlets>=5.14.3',
+    'wurlitzer>=1.0.3;platform_system!="Windows"',
 ]
 
 TEST_REQUIREMENTS = [


### PR DESCRIPTION
## Description of Changes

- Versions between 5.12 and 5.14.2 have a nasty bug that prevents setting the Matplotlib inline backend formats. So, we require 5.14.3 (the latest one at the moment) in Spyder-kernels.
- Depends on https://github.com/spyder-ide/spyder-kernels/pull/544.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24390

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
