### PR TITLE
Backport PR #24450 on branch 6.x (PR: Require a minimal version of the `traitlets` package (IPython console))

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = 3.x
-	commit = c76cdc9dd45ba6a55c3a28ea851ccfd6329d8601
-	parent = 39806f90a213c07d736078f94dd0b78d81d478f7
+	commit = 4594fabbaf77bc8072e97bc2ef034015bca4bffa
+	parent = 19f38d4c248343cfccfafd03ef445513fcbbc62b
 	method = merge
-	cmdver = 0.4.3
+	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/requirements/posix.txt
+++ b/external-deps/spyder-kernels/requirements/posix.txt
@@ -3,6 +3,7 @@ ipykernel>=6.29.3,<7
 ipython>=8.12.2,<9
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
-wurlitzer>=1.0.3
 pyxdg>=0.26
+traitlets>=5.14.3
+wurlitzer>=1.0.3
 setuptools<71.0

--- a/external-deps/spyder-kernels/requirements/windows.txt
+++ b/external-deps/spyder-kernels/requirements/windows.txt
@@ -3,4 +3,5 @@ ipykernel>=6.29.3,<7
 ipython>=8.12.2,<9
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
+traitlets>=5.14.3
 setuptools<71.0

--- a/external-deps/spyder-kernels/setup.py
+++ b/external-deps/spyder-kernels/setup.py
@@ -42,8 +42,12 @@ REQUIREMENTS = [
     'ipython>=8.13.0,<9,!=8.17.1; python_version>"3.8"',
     'jupyter-client>=7.4.9,<9',
     'pyzmq>=24.0.0',
-    'wurlitzer>=1.0.3;platform_system!="Windows"',
     'pyxdg>=0.26;platform_system=="Linux"',
+    # We need at least this version of traitlets to fix an error when setting
+    # the Matplotlib inline backend formats.
+    # Fixes spyder-ide/spyder#24390
+    'traitlets>=5.14.3',
+    'wurlitzer>=1.0.3;platform_system!="Windows"',
 ]
 
 TEST_REQUIREMENTS = [


### PR DESCRIPTION
Manual backport of PR #24450.