### PR TITLE
PR: Sort dict in collections editor by insertion order initially

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -782,6 +782,7 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):  # noqa: PLR09
     @Slot(object)
     def show_env(self, env):
         """Show environment variables."""
+        env = dict(sorted(env.items()))
         self.dialog_manager.show(RemoteEnvDialog(env, parent=self))
 
     def show_time(self, end=False):

--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -248,6 +248,7 @@ class NamespaceBrowser(
 
     def set_data(self, data):
         """Set data."""
+        data = dict(sorted(data.items()))
         if data != self.editor.source_model.get_data():
             self.editor.set_data(data)
             self.editor.adjust_columns()

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -128,6 +128,7 @@ def get_user_environment_variables():
         else:
             env_var = dict(os.environ)
 
+    env_var = dict(sorted(env_var.items()))
     return env_var
 
 

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -1056,7 +1056,9 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
         if data is not None:
             self.source_model.set_data(data, self.dictfilter)
             self.source_model.reset()
-            self.sortByColumn(0, Qt.AscendingOrder)
+
+            # Sort table using current sort column and order
+            self.setSortingEnabled(True)
 
     def _edit_value(self):
         self.edit(self.__index_clicked)

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -1611,9 +1611,12 @@ class CollectionsEditorTableView(BaseTableView):
         self.setup_table()
         self.menu = self.setup_menu()
 
-        # Sorting columns
+        # Leave unsorted if dict, sort by column 0 otherwise
+        if isinstance(data, dict):
+            self.horizontalHeader().setSortIndicator(-1, Qt.AscendingOrder)
+        else:
+            self.horizontalHeader().setSortIndicator(0, Qt.AscendingOrder)
         self.setSortingEnabled(True)
-        self.sortByColumn(0, Qt.AscendingOrder)
 
         if isinstance(data, (set, frozenset)):
             self.horizontalHeader().hideSection(0)

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -246,13 +246,7 @@ class ReadOnlyCollectionsModel(QAbstractTableModel, SpyderFontsMixin):
             self.title += _("Frozenset")
             self._data = list(data)
         elif isinstance(data, dict):
-            try:
-                self.keys = sorted(list(data.keys()), key=natsort)
-            except TypeError:
-                # This is necessary to display dictionaries with mixed
-                # types as keys.
-                # Fixes spyder-ide/spyder#13481
-                self.keys = list(data.keys())
+            self.keys = list(data.keys())
             self.title += _("Dictionary")
             if not self.names:
                 self.header0 = _("Key")

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -725,10 +725,6 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
         self.horizontalHeader().setSectionsMovable(True)
         self.adjust_columns()
 
-        # Sorting columns
-        self.setSortingEnabled(True)
-        self.sortByColumn(0, Qt.AscendingOrder)
-
         # Actions to take when the selection changes
         self.selectionModel().selectionChanged.connect(self.refresh_menu)
         self.selectionModel().selectionChanged.connect(
@@ -1614,6 +1610,11 @@ class CollectionsEditorTableView(BaseTableView):
 
         self.setup_table()
         self.menu = self.setup_menu()
+
+        # Sorting columns
+        self.setSortingEnabled(True)
+        self.sortByColumn(0, Qt.AscendingOrder)
+
         if isinstance(data, (set, frozenset)):
             self.horizontalHeader().hideSection(0)
 
@@ -2060,6 +2061,10 @@ class RemoteCollectionsEditorTableView(BaseTableView):
 
         if create_menu:
             self.menu = self.setup_menu()
+
+        # Sorting columns
+        self.setSortingEnabled(True)
+        self.sortByColumn(0, Qt.AscendingOrder)
 
     # ------ Remote/local API -------------------------------------------------
     def get_value(self, name):

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -341,6 +341,11 @@ class ReadOnlyCollectionsModel(QAbstractTableModel, SpyderFontsMixin):
         implementation is a bit of a hack. In Qt 6, the flag
         `sortIndicatorClearable` in `QHeaderView` has the same effect.
 
+        If a view uses a proxy model, then the sort function of the proxy model
+        overrides this function and the special handling of dictionaries
+        described in the previous paragraph does not happen. This happens in
+        `RemoteCollectionsEditorTableView` which is used in `NamespaceBrowser`.
+
         Parameters
         ----------
         column : int

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -327,9 +327,9 @@ class ReadOnlyCollectionsModel(QAbstractTableModel, SpyderFontsMixin):
         order: Qt.SortOrder = Qt.AscendingOrder
     ) -> None:
         """
-        Sort model by given column and order
+        Sort model by given column and order.
 
-        This overrides the method in the base class and it called by Qt if
+        This overrides the method in the base class and it's called by Qt if
         the user clicks on the header of a column.
 
         If the collection editor shows a dictionary and the user changes the

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -302,27 +302,21 @@ def test_create_dataframeeditor_with_correct_format(qtbot):
 
 
 def test_collectionsmodel_with_two_ints():
-    coll = {'x': 1, 'y': 2}
+    coll = {'y': 2, 'x': 1}
     cm = CollectionsModel(MockParent(), coll)
 
     assert cm.rowCount() == 2
     assert cm.columnCount() == 4
-    # dict is unordered, so first row might be x or y
-    assert data(cm, 0, 0) in {'x',
-                              'y'}
-    if data(cm, 0, 0) == 'x':
-        row_with_x = 0
-        row_with_y = 1
-    else:
-        row_with_x = 1
-        row_with_y = 0
-    assert data(cm, row_with_x, 1) == 'int'
-    assert data(cm, row_with_x, 2) == 1
-    assert data(cm, row_with_x, 3) == '1'
-    assert data(cm, row_with_y, 0) == 'y'
-    assert data(cm, row_with_y, 1) == 'int'
-    assert data(cm, row_with_y, 2) == 1
-    assert data(cm, row_with_y, 3) == '2'
+
+    # dict is sorted by insertion order
+    assert data(cm, 0, 0) == 'y'
+    assert data(cm, 0, 1) == 'int'
+    assert data(cm, 0, 2) == 1
+    assert data(cm, 0, 3) == '2'
+    assert data(cm, 1, 0) == 'x'
+    assert data(cm, 1, 1) == 'int'
+    assert data(cm, 1, 2) == 1
+    assert data(cm, 1, 3) == '1'
 
 
 def test_collectionsmodel_with_index():
@@ -531,6 +525,19 @@ def test_sort_and_fetch_collectionsmodel_with_many_rows():
     for _ in range(3):
         cm.fetchMore()
     assert cm.rowCount() == len(coll)
+
+
+def test_dict_in_tableview_sorting():
+    my_dict = {2: 3, 3: 1, 1: 2}
+    editor = CollectionsEditorTableView(None, my_dict)
+
+    # Test that dict is displayed in insertion order
+    assert data(editor.model(), 0, 0) == 2
+    assert data(editor.model(), 1, 0) == 3
+    assert data(editor.model(), 2, 0) == 1
+    assert data(editor.model(), 0, 3) == '3'
+    assert data(editor.model(), 1, 3) == '1'
+    assert data(editor.model(), 2, 3) == '2'
 
 
 def test_rename_and_duplicate_item_in_collection_editor():

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -527,19 +527,6 @@ def test_sort_and_fetch_collectionsmodel_with_many_rows():
     assert cm.rowCount() == len(coll)
 
 
-def test_dict_in_tableview_sorting():
-    my_dict = {2: 3, 3: 1, 1: 2}
-    editor = CollectionsEditorTableView(None, my_dict)
-
-    # Test that dict is displayed in insertion order
-    assert data(editor.model(), 0, 0) == 2
-    assert data(editor.model(), 1, 0) == 3
-    assert data(editor.model(), 2, 0) == 1
-    assert data(editor.model(), 0, 3) == '3'
-    assert data(editor.model(), 1, 3) == '1'
-    assert data(editor.model(), 2, 3) == '2'
-
-
 def test_rename_and_duplicate_item_in_collection_editor():
     collections = {'list': ([1, 2, 3], False, True),
                    'tuple': ((1, 2, 3), False, False),

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -96,10 +96,10 @@ def test_rename_variable(qtbot):
     editor.rename_item(new_name='b2')
     assert editor.model().rowCount() == 5
     assert data(editor.model(), 0, 0) == 'a'
-    assert data(editor.model(), 1, 0) == 'b2'
-    assert data(editor.model(), 2, 0) == 'c'
-    assert data(editor.model(), 3, 0) == 'd'
-    assert data(editor.model(), 4, 0) == 'e'
+    assert data(editor.model(), 1, 0) == 'c'
+    assert data(editor.model(), 2, 0) == 'd'
+    assert data(editor.model(), 3, 0) == 'e'
+    assert data(editor.model(), 4, 0) == 'b2'
 
     # Reset variables and try renaming one again
     new_variables = {'a': 1,
@@ -115,10 +115,10 @@ def test_rename_variable(qtbot):
     assert editor.model().rowCount() == 6
     assert data(editor.model(), 0, 0) == 'a'
     assert data(editor.model(), 1, 0) == 'b2'
-    assert data(editor.model(), 2, 0) == 'b3'
-    assert data(editor.model(), 3, 0) == 'c'
-    assert data(editor.model(), 4, 0) == 'd'
-    assert data(editor.model(), 5, 0) == 'e'
+    assert data(editor.model(), 2, 0) == 'c'
+    assert data(editor.model(), 3, 0) == 'd'
+    assert data(editor.model(), 4, 0) == 'e'
+    assert data(editor.model(), 5, 0) == 'b3'
 
 
 def test_remove_variable(qtbot):
@@ -525,6 +525,19 @@ def test_sort_and_fetch_collectionsmodel_with_many_rows():
     for _ in range(3):
         cm.fetchMore()
     assert cm.rowCount() == len(coll)
+
+
+def test_dict_in_tableview_sorting():
+    my_dict = {2: 3, 3: 1, 1: 2}
+    editor = CollectionsEditorTableView(None, my_dict)
+
+    # Test that dict is displayed in insertion order
+    assert data(editor.model(), 0, 0) == 2
+    assert data(editor.model(), 1, 0) == 3
+    assert data(editor.model(), 2, 0) == 1
+    assert data(editor.model(), 0, 3) == '3'
+    assert data(editor.model(), 1, 3) == '1'
+    assert data(editor.model(), 2, 3) == '2'
 
 
 def test_rename_and_duplicate_item_in_collection_editor():
@@ -1076,24 +1089,26 @@ def test_dicts_natural_sorting_mixed_types():
     editor = CollectionsEditor()
     editor.setup(dictionary)
     cm = editor.widget.editor.source_model
-    cm.sort(0)
     keys = cm.keys
     types = cm.types
     sizes = cm.sizes
 
-    assert keys == ['aStr', 'DSeries', 'kDict']
-    assert types == ['str', 'Series', 'dict']
-    assert sizes == [str_size, (0,), 2]
+    # Initially sorted by insertion order
+    assert keys == ['DSeries', 'aStr', 'kDict']
+    assert types == ['Series', 'str', 'dict']
+    assert sizes == [(0,), str_size, 2]
 
-    assert data_table(cm, 3, 3) == [['aStr', 'DSeries', 'kDict'],
-                                    ['str', 'Series', 'dict'],
-                                    [str_size, '(0,)', 2]]
+    assert data_table(cm, 3, 3) == [['DSeries', 'aStr', 'kDict'],
+                                    ['Series', 'str', 'dict'],
+                                    ['(0,)', str_size, 2]]
 
     # insert an item and check that it is still sorted correctly
     editor.widget.editor.new_value('List', [1, 2, 3])
-    assert data_table(cm, 4, 3) == [['aStr', 'DSeries', 'kDict', 'List'],
-                                    ['str', 'Series', 'dict', 'list'],
-                                    [str_size, '(0,)', 2, 3]]
+    assert data_table(cm, 4, 3) == [['DSeries', 'aStr', 'kDict', 'List'],
+                                    ['Series', 'str', 'dict', 'list'],
+                                    ['(0,)', str_size, 2, 3]]
+
+    # now sort by key
     cm.sort(0)
     assert data_table(cm, 4, 3) == [['aStr', 'DSeries', 'kDict', 'List'],
                                     ['str', 'Series', 'dict', 'list'],

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -550,7 +550,9 @@ def test_dict_in_tableview_sorting(qtbot):
     header = editor.horizontalHeader()
     x_col0 = header.sectionPosition(0) + header.sectionSize(0) // 2
     with qtbot.waitSignal(header.sectionClicked, timeout=200):
-        qtbot.mouseClick(header.viewport(), Qt.LeftButton, pos=QPoint(x_col0, 1))
+        qtbot.mouseClick(
+            header.viewport(), Qt.LeftButton, pos=QPoint(x_col0, 1)
+        )
 
     # Test that dict is sorted by key
     assert data_col(editor.model(), 0) == [1, 2, 3]
@@ -558,7 +560,9 @@ def test_dict_in_tableview_sorting(qtbot):
 
     # Click on header of first column
     with qtbot.waitSignal(header.sectionClicked, timeout=200):
-        qtbot.mouseClick(header.viewport(), Qt.LeftButton, pos=QPoint(x_col0, 1))
+        qtbot.mouseClick(
+            header.viewport(), Qt.LeftButton, pos=QPoint(x_col0, 1)
+        )
 
     # Test that dict is sorted by key in reverse order
     assert data_col(editor.model(), 0) == [3, 2, 1]
@@ -566,7 +570,9 @@ def test_dict_in_tableview_sorting(qtbot):
 
     # Click on header of first column
     with qtbot.waitSignal(header.sectionClicked, timeout=200):
-        qtbot.mouseClick(header.viewport(), Qt.LeftButton, pos=QPoint(x_col0, 1))
+        qtbot.mouseClick(
+            header.viewport(), Qt.LeftButton, pos=QPoint(x_col0, 1)
+        )
 
     # Test that dict is displayed in insertion order
     assert data_col(editor.model(), 0) == [2, 3, 1]
@@ -575,7 +581,9 @@ def test_dict_in_tableview_sorting(qtbot):
     # Click on header of fourth column
     x_col3 = header.sectionPosition(3) + header.sectionSize(3) // 2
     with qtbot.waitSignal(header.sectionClicked, timeout=2000):
-        qtbot.mouseClick(header.viewport(), Qt.LeftButton, pos=QPoint(x_col3, 1))
+        qtbot.mouseClick(
+            header.viewport(), Qt.LeftButton, pos=QPoint(x_col3, 1)
+        )
 
     # Test that dict is sorted by value
     assert data_col(editor.model(), 0) == [3, 1, 2]
@@ -583,7 +591,9 @@ def test_dict_in_tableview_sorting(qtbot):
 
     # Click on header of fourth column
     with qtbot.waitSignal(header.sectionClicked, timeout=200):
-        qtbot.mouseClick(header.viewport(), Qt.LeftButton, pos=QPoint(x_col3, 1))
+        qtbot.mouseClick(
+            header.viewport(), Qt.LeftButton, pos=QPoint(x_col3, 1)
+        )
 
     # Test that dict is sorted by value in reverse order
     assert data_col(editor.model(), 0) == [2, 1, 3]
@@ -592,7 +602,9 @@ def test_dict_in_tableview_sorting(qtbot):
     # Click on header of first column
     header = editor.horizontalHeader()
     with qtbot.waitSignal(header.sectionClicked, timeout=200):
-        qtbot.mouseClick(header.viewport(), Qt.LeftButton, pos=QPoint(x_col0, 1))
+        qtbot.mouseClick(
+            header.viewport(), Qt.LeftButton, pos=QPoint(x_col0, 1)
+        )
 
     # Test that dict is sorted by key
     assert data_col(editor.model(), 0) == [1, 2, 3]
@@ -1157,15 +1169,19 @@ def test_dicts_natural_sorting_mixed_types():
     assert types == ['Series', 'str', 'dict']
     assert sizes == [(0,), str_size, 2]
 
-    assert data_table(cm, 3, 3) == [['DSeries', 'aStr', 'kDict'],
-                                    ['Series', 'str', 'dict'],
-                                    ['(0,)', str_size, 2]]
+    assert data_table(cm, 3, 3) == [
+        ["DSeries", "aStr", "kDict"],
+        ["Series", "str", "dict"],
+        ["(0,)", str_size, 2],
+    ]
 
     # insert an item and check that it is still sorted correctly
     editor.widget.editor.new_value('List', [1, 2, 3])
-    assert data_table(cm, 4, 3) == [['DSeries', 'aStr', 'kDict', 'List'],
-                                    ['Series', 'str', 'dict', 'list'],
-                                    ['(0,)', str_size, 2, 3]]
+    assert data_table(cm, 4, 3) == [
+        ["DSeries", "aStr", "kDict", "List"],
+        ["Series", "str", "dict", "list"],
+        ["(0,)", str_size, 2, 3],
+    ]
 
     # now sort by key
     cm.sort(0)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

This PR displays dictionaries in the collections editor by insertion order, instead of ordering them alphabetically by key. This reflects a change in Python 3.7, which guaranteed that the order is preserved.

Clicking on the column header now cycles through three states: sorting that column in ascending order, sorting that column in descending order, and reverting to insertion order. See the video below for a demonstration.

Collections editors showing anything but a dictionary are not changed by this PR. 

The cycling through three sorting states is implemented in the model. That is a bit of a hack, because it would be more logical to do it in the view, but it is not clear how to get this to work. In Qt 6, `QHeaderView` has a flag `sortIndicatorClearable` which implements the three-state behaviour.

The PR also adds a test and some docstrings in classes and functions that it touches. The actions showing environment variables use the collections editor; they now explicitly sort the environment variables by name because showing them by insertion order makes no sense.

https://github.com/user-attachments/assets/0024a2d3-0840-44aa-a351-efdf1e28fb77

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #9136


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
