### PR TITLE
PR: Remove unnecessary margins around `RemoteExplorer` widget (Files)

### DIFF
--- a/spyder/plugins/explorer/widgets/remote_explorer.py
+++ b/spyder/plugins/explorer/widgets/remote_explorer.py
@@ -98,6 +98,7 @@ class RemoteExplorer(QWidget, SpyderWidgetMixin):
         self.view.entered.connect(self._on_entered_item)
 
         layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.view)
 
     @on_conf_change(


### PR DESCRIPTION
## Description of Changes

I noticed this small UI error when checking that widget to publish a tweet about it.

### Visual changes

**Before**

![image](https://github.com/user-attachments/assets/f915378f-4015-46e3-8e8c-f605defc58c9)

**After**

![image](https://github.com/user-attachments/assets/c9a4ea5e-7ede-4ede-8f7f-df8b03dbbd72)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
