### PR TITLE
PR: Increase minimal supported Python version to 3.9

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -106,7 +106,7 @@ else
     if [ "$RUN_SLOW" = "false" ]; then
         if [ "$OS" = "linux" ]; then
             curl https://pyenv.run | bash
-            $HOME/.pyenv/bin/pyenv install 3.8.1
+            $HOME/.pyenv/bin/pyenv install 3.10.6
         fi
     fi
 fi

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -70,13 +70,12 @@ jobs:
       fail-fast: false
       matrix:
         INSTALL_TYPE: ['pip', 'conda']
-        PYTHON_VERSION: ['3.8', '3.10', '3.12']
+        PYTHON_VERSION: ['3.9', '3.10', '3.12']
         TEST_TYPE: ['fast', 'slow']
         exclude:
-          # Only test Python 3.8 with pip because Conda-forge drop support for
-          # it
+          # Only test Python 3.9 with pip to save CI time
           - INSTALL_TYPE: 'conda'
-            PYTHON_VERSION: '3.8'
+            PYTHON_VERSION: '3.9'
           # We can't test with pip in Python 3.11+ due to an error, so we use
           # 3.10 instead.
           - INSTALL_TYPE: 'pip'

--- a/.github/workflows/test-remoteclient.yml
+++ b/.github/workflows/test-remoteclient.yml
@@ -65,11 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         INSTALL_TYPE: ['pip', 'conda']
-        PYTHON_VERSION: ['3.8', '3.12']
-        exclude:
-          # Only test Python 3.8 with pip because Conda-forge will drop it soon
-          - INSTALL_TYPE: 'conda'
-            PYTHON_VERSION: '3.8'
+        PYTHON_VERSION: ['3.9', '3.12']
     timeout-minutes: 90
     steps:
       - name: Setup Remote SSH Connection

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ a Python version equal or greater than 3.8.
 
 The basic dependencies to run Spyder are:
 
-* **Python** 3.8+: The core language Spyder is written in and for.
+* **Python** 3.9+: The core language Spyder is written in and for.
 * **PyQt5** 5.15+: Python bindings for Qt, used for Spyder's GUI.
 
 The rest our dependencies (both required and optional) are declared in

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ from setuptools.command.install import install
 # Taken from the notebook setup.py -- Modified BSD License
 # =============================================================================
 v = sys.version_info
-if v[:2] < (3, 8):
-    error = "ERROR: Spyder requires Python version 3.8 and above."
+if v[:2] < (3, 9):
+    error = "ERROR: Spyder requires Python version 3.9 and above."
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -220,18 +220,18 @@ setup_args = dict(
     package_data={LIBNAME: get_package_data(LIBNAME, EXTLIST)},
     scripts=[osp.join('scripts', fname) for fname in SCRIPTS],
     data_files=get_data_files(),
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Operating System :: MacOS',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',
@@ -246,7 +246,6 @@ setup_args = dict(
 qt_requirements = {
     'pyqt5': [
         'pyqt5>=5.15,<5.16',
-        'pyqt5-sip<12.16; python_version=="3.8"',
         'pyqtwebengine>=5.15,<5.16',
         'qtconsole>=5.6.1,<5.7.0',
     ],
@@ -281,8 +280,7 @@ install_requires += [
     # install in all cases and helps the tests to pass.
     'importlib-metadata>=4.6.0',
     'intervaltree>=3.0.2',
-    'ipython>=8.12.2,<8.13.0; python_version=="3.8"',
-    'ipython>=8.13.0,<9.0.0,!=8.17.1; python_version>"3.8"',
+    'ipython>=8.13.0,<9.0.0,!=8.17.1',
     'ipython_pygments_lexers>=1.0',
     'jedi>=0.17.2,<0.20.0',
     'jellyfish>=0.7',

--- a/spyder/app/tests/spyder-boilerplate/setup.py
+++ b/spyder/app/tests/spyder-boilerplate/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email="spyder.python@gmail.com",
     description="Plugin that registers a programmatic custom layout",
     license="MIT license",
-    python_requires='>= 3.8',
+    python_requires='>= 3.9',
     install_requires=[
         "qtpy",
         "qtawesome",
@@ -36,8 +36,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Education",
         "Intended Audience :: Science/Research",

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -18,10 +18,6 @@ from spyder.utils import programs
 
 HERE = osp.dirname(osp.abspath(__file__))
 
-# Python 3.8
-PY38 = sys.version_info[:2] == (3, 8)
-
-
 # =============================================================================
 # Kind of dependency
 # =============================================================================
@@ -45,7 +41,7 @@ COOKIECUTTER_REQVER = '>=1.6.0'
 DIFF_MATCH_PATCH_REQVER = '>=20181111'
 IMPORTLIB_METADATA_REQVER = '>=4.6.0'
 INTERVALTREE_REQVER = '>=3.0.2'
-IPYTHON_REQVER = ">=8.12.2,<8.13.0" if PY38 else ">=8.13.0,<9.0.0,!=8.17.1"
+IPYTHON_REQVER = ">=8.13.0,<9.0.0,!=8.17.1"
 IPYTHON_PYGMENTS_LEXERS_REQVER = ">=1.0"
 JEDI_REQVER = '>=0.17.2,<0.20.0'
 JELLYFISH_REQVER = '>=0.7'

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -231,15 +231,9 @@ class ScrollFlagArea(Panel):
         }
         dict_flag_lists.update(self._dict_flag_list)
 
-        # The ability to reverse dictionaries was added in Python 3.8.
-        # Fixes spyder-ide/spyder#21286
-        if sys.version_info[:2] > (3, 7):
-            # This is necessary to paint find matches above errors and
-            # warnings.
-            # See spyder-ide/spyder#20970
-            dict_flag_lists_iter = reversed(dict_flag_lists)
-        else:
-            dict_flag_lists_iter = dict_flag_lists
+        # This is necessary to paint find matches above errors and warnings.
+        # See spyder-ide/spyder#20970
+        dict_flag_lists_iter = reversed(dict_flag_lists)
 
         for flag_type in dict_flag_lists_iter:
             painter.setBrush(self._facecolors[flag_type])

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1669,9 +1669,8 @@ def test_recursive_pdb(ipyconsole, qtbot):
 
 
 @pytest.mark.skipif(
-    sys.version_info[:2] == (3, 8), reason="Fails in Python 3.8"
+    PYQT6, reason="Crashes ('QThread destroyed while running')"
 )
-@pytest.mark.skipif(PYQT6, reason="Crashes ('QThread destroyed while running')")
 def test_pdb_magics_are_recursive(ipyconsole, qtbot, tmp_path):
     """
     Check that calls to Pdb magics start a recursive debugger when called in

--- a/spyder/tests/test_dependencies_in_sync.py
+++ b/spyder/tests/test_dependencies_in_sync.py
@@ -11,11 +11,10 @@ import os.path as osp
 # Third party imports
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
-import pytest
 import yaml
 
 # Local imports
-from spyder.dependencies import DESCRIPTIONS, OPTIONAL, PY38
+from spyder.dependencies import DESCRIPTIONS, OPTIONAL
 
 # Constants
 HERE = osp.abspath(osp.dirname(__file__))
@@ -175,7 +174,6 @@ def test_dependencies_for_binder_in_sync():
     assert spyder_env == full_reqs
 
 
-@pytest.mark.skipif(PY38, reason="Fails in Python 3.8")
 def test_dependencies_for_spyder_dialog_in_sync():
     """
     Spyder dependencies dialog should share deps with main.yml.
@@ -218,8 +216,6 @@ def test_dependencies_for_spyder_setup_install_requires_in_sync():
     # We can't declare these as dependencies in setup.py
     for dep in ['python.app', 'fzf', 'fcitx-qt5']:
         full_reqs.pop(dep)
-    # Ignored `pyqt5-sip` constraint on conda
-    spyder_setup.pop('pyqt5-sip')
 
     assert spyder_setup == full_reqs
 

--- a/spyder/utils/tests/test_pyenv.py
+++ b/spyder/utils/tests/test_pyenv.py
@@ -25,7 +25,7 @@ if not find_program('pyenv'):
                     reason="Only runs on Linux")
 def test_get_list_pyenv_envs():
     output = get_list_pyenv_envs()
-    expected_envs = ['Pyenv: 3.8.1']
+    expected_envs = ['Pyenv: 3.10.6']
     assert set(expected_envs) == set(output.keys())
 
 


### PR DESCRIPTION
## Description of Changes

- Python 3.8 reached end-of-life last year, so we don't need to keep supporting it anymore.
- Also, tests started to fail with Python 3.8 and there's no need to fix them.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
