### PR TITLE
PR: Fix Remote client tests by passing `ClientSession` loop when closing APIs (Jupyter and Files APIs)

### DIFF
--- a/spyder/plugins/explorer/plugin.py
+++ b/spyder/plugins/explorer/plugin.py
@@ -284,13 +284,17 @@ class Explorer(SpyderDockablePlugin):
     def on_remote_client_teardown(self):
         if len(self._file_managers):
             for file_manager in self._file_managers.values():
-                AsyncDispatcher(early_return=False)(file_manager.close)()
+                AsyncDispatcher(
+                    loop=file_manager.session._loop, early_return=False
+                )(file_manager.close)()
             self._file_managers = {}
 
     def on_close(self, cancelable=False):
         if len(self._file_managers):
             for file_manager in self._file_managers.values():
-                AsyncDispatcher(early_return=False)(file_manager.close)()
+                AsyncDispatcher(
+                    loop=file_manager.session._loop, early_return=False
+                )(file_manager.close)()
             self._file_managers = {}
 
     # ---- Private API

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -669,8 +669,12 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):  # noqa: PLR09
 
         # Close jupyter api regardless of the kernel state
         if self.is_remote():
-            AsyncDispatcher(early_return=False)(self._jupyter_api.close)()
-            AsyncDispatcher(early_return=False)(self._files_api.close)()
+            AsyncDispatcher(
+                loop=self._jupyter_api.session._loop, early_return=False
+            )(self._jupyter_api.close)()
+            AsyncDispatcher(
+                loop=self._files_api.session._loop, early_return=False
+            )(self._files_api.close)()
 
         # Prevent errors in our tests
         try:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Changes needed due to the fix done and released with `aiohttp` 3.12.4: https://github.com/aio-libs/aiohttp/releases/tag/v3.12.4

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
