### PR TITLE
PR: Catch any error when creating a new Pdb history session (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/debugging.py
+++ b/spyder/plugins/ipythonconsole/widgets/debugging.py
@@ -89,7 +89,13 @@ class DebuggingHistoryWidget(RichJupyterWidget):
         """Start a new history session."""
         self._pdb_history_input_number = 0
         if self._pdb_history_file is not None:
-            self._pdb_history_file.new_session()
+            # Prevent errors when trying to create a new session.
+            # Fixes spyder-ide/spyder#24504
+            try:
+                self._pdb_history_file.new_session()
+            except Exception:
+                self._pdb_history_file = None
+                self._pdb_history = []
 
     def end_history_session(self):
         """End an history session."""


### PR DESCRIPTION
## Description of Changes

- Sometimes it's not possible to create a new sqlite session to save the Pdb history of commands, and that makes the debugger unusable.
- So, we catch any error in that case to prevent that problem.

### Issue(s) Resolved

Fixes #24504.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
