### PR TITLE
PR: Use GitHub's digest feature for release assets (Update manager)

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -386,6 +386,7 @@ jobs:
 
       - name: Create Checksums
         run: |
+          # TODO: Remove this step for Spyder 7
           sha256sum *.zip *.pkg *.sh *.exe > Spyder-checksums.txt
 
       - name: Upload Lock Files

--- a/spyder/plugins/updatemanager/tests/test_update_manager.py
+++ b/spyder/plugins/updatemanager/tests/test_update_manager.py
@@ -22,7 +22,6 @@ from spyder.plugins.updatemanager.widgets.update import UpdateManagerWidget
 logging.basicConfig()
 
 workers.get_github_releases = lru_cache(workers.get_github_releases)
-workers.get_asset_checksum = lru_cache(workers.get_asset_checksum)
 _tags = (
     "v6.0.5", "v6.0.5rc1", "v6.1.0a1", "v6.0.4",
     "v6.0.4rc1", "v6.0.3", "v6.0.3rc2", "v6.0.3rc1",

--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -184,13 +184,13 @@ def get_asset_info(
     elif update_type != UpdateType.Major:
         filename = "spyder-conda-lock.zip"
     else:
-        mach = platform.machine().lower().replace("amd64", "x86_64")
+        machine = platform.machine().lower().replace("amd64", "x86_64")
         if os.name == 'nt':
-            filename = f"Spyder-Windows-{mach}.exe"
+            filename = f"Spyder-Windows-{machine}.exe"
         if sys.platform == 'darwin':
-            filename = f"Spyder-macOS-{mach}.pkg"
+            filename = f"Spyder-macOS-{machine}.pkg"
         if sys.platform.startswith('linux'):
-            filename = f"Spyder-Linux-{mach}.sh"
+            filename = f"Spyder-Linux-{machine}.sh"
 
     asset_info = None
     for asset in release_info["assets"]:

--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -29,12 +29,7 @@ from spyder_kernels.utils.pythonenv import is_conda_env
 
 # Local imports
 from spyder import __version__
-from spyder.config.base import (
-    _,
-    is_conda_based_app,
-    running_in_ci,
-    running_under_pytest,
-)
+from spyder.config.base import _, is_conda_based_app, running_in_ci
 from spyder.plugins.updatemanager.utils import get_updater_info
 from spyder.utils.conda import get_spyder_conda_channel, find_conda
 from spyder.utils.programs import get_temp_dir
@@ -133,8 +128,8 @@ def get_github_releases(
     )
 
     if tags is None:
-        # Get the most recent releases
-        url += f"?per_page={100 if running_under_pytest() else 20}&page=1"
+        # Get 20 most recent releases
+        url += "?per_page=20&page=1"
         logger.info(f"Getting release info from {url}")
         page = requests.get(url, headers=GH_HEADERS)
         page.raise_for_status()

--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -149,36 +149,6 @@ def get_github_releases(
     return {parse(item['tag_name']): item for item in data}
 
 
-def get_asset_checksum(url: str, name: str) -> str | None:
-    """
-    Get the checksum for the provided asset.
-
-    Parameters
-    ----------
-    url : str
-        Url to the checksum asset
-    name : str
-        Name of the asset for which to obtain the checksum
-
-    Returns
-    -------
-    checksum : str | None
-        Checksum for the provided asset. None is returned if the checksum is
-        not available for the provided asset name.
-    """
-    logger.info(f"Getting checksum from {url}")
-    page = requests.get(url, headers=GH_HEADERS)
-    page.raise_for_status()
-
-    digest = page.text.strip().split("\n")
-    data = {k: v for v, k in [item.split() for item in digest]}
-    checksum = data.get(name, None)
-
-    logger.info(f"Checksum for {name}: {checksum}")
-
-    return checksum
-
-
 def get_asset_info(release_info: dict) -> AssetInfo | None:
     """
     Get the version, name, update type, download URL, and digest for the asset


### PR DESCRIPTION
Use GitHub's digest feature for release assets.

The checksum for a release artifact will now be available in the asset info from GitHub rest api so we no longer need a separate http request to read the checksum artifact.

We still need to generate the checksum artifact for future releases so that Spyder versions <6.1 can update. However, at some point in the future (assume Spyder 7), we can stop creating the checksum artifact.

Fixes #24531 