### PR TITLE
PR: Fix kernel activation for Mamba 2.0+ (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -164,21 +164,12 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
                 # installed in a non-standard location).
                 # See spyder-ide/spyder#23595
                 not_found_exe_message = _(
-                    "Spyder couldn't find conda or mamba in your system "
-                    "to activate the kernel's environment. Please add the "
-                    "directory where the conda or mamba executable is "
-                    "located to your PATH environment variable for it to "
+                    "Spyder couldn't find conda, mamba or micromamba in your "
+                    "system to activate the kernel's environment. Please add "
+                    "the directory where at least one of their executables "
+                    "is located to your PATH environment variable for it to "
                     "be detected."
                 )
-                if ".pixi" in pyexec:
-                    # Validate if the interpreter path contains ".pixi" to
-                    # handle pixi created environments when conda is not
-                    # installed and show proper feedback.
-                    # See spyder-ide/spyder#23558 (issuecomment-2707561132)
-                    not_found_exe_message = _(
-                        "Spyder doesn't support Pixi environments at the "
-                        "moment, but it will in version 6.1.0"
-                    )
                 raise SpyderKernelError(not_found_exe_message)
 
             # Get conda/mamba/micromamba version to perform some checks

--- a/spyder/utils/conda.py
+++ b/spyder/utils/conda.py
@@ -246,7 +246,7 @@ def get_spyder_conda_channel():
     return channel, channel_url
 
 
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=10)
 def conda_version(conda_executable=None):
     """
     Get the conda version if available.


### PR DESCRIPTION
## Description of Changes

Mamba 2.0 doesn't have the `--no-capture-output` option to pass the kernel's stdout/stderr to Spyder. Instead, it uses `--attach`, as Micromamba.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24513.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
