### PR TITLE
PR: Fix an Update manager test

### DIFF
--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -29,7 +29,12 @@ from spyder_kernels.utils.pythonenv import is_conda_env
 
 # Local imports
 from spyder import __version__
-from spyder.config.base import _, is_conda_based_app, running_in_ci
+from spyder.config.base import (
+    _,
+    is_conda_based_app,
+    running_in_ci,
+    running_under_pytest,
+)
 from spyder.plugins.updatemanager.utils import get_updater_info
 from spyder.utils.conda import get_spyder_conda_channel, find_conda
 from spyder.utils.programs import get_temp_dir
@@ -128,8 +133,8 @@ def get_github_releases(
     )
 
     if tags is None:
-        # Get 20 most recent releases
-        url += "?per_page=20&page=1"
+        # Get the most recent releases
+        url += f"?per_page={100 if running_under_pytest() else 20}&page=1"
         logger.info(f"Getting release info from {url}")
         page = requests.get(url, headers=GH_HEADERS)
         page.raise_for_status()


### PR DESCRIPTION
## Description of Changes

- `test_update_non_stable` started to fail after releasing 6.1.0a3. When trying to fix it, I noticed it was not actually testing what we wanted to, so I took the opportunity to improve it a bit.
- Request the max amount of Github releases we can when checking for updates while testing to prevent that test from failing again in a long time.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
