### PR TITLE
PR: Support Polars data frames in Variable Explorer

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = master
-	commit = 1cb08e8a64144369ee391bf93432e4e201f88f1e
-	parent = 4bce5e32afe82df04c1e6ee376aa583709ce9d1a
+	commit = 7987954c872db3f071d62011936167fea9c3ee6b
+	parent = 1f6f0d619101120070fdab401a43428f05f2bf44
 	method = merge
-	cmdver = 0.4.3
+	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/SECURITY.md
+++ b/external-deps/spyder-kernels/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+
+## Supported Versions
+
+Spyder-Kernels normally supports the version supporting the latest versions of Spyder with bug fixes, security updates and compatibility improvements.
+Additionally, the previous feature (major or minor) release will be supported for critical security and bug fixes only for two months following the release of a new Spyder feature version.
+
+The following summarizes the support status of recent Spyder-Kernels versions.
+
+| Version  | Supported          |
+| -------- | ------------------ |
+| 3.0.x    | :heavy_check_mark: |
+| <3       | :x:                |
+
+
+
+## Reporting a Vulnerability
+
+If you believe you've discovered a security vulnerability in Spyder-Kernels, please use open a new security advisory with [our GitHub repo's private vulnerability reporting](https://github.com/spyder-ide/spyder-kernels/security/advisories/new).
+Please be sure to carefully document the vulnerability, including a summary, describing the impacts, identifying the line(s) of code affected, stating the conditions under which it is exploitable and including a minimal reproducible test case.
+Further information and advice or patches on how to mitigate it is always welcome.
+You can usually expect to hear back within 1 week, at which point we'll inform you of our evaluation of the vulnerability and what steps we plan to take, and will reach out if we need further clarification from you.
+We'll discuss and update the advisory thread, and are happy to update you on its status should you further inquire.
+While this is a volunteer project and we don't have financial compensation to offer, we can certainly publicly thank and credit you for your help if you would like.
+Thanks!

--- a/external-deps/spyder-kernels/requirements/tests.txt
+++ b/external-deps/spyder-kernels/requirements/tests.txt
@@ -5,6 +5,8 @@ matplotlib
 mock
 numpy
 pandas
+polars
+pyarrow
 pytest
 pytest-cov
 scipy

--- a/external-deps/spyder-kernels/setup.py
+++ b/external-deps/spyder-kernels/setup.py
@@ -58,6 +58,8 @@ TEST_REQUIREMENTS = [
     "mock",
     "numpy",
     "pandas",
+    "polars",
+    "pyarrow",
     "pytest",
     "pytest-cov",
     "scipy",

--- a/external-deps/spyder-kernels/spyder_kernels/comms/commbase.py
+++ b/external-deps/spyder-kernels/spyder_kernels/comms/commbase.py
@@ -108,6 +108,7 @@ class CommsErrorWrapper():
             "call_id": self.call_id,
             "etype": self.etype.__name__,
             "args": self.error.args,
+            "error_name": getattr(self.error, "name", None),
             "tb": stacksummary_to_json(self.tb)
         }
 
@@ -124,6 +125,8 @@ class CommsErrorWrapper():
             type(etype, (Exception,), {})
         )
         instance.error = instance.etype(*json_data["args"])
+        if json_data["error_name"]:
+            instance.error.name = json_data["error_name"]
         instance.tb = staksummary_from_json(json_data["tb"])
         return instance
 

--- a/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/kernel.py
@@ -375,6 +375,11 @@ class SpyderKernel(IPythonKernel):
         """Get the value of a variable"""
         ns = self.shell._get_current_namespace()
         value = ns[name]
+
+        if str(type(value)) == "<class 'polars.dataframe.frame.DataFrame'>":
+            # Convert polars dataframes to pandas
+            value = value.to_pandas()
+
         if encoded:
             # Encode with cloudpickle
             value = cloudpickle.dumps(value)

--- a/external-deps/spyder-kernels/spyder_kernels/console/tests/test_console_kernel.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/tests/test_console_kernel.py
@@ -346,6 +346,17 @@ def test_get_value(kernel):
     assert kernel.get_value(name) == 124
 
 
+def test_get_value_with_polars(kernel):
+    """Test getting the value of a Polars DataFrame."""
+    import pandas
+    from pandas.testing import assert_frame_equal
+
+    command = "import polars; polars_df = polars.DataFrame({'a': [10]})"
+    asyncio.run(kernel.do_execute(command, True))
+    pandas_df = pandas.DataFrame({'a': [10]})
+    assert_frame_equal(kernel.get_value('polars_df'), pandas_df)
+
+
 def test_set_value(kernel):
     """Test setting the value of a variable."""
     name = 'a'

--- a/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/nsview.py
@@ -380,7 +380,10 @@ def value_to_display(value, minmax=False, level=0):
                 display = '%s  Mode: %s' % (address(value), value.mode)
             else:
                 display = 'Image'
-        elif isinstance(value, pd.DataFrame):
+        elif (
+            isinstance(value, pd.DataFrame)
+            or str(type(value)) == "<class 'polars.dataframe.frame.DataFrame'>"
+        ):
             if level == 0:
                 cols = value.columns
                 cols = [str(c) for c in cols]
@@ -558,7 +561,10 @@ def get_human_readable_type(item):
             return "Image"
         else:
             text = get_type_string(item)
-            return text[text.find('.')+1:]
+            if text == 'polars.dataframe.frame.DataFrame':
+                return 'Polars DataFrame'
+            else:
+                return text[text.find('.') + 1:]
     except Exception:
         return 'Unknown'
 

--- a/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_nsview.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/tests/test_nsview.py
@@ -25,9 +25,16 @@ import PIL.Image
 
 # Local imports
 from spyder_kernels.utils.nsview import (
-    sort_against, is_supported, value_to_display, get_size,
-    get_supported_types, get_type_string, get_numpy_type_string,
-    is_editable_type)
+    get_human_readable_type,
+    get_numpy_type_string,
+    get_size,
+    get_supported_types,
+    get_type_string,
+    is_editable_type,
+    is_supported,
+    sort_against,
+    value_to_display,
+)
 
 
 def generate_complex_object():
@@ -477,6 +484,14 @@ def test_get_numpy_type():
     # Pandas objects
     df = pd.DataFrame([1, 2, 3])
     assert get_numpy_type_string(df) == 'Unknown'
+
+
+def test_polars_dataframe():
+    import polars
+    df = polars.DataFrame({'name': ['Alice', 'Bob'], 'height': [1.77, 1.69]})
+    assert value_to_display(df) == 'Column names: name, height'
+    assert value_to_display(df, level=1) == 'Dataframe'
+    assert get_human_readable_type(df) == 'Polars DataFrame'
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
@@ -71,7 +71,7 @@ class NamepaceBrowserWidget(RichJupyterWidget):
             "install it in the same environment that you use to run Spyder."
         )
         reason_mismatched_python = _(
-            "There is a mistmatch between the Python versions used by Spyder "
+            "There is a mismatch between the Python versions used by Spyder "
             "({}) and the kernel of your current console ({}).<br><br>"
             "To fix it, you need to recreate your console environment with "
             "Python {} or {}."

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -279,9 +279,11 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
             except AttributeError:
                 # index.model() is not a QSortFilterProxyModel
                 source_index = index
+
             type_of_value = source_index.model().row_type(source_index.row())
             if type_of_value == 'Polars DataFrame':
                 readonly = True
+
             # We need to leave this import here for tests to pass.
             from .dataframeeditor import DataFrameEditor
             editor = DataFrameEditor(

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -86,6 +86,7 @@ from spyder.utils.stylesheet import AppStyle, MAC
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
+    from pandas import DataFrame
     from spyder.plugins.variableexplorer.widgets.namespacebrowser import (
         NamespaceBrowser
     )
@@ -214,13 +215,27 @@ def global_max(col_vals, index):
 
 class DataFrameModel(QAbstractTableModel, SpyderFontsMixin):
     """
-    DataFrame Table Model.
+    Model encapsulating a dataframe for the datafgrame editor
+
+    This is a model (in the sense of the Qt model/view architecture).
 
     Partly based in ExtDataModel and ExtFrameModel classes
     of the gtabview project.
 
     For more information please see:
     https://github.com/wavexx/gtabview/blob/master/gtabview/models.py
+
+    Parameters
+    ----------
+    dataFrame : DataFrame
+        The dataframe encapsulated by the model.
+    format_spec : str, optional
+        Format specification for floats. The default is DEFAULT_FORMAT.
+    parent : Optional[QWidget], optional
+        The parent widget for the model. The default is None.
+    readonly : bool, optional
+        If True, the underlying dataframe can not be edited by the user.
+        The default is False.
 
     Attributes
     ----------
@@ -234,13 +249,20 @@ class DataFrameModel(QAbstractTableModel, SpyderFontsMixin):
         Format specification for floats
     """
 
-    def __init__(self, dataFrame, format_spec=DEFAULT_FORMAT, parent=None):
+    def __init__(
+        self,
+        dataFrame: DataFrame,
+        format_spec: str = DEFAULT_FORMAT,
+        parent: Optional[QWidget] = None,
+        readonly: bool = False,
+    ):
         QAbstractTableModel.__init__(self)
         self.dialog = parent
         self.df = dataFrame
         self.df_columns_list = None
         self.df_index_list = None
         self._format_spec = format_spec
+        self.readonly = readonly
         self.complex_intran = None
         self.display_error_idxs = []
 
@@ -573,9 +595,10 @@ class DataFrameModel(QAbstractTableModel, SpyderFontsMixin):
 
     def flags(self, index):
         """Set flags"""
-        return (
-            QAbstractTableModel.flags(self, index) | Qt.ItemFlag.ItemIsEditable
-        )
+        result = super().flags(index)
+        if not self.readonly:
+            result |= Qt.ItemFlag.ItemIsEditable
+        return result
 
     def setData(self, index, value, role=Qt.EditRole, change_type=None):
         """Cell content change"""
@@ -673,7 +696,33 @@ class DataFrameModel(QAbstractTableModel, SpyderFontsMixin):
 
 class DataFrameView(QTableView, SpyderWidgetMixin):
     """
-    Data Frame view class.
+    View displaying a dataframe in the dataframe editor
+
+    This is a view (in the sense of the Qt model/view architecture) that is
+    used in the dataframe editor to display a dataframe. It only shows the
+    data but not the index (row headings) or header (column names).
+
+    Parameters
+    ----------
+    parent : Optional[QWidget]
+        The parent widget.
+    model : DataFrameModel
+        Model encapsulating the displayed dataframe.
+    header : QHeaderView
+        The header (column names) of the view.
+    hscroll : QScrollBar
+        The horizontal scroll bar.
+    vscroll : QScrollBar
+        The vertical scroll bar.
+    namespacebrowser : Optional[NamespaceBrowser], optional
+        The namespace browser that opened the editor containing this view.
+        The default is None.
+    data_function : Optional[Callable[[], Any]], optional
+        A function which returns the new data frame when the user clicks on
+        the Refresh button. The default is None.
+    readonly : bool, optional
+        If True, then the user can not edit the dataframe. The default is
+        False.
 
     Signals
     -------
@@ -694,10 +743,14 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
         hscroll: QScrollBar,
         vscroll: QScrollBar,
         namespacebrowser: Optional[NamespaceBrowser] = None,
-        data_function: Optional[Callable[[], Any]] = None
+        data_function: Optional[Callable[[], Any]] = None,
+        readonly: bool = False
     ):
-        """Constructor."""
         QTableView.__init__(self, parent)
+
+        self.namespacebrowser = namespacebrowser
+        self.data_function = data_function
+        self.readonly = readonly
 
         self.menu = None
         self.menu_header_h = None
@@ -734,8 +787,6 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
         self.header_class.customContextMenuRequested.connect(
             self.show_header_menu)
         self.header_class.sectionClicked.connect(self.sortByColumn)
-        self.namespacebrowser = namespacebrowser
-        self.data_function = data_function
         self.horizontalScrollBar().valueChanged.connect(
             self._load_more_columns)
         self.verticalScrollBar().valueChanged.connect(self._load_more_rows)
@@ -820,6 +871,7 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
             triggered=self.edit_header_item,
             register_action=False
         )
+        edit_header_action.setEnabled(not self.readonly)
         menu = self.create_menu(DataframeEditorMenus.Header, register=False)
         self.add_item_to_menu(edit_header_action, menu)
         return menu
@@ -830,8 +882,9 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
 
         # Enable/disable edit actions
         condition_edit = (
-            index.isValid() and
-            (len(self.selectedIndexes()) == 1)
+            index.isValid()
+            and len(self.selectedIndexes()) == 1
+            and not self.readonly
         )
 
         for action in [self.edit_action, self.insert_action_above,
@@ -842,13 +895,18 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
 
         # Enable/disable actions for remove col/row, copy and plot
         condition_copy_remove = (
-            index.isValid() and
-            (len(self.selectedIndexes()) > 0)
+            index.isValid()
+            and len(self.selectedIndexes()) > 0
+            and not self.readonly
         )
 
         for action in [self.copy_action, self.remove_row_action,
                        self.remove_col_action, self.histogram_action]:
             action.setEnabled(condition_copy_remove)
+
+        # Enable/disable action for plot
+        condition_plot = (index.isValid() and len(self.selectedIndexes()) > 0)
+        self.histogram_action.setEnabled(condition_plot)
 
     def setup_menu(self):
         """Setup context menu."""
@@ -1765,9 +1823,28 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
     """
     Dialog for displaying and editing DataFrame and related objects.
 
+    The main portion of the dialog is a table displaying the data. The column
+    names are displayed above the table nd the row index is displayed to the
+    left of the table. Above this all is a toolbar and below it all are buttons
+    for closing the dialog and saving the data.
+
     Based on the gtabview project (ExtTableView).
     For more information please see:
     https://github.com/wavexx/gtabview/blob/master/gtabview/viewer.py
+
+    Parameters
+    ----------
+    parent : Optional[QWidget]
+        The parent widget.
+    namespacebrowser : Optional[NamespaceBrowser], optional
+        The namespace browser that opened the editor containing this view.
+        The default is None.
+    data_function : Optional[Callable[[], Any]], optional
+        A function which returns the new data frame when the user clicks on
+        the Refresh button. The default is None.
+    readonly : bool, optional
+        If True, then the user can not edit the dataframe. The default is
+        False.
     """
     CONF_SECTION = 'variable_explorer'
 
@@ -1775,11 +1852,13 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
         self,
         parent: Optional[QWidget] = None,
         namespacebrowser: Optional[NamespaceBrowser] = None,
-        data_function: Optional[Callable[[], Any]] = None
+        data_function: Optional[Callable[[], Any]] = None,
+        readonly: bool = False
     ):
         super().__init__(parent)
         self.namespacebrowser = namespacebrowser
         self.data_function = data_function
+        self.readonly = readonly
 
         self.refresh_action = self.create_action(
             name=DataframeEditorActions.Refresh,
@@ -1869,7 +1948,11 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
 
         # Create the model and view of the data
         empty_data = EmptyDataFrame()
-        self.dataModel = DataFrameModel(empty_data, parent=self)
+        self.dataModel = DataFrameModel(
+            empty_data,
+            parent=self,
+            readonly=self.readonly
+        )
         self.dataModel.dataChanged.connect(self.save_and_close_enable)
         self.create_data_table()
 
@@ -1893,9 +1976,12 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
         btn_layout = QHBoxLayout()
         btn_layout.addStretch()
 
-        self.btn_save_and_close = QPushButton(_('Save and Close'))
-        self.btn_save_and_close.clicked.connect(self.accept)
-        btn_layout.addWidget(self.btn_save_and_close)
+        if self.readonly:
+            self.btn_save_and_close = None
+        else:
+            self.btn_save_and_close = QPushButton(_('Save and Close'))
+            self.btn_save_and_close.clicked.connect(self.accept)
+            btn_layout.addWidget(self.btn_save_and_close)
 
         self.btn_close = QPushButton(_('Close'))
         self.btn_close.setAutoDefault(True)
@@ -1942,7 +2028,11 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
             data = pd.DataFrame(data)
 
         # Create the model and view of the data
-        self.dataModel = DataFrameModel(data, parent=self)
+        self.dataModel = DataFrameModel(
+            data,
+            parent=self,
+            readonly=self.readonly
+        )
         self.dataModel.dataChanged.connect(self.save_and_close_enable)
         self.dataTable.setModel(self.dataModel)
 
@@ -1957,7 +2047,8 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
         self.setModel(self.dataModel)
         self.resizeColumnsToContents()
 
-        self.btn_save_and_close.setDisabled(True)
+        if self.btn_save_and_close:
+            self.btn_save_and_close.setDisabled(True)
         self.dataModel.set_format_spec(self.get_conf('dataframe_format'))
 
         if self.table_header.rowHeight(0) == 0:
@@ -2024,9 +2115,10 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
     @Slot(QModelIndex, QModelIndex)
     def save_and_close_enable(self, top_left, bottom_right):
         """Handle the data change event to enable the save and close button."""
-        self.btn_save_and_close.setEnabled(True)
-        self.btn_save_and_close.setAutoDefault(True)
-        self.btn_save_and_close.setDefault(True)
+        if self.btn_save_and_close:
+            self.btn_save_and_close.setEnabled(True)
+            self.btn_save_and_close.setAutoDefault(True)
+            self.btn_save_and_close.setDefault(True)
 
     def setup_menu_header(self, header):
         """Setup context header menu."""
@@ -2037,6 +2129,7 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
             triggered=lambda: self.edit_header_item(header=header),
             register_action=False
         )
+        edit_header_action.setEnabled(not self.readonly)
         menu = self.create_menu(DataframeEditorMenus.Index, register=False)
         self.add_item_to_menu(edit_header_action, menu)
         return menu
@@ -2115,7 +2208,8 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
             self.hscroll,
             self.vscroll,
             self.namespacebrowser,
-            self.data_function
+            self.data_function,
+            self.readonly
         )
         self.dataTable.verticalHeader().hide()
         self.dataTable.horizontalHeader().hide()
@@ -2369,7 +2463,7 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
         """
         assert self.data_function is not None
 
-        if self.btn_save_and_close.isEnabled():
+        if self.btn_save_and_close and self.btn_save_and_close.isEnabled():
             if not self.ask_for_refresh_confirmation():
                 return
 

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -1050,13 +1050,6 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
                 self.parent().table_index.resizeColumnsToContents()
                 self.parent().resize_to_contents()
 
-    def flags(self, index):
-        """Set flags"""
-        return (QAbstractTableModel.flags(self, index) |
-                Qt.ItemFlag.ItemIsEditable | Qt.ItemFlag.ItemIsEnabled |
-                Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.EditRole
-        )
-
     def edit_header_item(self):
         """Edit header item"""
         pos = self.header_class.currentIndex()
@@ -2064,14 +2057,6 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
         if self.table_index.indexAt(v).isValid():
             self.menu_header_v.popup(event.globalPos())
             event.accept()
-
-    def flags(self, index):
-        """Set flags"""
-        return (QAbstractTableModel.flags(self, index) |
-                Qt.ItemFlag.ItemIsEditable |
-                Qt.ItemFlag.ItemIsEnabled |
-                Qt.ItemFlag.ItemIsSelectable
-        )
 
     def create_table_level(self):
         """Create the QTableView that will hold the level model."""

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -1824,7 +1824,7 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
     Dialog for displaying and editing DataFrame and related objects.
 
     The main portion of the dialog is a table displaying the data. The column
-    names are displayed above the table nd the row index is displayed to the
+    names are displayed above the table and the row index is displayed to the
     left of the table. Above this all is a toolbar and below it all are buttons
     for closing the dialog and saving the data.
 

--- a/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
@@ -1176,5 +1176,22 @@ def test_dataframeeditor_plot():
     mock_hist.assert_called_once_with(ax=axis, column=['first', 'second'])
 
 
+def test_dataframeeditor_readonly(qtbot):
+    """
+    Test that a read-only dataframe editor has no "Save and Close" button and
+    that the data can not be edited.
+    """
+    df = DataFrame([[0, 10], [1, 20], [2, 40]])
+    editor = DataFrameEditor(readonly=True)
+    editor.setup_and_check(df)
+    model = editor.dataModel
+    view = editor.dataTable
+    view.setCurrentIndex(model.index(0, 0))
+
+    assert editor.btn_save_and_close is None
+    assert not (model.flags(model.index(0, 0)) & Qt.ItemFlag.ItemIsEditable)
+    assert not editor.dataTable.edit_action.isEnabled()
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

Support Polars data frames in the Variable Explorer. The user can open the Polars dataframe in Spyder, in which case the kernel converts it to a Pandas dataframe. This is so that we don't need to have `polars` installed in Spyder's runtime environment, only in the console environment. The disadvantage is firstly that the data frame can not be edited in Spyder, because converting from Polars to Pandas and then back to Polars does probably not always work. Therefore, the dataframe editor is read only. Secondly, the conversion from Polars to Pandas in the console environment only works if `pandas` and `pyarrow` are installed in the console environment. Thus, I added a new error message to handle the case where opening an editor in the Variable Explorer raises an `ModuleNotFoundError` in the kernel.

Before this PR, Polars dataframes opened in the Object Explorer which is not very useful.

This PR requires spyder-ide/spyder-kernels#549.

Video of opening a Polars dataframe, when `polars`, `pandas` and `pyarrow` are installed in the console environment but only `pandas` in the runtime environment:

https://github.com/user-attachments/assets/f94c2adc-93e2-469c-b5f8-a69681909752

Video of the error message shown if the user tries to open a Polars dataframe but `pyarrow` is not installed in the console environment:

https://github.com/user-attachments/assets/eee17f88-dbe4-4261-ac7d-0c01b1be0de8


### Issue(s) Resolved

Fixes #20281


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
