### PR TITLE
PR: Allow an adjustable time difference for modification detection (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -2405,9 +2405,17 @@ class EditorStack(QWidget, SpyderWidgetMixin):
                 finfo.editor.document().setModified(True)
                 self.modification_changed(index=index)
         else:
-            # Else, testing if it has been modified elsewhere:
+            # Else, testing if it has been modified elsewhere.
             lastm = QFileInfo(finfo.filename).lastModified()
-            if str(lastm.toString()) != str(finfo.lastmodified.toString()):
+            dt = finfo.lastmodified.msecsTo(lastm)
+
+            # We use a delta of one second below (instead of comparing the
+            # timestamps of the file loaded in Spyder and the one present in
+            # the filesystem) because there are some filesystems that cache
+            # file attributes (e.g. CIFS). So, it's possible to expect
+            # identical timestamps in that case.
+            # Fixes spyder-ide/spyder#21877.
+            if dt > 1000:
                 # Catch any error when trying to reload a file and close it if
                 # that's the case to prevent users from destroying external
                 # changes in Spyder.


### PR DESCRIPTION
## Description of Changes

This a redo of PR #22192 for Spyder 6 (thanks @and1bm for the patch!). According to them:

> For CIFS (and perhaps other network file systems), where caching file attributes is used, expecting identical timestamps causes many false positives. This hacky patch allows for some deviation.

### Issue(s) Resolved

Fixes #21877.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
