### PR TITLE
PR: Fix input method positioning (Editor/IPython console)

### DIFF
--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -1557,9 +1557,9 @@ class BaseEditMixin(object):
             return cursor_rect
 
         if isinstance(self, QPlainTextEdit):
-            QPlainTextEdit.inputMethodQuery(self, query)
+            return QPlainTextEdit.inputMethodQuery(self, query)
         elif isinstance(self, QTextEdit):
-            QTextEdit.inputMethodQuery(self, query)
+            return QTextEdit.inputMethodQuery(self, query)
 
 
 class TracebackLinksMixin(object):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Added return statements to `BaseEditMixin.inputMethodQuery` which were previously omitted. This caused queries to not properly inform the Microsoft IME of the cursor location, leading to various special text input prompts to be mis-located.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24561


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: athompson673

<!--- Thanks for your help making Spyder better for everyone! --->
