### PR TITLE
PR: Fix signal connection to trigger status bar update after kernel restart (IPython Console)

### DIFF
--- a/spyder/api/shellconnect/status.py
+++ b/spyder/api/shellconnect/status.py
@@ -70,7 +70,7 @@ class ShellConnectStatusBarWidget(StatusBarWidget, ShellConnectMixin):
         shellwidget.sig_config_spyder_kernel.connect(
             functools.partial(self.config_spyder_kernel, shellwidget)
         )
-        shellwidget.kernel_handler.sig_kernel_is_ready.connect(
+        shellwidget.sig_kernel_is_ready.connect(
             # We can't use functools.partial here because it gives memory leaks
             # in Python versions older than 3.10
             lambda sw=shellwidget: self.on_kernel_start(sw)

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -2042,9 +2042,11 @@ def test_restart_interactive_backend(ipyconsole, qtbot):
     with qtbot.waitSignal(shell.sig_kernel_is_ready, timeout=SHELL_TIMEOUT):
         ipyconsole.restart_kernel()
     assert shell.spyder_kernel_ready
-    qtbot.wait(SHELL_TIMEOUT)
     qtbot.waitUntil(lambda: shell.get_matplotlib_backend() == "tk")
     assert shell.get_mpl_interactive_backend() == "tk"
+    qtbot.waitUntil(
+        lambda: matplotlib_status.value == "Tk", timeout=SHELL_TIMEOUT
+    )
     assert matplotlib_status.value == "Tk"
 
 

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1984,7 +1984,7 @@ def test_pdb_comprehension_namespace(ipyconsole, qtbot, tmpdir):
         assert "_spyderpdb" not in key
 
 
-@flaky(max_runs=10)
+# @flaky(max_runs=10)
 @pytest.mark.auto_backend
 @pytest.mark.skipif(PYQT6, reason="Fails with PyQt6")
 def test_restart_interactive_backend(ipyconsole, qtbot):
@@ -2004,30 +2004,35 @@ def test_restart_interactive_backend(ipyconsole, qtbot):
 
     # Switch to the tk backend
     ipyconsole.set_conf('pylab/backend', 'tk')
+    qtbot.wait(500)
     assert bool(os.environ.get('BACKEND_REQUIRE_RESTART'))
-    assert shell.get_matplotlib_backend() == "qt"
+    qtbot.waitUntil(lambda: shell.get_matplotlib_backend() == "qt")
     assert matplotlib_status.value == "Qt"
 
     # Switch to the inline backend
     os.environ.pop('BACKEND_REQUIRE_RESTART')
     ipyconsole.set_conf('pylab/backend', 'inline')
+    qtbot.wait(500)
     assert not bool(os.environ.get('BACKEND_REQUIRE_RESTART'))
     qtbot.waitUntil(lambda: shell.get_matplotlib_backend() == "inline")
     assert matplotlib_status.value == "Inline"
 
     # Switch to the auto backend
     ipyconsole.set_conf('pylab/backend', 'auto')
+    qtbot.wait(500)
     assert not bool(os.environ.get('BACKEND_REQUIRE_RESTART'))
     qtbot.waitUntil(lambda: shell.get_matplotlib_backend() == "qt")
     assert matplotlib_status.value == "Qt"
 
     # Switch to the qt backend
     ipyconsole.set_conf('pylab/backend', 'qt')
+    qtbot.wait(500)
     assert not bool(os.environ.get('BACKEND_REQUIRE_RESTART'))
     assert matplotlib_status.value == "Qt"
 
     # Switch to the tk backend again
     ipyconsole.set_conf('pylab/backend', 'tk')
+    qtbot.wait(500)
     assert bool(os.environ.get('BACKEND_REQUIRE_RESTART'))
 
     # Check we no spurious messages are shown before the restart below
@@ -2035,7 +2040,8 @@ def test_restart_interactive_backend(ipyconsole, qtbot):
 
     # Restart kernel to check if the new interactive backend is set
     ipyconsole.restart_kernel()
-    qtbot.waitUntil(lambda: shell.spyder_kernel_ready, timeout=SHELL_TIMEOUT)
+    qtbot.waitSignal(shell.sig_kernel_is_ready, timeout=SHELL_TIMEOUT)
+    assert shell.spyder_kernel_ready
     qtbot.wait(SHELL_TIMEOUT)
     qtbot.waitUntil(lambda: shell.get_matplotlib_backend() == "tk")
     assert shell.get_mpl_interactive_backend() == "tk"

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -1984,7 +1984,7 @@ def test_pdb_comprehension_namespace(ipyconsole, qtbot, tmpdir):
         assert "_spyderpdb" not in key
 
 
-# @flaky(max_runs=10)
+@flaky(max_runs=10)
 @pytest.mark.auto_backend
 @pytest.mark.skipif(PYQT6, reason="Fails with PyQt6")
 def test_restart_interactive_backend(ipyconsole, qtbot):

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -2039,8 +2039,8 @@ def test_restart_interactive_backend(ipyconsole, qtbot):
     assert empty_console_text == shell._control.toPlainText()
 
     # Restart kernel to check if the new interactive backend is set
-    ipyconsole.restart_kernel()
-    qtbot.waitSignal(shell.sig_kernel_is_ready, timeout=SHELL_TIMEOUT)
+    with qtbot.waitSignal(shell.sig_kernel_is_ready, timeout=SHELL_TIMEOUT):
+        ipyconsole.restart_kernel()
     assert shell.spyder_kernel_ready
     qtbot.wait(SHELL_TIMEOUT)
     qtbot.waitUntil(lambda: shell.get_matplotlib_backend() == "tk")

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -2035,19 +2035,18 @@ def test_restart_interactive_backend(ipyconsole, qtbot):
     qtbot.wait(500)
     assert bool(os.environ.get('BACKEND_REQUIRE_RESTART'))
 
-    # Check we no spurious messages are shown before the restart below
+    # Check no spurious messages are shown before the restart below
     assert empty_console_text == shell._control.toPlainText()
 
     # Restart kernel to check if the new interactive backend is set
+    # Don't check `matplotlib_status.value` since it is set to "inline" when
+    # running tests on CI.
+    # See `spyder.plugins.ipythonconsole.widgets.status.MatplotlibStatus.on_kernel_start`
     with qtbot.waitSignal(shell.sig_kernel_is_ready, timeout=SHELL_TIMEOUT):
         ipyconsole.restart_kernel()
     assert shell.spyder_kernel_ready
     qtbot.waitUntil(lambda: shell.get_matplotlib_backend() == "tk")
     assert shell.get_mpl_interactive_backend() == "tk"
-    qtbot.waitUntil(
-        lambda: matplotlib_status.value == "Tk", timeout=SHELL_TIMEOUT
-    )
-    assert matplotlib_status.value == "Tk"
 
 
 def test_mpl_conf(ipyconsole, qtbot):

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -369,6 +369,7 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):  # noqa: PLR09
         kernel_handler.sig_stderr.connect(self.print_stderr)
         kernel_handler.sig_stdout.connect(self.print_stdout)
         kernel_handler.sig_fault.connect(self.print_fault)
+
         # This needs to be done only once (when the console is created) and not
         # on every kernel restart. That's why we connect directly to
         # kernel_handler.sig_kernel_is_ready.

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -369,6 +369,10 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):  # noqa: PLR09
         kernel_handler.sig_stderr.connect(self.print_stderr)
         kernel_handler.sig_stdout.connect(self.print_stdout)
         kernel_handler.sig_fault.connect(self.print_fault)
+        # This needs to be done only once (when the console is created) and not
+        # on every kernel restart. That's why we connect directly to
+        # kernel_handler.sig_kernel_is_ready.
+        # See spyder-ide/spyder#24577
         kernel_handler.sig_kernel_is_ready.connect(
             self._when_kernel_is_ready)
 

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -134,6 +134,9 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
     # Request plugins to send additional configuration to the Spyder kernel
     sig_config_spyder_kernel = Signal()
 
+    # Kernel ready
+    sig_kernel_is_ready = Signal()
+
     # To notify of kernel connection, disconnection and kernel errors
     sig_shellwidget_created = Signal(object)
     sig_shellwidget_deleted = Signal(object)
@@ -332,6 +335,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
         ):
             self.setup_spyder_kernel()
             self._show_banner()
+            self.sig_kernel_is_ready.emit()
 
     def handle_kernel_connection_error(self):
         """An error occurred when connecting to the kernel."""

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -335,7 +335,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
         ):
             self.setup_spyder_kernel()
             self._show_banner()
-            self.sig_kernel_is_ready.emit()
+        self.sig_kernel_is_ready.emit()
 
     def handle_kernel_connection_error(self):
         """An error occurred when connecting to the kernel."""

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -136,6 +136,16 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
 
     # Kernel ready
     sig_kernel_is_ready = Signal()
+    """
+    Signal used to inform other Qt objects that the kernel is ready.
+
+    Notes
+    -----
+    * Do not connect directly to the `kernel_handler.sig_kernel_is_ready`
+      signal to receive updates about this because that object is replaced on
+      kernel restarts.
+    * See spyder-ide/spyder#24577 for more context.
+    """
 
     # To notify of kernel connection, disconnection and kernel errors
     sig_shellwidget_created = Signal(object)

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -335,7 +335,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
         ):
             self.setup_spyder_kernel()
             self._show_banner()
-        self.sig_kernel_is_ready.emit()
+            self.sig_kernel_is_ready.emit()
 
     def handle_kernel_connection_error(self):
         """An error occurred when connecting to the kernel."""


### PR DESCRIPTION


<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

After requesting a console's kernel restart the related shellwidget `kernel_handler` instance changes. This change was preventing the status widget to detect the need for an update since the related update logic was connected to the initial `kernel_handler` instance.

This adds a signal to the `ShellWidget` to communicate that the kernel is ready (even if a kernel restart was requested and the `kernel_handler` instance was changed).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24538


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
