### PR TITLE
PR: Remove temporary patches from feedstock recipe when building in Spyder's CI

### DIFF
--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -285,7 +285,9 @@ class SpyderCondaPkg(BuildCondaPkg):
 
         spyder_reqs = [f"spyder-base =={self.version}"]
         for req in spyder_base_reqs.copy():
-            if req.startswith(('pyqt ', 'pyqtwebengine ', 'qtconsole ')):
+            if req.startswith(
+                ('pyqt ', 'pyqtwebengine ', 'qtconsole ', 'fcitx-qt5 ')
+            ):
                 spyder_reqs.append(req)
                 spyder_base_reqs.remove(req)
 
@@ -293,6 +295,12 @@ class SpyderCondaPkg(BuildCondaPkg):
                 spyder_base_reqs.append(
                     req.replace('qtconsole', 'qtconsole-base')
                 )
+
+        if sys.platform == "darwin":
+            spyder_base_reqs.append("__osx")
+        if sys.platform.startswith("linux"):
+            spyder_base_reqs.append("__linux")
+            spyder_reqs.append("__linux")
 
         self.recipe_clobber.update({
             "requirements": {"run": spyder_base_reqs},

--- a/installers-conda/build_conda_pkgs.py
+++ b/installers-conda/build_conda_pkgs.py
@@ -144,6 +144,9 @@ class BuildCondaPkg:
         for k, v in self.data.items():
             meta = re.sub(f".*set {k} =.*", f'{{% set {k} = "{v}" %}}', meta)
 
+        # Remove temporary patches
+        meta = re.sub(r"^\s*- temp-.+\.patch\n", "", meta, flags=re.MULTILINE)
+
         file.rename(file.parent / ("_" + file.name))  # keep copy of original
         file.write_text(meta)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

On occasion, temporary source code patches are needed in Spyder's feedstock recipe. However, these changes are usually merged into the source code in preparation for the next release, causing Spyder's CI builds to fail.

This change removes temporary patches from Spyder's feedstock recipe only for Spyder's CI builds. These temporary patch file names must satisfy the regular expression `temp-.*\.patch`, i.e. prefixed with `temp-` and extension `.patch`.