### PR TITLE
PR: Don't remove old options when migrating to the new ones (Pythonpath manager)

### DIFF
--- a/spyder/plugins/pythonpath/container.py
+++ b/spyder/plugins/pythonpath/container.py
@@ -207,10 +207,9 @@ class PythonpathContainer(PluginMainContainer):
         """
         path_file = get_conf_path('path')
         not_active_path_file = get_conf_path('not_active_path')
-        config_path = self.get_conf('path', None)
-        config_not_active_path = self.get_conf('not_active_path', None)
-        paths_in_conf_files = self.get_conf('paths_in_conf_files', None)
-        system_path = self.get_conf('system_path', None)
+        config_path = self.get_conf('path', ())
+        config_not_active_path = self.get_conf('not_active_path', ())
+        system_path = self.get_conf('system_path', ())
 
         path = []
         not_active_path = []
@@ -234,23 +233,17 @@ class PythonpathContainer(PluginMainContainer):
                 pass
 
         # Get path from config; supersedes paths from file
-        if config_path is not None:
+        if config_path:
             path = config_path
-            self.remove_conf('path')
 
         # Get inactive path from config; supersedes paths from file
         if config_not_active_path is not None:
             not_active_path = config_not_active_path
-            self.remove_conf('not_active_path')
-
-        if paths_in_conf_files is not None:
-            self.remove_conf('paths_in_conf_files')
 
         # Get system path
         system_paths = {}
-        if system_path is not None:
+        if system_path:
             system_paths = {p: p not in not_active_path for p in system_path}
-            self.remove_conf('system_path')
 
         # path config has all user and system paths; only want user paths
         user_paths = {


### PR DESCRIPTION
## Description of Changes

- This prevents a crash in `6.0.x` when users install and start `6.1.x` first and then downgrade to any of those versions. That behavior is not uncommon among users when they find something broken or that they don't like in a new version.
- I noticed this bug when trying to test something in the `6.x` branch.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
