### PR TITLE
[WIP] PR: Restore `open_dir` signal connection and prevent double setting working directory when opening a file/interacting with the toolbar (Working Directory)

### DIFF
--- a/spyder/plugins/workingdirectory/container.py
+++ b/spyder/plugins/workingdirectory/container.py
@@ -78,16 +78,6 @@ class WorkingDirectoryComboBox(PathComboBox):
         """Set current path as the tooltip of the widget on hover."""
         self.setToolTip(self.currentText())
 
-    def focusOutEvent(self, event):
-        """Handle focus out event restoring the last valid selected path."""
-        if self.add_current_text_if_valid():
-            self.selected()
-            self.hide_completer()
-        hide_status = getattr(self.lineEdit(), 'hide_status_icon', None)
-        if hide_status:
-            hide_status()
-        super().focusOutEvent(event)
-
     # ---- Own methods
     def valid_text(self):
         """Get valid version of current text."""
@@ -108,7 +98,7 @@ class WorkingDirectoryComboBox(PathComboBox):
 
             # If the directory is actually a file, open containing directory
             if osp.isfile(directory):
-                file = osp.basename(directory)
+                file = directory
                 directory = osp.dirname(directory)
 
             # If the directory name is malformed, open parent directory
@@ -201,6 +191,7 @@ class WorkingDirectoryContainer(PluginMainContainer):
         self.pathedit.selected_text = self.pathedit.currentText()
 
         # Signals
+        self.pathedit.open_dir.connect(self.chdir)
         self.pathedit.edit_goto.connect(self.edit_goto)
         self.pathedit.textActivated.connect(self.chdir)
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24400 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
