### PR TITLE
PR: Fix connecting to kernel when full path is not provided in `KernelConnectionDialog` (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
@@ -220,11 +220,16 @@ class KernelConnectionDialog(QDialog, SpyderConfigurationAccessor):
     def _validate_connection_file(self):
         cf_path = osp.dirname(self.cf.text())
         cf_filename = osp.basename(self.cf.text())
+
         try:
+            # We do this so that users can paste only the kernel id
+            if not cf_filename.startswith("kernel-"):
+                cf_filename = "kernel-" + cf_filename
             if not cf_filename.endswith(".json"):
                 cf_filename += ".json"
+
             connection_file = find_connection_file(
-                filename=cf_filename, path=cf_path
+                filename=cf_filename, path=cf_path if cf_path else None
             )
         except OSError:
             connection_file = None


### PR DESCRIPTION
## Description of Changes

- This is a regression introduced by #23898.
- Also, fix passing kernel id only instead of kernel connection name. 

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12  

<!--- Thanks for your help making Spyder better for everyone! --->
