### PR TITLE
PR: Split out Source menu sections to Edit and Search menus

### DIFF
--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -74,6 +74,11 @@
 * **Breaking** - The `sig_dir_opened` signal now emits two strings instead of a single one.
 * Add `server_id` kwarg to the `chdir` method.
 
+### Main menu
+
+* **Breaking** - Remove the `Cursor`, `Formatting` and `CodeAnalysis` sections from `SourceMenuSections`.
+* Add a `Formatting` section to `EditMenuSections`, `Cursor` to `SearchMenuSections` and `Autofix` to `SourceMenuSections`.
+
 #### SpyderPluginV2
 
 * Add `CAN_HANDLE_FILE_ACTIONS` and `FILE_EXTENSIONS` attributes and `create_new_file`, `open_file`, `get_current_filename`, `current_file_is_temporary`, `open_last_closed_file`, `save_file`, `save_all`, `save_file_as`, `save_copy_as`, `revert_file`, `close_file` and `close all` methods to allow other plugins to hook into file actions.

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -407,19 +407,48 @@ class Editor(SpyderDockablePlugin):
             mainmenu.add_item_to_application_menu(
                 edit_item,
                 menu_id=ApplicationMenus.Edit,
-                section=EditMenuSections.Editor
+                section=EditMenuSections.Editor,
+                before_section=EditMenuSections.Formatting,
+            )
+
+        # Formatting section
+        formatting_actions = [
+            widget.eol_menu,
+            widget.trailingspaces_action,
+            widget.fixindentation_action,
+        ]
+        for formatting_item in formatting_actions:
+            mainmenu.add_item_to_application_menu(
+                formatting_item,
+                menu_id=ApplicationMenus.Edit,
+                section=EditMenuSections.Formatting,
             )
 
         # ---- Search menu ----
         search_menu = mainmenu.get_application_menu(ApplicationMenus.Search)
         search_menu.aboutToShow.connect(widget.update_search_menu)
 
+        # Find section
         for search_item in widget.search_menu_actions:
             mainmenu.add_item_to_application_menu(
                 search_item,
                 menu_id=ApplicationMenus.Search,
                 section=SearchMenuSections.FindInText,
-                before_section=SearchMenuSections.FindInFiles
+                before_section=SearchMenuSections.Cursor,
+            )
+
+        # Cursor section
+        cursor_actions = [
+            widget.previous_edit_cursor_action,
+            widget.previous_cursor_action,
+            widget.next_cursor_action,
+        ]
+        for cursor_item in cursor_actions:
+            mainmenu.add_item_to_application_menu(
+                cursor_item,
+                menu_id=ApplicationMenus.Search,
+                section=SearchMenuSections.Cursor,
+                before_section=SearchMenuSections.FindInFiles,
             )
 
         # ---- Source menu ----
@@ -428,58 +457,40 @@ class Editor(SpyderDockablePlugin):
         )
         source_menu.aboutToShow.connect(widget.refresh_formatter_name)
 
-        # Cursor section
-        source_menu_cursor_actions = [
-            widget.previous_edit_cursor_action,
-            widget.previous_cursor_action,
-            widget.next_cursor_action,
-        ]
-        for cursor_item in source_menu_cursor_actions:
-            mainmenu.add_item_to_application_menu(
-                cursor_item,
-                menu_id=ApplicationMenus.Source,
-                section=SourceMenuSections.Cursor,
-                before_section=SourceMenuSections.Formatting
-            )
-
-        # Formatting section
-        source_menu_formatting_actions = [
-            widget.eol_menu,
-            widget.trailingspaces_action,
-            widget.fixindentation_action,
-            widget.formatting_action
-        ]
-        for formatting_item in source_menu_formatting_actions:
-            mainmenu.add_item_to_application_menu(
-                formatting_item,
-                menu_id=ApplicationMenus.Source,
-                section=SourceMenuSections.Formatting,
-                before_section=SourceMenuSections.CodeAnalysis
-            )
-
         # Options section
-        source_menu_option_actions = widget.checkable_actions.values()
-        for option_item in source_menu_option_actions:
+        option_actions = widget.checkable_actions.values()
+        for option_item in option_actions:
             mainmenu.add_item_to_application_menu(
                 option_item,
                 menu_id=ApplicationMenus.Source,
                 section=SourceMenuSections.Options,
-                before_section=SourceMenuSections.Linting
+                before_section=SourceMenuSections.Linting,
             )
 
         # Linting section
-        source_menu_linting_actions = [
+        linting_actions = [
             widget.todo_list_action,
             widget.warning_list_action,
             widget.previous_warning_action,
             widget.next_warning_action,
         ]
-        for linting_item in source_menu_linting_actions:
+        for linting_item in linting_actions:
             mainmenu.add_item_to_application_menu(
                 linting_item,
                 menu_id=ApplicationMenus.Source,
                 section=SourceMenuSections.Linting,
-                before_section=SourceMenuSections.Cursor
+                before_section=SourceMenuSections.Autofix,
+            )
+
+        # Autofix section
+        autofix_actions = [
+            widget.formatting_action,
+        ]
+        for autofix_item in autofix_actions:
+            mainmenu.add_item_to_application_menu(
+                autofix_item,
+                menu_id=ApplicationMenus.Source,
+                section=SourceMenuSections.Autofix,
             )
 
     @on_plugin_teardown(plugin=Plugins.MainMenu)
@@ -537,13 +548,38 @@ class Editor(SpyderDockablePlugin):
                 menu_id=ApplicationMenus.Edit
             )
 
+        # Formatting section
+        formatting_actions = [
+            widget.eol_menu,
+            widget.trailingspaces_action,
+            widget.fixindentation_action,
+        ]
+        for formatting_item in formatting_actions:
+            mainmenu.remove_item_from_application_menu(
+                formatting_item,
+                menu_id=ApplicationMenus.Edit
+            )
+
         # ---- Search menu ----
         search_menu = mainmenu.get_application_menu(ApplicationMenus.Search)
         search_menu.aboutToShow.disconnect(widget.update_search_menu)
 
+        # Find section
         for search_item in widget.search_menu_actions:
             mainmenu.remove_item_from_application_menu(
                 search_item,
+                menu_id=ApplicationMenus.Search
+            )
+
+        # Cursor section
+        cursor_actions = [
+            widget.previous_edit_cursor_action,
+            widget.previous_cursor_action,
+            widget.next_cursor_action,
+        ]
+        for cursor_item in cursor_actions:
+            mainmenu.remove_item_from_application_menu(
+                cursor_item,
                 menu_id=ApplicationMenus.Search
             )
 
@@ -553,49 +589,34 @@ class Editor(SpyderDockablePlugin):
         )
         source_menu.aboutToShow.disconnect(widget.refresh_formatter_name)
 
-        # Cursor section
-        source_menu_cursor_actions = [
-            widget.previous_edit_cursor_action,
-            widget.previous_cursor_action,
-            widget.next_cursor_action,
-        ]
-        for cursor_item in source_menu_cursor_actions:
-            mainmenu.remove_item_from_application_menu(
-                cursor_item,
-                menu_id=ApplicationMenus.Source
-            )
-
-        # Formatting section
-        source_menu_formatting_actions = [
-            widget.eol_menu,
-            widget.trailingspaces_action,
-            widget.fixindentation_action,
-            widget.formatting_action
-        ]
-        for formatting_item in source_menu_formatting_actions:
-            mainmenu.remove_item_from_application_menu(
-                formatting_item,
-                menu_id=ApplicationMenus.Source
-            )
-
         # Options section
-        source_menu_option_actions = widget.checkable_actions.values()
-        for option_item in source_menu_option_actions:
+        option_actions = widget.checkable_actions.values()
+        for option_item in option_actions:
             mainmenu.remove_item_from_application_menu(
                 option_item,
                 menu_id=ApplicationMenus.Source
             )
 
         # Linting section
-        source_menu_linting_actions = [
+        linting_actions = [
             widget.todo_list_action,
             widget.warning_list_action,
             widget.previous_warning_action,
             widget.next_warning_action,
         ]
-        for linting_item in source_menu_linting_actions:
+        for linting_item in linting_actions:
             mainmenu.remove_item_from_application_menu(
                 linting_item,
+                menu_id=ApplicationMenus.Source
+            )
+
+        # Autofix section
+        autofix_actions = [
+            widget.formatting_action,
+        ]
+        for autofix_item in autofix_actions:
+            mainmenu.remove_item_from_application_menu(
+                autofix_item,
                 menu_id=ApplicationMenus.Source
             )
 
@@ -874,7 +895,7 @@ class Editor(SpyderDockablePlugin):
             more details.
         text: Optional[str]
             Base text content that will be added to the file. The default is
-            `None`. If that's the case, the default content created will be 
+            `None`. If that's the case, the default content created will be
             created via a template file. See
             `Preferences > Editor > Advanced settings > Edit template for new files`  # noqa
         """

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -588,6 +588,8 @@ class EditorMainWidget(PluginMainWidget):
             tip=_("Replace tab characters by space characters"),
             triggered=self.fix_indentation
         )
+
+        # Autofix actions
         formatter = self.get_conf(
             ('provider_configuration', 'lsp', 'values', 'formatting'),
             default='',

--- a/spyder/plugins/mainmenu/api.py
+++ b/spyder/plugins/mainmenu/api.py
@@ -89,19 +89,19 @@ class EditMenuSections:
     UndoRedo = 'undo_redo_section'
     Copy = 'copy_section'
     Editor = 'editor_section'
+    Formatting = 'formatting_section'
 
 
 class SearchMenuSections:
     FindInText = 'find_text_section'
+    Cursor = 'cursor_section'
     FindInFiles = 'find_files_section'
 
 
 class SourceMenuSections:
     Options = 'options_section'
     Linting = 'linting_section'
-    Cursor = 'cursor_section'
-    Formatting = 'formatting_section'
-    CodeAnalysis = 'code_analysis_section'
+    Autofix = 'autofix_section'
 
 
 class RunMenuSections:

--- a/spyder/plugins/pylint/plugin.py
+++ b/spyder/plugins/pylint/plugin.py
@@ -135,7 +135,7 @@ class Pylint(SpyderDockablePlugin, RunExecutor):
             register_shortcut=True,
             add_to_menu={
                 "menu": ApplicationMenus.Source,
-                "section": SourceMenuSections.CodeAnalysis
+                "section": SourceMenuSections.Linting,
             },
             shortcut_widget_context=Qt.ApplicationShortcut,
         )


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] ~~Wrote at least one-line docstrings (for any new functions)~~
* [x] ~~Added unit test(s) covering the changes (if testable)~~
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Currently, a lot of items are crammed into the Source menu, with substantial overlap between it in the Edit menu, and to a lesser extent the Search menu. Following testing and discussion, it seems reasonable to move some sections out of the former menu where they would more convinviently fit in one of the others, and draw the boundary more clearly—namely, the Source menu is only for operations specific to (Python) source code, while operations that work on any text file belong in the Edit menu.

Therefore, we've implemented the following changes:

- Moved the Cursor section to the Search menu, since it involves navigation and applies to any file.
- Moved the Formatting section to the Edit menu as it (minus the autoformat item) applies to any file, as much or more so than the existing Editor section in the Edit menu
    - Retained the autoformat item in the Source menu, in a new section "Autofix" (where we can add further planned autofix support in the future with Ruff, Rope, etc.
- Merged the Run Static Code Analysis option from the Code Analysis section in to the Linting section

To keep things focused and atomic, changes to UI text and/or trimming individual items from the source menu will be made in a followup PR.


| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/20ce479c-f75a-43ca-83f0-ddcdcc06ef5a) | ![image](https://github.com/user-attachments/assets/fa3912c9-0cb2-4f0c-bbf2-cac120a40bef) |
| ![image](https://github.com/user-attachments/assets/15ad7d03-3038-4e3a-bbb5-270381223071) | ![image](https://github.com/user-attachments/assets/b6ad6f31-d2a6-4d40-919f-d4b54b2aa817) |
| ![image](https://github.com/user-attachments/assets/9814952b-5ea7-4364-b7c1-e31e857262b6) | ![image](https://github.com/user-attachments/assets/316cb295-fe8f-464b-8291-8af0e260d48d) |



### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM-Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
