### PR TITLE
PR: Fix getting options from manager instead of `jupyter_api` (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -2738,7 +2738,7 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):  # noqa: PLR090
             config_id
         ) as jupyter_api:
             return (await jupyter_api.list_kernel_specs(),
-                    jupyter_api.options.get("default_kernel_spec"))
+                    jupyter_api.manager.options.get("default_kernel_spec"))
 
     def __add_kernels_specs_callback(self, config_id: str, server_name: str):
         """Callback to add remote kernel specs."""

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -2737,8 +2737,10 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):  # noqa: PLR090
         async with self._plugin._remote_client.get_jupyter_api(
             config_id
         ) as jupyter_api:
-            return (await jupyter_api.list_kernel_specs(),
-                    jupyter_api.manager.options.get("default_kernel_spec"))
+            return (
+                await jupyter_api.list_kernel_specs(),
+                jupyter_api.manager.options.get("default_kernel_spec")
+            )
 
     def __add_kernels_specs_callback(self, config_id: str, server_name: str):
         """Callback to add remote kernel specs."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
get `remoteclient` options attribute from `manager`


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @hlouzada 

<!--- Thanks for your help making Spyder better for everyone! --->
