### PR TITLE
PR: Unload remote client manager on stop or close (Remote client)

### DIFF
--- a/spyder/plugins/remoteclient/plugin.py
+++ b/spyder/plugins/remoteclient/plugin.py
@@ -135,10 +135,11 @@ class RemoteClient(SpyderPluginV2):
 
     def on_close(self, cancellable=True):
         """Stops remote server and close any opened connection."""
-        for client in self._remote_clients.values():
+        while self._remote_clients:
+            client = self._remote_clients.popitem()[1]
             AsyncDispatcher(
                 loop="asyncssh",
-                early_return=False
+                early_return=False,
             )(client.close)()
 
     @on_plugin_available(plugin=Plugins.MainMenu)
@@ -191,8 +192,7 @@ class RemoteClient(SpyderPluginV2):
     @AsyncDispatcher(loop="asyncssh")
     async def stop_remote_server(self, config_id):
         """Stop remote server."""
-        if config_id in self._remote_clients:
-            client = self._remote_clients[config_id]
+        if client := self._remote_clients.pop(config_id, None):
             await client.close()
 
     @AsyncDispatcher(loop="asyncssh")
@@ -228,6 +228,11 @@ class RemoteClient(SpyderPluginV2):
         """Load remote server."""
         client = SpyderRemoteSSHAPIManager(config_id, options, _plugin=self)
         self._remote_clients[config_id] = client
+        _logger.debug(
+            "Remote SSH client for '%s' loaded with options: %s",
+            config_id,
+            options,
+        )
 
     def load_jupyterhub_client(
         self, config_id: str, options: JupyterHubClientOptions,
@@ -237,6 +242,11 @@ class RemoteClient(SpyderPluginV2):
             config_id, options, _plugin=self
         )
         self._remote_clients[config_id] = client
+        _logger.debug(
+            "Remote JupyterHub client for '%s' loaded with options: %s",
+            config_id,
+            options,
+        )
 
     def _load_jupyterhub_client_options(self, config_id):
         """Load JupyterHub remote server configuration."""
@@ -246,7 +256,8 @@ class RemoteClient(SpyderPluginV2):
 
         # We couldn't find saved options for config_id
         if not options:
-            return {}
+            msg = f"Configuration for remote server '{config_id}' not found."
+            raise ValueError(msg)
 
         # Password is mandatory in this case
         token = self.get_conf(f"{config_id}/token", secure=True)
@@ -262,7 +273,8 @@ class RemoteClient(SpyderPluginV2):
 
         # We couldn't find saved options for config_id
         if not options:
-            return {}
+            msg = f"Configuration for remote server '{config_id}' not found."
+            raise ValueError(msg)
 
         if options["client_keys"]:
             passphrase = self.get_conf(f"{config_id}/passphrase", secure=True)


### PR DESCRIPTION
## Description of Changes
Pop the loaded remote-clients from the `_remote_clients` dict at `on_close` or `stop_remote_server`


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @hlouzada 

<!--- Thanks for your help making Spyder better for everyone! --->
