### PR TITLE
PR: Prevent setting option to automatically get help to `page_control` widget (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -600,11 +600,11 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):  # noqa: PLR09
             name = self.given_name + u'/' + self.id_['str_id']
         return name
 
-    def get_control(self):
+    def get_control(self, pager=True):
         """Return the text widget (or similar) to give focus to"""
         # page_control is the widget used for paging
         page_control = self.shellwidget._page_control
-        if page_control and page_control.isVisible():
+        if pager and page_control and page_control.isVisible():
             return page_control
         else:
             return self.shellwidget._control

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -800,8 +800,9 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):  # noqa: PLR090
         for idx, client in enumerate(self.clients):
             self._change_client_conf(
                 client,
-                client.get_control().set_help_enabled,
-                value)
+                client.get_control(pager=False).set_help_enabled,
+                value
+            )
 
     @on_conf_change(section='appearance', option=['selected', 'ui_theme'])
     def change_clients_color_scheme(self, option, value):


### PR DESCRIPTION
## Description of Changes

That's because that option has to be applied to the `control` widget.

### Issue(s) Resolved

Fixes #24705.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
