### PR TITLE
shortcuts: Fix error in configuration GUI

### DIFF
--- a/spyder/plugins/shortcuts/widgets/table.py
+++ b/spyder/plugins/shortcuts/widgets/table.py
@@ -24,7 +24,7 @@ from qtpy.QtWidgets import (QAbstractItemView, QApplication, QDialog,
 # Local imports
 from spyder.api.shortcuts import SpyderShortcutsMixin
 from spyder.api.translations import _
-from spyder.config.manager import CONF
+from spyder.config.manager import CONF, NoDefault
 from spyder.plugins.shortcuts.utils import ShortcutData
 from spyder.utils.icon_manager import ima
 from spyder.utils.palette import SpyderPalette
@@ -438,7 +438,7 @@ class ShortcutEditor(QDialog):
         """Set the new sequence to the default value defined in the config."""
         sequence = CONF.get_default(
             'shortcuts', "{}/{}".format(self.context, self.name))
-        if sequence:
+        if sequence and sequence is not NoDefault:
             self._qsequences = sequence.split(', ')
             self.update_warning()
         else:


### PR DESCRIPTION
## Description of Changes

Fix error when resetting a shortcut to its default when the shortcut has no default.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

rear1019

<!--- Thanks for your help making Spyder better for everyone! --->
