### PR TITLE
PR: Use native path separator for “Copy relative path” (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -450,7 +450,7 @@ class EditorStack(QWidget, SpyderWidgetMixin):
 
             rel_path = osp.relpath(
                 self.get_current_filename(), base_path
-            ).replace(os.sep, "/")
+            )
 
             QApplication.clipboard().setText(rel_path)
 


### PR DESCRIPTION
## Description of Changes

Use native path separator for “Copy relative path” action in the editor.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

rear1019
<!--- Thanks for your help making Spyder better for everyone! --->