### PR TITLE
PR: Handle websocket message errors (IPython console)

### DIFF
--- a/external-deps/spyder-remote-services/.gitrepo
+++ b/external-deps/spyder-remote-services/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-remote-services
-	branch = main
-	commit = 22ab3fd0e36094532b641ef45fcd3df4255a1b6a
-	parent = 853ca29235bd58299a38ce20003eea2540a3deee
+	branch = fix/websocket-msg-size
+	commit = 6d7ac20cdefc82c0c964df2a66a4a8e1b1e13ee8
+	parent = eb29f0ce052db5d611b0462e04adc7215947771f
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-remote-services/.gitrepo
+++ b/external-deps/spyder-remote-services/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-remote-services
-	branch = fix/websocket-msg-size
-	commit = 6d7ac20cdefc82c0c964df2a66a4a8e1b1e13ee8
-	parent = eb29f0ce052db5d611b0462e04adc7215947771f
+	branch = main
+	commit = ace324ffdf7647ebe000cefc3c63dad801de260f
+	parent = f503e6c7456822d4a7af36efa09b284cea23d40b
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-remote-services/spyder_remote_services/app.py
+++ b/external-deps/spyder-remote-services/spyder_remote_services/app.py
@@ -110,6 +110,10 @@ class SpyderRemoteServices(ExtensionApp):
         "info": (SpyderServerInfoApp, SpyderServerInfoApp.description),
     }
 
+    settings = {
+        "websocket_max_message_size": 104857600,  # 100 MB
+    }
+
     def initialize_handlers(self):
         """Initialize handlers."""
         self.handlers.extend([(rf"/{self.name}{h[0]}", h[1]) for h in handlers])

--- a/spyder/plugins/ipythonconsole/utils/websocket_client.py
+++ b/spyder/plugins/ipythonconsole/utils/websocket_client.py
@@ -1114,7 +1114,7 @@ class SpyderWSKernelClient(QtKernelClientMixin, _WebSocketKernelClient):
 
     sig_spyder_kernel_info = Signal(object)
 
-    sig_max_channel_msg_size = Signal(int)
+    sig_ws_msg_size_overflow = Signal(int)
 
     def _handle_kernel_info_reply(self, rep):
         """Check spyder-kernels version."""
@@ -1131,6 +1131,6 @@ class SpyderWSKernelClient(QtKernelClientMixin, _WebSocketKernelClient):
                 self.session.session,
                 exc,
             )
-            self.sig_max_channel_msg_size.emit(self._ws._reader._max_msg_size)
+            self.sig_ws_msg_size_overflow.emit(self._ws._reader._max_msg_size)
         else:
             super()._handle_receiver_exception(exc)

--- a/spyder/plugins/ipythonconsole/utils/websocket_client.py
+++ b/spyder/plugins/ipythonconsole/utils/websocket_client.py
@@ -191,8 +191,10 @@ class _Session:
             return "closed", {}
 
         if msg.type is not aiohttp.WSMsgType.BINARY:
-            msg = (f"Received message {msg.type}:{msg.data!r}"
-                   " is not WSMsgType.BINARY")
+            msg = (
+                f"Received message {msg.type}:{msg.data!r}"
+                f" is not WSMsgType.BINARY"
+            )
             raise aiohttp.WSMessageTypeError(msg)
 
         channel, components = self._deserialize_components_v1_protocol(msg.data)
@@ -757,11 +759,11 @@ class _WebSocketKernelClient(Configurable):
 
                 await self._queues[channel].put(msg)
         except asyncio.CancelledError:
-            _LOGGER.debug("Receiver loop cancelled for %s", self.session.session)
-        except BaseException as exc:
-            await self._ws.close(
-                code=aiohttp.WSCloseCode.INTERNAL_ERROR,
+            _LOGGER.debug(
+                "Receiver loop cancelled for %s", self.session.session
             )
+        except BaseException as exc:
+            await self._ws.close(code=aiohttp.WSCloseCode.INTERNAL_ERROR)
             self._handle_receiver_exception(exc)
 
     @staticmethod
@@ -1124,8 +1126,10 @@ class SpyderWSKernelClient(QtKernelClientMixin, _WebSocketKernelClient):
 
     def _handle_receiver_exception(self, exc: BaseException):
         """Handle exceptions in the receiver loop."""
-        if (isinstance(exc, aiohttp.WebSocketError) and
-            exc.code == aiohttp.WSCloseCode.MESSAGE_TOO_BIG):
+        if (
+            isinstance(exc, aiohttp.WebSocketError)
+            and exc.code == aiohttp.WSCloseCode.MESSAGE_TOO_BIG
+        ):
             _LOGGER.error(
                 "WebSocket message too big for %s: %s",
                 self.session.session,

--- a/spyder/plugins/ipythonconsole/utils/websocket_client.py
+++ b/spyder/plugins/ipythonconsole/utils/websocket_client.py
@@ -733,6 +733,8 @@ class _WebSocketKernelClient(Configurable):
             params=qs,
             protocols=("v1.kernel.websocket.jupyter.org",),
             autoping=True,
+            autoclose=True,
+            max_msg_size=104857600,  # 100 MB
         )
 
     async def _receiver_loop(self):

--- a/spyder/plugins/remoteclient/api/modules/base.py
+++ b/spyder/plugins/remoteclient/api/modules/base.py
@@ -240,10 +240,12 @@ class JupyterAPI(SpyderBaseJupyterAPI):
         data = {}
         if spyder_kernel:
             data["spyder_kernel"] = True
-        data["name"] = (
+
+        if kernel_spec := (
             kernel_spec
             or self.manager.options.get("default_kernel_spec")
-        )
+        ):
+            data["name"] = kernel_spec
 
         async with self.session.post(
             self.api_url / "kernels", json=data


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)

- Fixed websocket msg typing errors and handle receiver loop exceptions on jupyter websocket client.
- Added  `sig_ws_msg_size_overflow` signal to `SpyderWSKernelClient` that is emitted when the websocket receives a message frame bigger than the maximum specified size.
- Set maximum size for websocket messages to 100mb.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @hlouzada

<!--- Thanks for your help making Spyder better for everyone! --->
