### PR TITLE
PR: Optionally show traceback on errors raised in console when getting or setting variables (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -14,6 +14,7 @@ import functools
 import math
 import operator
 import sys
+import traceback
 from typing import Any, Callable, Optional
 
 # Third party imports
@@ -375,7 +376,8 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
         Show error dialog box.
 
         This function is called when an error occurs while getting or setting
-        a variable in the console.
+        a variable in the console. The dialog box has a "Show details" button,
+        which shows the exception traceback.
 
         Parameters
         ----------
@@ -387,10 +389,12 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
         """
         the_problem_is = _('The problem is:')
         contents = f'{msg}<br><br>{the_problem_is}<br>{exception}'
+        details = ''.join(traceback.format_exception(exception))
 
         msg_box = QMessageBox(self.parent())
         msg_box.setTextFormat(Qt.RichText)  # Needed to enable links
         msg_box.setText(contents)
+        msg_box.setDetailedText(details)
         msg_box.setWindowTitle(_('Error'))
         msg_box.setIcon(QMessageBox.Critical)
         msg_box.exec_()

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -390,7 +390,10 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
 
         msg_box = QMessageBox(self.parent())
         msg_box.setTextFormat(Qt.RichText)  # Needed to enable links
-        msg_box.critical(self.parent(), _('Error'), contents)
+        msg_box.setText(contents)
+        msg_box.setWindowTitle(_('Error'))
+        msg_box.setIcon(QMessageBox.Critical)
+        msg_box.exec_()
 
     def create_dialog(self, editor, data):
         self._editors[id(editor)] = data


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

If an exception is raised when getting or setting variables in the IPython console from the Variable Explorer, then Spyder shows a dialog box to the user with some (hopefully) helpful and not too technical text. This PR adds a "Show details" button to the dialog box. When that button is clicked, the traceback of the exception is shown. If the exception is caused by an exception on the kernel side, then the traceback of the latter exception is also shown.

https://github.com/user-attachments/assets/c941d034-0304-425c-badb-678633bdc687


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22411


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
