### PR TITLE
PR: Handle Pandas version mismatch when getting dataframe with numeric index (Variable Explorer)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
@@ -76,6 +76,12 @@ class NamepaceBrowserWidget(RichJupyterWidget):
             "please upgrade <tt>numpy</tt> in the environment that you use to "
             "run Spyder to version 1.26.1 or higher."
         )
+        reason_mismatched_pandas = _(
+            "There is a mismatch between the Pandas versions used by Spyder "
+            "and the kernel of your current console. To fix this problem, "
+            "please upgrade <tt>pandas</tt> in the console environment "
+            "to version 2.0 or higher."
+        )
         reason_mismatched_python = _(
             "There is a mismatch between the Python versions used by Spyder "
             "({}) and the kernel of your current console ({}).<br><br>"
@@ -150,6 +156,8 @@ class NamepaceBrowserWidget(RichJupyterWidget):
                 reason = reason_missing_package_installer.format(e.name)
             elif e.name.startswith('numpy._core'):
                 reason = reason_mismatched_numpy
+            elif e.name == 'pandas.core.indexes.numeric':
+                reason = reason_mismatched_pandas
             else:
                 reason = reason_missing_package.format(e.name)
             raise ValueError(msg % reason)


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions) ­— **no new functions**
* [ ] Added unit test(s) covering the changes (if testable) — **not easily testable**
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

If the user tries to retrieve a Pandas dataframe with a numerical index, their console environment has Pandas version 1 and Spyder's runtime environment has Pandas version 2, then a ModuleNotFoundError on `pandas.core.indexes.numeric` occurs. In that case, show an error telling the user to upgrade Pandas in their console environment.

<img width="502" height="269" alt="pandas-mismatch" src="https://github.com/user-attachments/assets/efabf5f8-4466-494e-8b3a-48dcffcb4d6e" />


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24747 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
