### PR TITLE
PR: Remove linting config tab widgets show/hide setup to prevent showing widget before preference dialog appears (Completion/Preferences)

### DIFF
--- a/spyder/plugins/completion/providers/languageserver/conftabs/linting.py
+++ b/spyder/plugins/completion/providers/languageserver/conftabs/linting.py
@@ -177,8 +177,3 @@ class LintingConfigTab(SpyderPreferencesTab):
         linting_layout.addWidget(configuration_options_group)
         linting_layout.addWidget(additional_options_group)
         self.setLayout(linting_layout)
-
-        # Update widgets initial visibility
-        grid_widget.hide()
-        pyflakes_conf_options.show()
-        not_select_conf_options.hide()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Calling `pyflakes_conf_options.show()` before adding the widget to the linting preference tab layout causes it to be shown breafly before the preference dialog is shown. After futher check, seems like a manual call for the different widgets to be shown/hidden is not necessary so the lines related with that were removed.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24764 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
