### PR TITLE
PR: Update `max_min_col` after removing column in dataframe editor (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -1514,6 +1514,7 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
                     )
                     return False
 
+            self.model().max_min_col_update()
             self.parent()._reload()
             index = QModelIndex()
             self.model().dataChanged.emit(index, index)

--- a/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
@@ -1193,5 +1193,47 @@ def test_dataframeeditor_readonly(qtbot):
     assert not editor.dataTable.edit_action.isEnabled()
 
 
+def test_dataframeeditor_remove_column(qtbot):
+    """
+    Test that removing a column from a dataframe works as expected.
+    """
+    df = DataFrame({'num': [1, 2, 3], 'square': [1, 4, 9]})
+    editor = DataFrameEditor()
+    editor.setup_and_check(df)
+    model = editor.dataModel
+    view = editor.dataTable
+    view.setCurrentIndex(model.index(0, 0))
+    view.remove_item(force=True, axis=1)
+
+    expected = DataFrame({'square': [1, 4, 9]})
+    assert_frame_equal(model.df, expected)
+
+
+def test_dataframeeditor_remove_column_with_strings(qtbot):
+    """
+    Test that after removing the first column from a dataframe with a column of
+    numbers and a column of strings, the background color of the remaining
+    cells is the specified color for strings.
+
+    Regression test for spyder-ide/spyder#24796.
+    """
+    df = DataFrame({'num': [1, 2, 3], 'word': ['one', 'two', 'three']})
+    editor = DataFrameEditor()
+    editor.setup_and_check(df)
+    model = editor.dataModel
+    view = editor.dataTable
+    view.setCurrentIndex(model.index(0, 0))
+    view.remove_item(force=True, axis=1)
+
+    expected = DataFrame({'word': ['one', 'two', 'three']})
+    assert_frame_equal(model.df, expected)
+
+    h, s, v, dummy = QColor(
+        dataframeeditor.BACKGROUND_NONNUMBER_COLOR
+    ).getHsvF()
+    a = dataframeeditor.BACKGROUND_STRING_ALPHA
+    assert colorclose(bgcolor(model, 0, 0), (h, s, v, a))
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/)) **N/A**

After removing a column in the dataframe editor, `max_min_col` needs to be updated because otherwise the background colors will be wrong. In some cases (if the dataframe contains both numbers and non-numbers), computing the color may even cause an exception. This PR fixes the issue.

The PR also adds a regression test, and a straightforward test that removing a column works.





### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24796


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
