### PR TITLE
PR: Add methods to (un)register call handlers to `ShellWidget` (IPython console)

### DIFF
--- a/spyder/plugins/debugger/widgets/main_widget.py
+++ b/spyder/plugins/debugger/widgets/main_widget.py
@@ -515,8 +515,9 @@ class DebuggerWidget(ShellConnectMainWidget):
         shellwidget.sig_pdb_prompt_ready.connect(self.update_actions)
         shellwidget.executing.connect(self.update_actions)
 
-        shellwidget.kernel_handler.kernel_comm.register_call_handler(
-            "show_traceback", widget.show_exception)
+        shellwidget.register_kernel_call_handler(
+            "show_traceback", widget.show_exception
+        )
         shellwidget.sig_pdb_stack.connect(widget.set_from_pdb)
         shellwidget.sig_config_spyder_kernel.connect(
             widget.on_config_kernel)
@@ -558,8 +559,7 @@ class DebuggerWidget(ShellConnectMainWidget):
         shellwidget.sig_pdb_prompt_ready.disconnect(self.update_actions)
         shellwidget.executing.disconnect(self.update_actions)
 
-        shellwidget.kernel_handler.kernel_comm.unregister_call_handler(
-            "show_traceback")
+        shellwidget.unregister_kernel_call_handler("show_traceback")
         shellwidget.sig_pdb_stack.disconnect(widget.set_from_pdb)
         shellwidget.sig_config_spyder_kernel.disconnect(
             widget.on_config_kernel)

--- a/spyder/plugins/ipythonconsole/widgets/status.py
+++ b/spyder/plugins/ipythonconsole/widgets/status.py
@@ -9,7 +9,6 @@
 # Standard library imports
 import functools
 import logging
-import os
 import sys
 import textwrap
 
@@ -25,7 +24,6 @@ from spyder.api.shellconnect.status import ShellConnectStatusBarWidget
 from spyder.api.translations import _
 from spyder.api.widgets.menus import SpyderMenu
 from spyder.config.base import running_in_ci
-from spyder.utils.qthelpers import add_actions, create_action
 from spyder.utils.stylesheet import MAC, WIN
 
 
@@ -123,7 +121,7 @@ class MatplotlibStatus(ShellConnectStatusBarWidget):
         self.set_value(text)
 
     def config_spyder_kernel(self, shellwidget):
-        shellwidget.kernel_handler.kernel_comm.register_call_handler(
+        shellwidget.register_kernel_call_handler(
             "update_matplotlib_gui",
             functools.partial(
                 self.update_matplotlib_gui, shellwidget=shellwidget
@@ -167,9 +165,7 @@ class MatplotlibStatus(ShellConnectStatusBarWidget):
         """
         Overridden method to remove the call handler registered by this widget.
         """
-        shellwidget.kernel_handler.kernel_comm.unregister_call_handler(
-            "update_matplotlib_gui"
-        )
+        shellwidget.unregister_kernel_call_handler("update_matplotlib_gui")
         super().remove_shellwidget(shellwidget)
 
 


### PR DESCRIPTION
## Description of Changes

- This not only simplifies the API but it's also necessary to correctly register handlers on kernel restarts.
- I found this bug while working on #24794.
- Also, move some `ShellWidget` private methods to its corresponding section.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
