### PR TITLE
PR: Fix hyphens followed by digit in error messages (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -508,7 +508,7 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):  # noqa: PLR09
 
         # Don't break lines in hyphens
         # From https://stackoverflow.com/q/7691569/438386
-        error = error.replace('-', '&#8209')
+        error = error.replace('-', '&#8209;')
 
         # Create error page
         message = _("An error occurred while starting the kernel")


### PR DESCRIPTION
In error message hyphens are replaced by `&#8209` and if hyphen is followed by digits, this replacement will print garbage. Adding ';' fix the issue.

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Before fix:
![Capture d’écran du 2025-08-14 21-05-37](https://github.com/user-attachments/assets/9db2bb17-0fad-4b43-9f3e-a9e5c74fe83d)

After fix:
![Capture d’écran du 2025-08-14 21-16-45](https://github.com/user-attachments/assets/1571f01b-a6e5-40ae-a5f3-1b460922ea01)


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->
None

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: gschwind

<!--- Thanks for your help making Spyder better for everyone! --->
