### PR TITLE
PR: Remove depreciated `locale.getdefaultlocale`

### DIFF
--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -449,7 +449,7 @@ def get_interface_language():
         else:
             locale_language = DEFAULT_LANGUAGE
     else:
-        # Solves spyder-ide/spyder#3627.
+        # Fixes spyder-ide/spyder#3627.
         try:
             locale_language = locale.getlocale()[0]
         except ValueError:

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -437,10 +437,10 @@ def get_interface_language():
     """
     
     if os.name == "nt":
-        # spyder-ide/spyder#23318
-        # changing to locale.getlocale from locale.getdefaultlocale caused some
-        # windows machines to return non BCP47 locale codes. Instead use
+        # Changing to locale.getlocale from locale.getdefaultlocale caused some
+        # Windows machines to return non BCP47 locale codes. Instead use
         # win32 GetUserDefaultLocaleName which does seem to give BCP47 locale.
+        # Fixes spyder-ide/spyder#23318.
         from ctypes import create_unicode_buffer, windll
         bufsize = 85  # LOCALE_NAME_MAX_LENGTH
         buf = create_unicode_buffer(bufsize)

--- a/spyder/config/base.py
+++ b/spyder/config/base.py
@@ -435,12 +435,25 @@ def get_interface_language():
     2.) Spyder provides ('en', 'de', 'fr', 'es' 'hu' and 'pt_BR'), if the
     locale is either 'pt' or 'pt_BR', this function will return 'pt_BR'
     """
-
-    # Solves spyder-ide/spyder#3627.
-    try:
-        locale_language = locale.getdefaultlocale()[0]
-    except ValueError:
-        locale_language = DEFAULT_LANGUAGE
+    
+    if os.name == "nt":
+        # spyder-ide/spyder#23318
+        # changing to locale.getlocale from locale.getdefaultlocale caused some
+        # windows machines to return non BCP47 locale codes. Instead use
+        # win32 GetUserDefaultLocaleName which does seem to give BCP47 locale.
+        from ctypes import create_unicode_buffer, windll
+        bufsize = 85  # LOCALE_NAME_MAX_LENGTH
+        buf = create_unicode_buffer(bufsize)
+        if windll.kernel32.GetUserDefaultLocaleName(buf, bufsize):
+            locale_language = buf.value
+        else:
+            locale_language = DEFAULT_LANGUAGE
+    else:
+        # Solves spyder-ide/spyder#3627.
+        try:
+            locale_language = locale.getlocale()[0]
+        except ValueError:
+            locale_language = DEFAULT_LANGUAGE
 
     # Tests expect English as the interface language
     if running_under_pytest():


### PR DESCRIPTION
On windows use win32 GetUserDefaultLocaleName instead of locale.getlocale due to non-BCP47 locale code.

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

`locale.getdefaultlocale` is depreciated and is slated for removal in python 3.15. `locale.getlocale` as the suggested alternative does not return BCP47 locale codes (`"English_United States"` rather than `"en-US"`). Instead call the win32[`GetUserDefaultLocaleName`](https://learn.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-getuserdefaultlocalename) function via the `ctypes` builtin library in order to not add any dependencies.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23318


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: athompson673

<!--- Thanks for your help making Spyder better for everyone! --->
