### PR TITLE
PR: Prevent test failures on Mac and Windows (CI)

### DIFF
--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -134,7 +134,11 @@ jobs:
           .github/scripts/run_tests.sh -n 0 || \
           .github/scripts/run_tests.sh -n 1 || \
           .github/scripts/run_tests.sh -n 2 || \
-          .github/scripts/run_tests.sh -n 3
+          .github/scripts/run_tests.sh -n 3 || \
+          .github/scripts/run_tests.sh -n 4 || \
+          .github/scripts/run_tests.sh -n 5 || \
+          .github/scripts/run_tests.sh -n 6 || \
+          .github/scripts/run_tests.sh -n 7
       - name: Coverage
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -148,7 +148,11 @@ jobs:
           .github/scripts/run_tests.sh -n 0 || \
           .github/scripts/run_tests.sh -n 1 || \
           .github/scripts/run_tests.sh -n 2 || \
-          .github/scripts/run_tests.sh -n 3
+          .github/scripts/run_tests.sh -n 3 || \
+          .github/scripts/run_tests.sh -n 4 || \
+          .github/scripts/run_tests.sh -n 5 || \
+          .github/scripts/run_tests.sh -n 6 || \
+          .github/scripts/run_tests.sh -n 7
       - name: Coverage
         uses: codecov/codecov-action@v4
         with:

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -11,7 +11,6 @@ Tests for the main window.
 """
 
 # Standard library imports
-from collections import OrderedDict
 import gc
 import os
 import os.path as osp
@@ -377,8 +376,9 @@ def test_filter_numpy_warning(main_window, qtbot):
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(not sys.platform == 'darwin',
-                    reason="Fails on other than macOS")
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="Fails on other than Linux"
+)
 @pytest.mark.known_leak  # Opens Spyder/QtWebEngine/Default/Cookies
 def test_get_help_combo(main_window, qtbot):
     """
@@ -1000,8 +1000,8 @@ def test_shell_execution(main_window, qtbot, tmpdir):
 
 @flaky(max_runs=3)
 @pytest.mark.skipif(
-    sys.platform.startswith('linux') and running_in_ci(),
-    reason="Fails frequently on Linux and CI"
+    sys.platform == "darwin" and running_in_ci(),
+    reason="Fails frequently on Mac and CI",
 )
 @pytest.mark.order(after="test_debug_unsaved_function")
 def test_connection_to_external_kernel(main_window, qtbot):
@@ -1953,8 +1953,9 @@ def test_maximize_minimize_plugins(main_window, qtbot):
 
 @flaky(max_runs=3)
 @pytest.mark.skipif(
-    os.name == 'nt' or running_in_ci() and (PYQT5 and PYQT_VERSION >= '5.9'),
-    reason="It times out on Windows and segfaults in our CIs with PyQt >= 5.9")
+    not (sys.platform.startswith("linux") and running_in_ci()),
+    reason="Works reliably on Linux and CIs"
+)
 def test_issue_4066(main_window, qtbot):
     """
     Test for a segfault when these steps are followed:

--- a/spyder/widgets/tests/test_sidebardialog.py
+++ b/spyder/widgets/tests/test_sidebardialog.py
@@ -6,6 +6,9 @@
 
 """Tests for SidebarDialog."""
 
+# Standard library imports
+import sys
+
 # Third party imports
 from qtpy.QtWidgets import QLabel, QVBoxLayout
 import pytest
@@ -70,6 +73,10 @@ def sidebar_dialog(qapp, qtbot):
 
 # --- Tests
 # -----------------------------------------------------------------------------
+@pytest.mark.skipif(
+    sys.platform == "darwin" and running_in_ci(),
+    reason="Times out frequently on Mac and CIs"
+)
 def test_sidebardialog(sidebar_dialog, qtbot):
     dialog = sidebar_dialog
     assert dialog is not None


### PR DESCRIPTION
## Description of Changes

- Skip `test_connection_to_external_kernel`, `test_issue_4066` and `test_sidebardialog` on Mac because they started to timeout too much after switching to Python 3.12.
- Run `test_get_help_combo` only on Linux because it segfaults on Mac and Windows.
- Increase runs on Mac and Windows to avoid failures when tests timeout or segfault.
- This is a follow-up of #24837.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
