### PR TITLE
PR: Catch error when directory has junctions on Windows (Find)

### DIFF
--- a/spyder/plugins/findinfiles/widgets/search_thread.py
+++ b/spyder/plugins/findinfiles/widgets/search_thread.py
@@ -130,9 +130,15 @@ class SearchThread(QThread):
 
                     dirname = os.path.join(path, d)
 
-                    # Only search in regular directories
-                    st_dir_mode = os.stat(dirname).st_mode
-                    if not stat.S_ISDIR(st_dir_mode):
+                    # Only search in regular directories.
+                    # The try/except is necessary to catch an error when Python
+                    # can't access a directory with junctions on Windows.
+                    # Fixes spyder-ide/spyder#24898
+                    try:
+                        st_dir_mode = os.stat(dirname).st_mode
+                        if not stat.S_ISDIR(st_dir_mode):
+                            dirs.remove(d)
+                    except OSError:
                         dirs.remove(d)
 
                     if (self.exclude and


### PR DESCRIPTION
## Description of Changes

This is necessary to avoid an error due to Python not being able to access those directories.

### Issue(s) Resolved

Fixes #24898.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
