### PR TITLE
Fix update dialog button text cutoff ("After closing")

### DIFF
--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -682,7 +682,8 @@ def confirm_messagebox(parent, message, title, version=None, critical=False,
     box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
     box.setDefaultButton(QMessageBox.Yes)
     if on_close:
-        box.addButton(_("After closing"), QMessageBox.YesRole)
+        button  = box.addButton(_("After closing"), QMessageBox.YesRole)
+        button.setMinimumWidth(150)
     box.exec()
     return box
 


### PR DESCRIPTION
## Description
This PR fixes a minor UI issue where the "After closing" button
in the update dialog was being cut off due to insufficient width.

## Changes
- Set a minimum width (150 px) for the "After closing" button 
  in `confirm_messagebox`.

## Testing
- Verified the dialog via "Help → Check for updates".
- Confirmed that "After closing" is fully visible across DPI scaling.

Closes #24916
