### PR TITLE
PR: Fix flake8 filenames config placeholder `SyntaxWarning` (Completions/Linting)

### DIFF
--- a/spyder/plugins/completion/providers/languageserver/conftabs/linting.py
+++ b/spyder/plugins/completion/providers/languageserver/conftabs/linting.py
@@ -94,7 +94,7 @@ class LintingConfigTab(SpyderPreferencesTab):
             'flake8/filename',
             alignment=Qt.Horizontal,
             word_wrap=False,
-            placeholder=_("Check test files: test_.*\.py"),
+            placeholder=_("Check test files: test_.*\\.py"),
         )
 
         self.flake8_exclude = self.create_lineedit(


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

While checking #24794 noticed that a `SyntaxWarning` was being shown after the CI finishes (https://github.com/spyder-ide/spyder/actions/runs/17474839381/job/49638311796?pr=24908#step:15:5683):

```
   <unknown>:139: SyntaxWarning: invalid escape sequence '\.'
/home/runner/work/spyder/spyder/spyder/plugins/completion/providers/languageserver/conftabs/linting.py:139: SyntaxWarning: invalid escape sequence '\.'
  placeholder=_("Check test files: test_.*\.py"),
```

This adds a `\` to properly scape `\` in the placeholder string

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
