### PR TITLE
PR: Fix stuck drag cursor rendering (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -4685,7 +4685,6 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
         Inform Qt about the types of data that the widget accepts.
         """
         logger.debug("dragEnterEvent was received")
-        self._drag_cursor = self.cursorForPosition(event.pos())
         all_urls = mimedata2url(event.mimeData())
         if all_urls:
             # Let the parent widget handle this
@@ -4693,6 +4692,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
             event.ignore()
         else:
             logger.debug("Call TextEditBaseWidget dragEnterEvent method")
+            self._drag_cursor = self.cursorForPosition(event.pos())
             TextEditBaseWidget.dragEnterEvent(self, event)
 
     def dragMoveEvent(self, event):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
Don't create a drag cursor when dragging in files to the editor window. The `CodeEditor._drag_cursor` is intended to indicate where dragged text will be pasted. Dragged files do not need a cursor as they are opened rather than pasted. Creating the drag cursor when dragging in a file causes the cursor to get stuck as there is never a subsequent `dropEvent` or `dragLeaveEvent` to remove the drag cursor from being rendered.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24919


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: athompson673

<!--- Thanks for your help making Spyder better for everyone! --->
