### PR TITLE
PR: Fix updater checksum comparison with `sha256` prefix

### DIFF
--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -270,6 +270,12 @@ def validate_download(file: str, checksum: str) -> bool:
     valid = checksum.lstrip("sha256:") == _checksum.hexdigest()
     logger.debug(f"Valid {file}: {valid}")
 
+    # Extract validated zip files
+    if valid and file.endswith('.zip'):
+        with ZipFile(file, 'r') as f:
+            f.extractall(osp.dirname(file))
+        logger.debug(f"{file} extracted.")
+
     return valid
 
 
@@ -510,8 +516,6 @@ class WorkerUpdateUpdater(BaseWorker):
 
         if validate_download(self.installer_path, self.asset_info["checksum"]):
             logger.info('Download successfully completed.')
-            with ZipFile(self.installer_path, 'r') as f:
-                f.extractall(dirname)
         else:
             raise UpdateDownloadError("Download failed!")
 
@@ -647,10 +651,6 @@ class WorkerDownloadInstaller(BaseWorker):
 
         if validate_download(self.installer_path, self.asset_info["checksum"]):
             logger.info('Download successfully completed.')
-
-            if self.installer_path.endswith('.zip'):
-                with ZipFile(self.installer_path, 'r') as f:
-                    f.extractall(dirname)
         else:
             raise UpdateDownloadError("Download failed!")
 

--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -267,7 +267,7 @@ def validate_download(file: str, checksum: str) -> bool:
         while chunk := f.read(8192):
             _checksum.update(chunk)
 
-    valid = checksum == _checksum.hexdigest()
+    valid = checksum.lstrip("sha256:") == _checksum.hexdigest()
     logger.debug(f"Valid {file}: {valid}")
 
     return valid


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* The updater's download validation now considers hexdigests that may begin with `"sha256:"`.
* Zip file artifacts are extracted during download validation.
* The progress bar is closed and threads are cleaned up when an exception occurs.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24983
