### PR TITLE
PR: Improve a couple of messages shown when retrieving a variable fails (Variable Explorer/IPython console)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ requires = [
     "packaging",
 ]
 
+[tool.black]
+line-length = 79
+
 # We're not ready yet to build Spyder with the setuptools backend, but we're
 # leaving this for the future.
 # build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Description of Changes

* Mention that Spyder can be installed in a different environment when there's a mismatch of Python versions.

| Before | After |
| - | - |
| <img width="507" height="290" alt="image" src="https://github.com/user-attachments/assets/32685a4b-aa88-4718-87d5-11d20ac1f2c0" /> | <img width="505" height="304" alt="image" src="https://github.com/user-attachments/assets/f8f6c40b-d221-4658-9aa4-52d3a9ce774d" /> |


* Add link to Variable Explorer donations project when there's a missing module and don't show note. I'm basically saying the same when people have reported this error, and since there's nothing we can do about it, I don't think we should display the note in this case. 

| Before | After |
| - | - |
| <img width="504" height="256" alt="image" src="https://github.com/user-attachments/assets/e52f85a5-3ef8-49bc-843a-5e49b0ab8ea6" /> | <img width="505" height="256" alt="image" src="https://github.com/user-attachments/assets/6acfb1fb-b894-46c2-a52a-93582d69481f" /> |

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24950
Fixes #24922 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
