### PR TITLE
PR: Cast page name to string when adding it to `SidebarDialog` (Widgets)

### DIFF
--- a/spyder/widgets/sidebardialog.py
+++ b/spyder/widgets/sidebardialog.py
@@ -339,7 +339,7 @@ class SidebarDialog(QDialog, SpyderFontsMixin):
 
         # Add plugin entry item to contents widget
         item = QListWidgetItem(self.contents_widget)
-        item.setText(page.get_name())
+        item.setText(str(page.get_name()))
         item.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
 
         # In case the page doesn't have an icon


### PR DESCRIPTION
## Description of Changes

This is necessary in case users create remote connections with a name that has only numbers.

### Issue(s) Resolved

Fixes #24988.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
