### PR TITLE
PR: Prevent using Pyside 6.9+ and require PyQt 6.9+

### DIFF
--- a/changelogs/Spyder-6.md
+++ b/changelogs/Spyder-6.md
@@ -20,7 +20,7 @@
 
 ### Important fixes
 
-* Much better support for PyQt6 and PySide6.
+* Much better support for PyQt6 and PySide6. PyQt 6.9.0+ and PySide >=6.8.0,<6.9.0 are required now. 
 * Make shortcuts to move to different panes work when they are undocked.
 * Remove blank lines around cells when copying their contents to the console.
 * Automatically kill kernels when Spyder crashes.

--- a/spyder/requirements.py
+++ b/spyder/requirements.py
@@ -32,10 +32,10 @@ def show_warning(message):
 def check_qt():
     """Check Qt binding requirements"""
     qt_infos = dict(
-        pyqt5=("PyQt5", "5.15"),
-        pyside2=("PySide2", "5.15"),
-        pyqt6=("PyQt6", "6.5"),
-        pyside6=("PySide6", "6.5")
+        pyqt5=("PyQt5", ("5.15.0", "5.16")),
+        pyside2=("PySide2", ("5.15.0", "5.16")),
+        pyqt6=("PyQt6", ("6.9.0", "7.0.0")),
+        pyside6=("PySide6", ("6.8.0", "6.9.0")),
     )
 
     try:
@@ -43,13 +43,19 @@ def check_qt():
         package_name, required_ver = qt_infos[qtpy.API]
         actual_ver = qtpy.QT_VERSION
 
-        if (
-            actual_ver is None
-            or parse(actual_ver) < parse(required_ver)
+        if actual_ver is None or not (
+            parse(required_ver[0])
+            <= parse(actual_ver)
+            < parse(required_ver[1])
         ):
-            show_warning("Please check Spyder installation requirements:\n"
-                         "%s %s+ is required (found %s)."
-                         % (package_name, required_ver, actual_ver))
+            show_warning(
+                (
+                    "Please check Spyder installation requirements:\n\n"
+                    "{} >={},<{} is required but version {} was found."
+                ).format(
+                    package_name, required_ver[0], required_ver[1], actual_ver
+                )
+            )
     except ImportError:
         show_warning("Failed to import qtpy.\n"
                      "Please check Spyder installation requirements:\n\n"

--- a/spyder/requirements.py
+++ b/spyder/requirements.py
@@ -56,10 +56,5 @@ def check_qt():
                     package_name, required_ver[0], required_ver[1], actual_ver
                 )
             )
-    except ImportError:
-        show_warning("Failed to import qtpy.\n"
-                     "Please check Spyder installation requirements:\n\n"
-                     "qtpy 1.2.0+ and\n"
-                     "%s %s+\n\n"
-                     "are required to run Spyder."
-                     % (qt_infos['pyqt5']))
+    except Exception as e:
+        show_warning("Failed to import qtpy.\n\nThe error was {}".format(e))


### PR DESCRIPTION
## Description of Changes

- Unfortunately Spyder crashes with PySide 6.9 at the moment.
- PyQt 6.9+ is the first version with which Spyder exactly looks the same as with PyQt5.
- Also, update message about a failure to import Qtpy when doing those checks.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #24825.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
