### PR TITLE
PR: Revert Python version of installer's base environment to 3.11

### DIFF
--- a/installers-conda/resources/base_env.yml
+++ b/installers-conda/resources/base_env.yml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - python =3.12.11
+  - python =3.11.13
   - conda =25.7.0
   - menuinst =2.3.1
   - mamba =2.3.1  # Remove for Spyder 7

--- a/spyder/plugins/updatemanager/tests/test_update_manager.py
+++ b/spyder/plugins/updatemanager/tests/test_update_manager.py
@@ -128,6 +128,7 @@ def test_update_no_asset(qtbot, mocker):
     "app,version,release,update_type",
     [
         (True, "6.0.0", "6.0.7", UpdateType.Micro),
+        (True, "6.0.0b3", "6.0.0rc1", UpdateType.Minor),
         (True, "6.0.0", "6.1.0a3", UpdateType.Minor),
         (True, "5.0.0", "6.0.7", UpdateType.Major),
         (False, "6.0.0", "6.0.7", UpdateType.Major),

--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -174,7 +174,7 @@ def get_asset_info(
 
     if current_version.major < release.major or not is_conda_based_app():
         update_type = UpdateType.Major
-    elif current_version.minor < release.minor:
+    elif current_version.minor < release.minor or current_version.is_prerelease:
         update_type = UpdateType.Minor
     else:
         update_type = UpdateType.Micro


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Minor updates should not include minor Python version updates to the installer base environment since the base environment is only rebuilt on major Spyder updates.

* Pin installer base environment Python version to 3.11.13 (partial reversion of #23285)
* Micro updates from pre-releases are elevated to minor updates in order to rebuild the runtime environment in case a minor Python update occurred.