### PR TITLE
PR: Reorganize Editor preferences and improve UI text

### DIFF
--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -133,48 +133,46 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         # ---- Source code tab
         # -- Setting widgets
         closepar_box = newcb(
-            _("Automatic insertion of parentheses, braces and brackets"),
+            _("Automatically insert closing parentheses, brackets and braces"),
             'close_parentheses')
         close_quotes_box = newcb(
-            _("Automatic insertion of closing quotes"),
+            _("Automatically insert closing quotes"),
             'close_quotes')
         add_colons_box = newcb(
-            _("Automatic insertion of colons after 'for', 'if', 'def', etc"),
+            _("Automatically insert colons after 'for', 'if', 'def', etc"),
             'add_colons')
         autounindent_box = newcb(
-            _("Automatic indentation after 'else', 'elif', etc."),
+            _("Automatically un-indent 'else', 'elif', etc"),
             'auto_unindent')
         tab_mode_box = newcb(
-            _("Tab always indent"),
+            _("Tab always indents"),
             'tab_always_indent', default=False,
-            tip=_("If enabled, pressing Tab will always indent,\n"
-                  "even when the cursor is not at the beginning\n"
-                  "of a line (when this option is enabled, code\n"
-                  "completion may be triggered using the alternate\n"
-                  "shortcut: Ctrl+Space)"))
+            tip=_("If enabled, pressing <kbd>Tab</kbd> will always indent,\n"
+                  "even when the cursor is not at the beginning of a line.\n"
+                  "Code completion can still be triggered using the shortcut\n"
+                  "<kbd>Ctrl+Space</kbd>."))
         strip_mode_box = newcb(
-            _("Automatic stripping of trailing spaces on changed lines"),
+            _("Strip trailing spaces on changed lines"),
             'strip_trailing_spaces_on_modify', default=True,
             tip=_("If enabled, modified lines of code (excluding strings)\n"
-                  "will have their trailing whitespace stripped when leaving them.\n"
+                  "will have trailing whitespace stripped when leaving them.\n"
                   "If disabled, only whitespace added by Spyder will be stripped."))
         ibackspace_box = newcb(
             _("Intelligent backspace"),
             'intelligent_backspace',
-            tip=_("Make the backspace key automatically remove the amount of "
+            tip=_("Make the backspace key automatically remove the number of "
                   "indentation characters set above."),
             default=True)
         self.removetrail_box = newcb(
-            _("Automatic removal of trailing spaces when saving files"),
+            _("Strip all trailing spaces on save"),
             'always_remove_trailing_spaces',
             default=False)
         self.add_newline_box = newcb(
-            _("Insert a newline at the end if one does not exist when saving "
-              "a file"),
+            _("Automatically add missing end-of-file newline on save"),
             'add_newline',
             default=False)
         self.remove_trail_newline_box = newcb(
-            _("Trim all newlines after the final one when saving a file"),
+            _("Strip blank lines at end of file on save"),
             'always_remove_trailing_newlines',
             default=False)
 
@@ -200,9 +198,9 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
             'check_eol_chars',
             default=True,
             tip=_(
-                "When opening a file containing mixed end-of-line characters "
-                "(which may raise syntax errors in the console on Windows), "
-                "Spyder will fix the file automatically."
+                "When opening a file containing mixed end-of-line characters\n"
+                "(which may raise syntax errors in the console on Windows),\n"
+                "Spyder will convert them automatically if enabled."
             ),
         )
         convert_eol_on_save_box = newcb(

--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -62,6 +62,16 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         linenumbers_box = newcb(_("Show line numbers"), 'line_numbers')
         breakpoints_box = newcb(_("Show breakpoints"), 'editor_debugger_panel',
                                 section='debugger')
+        todolist_box = newcb(
+            _("Show code annotations"),
+            'todo_list',
+            tip=_(
+                "Display a marker to the left of line numbers when the "
+                "following annotations appear at the beginning of a comment: "
+                "<tt>TODO, FIXME, XXX, HINT, TIP, @todo, HACK, BUG, OPTIMIZE, "
+                "!!!, ???</tt>"
+            ),
+        )
         currentline_box = newcb(_("Highlight current line"),
                                 'highlight_current_line')
         currentcell_box = newcb(_("Highlight current cell"),
@@ -107,6 +117,7 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         helpers_layout.addWidget(showcodefolding_box)
         helpers_layout.addWidget(linenumbers_box)
         helpers_layout.addWidget(breakpoints_box)
+        helpers_layout.addWidget(todolist_box)
         helpers_group.setLayout(helpers_layout)
 
         highlight_group = QGroupBox(_("Highlight"))
@@ -293,23 +304,6 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         docstring_layout.addWidget(docstring_combo)
         docstring_group.setLayout(docstring_layout)
 
-        # -- Annotations
-        annotations_group = QGroupBox(_("Annotations"))
-        annotations_label = QLabel(
-            _("Display a marker to the left of line numbers when the "
-              "following annotations appear at the beginning of a comment: "
-              "<tt>TODO, FIXME, XXX, HINT, TIP, @todo, HACK, BUG, OPTIMIZE, "
-              "!!!, ???</tt>"))
-        annotations_label.setWordWrap(True)
-        todolist_box = newcb(
-            _("Display code annotations"),
-            'todo_list')
-
-        annotations_layout = QVBoxLayout()
-        annotations_layout.addWidget(annotations_label)
-        annotations_layout.addWidget(todolist_box)
-        annotations_group.setLayout(annotations_layout)
-
         # -- EOL
         eol_group = QGroupBox(_("End-of-line characters"))
         eol_label = QLabel(_("When opening a text file containing "
@@ -437,10 +431,16 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         )
 
         self.create_tab(
-            _("Advanced settings"),
-            [templates_group, autosave_group, docstring_group,
-             annotations_group, eol_group, multicursor_group,
-             multicursor_paste_group, mouse_shortcuts_group]
+            _("Advanced"),
+            [
+                templates_group,
+                autosave_group,
+                docstring_group,
+                eol_group,
+                multicursor_group,
+                multicursor_paste_group,
+                mouse_shortcuts_group,
+            ],
         )
 
     @on_conf_change(

--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -290,9 +290,9 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
 
         # ---- Advanced tab
         # -- Templates
-        templates_group = QGroupBox(_('Templates'))
+        templates_group = QGroupBox(_('Template'))
         template_btn = self.create_button(
-            text=_("Edit template for new files"),
+            text=_("Edit new file template"),
             callback=self.plugin.edit_template,
             set_modified_on_click=True
         )
@@ -305,7 +305,7 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         # -- Autosave
         autosave_group = QGroupBox(_('Autosave'))
         autosave_checkbox = newcb(
-            _('Automatically save a copy of files with unsaved changes'),
+            _('Automatically save a backup copy of unsaved files'),
             'autosave_enabled')
         autosave_spinbox = self.create_spinbox(
             _('Autosave interval: '),
@@ -320,28 +320,33 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         autosave_group.setLayout(autosave_layout)
 
         # -- Docstring
-        docstring_group = QGroupBox(_('Docstring type'))
+        docstring_group = QGroupBox(_('Docstring style'))
 
         numpy_url = "<a href='{}'>Numpy</a>".format(NUMPYDOC)
         googledoc_url = "<a href='{}'>Google</a>".format(GOOGLEDOC)
         sphinx_url = "<a href='{}'>Sphinx</a>".format(SPHINXDOC)
         docstring_label = QLabel(
-            _("Here you can select the type of docstrings ({}, {} or {}) you "
-              "want the editor to automatically introduce when pressing "
-              "<tt>{}</tt> after a function, method or class "
-              "declaration.").format(
-                  numpy_url, googledoc_url, sphinx_url, DOCSTRING_SHORTCUT)
+            _("Select the style of docstrings ({numpy}, {google} or {sphinx}) "
+              "to generate when pressing <kbd>{shortcut}</kbd> after a "
+              "function, method or class declaration").format(
+                  numpy=numpy_url,
+                  google=googledoc_url,
+                  sphinx=sphinx_url,
+                  shortcut=DOCSTRING_SHORTCUT,
+              ),
         )
         docstring_label.setOpenExternalLinks(True)
         docstring_label.setWordWrap(True)
 
-        docstring_combo_choices = ((_("Numpy"), 'Numpydoc'),
-                                   (_("Google"), 'Googledoc'),
-                                   (_("Sphinx"), 'Sphinxdoc'),)
+        docstring_combo_choices = (
+            (_("Numpy"), 'Numpydoc'),
+            (_("Google"), 'Googledoc'),
+            (_("Sphinx"), 'Sphinxdoc'),
+        )
         docstring_combo = self.create_combobox(
-            _("Type:"),
+            _("Style:"),
             docstring_combo_choices,
-            'docstring_type'
+            'docstring_type',
         )
 
         docstring_layout = QVBoxLayout()
@@ -350,24 +355,26 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         docstring_group.setLayout(docstring_layout)
 
         # -- Multi-cursor
-        multicursor_group = QGroupBox(_("Multi-Cursor"))
+        multicursor_group = QGroupBox(_("Multi-cursor"))
         multicursor_label = QLabel(
-            _("Enable adding multiple cursors for simultaneous editing. "
-              "Additional cursors and a column of cursors can be added using "
-              "the mouse shortcuts that can be configured below.")
+            _("Shortcuts for multi-cursor can be configured "
+              "in the Mouse Shortcuts section below")
         )
         multicursor_label.setWordWrap(True)
         multicursor_box = newcb(
-            _("Enable Multi-Cursor "),
-            'multicursor_support')
+            _("Enable multi-cursor support"),
+            'multicursor_support',
+            tip=_("Allows adding additional cursors and columns of cursors "
+                  "for simultaneous editing"),
+        )
 
         multicursor_layout = QVBoxLayout()
         multicursor_layout.addWidget(multicursor_label)
         multicursor_layout.addWidget(multicursor_box)
         multicursor_group.setLayout(multicursor_layout)
 
-        # -- Multicursor Paste
-        multicursor_paste_group = QGroupBox(_("Multi-Cursor paste behavior"))
+        # -- Multi-cursor paste
+        multicursor_paste_group = QGroupBox(_("Multi-cursor paste behavior"))
         multicursor_paste_bg = QButtonGroup(multicursor_paste_group)
 
         entire_clip_radio = self.create_radiobutton(
@@ -377,7 +384,7 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         )
         conditional_spread_radio = self.create_radiobutton(
             _(
-                "Paste one line per cursor if the number of of lines and cursors "
+                "Paste one line per cursor if the number of lines and cursors "
                 "match"
             ),
             "multicursor_paste/conditional_spread",
@@ -404,7 +411,7 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         multicursor_paste_layout.addWidget(always_spread_radio)
         multicursor_paste_group.setLayout(multicursor_paste_layout)
 
-        # -- Mouse Shortcuts
+        # -- Mouse shortcuts
         mouse_shortcuts_group = QGroupBox(_("Mouse shortcuts"))
         mouse_shortcuts_button = self.create_button(
             lambda: MouseShortcutEditor(self).exec_(),

--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -215,11 +215,15 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         automatic_layout.addWidget(autounindent_box)
         automatic_layout.addWidget(add_colons_box)
         automatic_layout.addWidget(close_quotes_box)
-        automatic_layout.addWidget(self.removetrail_box)
-        automatic_layout.addWidget(strip_mode_box)
-        automatic_layout.addWidget(self.add_newline_box)
-        automatic_layout.addWidget(self.remove_trail_newline_box)
         automatic_group.setLayout(automatic_layout)
+
+        whitespace_group = QGroupBox(_("Trailing whitespace"))
+        whitespace_layout = QVBoxLayout()
+        whitespace_layout.addWidget(self.removetrail_box)
+        whitespace_layout.addWidget(strip_mode_box)
+        whitespace_layout.addWidget(self.add_newline_box)
+        whitespace_layout.addWidget(self.remove_trail_newline_box)
+        whitespace_group.setLayout(whitespace_layout)
 
         indentation_group = QGroupBox(_("Indentation"))
         indentation_layout = QVBoxLayout()
@@ -423,7 +427,14 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
             ],
         )
 
-        self.create_tab(_("Source code"), [automatic_group, indentation_group])
+        self.create_tab(
+            _("Source code"),
+            [
+                automatic_group,
+                whitespace_group,
+                indentation_group,
+            ],
+        )
 
         self.create_tab(
             _("Advanced settings"),

--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -74,7 +74,7 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
                 "Display a marker to the left of line numbers when the "
                 "following annotations appear at the beginning of a comment: "
                 "<tt>TODO, FIXME, XXX, HINT, TIP, @todo, HACK, BUG, OPTIMIZE, "
-                "!!!, ???</tt>"
+                "!!!, ???</tt> (and their lowercase variants)"
             ),
         )
         currentline_box = newcb(_("Highlight current line"),
@@ -194,7 +194,7 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
             default=4, min_=1, max_=8, step=1)
 
         check_eol_box = newcb(
-            _("Fix mixed EOLs automatically and show warning"),
+            _("Fix mixed end-of-lines automatically and show warning dialog"),
             'check_eol_chars',
             default=True,
             tip=_(
@@ -209,8 +209,8 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
             default=False,
         )
         eol_combo_choices = (
-            (_("LF (Linux/macOS)"), 'LF'),
-            (_("CRLF (Windows)"), 'CRLF'),
+            ("LF (Linux/macOS)", 'LF'),
+            ("CRLF (Windows)", 'CRLF'),
             (_("CR (legacy Mac)"), 'CR'),
         )
         convert_eol_on_save_combo = self.create_combobox(
@@ -340,9 +340,9 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         docstring_label.setWordWrap(True)
 
         docstring_combo_choices = (
-            (_("Numpy"), 'Numpydoc'),
-            (_("Google"), 'Googledoc'),
-            (_("Sphinx"), 'Sphinxdoc'),
+            ("Numpy", 'Numpydoc'),
+            ("Google", 'Googledoc'),
+            ("Sphinx", 'Sphinxdoc'),
         )
         docstring_combo = self.create_combobox(
             _("Style:"),
@@ -357,11 +357,6 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
 
         # -- Multi-cursor
         multicursor_group = QGroupBox(_("Multi-cursor"))
-        multicursor_label = QLabel(
-            _("Shortcuts for multi-cursor can be configured "
-              "in the Mouse Shortcuts section below")
-        )
-        multicursor_label.setWordWrap(True)
         multicursor_box = newcb(
             _("Enable multi-cursor support"),
             'multicursor_support',
@@ -370,7 +365,6 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         )
 
         multicursor_layout = QVBoxLayout()
-        multicursor_layout.addWidget(multicursor_label)
         multicursor_layout.addWidget(multicursor_box)
         multicursor_group.setLayout(multicursor_layout)
 

--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -62,12 +62,10 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         linenumbers_box = newcb(_("Show line numbers"), 'line_numbers')
         breakpoints_box = newcb(_("Show breakpoints"), 'editor_debugger_panel',
                                 section='debugger')
-        blanks_box = newcb(_("Show blank spaces"), 'blank_spaces')
         currentline_box = newcb(_("Highlight current line"),
                                 'highlight_current_line')
         currentcell_box = newcb(_("Highlight current cell"),
                                 'highlight_current_cell')
-        wrap_mode_box = newcb(_("Wrap lines"), 'wrap')
         scroll_past_end_box = newcb(_("Scroll past the end"),
                                     'scroll_past_end')
 
@@ -95,17 +93,21 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         occurrence_layout.addLayout(occurrence_glayout)
         occurrence_layout.addStretch(1)
 
-        display_group = QGroupBox(_("Display"))
+        display_group = QGroupBox(_("Interface"))
         display_layout = QVBoxLayout()
         display_layout.addWidget(showtabbar_box)
         display_layout.addWidget(show_filename_box)
         display_layout.addWidget(showclassfuncdropdown_box)
-        display_layout.addWidget(showindentguides_box)
-        display_layout.addWidget(showcodefolding_box)
-        display_layout.addWidget(linenumbers_box)
-        display_layout.addWidget(breakpoints_box)
-        display_layout.addWidget(blanks_box)
+        display_layout.addWidget(scroll_past_end_box)
         display_group.setLayout(display_layout)
+
+        helpers_group = QGroupBox(_("Helpers"))
+        helpers_layout = QVBoxLayout()
+        helpers_layout.addWidget(showindentguides_box)
+        helpers_layout.addWidget(showcodefolding_box)
+        helpers_layout.addWidget(linenumbers_box)
+        helpers_layout.addWidget(breakpoints_box)
+        helpers_group.setLayout(helpers_layout)
 
         highlight_group = QGroupBox(_("Highlight"))
         highlight_layout = QVBoxLayout()
@@ -113,12 +115,6 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         highlight_layout.addWidget(currentcell_box)
         highlight_layout.addLayout(occurrence_layout)
         highlight_group.setLayout(highlight_layout)
-
-        other_group = QGroupBox(_("Other"))
-        other_layout = QVBoxLayout()
-        other_layout.addWidget(wrap_mode_box)
-        other_layout.addWidget(scroll_past_end_box)
-        other_group.setLayout(other_layout)
 
         # ---- Source code tab
         closepar_box = newcb(
@@ -419,8 +415,12 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
 
         # --- Tabs ---
         self.create_tab(
-            _("Interface"),
-            [display_group, highlight_group, other_group]
+            _("Display"),
+            [
+                display_group,
+                helpers_group,
+                highlight_group,
+            ],
         )
 
         self.create_tab(_("Source code"), [automatic_group, indentation_group])

--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -50,18 +50,23 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         # ---- Display tab
         showtabbar_box = newcb(_("Show tab bar"), 'show_tab_bar')
         show_filename_box = newcb(
-            _("Show full file name on top of tab bar"),
+            _("Show full file path above editor"),
             'show_filename_toolbar'
         )
         showclassfuncdropdown_box = newcb(
-                _("Show selector for classes and functions"),
+                _("Show class/function selector"),
                 'show_class_func_dropdown')
+        scroll_past_end_box = newcb(_("Allow scrolling past file end"),
+                                    'scroll_past_end')
         showindentguides_box = newcb(_("Show indent guides"),
                                      'indent_guides')
         showcodefolding_box = newcb(_("Show code folding"), 'code_folding')
         linenumbers_box = newcb(_("Show line numbers"), 'line_numbers')
-        breakpoints_box = newcb(_("Show breakpoints"), 'editor_debugger_panel',
-                                section='debugger')
+        breakpoints_box = newcb(
+            _("Show debugger breakpoints"),
+            'editor_debugger_panel',
+            section='debugger',
+        )
         todolist_box = newcb(
             _("Show code annotations"),
             'todo_list',
@@ -76,11 +81,9 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
                                 'highlight_current_line')
         currentcell_box = newcb(_("Highlight current cell"),
                                 'highlight_current_cell')
-        scroll_past_end_box = newcb(_("Scroll past the end"),
-                                    'scroll_past_end')
-
         occurrence_box = newcb(_("Highlight occurrences after"),
                                'occurrence_highlighting')
+
         occurrence_spin = self.create_spinbox(
             "", _(" ms"),
             'occurrence_highlighting/timeout',

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -516,12 +516,12 @@ class EditorMainWidget(PluginMainWidget):
         # EOL menu
         self.win_eol_action = self.create_action(
             EditorWidgetActions.WinEOL,
-            text=_("CRLF (Windows)"),
+            text="CRLF (Windows)",
             toggled=lambda checked: self.toggle_eol_chars('nt', checked)
         )
         self.linux_eol_action = self.create_action(
             EditorWidgetActions.LinuxEOL,
-            text=_("LF (Linux/macOS)"),
+            text="LF (Linux/macOS)",
             toggled=lambda checked: self.toggle_eol_chars('posix', checked)
         )
         self.mac_eol_action = self.create_action(


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

* Rewrite UI text throughout to be clearer, more concise and more polished
* Rename `Interface` tab to `Display` and `Advanced settings` tab to `Advanced`
* Split the `Display` section (of `Interface`) into more focused `Interface` and `Helpers` sections
* Split the whitespace options in the `Automatic changes` section (of `Source code`) into a more focused `Whitespace` section
* Add `Scroll past the end` to `Interface section` and remove now-empty `Other` section
* Move `Display code annotations` option from `Advanced` to `Display > Helpers`, the description to a tooltip and remove `Annotations` section
* Move `End-of-line characters` section to `Source code` and the description to a tooltip
* Remove `Warp lines` and `Show blank spaces` that duplicate more easily-accessible options in the menus


| Before | After |
| --- | --- |
| <img width="902" height="692" alt="image" src="https://github.com/user-attachments/assets/839b2c69-7fb1-4b2a-a0f8-a4a957187f2a" /> | <img width="888" height="721" alt="image" src="https://github.com/user-attachments/assets/90d700e9-d439-464f-90d4-54a57802ca74" /> |
| <img width="902" height="692" alt="image" src="https://github.com/user-attachments/assets/48c45b24-9729-45f3-8268-b027cad1ca0d" /> | <img width="888" height="721" alt="image" src="https://github.com/user-attachments/assets/89a61dd6-3f6b-4044-84db-6d92be6f939f" /> |
| <img width="902" height="692" alt="image" src="https://github.com/user-attachments/assets/41f103b6-9420-4170-8219-2ee457065399" /> | <img width="888" height="721" alt="image" src="https://github.com/user-attachments/assets/aa0066bb-5dc0-4f05-b2c1-717755ca31ab" /> |


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM-Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
