### PR TITLE
PR: Use consistant terms for syntax highlighting theme in prefs

### DIFF
--- a/spyder/plugins/appearance/confpage.py
+++ b/spyder/plugins/appearance/confpage.py
@@ -95,9 +95,9 @@ class AppearanceConfigPage(PluginConfigPage):
         syntax_group = QGroupBox(_("Syntax highlighting theme"))
 
         # Syntax Widgets
-        edit_button = QPushButton(_("Edit selected scheme"))
-        create_button = QPushButton(_("Create new scheme"))
-        self.delete_button = QPushButton(_("Delete scheme"))
+        edit_button = QPushButton(_("Edit selected theme"))
+        create_button = QPushButton(_("Create new theme"))
+        self.delete_button = QPushButton(_("Delete theme"))
         self.reset_button = QPushButton(_("Reset to defaults"))
 
         self.stacked_widget = QStackedWidget(self)
@@ -560,10 +560,12 @@ class AppearanceConfigPage(PluginConfigPage):
         """Deletes the currently selected custom color scheme."""
         scheme_name = self.current_scheme
 
-        answer = QMessageBox.warning(self, _("Warning"),
-                                     _("Are you sure you want to delete "
-                                       "this scheme?"),
-                                     QMessageBox.Yes | QMessageBox.No)
+        answer = QMessageBox.warning(
+            self,
+            _("Warning"),
+            _("Are you sure you want to delete this theme?"),
+            QMessageBox.Yes | QMessageBox.No,
+        )
         if answer == QMessageBox.Yes:
             # Put the combobox in Spyder by default, when deleting a scheme
             names = self.get_option('names')

--- a/spyder/plugins/appearance/widgets.py
+++ b/spyder/plugins/appearance/widgets.py
@@ -150,14 +150,14 @@ class SchemeEditor(QDialog):
 
         parent = self.parent
         self.line_edit = parent.create_lineedit(
-            _("Scheme name:"), '{0}/name'.format(scheme_name)
+            _("Theme name:"), '{0}/name'.format(scheme_name)
         )
 
         self.widgets[scheme_name] = {}
 
         # Widget setup
         self.line_edit.label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
-        self.setWindowTitle(_('Color scheme editor'))
+        self.setWindowTitle(_('Syntax highlighting theme editor'))
 
         # Layout
         name_layout = QHBoxLayout()
@@ -243,7 +243,7 @@ class SchemeEditor(QDialog):
         self.line_edit.textbox.setText(
             str(parent.get_option('{0}/name'.format(scheme_name)))
         )
-        
+
         for key, value in self.original_scheme.items():
             if isinstance(value, tuple):
                 color = QColor()
@@ -255,7 +255,7 @@ class SchemeEditor(QDialog):
                 color = QColor()
                 color.setNamedColor(value)
                 self.widgets[scheme_name][key][0].update_text(color)
-    
+
     def reject(self):
         """Executes when Cancel is pressed: Restores the edited scheme."""
         self.restore_original_scheme(self.last_used_scheme)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Presently, the Appearance preferences pane uses a mix of the newer "theme" and the older "scheme" to refer to syntax highlighting themes. This PR standardizes the UI text to consistently use "theme" throughout.

| Before | After |
| --- | --- |
| <img width="902" height="692" alt="image" src="https://github.com/user-attachments/assets/6e11a8ef-a5fc-4034-aeb8-2dcb95797079" /> | <img width="888" height="692" alt="image" src="https://github.com/user-attachments/assets/9552c5c7-5678-4db0-8a97-803e553c92c8" /> |
| <img width="548" height="475" alt="image" src="https://github.com/user-attachments/assets/095b874a-1aa7-42dc-8d7b-7aa59e9b261c" /> | <img width="548" height="475" alt="image" src="https://github.com/user-attachments/assets/d660a290-9b1b-4b85-bf2e-bf2715217639" /> |



### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM-Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
