### PR TITLE
PR: Clarify and polish UI text for keyboard shortcuts pref pane

### DIFF
--- a/spyder/plugins/shortcuts/confpage.py
+++ b/spyder/plugins/shortcuts/confpage.py
@@ -30,14 +30,10 @@ class ShortcutsConfigPage(PluginConfigPage):
         reset_btn = self.create_button(
             icon=ima.icon("restart"),
             callback=self.reset_to_default,
-            tooltip=_("Reset to default values"),
+            tooltip=_("Reset all shortcuts to default values"),
         )
         top_label = QLabel(
-            _(
-                "Here you can browse the list of all available shortcuts in "
-                "Spyder. You can also customize them by double-clicking on "
-                "any entry in this table."
-            )
+            _("Customize a shortcut by double-clicking on its entry below.")
         )
 
         # Widget setup
@@ -71,11 +67,11 @@ class ShortcutsConfigPage(PluginConfigPage):
         self.table.check_shortcuts()
 
     def reset_to_default(self, force=False):
-        """Reset to default values of the shortcuts making a confirmation."""
+        """Reset all shortcuts to default values after confirmation."""
         if not force:
             reset = QMessageBox.warning(
                 self,
-                _("Shortcuts reset"),
+                _("Reset all shortcuts"),
                 _(
                     "Do you want to reset all shortcuts to their default "
                     "values?"

--- a/spyder/plugins/shortcuts/widgets/table.py
+++ b/spyder/plugins/shortcuts/widgets/table.py
@@ -180,9 +180,12 @@ class ShortcutEditor(QDialog):
         # Widgets
         self.label_info = QLabel()
         self.label_info.setText(
-            _("Press the new shortcut and select <b>Ok</b> to confirm, "
-              "click <b>Cancel</b> to revert to the previous state, "
-              "or use <b>Clear</b> to unbind the command from a shortcut.")
+            _(
+                "Press the new shortcut and select <b>Ok</b> to confirm, "
+                "click <b>Cancel</b> to revert to the previous state, "
+                "use <b>Clear</b> to unbind the command from a shortcut "
+                "or press <b>Default</b> to restore the default shortcut."
+            )
         )
         self.label_info.setAlignment(Qt.AlignTop | Qt.AlignLeft)
         self.label_info.setWordWrap(True)
@@ -399,9 +402,13 @@ class ShortcutEditor(QDialog):
                 tip_body += ' - {0}: <b>{1}</b><br>'.format(s.context, s.name)
             tip_body += '<br>'
             if len(conflicts) == 1:
-                tip_override = _("Press 'Ok' to unbind it and assign it to")
+                tip_override = _(
+                    "Press 'Ok' to unbind it and assign the shortcut to"
+                )
             else:
-                tip_override = _("Press 'Ok' to unbind them and assign it to")
+                tip_override = _(
+                    "Press 'Ok' to unbind them and assign the shortcut to"
+                )
             tip_override += ' <b>{}</b>.'.format(self.name)
             tip = template.format(tip_title, tip_body, tip_override)
             icon = ima.icon('warning')

--- a/spyder/plugins/shortcuts/widgets/table.py
+++ b/spyder/plugins/shortcuts/widgets/table.py
@@ -208,15 +208,15 @@ class ShortcutEditor(QDialog):
         self.label_warning.setAlignment(Qt.AlignTop | Qt.AlignLeft)
 
         self.button_default = QPushButton(_('Default'))
+        self.button_clear = QPushButton(_('Clear'))
         self.button_ok = QPushButton(_('Ok'))
         self.button_ok.setEnabled(False)
-        self.button_clear = QPushButton(_('Clear'))
         self.button_cancel = QPushButton(_('Cancel'))
         button_box = QHBoxLayout()
         button_box.addWidget(self.button_default)
+        button_box.addWidget(self.button_clear)
         button_box.addStretch(100)
         button_box.addWidget(self.button_ok)
-        button_box.addWidget(self.button_clear)
         button_box.addWidget(self.button_cancel)
 
         # New Sequence button box


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

* Clarify and polish the UI text throughout the preference pane and its dialogs
* Add missing description of the "Defaults" button to the keyboard shortcut editor
* Move the Clear button in the Keyboard Shortcuts editor from splitting the "Ok" and "Cancel" buttons (big no-no) to be instead next to the Defaults button that it is more similar to



| Before | After |
| --- | --- |
| <img width="895" height="688" alt="image" src="https://github.com/user-attachments/assets/d3afbba5-f8cf-4715-8aa0-27e9123abfae" /> | <img width="884" height="695" alt="image" src="https://github.com/user-attachments/assets/ee3d927a-92fc-44ba-820e-9362eb74fa57" /> |



### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM-Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
