### PR TITLE
PR: Increase default max console buffer and warn if it's big (IPython console)

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -160,7 +160,7 @@ DEFAULTS = [
               'show_calltips': True,
               'ask_before_closing': False,
               'show_reset_namespace_warning': True,
-              'buffer_size': 500,
+              'buffer_size': 5000,
               'pylab': True,
               'pylab/autoload': False,
               'pylab/backend': 'inline',
@@ -721,4 +721,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '87.4.0'
+CONF_VERSION = '87.5.0'

--- a/spyder/plugins/ipythonconsole/confpage.py
+++ b/spyder/plugins/ipythonconsole/confpage.py
@@ -49,7 +49,7 @@ class IPythonConsoleConfigPage(PluginConfigPage):
             'show_elapsed_time',
             tip=_("Display the time since the current console was started "
                   "in the tab bar"),
-            )
+        )
 
         display_layout = QVBoxLayout()
         display_layout.addWidget(banner_box)
@@ -187,7 +187,7 @@ class IPythonConsoleConfigPage(PluginConfigPage):
             (inline, 'inline'),
             (automatic, 'auto'),
             ("Qt", 'qt'),
-            ("Tk", 'tk')
+            ("Tk", 'tk'),
         ]
 
         if sys.platform == 'darwin':
@@ -239,13 +239,23 @@ class IPythonConsoleConfigPage(PluginConfigPage):
             tip=_("Only used when the format is PNG. Default is 144."),
         )
         width_spin = self.create_spinbox(
-                          _("Width:")+"  ", " "+_("inches"),
-                          'pylab/inline/width', min_=2, max_=20, step=1,
-                          tip=_("Default is 6"))
+            _("Width:") + "  ",
+            " " + _("inches"),
+            'pylab/inline/width',
+            min_=2,
+            max_=20,
+            step=1,
+            tip=_("Default is 6"),
+        )
         height_spin = self.create_spinbox(
-                          _("Height:")+"  ", " "+_("inches"),
-                          'pylab/inline/height', min_=1, max_=20, step=1,
-                          tip=_("Default is 4"))
+            _("Height:") + "  ",
+            " " + _("inches"),
+            'pylab/inline/height',
+            min_=1,
+            max_=20,
+            step=1,
+            tip=_("Default is 4"),
+        )
         fontsize_spin = self.create_spinbox(
             _("Font size:") + "  ",
             " " + _("points"),
@@ -253,7 +263,7 @@ class IPythonConsoleConfigPage(PluginConfigPage):
             min_=5,
             max_=48,
             step=1.0,
-            tip=_("Default is 10")
+            tip=_("Default is 10"),
         )
         bottom_spin = self.create_spinbox(
             _("Bottom edge:") + "  ",

--- a/spyder/plugins/ipythonconsole/confpage.py
+++ b/spyder/plugins/ipythonconsole/confpage.py
@@ -12,7 +12,12 @@ import sys
 # Third party imports
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
-    QGridLayout, QGroupBox, QHBoxLayout, QLabel, QMessageBox, QVBoxLayout
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QVBoxLayout,
 )
 
 # Local imports
@@ -129,15 +134,15 @@ class IPythonConsoleConfigPage(PluginConfigPage):
             _("Buffer:"),
             _(" lines"),
             'buffer_size',
-            min_=-1,
+            min_=100,
             # >10k can make Spyder slow, see spyder-ide/spyder#19091
-            max_=100_000,
+            max_=50_000,
             step=100,
             tip=_(
                 "The maximum number of output lines "
                 "retained in each console at a time.\n"
-                "Warning; Buffer sizes >10,000 lines can slow down Spyder.\n"
-                "Specifying -1 means no limit (not recommended)."
+                "Warning; Buffer sizes greater than 10000 lines can slow "
+                "down Spyder."
             ),
         )
         sympy_box = newcb(
@@ -478,7 +483,7 @@ class IPythonConsoleConfigPage(PluginConfigPage):
 
         # >10k line buffers can make Spyder slow, see spyder-ide/spyder#19091
         if buffer_size > 10_000:
-            msg = _("Buffer sizes over 10,000 lines can slow down Spyder")
+            msg = _("Buffer sizes over 10000 lines can slow down Spyder")
         elif buffer_size == -1:
             msg = _("Unlimited buffer size can slow down Spyder severely")
         if msg:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Followup to #25010 
Related to #19091

The current default value of the Console buffer size (scrollback length) under `Preferences > IPython Console > Interface` is very low at only 500 lines, barely a handful of screenfulls of text. Given in 2025 machines can easily handle, and many users expect, far more, and the default setting results in permanent data loss, it seems reasonable to increase it to at least 5000.

Meanwhile, the maximum value was apparently set to only 5000 due to #19091, where a user reported that Spyder was very slugging when the Console buffer size (scrollback length) was set to 50k lines. @ccordoba12 postulated that this could occur with a buffer size >10k lines, and although the maximum was set to half of that still.

However, the setting still allows (and even mentions in the tooltip) a value of `-1`, which sets the buffer size to unlimited. Given a user desiring a buffer size larger than 5k would have no choice but to set that, which is strictly worse for Spyder's performance than any fixed buffer size, it seems only reasonable to allow a much larger maximum (or none at all); I've set it to 100k for now.

Yet, we should warn users about this more visibility than just a mention in the tooltip. As such, I've implemented a callback on applying a change to this setting that pops up a warning dialog if either >10k lines is set for the buffer, or an unlimited buffer (`-1`) is set.

Additionally, I've cleaned up a handful of remaining formatting issues not caught in #25010 

<img width="881" height="686" alt="image" src="https://github.com/user-attachments/assets/050cebfe-43c7-4354-9987-8a0b81905722" />



### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM-Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
