### PR TITLE
PR: Use `windows-2022` image on Windows workflows (CI)

### DIFF
--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -42,7 +42,7 @@ jobs:
           - os: ubuntu-latest
             pkg: spyder-kernels
             cache-arch: unix
-          - os: windows-latest
+          - os: windows-2022
             pkg: spyder-kernels
             python-version: '3.12'
             cache-arch: win-64

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -93,7 +93,7 @@ jobs:
         fi
         if [[ $BUILD_WIN == "true" ]]; then
             target_platform=${target_platform:+"$target_platform, "}"'win-64'"
-            include=${include:+"$include, "}"{'os': 'windows-latest', 'target-platform': 'win-64', 'spyk-arch': 'win-64'}"
+            include=${include:+"$include, "}"{'os': 'windows-2022', 'target-platform': 'win-64', 'spyk-arch': 'win-64'}"
         fi
 
         if [[ $GITHUB_EVENT_NAME == "schedule" ]]; then

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -54,7 +54,7 @@ jobs:
     # Use this to disable the workflow
     # if: false
     name: Windows - Py${{ matrix.PYTHON_VERSION }}, ${{ matrix.INSTALL_TYPE }}, ${{ matrix.TEST_TYPE }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       CI: 'true'
       QTCONSOLE_TESTING: 'true'


### PR DESCRIPTION
## Description of Changes

This avoids failures in some tests with the `windows-latest` image and potential issues with our installers.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
