### PR TITLE
PR: Allow aborting connections (Remote client)

### DIFF
--- a/spyder/plugins/remoteclient/api/manager/base.py
+++ b/spyder/plugins/remoteclient/api/manager/base.py
@@ -324,7 +324,9 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
             # User aborted
             if self.__abort_requested.is_set():
                 self.__connection_task.cancel()
-                self.logger.warning("Connection attempt aborted by user")
+                abort_task.cancel()
+                self.__connection_task = None
+                self.logger.debug("Connection attempt aborted by user")
                 self._emit_connection_status(
                     ConnectionStatus.Inactive,
                     _("The connection attempt was cancelled"),

--- a/spyder/plugins/remoteclient/api/manager/base.py
+++ b/spyder/plugins/remoteclient/api/manager/base.py
@@ -103,7 +103,7 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
         self.__abort_requested = asyncio.Event()
         self.__lock = asyncio.Lock()
 
-    def _emit_connection_status(self, status: ConnectionStatus, message: str):
+    def _emit_connection_status(self, status: str, message: str):
         if self._plugin is not None:
             self._plugin.sig_connection_status_changed.emit(
                 ConnectionInfo(

--- a/spyder/plugins/remoteclient/api/manager/base.py
+++ b/spyder/plugins/remoteclient/api/manager/base.py
@@ -399,7 +399,7 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
         msg = "This method should be implemented in the derived class"
         raise NotImplementedError(msg)
 
-    def _reset_connection_stablished(self):
+    def _reset_connection_established(self):
         """Reset the connection status."""
         self.__connection_task = None
 

--- a/spyder/plugins/remoteclient/api/manager/base.py
+++ b/spyder/plugins/remoteclient/api/manager/base.py
@@ -245,8 +245,7 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
 
         self.__starting_server = True
         self._emit_connection_status(
-            ConnectionStatus.Starting,
-            _("Starting Spyder remote services."),
+            ConnectionStatus.Starting, _("Starting Spyder remote services")
         )
         try:
             if await self._start_remote_server():
@@ -312,7 +311,9 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
             )
 
             self.__abort_requested.clear()
-            self.__connection_task = asyncio.create_task(self._create_new_connection())
+            self.__connection_task = asyncio.create_task(
+                self._create_new_connection()
+            )
             abort_task = asyncio.create_task(self.__abort_requested.wait())
 
             await asyncio.wait(

--- a/spyder/plugins/remoteclient/api/manager/base.py
+++ b/spyder/plugins/remoteclient/api/manager/base.py
@@ -83,7 +83,7 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
 
         self.__installing_server = False
         self.__starting_server = False
-        self.__creating_connection = False
+        self.__connection_task: asyncio.Task | None = None
 
         # For logging
         self.logger = logging.getLogger(
@@ -100,9 +100,10 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
     async def __create_events(self):
         self.__server_installed = asyncio.Event()
         self.__starting_event = asyncio.Event()
-        self.__connection_established = asyncio.Event()
+        self.__abort_requested = asyncio.Event()
+        self.__lock = asyncio.Lock()
 
-    def _emit_connection_status(self, status, message):
+    def _emit_connection_status(self, status: ConnectionStatus, message: str):
         if self._plugin is not None:
             self._plugin.sig_connection_status_changed.emit(
                 ConnectionInfo(
@@ -119,11 +120,22 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
         return self.__starting_event.is_set() and not self.__starting_server
 
     @property
-    def connected(self):
-        """Check if SSH connection is open."""
+    def connected(self) -> bool:
+        """Check if a connection is currently established."""
         return (
-            self.__connection_established.is_set()
-            and not self.__creating_connection
+            self.__connection_task is not None
+            and self.__connection_task.done()
+            and not self.__connection_task.cancelled()
+            and not self.__connection_task.exception()
+            and self.__connection_task.result() is True
+        )
+
+    @property
+    def is_connecting(self) -> bool:
+        """Check if a connection attempt is ongoing."""
+        return (
+            self.__connection_task is not None
+            and not self.__connection_task.done()
         )
 
     @property
@@ -162,7 +174,7 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
         await self.close_connection()
 
     def _handle_connection_lost(self, exc: Exception | None = None):
-        self.__connection_established.clear()
+        self.__connection_task = None
         self.__starting_event.clear()
         self._port_forwarder = None
         if exc:
@@ -232,6 +244,10 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
             return self.server_started
 
         self.__starting_server = True
+        self._emit_connection_status(
+            ConnectionStatus.Starting,
+            _("Starting Spyder remote services."),
+        )
         try:
             if await self._start_remote_server():
                 self.__starting_event.set()
@@ -278,20 +294,64 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
         raise NotImplementedError(msg)
 
     async def create_new_connection(self) -> bool:
-        if self.__creating_connection:
-            await self.__connection_established.wait()
-            return self.connected
+        """Create a new connection, supporting user abort."""
+        if self.connected:
+            self.logger.debug(
+                "Atempting to create a new connection with an existing for %s",
+                self.server_name,
+            )
+            await self.close_connection()
 
-        self.__creating_connection = True
-        try:
-            if await self._create_new_connection():
-                self.__connection_established.set()
-                return True
-        finally:
-            self.__creating_connection = False
+        async with self.__lock:
+            if self.__connection_task is not None:
+                return self.connected
 
-        self.__connection_established.clear()
-        return False
+            self._emit_connection_status(
+                ConnectionStatus.Connecting,
+                _("We're establishing the connection. Please be patient"),
+            )
+
+            self.__abort_requested.clear()
+            self.__connection_task = asyncio.create_task(self._create_new_connection())
+
+            await asyncio.wait(
+                [self.__connection_task, self.__abort_requested.wait()],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            # User aborted
+            if self.__abort_requested.is_set():
+                self.__connection_task.cancel()
+                self.logger.warning("Connection attempt aborted by user")
+                self._emit_connection_status(
+                    ConnectionStatus.Inactive,
+                    _("The connection attempt was cancelled"),
+                )
+                return False
+
+            # Connection completed
+            try:
+                if await self.__connection_task:
+                    self._emit_connection_status(
+                        ConnectionStatus.Connected,
+                        _("The connection was successfully established"),
+                    )
+                    return True
+            except BaseException:
+                self.logger.exception(
+                    "Error creating a new connection for %s", self.server_name
+                )
+                self._emit_connection_status(
+                    ConnectionStatus.Error,
+                    _("There was an error establishing the connection"),
+                )
+
+            return False
+
+    async def abort_connection(self):
+        """Abort an ongoing connection attempt."""
+        if self.is_connecting:
+            self.__abort_requested.set()
 
     @abstractmethod
     async def _create_new_connection(self) -> bool:
@@ -337,7 +397,7 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
 
     def _reset_connection_stablished(self):
         """Reset the connection status."""
-        self.__connection_established.clear()
+        self.__connection_task = None
 
     @staticmethod
     def get_free_port():

--- a/spyder/plugins/remoteclient/api/manager/base.py
+++ b/spyder/plugins/remoteclient/api/manager/base.py
@@ -313,9 +313,10 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
 
             self.__abort_requested.clear()
             self.__connection_task = asyncio.create_task(self._create_new_connection())
+            abort_task = asyncio.create_task(self.__abort_requested.wait())
 
             await asyncio.wait(
-                [self.__connection_task, self.__abort_requested.wait()],
+                [self.__connection_task, abort_task],
                 return_when=asyncio.FIRST_COMPLETED,
             )
 

--- a/spyder/plugins/remoteclient/api/manager/jupyterhub.py
+++ b/spyder/plugins/remoteclient/api/manager/jupyterhub.py
@@ -250,7 +250,7 @@ class SpyderRemoteJupyterHubAPIManager(SpyderRemoteAPIManagerBase):
         await self._session.close()
         self._session = None
         self.logger.info("Connection closed")
-        self._reset_connection_stablished()
+        self._reset_connection_established()
         self._emit_connection_status(
             ConnectionStatus.Inactive,
             _("The connection was closed successfully"),

--- a/spyder/plugins/remoteclient/api/manager/jupyterhub.py
+++ b/spyder/plugins/remoteclient/api/manager/jupyterhub.py
@@ -75,7 +75,7 @@ class SpyderRemoteJupyterHubAPIManager(SpyderRemoteAPIManagerBase):
                 if await self.check_server_version():
                     self._emit_connection_status(
                         ConnectionStatus.Active,
-                        _("The connection was established successfully"),
+                        _("Spyder remote services are active"),
                     )
                     return True
                 return False
@@ -127,7 +127,7 @@ class SpyderRemoteJupyterHubAPIManager(SpyderRemoteAPIManagerBase):
         if ready and await self.check_server_version():
             self._emit_connection_status(
                 ConnectionStatus.Active,
-                _("The connection was established successfully"),
+                _("Spyder remote services are active"),
             )
             return True
 

--- a/spyder/plugins/remoteclient/api/manager/jupyterhub.py
+++ b/spyder/plugins/remoteclient/api/manager/jupyterhub.py
@@ -217,18 +217,7 @@ class SpyderRemoteJupyterHubAPIManager(SpyderRemoteAPIManagerBase):
         return False
 
     async def _create_new_connection(self) -> bool:
-        if self.connected:
-            self.logger.debug(
-                "Atempting to create a new connection with an existing for %s",
-                self.server_name,
-            )
-            await self.close_connection()
-
-        self._emit_connection_status(
-            ConnectionStatus.Connecting,
-            _("We're establishing the connection. Please be patient"),
-        )
-
+        """Create a new SSH connection."""
         self.logger.debug("Connecting to jupyterhub at %s", self.hub_url)
 
         self._session = aiohttp.ClientSession(
@@ -237,13 +226,9 @@ class SpyderRemoteJupyterHubAPIManager(SpyderRemoteAPIManagerBase):
         )
 
         user_data = None
-        try:
-            async with self._session.get("hub/api/user") as response:
-                if response.ok:
-                    user_data = await response.json()
-        except aiohttp.ClientError:
-            self.logger.exception("Error connecting to JupyterHub")
-            return False
+        async with self._session.get("hub/api/user") as response:
+            if response.ok:
+                user_data = await response.json()
 
         if user_data is None:
             self.logger.error(

--- a/spyder/plugins/remoteclient/api/manager/ssh.py
+++ b/spyder/plugins/remoteclient/api/manager/ssh.py
@@ -329,7 +329,7 @@ class SpyderRemoteSSHAPIManager(SpyderRemoteAPIManagerBase):
         return True
 
     async def _create_new_connection(self) -> bool:
-        """Creates a new SSH connection to the remote server machine.
+        """Create a new SSH connection to the remote server machine.
 
         Args
         ----
@@ -341,37 +341,18 @@ class SpyderRemoteSSHAPIManager(SpyderRemoteAPIManagerBase):
         bool
             True if the connection was successful, False otherwise.
         """
-        if self.connected:
-            self.logger.debug(
-                f"Atempting to create a new connection with an existing for "
-                f"{self.peer_host}"
-            )
-            await self.close_connection()
-
-        self._emit_connection_status(
-            ConnectionStatus.Connecting,
-            _("We're establishing the connection. Please be patient"),
-        )
-
         connect_kwargs = {
             k: v
             for k, v in self.options.items()
             if k not in self._extra_options
         }
         self.logger.debug("Opening SSH connection")
-        try:
-            self._ssh_connection = await asyncssh.connect(
-                **connect_kwargs, client_factory=self.client_factory
-            )
-        except (OSError, asyncssh.Error) as e:
-            self.logger.error(f"Failed to open ssh connection: {e}")
-            self._emit_connection_status(
-                ConnectionStatus.Error,
-                _("It was not possible to open a connection to this machine"),
-            )
-            return False
 
-        self.logger.info(f"SSH connection opened for {self.peer_host}")
+        self._ssh_connection = await asyncssh.connect(
+            **connect_kwargs, client_factory=self.client_factory
+        )
+
+        self.logger.info("SSH connection established for %s", self.peer_host)
 
         return True
 

--- a/spyder/plugins/remoteclient/api/manager/ssh.py
+++ b/spyder/plugins/remoteclient/api/manager/ssh.py
@@ -166,7 +166,7 @@ class SpyderRemoteSSHAPIManager(SpyderRemoteAPIManagerBase):
                 if await self.forward_local_port():
                     self._emit_connection_status(
                         ConnectionStatus.Active,
-                        _("The connection was established successfully"),
+                        _("Spyder remote services are active"),
                     )
                     return True
 
@@ -181,7 +181,7 @@ class SpyderRemoteSSHAPIManager(SpyderRemoteAPIManagerBase):
 
             self._emit_connection_status(
                 ConnectionStatus.Active,
-                _("The connection was established successfully"),
+                _("Spyder remote services are active"),
             )
 
             return True
@@ -228,7 +228,7 @@ class SpyderRemoteSSHAPIManager(SpyderRemoteAPIManagerBase):
         if await self.forward_local_port():
             self._emit_connection_status(
                 ConnectionStatus.Active,
-                _("The connection was established successfully"),
+                _("Spyder remote services are active"),
             )
             return True
 

--- a/spyder/plugins/remoteclient/api/manager/ssh.py
+++ b/spyder/plugins/remoteclient/api/manager/ssh.py
@@ -433,7 +433,7 @@ class SpyderRemoteSSHAPIManager(SpyderRemoteAPIManagerBase):
         await self._ssh_connection.wait_closed()
         self._ssh_connection = None
         self.logger.info("SSH connection closed")
-        self._reset_connection_stablished()
+        self._reset_connection_established()
         self._emit_connection_status(
             ConnectionStatus.Inactive,
             _("The connection was closed successfully"),

--- a/spyder/plugins/remoteclient/api/protocol.py
+++ b/spyder/plugins/remoteclient/api/protocol.py
@@ -11,6 +11,7 @@ Spyder Remote Client API.
 from __future__ import annotations
 import logging
 import typing
+from enum import Enum
 
 
 class KernelInfo(typing.TypedDict):
@@ -53,14 +54,16 @@ class JupyterHubClientOptions(typing.TypedDict):
     default_kernel_spec: str | None
 
 
-class ClientType:
+class ClientType(Enum):
     SSH = "ssh"
     JupyterHub = "jupyterhub"
 
 
-class ConnectionStatus:
+class ConnectionStatus(Enum):
     Inactive = "inactive"
     Connecting = "connecting"
+    Connected = "connected"
+    Starting = "starting"
     Active = "active"
     Stopping = "stopping"
     Error = "error"

--- a/spyder/plugins/remoteclient/api/protocol.py
+++ b/spyder/plugins/remoteclient/api/protocol.py
@@ -11,7 +11,6 @@ Spyder Remote Client API.
 from __future__ import annotations
 import logging
 import typing
-from enum import Enum
 
 
 class KernelInfo(typing.TypedDict):
@@ -54,12 +53,12 @@ class JupyterHubClientOptions(typing.TypedDict):
     default_kernel_spec: str | None
 
 
-class ClientType(Enum):
+class ClientType:
     SSH = "ssh"
     JupyterHub = "jupyterhub"
 
 
-class ConnectionStatus(Enum):
+class ConnectionStatus:
     Inactive = "inactive"
     Connecting = "connecting"
     Connected = "connected"
@@ -71,7 +70,7 @@ class ConnectionStatus(Enum):
 
 class ConnectionInfo(typing.TypedDict):
     id: str
-    status: ConnectionStatus
+    status: str
     message: str
 
 

--- a/spyder/plugins/remoteclient/plugin.py
+++ b/spyder/plugins/remoteclient/plugin.py
@@ -490,3 +490,11 @@ class RemoteClient(SpyderPluginV2):
         for config_id in self.get_config_ids():
             self.set_conf(f"{config_id}/status", ConnectionStatus.Inactive)
             self.set_conf(f"{config_id}/status_message", "")
+
+    @AsyncDispatcher(loop="asyncssh")
+    async def _abort_connection(self, config_id: str):
+        if config_id not in self._remote_clients:
+            return
+
+        client = self._remote_clients[config_id]
+        await client.abort_connection()

--- a/spyder/plugins/remoteclient/widgets/connectionstatus.py
+++ b/spyder/plugins/remoteclient/widgets/connectionstatus.py
@@ -41,6 +41,8 @@ from spyder.widgets.simplecodeeditor import SimpleCodeEditor
 STATUS_TO_TRANSLATION_STRINGS = {
     ConnectionStatus.Inactive: _("Inactive"),
     ConnectionStatus.Connecting: _("Connecting..."),
+    ConnectionStatus.Connected: _("Connected..."),
+    ConnectionStatus.Starting: _("Starting..."),
     ConnectionStatus.Active: _("Active"),
     ConnectionStatus.Stopping: _("Stopping..."),
     ConnectionStatus.Error: _("Error"),
@@ -50,6 +52,8 @@ STATUS_TO_COLOR = {
     ConnectionStatus.Inactive: SpyderPalette.COLOR_OCCURRENCE_5,
     ConnectionStatus.Connecting: SpyderPalette.COLOR_WARN_4,
     ConnectionStatus.Active: SpyderPalette.COLOR_SUCCESS_3,
+    ConnectionStatus.Connected: SpyderPalette.COLOR_WARN_4,
+    ConnectionStatus.Starting: SpyderPalette.COLOR_WARN_4,
     ConnectionStatus.Stopping: SpyderPalette.COLOR_WARN_4,
     ConnectionStatus.Error: SpyderPalette.COLOR_ERROR_2,
 }
@@ -57,6 +61,8 @@ STATUS_TO_COLOR = {
 STATUS_TO_ICON = {
     ConnectionStatus.Inactive: "connection_disconnected",
     ConnectionStatus.Connecting: "connection_waiting",
+    ConnectionStatus.Connected: "connection_waiting",
+    ConnectionStatus.Starting: "connection_waiting",
     ConnectionStatus.Active: "connection_connected",
     ConnectionStatus.Stopping: "connection_waiting",
     ConnectionStatus.Error: "connection_error",

--- a/spyder/plugins/remoteclient/widgets/container.py
+++ b/spyder/plugins/remoteclient/widgets/container.py
@@ -158,6 +158,9 @@ class RemoteClientContainer(PluginMainContainer):
         connection_dialog.sig_stop_server_requested.connect(
             self.sig_stop_server_requested
         )
+        connection_dialog.sig_abort_connection_requested.connect(
+            self._plugin._abort_connection
+        )
         connection_dialog.sig_connections_changed.connect(
             self.sig_server_changed
         )


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


Added `is_connecting` property to remote client manager to check whether it's currently creating a new conenction;
Added `abort_connection` coroutine to abort current connection attempt;
Modified `create_new_connection` coroutine to allow idempotent connections creation and abortion;
Added `Connected` and `Starting` ConnectionStatus Enum for better status updates of current remote client connections stage.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @hlouzada 

<!--- Thanks for your help making Spyder better for everyone! --->
