### PR TITLE
PR: Rework Editor indent prefs to separate char & width options

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -250,6 +250,7 @@ DEFAULTS = [
               'add_colons': True,
               'auto_unindent': True,
               'indent_chars': '*    *',
+              'indent_with_spaces': True,
               'tab_stop_width_spaces': 4,
               'check_eol_chars': True,
               'convert_eol_on_save': False,


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Reworks the indentation options in the Editor preferences, which previously conflated the indentation width and the indentation character into a single setting with limited options, while splitting space width and tab width into separate settings, into two settings: indent character and indent width.

| Before | After |
| --- | --- |
| <img width="892" height="843" alt="image" src="https://github.com/user-attachments/assets/1a6fa0cb-de92-4af6-8547-57a422579c8e" /> | <img width="893" height="890" alt="image" src="https://github.com/user-attachments/assets/d9b52821-c0ff-4301-977f-66bf8c7ddeae" /> |


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM-Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
