### PR TITLE
PR: Some improvements to the Update manager statusbar widget

### DIFF
--- a/spyder/plugins/updatemanager/widgets/status.py
+++ b/spyder/plugins/updatemanager/widgets/status.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 class UpdateManagerStatus(StatusBarWidget):
     """Status bar widget for update manager."""
     ID = 'update_manager_status'
+    INTERACT_ON_CLICK = True
 
     sig_check_update = Signal()
     """Signal to request checking for updates."""
@@ -105,7 +106,7 @@ class UpdateManagerStatus(StatusBarWidget):
         return self.tooltip
 
     def get_icon(self):
-        return ima.icon('spyder_about')
+        return ima.icon('update')
 
     def set_download_progress(self, percent_progress):
         """Set download progress in status bar"""

--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -572,7 +572,7 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
                 "Updating Spyder, this will take a few minutes ..."
             ),
             "success_message": _(
-                "The update was succesful!<br>Spyder will be launched shortly"
+                "The update was succesful! Spyder will be launched shortly"
             ),
             "failure_message": _("Unfortunately the update failed"),
             "error_message": _("There was an error in the update process"),

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -298,6 +298,7 @@ class IconManager():
             'close_pane':              [('mdi.window-close',), {'color': self.MAIN_FG_COLOR}],
             'toolbar_ext_button':      [('mdi.dots-horizontal',), {'color': self.MAIN_FG_COLOR}],
             'inapp_appeal':            [('mdi6.heart',), {'color': SpyderPalette.COLOR_HEART}],
+            'update':                  [('mdi6.tray-arrow-down',), {'color': self.MAIN_FG_COLOR}],
             # --- Autocompletion/document symbol type icons --------------
             'completions':             [('mdi.code-tags-check',), {'color': self.MAIN_FG_COLOR}],
             'keyword':                 [('mdi.alpha-k-box',), {'color': SpyderPalette.GROUP_9, 'scale_factor': self.BIG_ATTR_FACTOR}],


### PR DESCRIPTION
## Description of Changes

- Change its icon to use a more standard one (the same is also used in Zed and Discord).
- Set INTERACT_ON_CLICK to True on it so user know they can click on it.
- Also, fix message in spyder-updater after recent changes to its UI.

### Visual changes

| Before | After |
| - | - |
| <img width="177" height="28" alt="image" src="https://github.com/user-attachments/assets/185fd3ca-a1f0-4cce-8898-27e41d051c27" /> | <img width="186" height="28" alt="image" src="https://github.com/user-attachments/assets/a476eac1-b18a-4479-9bab-405c6ea1eaea" />

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
