### PR TITLE
Remove unset HISTFILE from shell scripts

### DIFF
--- a/installers-conda/resources/post-install.sh
+++ b/installers-conda/resources/post-install.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -i
 set -e
-unset HISTFILE
 
 echo "*** Running post install script for ${INSTALLER_NAME} ..."
 

--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -56,7 +56,6 @@ def _get_user_env_script():
         script_text = dedent(
             f"""\
             #!{shell} -i
-            unset HISTFILE
             {shell} -l -c "'{sys.executable}' -c 'import os; print(dict(os.environ))'"
             """
         )


### PR DESCRIPTION
## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

This is removing all `unset HISTFILE` shell commands: when I update spyder and the post install script runs this triggers a malicious script alerts in crowdstrike (www.crowdstrike.com) and many questions from my security team.

Unsetting HISTFILE is not necessary to update sypder, so I am proposing to remove those.

Doc, for bash: https://www.gnu.org/software/bash/manual/bash.html#index-HISTFILE

### Issue(s) Resolved

See above.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: remisalmon