### PR TITLE
PR: Fix calling `_confirm_install` method in `UpdateManagerWidget`

### DIFF
--- a/spyder/plugins/updatemanager/widgets/update.py
+++ b/spyder/plugins/updatemanager/widgets/update.py
@@ -386,7 +386,7 @@ class UpdateManagerWidget(QWidget, SpyderConfigurationAccessor):
         """
         if self._validate_download():
             # Update already downloaded, start install
-            self.confirm_install()
+            self._confirm_install()
             return
 
         self.cancelled = False


### PR DESCRIPTION
@ccordoba12, sorry for the error, but there was one commit that was in the post1 builds but accidentally did not get pushed up on #25088 before it was merged.