### PR TITLE
PR: Fix several errors when closing remote consoles (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -2796,7 +2796,8 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):  # noqa: PLR090
             # We use the server name as hostname because for clients it's the
             # attribute used by the IPython console to set their tab name.
             hostname=jupyter_api.server_name,
-            # These values are not necessary at this point.
+            # These values are not necessary for the new remote development
+            # architecture.
             sshkey=None,
             password=None,
             # We save the jupyter_api in the client to perform on it operations

--- a/spyder/plugins/ipythonconsole/widgets/status.py
+++ b/spyder/plugins/ipythonconsole/widgets/status.py
@@ -144,9 +144,11 @@ class MatplotlibStatus(ShellConnectStatusBarWidget):
             # Fixes spyder-ide/spyder#22194
             # TimeoutError: Prevent error that seems to happen sporadically.
             # Fixes spyder-ide/spyder#24865
+            # RuntimeError: A remote console can be closed too quickly, which
+            # raises a "Kernel is dead" error from comms.
             try:
                 mpl_backend = shellwidget.get_matplotlib_backend()
-            except (CommError, TimeoutError):
+            except (CommError, TimeoutError, RuntimeError):
                 mpl_backend = None
 
         # Associate detected backend to shellwidget


### PR DESCRIPTION
## Description of Changes

- Fix error setting cwd when last closed console is remote.
- Catch connection reset error when connection is closed in websocket client.
- Catch error in Matplotlib status widget if console is closed too quickly.
- Fix error when closing remote files API (we were not checking separately if that API is closed before trying to do it).

### Issue(s) Resolved

Fixes #25120.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12.

<!--- Thanks for your help making Spyder better for everyone! --->
