### PR TITLE
PR: Restore Shortcuts as one of Application's optional plugins

### DIFF
--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -55,8 +55,9 @@ class Application(SpyderPluginV2):
         Plugins.IPythonConsole,
         Plugins.MainMenu,
         Plugins.StatusBar,
+        Plugins.Shortcuts,  # Needed to display the app context menu
         Plugins.Toolbar,
-        Plugins.UpdateManager,
+        Plugins.UpdateManager,  # Required in the confpage
     ]
     CONTAINER_CLASS = ApplicationContainer
     CONF_SECTION = 'main'


### PR DESCRIPTION
## Description of Changes

- That fixes an error when showing the application context menu.
- Also, add comments about plugins that are not needed for on_plugin_available methods.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #25133.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
