### PR TITLE
PR: Pin IPykernel to version 6 for pip tests (CI)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -72,6 +72,10 @@ else
     # To check our manifest
     pip install -q check-manifest
 
+    # Pin IPykernel to the last version 6 available because version 7 has some
+    # issues
+    pip install ipykernel==6.30.1
+
     # Pin Jedi to 0.19.1 because test_update_outline fails frequently with
     # 0.19.2, although it passes locally
     if [ "$OS" = "linux" ]; then


### PR DESCRIPTION
## Description of Changes

Some tests started to fail due to the release of IPykernel 7.0

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
