### PR TITLE
PR: Update menuinst to version 2.4 in installer base environment

### DIFF
--- a/installers-conda/resources/base_env.yml
+++ b/installers-conda/resources/base_env.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
   - python =3.11.13
   - conda =25.7.0
-  - menuinst =2.3.1
+  - menuinst =2.4
   - mamba =2.3.1  # Remove for Spyder 7
 platforms:
   - linux-64


### PR DESCRIPTION
Update `menuinst` to version 2.4 in the installer base environment.
See conda-forge/spyder-feedstock#264.