### PR TITLE
PR: Reset connection tasks after errors to allow re-tries (Remote client)

### DIFF
--- a/spyder/plugins/remoteclient/api/manager/base.py
+++ b/spyder/plugins/remoteclient/api/manager/base.py
@@ -326,11 +326,13 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
                 self.__connection_task.cancel()
                 abort_task.cancel()
                 self.__connection_task = None
+
                 self.logger.debug("Connection attempt aborted by user")
                 self._emit_connection_status(
                     ConnectionStatus.Inactive,
                     _("The connection attempt was cancelled"),
                 )
+
                 return False
 
             # Connection completed
@@ -345,6 +347,13 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
                 self.logger.exception(
                     "Error creating a new connection for %s", self.server_name
                 )
+
+                # Cancel and reset connection tasks to allow re-tries after
+                # errors
+                self.__connection_task.cancel()
+                abort_task.cancel()
+                self.__connection_task = None
+
                 self._emit_connection_status(
                     ConnectionStatus.Error,
                     _("There was an error establishing the connection"),


### PR DESCRIPTION
## Description of Changes

If there were errors when connecting to a remote machine, it was not possible to change the connection info to retry the connection again.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
