### PR TITLE
PR: Update `python-lsp-server` subrepo (`flake8` cmd on Windows fix) 

### DIFF
--- a/external-deps/python-lsp-server/.gitignore
+++ b/external-deps/python-lsp-server/.gitignore
@@ -100,6 +100,7 @@ ENV/
 
 # Spyder project settings
 .spyderproject
+.spyproject
 
 # Rope project settings
 .ropeproject

--- a/external-deps/python-lsp-server/.gitrepo
+++ b/external-deps/python-lsp-server/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/python-lsp/python-lsp-server.git
 	branch = develop
-	commit = 8c96441745876a104554450d779a3d01ac4e76dd
-	parent = 3a670e0e326ca226e8e21d931fc65b53863e9bbd
+	commit = 6a24326890964b56b8349b605ed76727f3502326
+	parent = b1eb96f846d1564e689ffb1c02ccaa93b1005471
 	method = merge
 	cmdver = 0.4.3

--- a/external-deps/python-lsp-server/CHANGELOG.md
+++ b/external-deps/python-lsp-server/CHANGELOG.md
@@ -1,5 +1,17 @@
 # History of changes
 
+## Version 1.13.1 (2025/08/26)
+
+### Pull Requests Merged
+
+* [PR 667](https://github.com/python-lsp/python-lsp-server/pull/667) - Use PyQt6 for testing, by [@WhyNotHugo](https://github.com/WhyNotHugo)
+* [PR 666](https://github.com/python-lsp/python-lsp-server/pull/666) - Expose a shutdown hook, by [@dlax](https://github.com/dlax)
+* [PR 663](https://github.com/python-lsp/python-lsp-server/pull/663) - Copy `LAST_JEDI_COMPLETIONS` to cell document so that `completionItem/resolve` will work, by [@hjr265](https://github.com/hjr265)
+
+In this release 3 pull requests were closed.
+
+----
+
 ## Version 1.13.0 (2025/07/07)
 
 ### New features

--- a/external-deps/python-lsp-server/README.md
+++ b/external-deps/python-lsp-server/README.md
@@ -2,8 +2,7 @@
 
 [![image](https://github.com/python-ls/python-ls/workflows/Linux%20tests/badge.svg)](https://github.com/python-ls/python-ls/actions?query=workflow%3A%22Linux+tests%22) [![image](https://github.com/python-ls/python-ls/workflows/Mac%20tests/badge.svg)](https://github.com/python-ls/python-ls/actions?query=workflow%3A%22Mac+tests%22) [![image](https://github.com/python-ls/python-ls/workflows/Windows%20tests/badge.svg)](https://github.com/python-ls/python-ls/actions?query=workflow%3A%22Windows+tests%22) [![image](https://img.shields.io/github/license/python-ls/python-ls.svg)](https://github.com/python-ls/python-ls/blob/master/LICENSE)
 
-A Python 3.8+ implementation of the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol).
-(Note: versions <1.4 should still work with Python 3.6)
+A Python 3.9+ implementation of the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol).
 
 ## Installation
 

--- a/external-deps/python-lsp-server/pylsp/hookspecs.py
+++ b/external-deps/python-lsp-server/pylsp/hookspecs.py
@@ -138,3 +138,8 @@ def pylsp_signature_help(config, workspace, document, position) -> None:
 @hookspec
 def pylsp_workspace_configuration_changed(config, workspace) -> None:
     pass
+
+
+@hookspec
+def pylsp_shutdown(config, workspace) -> None:
+    pass

--- a/external-deps/python-lsp-server/pylsp/plugins/flake8_lint.py
+++ b/external-deps/python-lsp-server/pylsp/plugins/flake8_lint.py
@@ -34,6 +34,13 @@ ERROR_CODES = (
     | {"E999"}
 )
 
+if sys.platform == "win32":
+    from subprocess import CREATE_NO_WINDOW
+else:
+    # CREATE_NO_WINDOW flag only available on Windows.
+    # Set constant as default `Popen` `creationflag` kwarg value (`0`)
+    CREATE_NO_WINDOW = 0
+
 
 @hookimpl
 def pylsp_settings():
@@ -128,7 +135,7 @@ def run_flake8(flake8_executable, args, document, source):
         )
 
     log.debug("Calling %s with args: '%s'", flake8_executable, args)
-    popen_kwargs = {}
+    popen_kwargs = {"creationflags": CREATE_NO_WINDOW}
     if cwd := document._workspace.root_path:
         popen_kwargs["cwd"] = cwd
     try:

--- a/external-deps/python-lsp-server/pylsp/python_lsp.py
+++ b/external-deps/python-lsp-server/pylsp/python_lsp.py
@@ -237,6 +237,7 @@ class PythonLSPServer(MethodDispatcher):
     def m_shutdown(self, **_kwargs) -> None:
         for workspace in self.workspaces.values():
             workspace.close()
+        self._hook("pylsp_shutdown")
         self._shutdown = True
 
     def m_invalid_request_after_shutdown(self, **_kwargs):
@@ -721,6 +722,12 @@ class PythonLSPServer(MethodDispatcher):
             for item in completions.get("items", []):
                 if item.get("data", {}).get("doc_uri") == temp_uri:
                     item["data"]["doc_uri"] = cellDocument.uri
+
+            # Copy LAST_JEDI_COMPLETIONS to cell document so that completionItem/resolve will work
+            tempDocument = workspace.get_document(temp_uri)
+            cellDocument.shared_data["LAST_JEDI_COMPLETIONS"] = (
+                tempDocument.shared_data.get("LAST_JEDI_COMPLETIONS", None)
+            )
 
             return completions
 

--- a/external-deps/python-lsp-server/pyproject.toml
+++ b/external-deps/python-lsp-server/pyproject.toml
@@ -10,7 +10,8 @@ name = "python-lsp-server"
 authors = [{name = "Python Language Server Contributors"}]
 description = "Python Language Server for the Language Server Protocol"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
 dependencies = [
     "docstring-to-markdown",
@@ -57,7 +58,7 @@ test = [
     "numpy",
     "pandas",
     "matplotlib",
-    "pyqt5",
+    "pyqt6",
     "flaky",
     "websockets>=10.3",
 ]
@@ -170,7 +171,6 @@ docstring-code-format = false
 docstring-code-line-length = "dynamic"
 
 [tool.setuptools]
-license-files = ["LICENSE"]
 include-package-data = false
 
 [tool.setuptools.packages.find]

--- a/external-deps/python-lsp-server/test/plugins/test_completion.py
+++ b/external-deps/python-lsp-server/test/plugins/test_completion.py
@@ -282,8 +282,8 @@ def test_jedi_method_completion(config, workspace) -> None:
     reason="Test in Python 3 and not on CIs on Linux because wheels don't work on them.",
 )
 def test_pyqt_completion(config, workspace) -> None:
-    # Over 'QA' in 'from PyQt5.QtWidgets import QApplication'
-    doc_pyqt = "from PyQt5.QtWidgets import QA"
+    # Over 'QA' in 'from PyQt6.QtWidgets import QApplication'
+    doc_pyqt = "from PyQt6.QtWidgets import QA"
     com_position = {"line": 0, "character": len(doc_pyqt)}
     doc = Document(DOC_URI, workspace, doc_pyqt)
     completions = pylsp_jedi_completions(config, doc, com_position)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

- Update `python-lsp-server` subrepo to check fix that prevents showing cmd on Windows when pylsp runs `flake8`
- Depends on https://github.com/python-lsp/python-lsp-server/pull/683

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #25195 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
