### PR TITLE
PR: Fix test at the end of `collectionseditor` module with Pillow 12 (Widgets)

### DIFF
--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -2423,8 +2423,7 @@ class CollectionsCustomSortFilterProxy(CustomSortFilterProxy):
 # =============================================================================
 def get_test_data():
     """Create test data."""
-    image = PIL.Image.fromarray(np.random.randint(256, size=(100, 100)),
-                                mode='P')
+    image = PIL.Image.fromarray(255 * np.random.rand(100, 100))
     testdict = {'d': 1, 'a': np.random.rand(10, 10), 'b': [1, 2]}
     testdate = datetime.date(1945, 5, 8)
     test_timedelta = datetime.timedelta(days=-1, minutes=42, seconds=13)
@@ -2490,7 +2489,7 @@ def get_test_data():
             'timedelta_pd': test_pd_td,
             'datetimeindex': test_dtindex,
             'series': test_series,
-            'ddataframe': test_df,
+            'dataframe': test_df,
             'None': None,
             'unsupported1': np.arccos,
             'unsupported2': np.asarray,


### PR DESCRIPTION
## Description of Changes

The test started to fail a few hours ago after that Pillow version was added to Conda-forge.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
