### PR TITLE
PR: Don't get pyflakes value from config to prevent flickering when processing code analysis markers info (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
@@ -203,6 +203,7 @@ class LSPMixin:
         self.formatting_in_progress = False
         self.symbols_in_sync = False
         self.folding_in_sync = False
+        self.pyflakes_linting_enabled = True
 
     # ---- Helper private methods
     # -------------------------------------------------------------------------
@@ -611,11 +612,8 @@ class LSPMixin:
             if "analysis:ignore" in text:
                 continue
 
-            # This only works for Python.
-            pyflakes = ("provider_configuration", "lsp", "values", "pyflakes")
-            if self.language == "Python" and self.get_conf(
-                pyflakes, section="completions"
-            ):
+            # This only works for Python and it's only needed with pyflakes.
+            if self.language == "Python" and self.pyflakes_linting_enabled:
                 if NOQA_INLINE_REGEXP.search(text) is not None:
                     continue
 

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -787,6 +787,16 @@ class EditorStack(QWidget, SpyderWidgetMixin):
         self.send_to_help(name, help_text, force=True)
 
     # ---- Editor Widget Settings
+    @on_conf_change(
+        option=("provider_configuration", "lsp", "values", "pyflakes"),
+        section='completions',
+    )
+    def on_pyflakes_enabled_change(self, value):
+        if self.data:
+            for finfo in self.data:
+                if finfo.editor.is_python_like():
+                    finfo.editor.pyflakes_linting_enabled = value
+
     @on_conf_change(section='help', option='connect/editor')
     def on_help_connection_change(self, value):
         self.set_help_enabled(value)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes
<!--- Explain what you've done and why --->

Prevent trying to get config value in the CodeEditor method related with conde analysis processing to prevent code analysis markers flickering. For a more detailed explanation see https://github.com/spyder-ide/spyder/issues/25208#issuecomment-3458088901


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #25208


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
