### PR TITLE
PR: Set autofit to `False` if no plots are left when removing a thumbnail (Plots)

### DIFF
--- a/spyder/plugins/plots/widgets/figurebrowser.py
+++ b/spyder/plugins/plots/widgets/figurebrowser.py
@@ -1058,8 +1058,9 @@ class ThumbnailScrollBar(QFrame):
                     min(index, len(self._thumbnails) - 1)
                 )
             else:
-                self.figure_viewer.figcanvas.clear_canvas()
                 self.current_thumbnail = None
+                self.figure_viewer.auto_fit_plotting = False
+                self.figure_viewer.figcanvas.clear_canvas()
 
         # Hide and close thumbnails
         self.layout().removeWidget(thumbnail)
@@ -1068,7 +1069,8 @@ class ThumbnailScrollBar(QFrame):
 
         # See: spyder-ide/spyder#12459
         QTimer.singleShot(
-            150, lambda: self._remove_thumbnail_parent(thumbnail))
+            150, lambda: self._remove_thumbnail_parent(thumbnail)
+        )
 
     def _remove_thumbnail_parent(self, thumbnail):
         try:


### PR DESCRIPTION
## Description of Changes

This change is necessary to prevent the autofit action to be left as toggled when a single plot is shown in Plots and it's removed.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
