### PR TITLE
PR: Fix connecting loop when any connection fails before tcp (Remote client)

### DIFF
--- a/spyder/plugins/remoteclient/api/manager/base.py
+++ b/spyder/plugins/remoteclient/api/manager/base.py
@@ -250,6 +250,11 @@ class SpyderRemoteAPIManagerBase(metaclass=ABCMeta):
         try:
             if await self._start_remote_server():
                 self.__starting_event.set()
+                # emit signal that connection and server are established
+                if self._plugin:
+                    self._plugin.sig_connection_established.emit(
+                        self.config_id
+                    )
                 return True
         finally:
             self.__starting_server = False

--- a/spyder/plugins/remoteclient/api/ssh.py
+++ b/spyder/plugins/remoteclient/api/ssh.py
@@ -30,10 +30,6 @@ class SpyderSSHClient(SSHClient):
         :type conn: :class:`SSHClientConnection`
 
         """
-        if self.client._plugin:
-            self.client._plugin.sig_connection_established.emit(
-                self.client.config_id
-            )
 
     def connection_lost(self, exc: Optional[Exception]) -> None:
         """Called when a connection is lost or closed


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
Only emit connection stablished signal when the remote server is succesfully started, instead when only TCP connections is made.
This prevents inifnite re-connecting loop when there is TCP connection but any other error happened after, as any attached slots will try to reconnect again.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:  @hlouzada

<!--- Thanks for your help making Spyder better for everyone! --->
