### PR TITLE
PR: Correct color in `interrupt and debug` icon and remove typos in some color definitions

### DIFF
--- a/spyder/images/svg/interrupt_and_debug.svg
+++ b/spyder/images/svg/interrupt_and_debug.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="24" height="24">
-    <path d="M2.012 1.998v14h4.277v-5.87c0-1.35 1.507-1.97 2.711-1.142l7 4.81V2Z" class="ICON_1"/>
+    <path d="M2.012 1.998v14h4.277v-5.87c0-1.35 1.507-1.97 2.711-1.142l7 4.81V2Z" class="ICON_4"/>
     <path d="M9 11.99v10l7.254-5zm8.87 0v10h1.976v-10zm4.153 0v10H24v-10z" class="ICON_2"/>
 </svg>

--- a/spyder/utils/color_system.py
+++ b/spyder/utils/color_system.py
@@ -43,7 +43,7 @@ class Red:
     B120 = '#FEDDDA'
     B130 = '#FFEEEE'
     B140 = '#FFF5F5'
-    B150 = '##FFFFFF'
+    B150 = '#FFFFFF'
 
 
 class Orange:
@@ -62,7 +62,7 @@ class Orange:
     B120 = '#FFEACA'
     B130 = '#FFF3E2'
     B140 = '#FFFBF5'
-    B150 = '##FFFFFF'
+    B150 = '#FFFFFF'
 
 
 class GroupDark:


### PR DESCRIPTION
## Description of Changes
- Changed variable ICON_1 for ICON_4 in `spyder/images/svg/interrupt_and_debug.svg`
- Removed extra `#` in some color definitions at `spyder/utils/color_system.py`

## Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@conradolandia 
<!--- Thanks for your help making Spyder better for everyone! --->
