### PR TITLE
PR: Fix resetting JupyterHub info in new connection page (Remote client)

### DIFF
--- a/spyder/plugins/remoteclient/widgets/connectionpages.py
+++ b/spyder/plugins/remoteclient/widgets/connectionpages.py
@@ -929,7 +929,7 @@ class NewConnectionPage(BaseConnectionPage):
             self.ssh_widget.layout().setCurrentWidget(ssh_clean_info_widget)
 
             jupyterhub_clean_info_widget = (
-                self.create_ssh_connection_info_widget()
+                self.create_jupyterhub_connection_info_widget()
             )
             self.jupyterhub_widget.layout().addWidget(
                 jupyterhub_clean_info_widget


### PR DESCRIPTION
## Description of Changes

Clicking the `Clear` button in the Remote connections dialog when the JupyterHub tab is selected was showing a fresh set of SSH widgets. Now it shows JupyterHub widgets instead.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
