### PR TITLE
PR: Expand environment variables passed to the kernel on Windows (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -250,6 +250,10 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
         """Setter for environment variables for kernels"""
         env_vars = dict(env_vars)
         if os.name == "nt":
+            # Expand variables in case some are unexpanded.
+            # Fixes spyder-ide/spyder#25275
+            env_vars = {k: osp.expandvars(v) for k, v in env_vars.items()}
+
             # Use case insensitive dictionary
             env_vars = CaseInsensitiveDict(env_vars)
 


### PR DESCRIPTION
## Description of Changes

In some systems the kernel fails to start due to env vars like `TEMP` being unexpanded.

### Issue(s) Resolved

Fixes #25275.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
