### PR TITLE
PR: Complete connection file name from id if it's not an absolute path (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
+++ b/spyder/plugins/ipythonconsole/widgets/kernelconnect.py
@@ -257,10 +257,11 @@ class KernelConnectionDialog(QDialog, SpyderConfigurationAccessor):
 
         try:
             # We do this so that users can paste only the kernel id
-            if not cf_filename.startswith("kernel-"):
-                cf_filename = "kernel-" + cf_filename
-            if not cf_filename.endswith(".json"):
-                cf_filename += ".json"
+            if not cf_path:
+                if not cf_filename.startswith("kernel-"):
+                    cf_filename = "kernel-" + cf_filename
+                if not cf_filename.endswith(".json"):
+                    cf_filename += ".json"
 
             connection_file = find_connection_file(
                 filename=cf_filename, path=cf_path if cf_path else None


### PR DESCRIPTION
## Description of Changes

* In the `Connect to existing kernel` dialog, we allow to pass the kernel id for simplicity, from which we build a connection file name of the form `kernel-id.json`.
* But that's only necessary when the connection file is not an absolute path.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #25337

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
