### PR TITLE
PR: Fix printing with PyQt6 (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -1937,13 +1937,16 @@ class EditorMainWidget(PluginMainWidget):
         self._print_editor.set_font(self._font)
 
         # Create printer
-        printer = SpyderPrinter(mode=QPrinter.HighResolution,
-                                header_font=self._font)
+        printer = SpyderPrinter(
+            mode=QPrinter.PrinterMode.HighResolution, header_font=self._font
+        )
         print_dialog = QPrintDialog(printer, self._print_editor)
 
         # Adjust print options when user has selected text
         if editor.has_selected_text():
-            print_dialog.setOption(QAbstractPrintDialog.PrintSelection, True)
+            print_dialog.setOption(
+                QAbstractPrintDialog.PrintDialogOption.PrintSelection, True
+            )
 
             # Copy selection from current editor to print editor
             cursor_1 = editor.textCursor()
@@ -1979,8 +1982,9 @@ class EditorMainWidget(PluginMainWidget):
         self._print_editor.set_font(self._font)
 
         # Create printer
-        printer = SpyderPrinter(mode=QPrinter.HighResolution,
-                                header_font=self._font)
+        printer = SpyderPrinter(
+            mode=QPrinter.PrinterMode.HighResolution, header_font=self._font
+        )
 
         # Create preview
         preview = SpyderPrintPreviewDialog(printer, self)

--- a/spyder/widgets/printer.py
+++ b/spyder/widgets/printer.py
@@ -18,11 +18,13 @@ from spyder.utils.stylesheet import PANES_TOOLBAR_STYLESHEET
 
 # TODO: Implement header and footer support
 class SpyderPrinter(QPrinter):
-    def __init__(self, mode=QPrinter.PrinterMode.ScreenResolution,
-                 header_font=None):
+
+    def __init__(
+        self, mode=QPrinter.PrinterMode.ScreenResolution, header_font=None
+    ):
         QPrinter.__init__(self, mode)
-        self.setColorMode(QPrinter.Color)
-        self.setPageOrder(QPrinter.FirstPageFirst)
+        self.setColorMode(QPrinter.ColorMode.Color)
+        self.setPageOrder(QPrinter.PageOrder.FirstPageFirst)
         self.date = time.ctime()
         if header_font is not None:
             self.header_font = header_font


### PR DESCRIPTION
## Description of Changes

The failure was caused by accessing some unscoped enums, which doesn't work in PyQt6.

### Issue(s) Resolved

Fixes #25332.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
