### PR TITLE
PR: Use `macos-14` image to run our tests on Mac (CI)

### DIFF
--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -54,7 +54,7 @@ jobs:
     # Use this to disable the workflow
     # if: false
     name: Mac - Py${{ matrix.PYTHON_VERSION }}, ${{ matrix.INSTALL_TYPE }}, ${{ matrix.TEST_TYPE }}
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       CI: 'true'
       QTCONSOLE_TESTING: 'true'


### PR DESCRIPTION
## Description of Changes

This is because the `macos-13` image will be removed in a couple of weeks.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
