### PR TITLE
PR: Use `macos-15-intel` for macOS x86_64 installers because `macos-13` is deprecated

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -81,7 +81,7 @@ jobs:
       run: |
         if [[ $BUILD_MAC == "true" ]]; then
             target_platform="'osx-64'"
-            include="{'os': 'macos-13', 'target-platform': 'osx-64', 'spyk-arch': 'unix'}"
+            include="{'os': 'macos-15-intel', 'target-platform': 'osx-64', 'spyk-arch': 'unix'}"
         fi
         if [[ $BUILD_ARM == "true" ]]; then
             target_platform=${target_platform:+"$target_platform, "}"'osx-arm64'"


### PR DESCRIPTION
Use macos-15-intel for x86_64 installers because macos-13 is deprecated