### PR TITLE
PR: Prevent error when profiling is stopped (Profiler)

### DIFF
--- a/spyder/plugins/profiler/widgets/main_widget.py
+++ b/spyder/plugins/profiler/widgets/main_widget.py
@@ -540,7 +540,7 @@ class ProfilerWidget(ShellConnectMainWidget):
 
     def _stop_profiling(self):
         widget = self.current_widget()
-        if widget is None:
+        if widget is None or self.is_current_widget_error_message():
             return
 
         if widget.is_profiling:


### PR DESCRIPTION
## Description of Changes

That's run when the kernel is ready and it seems the associated signal is emitted in some cases even when the kernel fails to start.

### Issue(s) Resolved

Fixes #25327.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
