### PR TITLE
PR: Use short name path on Windows for `TMP` and `TEMP` environment variables in kernelspec (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/kernelspec.py
+++ b/spyder/plugins/ipythonconsole/utils/kernelspec.py
@@ -12,10 +12,11 @@ Kernel spec for Spyder kernels
 import logging
 import os
 import os.path as osp
+
 try:
     from win32api import GetShortPathName
-except ImportError:
-    pass
+except Exception:
+    GetShortPathName = None
 
 # Third party imports
 from jupyter_client.kernelspec import KernelSpec
@@ -269,10 +270,11 @@ class SpyderKernelSpec(KernelSpec, SpyderConfigurationAccessor):
 
             # Use short path name for temporary directories in case path has
             # spaces. See spyder-ide/spyder#25403
-            if "tmp" in env_vars:
-                env_vars["tmp"] = GetShortPathName(env_vars["tmp"])
-            if "temp" in env_vars:
-                env_vars["temp"] = GetShortPathName(env_vars["temp"])
+            if GetShortPathName is not None:
+                if "tmp" in env_vars:
+                    env_vars["tmp"] = GetShortPathName(env_vars["tmp"])
+                if "temp" in env_vars:
+                    env_vars["temp"] = GetShortPathName(env_vars["temp"])
 
         # User variables supersede system variables
         for k, v in os.environ.items():


### PR DESCRIPTION
Fix issue where IPython consoles fail to start if the username has spaces on Windows.

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Use the short path name on Windows for `TMP` and `TEMP` environment variables.

#23761 changed the environment variable preference order for `KernelSpec.env` from HKLM to HKCU.
If the user name has spaces, then this could result in the `TMP` and `TEMP` environment variables to also have spaces, if defined in HKCU. Some downstream mechanism (`spyder-kernels`, `traitlets`, or `jupyter_client`) then cannot find the generated kernel file, e.g. `%USERPROFILE%\AppData\roaming\jupyter\runtime\kernel-*.json` resulting in the console failing to start. Note that the kernel file is correctly created, but just not found.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #25403
