### PR TITLE
PR: Add & revise docstrings in the `spyder.api.config` module

### DIFF
--- a/spyder/api/config/decorators.py
+++ b/spyder/api/config/decorators.py
@@ -57,7 +57,7 @@ def on_conf_change(
         def method(self, value: Any):
             ...
 
-    when observing a single value or the whole section and
+    when observing a single value or the whole section, and
 
     .. code-block:: python
 
@@ -71,7 +71,7 @@ def on_conf_change(
     func: Callable | None, optional
         Method to decorate, passed automatically when applying the decorator.
     section: str | None, optional
-        Name of the configuration whose option to observe for changes.
+        Name of the configuration section to observe for changes.
         If ``None``, then the ``CONF_SECTION`` attribute of the class
         where the method defined is used.
     option: ConfigurationKeyOrList | None, optional

--- a/spyder/api/config/mixins.py
+++ b/spyder/api/config/mixins.py
@@ -247,7 +247,7 @@ class SpyderConfigurationAccessor:
 
     @property
     def old_spyder_conf_version(self) -> str:
-        """Get previous verison of the Spyder configuration system.
+        """Get previous version of the Spyder configuration system.
 
         Returns
         -------
@@ -261,10 +261,7 @@ class SpyderConfigurationAccessor:
 
 class SpyderConfigurationObserver(SpyderConfigurationAccessor):
     """
-    Methods to recieve and respond to changes in Spyder's configuration.
-
-    Concrete implementation of the protocol
-    :class:`spyder.config.types.ConfigurationObserver`.
+    Methods to receive and respond to changes in Spyder's configuration.
 
     This mixin enables a class to receive configuration updates seamlessly,
     by registering methods using the
@@ -342,7 +339,7 @@ class SpyderConfigurationObserver(SpyderConfigurationAccessor):
                     self._add_listener(method_name, option, section)
 
     def _merge_none_observers(self):
-        """Replace observers of section ``None`` with ``CONF_SECTION``."""
+        """Replace section ``None`` with ``CONF_SECTION`` in observers."""
         default_selectors = self._configuration_listeners.get(None, {})
         section_selectors = self._configuration_listeners.get(
             self.CONF_SECTION, {}
@@ -370,7 +367,7 @@ class SpyderConfigurationObserver(SpyderConfigurationAccessor):
         func: Callable
             Function/method that will be called when ``option`` changes.
         option: spyder.config.types.ConfigurationKey
-            Name of the configuration option to observe.
+            Name/tuple path of the configuration option to observe.
         section: str
             Name of the section containing ``option``, e.g. ``"shortcuts"``.
 
@@ -393,7 +390,7 @@ class SpyderConfigurationObserver(SpyderConfigurationAccessor):
         Parameters
         ----------
         option: spyder.config.types.ConfigurationKey
-            Name of the configuration option that changed.
+            Name/tuple path of the configuration option that changed.
         section: str
             Name of the section containing ``option``, e.g. ``"shortcuts"``.
         value: BasicTypes
@@ -428,7 +425,7 @@ class SpyderConfigurationObserver(SpyderConfigurationAccessor):
         func: Callable
             Function/method that will be called when ``option`` changes.
         option: spyder.config.types.ConfigurationKey
-            Name of the configuration option to observe.
+            Name/tuple path of the configuration option to observe.
         section: str | None, optional
             Name of the section containing ``option``, e.g. ``"shortcuts"``.
             If ``None``, then the value of


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] ~Added unit test(s) covering the changes (if testable)~
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] ~Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))~


<!--- Explain what you've done and why --->

Required by spyder-ide/spyder-api-docs#16

* Thoroughly revise the docstring content for the `spyder.api.config` modules:
	* Ensure all modules and APIs have a proper summary line
	* Document un(der) documented public APIs
	* Greatly clarify and expand existing descriptions
	* Add all param, return and attribute types to both signatures and docstrings
	* Fix and clarify many instances of missing, incorrect or unclear param types in the signature and docstrings related to parameters accepting `None` and/or having a default value, and clarify in the docstring what that value is and its meaning.
	* Add and fix Sphinx roles and directives throughout
	* Fix all Sphinx broken references in the affected modules
* Additionally, perform related and opportunistic refactoring and cleanup in the touched modules:
	- Replace aliases in the `typing` module deprecated in Python 3.9 or before with their `collections.abc` equivalents in signatures and docstrings, and `typing.Union` with `|` where possible.
	- Add explicit return types to functions returning `None`, for clarity and consistency in the code, docs and type checkers.
	- Add explicit TypeAlias type to type aliases for clarity, to avoid edge cases in type checkers and to ensure they are recognized by the latest Sphinx
	- Update the file header across touched files in `spyder.api` to remove the obsolete encoding pragma and use the modern standard license header format form our governance and guidelines repo
	- Blacken touched lines/files where not already formatted


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM-Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
