### PR TITLE
PR: Remove translation call for variable on `QInputDialogCombobox` (Explorer)

### DIFF
--- a/spyder/plugins/explorer/widgets/explorer.py
+++ b/spyder/plugins/explorer/widgets/explorer.py
@@ -226,7 +226,7 @@ class QInputDialogCombobox(QDialog):
         grid_layout.addWidget(QLabel(label), 0, 0)
         grid_layout.addWidget(self.text_edit, 1, 0)
 
-        combo_label = QLabel(_(label_combo))
+        combo_label = QLabel(label_combo)
         self.combo = SpyderComboBox(self)
         self.combo.addItems(items)
         grid_layout.addWidget(combo_label, 0, 1)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

A warning/error was generated while doing the compilation of translations strings:

    *** /home/daniel/Documents/spyder/spyder/plugins/explorer/widgets/explorer.py:229: Seen unexpected token "label_combo"

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
