### PR TITLE
PR: Increase max number of plots shown by default in Plots (Config)

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -229,7 +229,7 @@ DEFAULTS = [
              {
               'mute_inline_plotting': True,
               'show_plot_outline': False,
-              'max_plots': 30,
+              'max_plots': 50,
              }),
             ('editor',
              {


### PR DESCRIPTION
## Description of Changes

After talking about this internally, we decided to increase the number to 50 to prevent users confusion in case they generate a lot of plots in a single execution and don't see all of them in the pane.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
