### PR TITLE
Fix Jedi completion fuzzy config doesn't work

### DIFF
--- a/spyder/config/lsp.py
+++ b/spyder/config/lsp.py
@@ -86,7 +86,8 @@ PYTHON_CONFIG = {
                     'include_params': False,
                     'include_class_objects': False,
                     'include_function_objects': False,
-                    'fuzzy': False,
+                    # Set fuzzy default True
+                    'fuzzy': True,
                 },
                 'jedi_definition': {
                     'enabled': True,

--- a/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
@@ -721,6 +721,14 @@ class LSPMixin:
             if len(word) > 0:
                 first_letter = word[0]
 
+            # Get providers order for new sort key
+            from collections import OrderedDict
+            providers_order = {key: index for index, key in enumerate(
+                list(OrderedDict.fromkeys(
+                    [completion["provider"] for completion in completions]
+                ))
+            )}
+
             def sort_key(completion):
                 if "textEdit" in completion:
                     text_insertion = completion["textEdit"]["newText"]
@@ -728,12 +736,30 @@ class LSPMixin:
                     text_insertion = completion["insertText"]
 
                 first_insert_letter = text_insertion[0]
-                case_mismatch = (
-                    first_letter.isupper() and first_insert_letter.islower()
-                ) or (first_letter.islower() and first_insert_letter.isupper())
 
-                # False < True, so case matches go first
-                return (case_mismatch, completion["sortText"])
+                # New sort key
+                # 1: provider order
+                # 2: same case > same letter > orders
+                # 3: sortText 
+                if first_letter == first_insert_letter:
+                    return (
+                        providers_order[completion["provider"]],
+                        0,
+                        completion["sortText"]
+                    )
+                
+                if first_letter.lower() == first_insert_letter.lower():
+                    return (
+                        providers_order[completion["provider"]],
+                        1,
+                        completion["sortText"]
+                    )
+                
+                return (
+                        providers_order[completion["provider"]],
+                        2,
+                        completion["sortText"]
+                    )
 
             completion_list = sorted(completions, key=sort_key)
 

--- a/spyder/plugins/editor/widgets/completion.py
+++ b/spyder/plugins/editor/widgets/completion.py
@@ -442,7 +442,8 @@ class CompletionWidget(QListWidget, SpyderConfigurationAccessor):
         if not current_word:
             return True
 
-        return str(filter_text).lower().startswith(str(current_word).lower())
+        # Allow suggestions not starts with current word
+        return True
 
     def is_position_correct(self):
         """Check if the position is correct."""


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
1. Modify the config of python-lsp-server in spyder\config\lsp.py. Set the fuzzy config of jedi_completion default True.
2. Modify the check_can_complete function in spyder\plugins\editor\widgets\completion.py. Allow completion suggestions do not start with current word.
3. Modify the process_completion method in spyder\plugins\editor\widgets\codeeditor\lsp_mixin.py. Use a new sort key for fuzzy completion suggestions. 
<img width="985" height="430" alt="fuzzy_completion" src="https://github.com/user-attachments/assets/9243c8e7-d261-4f4a-a58e-4e9fa5b896dc" />


<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #11535


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
mossisnotwhy
<!--- Thanks for your help making Spyder better for everyone! --->
