### PR TITLE
PR: Fix `test_get_calltips` for Numpy 2.4.0+ (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -83,7 +83,7 @@ def test_banners(ipyconsole, qtbot):
     [("np.arange",  # Check we get the signature from the object's docstring
       ["start", "stop"],
       ["Return evenly spaced values within a given interval.<br>",
-       "open interval<br>..."]),
+       "positional arguments:<br>..."]),
      ("np.vectorize",  # Numpy function with a proper signature
       ["pyfunc", "otype", "signature"],
       ["Returns an object that acts like pyfunc, but takes<br>arrays as input."
@@ -112,10 +112,14 @@ def test_banners(ipyconsole, qtbot):
       ["My function"])
      ]
 )
-@pytest.mark.skipif(running_in_ci() and not os.name == 'nt',
-                    reason="Times out on macOS and fails on Linux")
-@pytest.mark.skipif(parse(np.__version__) < parse('1.25.0'),
-                    reason="Documentation for np.vectorize is different")
+@pytest.mark.skipif(
+    running_in_ci() and not os.name == 'nt',
+    reason="Times out on macOS and fails on Linux"
+)
+@pytest.mark.skipif(
+    parse(np.__version__) < parse('2.4.0'),
+    reason="Documentation for np.arange is different"
+)
 def test_get_calltips(ipyconsole, qtbot, function, signature, documentation):
     """Test that calltips show the documentation."""
     shell = ipyconsole.get_current_shellwidget()


### PR DESCRIPTION
## Description of Changes

That test started to fail due to a change in the `np.arange` docs in that version.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
