### PR TITLE
PR: Allow to do searches with Enter key in `FindReplace` widget (Widgets)

### DIFF
--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -307,7 +307,7 @@ class FindReplace(QWidget, SpyderShortcutsMixin):
             key = event.key()
             shift = event.modifiers() & Qt.ShiftModifier
 
-            if key == Qt.Key_Return:
+            if key in (Qt.Key_Return, Qt.Key_Enter):
                 if shift:
                     self.return_shift_pressed.emit()
                 else:


### PR DESCRIPTION
## Description of Changes

That corresponds to the key labeled `Intro` among the numpad keys.

### Issue(s) Resolved

Fixes #25553.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
