### PR TITLE
PR: Fix recursion issue when getting environment variables on Linux

### DIFF
--- a/spyder/utils/environ.py
+++ b/spyder/utils/environ.py
@@ -59,9 +59,12 @@ def _get_user_env_script():
             #!{shell} -i
             unset HISTFILE
 
-            # PackageKit-command-not-found package can cause recursion, so unset it here
-            # See spyder-ide/spyder#24716
-            type command_not_found_handle &>/dev/null && unset -f command_not_found_handle
+            # PackageKit's `command-not-found` package can cause recursion, so
+            # unset it here.
+            # Fixes spyder-ide/spyder#24716
+            if type command_not_found_handle >/dev/null 2>&1; then
+                unset -f command_not_found_handle
+            fi
 
             {shell} -l -c "'{sys.executable}' -c 'import os; print(dict(os.environ))'"
             """


### PR DESCRIPTION
PackageKit command-not-found package causes recursion when using the interactive flag in bash scripts.

Unset `command_not_found_handle` function inside `user-env.sh` script.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #24716
