### PR TITLE
PR: Show "Searching..." in `ResultsBrowser` title when search starts (Find)

### DIFF
--- a/spyder/plugins/findinfiles/widgets/results_browser.py
+++ b/spyder/plugins/findinfiles/widgets/results_browser.py
@@ -259,9 +259,9 @@ class ResultsBrowser(OneColumnTree, SpyderFontsMixin):
         self.files = {}
         self.set_sorting(OFF)
         self.search_text = search_text
-        title = "'%s' - " % search_text
-        text = _('String not found')
-        self.set_title(title + text)
+
+        # See spyder-ide/spyder#25575 for the rationale to select this title
+        self.set_title(f"'{search_text}' - " + _("Searching..."))
 
     def set_title(self, title):
         # Prevent the title's width to be bigger than the widget's one.


### PR DESCRIPTION
## Description of Changes

- And only show "String not found" there if the search failed or it was stopped and no result was found.
- That makes the UI clearer for users.

### Visual changes

![better-ui-for-find](https://github.com/user-attachments/assets/4caa968a-b8e2-4325-b237-ea6feeadeb04)

### Issue(s) Resolved

Fixes #25565

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
