### PR TITLE
PR: Omit log message when opening `PyVista` objects in the Variable Explorer

### DIFF
--- a/spyder/plugins/console/widgets/main_widget.py
+++ b/spyder/plugins/console/widgets/main_widget.py
@@ -388,13 +388,19 @@ class ConsoleWidget(PluginMainWidget):
         label = error_data.get("label", "")
         steps = error_data.get("steps", "")
 
-        omit_messages = [
+        benign_messages = [
+            # Skip log message when opening PyVista objects in the Variable
+            # Explorer.
+            # Fixes spyder-ide/spyder#21639
             "ERROR:root:No data to measure...!\n",
         ]
 
         # Skip errors without traceback (and no text) or dismiss
-        if ((not text and not is_traceback and self.error_dlg is None)
-                or self.dismiss_error or text in omit_messages):
+        if (
+            (not text and not is_traceback and self.error_dlg is None)
+            or self.dismiss_error
+            or text in benign_messages
+        ):
             return
 
         InstallerInternalError(title + text)


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->
Fix Opening a PyVista object can cause the error report dialog to be shown




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #21639 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@jsbautista 
<!--- Thanks for your help making Spyder better for everyone! --->
