### PR TITLE
PR: Show warning when trying to open remote files in the Editor (Files)

### DIFF
--- a/spyder/plugins/explorer/widgets/remote_explorer.py
+++ b/spyder/plugins/explorer/widgets/remote_explorer.py
@@ -30,6 +30,7 @@ from spyder.api.config.decorators import on_conf_change
 from spyder.api.translations import _
 from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.config.base import get_conf_path
+from spyder.config.utils import EDIT_EXTENSIONS
 from spyder.plugins.editor.utils.editor import get_default_file_content
 from spyder.plugins.remoteclient.api.modules.base import (
     SpyderRemoteSessionClosed,
@@ -333,6 +334,19 @@ class RemoteExplorer(QWidget, SpyderWidgetMixin):
             data_type = data["type"]
             if data_type == "directory":
                 self.chdir(data_name, emit=True)
+            elif (
+                data_type == "file"
+                and os.path.splitext(data_name)[1] in EDIT_EXTENSIONS
+            ):
+                QMessageBox.warning(
+                    self,
+                    _("Unsupported functionality"),
+                    _(
+                        "Opening remote files in the Editor is not yet "
+                        "supported. This feature will be added in Spyder "
+                        "6.2.0"
+                    )
+                )
             elif data_type == "ACTION" and data_name == "FETCH_MORE":
                 self.fetch_more_files()
 


### PR DESCRIPTION
## Description of Changes

The message is shown when users double-click on a remote file that has an extension that can be handled by the Editor (e.g. `.py` or `.txt`).

### Visual changes

<img width="507" height="139" alt="image" src="https://github.com/user-attachments/assets/31a98ba2-e073-483b-b995-3acf97339a5f" />

### Issue(s) Resolved

Fixes #25571 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
