### PR TITLE
PR: Do not create console at startup if there's an active project (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -704,10 +704,7 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
                 client.show_kernel_connection_error()
             else:
                 self.create_client_for_kernel(cf_path, give_focus=False)
-        elif (
-            projects is not None
-            and projects.get_conf('current_project_path', default=None)
-        ):
+        elif projects is not None and projects.get_active_project():
             # If there is a current project path, the Projects plugin will
             # start a console
             pass


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

At Spyder launch, if the Projects plugin is active and loading a previous project, the IPython console plugin will not start a console.

This prevents a console being started _before_ the Projects plugin is ready and unnecessarily restarting the console when the Projects plugin becomes ready.