### PR TITLE
PR: Prevent error when Spyder is closed while a project is loaded and the paths provided by `fzf` are processed (Projects)

### DIFF
--- a/spyder/plugins/projects/widgets/main_widget.py
+++ b/spyder/plugins/projects/widgets/main_widget.py
@@ -1124,10 +1124,18 @@ class ProjectExplorerWidget(PluginMainWidget):
         # List of results with absolute path
         if relative_path_list != ['']:
             project_path = self.get_active_project_path()
-            result_list = [
-                osp.normpath(os.path.join(project_path, path))
-                for path in relative_path_list
-            ]
+
+            # If Spyder is closed while a project is loaded at startup,
+            # project_path can become None. So, we need to check for that
+            # possibility.
+            # Fixes spyder-ide/spyder#25636
+            if project_path is not None:
+                result_list = [
+                    osp.normpath(os.path.join(project_path, path))
+                    for path in relative_path_list
+                ]
+            else:
+                result_list = []
         else:
             result_list = []
 


### PR DESCRIPTION
## Description of Changes

This was happening because processing the `fzf` results is done asynchronously.

### Issue(s) Resolved

Fixes #25636.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
