### PR TITLE
PR: Fix issue where custom conda executable could not be selected on macOS or Linux

### DIFF
--- a/spyder/plugins/maininterpreter/confpage.py
+++ b/spyder/plugins/maininterpreter/confpage.py
@@ -133,7 +133,7 @@ class MainInterpreterConfigPage(PluginConfigPage):
         conda_path = self.create_browsefile(
             "",
             'conda_path',
-            filters='*.exe',
+            filters=filters,
             validate_callback=validate_conda,
             validate_reason=_(
                 "The selected file is not a valid Conda executable"


### PR DESCRIPTION
The file explorer dialog box had filters set for Windows only and not the correct ones for macOS and Linux.