### PR TITLE
PR: Fix a couple of issues when trying to display Numpy arrays and Pandas dataframes with a mismatch of versions

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
@@ -161,8 +161,7 @@ class NamepaceBrowserWidget(RichJupyterWidget):
                 # kernel 3.10-, or the other way around. In that case,
                 # cloudpickle can't deserialize the objects sent from the
                 # kernel and we need to inform users about it.
-                # Fixes spyder-ide/spyder#24125.
-                # Fixes spyder-ide/spyder#24950.
+                # Fixes spyder-ide/spyder#24125 and spyder-ide/spyder#24950.
                 py_spyder_version = ".".join(
                     [str(n) for n in sys.version_info[:3]]
                 )
@@ -232,7 +231,7 @@ class NamepaceBrowserWidget(RichJupyterWidget):
             if not kernel_call_success:
                 name = e.args[0].error.name
                 reason = reason_missing_package_target.format(name)
-            elif e.name.startswith('numpy._core') and not is_conda_based_app():
+            elif e.name.startswith('numpy._core'):
                 reason = reason_mismatched_numpy
             elif e.name == 'pandas.core.indexes.numeric':
                 reason = reason_mismatched_pandas_2


### PR DESCRIPTION
## Description of Changes

- Show Numpy mismatch error for standalone installers. The related problem can happen when users are working with an external environment that has Numpy 1, so we must show that message for our installers too.
- Catch error when trying to display a Pandas dataframe created in an environment with version 3 when Spyder's environment has Pandas 2.

### Issue(s) Resolved

Fixes #25666
Fixes #25589

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
