### PR TITLE
Fix Variable Explorer PicklingError for deeply nested objects

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
+++ b/spyder/plugins/ipythonconsole/widgets/namespacebrowser.py
@@ -275,6 +275,15 @@ class NamepaceBrowserWidget(RichJupyterWidget):
             else:
                 raise ValueError(msg_without_note % reason)
         except Exception:
+            # Safety net: check if the exception is a dynamically-created
+            # PicklingError from the comm layer that didn't match the
+            # pickle.PicklingError type above.
+            # Fixes spyder-ide/spyder#25699
+            exc_type = sys.exc_info()[0]
+            if exc_type is not None and exc_type.__name__ in (
+                "PicklingError", "UnpicklingError"
+            ):
+                raise ValueError(msg % reason_not_picklable)
             raise ValueError(msg % reason_other)
 
     def set_value(self, name, value):


### PR DESCRIPTION
## Description

Fixes #25699 — Variable Explorer throws "An unknown error occurred, sorry" when clicking on lists, dictionaries, or Pandas DataFrames that require deep recursion to pickle.

## Root Cause

A 3-layer failure in the error handling chain:

1. **Kernel side** (`kernel.py`): `cloudpickle.dumps(value)` raises `pickle.PicklingError` for deeply nested structures with no fallback.
2. **Comm layer** (`commbase.py`): `from_json()` reconstructs the error type using `getattr(builtins, "PicklingError", ...)`. Since `PicklingError` is NOT in `builtins`, a dynamically-created class inheriting from `Exception` (not `pickle.PicklingError`) is created.
3. **Frontend** (`namespacebrowser.py`): `except (PicklingError, ...)` catches `pickle.PicklingError`, but the dynamically-created class doesn't match, so the error falls through to the generic `except Exception` handler showing the unhelpful message.

## Changes

### 1. `commbase.py` — Fix exception type reconstruction
`from_json()` now resolves exception types from well-known modules (`pickle`, `_pickle`) before falling back to `builtins`/dynamic creation. This ensures `pickle.PicklingError` raised in the kernel is properly reconstructed on the Spyder side.

### 2. `kernel.py` — Add recursion limit fallback
`get_value()` now catches `PicklingError`/`RecursionError` on the first pickle attempt and retries with a temporarily increased recursion limit (10x), allowing most normal objects (lists, dicts, DataFrames) that happen to be moderately deep to succeed.

### 3. `namespacebrowser.py` — Safety net in generic handler
The final `except Exception` block now checks the exception's class name. If it's `PicklingError` or `UnpicklingError` (even from a dynamically-created class), it shows the proper "not picklable" message instead of "unknown error."