### PR TITLE
PR: Fix `KeyError` when using Run or Run Configuration actions

### DIFF
--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -1780,6 +1780,9 @@ class EditorMainWidget(PluginMainWidget):
 
         current_es.set_current_filename(finfo.filename)
 
+        # Prevent KeyError when closing all files and not giving focus to
+        # the untitled one that is created before running it.
+        # Fixes spyder-ide/spyder#23299
         if self.editorstacks[0].get_stack_count() == 1:
             self.update_run_focus_file()
 


### PR DESCRIPTION
## Description of Changes

Fix `KeyError` when using Run or Run Configuration action under certain conditions. See commit message for details.

Fixes #23299.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

rear1019