### PR TITLE
PR: Pin specific Python versions for Linux tests (CI)

### DIFF
--- a/.github/workflows/test-linux-qt6.yml
+++ b/.github/workflows/test-linux-qt6.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         INSTALL_TYPE: ['pip']  # conda has no PyQt6 package
-        PYTHON_VERSION: ['3.10']
+        PYTHON_VERSION: ['3.10.19']
         TEST_TYPE: ['fast', 'slow']
         SPYDER_QT_BINDING: ['pyqt6'] # TODO add 'pyside6' once Spyder supports it
     timeout-minutes: 90

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         INSTALL_TYPE: ['pip', 'conda']
-        PYTHON_VERSION: ['3.9', '3.12']
+        PYTHON_VERSION: ['3.9', '3.12.12']
         TEST_TYPE: ['fast', 'slow']
         exclude:
           # Only test Python 3.9 with pip to save CI time

--- a/.github/workflows/test-remoteclient.yml
+++ b/.github/workflows/test-remoteclient.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         INSTALL_TYPE: ['pip', 'conda']
-        PYTHON_VERSION: ['3.9', '3.12']
+        PYTHON_VERSION: ['3.9', '3.12.12']
         exclude:
           - INSTALL_TYPE: 'conda'  # `python-lsp-ruff` conda-forge package `python_min` is 3.10
             PYTHON_VERSION: '3.9'


### PR DESCRIPTION
## Description of Changes

Newer versions of Python 3.10 and 3.12 released by Conda-forge break some pip packages (like `defusedxml`) with strange undefined symbols errors.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
