### PR TITLE
PR: Add initial implementation of a combobox that shows available connections (Remote client)

### DIFF
--- a/spyder/plugins/remoteclient/widgets/connectioncombobox.py
+++ b/spyder/plugins/remoteclient/widgets/connectioncombobox.py
@@ -45,10 +45,11 @@ class ConnectionComboBox(SpyderComboBox, SpyderConfigurationAccessor):
     @staticmethod
     def create_combobox(
         label: str = _("Server:"),
+        parent: QWidget | None = None,
         items_elide_mode: Qt.TextElideMode | None = None,
         item_template: str = "{server_name}",
         default_item: tuple = (_("Local"), None),
-    ):
+    ) -> QWidget:
         """
         Create a connection combobox instance inside a layout with a label.
 
@@ -57,20 +58,22 @@ class ConnectionComboBox(SpyderComboBox, SpyderConfigurationAccessor):
         label : str, optional
             Text to use for label in the left side of the combobox.
             The default is _("Server:").
+        parent : QWidget, optional
+            Parent widget to set. The default is None.
         items_elide_mode : Qt.TextElideMode, optional
             Elide mode items should use. The default is None.
-        item_template : TYPE, optional
+        item_template : str, optional
             Template to use when creating an item label. The default is "{server_name}".
-        default_item : TYPE, optional
+        default_item : tuple, optional
             Default item to add to the combobox. The default is (_("Local"), None).
 
         Returns
         -------
-        TYPE
-            DESCRIPTION.
+        QWidget
+            Wrapper widget containing label and actual combobox widgets.
         """
         layout = QHBoxLayout()
-        widget = QWidget(self)
+        widget = QWidget(parent)
         widget.label = QLabel(label)
         widget.combobox = ConnectionComboBox(
             parent=widget,
@@ -85,7 +88,7 @@ class ConnectionComboBox(SpyderComboBox, SpyderConfigurationAccessor):
 
         return widget
 
-    def get_current_server_id(self):
+    def get_current_server_id(self) -> str:
         return self.currentData()
 
     # ---- Private API
@@ -109,7 +112,7 @@ class ConnectionComboBox(SpyderComboBox, SpyderConfigurationAccessor):
             self.addItem(item_text, server_id)
 
 
-def test():
+def test() -> None:
     import sys
 
     from spyder.utils.qthelpers import qapplication


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

Adds a new combobox class that handles logic to show as items the currently ~active~ available connections. This is an initial step to handle being able to create/open projects in remote machines. The data associated with each item is the server/connection id or `None` (in case of the default item referencing a local project which will be defined as default when instanciating the combobox from the Projects logic). A test function definition is added in the bottom of the new widget file definition to showcase the possible usage.

A preview running the example available withing the new connections combobox widget file in a setup with a couple of connections saved:

![connections_combobox](https://github.com/user-attachments/assets/c546b66e-13d7-43fa-b67c-4213e68d48f4)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #12828 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
