### PR TITLE
PR: Prevent bringing main window to the front when showing hint from undocked editor window (Widgets)

### DIFF
--- a/spyder/widgets/calltip.py
+++ b/spyder/widgets/calltip.py
@@ -57,10 +57,10 @@ class ToolTipWidget(QLabel):
         """
         Shows tooltips that can be styled with the different themes.
         """
-        # Don't set parent on Windows to prevent bringing the mainwindow to the
-        # front even when the trigger comes from another top-level window
+        # Don't set parent on Windows to prevent bringing the main window to
+        # the front even when the trigger comes from another top-level window.
         # (i.e undocked pane).
-        # See spyder-ide/spyder#25605
+        # Fixes spyder-ide/spyder#25605
         super().__init__(None if os.name == "nt" else parent, Qt.ToolTip)
 
         # Variables


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


A preview:

![undock_editor_tooltip_hint](https://github.com/user-attachments/assets/fb7a3d36-5e63-423c-a199-5a7fa9edf982)


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #25605 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
