### PR TITLE
PR: Add a `Close all viewers` action to the Variable Explorer

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -491,6 +491,21 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
         except RuntimeError:
             pass
 
+    def close_all_editors(self):
+        """Close all opened non-modal editor dialogs."""
+        for editor_id, data in list(self._editors.items()):
+            editor = data.get('editor')
+            if editor is None:
+                self._editors.pop(editor_id, None)
+                continue
+
+            try:
+                editor.reject()
+            except RuntimeError:
+                pass
+            finally:
+                self._editors.pop(editor_id, None)
+
     def commitAndCloseEditor(self):
         """Overriding method commitAndCloseEditor"""
         editor = self.sender()

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -200,8 +200,8 @@ class VariableExplorerWidget(ShellConnectMainWidget):
 
         close_all_editors_action = self.create_action(
             VariableExplorerWidgetActions.CloseAllEditors,
-            _("Close all editors"),
-            icon=self.create_icon('close_pane'),
+            _("Close all viewers"),
+            icon=self.create_icon("filecloseall"),
             triggered=self.close_all_editors
         )
 
@@ -330,8 +330,13 @@ class VariableExplorerWidget(ShellConnectMainWidget):
 
         # Main toolbar
         main_toolbar = self.get_main_toolbar()
-        for item in [import_data_action, save_action, save_as_action,
-                     reset_namespace_action, close_all_editors_action]:
+        for item in [
+            import_data_action,
+            save_action,
+            save_as_action,
+            reset_namespace_action,
+            close_all_editors_action,
+        ]:
             self.add_item_to_toolbar(
                 item,
                 toolbar=main_toolbar,

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -47,6 +47,7 @@ class VariableExplorerWidgetActions:
     # Resize
     ResizeRowsAction = 'resize_rows_action'
     ResizeColumnsAction = 'resize_columns_action'
+    CloseAllEditors = 'close_all_editors_action'
 
 
 class VariableExplorerWidgetOptionsMenuSections:
@@ -197,6 +198,12 @@ class VariableExplorerWidget(ShellConnectMainWidget):
             triggered=self.resize_columns
         )
 
+        close_all_editors_action = self.create_action(
+            VariableExplorerWidgetActions.CloseAllEditors,
+            _("Close all editors"),
+            triggered=self.close_all_editors
+        )
+
         self.paste_action = self.create_action(
             VariableExplorerContextMenuActions.PasteAction,
             _("Paste"),
@@ -309,7 +316,11 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         self._enable_filter_actions(self.get_conf('filter_on'))
 
         # Resize
-        for item in [resize_rows_action, resize_columns_action]:
+        for item in [
+            resize_rows_action,
+            resize_columns_action,
+            close_all_editors_action,
+        ]:
             self.add_item_to_menu(
                 item,
                 menu=options_menu,
@@ -615,6 +626,13 @@ class VariableExplorerWidget(ShellConnectMainWidget):
     def resize_columns(self):
         if self._current_editor is not None:
             self._current_editor.resize_column_contents()
+
+    def close_all_editors(self):
+        for index in range(self.count()):
+            nsb = self._stack.widget(index)
+            editor = getattr(nsb, 'editor', None)
+            if editor is not None:
+                editor.close_all_editors()
 
     def paste(self):
         self._current_editor.paste()

--- a/spyder/plugins/variableexplorer/widgets/main_widget.py
+++ b/spyder/plugins/variableexplorer/widgets/main_widget.py
@@ -201,6 +201,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         close_all_editors_action = self.create_action(
             VariableExplorerWidgetActions.CloseAllEditors,
             _("Close all editors"),
+            icon=self.create_icon('close_pane'),
             triggered=self.close_all_editors
         )
 
@@ -330,7 +331,7 @@ class VariableExplorerWidget(ShellConnectMainWidget):
         # Main toolbar
         main_toolbar = self.get_main_toolbar()
         for item in [import_data_action, save_action, save_as_action,
-                     reset_namespace_action]:
+                     reset_namespace_action, close_all_editors_action]:
             self.add_item_to_toolbar(
                 item,
                 toolbar=main_toolbar,

--- a/spyder/plugins/variableexplorer/widgets/tests/test_collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_collectionsdelegate.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+#
+
+"""Tests for collectionsdelegate.py."""
+
+# Local imports
+from spyder.plugins.variableexplorer.widgets.collectionsdelegate import (
+    CollectionsDelegate,
+)
+
+
+class MockEditor:
+    def __init__(self):
+        self.rejected = False
+
+    def reject(self):
+        self.rejected = True
+
+
+def test_close_all_editors():
+    """Test all tracked non-modal editors are closed."""
+    delegate = CollectionsDelegate()
+
+    editor_1 = MockEditor()
+    editor_2 = MockEditor()
+    delegate._editors = {
+        id(editor_1): {"editor": editor_1},
+        id(editor_2): {"editor": editor_2},
+    }
+
+    delegate.close_all_editors()
+
+    assert editor_1.rejected
+    assert editor_2.rejected
+    assert not delegate._editors

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -2240,6 +2240,10 @@ class RemoteCollectionsEditorTableView(BaseTableView):
             QMessageBox.critical(self, _("Error"), "TypeError: %s" % str(e))
         self.namespacebrowser.refresh_namespacebrowser()
 
+    def close_all_editors(self):
+        """Close all editors opened from this table view."""
+        self.delegate.close_all_editors()
+
     def remove_values(self, names):
         """Remove values from data"""
         for name in names:


### PR DESCRIPTION
## Description
- add a new Close all editors action to the Variable Explorer options menu
- wire the action to close all opened non-modal editor windows across Variable Explorer namespace browsers
- expose a helper on RemoteCollectionsEditorTableView to close delegate-managed editor windows
- add a focused test for CollectionsDelegate.close_all_editors()

Part of #25844

## Testing
- python -m pytest spyder/plugins/variableexplorer/widgets/tests/test_collectionsdelegate.py -q