### PR TITLE
PR: Only increase scrollflag width for macOS when not launched through an application bundle (Editor)

### DIFF
--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -11,6 +11,7 @@ Scroll flag panel for the editor.
 # Standard library imports
 import logging
 from math import ceil
+import os
 import sys
 
 # Third party imports
@@ -34,10 +35,21 @@ REFRESH_RATE = 1000
 # Maximum number of flags to paint in a file
 MAX_FLAGS = 1000
 
+_cfbundleid = os.getenv("__CFBundleIdentifier", "")
 
 class ScrollFlagArea(Panel):
     """Source code editor's scroll flag area"""
-    WIDTH = 24 if sys.platform == 'darwin' else 12
+
+    WIDTH = 12
+    if (
+        sys.platform == "darwin"
+        and not _cfbundleid.startswith("org.spyder-ide")
+    ):
+        # Increase width of scroll flag area on macOS when not launched from
+        # an application bundle so that it is not hidden by the scroll bars.
+        # Expects "AppleShowScrollBars Always" to be written to defaults for
+        # the application bundle ID. spyder-ide/spyder#13118
+        WIDTH =24
     FLAGS_DX = 4
     FLAGS_DY = 2
 

--- a/spyder/plugins/editor/panels/scrollflag.py
+++ b/spyder/plugins/editor/panels/scrollflag.py
@@ -37,6 +37,7 @@ MAX_FLAGS = 1000
 
 _cfbundleid = os.getenv("__CFBundleIdentifier", "")
 
+
 class ScrollFlagArea(Panel):
     """Source code editor's scroll flag area"""
 
@@ -49,7 +50,9 @@ class ScrollFlagArea(Panel):
         # an application bundle so that it is not hidden by the scroll bars.
         # Expects "AppleShowScrollBars Always" to be written to defaults for
         # the application bundle ID. spyder-ide/spyder#13118
-        WIDTH =24
+        # the application bundle ID.
+        # See spyder-ide/spyder#13118
+        WIDTH = 24
     FLAGS_DX = 4
     FLAGS_DY = 2
 


### PR DESCRIPTION

## Description of Changes

Only increase scrollflag width for macOS when not launched through an application bundle.

See also conda-forge/spyder-feedstock#282

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #13118
