### PR TITLE
PR: Fix JupyterHub connection error message misspelling (Remote Client)

### DIFF
--- a/spyder/plugins/remoteclient/api/manager/jupyterhub.py
+++ b/spyder/plugins/remoteclient/api/manager/jupyterhub.py
@@ -196,7 +196,7 @@ class SpyderRemoteJupyterHubAPIManager(SpyderRemoteAPIManagerBase):
             self._emit_version_mismatch(version)
             self._emit_connection_status(
                 status=ConnectionStatus.Error,
-                message=_("Error staring the remote server"),
+                message=_("Error starting the remote server"),
             )
             return False
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

While checking spanish translations on Crowdin noticed a misspelling in JupyterHub error messages (`staring` instead of `starting`)

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
