### PR TITLE
PR: Do not copy spyder.ico file to Scripts directory on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,8 +96,6 @@ def get_data_files():
                       ('share/icons', ['img_src/spyder.png']),
                       ('share/metainfo',
                        ['scripts/org.spyder_ide.spyder.appdata.xml'])]
-    elif os.name == 'nt':
-        data_files = [('scripts', ['img_src/spyder.ico'])]
     else:
         data_files = []
 


### PR DESCRIPTION
Do not copy spyder.ico file to Scripts directory on Windows so that we can have a full noarch build.
