### PR TITLE
PR: Remove shortcut to clear multiple cursors with the `Esc` key (Editor)

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -554,7 +554,6 @@ DEFAULTS = [
               'editor/run selection in debugger': CTRL + '+F9',
               'editor/add cursor up': 'Alt+Shift+Up',
               'editor/add cursor down': 'Alt+Shift+Down',
-              'editor/clear extra cursors': 'Esc',
               # -- Internal console --
               'internal_console/inspect current object': "Ctrl+I",
               'internal_console/clear shell': "Ctrl+L",
@@ -726,4 +725,4 @@ NAME_MAP = {
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = '87.6.0'
+CONF_VERSION = '88.0.0'

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -683,7 +683,6 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
                 self.enter_array_table)),
             ('add cursor up', self.add_cursor_up),
             ('add cursor down', self.add_cursor_down),
-            ('clear extra cursors', self.clear_extra_cursors)
         )
 
         for name, callback in shortcuts:
@@ -3589,6 +3588,8 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
         # of multiple overwrite cursors. Must unset overwrite before return.
         self.setOverwriteMode(self.overwrite_mode)
         self.start_cursor_blink()  # reset cursor blink by reseting timer
+
+        # Handle key press events when using extra cursors
         if self.extra_cursors:
             self.handle_multi_cursor_keypress(event)
             self.setOverwriteMode(False)
@@ -3644,6 +3645,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
         if text not in self.auto_completion_characters:
             if text in operators or text in delimiters:
                 self.completion_widget.hide()
+
         if key in (Qt.Key_Enter, Qt.Key_Return):
             if not shift and not ctrl:
                 if (

--- a/spyder/plugins/editor/widgets/codeeditor/multicursor_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/multicursor_mixin.py
@@ -285,6 +285,12 @@ class MultiCursorMixin:
             self.overwrite_mode = not self.overwrite_mode
             return
 
+        # ---- Handle Esc
+        if key == Qt.Key_Escape:
+            self.clear_extra_cursors()
+            self.sig_key_pressed.emit(event)
+            return
+
         self.textCursor().beginEditBlock()
         self.multi_cursor_ignore_history = True
 


### PR DESCRIPTION
## Description of Changes

- That was preventing to use `Esc` for other tasks, like hiding calltips.
- Instead, we handle `Esc` directly in the multicursor keypress method.

### Issue(s) Resolved

Fixes #25198.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
