### PR TITLE
PR: Add `Close all` button to Variable Explorer editors

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -207,7 +207,8 @@ DEFAULTS = [
               'show_remove_message_dataframe': True,
               'show_remove_message_collections': True,
               'show_special_attributes': False,
-              'filter_on': True
+              'filter_on': True,
+              'ask_close_all_editors': True
              }),
             ('debugger',
              {

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -20,8 +20,16 @@ from typing import Callable, Optional, TYPE_CHECKING
 
 # Third party imports
 from qtpy.compat import from_qvariant, to_qvariant
-from qtpy.QtCore import (QAbstractTableModel, QItemSelection, QLocale,
-                         QItemSelectionRange, QModelIndex, Qt, Slot, Signal)
+from qtpy.QtCore import (
+    QAbstractTableModel,
+    QItemSelection,
+    QItemSelectionRange,
+    QLocale,
+    QModelIndex,
+    Qt,
+    Signal,
+    Slot,
+)
 from qtpy.QtGui import QColor, QCursor, QDoubleValidator, QKeySequence
 from qtpy.QtWidgets import (
     QAbstractItemDelegate, QApplication, QDialog, QHBoxLayout, QInputDialog,
@@ -742,7 +750,9 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
         self.dim_indexes = [{}, {}, {}]
         self.last_dim = 0  # Adjust this for changing the startup dimension
 
-    def setup_and_check(self, data, title='', readonly=False, from_variable_explorer=False):
+    def setup_and_check(
+        self, data, title='', readonly=False, from_variable_explorer=False
+    ):
         """
         Setup the editor.
 

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -21,7 +21,7 @@ from typing import Callable, Optional, TYPE_CHECKING
 # Third party imports
 from qtpy.compat import from_qvariant, to_qvariant
 from qtpy.QtCore import (QAbstractTableModel, QItemSelection, QLocale,
-                         QItemSelectionRange, QModelIndex, Qt, Slot)
+                         QItemSelectionRange, QModelIndex, Qt, Slot, Signal)
 from qtpy.QtGui import QColor, QCursor, QDoubleValidator, QKeySequence
 from qtpy.QtWidgets import (
     QAbstractItemDelegate, QApplication, QDialog, QHBoxLayout, QInputDialog,
@@ -58,6 +58,7 @@ class ArrayEditorActions:
     Preferences = 'preferences_action'
     Refresh = 'refresh_action'
     Resize = 'resize_action'
+    CloseAllEditors = 'close_all_editors_action'
 
 
 class ArrayEditorMenus:
@@ -703,6 +704,8 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
 
     CONF_SECTION = 'variable_explorer'
 
+    sig_close_all_editors_requested = Signal()
+
     def __init__(
         self,
         parent: Optional[QWidget] = None,
@@ -800,6 +803,12 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
             triggered=do_nothing,
             register_action=False
         )
+        self.close_all_editors_action = self.create_action(
+            name=ArrayEditorActions.CloseAllEditors,
+            text=_("Close all viewers"),
+            icon=self.create_icon("filecloseall"),
+            triggered=self.sig_close_all_editors_requested.emit
+        )
 
         # ---- Toolbar and options menu
 
@@ -824,8 +833,8 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
             register=False
         )
         stretcher = self.create_stretcher(ArrayEditorWidgets.ToolbarStretcher)
-        for item in [stretcher, self.resize_action, self.refresh_action,
-                     options_button]:
+        for item in [self.close_all_editors_action,stretcher,
+                     self.resize_action, self.refresh_action, options_button]:
             self.add_item_to_toolbar(item, toolbar)
 
         toolbar.render()

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -742,16 +742,16 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
         self.dim_indexes = [{}, {}, {}]
         self.last_dim = 0  # Adjust this for changing the startup dimension
 
-    def setup_and_check(self, data, title='', readonly=False):
+    def setup_and_check(self, data, title='', readonly=False, from_variable_explorer=False):
         """
         Setup the editor.
 
         It returns False if data is not supported, True otherwise.
         """
-        self.setup_ui(title, readonly)
+        self.setup_ui(title, readonly, from_variable_explorer)
         return self.set_data_and_check(data, readonly)
 
-    def setup_ui(self, title='', readonly=False):
+    def setup_ui(self, from_variable_explorer, title='', readonly=False):
         """
         Create the user interface.
 
@@ -809,6 +809,7 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
             icon=self.create_icon("filecloseall"),
             triggered=self.sig_close_all_editors_requested.emit
         )
+        self.close_all_editors_action.setVisible(from_variable_explorer)
 
         # ---- Toolbar and options menu
 

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -833,8 +833,13 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
             register=False
         )
         stretcher = self.create_stretcher(ArrayEditorWidgets.ToolbarStretcher)
-        for item in [self.close_all_editors_action,stretcher,
-                     self.resize_action, self.refresh_action, options_button]:
+        for item in [
+            self.close_all_editors_action,
+            stretcher,
+            self.resize_action,
+            self.refresh_action,
+            options_button
+        ]:
             self.add_item_to_toolbar(item, toolbar)
 
         toolbar.render()

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -748,7 +748,7 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
 
         It returns False if data is not supported, True otherwise.
         """
-        self.setup_ui(title, readonly, from_variable_explorer)
+        self.setup_ui(from_variable_explorer, title, readonly)
         return self.set_data_and_check(data, readonly)
 
     def setup_ui(self, from_variable_explorer, title='', readonly=False):

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -244,6 +244,7 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
                 parent=parent,
                 data_function=self.make_data_function(index)
             )
+            editor.sig_close_all_editors_requested.connect(self.close_all_editors)
             if not editor.setup_and_check(value, title=key, readonly=readonly):
                 self.sig_editor_shown.emit()
                 return

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -42,8 +42,6 @@ from qtpy.QtWidgets import (
     QStyleOptionButton,
     QTableView,
 )
-from spyder.config.base import running_under_pytest
-from spyder.config.manager import CONF
 from spyder_kernels.comms.commbase import CommsErrorWrapper
 from spyder_kernels.utils.lazymodules import (
     FakeObject, numpy as np, pandas as pd, PIL)
@@ -51,8 +49,10 @@ from spyder_kernels.utils.nsview import (display_to_value, is_editable_type,
                                          is_known_type)
 
 # Local imports
+from spyder.api.config.mixins import SpyderConfigurationAccessor
 from spyder.api.fonts import SpyderFontsMixin, SpyderFontType
 from spyder.api.translations import _
+from spyder.config.base import running_under_pytest
 from spyder.plugins.variableexplorer.widgets.arrayeditor import ArrayEditor
 from spyder.plugins.variableexplorer.widgets.dataframeeditor import (
     DataFrameEditor)
@@ -73,7 +73,11 @@ MAX_INT_BIT_LENGTH_FOR_EDITING = (
 )
 
 
-class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
+class CollectionsDelegate(
+    QItemDelegate,
+    SpyderConfigurationAccessor,
+    SpyderFontsMixin,
+):
     """CollectionsEditor Item Delegate"""
     sig_free_memory_requested = Signal()
     sig_editor_creation_started = Signal()
@@ -231,7 +235,9 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
             )
             editor.setup(value, key, icon=self.parent().windowIcon(),
                          readonly=readonly)
-            editor.sig_close_all_editors_requested.connect(self.close_all_editors)
+            editor.sig_close_all_editors_requested.connect(
+                self.close_all_editors
+            )
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
                                             key=key, readonly=readonly))
             return None
@@ -244,7 +250,9 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
                 parent=parent,
                 data_function=self.make_data_function(index)
             )
-            editor.sig_close_all_editors_requested.connect(self.close_all_editors)
+            editor.sig_close_all_editors_requested.connect(
+                self.close_all_editors
+            )
             if not editor.setup_and_check(value, title=key, readonly=readonly):
                 self.sig_editor_shown.emit()
                 return
@@ -498,19 +506,28 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
 
     def close_all_editors(self):
         """Close all opened non-modal editor dialogs."""
-        ask_close_all_editors = CONF.get('variable_explorer', 'ask_close_all_editors')
+        ask_close_all_editors = self.get_conf(
+            "ask_close_all_editors", section="variable_explorer"
+        )
         close_all = True
         if ask_close_all_editors and not running_under_pytest():
-            message = MessageCheckBox(icon=QMessageBox.Question, parent=self.parent())
+            message = MessageCheckBox(
+                icon=QMessageBox.Question, parent=self.parent()
+            )
             message.set_checkbox_text(_("Don't ask again."))
             message.set_checked(False)
             message.set_check_visible(True)
             message.setText(_('Are you sure you want to close all editors?'))
             message.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+
             result = message.exec_()
             check = message.is_checked()
             if check:
-                CONF.set('variable_explorer', 'ask_close_all_editors', not check)
+                self.set_conf(
+                    "ask_close_all_editors",
+                    not check,
+                    section="variable_explorer",
+                )
             close_all = result == QMessageBox.Yes
 
         if not close_all:
@@ -815,7 +832,9 @@ class ToggleColumnDelegate(CollectionsDelegate):
             )
             editor.setup(value, key, icon=self.parent().windowIcon(),
                          readonly=readonly)
-            editor.sig_close_all_editors_requested.connect(self.close_all_editors)
+            editor.sig_close_all_editors_requested.connect(
+                self.close_all_editors
+            )
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
                                             key=key, readonly=readonly))
             return None

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -230,7 +230,7 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
                 data_function=self.make_data_function(index)
             )
             editor.setup(value, key, icon=self.parent().windowIcon(),
-                         readonly=readonly)
+                         readonly=readonly, from_variable_explorer=True)
             editor.sig_close_all_editors_requested.connect(self.close_all_editors)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
                                             key=key, readonly=readonly))
@@ -245,7 +245,10 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
                 data_function=self.make_data_function(index)
             )
             editor.sig_close_all_editors_requested.connect(self.close_all_editors)
-            if not editor.setup_and_check(value, title=key, readonly=readonly):
+            if not editor.setup_and_check(value,
+                                          title=key,
+                                          readonly=readonly,
+                                          from_variable_explorer=True):
                 self.sig_editor_shown.emit()
                 return
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
@@ -291,7 +294,8 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
                 data_function=self.make_data_function(index),
                 readonly=readonly
             )
-            if not editor.setup_and_check(value, title=key):
+            editor.sig_close_all_editors_requested.connect(self.close_all_editors)
+            if not editor.setup_and_check(value, title=key, from_variable_explorer=True):
                 self.sig_editor_shown.emit()
                 return
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
@@ -814,7 +818,7 @@ class ToggleColumnDelegate(CollectionsDelegate):
                 data_function=self.make_data_function(index)
             )
             editor.setup(value, key, icon=self.parent().windowIcon(),
-                         readonly=readonly)
+                         readonly=readonly, from_variable_explorer=True)
             editor.sig_close_all_editors_requested.connect(self.close_all_editors)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
                                             key=key, readonly=readonly))

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -43,6 +43,7 @@ from qtpy.QtWidgets import (
     QTableView,
 )
 from spyder.config.base import running_under_pytest
+from spyder.config.manager import CONF
 from spyder_kernels.comms.commbase import CommsErrorWrapper
 from spyder_kernels.utils.lazymodules import (
     FakeObject, numpy as np, pandas as pd, PIL)
@@ -496,11 +497,10 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
 
     def close_all_editors(self):
         """Close all opened non-modal editor dialogs."""
-        ask_close_all_editors = (
-            ask_close_all_editors and self.get_conf('ask_close_all_editors'))
+        ask_close_all_editors = CONF.get('variable_explorer', 'ask_close_all_editors')
         close_all = True
         if ask_close_all_editors and not running_under_pytest():
-            message = MessageCheckBox(icon=QMessageBox.Question, parent=self)
+            message = MessageCheckBox(icon=QMessageBox.Question, parent=self.parent())
             message.set_checkbox_text(_("Don't ask again."))
             message.set_checked(False)
             message.set_check_visible(True)
@@ -509,7 +509,7 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
             result = message.exec_()
             check = message.is_checked()
             if check:
-                self.set_conf('ask_close_all_editors', not check)
+                CONF.set('variable_explorer', 'ask_close_all_editors', not check)
             close_all = result == QMessageBox.Yes
 
         if not close_all:

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -253,10 +253,12 @@ class CollectionsDelegate(
             editor.sig_close_all_editors_requested.connect(
                 self.close_all_editors
             )
-            if not editor.setup_and_check(value,
-                                          title=key,
-                                          readonly=readonly,
-                                          from_variable_explorer=True):
+            if not editor.setup_and_check(
+                value,
+                title=key,
+                readonly=readonly,
+                from_variable_explorer=True
+            ):
                 self.sig_editor_shown.emit()
                 return
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
@@ -302,8 +304,12 @@ class CollectionsDelegate(
                 data_function=self.make_data_function(index),
                 readonly=readonly
             )
-            editor.sig_close_all_editors_requested.connect(self.close_all_editors)
-            if not editor.setup_and_check(value, title=key, from_variable_explorer=True):
+            editor.sig_close_all_editors_requested.connect(
+                self.close_all_editors
+            )
+            if not editor.setup_and_check(
+                value, title=key, from_variable_explorer=True
+            ):
                 self.sig_editor_shown.emit()
                 return
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
@@ -514,11 +520,12 @@ class CollectionsDelegate(
             "ask_close_all_editors", section="variable_explorer"
         )
         close_all = True
+
         if ask_close_all_editors and not running_under_pytest():
             message = MessageCheckBox(
                 icon=QMessageBox.Question, parent=self.parent()
             )
-            message.set_checkbox_text(_("Don't ask again."))
+            message.set_checkbox_text(_("Don't ask again"))
             message.set_checked(False)
             message.set_check_visible(True)
             message.setText(_('Are you sure you want to close all editors?'))
@@ -532,10 +539,12 @@ class CollectionsDelegate(
                     not check,
                     section="variable_explorer",
                 )
+
             close_all = result == QMessageBox.Yes
 
         if not close_all:
             return
+
         for editor_id, data in list(self._editors.items()):
             editor = data.get('editor')
             if editor is None:

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -42,6 +42,7 @@ from qtpy.QtWidgets import (
     QStyleOptionButton,
     QTableView,
 )
+from spyder.config.base import running_under_pytest
 from spyder_kernels.comms.commbase import CommsErrorWrapper
 from spyder_kernels.utils.lazymodules import (
     FakeObject, numpy as np, pandas as pd, PIL)
@@ -56,6 +57,7 @@ from spyder.plugins.variableexplorer.widgets.dataframeeditor import (
     DataFrameEditor)
 from spyder.plugins.variableexplorer.widgets.texteditor import TextEditor
 from spyder.utils.icon_manager import ima
+from spyder.widgets.helperwidgets import MessageCheckBox
 
 
 LARGE_COLLECTION = 1e5
@@ -228,6 +230,7 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
             )
             editor.setup(value, key, icon=self.parent().windowIcon(),
                          readonly=readonly)
+            editor.sig_close_all_editors_requested.connect(self.close_all_editors)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
                                             key=key, readonly=readonly))
             return None
@@ -493,12 +496,29 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
 
     def close_all_editors(self):
         """Close all opened non-modal editor dialogs."""
+        ask_close_all_editors = (
+            ask_close_all_editors and self.get_conf('ask_close_all_editors'))
+        close_all = True
+        if ask_close_all_editors and not running_under_pytest():
+            message = MessageCheckBox(icon=QMessageBox.Question, parent=self)
+            message.set_checkbox_text(_("Don't ask again."))
+            message.set_checked(False)
+            message.set_check_visible(True)
+            message.setText(_('Are you sure you want to close all editors?'))
+            message.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+            result = message.exec_()
+            check = message.is_checked()
+            if check:
+                self.set_conf('ask_close_all_editors', not check)
+            close_all = result == QMessageBox.Yes
+
+        if not close_all:
+            return
         for editor_id, data in list(self._editors.items()):
             editor = data.get('editor')
             if editor is None:
                 self._editors.pop(editor_id, None)
                 continue
-
             try:
                 editor.reject()
             except RuntimeError:
@@ -794,6 +814,7 @@ class ToggleColumnDelegate(CollectionsDelegate):
             )
             editor.setup(value, key, icon=self.parent().windowIcon(),
                          readonly=readonly)
+            editor.sig_close_all_editors_requested.connect(self.close_all_editors)
             self.create_dialog(editor, dict(model=index.model(), editor=editor,
                                             key=key, readonly=readonly))
             return None

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -233,8 +233,13 @@ class CollectionsDelegate(
                 namespacebrowser=self.namespacebrowser,
                 data_function=self.make_data_function(index)
             )
-            editor.setup(value, key, icon=self.parent().windowIcon(),
-                         readonly=readonly, from_variable_explorer=True)
+            editor.setup(
+                value,
+                key,
+                icon=self.parent().windowIcon(),
+                readonly=readonly,
+                from_variable_explorer=True
+            )
             editor.sig_close_all_editors_requested.connect(
                 self.close_all_editors
             )
@@ -530,7 +535,7 @@ class CollectionsDelegate(
             message.set_checkbox_text(_("Don't ask again"))
             message.set_checked(False)
             message.set_check_visible(True)
-            message.setText(_('Are you sure you want to close all editors?'))
+            message.setText(_("Are you sure you want to close all viewers?"))
             message.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
 
             result = message.exec_()

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -415,8 +415,8 @@ class CollectionsDelegate(
                 parent=parent,
                 namespacebrowser=self.namespacebrowser,
                 data_function=self.make_data_function(index),
-                readonly=readonly
-                )
+                readonly=readonly,
+            )
             editor.sig_close_all_editors_requested.connect(self.close_all_editors)
             self.create_dialog(editor, dict(model=index.model(),
                                             editor=editor,

--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -409,7 +409,9 @@ class CollectionsDelegate(
                 parent=parent,
                 namespacebrowser=self.namespacebrowser,
                 data_function=self.make_data_function(index),
-                readonly=readonly)
+                readonly=readonly
+                )
+            editor.sig_close_all_editors_requested.connect(self.close_all_editors)
             self.create_dialog(editor, dict(model=index.model(),
                                             editor=editor,
                                             key=key, readonly=readonly))

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -1893,7 +1893,9 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
         self.dataTable = None
         self.resizeToHeader = False
 
-    def setup_and_check(self, data, title='', from_variable_explorer=False) -> bool:
+    def setup_and_check(
+        self, data, title="", from_variable_explorer=False
+    ) -> bool:
         """
         Setup editor.
 

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -1002,12 +1002,6 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
             triggered=self.plot_hist,
             register_action=False
         )
-        self.close_all_editors_action = self.create_action(
-            name=DataframeEditorActions.CloseAllEditors,
-            text=_("Close all viewers"),
-            icon=self.create_icon("filecloseall"),
-            triggered=self.sig_close_all_editors_requested.emit
-        )
 
         # ---- Create context menu and fill it
 
@@ -1834,6 +1828,9 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
         If True, then the user can not edit the dataframe. The default is
         False.
     """
+    
+    sig_close_all_editors_requested = Signal()
+
     CONF_SECTION = 'variable_explorer'
 
     def __init__(
@@ -1856,6 +1853,7 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
             triggered=self.refresh_editor,
             register_action=False
         )
+
         self.refresh_action.setEnabled(self.data_function is not None)
         self.preferences_action = self.create_action(
             name=DataframeEditorActions.Preferences,
@@ -1875,6 +1873,14 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
         )
         self.register_shortcut_for_widget(name='close', triggered=self.reject)
 
+        
+        self.close_all_editors_action = self.create_action(
+            name=DataframeEditorActions.CloseAllEditors,
+            text=_("Close all viewers"),
+            icon=self.create_icon("filecloseall"),
+            triggered=self.sig_close_all_editors_requested.emit
+        )
+
         # Destroying the C++ object right after closing the dialog box,
         # otherwise it may be garbage-collected in another QThread
         # (e.g. the editor's analysis thread in Spyder), thus leading to
@@ -1887,7 +1893,7 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
         self.dataTable = None
         self.resizeToHeader = False
 
-    def setup_and_check(self, data, title='') -> bool:
+    def setup_and_check(self, data, title='', from_variable_explorer=False) -> bool:
         """
         Setup editor.
 
@@ -1899,13 +1905,16 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
         else:
             title = _("%s editor") % data.__class__.__name__
 
-        self.setup_ui(title)
+        self.setup_ui(title, from_variable_explorer)
         return self.set_data_and_check(data)
 
-    def setup_ui(self, title: str) -> None:
+    def setup_ui(self, title: str, from_variable_explorer) -> None:
         """
         Create user interface.
         """
+        
+        self.close_all_editors_action.setVisible(from_variable_explorer)
+
         # ---- Toolbar (to be filled later)
 
         self.toolbar = self.create_toolbar(
@@ -2083,6 +2092,7 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
             self.dataTable.insert_action_after,
             self.dataTable.duplicate_col_action,
             self.dataTable.remove_col_action,
+            self.close_all_editors_action,
             stretcher,
             self.dataTable.histogram_action,
             self.dataTable.resize_action,

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -121,6 +121,7 @@ class DataframeEditorActions:
     RemoveRow = 'remove_row_action'
     ResizeColumns = 'resize_columns_action'
     ResizeRows = 'resize_rows_action'
+    CloseAllEditors = 'close_all_editors_action'
 
 
 class DataframeEditorMenus:
@@ -1000,6 +1001,12 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
             icon=ima.icon('hist'),
             triggered=self.plot_hist,
             register_action=False
+        )
+        self.close_all_editors_action = self.create_action(
+            name=DataframeEditorActions.CloseAllEditors,
+            text=_("Close all viewers"),
+            icon=self.create_icon("filecloseall"),
+            triggered=self.sig_close_all_editors_requested.emit
         )
 
         # ---- Create context menu and fill it

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -14,7 +14,7 @@ import traceback
 from typing import Any, Callable, Optional
 
 # Third-party imports
-from qtpy.QtCore import Slot, QModelIndex, QPoint, QSize, Qt
+from qtpy.QtCore import Signal, Slot, QModelIndex, QPoint, QSize, Qt
 from qtpy.QtGui import QTextOption
 from qtpy.QtWidgets import (
     QAbstractItemView, QButtonGroup, QGroupBox, QHBoxLayout, QHeaderView,
@@ -43,6 +43,7 @@ class ObjectExplorerActions:
     Refresh = 'refresh_action'
     ShowCallable = 'show_callable_action'
     ShowSpecialAttributes = 'show_special_attributes_action'
+    CloseAllEditors = 'close_all_editors_action'
 
 
 class ObjectExplorerMenus:
@@ -66,6 +67,8 @@ EDITOR_NAME = 'Object'
 class ObjectExplorer(BaseDialog, SpyderWidgetMixin, SpyderFontsMixin):
     """Object explorer main widget window."""
     CONF_SECTION = 'variable_explorer'
+
+    sig_close_all_editors_requested = Signal()
 
     def __init__(self,
                  obj,
@@ -247,6 +250,13 @@ class ObjectExplorer(BaseDialog, SpyderWidgetMixin, SpyderFontsMixin):
             register_action=False
         )
 
+        self.close_all_editors_action = self.create_action(
+            name=ObjectExplorerActions.CloseAllEditors,
+            text=_("Close all viewers"),
+            icon=self.create_icon("filecloseall"),
+            triggered=self.sig_close_all_editors_requested.emit
+        )
+
         stretcher = self.create_stretcher(
             ObjectExplorerWidgets.ToolbarStretcher
         )
@@ -300,6 +310,7 @@ class ObjectExplorer(BaseDialog, SpyderWidgetMixin, SpyderFontsMixin):
         for item in [
             self.toggle_show_callable_action,
             self.toggle_show_special_attribute_action,
+            self.close_all_editors_action,
             stretcher,
             self.refresh_action,
             self.options_button

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -14,7 +14,7 @@ import traceback
 from typing import Any, Callable, Optional
 
 # Third-party imports
-from qtpy.QtCore import Signal, Slot, QModelIndex, QPoint, QSize, Qt
+from qtpy.QtCore import QModelIndex, QPoint, QSize, Qt, Signal, Slot
 from qtpy.QtGui import QTextOption
 from qtpy.QtWidgets import (
     QAbstractItemView, QButtonGroup, QGroupBox, QHBoxLayout, QHeaderView,

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -1838,7 +1838,7 @@ class CollectionsEditorWidget(QWidget, SpyderWidgetMixin):
         self,
         parent,
         data,
-        from_variable_explorer,
+        from_variable_explorer=False,
         namespacebrowser=None,
         data_function: Optional[Callable[[], Any]] = None,
         readonly=False,

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -956,8 +956,13 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
                 section=CollectionsEditorContextMenuSections.AddRemove
             )
 
-        for action in [self.view_action, self.close_all_editors_action,
-                       self.plot_action, self.hist_action, self.imshow_action]:
+        for action in [
+            self.view_action,
+            self.close_all_editors_action,
+            self.plot_action,
+            self.hist_action,
+            self.imshow_action
+        ]:
             self.add_item_to_menu(
                 action,
                 menu,
@@ -2044,7 +2049,8 @@ class CollectionsEditor(BaseDialog):
             self.save_and_close_enable
         )
         self.widget.editor.sig_close_all_editors_requested.connect(
-            self.sig_close_all_editors_requested)
+            self.sig_close_all_editors_requested
+        )
 
         # Buttons configuration
         btn_layout = QHBoxLayout()

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -133,7 +133,7 @@ class CollectionsEditorContextMenuSections:
 class CollectionsEditorToolbarSections:
     AddDelete = 'add_delete_section'
     View = 'view_section'
-    CloseAndRest = 'close_and_rest_section'
+    CloseAndReset = 'close_and_rest_section'
 
 
 # Maximum length of a serialized variable to be set in the kernel
@@ -953,7 +953,7 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
             self.view_action,
             self.plot_action,           
             self.hist_action,
-            self.imshow_action
+            self.imshow_action,
         ]:
             self.add_item_to_menu(
                 action,
@@ -1945,7 +1945,7 @@ class CollectionsEditorWidget(QWidget, SpyderWidgetMixin):
             self.add_item_to_toolbar(
                 item,
                 toolbar,
-                section=CollectionsEditorToolbarSections.CloseAndRest
+                section=CollectionsEditorToolbarSections.CloseAndReset
             )
 
         toolbar.render()

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -739,7 +739,6 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
     sig_free_memory_requested = Signal()
     sig_editor_creation_started = Signal()
     sig_editor_shown = Signal()
-    sig_close_all_editors_requested = Signal()
 
     def __init__(self, parent):
         super().__init__(parent=parent)
@@ -927,12 +926,6 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
             triggered=self.view_item,
             register_action=False
         )
-        self.close_all_editors_action = self.create_action(
-            name=CollectionsEditorActions.CloseAllEditors,
-            text=_("Close all viewers"),
-            icon=self.create_icon("filecloseall"),
-            triggered=self.sig_close_all_editors_requested.emit
-        )
 
         menu = self.create_menu(
             CollectionsEditorMenus.Context,
@@ -956,8 +949,8 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
                 section=CollectionsEditorContextMenuSections.AddRemove
             )
 
-        for action in [self.view_action, self.close_all_editors_action,
-                       self.plot_action, self.hist_action, self.imshow_action]:
+        for action in [self.view_action, self.plot_action,
+                       self.hist_action, self.imshow_action]:
             self.add_item_to_menu(
                 action,
                 menu,
@@ -1834,12 +1827,14 @@ class CollectionsEditorWidget(QWidget, SpyderWidgetMixin):
     CONF_SECTION = "variable_explorer"
 
     sig_refresh_requested = Signal()
-    sig_close_window_requested = Signal()
+    sig_close_window_requested = Signal()    
+    sig_close_all_editors_requested = Signal()
 
     def __init__(
         self,
         parent,
         data,
+        from_variable_explorer,
         namespacebrowser=None,
         data_function: Optional[Callable[[], Any]] = None,
         readonly=False,
@@ -1876,6 +1871,14 @@ class CollectionsEditorWidget(QWidget, SpyderWidgetMixin):
         self.register_shortcut_for_widget(
             name='close', triggered=self.close_window
         )
+        
+        self.close_all_editors_action = self.create_action(
+            name=CollectionsEditorActions.CloseAllEditors,
+            text=_("Close all viewers"),
+            icon=self.create_icon("filecloseall"),
+            triggered=self.sig_close_all_editors_requested.emit
+        )
+        self.close_all_editors_action.setVisible(from_variable_explorer)
 
         toolbar = self.create_toolbar(
             CollectionsEditorWidgets.Toolbar,
@@ -1928,7 +1931,7 @@ class CollectionsEditorWidget(QWidget, SpyderWidgetMixin):
             )
 
         for item in [
-            self.editor.close_all_editors_action,
+            self.close_all_editors_action,
             stretcher,
             self.editor.resize_action,
             self.editor.resize_columns_action,
@@ -2005,6 +2008,7 @@ class CollectionsEditor(BaseDialog):
         parent=None,
         loading_msg=None,
         loading_img=None,
+        from_variable_explorer=False
     ):
         """Setup editor."""
         if isinstance(data, (dict, set, frozenset)):
@@ -2032,6 +2036,7 @@ class CollectionsEditor(BaseDialog):
         self.widget = CollectionsEditorWidget(
             self,
             self.data_copy,
+            from_variable_explorer,
             self.namespacebrowser,
             self.data_function,
             title=title,
@@ -2043,7 +2048,7 @@ class CollectionsEditor(BaseDialog):
         self.widget.editor.source_model.sig_setting_data.connect(
             self.save_and_close_enable
         )
-        self.widget.editor.sig_close_all_editors_requested.connect(
+        self.widget.sig_close_all_editors_requested.connect(
             self.sig_close_all_editors_requested)
 
         # Buttons configuration

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -106,6 +106,7 @@ class CollectionsEditorActions:
     Save = 'save_action'
     ShowImage = 'show_image_action'
     ViewObject = 'view_object_action'
+    CloseAllEditors = 'close_all_editors_action'
 
 
 class CollectionsEditorMenus:
@@ -131,7 +132,8 @@ class CollectionsEditorContextMenuSections:
 
 class CollectionsEditorToolbarSections:
     AddDelete = 'add_delete_section'
-    ViewAndRest = 'view_section'
+    View = 'view_section'
+    CloseAndRest = 'close_and_rest_section'
 
 
 # Maximum length of a serialized variable to be set in the kernel
@@ -737,6 +739,7 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
     sig_free_memory_requested = Signal()
     sig_editor_creation_started = Signal()
     sig_editor_shown = Signal()
+    sig_close_all_editors_requested = Signal()
 
     def __init__(self, parent):
         super().__init__(parent=parent)
@@ -924,6 +927,12 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
             triggered=self.view_item,
             register_action=False
         )
+        self.close_all_editors_action = self.create_action(
+            name=CollectionsEditorActions.CloseAllEditors,
+            text=_("Close all viewers"),
+            icon=self.create_icon("filecloseall"),
+            triggered=self.sig_close_all_editors_requested.emit
+        )
 
         menu = self.create_menu(
             CollectionsEditorMenus.Context,
@@ -947,8 +956,8 @@ class BaseTableView(QTableView, SpyderWidgetMixin):
                 section=CollectionsEditorContextMenuSections.AddRemove
             )
 
-        for action in [self.view_action, self.plot_action,
-                       self.hist_action, self.imshow_action]:
+        for action in [self.view_action, self.close_all_editors_action,
+                       self.plot_action, self.hist_action, self.imshow_action]:
             self.add_item_to_menu(
                 action,
                 menu,
@@ -1910,7 +1919,16 @@ class CollectionsEditorWidget(QWidget, SpyderWidgetMixin):
             self.editor.view_action,
             self.editor.plot_action,
             self.editor.hist_action,
-            self.editor.imshow_action,
+            self.editor.imshow_action
+        ]:
+            self.add_item_to_toolbar(
+                item,
+                toolbar,
+                section=CollectionsEditorToolbarSections.View
+            )
+
+        for item in [
+            self.editor.close_all_editors_action,
             stretcher,
             self.editor.resize_action,
             self.editor.resize_columns_action,
@@ -1920,7 +1938,7 @@ class CollectionsEditorWidget(QWidget, SpyderWidgetMixin):
             self.add_item_to_toolbar(
                 item,
                 toolbar,
-                section=CollectionsEditorToolbarSections.ViewAndRest
+                section=CollectionsEditorToolbarSections.CloseAndRest
             )
 
         toolbar.render()
@@ -1951,6 +1969,8 @@ class CollectionsEditorWidget(QWidget, SpyderWidgetMixin):
 
 class CollectionsEditor(BaseDialog):
     """Collections Editor Dialog"""
+
+    sig_close_all_editors_requested = Signal()
 
     def __init__(
         self,
@@ -2023,6 +2043,8 @@ class CollectionsEditor(BaseDialog):
         self.widget.editor.source_model.sig_setting_data.connect(
             self.save_and_close_enable
         )
+        self.widget.editor.sig_close_all_editors_requested.connect(
+            self.sig_close_all_editors_requested)
 
         # Buttons configuration
         btn_layout = QHBoxLayout()


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Add "Close all" button for numerous Variable Explorer viewer windows


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #25844 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@jsbautista 
<!--- Thanks for your help making Spyder better for everyone! --->
