### PR TITLE
PR: Add multiline split & merge functionality to the Editor

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -484,6 +484,8 @@ DEFAULTS = [
               'editor/delete line': 'Ctrl+D',
               'editor/transform to uppercase': 'Alt+Shift+U',
               'editor/transform to lowercase': 'Alt+U',
+              'editor/multiline split': 'Alt+Shift+M',
+              'editor/multiline merge': 'Alt+M',
               'editor/indent': 'Ctrl+]',
               'editor/unindent': 'Ctrl+[',
               'editor/move line up': "Alt+Up",

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -55,3 +55,5 @@ class EditorWidgetActions:
     Unindent = "unindent_action"
     TransformToUppercase = "transform to uppercase"
     TransformToLowercase = "transform to lowercase"
+    MultilineSplit = "multiline split"
+    MultilineMerge = "multiline merge"

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -18,6 +18,7 @@ Editor widget based on QtGui.QPlainTextEdit
 
 # Standard library imports
 from __future__ import annotations
+import ast
 from collections.abc import Callable
 import functools
 import logging
@@ -27,7 +28,6 @@ import re
 import sys
 from typing import TypedDict
 import textwrap
-import ast
 from unicodedata import category
 
 # Third party imports
@@ -3113,13 +3113,15 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
         """Auto-select word or line under cursor, get its previous position."""
         cursor = self.textCursor()
         if cursor.hasSelection():
-            return None
+            return
+
         prev_pos = cursor.position()
         if word:
             cursor.select(QTextCursor.WordUnderCursor)
         elif line:
             cursor.select(QTextCursor.LineUnderCursor)
         self.setTextCursor(cursor)
+
         return prev_pos
     
     def replace_selected_text(self, text):
@@ -3127,13 +3129,16 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
         cursor = self.textCursor()
         if not text or not cursor.hasSelection():
             return
+
         # Pre-handle selection zone
         sel_is_forward = cursor.position() > cursor.anchor()
         start = cursor.selectionStart()
         end = start + len(text)
         new_anchor, new_pos = (start, end) if sel_is_forward else (end, start)
+
         # Replace text
         cursor.insertText(text)
+
         # Restore selection
         cursor.setPosition(new_anchor, QTextCursor.MoveAnchor)
         cursor.setPosition(new_pos, QTextCursor.KeepAnchor)
@@ -3156,20 +3161,28 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
     def multiline_split(self):
         prev_pos = self.auto_select_text(line=True)
         text = self.get_selected_text()
-        if not text : return
+        if not text:
+            return
+
         # Pre-handle indentation
         selstartcolidx = self.get_selection_start_end()[0][1]
         initial_indent = self.get_line_indentation(text)
         indent = selstartcolidx + initial_indent
+
         # Transform
         new_text = self.transform_multiline(text, split=True)
-        if not new_text: return
+        if not new_text:
+            return
+
         # Adjust indentation
         line_sep = self.get_line_separator()
         lines = new_text.split(line_sep)
-        lines = [self.adjust_indentation(lines[0], initial_indent)]  \
+        lines = (
+            [self.adjust_indentation(lines[0], initial_indent)]
             + [self.adjust_indentation(line, indent) for line in lines[1:]]
+        )
         new_text = line_sep.join(lines)
+
         # Insert in editor
         self.replace_selected_text(new_text)
         if prev_pos:
@@ -3177,11 +3190,15 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
     
     def multiline_merge(self):
         text = self.get_selected_text()
-        if not text : return
+        if not text:
+            return
+
         lines = text.split(self.get_line_separator())
         indentation = min([self.get_line_indentation(line) for line in lines])
         new_text = self.transform_multiline(text, split=False)
-        if not new_text : return
+        if not new_text:
+            return
+
         new_text = self.adjust_indentation(new_text, indentation)
         self.replace_selected_text(new_text)
 
@@ -3190,30 +3207,46 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
         # Sanitize input and pre-handle suffix
         line_sep = self.get_line_separator()
         text = line_sep.join([line.strip() for line in text.split(line_sep)])
-        if not text: return None
+        if not text:
+            return
+
         suf = next(
             (s for s in [',' + line_sep, ',', line_sep] if text.endswith(s)),
-            '') # suffix to preserve trailing newline and/or comma
+            ''
+        ) # suffix to preserve trailing newline and/or comma
+
         # Unparsing functions
-        def get_items(node):  # unparses sequence to list of items
+        def get_items(node):
+            """Unparses sequence to list of items."""
             if isinstance(node, (ast.Tuple, ast.List)):
-                items = [ast.unparse(elt)
-                         for elt in node.elts if elt is not None]
+                items = [
+                    ast.unparse(elt)
+                    for elt in node.elts if elt is not None
+                ]
             elif isinstance(node, ast.Call):
-                items = [ast.unparse(elt)
-                         for elt in node.args + node.keywords
-                         if elt is not None]
+                items = [
+                    ast.unparse(elt)
+                    for elt in node.args + node.keywords
+                    if elt is not None
+                ]
             elif isinstance(node, ast.Dict):
-                items = [f'{ast.unparse(k)}: {ast.unparse(v)}'
-                         for k, v in zip(node.keys, node.values) if k]
+                items = [
+                    f'{ast.unparse(k)}: {ast.unparse(v)}'
+                    for k, v in zip(node.keys, node.values) if k
+                ]
+
             return items
-        def get_item_singleton(node):  # unparse item to list of size one
+
+        def get_item_singleton(node):
+            """Unparse item to list of size one."""
             return [ast.unparse(node)] if node is not None else []
+
         # Try to extract all LHS and RHS items from assignments
         try:
             node = ast.parse(text, mode='exec')
-            if node.body and all(isinstance(stmt, ast.Assign)
-                                 for stmt in node.body):
+            if node.body and all(
+                isinstance(stmt, ast.Assign) for stmt in node.body
+            ):
                 lhs_all, rhs_all = [], []
                 for stmt in node.body:
                     if stmt.targets and stmt.value:  # Infer assignment kind :
@@ -3225,18 +3258,22 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
                         elif isinstance(stmt.targets[0], ast.Name):  # :single
                             lhs = get_item_singleton(stmt.targets[0])
                             rhs = get_item_singleton(stmt.value)
+
                         if len(lhs) != len(rhs):
-                            return None
+                            return
+
                         lhs_all.extend(lhs)
                         rhs_all.extend(rhs)
+
                 if split:  #-> splitted assignments
                     return line_sep.join(
                         f'{ll} = {rr}' for ll, rr in zip(lhs_all, rhs_all)
-                        ) + suf
+                    ) + suf
                 else:  #-> merged assignment
                     return f'{", ".join(lhs_all)} = {", ".join(rhs_all)}' + suf
         except SyntaxError:
             pass
+
         # Try to extract sequence items. First as a tuple, then by wrapping it 
         # to assess syntax validity as call args or then as dict pairs.
         items_sep = ',' + line_sep if split else ', '
@@ -3248,7 +3285,8 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
                 return items_sep.join(items) + suf
             except SyntaxError:
                 pass
-        return None
+
+        return
 
     def blockcomment(self):
         """Block comment current line or selection."""

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -27,6 +27,7 @@ import re
 import sys
 from typing import TypedDict
 import textwrap
+import ast
 from unicodedata import category
 
 # Third party imports
@@ -630,6 +631,8 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
                 self.transform_to_uppercase)),
             ('transform to lowercase', self.for_each_cursor(
                 self.transform_to_lowercase)),
+            ('multiline split', self.multiline_split),
+            ('multiline merge', self.multiline_merge),
             ('indent', self.for_each_cursor(lambda: self.indent(force=True))),
             ('unindent', self.for_each_cursor(
                 lambda: self.unindent(force=True), False)),
@@ -3106,35 +3109,146 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
                                     79 - len(self.comment_string))
         return blockcomment_bar
 
+    def auto_select_text(self, word=False, line=False):
+        """Auto-select word or line under cursor, get its previous position."""
+        cursor = self.textCursor()
+        if cursor.hasSelection():
+            return None
+        prev_pos = cursor.position()
+        if word:
+            cursor.select(QTextCursor.WordUnderCursor)
+        elif line:
+            cursor.select(QTextCursor.LineUnderCursor)
+        self.setTextCursor(cursor)
+        return prev_pos
+    
+    def replace_selected_text(self, text):
+        """Replace the selected text, preserving selection."""
+        cursor = self.textCursor()
+        if not text or not cursor.hasSelection():
+            return
+        # Pre-handle selection zone
+        sel_is_forward = cursor.position() > cursor.anchor()
+        start = cursor.selectionStart()
+        end = start + len(text)
+        new_anchor, new_pos = (start, end) if sel_is_forward else (end, start)
+        # Replace text
+        cursor.insertText(text)
+        # Restore selection
+        cursor.setPosition(new_anchor, QTextCursor.MoveAnchor)
+        cursor.setPosition(new_pos, QTextCursor.KeepAnchor)
+        self.setTextCursor(cursor)
+
     def transform_to_uppercase(self):
         """Change to uppercase current line or selection."""
-        cursor = self.textCursor()
-        prev_pos = cursor.position()
-        selected_text = str(cursor.selectedText())
-
-        if len(selected_text) == 0:
-            prev_pos = cursor.position()
-            cursor.select(QTextCursor.WordUnderCursor)
-            selected_text = str(cursor.selectedText())
-
-        s = selected_text.upper()
-        cursor.insertText(s)
-        self.set_cursor_position(prev_pos)
+        prev_pos = self.auto_select_text(word=True)
+        self.replace_selected_text(self.get_selected_text().upper())
+        if prev_pos:
+            self.set_cursor_position(prev_pos)
 
     def transform_to_lowercase(self):
         """Change to lowercase current line or selection."""
-        cursor = self.textCursor()
-        prev_pos = cursor.position()
-        selected_text = str(cursor.selectedText())
+        prev_pos = self.auto_select_text(word=True)
+        self.replace_selected_text(self.get_selected_text().lower())
+        if prev_pos:
+            self.set_cursor_position(prev_pos)
+    
+    def multiline_split(self):
+        prev_pos = self.auto_select_text(line=True)
+        text = self.get_selected_text()
+        if not text : return
+        # Pre-handle indentation
+        selstartcolidx = self.get_selection_start_end()[0][1]
+        initial_indent = self.get_line_indentation(text)
+        indent = selstartcolidx + initial_indent
+        # Transform
+        new_text = self.transform_multiline(text, split=True)
+        if not new_text: return
+        # Adjust indentation
+        line_sep = self.get_line_separator()
+        lines = new_text.split(line_sep)
+        lines = [self.adjust_indentation(lines[0], initial_indent)]  \
+            + [self.adjust_indentation(line, indent) for line in lines[1:]]
+        new_text = line_sep.join(lines)
+        # Insert in editor
+        self.replace_selected_text(new_text)
+        if prev_pos:
+            self.set_cursor_position(prev_pos)
+    
+    def multiline_merge(self):
+        text = self.get_selected_text()
+        if not text : return
+        lines = text.split(self.get_line_separator())
+        indentation = min([self.get_line_indentation(line) for line in lines])
+        new_text = self.transform_multiline(text, split=False)
+        if not new_text : return
+        new_text = self.adjust_indentation(new_text, indentation)
+        self.replace_selected_text(new_text)
 
-        if len(selected_text) == 0:
-            prev_pos = cursor.position()
-            cursor.select(QTextCursor.WordUnderCursor)
-            selected_text = str(cursor.selectedText())
-
-        s = selected_text.lower()
-        cursor.insertText(s)
-        self.set_cursor_position(prev_pos)
+    def transform_multiline(self, text, split=True):
+        """Transform sequence or assignments (multiline split or merge)."""
+        # Sanitize input and pre-handle suffix
+        line_sep = self.get_line_separator()
+        text = line_sep.join([line.strip() for line in text.split(line_sep)])
+        if not text: return None
+        suf = next(
+            (s for s in [',' + line_sep, ',', line_sep] if text.endswith(s)),
+            '') # suffix to preserve trailing newline and/or comma
+        # Unparsing functions
+        def get_items(node):  # unparses sequence to list of items
+            if isinstance(node, (ast.Tuple, ast.List)):
+                items = [ast.unparse(elt)
+                         for elt in node.elts if elt is not None]
+            elif isinstance(node, ast.Call):
+                items = [ast.unparse(elt)
+                         for elt in node.args + node.keywords
+                         if elt is not None]
+            elif isinstance(node, ast.Dict):
+                items = [f'{ast.unparse(k)}: {ast.unparse(v)}'
+                         for k, v in zip(node.keys, node.values) if k]
+            return items
+        def get_item_singleton(node):  # unparse item to list of size one
+            return [ast.unparse(node)] if node is not None else []
+        # Try to extract all LHS and RHS items from assignments
+        try:
+            node = ast.parse(text, mode='exec')
+            if node.body and all(isinstance(stmt, ast.Assign)
+                                 for stmt in node.body):
+                lhs_all, rhs_all = [], []
+                for stmt in node.body:
+                    if stmt.targets and stmt.value:  # Infer assignment kind :
+                        if len(stmt.targets) != 1:  # :chained
+                            return None
+                        elif isinstance(stmt.targets[0], ast.Tuple):  # :multi
+                            lhs = get_items(stmt.targets[0])
+                            rhs = get_items(stmt.value)
+                        elif isinstance(stmt.targets[0], ast.Name):  # :single
+                            lhs = get_item_singleton(stmt.targets[0])
+                            rhs = get_item_singleton(stmt.value)
+                        if len(lhs) != len(rhs):
+                            return None
+                        lhs_all.extend(lhs)
+                        rhs_all.extend(rhs)
+                if split:  #-> splitted assignments
+                    return line_sep.join(
+                        f'{ll} = {rr}' for ll, rr in zip(lhs_all, rhs_all)
+                        ) + suf
+                else:  #-> merged assignment
+                    return f'{", ".join(lhs_all)} = {", ".join(rhs_all)}' + suf
+        except SyntaxError:
+            pass
+        # Try to extract sequence items. First as a tuple, then by wrapping it 
+        # to assess syntax validity as call args or then as dict pairs.
+        items_sep = ',' + line_sep if split else ', '
+        for wrapper in ['', 'f({})', '{{{}}}']:
+            try:
+                src = wrapper.format(text) if wrapper else text
+                node = ast.parse(src, mode='eval').body
+                items = get_items(node)
+                return items_sep.join(items) + suf
+            except SyntaxError:
+                pass
+        return None
 
     def blockcomment(self):
         """Block comment current line or selection."""

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -3255,7 +3255,8 @@ class CodeEditor(LSPMixin, TextEditBaseWidget, MultiCursorMixin):
                         elif isinstance(stmt.targets[0], ast.Tuple):  # :multi
                             lhs = get_items(stmt.targets[0])
                             rhs = get_items(stmt.value)
-                        elif isinstance(stmt.targets[0], ast.Name):  # :single
+                        elif isinstance(stmt.targets[0],
+                                        (ast.Name, ast.Subscript)):  # :single
                             lhs = get_item_singleton(stmt.targets[0])
                             rhs = get_item_singleton(stmt.value)
 

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -657,6 +657,24 @@ class EditorMainWidget(PluginMainWidget):
             context=Qt.WidgetShortcut,
             register_shortcut=True
         )
+        self.text_multiline_split_action = self.create_action(
+            EditorWidgetActions.MultilineSplit,
+            text=_("Multiline split"),
+            icon=self.create_icon('multiline_split'),
+            tip=_("Split selected items into multiple lines"),
+            triggered=self.multiline_split,
+            context=Qt.WidgetShortcut,
+            register_shortcut=True
+        )
+        self.text_multiline_merge_action = self.create_action(
+            EditorWidgetActions.MultilineMerge,
+            text=_("Multiline merge"),
+            icon=self.create_icon('multiline_merge'),
+            tip=_("Merge selected items into a single line"),
+            triggered=self.multiline_merge,
+            context=Qt.WidgetShortcut,
+            register_shortcut=True
+        )
 
         self.edit_menu_actions = [
             self.toggle_comment_action,
@@ -665,7 +683,9 @@ class EditorMainWidget(PluginMainWidget):
             self.indent_action,
             self.unindent_action,
             self.text_uppercase_action,
-            self.text_lowercase_action
+            self.text_lowercase_action,
+            self.text_multiline_split_action,
+            self.text_multiline_merge_action,
         ]
 
         # ---- CodeEditor context menu
@@ -2322,6 +2342,20 @@ class EditorMainWidget(PluginMainWidget):
         editor = self.get_current_editor()
         if editor is not None:
             editor.transform_to_lowercase()
+
+    @Slot()
+    def multiline_split(self):
+        """Split selected items into multiple lines."""
+        editor = self.get_current_editor()
+        if editor is not None:
+            editor.multiline_split()
+
+    @Slot()
+    def multiline_merge(self):
+        """Merge selected items into a single line."""
+        editor = self.get_current_editor()
+        if editor is not None:
+            editor.multiline_merge()
 
     @Slot()
     def toggle_comment(self):

--- a/spyder/utils/icon_manager.py
+++ b/spyder/utils/icon_manager.py
@@ -174,6 +174,8 @@ class IconManager():
             'unindent':                [('mdi.format-indent-decrease',), {'color': self.MAIN_FG_COLOR}],
             'toggle_lowercase':        [('mdi.format-letter-case-lower',), {'color': self.MAIN_FG_COLOR}],
             'toggle_uppercase':        [('mdi.format-letter-case-upper',), {'color': self.MAIN_FG_COLOR}],
+            'multiline_split':         [('mdi.set-split',), {'color': self.MAIN_FG_COLOR}],
+            'multiline_merge':         [('mdi.set-merge',), {'color': self.MAIN_FG_COLOR}],
             'gotoline':                [('mdi.format-line-spacing',), {'color': self.MAIN_FG_COLOR}],
             'error':                   [('mdi.close-circle',), {'color': SpyderPalette.COLOR_ERROR_1}],
             'warning':                 [('mdi.alert',), {'color': SpyderPalette.COLOR_WARN_2}],


### PR DESCRIPTION
## Description of Changes

### Added Multiline split and merge operations to editor.
(note : no unit tests written)

- Added `replace_selected_text` and `auto_select_text` methods to `CodeEditor` in `codeeditor.py`, for conveniently auto selecting line or word under cursor and replacing selected text by preserving selection. -> `transform_upper_case` and ``transform_upper_case` benefit now from selection preservation.

- Added `transform_multiline` method, that uses `ast` (imported now at top-level in `codeeditor.py`) to parse sequences (of list/tuple items or args/kwargs combinations) or assignments within single or multiple lines of code, to output the one-line (merge) or one-per-line (split) version.

- Added `multiline_split` and `multiline_merge` functions, calling all of the introduced methods, and handling indentation, to transform selected code to multiline or one-line in the editor.

- Added 2 keyboard shortcut entries in `config/main.py`, assigning Alt+Shift+M to 'multiline split' operation and Alt+M to 'multiline merge'.

[Video demo is here](https://github.com/spyder-ide/spyder/issues/25908#issuecomment-4173244235) (but some trailing newline handling error has been fixed before PR).


### Issue(s) Resolved

Fixes #25908


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:
hprodh

