### PR TITLE
PR: Use natsort for initial sort in namespace browser (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/namespacebrowser.py
@@ -35,10 +35,13 @@ from spyder.api.translations import _
 from spyder.api.shellconnect.mixins import ShellConnectWidgetForStackMixin
 from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.config.utils import IMPORT_EXT
-from spyder.widgets.collectionseditor import RemoteCollectionsEditorTableView
 from spyder.plugins.variableexplorer.widgets.importwizard import ImportWizard
 from spyder.utils import encoding
 from spyder.utils.misc import getcwd_or_home, remove_backslashes
+from spyder.widgets.collectionseditor import (
+    natsort,
+    RemoteCollectionsEditorTableView
+)
 from spyder.widgets.helperwidgets import FinderWidget
 
 
@@ -248,7 +251,7 @@ class NamespaceBrowser(
 
     def set_data(self, data):
         """Set data."""
-        data = dict(sorted(data.items()))
+        data = dict(sorted(data.items(), key=lambda x: natsort(x[0])))
         if data != self.editor.source_model.get_data():
             self.editor.set_data(data)
             self.editor.adjust_columns()

--- a/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_namespacebrowser.py
@@ -108,7 +108,8 @@ def test_keys_sorted_and_sort_with_large_rows(namespacebrowser, qtbot):
     Test that keys are sorted and sorting works as expected when
     there's a large number of rows.
 
-    This is a regression test for issue spyder-ide/spyder#10702
+    This is a regression test for issues spyder-ide/spyder#10702
+    and spyder-ide/spyder#25439
     """
     browser = namespacebrowser
 
@@ -120,10 +121,7 @@ def test_keys_sorted_and_sort_with_large_rows(namespacebrowser, qtbot):
     )
 
     for i in range(100):
-        if i < 10:
-            var = 'd_0' + str(i)
-        else:
-            var = 'd_' + str(i)
+        var = f"d_{i}"
         variables[var] = (
             {'type': 'int', 'size': 1, 'view': '1', 'python_type': 'int',
              'numpy_type': 'Unknown'}
@@ -139,6 +137,9 @@ def test_keys_sorted_and_sort_with_large_rows(namespacebrowser, qtbot):
     assert model.canFetchMore(QModelIndex())
 
     # Assert keys are sorted
+    # The namespace browser uses natural sorting, so the rows are sorted
+    # d_0, d_1, d_2, d_3, ..., d_9, d_10, d_11, ..., d_99, i even though
+    # strings compare as "d_10" < "d_2" in Python
     assert data(model, 49, 0) == 'd_49'
 
     # Sort


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions) **N/A** (no new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


Before this PR, the namespace browser used the Python sort to initially sort the entries, but natural sort as implemented by `natsort()` later. This led to discrepancies if there are more than `ROWS_TO_LOAD` = 50 rows. Therefore, this PR ensures that `natsort()` is used throughout. The PR also slightly adapt one of the tests so that it checks that `natsort()` is indeed uses for the initial sort.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #25439.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
