### PR TITLE
PR: Allow to set custom annotations in Editor (Preferences)

### DIFF
--- a/spyder/plugins/editor/confpage.py
+++ b/spyder/plugins/editor/confpage.py
@@ -113,6 +113,11 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
                 "!!!, ???</tt> (and their lowercase variants)"
             ),
         )
+        custom_annotations_input = self.create_lineedit(
+            _("Custom code annotations:"),
+            'custom_annotations',
+            tip=_("Add comma-separated comment annotations to be highlighted."),
+        )
 
         helpers_layout = QVBoxLayout()
         helpers_layout.addWidget(showindentguides_box)
@@ -120,6 +125,7 @@ class EditorConfigPage(PluginConfigPage, SpyderConfigurationObserver):
         helpers_layout.addWidget(linenumbers_box)
         helpers_layout.addWidget(breakpoints_box)
         helpers_layout.addWidget(todolist_box)
+        helpers_layout.addWidget(custom_annotations_input)
         helpers_group.setLayout(helpers_layout)
 
         # -- Highlight group

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -74,6 +74,8 @@ class Editor(SpyderDockablePlugin):
     CONF_SECTION = NAME
     CONF_WIDGET_CLASS = EditorConfigPage
     CONF_FILE = False
+    CONF_DEFAULTS = [(CONF_SECTION, {'todo_list': True,
+                                     'custom_annotations': 'NOTE, note'})]
 
     # ---- Signals
     # ------------------------------------------------------------------------

--- a/spyder/plugins/editor/utils/findtasks.py
+++ b/spyder/plugins/editor/utils/findtasks.py
@@ -24,9 +24,29 @@ TASKS_PATTERN = (
 )
 
 
-def find_tasks(source_code):
+def find_tasks(source_code, custom_patterns=''):
     """Find tasks in source code (TODO, FIXME, XXX, ...)."""
     results = []
+    
+    # Default patterns
+    default_patterns = (
+        r"TODO|todo|FIXME|fixme|XXX|xxx|HINT|hint|TIP|tip|@todo|@TODO|"
+        r"HACK|hack|BUG|bug|OPTIMIZE|optimize|!!!|\?\?\?"
+    )
+    
+    # Add custom patterns if provided
+    pattern_parts = [default_patterns]
+    if custom_patterns.strip():
+        # Split by comma, strip whitespace, validate (alphanumeric + underscore)
+        custom_list = [p.strip() for p in custom_patterns.split(',')]
+        # Filter valid patterns (letters, numbers, underscore only)
+        valid_custom = [p for p in custom_list if p and re.match(r'^\w+$', p)]
+        if valid_custom:
+            pattern_parts.append('|'.join(valid_custom))
+    
+    full_pattern = '|'.join(pattern_parts)
+    TASKS_PATTERN = rf"#\s*({full_pattern})([^#]*)"
+    
     for line, text in enumerate(source_code.splitlines()):
         for todo in re.findall(TASKS_PATTERN, text):
             todo_text = (todo[-1].strip(' :').capitalize() if todo[-1]

--- a/spyder/plugins/editor/widgets/editorstack/helpers.py
+++ b/spyder/plugins/editor/widgets/editorstack/helpers.py
@@ -190,7 +190,11 @@ class FileInfo(QObject):
     def run_todo_finder(self):
         """Run TODO finder."""
         if self.editor.is_python_or_ipython():
-            self.threadmanager.add_thread(find_tasks,
+            from spyder.config.manager import CONF
+            custom_annotations = CONF.get('editor', 'custom_annotations', '')
+            def find_with_custom(source_code): # Closure to pass custom patterns
+                return find_tasks(source_code, custom_annotations)
+            self.threadmanager.add_thread(find_with_custom,
                                           self.todo_finished,
                                           self.get_source_code(), self)
 


### PR DESCRIPTION

## Description of Changes

I've added a field in the editor preferences to set custom annotations to be highlighted.

I tried to make a checkbox, then realized that refreshing the markups in the editor after clicking apply would be tricky, so I kept the functionality simple.
Probably the layout would benefit from a bit of redesign/alignment.

### Issue(s) Resolved

Fixes #23617

Screenshot :
<img width="953" height="712" alt="Screenshot from 2026-04-06 21-28-10" src="https://github.com/user-attachments/assets/fc097564-86bc-41ed-96e6-9cb4e3afa826" />

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:
hprodh
