### PR TITLE
PR: Revert multicursor addition on changing direction (up/down) with keyboard shortcuts (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor/multicursor_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/multicursor_mixin.py
@@ -52,6 +52,7 @@ class MultiCursorMixin:
         self.painted.connect(self.paint_cursors)
         self.multi_cursor_ignore_history = False
         self._drag_cursor = None
+        self.last_append_direction = 0
 
     def toggle_multi_cursor(self, enabled):
         """Enable/disable multi-cursor editing."""
@@ -71,8 +72,7 @@ class MultiCursorMixin:
 
         self.multi_cursor_ignore_history = True
 
-        # Ctrl-Shift-Alt click adds colum of cursors towards primary
-        # cursor
+        # Ctrl-Shift-Alt click adds colum of cursors towards primary cursor
         cursor_for_pos = self.cursorForPosition(event.pos())
         first_cursor = self.textCursor()
         anchor_block = first_cursor.block()
@@ -126,6 +126,7 @@ class MultiCursorMixin:
         self.merge_extra_cursors(True)
         self.multi_cursor_ignore_history = False
         self.cursorPositionChanged.emit()
+        self.last_append_direction = 0
 
     def add_remove_cursor(self, event):
         """Add or remove extra cursor on mouse click event"""
@@ -173,18 +174,31 @@ class MultiCursorMixin:
 
         self.multi_cursor_ignore_history = False
         self.cursorPositionChanged.emit()
+        self.last_append_direction = 0
 
     def add_cursor_up(self):
         if self.multi_cursor_enabled:
-            self.extra_cursors.append(self.textCursor())
+            if not self.extra_cursors:
+                self.last_append_direction = 0
+            if self.last_append_direction > 0:  # was appending down
+                del self.extra_cursors[-1]  # undo last
+            else:
+                self.extra_cursors.append(self.textCursor())
             self.moveCursor(QTextCursor.MoveOperation.Up)
             self.merge_extra_cursors(True)
+            self.last_append_direction -= 1
 
     def add_cursor_down(self):
         if self.multi_cursor_enabled:
-            self.extra_cursors.append(self.textCursor())
+            if not self.extra_cursors:
+                self.last_append_direction = 0
+            if self.last_append_direction < 0:  # was appending up
+                del self.extra_cursors[-1]  # undo last
+            else:
+                self.extra_cursors.append(self.textCursor())
             self.moveCursor(QTextCursor.MoveOperation.Down)
             self.merge_extra_cursors(True)
+            self.last_append_direction += 1
 
     def set_extra_cursor_selections(self):
         selections = []

--- a/spyder/plugins/editor/widgets/codeeditor/multicursor_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/multicursor_mixin.py
@@ -180,10 +180,12 @@ class MultiCursorMixin:
         if self.multi_cursor_enabled:
             if not self.extra_cursors:
                 self.last_append_direction = 0
+
             if self.last_append_direction > 0:  # was appending down
                 del self.extra_cursors[-1]  # undo last
             else:
                 self.extra_cursors.append(self.textCursor())
+
             self.moveCursor(QTextCursor.MoveOperation.Up)
             self.merge_extra_cursors(True)
             self.last_append_direction -= 1
@@ -192,10 +194,12 @@ class MultiCursorMixin:
         if self.multi_cursor_enabled:
             if not self.extra_cursors:
                 self.last_append_direction = 0
+
             if self.last_append_direction < 0:  # was appending up
                 del self.extra_cursors[-1]  # undo last
             else:
                 self.extra_cursors.append(self.textCursor())
+
             self.moveCursor(QTextCursor.MoveOperation.Down)
             self.merge_extra_cursors(True)
             self.last_append_direction += 1


### PR DESCRIPTION
## Description of Changes

I made small code modifications to enhance the behavior when adding extra cursors in the editor with keyboard shortcuts. Adding cursors up (resp. down) after adding them down (resp. up) now reverts the adding.
No method added, just a counter logic (the counter is resetted when cursors are added by mouse clicking or when only one cursor was existing, to avoid *unexpected edge cases* behavior).

[Video](https://github.com/user-attachments/assets/5042d52d-3ee3-4e11-9461-035e8cd69a78)

No reported issues fixed.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:
hprodh
