### PR TITLE
PR: Support dynamic plugin fixtures with pytest 9

### DIFF
--- a/spyder/api/plugins/tests.py
+++ b/spyder/api/plugins/tests.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 # Standard library imports
 import gc
+import inspect
 import sys
 from typing import TYPE_CHECKING
 
@@ -32,6 +33,38 @@ __all__ = [
     "plugins_cls",
     "register_fixture",
 ]
+
+
+_FIXTUREDEF_PARAMETERS = inspect.signature(FixtureDef).parameters
+
+
+def _create_fixturedef(
+    request: SubRequest,
+    fixture_name: str,
+    fixture_func,
+) -> FixtureDef:
+    """Create a pytest FixtureDef compatible with the installed pytest."""
+    kwargs = {
+        "argname": fixture_name,
+        "func": fixture_func,
+        "scope": "session",
+        "baseid": request.node.nodeid,
+        "params": None,
+    }
+
+    if "fixturemanager" in _FIXTUREDEF_PARAMETERS:
+        kwargs["fixturemanager"] = request._fixturemanager
+
+    if "config" in _FIXTUREDEF_PARAMETERS:
+        kwargs["config"] = request.config
+
+    if "ids" in _FIXTUREDEF_PARAMETERS:
+        kwargs["ids"] = None
+
+    if "_ispytest" in _FIXTUREDEF_PARAMETERS:
+        kwargs["_ispytest"] = True
+
+    return FixtureDef(**kwargs)
 
 
 class MainWindowMock(QMainWindow):
@@ -125,12 +158,9 @@ def register_fixture(request: SubRequest, plugins_cls) -> None:
             return register_plugin
 
         request._fixturemanager._arg2fixturedefs[fixture_name] = [
-            FixtureDef(
-                argname=fixture_name,
-                func=register_plugin_factory(plugin_cls),
-                scope="session",
-                fixturemanager=request._fixturemanager,
-                baseid=request.node.nodeid,
-                params=None,
+            _create_fixturedef(
+                request,
+                fixture_name,
+                register_plugin_factory(plugin_cls),
             )
         ]

--- a/spyder/api/tests/test_plugin_fixtures.py
+++ b/spyder/api/tests/test_plugin_fixtures.py
@@ -1,0 +1,98 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2026- Spyder Project Contributors
+#
+# Released under the terms of the MIT License
+# (see LICENSE.txt in the project root directory for details)
+# -----------------------------------------------------------------------------
+
+"""Tests for plugin testing helpers."""
+
+from types import SimpleNamespace
+
+from spyder.api.plugins import tests as plugin_tests
+
+
+def test_create_fixturedef_with_fixturemanager(monkeypatch):
+    """Test creating a FixtureDef for pytest versions before 9."""
+    kwargs = {}
+
+    class DummyFixtureDef:
+        def __init__(self, **fixture_kwargs):
+            kwargs.update(fixture_kwargs)
+
+    request = SimpleNamespace(
+        config=object(),
+        node=SimpleNamespace(nodeid="nodeid"),
+        _fixturemanager=object(),
+    )
+    fixture_func = object()
+
+    monkeypatch.setattr(plugin_tests, "FixtureDef", DummyFixtureDef)
+    monkeypatch.setattr(
+        plugin_tests,
+        "_FIXTUREDEF_PARAMETERS",
+        {
+            "argname": None,
+            "func": None,
+            "scope": None,
+            "fixturemanager": None,
+            "baseid": None,
+            "params": None,
+        },
+    )
+
+    plugin_tests._create_fixturedef(request, "plugin_fixture", fixture_func)
+
+    assert kwargs == {
+        "argname": "plugin_fixture",
+        "func": fixture_func,
+        "scope": "session",
+        "fixturemanager": request._fixturemanager,
+        "baseid": "nodeid",
+        "params": None,
+    }
+
+
+def test_create_fixturedef_with_config(monkeypatch):
+    """Test creating a FixtureDef for pytest 9 and later."""
+    kwargs = {}
+
+    class DummyFixtureDef:
+        def __init__(self, **fixture_kwargs):
+            kwargs.update(fixture_kwargs)
+
+    request = SimpleNamespace(
+        config=object(),
+        node=SimpleNamespace(nodeid="nodeid"),
+        _fixturemanager=object(),
+    )
+    fixture_func = object()
+
+    monkeypatch.setattr(plugin_tests, "FixtureDef", DummyFixtureDef)
+    monkeypatch.setattr(
+        plugin_tests,
+        "_FIXTUREDEF_PARAMETERS",
+        {
+            "config": None,
+            "baseid": None,
+            "argname": None,
+            "func": None,
+            "scope": None,
+            "params": None,
+            "ids": None,
+            "_ispytest": None,
+        },
+    )
+
+    plugin_tests._create_fixturedef(request, "plugin_fixture", fixture_func)
+
+    assert kwargs == {
+        "config": request.config,
+        "baseid": "nodeid",
+        "argname": "plugin_fixture",
+        "func": fixture_func,
+        "scope": "session",
+        "params": None,
+        "ids": None,
+        "_ispytest": True,
+    }


### PR DESCRIPTION
## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

This PR makes the dynamic plugin fixture helper in `spyder.api.plugins.tests` adapt to the `FixtureDef` signature exposed by the installed pytest version.

In practice, this keeps the helper working on current pytest releases, including pytest 9 where `fixturemanager` was replaced by `config` and `_ispytest` is required by the constructor.

I also added focused unit tests that validate the helper builds the correct `FixtureDef` arguments for both the pre-pytest-9 and pytest-9-style signatures.

### Issue(s) Resolved

Fixes #25794

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:

officialasishkumar
