### PR TITLE
PR: Handle missing updater logs on Windows (Update manager)

### DIFF
--- a/spyder/plugins/updatemanager/tests/test_update_manager.py
+++ b/spyder/plugins/updatemanager/tests/test_update_manager.py
@@ -7,14 +7,16 @@
 import os
 from functools import lru_cache
 import logging
-from packaging.version import parse
+import subprocess
+from types import SimpleNamespace
 
 import pytest
+from packaging.version import parse
 
 from spyder.config.base import running_in_ci
 from spyder.plugins.updatemanager import workers
 from spyder.plugins.updatemanager.workers import (
-    UpdateType, get_asset_info, WorkerUpdate
+    UpdateType, get_asset_info, WorkerUpdate, WorkerUpdateUpdater
 )
 from spyder.plugins.updatemanager.widgets import update
 from spyder.plugins.updatemanager.widgets.update import UpdateManagerWidget
@@ -152,6 +154,33 @@ def test_get_asset_info(qtbot, mocker, app, version, release, update_type):
     else:
         assert info['url'].endswith(".zip")
         assert info['filename'].endswith(".zip")
+
+
+def test_update_updater_missing_windows_stderr_log(tmp_path, mocker):
+    """Test missing updater stderr logs are reported as handled errors."""
+    worker = WorkerUpdateUpdater(False)
+    worker.updater_version = parse("0.2.0")
+    worker.installer_path = str(tmp_path / "spyder-conda-lock.zip")
+
+    (tmp_path / "spyder-updater-0.2.0.conda").write_text("")
+    (tmp_path / "updater_stdout.log").write_text("")
+
+    mocker.patch.object(workers, "find_conda", return_value="conda")
+    mocker.patch.object(workers, "find_program", return_value="powershell")
+    mocker.patch.object(workers, "is_installed_all_users", return_value=False)
+    mocker.patch.object(workers, "os", new=SimpleNamespace(name="nt"))
+    mocker.patch.object(
+        workers.subprocess,
+        "run",
+        return_value=subprocess.CompletedProcess(
+            args="powershell", returncode=0, stdout="", stderr=""
+        ),
+    )
+
+    with pytest.raises(subprocess.CalledProcessError) as error:
+        worker._install_update()
+
+    assert "updater_stderr.log" in error.value.stderr
 
 
 # ---- Test WorkerDownloadInstaller

--- a/spyder/plugins/updatemanager/workers.py
+++ b/spyder/plugins/updatemanager/workers.py
@@ -247,6 +247,19 @@ def _check_asset_available(
     return asset_info
 
 
+def _read_updater_log(log_path: str) -> tuple[str, str | None]:
+    """Read a Spyder-updater log file and report OS errors separately."""
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+            return f.read(), None
+    except OSError as err:
+        logger.warning(
+            "Unable to read Spyder-updater log file %s", log_path,
+            exc_info=err
+        )
+        return "", f"Unable to read {log_path}: {err}"
+
+
 def validate_download(file: str, checksum: str) -> bool:
     """
     Compute the sha256 checksum of the provided file and compare against
@@ -628,10 +641,17 @@ class WorkerUpdateUpdater(BaseWorker):
             # Check for errors there by reading the logs
             updater_stdout = osp.join(installer_dir, "updater_stdout.log")
             updater_stderr = osp.join(installer_dir, "updater_stderr.log")
-            with open(updater_stderr, "r") as f:
-                stderr = f.read()
-            with open(updater_stdout, "r") as f:
-                stdout = f.read()
+            stdout, __ = _read_updater_log(updater_stdout)
+            stderr, stderr_error = _read_updater_log(updater_stderr)
+
+            if stderr_error is not None:
+                raise subprocess.CalledProcessError(
+                    1,
+                    " ".join(cmd),
+                    output=stdout,
+                    stderr=stderr_error,
+                )
+
             if stderr:
                 raise subprocess.CalledProcessError(
                     1, " ".join(cmd), output=stdout, stderr=stderr


### PR DESCRIPTION
## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

This PR handles a Windows-specific failure mode when updating Spyder-updater.

Before this change, if `updater_stderr.log` could not be opened after the PowerShell launcher returned successfully, Spyder raised an untracked `FileNotFoundError`. With this patch, that condition is converted into a normal `CalledProcessError`, so users get the standard updater error dialog instead of an internal exception.

I also added a regression test that reproduces the missing-log scenario and checks that it is reported as a handled updater error.

### Issue(s) Resolved

Fixes #25735

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:

officialasishkumar
