### PR TITLE
PR: ipython magic command to rename tab from the console (status: dirty)

### DIFF
--- a/external-deps/spyder-kernels/spyder_kernels/customize/code_runner.py
+++ b/external-deps/spyder-kernels/spyder_kernels/customize/code_runner.py
@@ -163,6 +163,16 @@ class SpyderCodeRunner(Magics):
             namelist=os.environ.get("SPY_UMR_NAMELIST", None),
             shell=self.shell,
         )
+    
+    @line_magic  
+    def rename_tab(self, line):  
+        """Rename the current console tab."""
+        # Emulate prior eval of the name and send request
+        # (ipython magics have precedence over eval of the line)
+        globals_ = {"__builtins__": {}}  # Restrict scope for safety
+        locals_ = self.shell.user_ns  # Fetch locals
+        new_name = str(eval(line, globals_, locals_))
+        frontend_request(blocking=False).rename_tab(new_name)
 
     @runfile_arguments
     @needs_local_scope

--- a/spyder/plugins/ipythonconsole/widgets/shell.py
+++ b/spyder/plugins/ipythonconsole/widgets/shell.py
@@ -219,6 +219,7 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
             'show_pdb_output': self.show_pdb_output,
             'pdb_input': self.pdb_input,
             'update_state': self.update_state,
+            'rename_tab': self.rename_tab,
         })
         self.kernel_comm_handlers = handlers
 
@@ -729,6 +730,13 @@ class ShellWidget(NamepaceBrowserWidget, HelpWidget, DebuggingWidget,
           switching consoles to update the Working Directory toolbar.
         """
         return self._kernel_configuration.get("cwd", '')
+
+    def rename_tab(self, new_name):  
+        """Rename the current tab from kernel request."""
+        tabwidget = self.ipyclient.container.tabwidget
+        index = tabwidget.indexOf(self.ipyclient)
+        tabwidget.setTabText(index, new_name)
+        self.ipyclient.given_name = new_name
 
     def update_state(self, state):
         """


### PR DESCRIPTION
## Description of Changes

A small code modification adding a magic command `%rename_tab`.
[Demo_rename_tabs.webm](https://github.com/user-attachments/assets/753afb08-764d-4e60-bf88-2316014e130c)

There were 2 choices to be done : 
- (First) There are magics commands registered in several places in spyder, I chose to register the new `rename_tab` in `spyder/external-deps/spyder-kernels/spyder_kernels/customize/code_runner.py` (alongside runfile, debugfile, profilefile, runcell, ...), simply because it did not need to create a signal and it felt simpler.
I think it is possible to homogeneize it with the other methods especially regarding the local scope (and the `@needs_local_scope` decorator maybe ?). (Actually, I have a feeling I did not put it in the right place, possibly it should belong alongside `%clear`, `%edit`, etc... but I struggled figuring out the whole Ipython console <-> spyder widget pipeline...)
- (Second) (much easier) : ipython magics sends the line before it is evaluated, I chose to emulate prior evaluation with the local scope to avoid surprising results regarding the effective tab names generated.

There are some glitches regarding the tab name suffixes '/A' auto-generated, I do not consider it a major concern,  yet it might need to be confirmed it is not an issue.

### To be clarified

Were the added declarations in the right place ?
Can we make the automatic tab name suffixes more stable ?

### Issue(s) Resolved

Provides alternative solutions to #22132 and #17415


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:
hprodh
