### PR TITLE
PR: Fix errors when disabling several plugins

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -279,7 +279,7 @@ Before releasing new minor or major versions, it's necessary to:
 
 * Add changelog for new version to `spyder/plugins/application/widgets/appeal_page/changelog.md` (only `New features` and `Important fixes`).
 
-* Update `CHANGELOG_URL` in `spyder/plugins/application/widgets/status.py` to point to the changelog for the new version.
+* Update `CHANGELOG_URL` in `spyder/plugins/application/container.py` to point to the changelog for the new version.
 
 * `git add .` and `git commit -m "Update Changelog [ci skip]"`
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -799,6 +799,10 @@ class MainWindow(QMainWindow, SpyderMainWindowMixin, SpyderShortcutsMixin):
         if self.splash is not None:
             self.splash.hide()
 
+        # Hide status bar if its plugin is disabled
+        if not self.is_plugin_enabled(Plugins.StatusBar):
+            self.statusBar().hide()
+
         # Register custom layouts
         if self.layouts is not None:
             self.layouts.register_custom_layouts()

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -1024,6 +1024,11 @@ class ApplicationContainer(PluginMainContainer):
         self._show_dialog(show_appeal=True)
 
     def _create_appeal_dialog(self):
+        cli_options = self._plugin.get_command_line_options()
+        if cli_options.no_web_widgets:
+            self._appeal_dialog = FakeInAppAppealDialog
+            return
+
         try:
             self._appeal_dialog = InAppAppealDialog(self)
         except QtModuleNotInstalledError:

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -11,14 +11,17 @@ Holds references for base actions in the Application of Spyder.
 """
 
 # Standard library imports
+from __future__ import annotations
 import functools
 import glob
 import os
 import os.path as osp
 import sys
 from typing import Optional
+import webbrowser
 
 # Third party imports
+from qtpy import QtModuleNotInstalledError
 from qtpy.compat import getopenfilenames
 from qtpy.QtCore import QDir, Qt, QThread, QTimer, Signal, Slot
 from qtpy.QtGui import QGuiApplication
@@ -45,7 +48,12 @@ from spyder.config.utils import (
     get_edit_filters,
     get_filter,
 )
-from spyder.plugins.application.widgets import AboutDialog, InAppAppealStatus
+from spyder.plugins.application.widgets import (
+    AboutDialog,
+    FakeInAppAppealDialog,
+    InAppAppealDialog,
+    InAppAppealStatus,
+)
 from spyder.plugins.console.api import ConsoleActions
 from spyder.utils.icon_manager import ima
 from spyder.utils.installers import InstallerMissingDependencies
@@ -53,6 +61,13 @@ from spyder.utils.environ import UserEnvDialog
 from spyder.utils.qthelpers import start_file, DialogManager
 from spyder.widgets.dependencies import DependenciesDialog
 from spyder.widgets.helperwidgets import MessageCheckBox
+
+
+DONATIONS_URL = "https://www.spyder-ide.org/donate"
+CHANGELOG_URL = (
+    "https://github.com/spyder-ide/spyder/blob/6.x/changelogs/"
+    "Spyder-6.md#version-614-2026-04-06"
+)
 
 
 class ApplicationPluginMenus:
@@ -243,22 +258,28 @@ class ApplicationContainer(PluginMainContainer):
         self.current_dpi = None
         self.dpi_messagebox = None
 
+        # To manage the user env vars dialog
+        self.dialog_manager = DialogManager()
+
         # Keep track of list of recent files
         self.recent_files = self.get_conf('recent_files', [])
-
-    # ---- PluginMainContainer API
-    # -------------------------------------------------------------------------
-    def setup(self):
 
         # Compute dependencies in a thread to not block the interface.
         self.dependencies_thread = QThread(None)
         self.dependencies_dialog = DependenciesDialog(self)
 
-        # Attributes
-        self.dialog_manager = DialogManager()
+        # For the in-app appeal message
         self.inapp_appeal_status = InAppAppealStatus(self)
+        self.inapp_appeal_status.sig_clicked.connect(
+            self._on_inapp_appeal_status_clicked
+        )
+        self._appeal_dialog: (
+            InAppAppealDialog | FakeInAppAppealDialog | None
+        ) = None
 
-        # Actions
+    # ---- PluginMainContainer API
+    # -------------------------------------------------------------------------
+    def setup(self):
         # Documentation actions
         self.documentation_action = self.create_action(
             ApplicationActions.SpyderDocumentationAction,
@@ -300,13 +321,13 @@ class ApplicationContainer(PluginMainContainer):
         self.create_action(
             ApplicationActions.ShowChangelogAction,
             _("Show changelog"),
-            triggered=self.inapp_appeal_status.show_changelog,
+            triggered=self.show_changelog,
         )
         self.create_action(
             ApplicationActions.HelpSpyderAction,
             _("Help Spyder..."),
             icon=self.create_icon("inapp_appeal"),
-            triggered=self.inapp_appeal_status.show_appeal,
+            triggered=self.show_appeal,
         )
 
         # About action
@@ -968,3 +989,55 @@ class ApplicationContainer(PluginMainContainer):
             # Fixes spyder-ide/spyder#17677
             self.dpi_messagebox.move(int(x), int(y))
             self.dpi_messagebox.adjustSize()
+
+    # ---- In-app appeal
+    # -------------------------------------------------------------------------
+    def _on_inapp_appeal_status_clicked(self):
+        """Handle widget clicks."""
+        if self._appeal_dialog is None:
+            self._create_appeal_dialog()
+
+        if self._appeal_dialog is not FakeInAppAppealDialog:
+            if self._appeal_dialog.isVisible():
+                self._appeal_dialog.hide()
+            else:
+                self.show_appeal()
+        else:
+            webbrowser.open(DONATIONS_URL)
+
+    def show_changelog(self):
+        if self._appeal_dialog is None:
+            self._create_appeal_dialog()
+
+        if self._appeal_dialog is not FakeInAppAppealDialog:
+            self._appeal_dialog.setWindowTitle(_("Changelog"))
+
+        self._show_dialog(show_appeal=False)
+
+    def show_appeal(self):
+        if self._appeal_dialog is None:
+            self._create_appeal_dialog()
+
+        if self._appeal_dialog is not FakeInAppAppealDialog:
+            self._appeal_dialog.setWindowTitle(_("Help Spyder"))
+
+        self._show_dialog(show_appeal=True)
+
+    def _create_appeal_dialog(self):
+        try:
+            self._appeal_dialog = InAppAppealDialog(self)
+        except QtModuleNotInstalledError:
+            # QtWebEngineWidgets is optional.
+            # See spyder-ide/spyder#24905 for the details.
+            self._appeal_dialog = FakeInAppAppealDialog
+
+    def _show_dialog(self, show_appeal: bool):
+        if self._appeal_dialog is not FakeInAppAppealDialog:
+            if not self._appeal_dialog.isVisible():
+                self._appeal_dialog.set_message(show_appeal)
+                self._appeal_dialog.show()
+        else:
+            if show_appeal:
+                webbrowser.open(DONATIONS_URL)
+            else:
+                webbrowser.open(CHANGELOG_URL)

--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -269,10 +269,7 @@ class ApplicationContainer(PluginMainContainer):
         self.dependencies_dialog = DependenciesDialog(self)
 
         # For the in-app appeal message
-        self.inapp_appeal_status = InAppAppealStatus(self)
-        self.inapp_appeal_status.sig_clicked.connect(
-            self._on_inapp_appeal_status_clicked
-        )
+        self.inapp_appeal_status: InAppAppealStatus | None = None
         self._appeal_dialog: (
             InAppAppealDialog | FakeInAppAppealDialog | None
         ) = None
@@ -992,7 +989,7 @@ class ApplicationContainer(PluginMainContainer):
 
     # ---- In-app appeal
     # -------------------------------------------------------------------------
-    def _on_inapp_appeal_status_clicked(self):
+    def on_inapp_appeal_status_clicked(self):
         """Handle widget clicks."""
         if self._appeal_dialog is None:
             self._create_appeal_dialog()

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -260,7 +260,7 @@ class Application(SpyderPluginV2):
         # Show appeal the fifth and 25th time Spyder starts
         spyder_runs = self.get_conf("spyder_runs_for_appeal", default=1)
         if spyder_runs in [5, 25]:
-            container.inapp_appeal_status.show_appeal()
+            QTimer.singleShot(1500, container.show_appeal)
 
             # Increase counting in one to not get stuck at this point.
             # Fixes spyder-ide/spyder#22457
@@ -648,7 +648,7 @@ class Application(SpyderPluginV2):
         container = self.get_container()
 
         # Delay showing the changelog a little bit for better UX
-        QTimer.singleShot(2500, container.inapp_appeal_status.show_changelog)
+        QTimer.singleShot(2500, container.show_changelog)
 
     # ---- Public API
     # ------------------------------------------------------------------------

--- a/spyder/plugins/application/plugin.py
+++ b/spyder/plugins/application/plugin.py
@@ -9,11 +9,11 @@ Application Plugin.
 """
 
 # Standard library imports
+from __future__ import annotations
 import os
 import os.path as osp
 import subprocess
 import sys
-from typing import Dict, Optional, Tuple
 
 # Third party imports
 from qtpy.QtCore import QTimer, Slot
@@ -30,7 +30,11 @@ from spyder.config.base import (get_module_path, get_debug_level,
                                 running_under_pytest)
 from spyder.plugins.application.confpage import ApplicationConfigPage
 from spyder.plugins.application.container import (
-    ApplicationActions, ApplicationContainer, ApplicationPluginMenus)
+    ApplicationActions,
+    ApplicationContainer,
+    ApplicationPluginMenus,
+)
+from spyder.plugins.application.widgets import InAppAppealStatus
 from spyder.plugins.console.api import ConsoleActions
 from spyder.plugins.editor.api.actions import EditorWidgetActions
 from spyder.plugins.mainmenu.api import (
@@ -67,10 +71,10 @@ class Application(SpyderPluginV2):
 
     def __init__(self, parent, configuration=None):
         super().__init__(parent, configuration)
-        self.focused_plugin: Optional[SpyderDockablePlugin] = None
-        self.file_action_enabled: Dict[Tuple[str, str], bool] = {}
-        self.edit_action_enabled: Dict[Tuple[str, str], bool] = {}
-        self.search_action_enabled: Dict[Tuple[str, str], bool] = {}
+        self.focused_plugin: SpyderDockablePlugin | None = None
+        self.file_action_enabled: dict[tuple[str, str], bool] = {}
+        self.edit_action_enabled: dict[tuple[str, str], bool] = {}
+        self.search_action_enabled: dict[tuple[str, str], bool] = {}
 
     @staticmethod
     def get_name():
@@ -159,8 +163,13 @@ class Application(SpyderPluginV2):
     @on_plugin_available(plugin=Plugins.StatusBar)
     def on_statusbar_available(self):
         statusbar = self.get_plugin(Plugins.StatusBar)
-        inapp_appeal_status = self.get_container().inapp_appeal_status
-        statusbar.add_status_widget(inapp_appeal_status)
+        container = self.get_container()
+
+        container.inapp_appeal_status = InAppAppealStatus(container)
+        container.inapp_appeal_status.sig_clicked.connect(
+            container.on_inapp_appeal_status_clicked
+        )
+        statusbar.add_status_widget(container.inapp_appeal_status)
 
     @on_plugin_available(plugin=Plugins.Toolbar)
     def on_toolbar_available(self):
@@ -212,8 +221,7 @@ class Application(SpyderPluginV2):
     @on_plugin_teardown(plugin=Plugins.StatusBar)
     def on_statusbar_teardown(self):
         statusbar = self.get_plugin(Plugins.StatusBar)
-        inapp_appeal_status = self.get_container().inapp_appeal_status
-        statusbar.remove_status_widget(inapp_appeal_status.ID)
+        statusbar.remove_status_widget(InAppAppealStatus.ID)
 
     @on_plugin_teardown(plugin=Plugins.Toolbar)
     def on_toolbar_teardown(self):
@@ -559,7 +567,7 @@ class Application(SpyderPluginV2):
                 menu_id=ApplicationMenus.Tools)
 
     def _update_focused_plugin(
-        self, plugin: Optional[SpyderDockablePlugin]
+        self, plugin: SpyderDockablePlugin | None
     ) -> None:
         """
         Update which plugin has currently focus.

--- a/spyder/plugins/application/widgets/__init__.py
+++ b/spyder/plugins/application/widgets/__init__.py
@@ -8,4 +8,5 @@
 """Widgets for the Application plugin."""
 
 from .about import AboutDialog  # noqa
+from .appeal import FakeInAppAppealDialog, InAppAppealDialog  # noqa
 from .status import InAppAppealStatus  # noqa

--- a/spyder/plugins/application/widgets/appeal.py
+++ b/spyder/plugins/application/widgets/appeal.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+"""In-app appeal dialog."""
+
+# Standard library imports
+import os.path as osp
+from string import Template
+
+# Third-party imports
+from markdown_it import MarkdownIt
+from qtpy.QtCore import Qt, QUrl
+from qtpy.QtWidgets import QDialog, QVBoxLayout
+
+# Local imports
+from spyder.api.fonts import SpyderFontType, SpyderFontsMixin
+from spyder.config.base import get_module_source_path
+from spyder.config.gui import is_dark_interface
+from spyder.utils.icon_manager import ima
+from spyder.utils.qthelpers import start_file
+from spyder.utils.stylesheet import WIN
+
+
+class FakeInAppAppealDialog:
+    """Fake class used as the in-app dialog in case it can't be built."""
+    pass
+
+
+class InAppAppealDialog(QDialog, SpyderFontsMixin):
+
+    CONF_SECTION = "main"
+    WIDTH = 530
+    HEIGHT = 620 if WIN else 640  # TODO: Check on Win/Mac
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        # Leave this import here to make Spyder work without WebEngine.
+        from spyder.widgets.browser import WebView
+
+        # Attributes
+        self.setWindowFlags(
+            self.windowFlags() & ~Qt.WindowContextHelpButtonHint
+        )
+        self.setFixedWidth(self.WIDTH)
+        self.setFixedHeight(self.HEIGHT)
+        self.setWindowIcon(ima.icon("inapp_appeal"))
+
+        # Paths to content to be loaded
+        appeal_page_dir = osp.join(
+            get_module_source_path("spyder.plugins.application.widgets"),
+            "appeal_page",
+        )
+        changelog_path = osp.join(appeal_page_dir, "changelog.md")
+        self._appeal_page_path = osp.join(
+            appeal_page_dir,
+            "dark" if is_dark_interface() else "light",
+            "index.html",
+        )
+
+        # Render changelog to html
+        with open(changelog_path, "r") as f:
+            changelog_md = f.read()
+
+        self._changelog = (
+            MarkdownIt(options_update={"breaks": True})
+            .render(changelog_md)
+            .strip()
+            .replace("\n", "")
+        )
+
+        # Read html for appeal page
+        with open(self._appeal_page_path, "r") as f:
+            self._appeal_page = f.read()
+
+        # Create webview to render the appeal message and changelog
+        self._webview = WebView(self, handle_links=True)
+
+        # Set font used in the view
+        app_font = self.get_font(SpyderFontType.Interface)
+        self._webview.set_font(app_font, size_delta=2)
+
+        # Open links in external browser
+        self._webview.page().linkClicked.connect(self._handle_link_clicks)
+
+        # Layout
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._webview)
+        self.setLayout(layout)
+
+    def _handle_link_clicks(self, url):
+        url = str(url.toString())
+        if url.startswith('http'):
+            start_file(url)
+
+    def set_message(self, appeal: bool):
+        template = Template(self._appeal_page)
+        rendered_page = template.substitute(
+            changelog_html=self._changelog,
+            show_changelog="false" if appeal else "true",
+        )
+
+        # Load page
+        self._webview.setHtml(
+            rendered_page,
+            QUrl.fromLocalFile(self._appeal_page_path)
+        )

--- a/spyder/plugins/application/widgets/status.py
+++ b/spyder/plugins/application/widgets/status.py
@@ -8,119 +8,10 @@
 
 # Standard library imports
 import datetime
-import os.path as osp
-from string import Template
-import webbrowser
-
-# Third-party imports
-from markdown_it import MarkdownIt
-from qtpy import QtModuleNotInstalledError
-from qtpy.QtCore import Qt, QUrl
-from qtpy.QtWidgets import QDialog, QVBoxLayout
 
 # Local imports
-from spyder.api.fonts import SpyderFontType, SpyderFontsMixin
 from spyder.api.widgets.status import BaseTimerStatus
 from spyder.api.translations import _
-from spyder.config.base import get_module_source_path
-from spyder.config.gui import is_dark_interface
-from spyder.utils.icon_manager import ima
-from spyder.utils.qthelpers import start_file
-from spyder.utils.stylesheet import WIN
-
-
-DONATIONS_URL = "https://www.spyder-ide.org/donate"
-CHANGELOG_URL = (
-    "https://github.com/spyder-ide/spyder/blob/6.x/changelogs/"
-    "Spyder-6.md#version-614-2026-04-06"
-)
-
-
-class FakeInAppAppealDialog:
-    """Fake class used as the in-app dialog in case it can't be built."""
-    pass
-
-
-class InAppAppealDialog(QDialog, SpyderFontsMixin):
-
-    CONF_SECTION = "main"
-    WIDTH = 530
-    HEIGHT = 620 if WIN else 640  # TODO: Check on Win/Mac
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-
-        # Leave this import here to make Spyder work without WebEngine.
-        from spyder.widgets.browser import WebView
-
-        # Attributes
-        self.setWindowFlags(
-            self.windowFlags() & ~Qt.WindowContextHelpButtonHint
-        )
-        self.setFixedWidth(self.WIDTH)
-        self.setFixedHeight(self.HEIGHT)
-        self.setWindowIcon(ima.icon("inapp_appeal"))
-
-        # Paths to content to be loaded
-        appeal_page_dir = osp.join(
-            get_module_source_path("spyder.plugins.application.widgets"),
-            "appeal_page",
-        )
-        changelog_path = osp.join(appeal_page_dir, "changelog.md")
-        self._appeal_page_path = osp.join(
-            appeal_page_dir,
-            "dark" if is_dark_interface() else "light",
-            "index.html",
-        )
-
-        # Render changelog to html
-        with open(changelog_path, "r") as f:
-            changelog_md = f.read()
-
-        self._changelog = (
-            MarkdownIt(options_update={"breaks": True})
-            .render(changelog_md)
-            .strip()
-            .replace("\n", "")
-        )
-
-        # Read html for appeal page
-        with open(self._appeal_page_path, "r") as f:
-            self._appeal_page = f.read()
-
-        # Create webview to render the appeal message and changelog
-        self._webview = WebView(self, handle_links=True)
-
-        # Set font used in the view
-        app_font = self.get_font(SpyderFontType.Interface)
-        self._webview.set_font(app_font, size_delta=2)
-
-        # Open links in external browser
-        self._webview.page().linkClicked.connect(self._handle_link_clicks)
-
-        # Layout
-        layout = QVBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._webview)
-        self.setLayout(layout)
-
-    def _handle_link_clicks(self, url):
-        url = str(url.toString())
-        if url.startswith('http'):
-            start_file(url)
-
-    def set_message(self, appeal: bool):
-        template = Template(self._appeal_page)
-        rendered_page = template.substitute(
-            changelog_html=self._changelog,
-            show_changelog="false" if appeal else "true",
-        )
-
-        # Load page
-        self._webview.setHtml(
-            rendered_page,
-            QUrl.fromLocalFile(self._appeal_page_path)
-        )
 
 
 class InAppAppealStatus(BaseTimerStatus):
@@ -136,70 +27,12 @@ class InAppAppealStatus(BaseTimerStatus):
         super().__init__(parent)
 
         self._is_shown = False
-        self._appeal_dialog = None
 
         # We don't need to show a label for this widget
         self.label_value.setVisible(False)
 
         # Update status every hour
         self.set_interval(60 * 60 * 1000)
-
-        # Show appeal on click
-        self.sig_clicked.connect(self._on_click)
-
-    # ---- Private API
-    # -------------------------------------------------------------------------
-    def _on_click(self):
-        """Handle widget clicks."""
-        if self._appeal_dialog is None:
-            self._create_appeal_dialog()
-
-        if self._appeal_dialog is not FakeInAppAppealDialog:
-            if self._appeal_dialog.isVisible():
-                self._appeal_dialog.hide()
-            else:
-                self._appeal_dialog.show()
-        else:
-            webbrowser.open(DONATIONS_URL)
-
-    def _create_appeal_dialog(self):
-        try:
-            self._appeal_dialog = InAppAppealDialog(self)
-        except QtModuleNotInstalledError:
-            # QtWebEngineWidgets is optional.
-            # See spyder-ide/spyder#24905 for the details.
-            self._appeal_dialog = FakeInAppAppealDialog
-
-    def _show_dialog(self, show_appeal: bool):
-        if self._appeal_dialog is not FakeInAppAppealDialog:
-            if not self._appeal_dialog.isVisible():
-                self._appeal_dialog.set_message(show_appeal)
-                self._appeal_dialog.show()
-        else:
-            if show_appeal:
-                webbrowser.open(DONATIONS_URL)
-            else:
-                webbrowser.open(CHANGELOG_URL)
-
-    # ---- Public API
-    # -------------------------------------------------------------------------
-    def show_changelog(self):
-        if self._appeal_dialog is None:
-            self._create_appeal_dialog()
-
-        if self._appeal_dialog is not FakeInAppAppealDialog:
-            self._appeal_dialog.setWindowTitle(_("Changelog"))
-
-        self._show_dialog(show_appeal=False)
-
-    def show_appeal(self):
-        if self._appeal_dialog is None:
-            self._create_appeal_dialog()
-
-        if self._appeal_dialog is not FakeInAppAppealDialog:
-            self._appeal_dialog.setWindowTitle(_("Help Spyder"))
-
-        self._show_dialog(show_appeal=True)
 
     # ---- StatusBarWidget API
     # -------------------------------------------------------------------------

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -248,13 +248,14 @@ class CompletionPlugin(SpyderPluginV2):
                                f'point {entry_point}')
                 raise e
 
-        # Register statusbar widgets
-        self.register_statusbar_widgets(plugin_loaded=False)
+        # To hold a reference to the statusbar plugin
+        self.statusbar = None
 
         # Define configuration page and tabs
         (conf_providers, conf_tabs) = self.gather_providers_and_configtabs()
         self.CONF_WIDGET_CLASS = partialclass(
-            CompletionConfigPage, providers=conf_providers)
+            CompletionConfigPage, providers=conf_providers
+        )
         self.ADDITIONAL_CONF_TABS = {'completions': conf_tabs}
 
     # ---- SpyderPluginV2 API
@@ -293,10 +294,8 @@ class CompletionPlugin(SpyderPluginV2):
 
     @on_plugin_available(plugin=Plugins.StatusBar)
     def on_statusbar_available(self):
-        container = self.get_container()
         self.statusbar = self.get_plugin(Plugins.StatusBar)
-        for sb in container.all_statusbar_widgets():
-            self.statusbar.add_status_widget(sb)
+        self.register_statusbar_widgets()
 
     @on_plugin_available(plugin=Plugins.MainMenu)
     def on_mainmenu_available(self):
@@ -341,7 +340,7 @@ class CompletionPlugin(SpyderPluginV2):
     @on_plugin_teardown(plugin=Plugins.StatusBar)
     def on_statusbar_teardown(self):
         container = self.get_container()
-        self.statusbar = self.get_plugin(Plugins.StatusBar)
+
         for sb in container.all_statusbar_widgets():
             self.statusbar.remove_status_widget(sb.ID)
 
@@ -434,7 +433,8 @@ class CompletionPlugin(SpyderPluginV2):
                 option_name, provider_name, *__ = option
                 if option_name == 'enabled_providers':
                     provider_status = self.get_conf(
-                        ('enabled_providers', provider_name))
+                        ('enabled_providers', provider_name)
+                    )
                     if provider_status:
                         self.start_provider_instance(provider_name)
                         self.register_statusbar_widget(provider_name)
@@ -458,15 +458,15 @@ class CompletionPlugin(SpyderPluginV2):
         ----------
         plugin_loaded: bool
             True if the plugin is already loaded in Spyder, False if it is
-            being loaded. This is needed to avoid adding statusbar widgets
-            multiple times at startup.
+            being loaded. It has no effect since 6.1.5 and will be removed in
+            6.2.0
         """
         for provider_key in self.providers:
             provider_on = self.get_conf(
-                ('enabled_providers', provider_key), True)
+                ('enabled_providers', provider_key), True
+            )
             if provider_on:
-                self.register_statusbar_widget(
-                    provider_key, plugin_loaded=plugin_loaded)
+                self.register_statusbar_widget(provider_key)
 
     def register_statusbar_widget(self, provider_name, plugin_loaded=True):
         """
@@ -478,20 +478,25 @@ class CompletionPlugin(SpyderPluginV2):
             Name of the provider that is going to create statusbar widgets.
         plugin_loaded: bool
             True if the plugin is already loaded in Spyder, False if it is
-            being loaded.
+            being loaded. It has no effect since 6.1.5 and will be removed in
+            6.2.0.
         """
+        if self.statusbar is None:
+            return
+
         container = self.get_container()
         provider = self.providers[provider_name]['instance']
         widgets_ids = container.register_statusbar_widgets(
-            provider.STATUS_BAR_CLASSES, provider_name)
-        if plugin_loaded:
-            for id_ in widgets_ids:
-                current_widget = container.statusbar_widgets[id_]
-                # Validation to check for status bar registration before trying
-                # to add a widget.
-                # See spyder-ide/spyder#16997
-                if id_ not in self.statusbar.get_status_widgets():
-                    self.statusbar.add_status_widget(current_widget)
+            provider.STATUS_BAR_CLASSES, provider_name
+        )
+
+        for id_ in widgets_ids:
+            current_widget = container.statusbar_widgets[id_]
+            # Validation to check for status bar registration before trying
+            # to add a widget.
+            # See spyder-ide/spyder#16997
+            if id_ not in self.statusbar.get_status_widgets():
+                self.statusbar.add_status_widget(current_widget)
 
     def unregister_statusbar(self, provider_name):
         """
@@ -502,9 +507,14 @@ class CompletionPlugin(SpyderPluginV2):
         provider_name: str
             Name of the provider that is going to delete statusbar widgets.
         """
+        if self.statusbar is None:
+            return
+
         container = self.get_container()
         provider_keys = self.get_container().get_provider_statusbar_keys(
-            provider_name)
+            provider_name
+        )
+
         for id_ in provider_keys:
             # Validation to check for status bar registration before trying
             # to remove a widget.

--- a/spyder/plugins/debugger/plugin.py
+++ b/spyder/plugins/debugger/plugin.py
@@ -377,6 +377,9 @@ class Debugger(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
     @on_plugin_available(plugin=Plugins.Toolbar)
     def on_toolbar_available(self):
         toolbar = self.get_plugin(Plugins.Toolbar)
+        toolbar.create_application_toolbar(
+            ApplicationToolbars.Debug, _("Debug toolbar")
+        )
 
         for action_id in [
             DebuggerWidgetActions.Next,
@@ -412,6 +415,8 @@ class Debugger(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
                 action_id,
                 toolbar_id=ApplicationToolbars.Debug,
             )
+
+        toolbar.remove_application_toolbar(ApplicationToolbars.Debug)
 
     # ---- Private API
     # ------------------------------------------------------------------------

--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -33,6 +33,13 @@ from spyder.plugins.editor.api.run import (
 )
 from spyder.plugins.editor.confpage import EditorConfigPage
 from spyder.plugins.editor.widgets.main_widget import EditorMainWidget
+from spyder.plugins.editor.widgets.status import (
+    CursorPositionStatus,
+    EncodingStatus,
+    EOLStatus,
+    ReadWriteStatus,
+    VCSStatus,
+)
 from spyder.plugins.mainmenu.api import (
     ApplicationMenus,
     EditMenuSections,
@@ -238,22 +245,43 @@ class Editor(SpyderDockablePlugin):
         # Add status widgets
         statusbar = self.get_plugin(Plugins.StatusBar)
         widget = self.get_widget()
+
+        widget.readwrite_status = ReadWriteStatus(widget)
         statusbar.add_status_widget(widget.readwrite_status)
+
+        widget.eol_status = EOLStatus(widget)
         statusbar.add_status_widget(widget.eol_status)
+
+        widget.encoding_status = EncodingStatus(widget)
         statusbar.add_status_widget(widget.encoding_status)
+
+        widget.cursorpos_status = CursorPositionStatus(widget)
         statusbar.add_status_widget(widget.cursorpos_status)
+
+        widget.vcs_status = VCSStatus(widget)
         statusbar.add_status_widget(widget.vcs_status)
+
+        # This is necessary for the first editorstack that is created because
+        # when that's done these widgets can't exist yet.
+        widget.register_status_widgets()
 
     @on_plugin_teardown(plugin=Plugins.StatusBar)
     def on_statusbar_teardown(self):
         # Remove status widgets
         statusbar = self.get_plugin(Plugins.StatusBar)
         widget = self.get_widget()
-        statusbar.remove_status_widget(widget.readwrite_status.ID)
-        statusbar.remove_status_widget(widget.eol_status.ID)
-        statusbar.remove_status_widget(widget.encoding_status.ID)
-        statusbar.remove_status_widget(widget.cursorpos_status.ID)
-        statusbar.remove_status_widget(widget.vcs_status.ID)
+
+        statusbar.remove_status_widget(ReadWriteStatus.ID)
+        statusbar.remove_status_widget(EOLStatus.ID)
+        statusbar.remove_status_widget(EncodingStatus.ID)
+        statusbar.remove_status_widget(CursorPositionStatus.ID)
+        statusbar.remove_status_widget(VCSStatus.ID)
+
+        widget.readwrite_status = None
+        widget.eol_status = None
+        widget.encoding_status = None
+        widget.cursorpos_status = None
+        widget.vcs_status = None
 
     @on_plugin_available(plugin=Plugins.Run)
     def on_run_available(self):

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -283,11 +283,13 @@ class EditorMainWidget(PluginMainWidget):
         # Configuration dialog size
         self.dialog_size = None
 
-        self.vcs_status = VCSStatus(self)
-        self.cursorpos_status = CursorPositionStatus(self)
-        self.encoding_status = EncodingStatus(self)
-        self.eol_status = EOLStatus(self)
-        self.readwrite_status = ReadWriteStatus(self)
+        # These attrs are set by the plugin if the StatusBar plugin is
+        # available
+        self.readwrite_status: ReadWriteStatus | None = None
+        self.eol_status: EOLStatus | None = None
+        self.encoding_status: EncodingStatus | None = None
+        self.cursorpos_status: CursorPositionStatus| None = None
+        self.vcs_status: VCSStatus | None = None
 
         self.last_edit_cursor_pos = None
         self.cursor_undo_history = []
@@ -1242,6 +1244,39 @@ class EditorMainWidget(PluginMainWidget):
 
     # ---- Handling editorstacks
     # -------------------------------------------------------------------------
+    def register_status_widgets(self, editorstack: EditorStack | None = None):
+        if editorstack is None:
+            editorstack = self.get_current_editorstack()
+
+        if self.readwrite_status is not None:
+            editorstack.reset_statusbar.connect(self.readwrite_status.hide)
+            editorstack.readonly_changed.connect(
+                self.readwrite_status.update_readonly
+            )
+
+        if self.encoding_status is not None:
+            editorstack.reset_statusbar.connect(self.encoding_status.hide)
+            editorstack.encoding_changed.connect(
+                self.encoding_status.update_encoding
+            )
+
+        if self.cursorpos_status is not None:
+            editorstack.reset_statusbar.connect(self.cursorpos_status.hide)
+            editorstack.sig_editor_cursor_position_changed.connect(
+                self.cursorpos_status.update_cursor_position
+            )
+
+        if self.eol_status is not None:
+            editorstack.sig_refresh_eol_chars.connect(
+                self.eol_status.update_eol
+            )
+
+        if self.vcs_status is not None:
+            editorstack.current_file_changed.connect(
+                self.vcs_status.update_vcs
+            )
+            editorstack.file_saved.connect(self.vcs_status.update_vcs_state)
+
     def register_editorstack(self, editorstack):
         logger.debug("Registering new EditorStack")
         self.editorstacks.append(editorstack)
@@ -1250,26 +1285,16 @@ class EditorMainWidget(PluginMainWidget):
             # editorstack is a child of the Editor plugin
             self.set_last_focused_editorstack(self, editorstack)
             editorstack.set_closable(len(self.editorstacks) > 1)
+
             if self.outlineexplorer is not None:
                 editorstack.set_outlineexplorer(self.outlineexplorer)
+
             editorstack.set_find_widget(self.find_widget)
-            editorstack.reset_statusbar.connect(self.readwrite_status.hide)
-            editorstack.reset_statusbar.connect(self.encoding_status.hide)
-            editorstack.reset_statusbar.connect(self.cursorpos_status.hide)
-            editorstack.readonly_changed.connect(
-                                        self.readwrite_status.update_readonly)
-            editorstack.encoding_changed.connect(
-                                         self.encoding_status.update_encoding)
             editorstack.sig_editor_cursor_position_changed.connect(
-                                 self.cursorpos_status.update_cursor_position)
-            editorstack.sig_editor_cursor_position_changed.connect(
-                self.current_editor_cursor_changed)
-            editorstack.sig_refresh_eol_chars.connect(
-                self.eol_status.update_eol)
-            editorstack.current_file_changed.connect(
-                self.vcs_status.update_vcs)
-            editorstack.file_saved.connect(
-                self.vcs_status.update_vcs_state)
+                self.current_editor_cursor_changed
+            )
+
+            self.register_status_widgets(editorstack)
 
         editorstack.update_switcher_actions(self.switcher_manager is not None)
         editorstack.set_tempfile_path(self.TEMPFILE_PATH)

--- a/spyder/plugins/editor/widgets/window.py
+++ b/spyder/plugins/editor/widgets/window.py
@@ -112,38 +112,32 @@ class EditorWidget(QSplitter, SpyderConfigurationObserver):
         self.find_widget.hide()
 
         # ---- Status bar
-        # Check if widgets are available in main_widget to also create them
-        # here (they couldn't be if the StatusBar plugin is disabled).
         statusbar = parent.statusBar()
 
-        if self.main_widget.vcs_status is not None:
+        # Check if the StatusBar plugin is enabled to create status widgets
+        if self.get_conf("enable", section="statusbar", default=True):
+            # *DON'T* change the order in which these widgets are added. It's
+            # the same one used in the main window.
+            self.readwrite_status = ReadWriteStatus(self)
+            statusbar.insertPermanentWidget(0, self.readwrite_status)
+
+            self.eol_status = EOLStatus(self)
+            statusbar.insertPermanentWidget(0, self.eol_status)
+
+            self.encoding_status = EncodingStatus(self)
+            statusbar.insertPermanentWidget(0, self.encoding_status)
+
+            self.cursorpos_status = CursorPositionStatus(self)
+            statusbar.insertPermanentWidget(0, self.cursorpos_status)
+
             self.vcs_status = VCSStatus(self)
             statusbar.insertPermanentWidget(0, self.vcs_status)
         else:
+            statusbar.hide()
             self.vcs_status = None
-
-        if self.main_widget.cursorpos_status is not None:
-            self.cursorpos_status = CursorPositionStatus(self)
-            statusbar.insertPermanentWidget(0, self.cursorpos_status)
-        else:
             self.cursorpos_status = None
-
-        if self.main_widget.encoding_status is not None:
-            self.encoding_status = EncodingStatus(self)
-            statusbar.insertPermanentWidget(0, self.encoding_status)
-        else:
             self.encoding_status = None
-
-        if self.main_widget.eol_status is not None:
-            self.eol_status = EOLStatus(self)
-            statusbar.insertPermanentWidget(0, self.eol_status)
-        else:
             self.eol_status = None
-
-        if self.main_widget.readwrite_status is not None:
-            self.readwrite_status = ReadWriteStatus(self)
-            statusbar.insertPermanentWidget(0, self.readwrite_status)
-        else:
             self.readwrite_status = None
 
         # ---- Outline.

--- a/spyder/plugins/editor/widgets/window.py
+++ b/spyder/plugins/editor/widgets/window.py
@@ -20,8 +20,13 @@ import sys
 import qstylizer.style
 from qtpy.QtCore import QByteArray, QEvent, QPoint, QSize, Qt, Signal, Slot
 from qtpy.QtGui import QFont
-from qtpy.QtWidgets import (QAction, QApplication, QMainWindow, QSplitter,
-                            QVBoxLayout, QWidget)
+from qtpy.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QSplitter,
+    QVBoxLayout,
+    QWidget,
+)
 
 # Local imports
 from spyder.api.plugins import Plugins
@@ -107,18 +112,39 @@ class EditorWidget(QSplitter, SpyderConfigurationObserver):
         self.find_widget.hide()
 
         # ---- Status bar
+        # Check if widgets are available in main_widget to also create them
+        # here (they couldn't be if the StatusBar plugin is disabled).
         statusbar = parent.statusBar()
-        self.vcs_status = VCSStatus(self)
-        self.cursorpos_status = CursorPositionStatus(self)
-        self.encoding_status = EncodingStatus(self)
-        self.eol_status = EOLStatus(self)
-        self.readwrite_status = ReadWriteStatus(self)
 
-        statusbar.insertPermanentWidget(0, self.readwrite_status)
-        statusbar.insertPermanentWidget(0, self.eol_status)
-        statusbar.insertPermanentWidget(0, self.encoding_status)
-        statusbar.insertPermanentWidget(0, self.cursorpos_status)
-        statusbar.insertPermanentWidget(0, self.vcs_status)
+        if self.main_widget.vcs_status is not None:
+            self.vcs_status = VCSStatus(self)
+            statusbar.insertPermanentWidget(0, self.vcs_status)
+        else:
+            self.vcs_status = None
+
+        if self.main_widget.cursorpos_status is not None:
+            self.cursorpos_status = CursorPositionStatus(self)
+            statusbar.insertPermanentWidget(0, self.cursorpos_status)
+        else:
+            self.cursorpos_status = None
+
+        if self.main_widget.encoding_status is not None:
+            self.encoding_status = EncodingStatus(self)
+            statusbar.insertPermanentWidget(0, self.encoding_status)
+        else:
+            self.encoding_status = None
+
+        if self.main_widget.eol_status is not None:
+            self.eol_status = EOLStatus(self)
+            statusbar.insertPermanentWidget(0, self.eol_status)
+        else:
+            self.eol_status = None
+
+        if self.main_widget.readwrite_status is not None:
+            self.readwrite_status = ReadWriteStatus(self)
+            statusbar.insertPermanentWidget(0, self.readwrite_status)
+        else:
+            self.readwrite_status = None
 
         # ---- Outline.
         self.outlineexplorer = None
@@ -225,16 +251,34 @@ class EditorWidget(QSplitter, SpyderConfigurationObserver):
         editorstack.tabs.setStyleSheet(css.toString())
 
         # Signals
-        editorstack.reset_statusbar.connect(self.readwrite_status.hide)
-        editorstack.reset_statusbar.connect(self.encoding_status.hide)
-        editorstack.reset_statusbar.connect(self.cursorpos_status.hide)
-        editorstack.readonly_changed.connect(
-            self.readwrite_status.update_readonly)
-        editorstack.encoding_changed.connect(
-            self.encoding_status.update_encoding)
-        editorstack.sig_editor_cursor_position_changed.connect(
-            self.cursorpos_status.update_cursor_position)
-        editorstack.sig_refresh_eol_chars.connect(self.eol_status.update_eol)
+        if self.readwrite_status is not None:
+            editorstack.reset_statusbar.connect(self.readwrite_status.hide)
+            editorstack.readonly_changed.connect(
+                self.readwrite_status.update_readonly
+            )
+
+        if self.encoding_status is not None:
+            editorstack.reset_statusbar.connect(self.encoding_status.hide)
+            editorstack.encoding_changed.connect(
+                self.encoding_status.update_encoding
+            )
+
+        if self.cursorpos_status is not None:
+            editorstack.reset_statusbar.connect(self.cursorpos_status.hide)
+            editorstack.sig_editor_cursor_position_changed.connect(
+                self.cursorpos_status.update_cursor_position
+            )
+
+        if self.eol_status is not None:
+            editorstack.sig_refresh_eol_chars.connect(
+                self.eol_status.update_eol
+            )
+
+        if self.vcs_status is not None:
+            editorstack.current_file_changed.connect(
+                self.vcs_status.update_vcs
+            )
+            editorstack.file_saved.connect(self.vcs_status.update_vcs_state)
 
         # Register stack
         self.main_widget.register_editorstack(editorstack)

--- a/spyder/plugins/ipythonconsole/plugin.py
+++ b/spyder/plugins/ipythonconsole/plugin.py
@@ -33,14 +33,26 @@ from spyder.plugins.ipythonconsole.api import (
 )
 from spyder.plugins.ipythonconsole.confpage import IPythonConsoleConfigPage
 from spyder.plugins.ipythonconsole.widgets.run_conf import IPythonConfigOptions
+from spyder.plugins.ipythonconsole.widgets import (
+    MatplotlibStatus,
+    PythonEnvironmentStatus,
+)
 from spyder.plugins.ipythonconsole.widgets.main_widget import (
     IPythonConsoleWidget
 )
 from spyder.plugins.mainmenu.api import (
-    ApplicationMenus, ConsolesMenuSections, HelpMenuSections)
+    ApplicationMenus,
+    ConsolesMenuSections,
+    HelpMenuSections,
+)
 from spyder.plugins.run.api import (
-    RunContext, RunExecutor, RunConfiguration,
-    ExtendedRunExecutionParameters, RunResult, run_execute)
+    ExtendedRunExecutionParameters,
+    RunContext,
+    RunConfiguration,
+    RunExecutor,
+    RunResult,
+    run_execute,
+)
 from spyder.plugins.editor.api.run import CellRun, FileRun, SelectionRun
 
 
@@ -423,12 +435,19 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
     def on_statusbar_available(self):
         # Add status widgets
         statusbar = self.get_plugin(Plugins.StatusBar)
+        widget = self.get_widget()
 
-        pythonenv_status = self.get_widget().pythonenv_status
+        pythonenv_status = PythonEnvironmentStatus(widget)
         statusbar.add_status_widget(pythonenv_status)
         pythonenv_status.register_ipythonconsole(self)
+        pythonenv_status.sig_interpreter_changed.connect(
+            widget.sig_interpreter_changed
+        )
+        pythonenv_status.sig_open_preferences_requested.connect(
+            widget.sig_open_preferences_requested
+        )
 
-        matplotlib_status = self.get_widget().matplotlib_status
+        matplotlib_status = MatplotlibStatus(widget)
         statusbar.add_status_widget(matplotlib_status)
         matplotlib_status.register_ipythonconsole(self)
 
@@ -436,14 +455,23 @@ class IPythonConsole(SpyderDockablePlugin, RunExecutor):
     def on_statusbar_teardown(self):
         # Remove status widgets
         statusbar = self.get_plugin(Plugins.StatusBar)
+        widget = self.get_widget()
 
-        pythonenv_status = self.get_widget().pythonenv_status
+        pythonenv_status = statusbar.get_status_widget(
+            PythonEnvironmentStatus.ID
+        )
+        pythonenv_status.sig_interpreter_changed.disconnect(
+            widget.sig_interpreter_changed
+        )
+        pythonenv_status.sig_open_preferences_requested.disconnect(
+            widget.sig_open_preferences_requested
+        )
         pythonenv_status.unregister_ipythonconsole(self)
-        statusbar.remove_status_widget(pythonenv_status.ID)
+        statusbar.remove_status_widget(PythonEnvironmentStatus.ID)
 
-        matplotlib_status = self.get_widget().matplotlib_status
+        matplotlib_status = statusbar.get_status_widget(MatplotlibStatus.ID)
         matplotlib_status.unregister_ipythonconsole(self)
-        statusbar.remove_status_widget(matplotlib_status.ID)
+        statusbar.remove_status_widget(MatplotlibStatus.ID)
 
     @on_plugin_available(plugin=Plugins.Preferences)
     def on_preferences_available(self):

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -58,7 +58,6 @@ from spyder.plugins.ipythonconsole.widgets import (
     KernelConnectionDialog,
     MatplotlibStatus,
     PageControlWidget,
-    PythonEnvironmentStatus,
     ShellWidget,
 )
 from spyder.plugins.ipythonconsole.widgets.mixins import CachedKernelMixin
@@ -401,14 +400,9 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):  # noqa: PLR090
         # See spyder-ide/spyder#11880
         self._init_asyncio_patch()
 
-        # Create status widgets
-        self.matplotlib_status = MatplotlibStatus(self)
-        self.pythonenv_status = PythonEnvironmentStatus(self)
-        self.pythonenv_status.sig_interpreter_changed.connect(
-            self.sig_interpreter_changed
-        )
-        self.pythonenv_status.sig_open_preferences_requested.connect(
-            self.sig_open_preferences_requested)
+        # Create status widgets for tests
+        if running_under_pytest():
+            self.matplotlib_status = MatplotlibStatus(self)
 
         # Initial value for the current working directory
         self._current_working_directory = get_home_dir()

--- a/spyder/plugins/profiler/plugin.py
+++ b/spyder/plugins/profiler/plugin.py
@@ -45,7 +45,12 @@ class Profiler(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
     """
 
     NAME = 'profiler'
-    REQUIRES = [Plugins.Preferences, Plugins.IPythonConsole, Plugins.Run]
+    REQUIRES = [
+        Plugins.Preferences,
+        Plugins.IPythonConsole,
+        Plugins.Run,
+        Plugins.Toolbar,
+    ]
     OPTIONAL = [Plugins.Editor]
     TABIFY = [Plugins.VariableExplorer, Plugins.Help]
     WIDGET_CLASS = ProfilerWidget
@@ -234,6 +239,18 @@ class Profiler(SpyderDockablePlugin, ShellConnectPluginMixin, RunExecutor):
     def on_preferences_teardown(self):
         preferences = self.get_plugin(Plugins.Preferences)
         preferences.deregister_plugin_preferences(self)
+
+    @on_plugin_available(plugin=Plugins.Toolbar)
+    def on_toolbar_available(self):
+        toolbar = self.get_plugin(Plugins.Toolbar)
+        toolbar.create_application_toolbar(
+            ApplicationToolbars.Profile, _("Profile toolbar")
+        )
+
+    @on_plugin_teardown(plugin=Plugins.Toolbar)
+    def on_toolbar_teardown(self):
+        toolbar = self.get_plugin(Plugins.Toolbar)
+        toolbar.remove_application_toolbar(ApplicationToolbars.Profile)
 
     def on_mainwindow_visible(self):
         # Make plugin visible in case it's not but only once. For most users

--- a/spyder/plugins/run/container.py
+++ b/spyder/plugins/run/container.py
@@ -407,7 +407,12 @@ class RunContainer(PluginMainContainer):
 
         self.metadata_model.set_current_run_configuration(uuid)
 
-        if uuid is not None:
+        # For now, the default executor for run_action is the IPython console,
+        # so we check if it's enabled to enable the action too.
+        # TODO: Fix this when we make the executor configurable.
+        if uuid is not None and self._plugin.is_plugin_enabled(
+            Plugins.IPythonConsole
+        ):
             self.run_action.setEnabled(True)
             self.configure_action.setEnabled(True)
 

--- a/spyder/plugins/run/plugin.py
+++ b/spyder/plugins/run/plugin.py
@@ -141,6 +141,9 @@ class Run(SpyderPluginV2):
     @on_plugin_available(plugin=Plugins.Toolbar)
     def on_toolbar_available(self):
         toolbar = self.get_plugin(Plugins.Toolbar)
+        toolbar.create_application_toolbar(
+            ApplicationToolbars.Run, _("Run toolbar")
+        )
         toolbar.add_item_to_application_toolbar(
             self.get_action(RunActions.Run), ApplicationToolbars.Run
         )
@@ -208,13 +211,17 @@ class Run(SpyderPluginV2):
     def on_toolbar_teardown(self):
         toolbar = self.get_plugin(Plugins.Toolbar)
         toolbar.remove_item_from_application_toolbar(
-            RunActions.Run, ApplicationToolbars.Run)
+            RunActions.Run, ApplicationToolbars.Run
+        )
+
         for key in self.toolbar_actions:
             (_, count, action_id) = self.all_run_actions[key]
             if count > 0:
                 toolbar.remove_item_from_application_toolbar(
                     action_id, ApplicationToolbars.Run
                 )
+
+        toolbar.remove_application_toolbar(ApplicationToolbars.Run)
 
     @on_plugin_teardown(plugin=Plugins.Shortcuts)
     def on_shortcuts_teardown(self):

--- a/spyder/plugins/run/tests/test_run.py
+++ b/spyder/plugins/run/tests/test_run.py
@@ -21,15 +21,36 @@ import pytest
 from qtpy import PYQT6
 from qtpy.QtCore import Signal, Qt
 from qtpy.QtWidgets import (
-    QAction, QWidget, QCheckBox, QLineEdit, QVBoxLayout, QHBoxLayout, QLabel)
+    QAction,
+    QCheckBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QVBoxLayout,
+    QWidget,
+)
 
 # Local imports
+from spyder.api.plugins import Plugins
 from spyder.plugins.run.api import (
-    RunExecutor, RunConfigurationProvider, RunConfigurationMetadata, Context,
-    RunConfiguration, SupportedExtensionContexts, RunExecutionParameters,
-    RunExecutorConfigurationGroup, ExtendedRunExecutionParameters,
-    PossibleRunResult, RunContext, ExtendedContext, RunActions, run_execute,
-    WorkingDirOpts, WorkingDirSource, StoredRunExecutorParameters)
+    Context,
+    ExtendedContext,
+    ExtendedRunExecutionParameters,
+    PossibleRunResult,
+    RunActions,
+    RunConfiguration,
+    RunConfigurationProvider,
+    RunConfigurationMetadata,
+    RunContext,
+    RunExecutor,
+    RunExecutionParameters,
+    RunExecutorConfigurationGroup,
+    StoredRunExecutorParameters,
+    SupportedExtensionContexts,
+    WorkingDirOpts,
+    WorkingDirSource,
+    run_execute,
+)
 from spyder.plugins.run.plugin import Run
 
 
@@ -37,8 +58,15 @@ logger = logging.getLogger(__name__)
 
 
 class MockedMainWindow(QWidget, MagicMock):
+
     def get_plugin(self, name, error=True):
         return MagicMock()
+
+    def is_plugin_enabled(self, name):
+        if name == Plugins.IPythonConsole:
+            return True
+        else:
+            return False
 
 
 class ExampleConfigurationProvider(RunConfigurationProvider):

--- a/spyder/plugins/statusbar/plugin.py
+++ b/spyder/plugins/statusbar/plugin.py
@@ -76,7 +76,8 @@ class StatusBar(SpyderPluginV2):
         self.add_status_widget(self.mem_status, StatusBarWidgetPosition.Right)
         self.add_status_widget(self.cpu_status, StatusBarWidgetPosition.Right)
         self.add_status_widget(
-            self.clock_status, StatusBarWidgetPosition.Right)
+            self.clock_status, StatusBarWidgetPosition.Right
+        )
 
     def on_close(self, _unused):
         self._statusbar.setVisible(False)

--- a/spyder/plugins/toolbar/container.py
+++ b/spyder/plugins/toolbar/container.py
@@ -403,9 +403,10 @@ class ToolbarContainer(PluginMainContainer):
                 toolbars_order
                 + [ApplicationToolbars.WorkingDirectory]
             ):
-                toolbar = app_toolbars[toolbar_id]
-                self._plugin.main.addToolBar(toolbar)
-                toolbar.render()
+                toolbar = app_toolbars.get(toolbar_id)
+                if toolbar:
+                    self._plugin.main.addToolBar(toolbar)
+                    toolbar.render()
         else:
             logger.debug("Render application toolbars")
 

--- a/spyder/plugins/toolbar/plugin.py
+++ b/spyder/plugins/toolbar/plugin.py
@@ -53,12 +53,13 @@ class Toolbar(SpyderPluginV2):
         return QIcon()
 
     def on_initialize(self):
-        create_app_toolbar = self.create_application_toolbar
-        create_app_toolbar(ApplicationToolbars.File, _("File toolbar"))
-        create_app_toolbar(ApplicationToolbars.Run, _("Run toolbar"))
-        create_app_toolbar(ApplicationToolbars.Debug, _("Debug toolbar"))
-        create_app_toolbar(ApplicationToolbars.Profile, _("Profile toolbar"))
-        create_app_toolbar(ApplicationToolbars.Main, _("Main toolbar"))
+        # Only create here toolbars for plugins that can't be disabled
+        self.create_application_toolbar(
+            ApplicationToolbars.File, _("File toolbar")
+        )
+        self.create_application_toolbar(
+            ApplicationToolbars.Main, _("Main toolbar")
+        )
 
     @on_plugin_available(plugin=Plugins.MainMenu)
     def on_main_menu_available(self):

--- a/spyder/plugins/toolbar/tests/test_toolbar.py
+++ b/spyder/plugins/toolbar/tests/test_toolbar.py
@@ -30,10 +30,18 @@ def toolbar(qtbot):
     toolbar = Toolbar(main_window, configuration=CONF)
     toolbar.on_initialize()
 
-    # Add working directory toolbar
+    # Add toolbars from other plugins
     cwd = WorkingDirectory(main_window, None)
     cwd.on_initialize()
     toolbar.add_application_toolbar(cwd.get_container().toolbar)
+
+    toolbar.create_application_toolbar(ApplicationToolbars.Run, "Run toolbar")
+    toolbar.create_application_toolbar(
+        ApplicationToolbars.Debug, "Debug toolbar"
+    )
+    toolbar.create_application_toolbar(
+        ApplicationToolbars.Profile, "Profile toolbar"
+    )
 
     # Add buttons to the other toolbars
     actions = [
@@ -69,6 +77,7 @@ def test_default_order(toolbar):
         ApplicationToolbars.File,
         ApplicationToolbars.Run,
         ApplicationToolbars.Debug,
+        ApplicationToolbars.Profile,
         ApplicationToolbars.Main,
         ApplicationToolbars.WorkingDirectory,
     ]
@@ -91,6 +100,7 @@ def test_restore_toolbars_order(toolbar, qtbot):
         ApplicationToolbars.Debug,
         ApplicationToolbars.File,
         ApplicationToolbars.Run,
+        ApplicationToolbars.Profile,
         ApplicationToolbars.Main,
     ]
 

--- a/spyder/plugins/updatemanager/container.py
+++ b/spyder/plugins/updatemanager/container.py
@@ -11,6 +11,7 @@ Holds references for base actions in the Application of Spyder.
 """
 
 # Standard library imports
+from __future__ import annotations
 import logging
 
 # Third party imports
@@ -44,7 +45,9 @@ class UpdateManagerContainer(PluginMainContainer):
     def setup(self):
         self.dialog_manager = DialogManager()
         self.update_manager = UpdateManagerWidget(parent=self)
-        self.update_manager_status = UpdateManagerStatus(parent=self)
+
+        # This is set by the plugin
+        self.update_manager_status: UpdateManagerStatus | None = None
 
         # Actions
         self.check_update_action = self.create_action(
@@ -54,26 +57,34 @@ class UpdateManagerContainer(PluginMainContainer):
         )
 
         # Signals
-        self.update_manager.sig_set_status.connect(self.set_status)
         self.update_manager.sig_disable_actions.connect(
             self._set_actions_state
         )
-        self.update_manager.sig_block_status_signals.connect(
-            self.update_manager_status.blockSignals)
-        self.update_manager.sig_download_progress.connect(
-            self.update_manager_status.set_download_progress)
         self.update_manager.sig_exception_occurred.connect(
             self.sig_exception_occurred
         )
         self.update_manager.sig_install_on_close.connect(
-            self.set_install_on_close)
+            self.set_install_on_close
+        )
         self.update_manager.sig_quit_requested.connect(self.sig_quit_requested)
 
-        self.update_manager_status.sig_check_update.connect(
-            self.start_check_update)
-        self.update_manager_status.sig_start_update.connect(self.start_update)
-        self.update_manager_status.sig_show_progress_dialog.connect(
-            self.update_manager.show_progress_dialog)
+        if self.update_manager_status is not None:
+            self.update_manager.sig_set_status.connect(self.set_status)
+            self.update_manager.sig_block_status_signals.connect(
+                self.update_manager_status.blockSignals
+            )
+            self.update_manager.sig_download_progress.connect(
+                self.update_manager_status.set_download_progress
+            )
+            self.update_manager_status.sig_check_update.connect(
+                self.start_check_update
+            )
+            self.update_manager_status.sig_start_update.connect(
+                self.start_update
+            )
+            self.update_manager_status.sig_show_progress_dialog.connect(
+                self.update_manager.show_progress_dialog
+            )
 
     def update_actions(self):
         pass

--- a/spyder/plugins/updatemanager/plugin.py
+++ b/spyder/plugins/updatemanager/plugin.py
@@ -19,11 +19,12 @@ from spyder.api.plugin_registration.decorators import (
     on_plugin_teardown
 )
 from spyder.config.base import is_conda_based_app
+from spyder.plugins.mainmenu.api import ApplicationMenus, HelpMenuSections
 from spyder.plugins.updatemanager.container import (
     UpdateManagerActions,
     UpdateManagerContainer
 )
-from spyder.plugins.mainmenu.api import ApplicationMenus, HelpMenuSections
+from spyder.plugins.updatemanager.widgets.status import UpdateManagerStatus
 
 
 class UpdateManager(SpyderPluginV2):
@@ -58,7 +59,7 @@ class UpdateManager(SpyderPluginV2):
 
     # ---- Plugin initialization
     def on_initialize(self):
-        pass
+        self.update_manager_status = None
 
     @on_plugin_available(plugin=Plugins.Preferences)
     def on_preferences_available(self):
@@ -83,6 +84,10 @@ class UpdateManager(SpyderPluginV2):
     def on_statusbar_available(self):
         # Add status widget
         statusbar = self.get_plugin(Plugins.StatusBar)
+        container = self.get_container()
+
+        self.update_manager_status = UpdateManagerStatus(parent=container)
+        container.update_manager_status = self.update_manager_status
         statusbar.add_status_widget(self.update_manager_status)
 
     # ---- Plugin teardown
@@ -111,7 +116,8 @@ class UpdateManager(SpyderPluginV2):
 
         # Initialize status.
         # Note that NO_STATUS also hides the statusbar widget.
-        container.update_manager_status.set_no_status()
+        if self.update_manager_status is not None:
+            self.update_manager_status.set_no_status()
 
         # Check for updates on startup
         if self.get_conf('check_updates_on_startup'):
@@ -172,8 +178,3 @@ class UpdateManager(SpyderPluginV2):
     def check_update_action(self):
         """Check if a new version of Spyder is available."""
         return self.get_container().check_update_action
-
-    @property
-    def update_manager_status(self):
-        """Get Update manager statusbar widget"""
-        return self.get_container().update_manager_status


### PR DESCRIPTION
## Description of Changes

* Don't enable Run action when the IPython console is disabled.
* Move Debugger, Profiler and Run toolbars creation to their respective plugins so they are not created when those plugins are disabled.
* Move status bar widgets creation to their respective plugins (from the main widget or container) so they are instantiated only when the Status bar plugin is enabled.
* Hide main window status bar if its plugin is not enabled.

### Issue(s) Resolved

Fixes #25931 
Fixes #25677

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
