### PR TITLE
PR: Fix errors with splits in Editor windows & other fixes

### DIFF
--- a/spyder/plugins/editor/plugin.py
+++ b/spyder/plugins/editor/plugin.py
@@ -678,6 +678,7 @@ class Editor(SpyderDockablePlugin):
         outline_widget = outline.get_widget()
 
         widget.set_outlineexplorer(outline_widget)
+        widget.outline_plugin = outline
 
     @on_plugin_teardown(plugin=Plugins.OutlineExplorer)
     def on_outlinexplorer_teardown(self):
@@ -1054,12 +1055,8 @@ class Editor(SpyderDockablePlugin):
             If any previously open file should be closed. Default `True`.
         """
         widget = self.get_widget()
-        outline = self.get_plugin(Plugins.OutlineExplorer, error=False)
-        if outline:
-            widget.setup_other_windows(self._main, outline)
-        return self.get_widget().setup_open_files(
-            close_previous_files=close_previous_files
-        )
+        widget.setup_open_files(close_previous_files=close_previous_files)
+        widget.setup_other_windows()
 
     def save_open_files(self,):
         """Save the list of open files."""

--- a/spyder/plugins/editor/tests/conftest.py
+++ b/spyder/plugins/editor/tests/conftest.py
@@ -27,6 +27,7 @@ import pytest
 from spyder.config.manager import CONF
 from spyder.plugins.debugger.plugin import Debugger
 from spyder.plugins.editor.plugin import Editor
+from spyder.plugins.outlineexplorer.plugin import OutlineExplorer
 
 
 @pytest.fixture
@@ -56,12 +57,15 @@ def editor_plugin(qtbot, monkeypatch):
     # Setup editor
     editor = Editor(window, configuration)
     editor.on_initialize()
-    #editor.add_panel(DebuggerPanel)
     editor.update_font()  # Set initial font
 
     # Setup debugger
     debugger = Debugger(window, configuration)
     debugger.on_initialize()
+
+    # Setup Outline
+    outline = OutlineExplorer(window, configuration)
+    outline.on_initialize()
 
     # Set get_plugin for main window
     def get_plugin(plugin_name, error=True):
@@ -74,11 +78,14 @@ def editor_plugin(qtbot, monkeypatch):
             return editor
         elif plugin_name == Plugins.Debugger:
             return debugger
+        elif plugin_name == Plugins.OutlineExplorer:
+            return outline
         else:
             return Mock()
 
     window.get_plugin = get_plugin
     debugger.on_editor_available()
+    editor.on_outlineexplorer_available()
 
     # Show window
     window.setCentralWidget(editor.get_widget())

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -12,14 +12,17 @@
 import os
 import os.path as osp
 import shutil
+import sys
 
 # Third party imports
 from qtpy.QtCore import QSize, Qt
 from qtpy.QtGui import QColor, QFontMetrics, QPainter
+from qtpy.QtWidgets import QApplication
 import pytest
 
 # Local imports
 from spyder.api.plugins import Plugins
+from spyder.config.base import running_in_ci
 from spyder.plugins.debugger.panels.debuggerpanel import DebuggerPanel
 from spyder.plugins.editor.api.panel import Panel, PanelPosition
 from spyder.plugins.editor.utils.autosave import AutosaveForPlugin
@@ -541,10 +544,15 @@ def test_save_with_os_eol_chars(editor_plugin, mocker, qtbot, tmpdir):
     assert get_eol_chars(text) == os.linesep
 
 
-def test_remove_editorstacks_and_windows(editor_plugin, qtbot):
+@pytest.mark.skipif(
+    sys.platform.startswith("linux") and running_in_ci(),
+    reason="Segfaults on Linux and CIs"
+)
+def test_editorstacks_and_windows(editor_plugin, qtbot):
     """
     Check that editor stacks and windows are removed from the list maintained
-    for them in the editor when closing editor windows and split editors.
+    for them in the editor when closing editor windows and split editors. Also
+    check that splits work as expected in editor windows.
 
     This is a regression test for spyder-ide/spyder#20144.
     """
@@ -554,6 +562,22 @@ def test_remove_editorstacks_and_windows(editor_plugin, qtbot):
     # Create editor window
     editor_window = editor_plugin.get_widget().create_new_window()
     qtbot.wait(500)  # To check visually that the window was created
+
+    # Check split in window is performed without errors and has the right attrs
+    editor_window.editorwidget.editorstacks[0].versplit_action.trigger()
+    assert len(editor_window.editorwidget.editorstacks) == 2
+    assert len(editor_plugin.get_widget().editorstacks) == 3
+    assert editor_window.editorwidget.editorstacks[1].new_window
+
+    # Close split in window and check focus is given to the current editor
+    # in the main stack of the window
+    editor_window.editorwidget.editorstacks[1].close_split_action.trigger()
+    qtbot.waitUntil(lambda: len(editor_window.editorwidget.editorstacks) == 1)
+    assert len(editor_plugin.get_widget().editorstacks) == 2
+    assert (
+        editor_window.editorwidget.editorstacks[0].get_current_editor()
+        is QApplication.focusWidget()
+    )
 
     # This is not done automatically by Qt when running our tests (don't know
     # why), but it's done in normal usage. So we need to do it manually

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -144,6 +144,9 @@ def test_restore_open_files(qtbot, editor_plugin_open_files):
         filename = expected_filenames.pop()
         editor.close_file_from_name(filename)
 
+    # Create editor window to check its restored
+    editor.get_widget().create_new_window()
+
     # Close editor and check that opened files are saved
     editor.on_close()
     filenames = [osp.normcase(f) for f in editor.get_conf("filenames")]
@@ -154,6 +157,9 @@ def test_restore_open_files(qtbot, editor_plugin_open_files):
     filenames = editor.get_current_editorstack().get_filenames()
     filenames = [osp.normcase(f) for f in filenames]
     assert filenames == expected_filenames
+
+    # Check editor windows are restored too
+    assert len(editor.get_widget().editorwindows) == 1
 
 
 def test_setup_open_files_cleanprefs(editor_plugin_open_files):

--- a/spyder/plugins/editor/tests/test_plugin.py
+++ b/spyder/plugins/editor/tests/test_plugin.py
@@ -700,5 +700,48 @@ def test_debugger_panel_visibility(editor_plugin, mocker, tmp_path):
     assert debugger_panel.isVisible()
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("linux") and running_in_ci(),
+    reason="Segfaults on Linux and CIs"
+)
+def test_outline_visibility_in_editor_window(editor_plugin, qtbot):
+    """Check that the outline is shown/hidden as expected in editor windows."""
+    # Create empty file
+    editor_plugin.new()
+    widget = editor_plugin.get_widget()
+
+    # Create editor window
+    editor_window = widget.create_new_window()
+    qtbot.wait(500)  # To check visually that the window was created
+
+    # Check Outline is visible (the default)
+    assert editor_window.editorwidget.outlineexplorer.width() > 0
+
+    # Hide Outline
+    editor_window.toggle_outline_action.trigger()
+    assert not editor_plugin.get_conf("show_outline_in_editor_window")
+    assert editor_window.editorwidget.outlineexplorer.width() == 0
+
+    # Close window and create new one
+    editor_window.close()
+    editor_window = widget.create_new_window()
+
+    # Check Outline is not visible because it was closed above and we should
+    # preserve that state for new windows
+    assert editor_window.editorwidget.outlineexplorer.width() == 0
+
+    # Show Outline
+    editor_window.toggle_outline_action.trigger()
+    assert editor_plugin.get_conf("show_outline_in_editor_window")
+    assert editor_window.editorwidget.outlineexplorer.width() > 0
+
+    # Close window and create new one
+    editor_window.close()
+    editor_window = widget.create_new_window()
+
+    # Check Outline is visible this time
+    assert editor_window.editorwidget.outlineexplorer.width() > 0
+
+
 if __name__ == "__main__":
     pytest.main(['-x', osp.basename(__file__), '-vv', '-rw'])

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -97,7 +97,7 @@ class EditorStackMenuSections:
     CloseOrderSection = "close_order_section"
     SplitCloseSection = "split_close_section"
     WindowSection = "window_section"
-    NewWindowCloseSection = "new_window_and_close_section"
+    MainWidgetSection = "main_widget_section"
 
 
 class EditorStack(QWidget, SpyderWidgetMixin):
@@ -310,6 +310,7 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             register_shortcut=True,
             register_action=False
         )
+
         self.new_window_action = None
         if parent is not None:
             self.new_window_action = self.create_action(
@@ -1396,24 +1397,26 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             for menu_action in (new_action, open_action):
                 self.menu.add_action(menu_action)
 
+        for window_action in self.__get_window_actions():
+            self.menu.add_action(
+                window_action, section=EditorStackMenuSections.WindowSection
+            )
+
         for split_actions in self.__get_split_actions():
             self.menu.add_action(
                 split_actions,
                 section=EditorStackMenuSections.SplitCloseSection
             )
 
-        for window_actions in self.__get_window_actions():
-            self.menu.add_action(
-                window_actions, section=EditorStackMenuSections.WindowSection
-            )
-
-        for new_window_and_close_action in (
-            self.__get_new_window_and_close_actions()
-        ):
-            self.menu.add_action(
-                new_window_and_close_action,
-                section=EditorStackMenuSections.NewWindowCloseSection
-            )
+        # These actions need to *only* be visible in the main editorstack to
+        # avoid confusions when closing a split stack in the main or new
+        # windows.
+        if not (self.is_closable or self.new_window):
+            for main_widget_action in self.__get_main_widget_actions():
+                self.menu.add_action(
+                    main_widget_action,
+                    section=EditorStackMenuSections.MainWidgetSection
+                )
 
         self.menu.render()
 
@@ -1461,6 +1464,8 @@ class EditorStack(QWidget, SpyderWidgetMixin):
     # ---- Window actions
     def __get_window_actions(self):
         actions = []
+        if self.new_window_action:
+            actions += [self.new_window_action]
 
         if self.new_window:
             window = self.window()
@@ -1472,14 +1477,12 @@ class EditorStack(QWidget, SpyderWidgetMixin):
                 register_action=False
             )
 
-            if self.new_window_action:
-                actions += [self.new_window_action]
             actions += [close_window_action]
 
         return actions
 
     # ---- New window and close/docking/undocking actions
-    def __get_new_window_and_close_actions(self):
+    def __get_main_widget_actions(self):
         actions = []
         if self.parent() is not None:
             main_widget = self.get_main_widget()
@@ -1490,14 +1493,11 @@ class EditorStack(QWidget, SpyderWidgetMixin):
             if main_widget.windowwidget is not None:
                 actions += [main_widget.dock_action]
             else:
-                if self.new_window_action:
-                    actions += [self.new_window_action]
-                if not self.new_window:
-                    actions += [
-                        main_widget.lock_unlock_action,
-                        main_widget.undock_action,
-                        main_widget.close_action
-                    ]
+                actions += [
+                    main_widget.lock_unlock_action,
+                    main_widget.undock_action,
+                    main_widget.close_action
+                ]
 
         return actions
 

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -1490,11 +1490,8 @@ class EditorMainWidget(PluginMainWidget):
 
     # ---- Handling editor windows
     # -------------------------------------------------------------------------
-    def setup_other_windows(self, main, outline_plugin):
+    def setup_other_windows(self):
         """Setup toolbars and menus for 'New window' instances"""
-        # Outline setup
-        self.outline_plugin = outline_plugin
-
         # Create pending new windows:
         for layout_settings in self.editorwindows_to_be_created:
             win = self.create_new_window()
@@ -1935,7 +1932,11 @@ class EditorMainWidget(PluginMainWidget):
                 filenames = from_qvariant(action.data(), str)
 
         focus_widget = QApplication.focusWidget()
-        if self.editorwindows and not self.dockwidget.isVisible():
+        if (
+            self.editorwindows
+            and self.dockwidget
+            and not self.dockwidget.isVisible()
+        ):
             # We override the editorwindow variable to force a focus on
             # the editor window instead of the hidden editor dockwidget.
             # See spyder-ide/spyder#5742.
@@ -1943,9 +1944,12 @@ class EditorMainWidget(PluginMainWidget):
                 editorwindow = self.editorwindows[0]
             editorwindow.setFocus()
             editorwindow.raise_()
-        elif (self.dockwidget and not self._is_maximized
-              and not self.dockwidget.isAncestorOf(focus_widget)
-              and not isinstance(focus_widget, CodeEditor)):
+        elif (
+            self.dockwidget
+            and not self._is_maximized
+            and not self.dockwidget.isAncestorOf(focus_widget)
+            and not isinstance(focus_widget, CodeEditor)
+        ):
             self.switch_to_plugin()
 
         def _convert(fname):
@@ -3134,6 +3138,7 @@ class EditorMainWidget(PluginMainWidget):
                     editorstack.tabs.refresh_style()
         else:
             self.__load_temp_file()
+
         self.set_create_new_file_if_empty(True)
         self.sig_open_files_finished.emit()
 

--- a/spyder/plugins/editor/widgets/window.py
+++ b/spyder/plugins/editor/widgets/window.py
@@ -205,6 +205,8 @@ class EditorWidget(QSplitter, SpyderConfigurationObserver):
         # ---- Splitter
         self.splitter = QSplitter(self)
         self.splitter.setContentsMargins(0, 0, 0, 0)
+        self.splitter.splitterMoved.connect(self.on_splitter_moved)
+
         if self.outlineexplorer is not None:
             self.splitter.addWidget(self.outlineexplorer)
         self.splitter.addWidget(editor_widgets)
@@ -215,14 +217,6 @@ class EditorWidget(QSplitter, SpyderConfigurationObserver):
         # This sets the same UX as the one users encounter when the editor is
         # maximized.
         self.splitter.setChildrenCollapsible(False)
-
-        self.splitter.splitterMoved.connect(self.on_splitter_moved)
-
-        if (
-            self.outlineexplorer is not None
-            and not self.get_conf("show_outline_in_editor_window")
-        ):
-            self.outlineexplorer.close_dock()
 
         # ---- Style
         self.splitter.setStyleSheet(self._splitter_css.toString())
@@ -357,7 +351,7 @@ class EditorWidget(QSplitter, SpyderConfigurationObserver):
         """Toggle outline explorer visibility."""
         if value:
             # When self._sizes is not available, the splitter sizes are set
-            # automatically by the ratios set for it above.
+            # automatically by the ratios set for it.
             if self._sizes is not None:
                 self.splitter.setSizes(self._sizes)
 
@@ -386,6 +380,17 @@ class EditorWidget(QSplitter, SpyderConfigurationObserver):
                 self.splitter.handle(1).setEnabled(False)
 
             self.splitter.setChildrenCollapsible(False)
+
+    def showEvent(self, event):
+        # Wait until the window is shown to check if we need to close the
+        # Outline. Otherwise outline ends up taking the entire window width.
+        if (
+            self.outlineexplorer is not None
+            and not self.get_conf("show_outline_in_editor_window")
+        ):
+            self.outlineexplorer.close_dock()
+
+        super().showEvent(event)
 
 
 class EditorMainWindow(QMainWindow, SpyderWidgetMixin):

--- a/spyder/plugins/editor/widgets/window.py
+++ b/spyder/plugins/editor/widgets/window.py
@@ -232,6 +232,7 @@ class EditorWidget(QSplitter, SpyderConfigurationObserver):
         editorstack.set_closable(len(self.editorstacks) > 1)
         editorstack.set_outlineexplorer(self.outlineexplorer)
         editorstack.set_find_widget(self.find_widget)
+        editorstack.new_window = True
 
         # Adjust style.
         # This is necessary to give some space between the tabwidget pane and

--- a/spyder/plugins/editor/widgets/window.py
+++ b/spyder/plugins/editor/widgets/window.py
@@ -108,7 +108,12 @@ class EditorWidget(QSplitter, SpyderConfigurationObserver):
         self._splitter_css = self._generate_splitter_stylesheet()
 
         # ---- Find widget
-        self.find_widget = FindReplace(self, enable_replace=True)
+        self.find_widget = FindReplace(
+            self,
+            enable_replace=True,
+            margin_top=0,
+            margin_bottom=AppStyle.MarginSize,
+        )
         self.find_widget.hide()
 
         # ---- Status bar
@@ -186,6 +191,7 @@ class EditorWidget(QSplitter, SpyderConfigurationObserver):
         editor_layout.setSpacing(0)
         editor_layout.setContentsMargins(0, 0, 0, 0)
         editor_widgets.setLayout(editor_layout)
+
         self.editorsplitter = EditorSplitter(
             self,
             main_widget,

--- a/spyder/plugins/editor/widgets/window.py
+++ b/spyder/plugins/editor/widgets/window.py
@@ -308,6 +308,14 @@ class EditorWidget(QSplitter, SpyderConfigurationObserver):
         logger.debug("Unregistering editorstack")
         self.main_widget.unregister_editorstack(editorstack)
         self.editorstacks.pop(self.editorstacks.index(editorstack))
+
+        # Give focus to current editor of the main stack so the find widget is
+        # bound to it after a split stack is closed (otherwise a RuntimeError
+        # is raised because we're trying to do that for the current editor of
+        # closed stack).
+        if self.editorstacks:
+            self.editorstacks[0].get_current_editor().setFocus()
+
         self.__print_editorstacks()
 
     def unregister_all_editorstacks(self):

--- a/spyder/widgets/findreplace.py
+++ b/spyder/widgets/findreplace.py
@@ -12,6 +12,7 @@
 # pylint: disable=R0201
 
 # Standard library imports
+from __future__ import annotations
 import re
 import sys
 
@@ -70,7 +71,13 @@ class FindReplace(QWidget, SpyderShortcutsMixin):
     return_shift_pressed = Signal()
     return_pressed = Signal()
 
-    def __init__(self, parent, enable_replace=False):
+    def __init__(
+        self,
+        parent: QWidget,
+        enable_replace: bool = False,
+        margin_top: int | None = None,
+        margin_bottom: int | None = None,
+    ):
         if not PYSIDE2:
             super().__init__(parent)
         else:
@@ -83,9 +90,9 @@ class FindReplace(QWidget, SpyderShortcutsMixin):
         glayout = QGridLayout()
         glayout.setContentsMargins(
             2 * AppStyle.MarginSize,
-            AppStyle.MarginSize,
+            AppStyle.MarginSize if margin_top is None else margin_top,
             2 * AppStyle.MarginSize,
-            0
+            0 if margin_bottom is None else margin_bottom,
         )
         if sys.platform == "darwin":
             # Spacing is too big on Mac, which makes the widget look bad


### PR DESCRIPTION
## Description of Changes

- Reorganize sections in the `EditorStack` Options menu to avoid confusions when closing split panels in the main and editor windows.
- Fix error after closing a split in Editor windows.
- Fix top and bottom margins of `FindReplace` widget in editor windows.
- Fix hiding Outline in editor windows if it was closed before.
- Fix restoring editor windows at startup. That probably broke with the release of 6.0.
- Add tests for most of these fixes.

### Visual changes

* Options menu for initial `EditorStack` in the main window (`New window` moved to its own section).

    | Before | After |
    |--------|--------|
    | <img width="272" height="632" alt="image" src="https://github.com/user-attachments/assets/00b22099-618b-4568-8bbd-b7de0b2e39ff" /> | <img width="272" height="647" alt="image" src="https://github.com/user-attachments/assets/41c7c8fc-ff45-474a-8588-3dfff8e35d10" /> |

* Options menu for initial `EditorStack` in editor windows (`Close window` below `New window` and main widget actions not available).

    | Before | After |
    |--------|--------|
    | <img width="273" height="591" alt="image" src="https://github.com/user-attachments/assets/e1c7645e-c405-4a5f-a7f4-18485c368614" /> | <img width="273" height="577" alt="image" src="https://github.com/user-attachments/assets/2f66083f-46bc-42b6-84ec-aa5e32167f79" /> |

* Options menu for split `EditorStack` (main widget actions not available).

    | Before | After |
    |--------|--------|
    | <img width="271" height="636" alt="image" src="https://github.com/user-attachments/assets/05aa5610-14af-4549-b5ac-ed930310bb38" /> | <img width="274" height="549" alt="image" src="https://github.com/user-attachments/assets/ba8e5786-b860-4e3f-91fb-5456be9e32ea" /> |

* `FindReplace` widget in editor windows (fix top and bottom margins)

    | Before | After |
    |--------|--------|
    | <img width="626" height="48" alt="image" src="https://github.com/user-attachments/assets/0b0ea614-990f-4188-b04d-7fb444707811" /> | <img width="621" height="46" alt="image" src="https://github.com/user-attachments/assets/5bf441c9-05cc-46c4-a18c-4702de006e01" /> | 

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
