### PR TITLE
PR: Initial file dialog definition to select a remote directory/file (Remote Client/Explorer)

### DIFF
--- a/spyder/plugins/explorer/widgets/main_widget.py
+++ b/spyder/plugins/explorer/widgets/main_widget.py
@@ -32,6 +32,7 @@ from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.config.main import NAME_FILTERS
 from spyder.plugins.explorer.widgets.remote_explorer import RemoteExplorer
+from spyder.plugins.explorer.widgets.remote_dialog import RemoteFileDialog
 from spyder.plugins.explorer.widgets.explorer import (
     DirViewActions,
     ExplorerTreeWidget,
@@ -397,11 +398,13 @@ class ExplorerWidget(PluginMainWidget):
 
             @AsyncDispatcher.QtSlot
             def remote_ls(future):
+                remote_files_manager = future.result()
+                # print(RemoteFileDialog.get_remote_directory(server_id, remote_files_manager, directory, parent=self))
                 self.remote_treewidget.chdir(
                     directory,
                     server_id=server_id,
                     emit=emit,
-                    remote_files_manager=future.result()
+                    remote_files_manager=remote_files_manager
                 )
 
             self._plugin._get_remote_files_manager(server_id).connect(

--- a/spyder/plugins/explorer/widgets/main_widget.py
+++ b/spyder/plugins/explorer/widgets/main_widget.py
@@ -32,7 +32,6 @@ from spyder.api.widgets.dialogs import SpyderDialogButtonBox
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.config.main import NAME_FILTERS
 from spyder.plugins.explorer.widgets.remote_explorer import RemoteExplorer
-from spyder.plugins.explorer.widgets.remote_dialog import RemoteFileDialog
 from spyder.plugins.explorer.widgets.explorer import (
     DirViewActions,
     ExplorerTreeWidget,

--- a/spyder/plugins/explorer/widgets/main_widget.py
+++ b/spyder/plugins/explorer/widgets/main_widget.py
@@ -398,13 +398,11 @@ class ExplorerWidget(PluginMainWidget):
 
             @AsyncDispatcher.QtSlot
             def remote_ls(future):
-                remote_files_manager = future.result()
-                # print(RemoteFileDialog.get_remote_directory(server_id, remote_files_manager, directory, parent=self))
                 self.remote_treewidget.chdir(
                     directory,
                     server_id=server_id,
                     emit=emit,
-                    remote_files_manager=remote_files_manager
+                    remote_files_manager=future.result()
                 )
 
             self._plugin._get_remote_files_manager(server_id).connect(

--- a/spyder/plugins/explorer/widgets/remote_dialog.py
+++ b/spyder/plugins/explorer/widgets/remote_dialog.py
@@ -97,7 +97,9 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         self.toolbar.addWidget(self._spinner)
 
         # RemoteExplorer
-        self.remote_treewidget = RemoteExplorer(parent=self, only_dir=only_dir)
+        self.remote_treewidget = RemoteExplorer(
+            parent=self, only_dir=only_dir, register_actions_and_menus=False
+        )
         self.remote_treewidget.previous_action = self.previous_action
         self.remote_treewidget.next_action = self.next_action
         self.remote_treewidget.view.header().hide()

--- a/spyder/plugins/explorer/widgets/remote_dialog.py
+++ b/spyder/plugins/explorer/widgets/remote_dialog.py
@@ -50,11 +50,15 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         directory: str,
         parent: QWidget = None,
         class_parent: QObject = None,
-        only_dir: bool = True,
+        only_dir: bool = False,
     ) -> None:
         super().__init__(parent=parent, class_parent=parent)
 
-        self.setWindowTitle(_("Remote Files"))
+        self.setWindowTitle(
+            _("Select remote directory")
+            if only_dir
+            else _("Select remote file")
+        )
         self.setModal(True)
         self._directory = None
 
@@ -105,6 +109,7 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         self.remote_treewidget.view.setIconSize(QSize(22, 22))
         self.remote_treewidget.set_single_click_to_open(False)
 
+        # Signals
         self.remote_treewidget.sig_dir_opened.connect(
             self.set_selected_directory
         )
@@ -145,12 +150,11 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         Parameters
         ----------
         directory : str
-            Path of the directory that should be shown.
+            Path of the directory that will be shown.
         server_id : str
-            Id of the server where the path is reachable.
+            Id of the server where the directory is located.
         remote_files_manager : SpyderRemoteFileServicesAPI
-            Instance to handle server retome files access/operations.
-
+            API instance to handle remote files access/operations.
         """
         self.start_spinner()
         self.remote_treewidget.chdir(
@@ -187,19 +191,18 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         ----------
         directory : str
             Path to the currently selected directory.
-
         """
         if directory:
             self._directory = directory
 
     def get_selected_directory(self) -> str | None:
         """
-        Give currently selected directory.
+        Get currently selected directory.
 
         Returns
         -------
         str | None
-            Current selected directory path or `None` if nothing has been selected.
+            Current selected directory or `None` if nothing has been selected.
         """
         return self._directory
 
@@ -215,22 +218,24 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         """
         Allow to get a remote files system directory path.
 
-        Handles `RemoteFileDialog` instanciation.
+        Handles `RemoteFileDialog` instantiation.
 
         Parameters
         ----------
         server_id : str
-            Id of the server where the path is reachable.
+            Id of the server where the directory is located.
         remote_files_manager : SpyderRemoteFileServicesAPI
-            Instance to handle server retome files access/operations.
+            API instance to handle remote files access/operations.
         directory : str
-            Path of the initial directory to show in the `RemoteFileDialog`.
+            Path of the initial directory to show in the dialog.
         parent : QWidget, optional
             Parent widget to use for the dialog. The default is `None`.
         class_parent : QObject, optional
-            Class definition of the parent to use for the dialog. The default is `None`.
+            Class definition of the parent to use for the dialog. The default
+            is `None`.
         only_dir : bool, optional
-            If only directories should be shown/listed in the dialog. The default is `True`.
+            If only directories should be shown/listed in the dialog. The
+            default is `True`.
 
         Returns
         -------

--- a/spyder/plugins/explorer/widgets/remote_dialog.py
+++ b/spyder/plugins/explorer/widgets/remote_dialog.py
@@ -14,6 +14,7 @@ from qtpy.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QLabel,
+    QSizePolicy,
     QToolBar,
     QTreeView,
     QVBoxLayout,
@@ -63,7 +64,7 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
             else _("Select remote file")
         )
         self.setModal(True)
-        self.setFixedSize(600, 400)
+        self.setFixedSize(650, 400)
         self._server_name = server_name
         self._current_directory = None
         self._selected = None
@@ -95,6 +96,12 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         # Toolbar
         self.toolbar = QToolBar(self)
         self.current_directory = QLabel(self)
+        self.current_directory.setSizePolicy(
+            QSizePolicy.Expanding, QSizePolicy.Preferred,
+        )
+
+        self.toolbar.addWidget(self.current_directory)
+        self.toolbar.addWidget(self._spinner)
 
         for action in [
             self.previous_action,
@@ -102,9 +109,6 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
             self.parent_action,
         ]:
             self.toolbar.addAction(action)
-
-        self.toolbar.addWidget(self.current_directory)
-        self.toolbar.addWidget(self._spinner)
 
         # RemoteExplorer
         self.remote_treewidget = RemoteExplorer(
@@ -273,10 +277,9 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         directory: str,
         parent: QWidget = None,
         class_parent: QObject = None,
-        only_dir: bool = True,
     ) -> str | None:
         """
-        Allow to get a remote files system directory path.
+        Allow to get a directory path from a remote file system.
 
         Handles `RemoteFileDialog` instantiation.
 
@@ -295,9 +298,6 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         class_parent : QObject, optional
             Class definition of the parent to use for the dialog. The default
             is `None`.
-        only_dir : bool, optional
-            If only directories should be shown/listed in the dialog. The
-            default is `True`.
 
         Returns
         -------
@@ -327,7 +327,7 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         class_parent: QObject = None,
     ) -> str | None:
         """
-        Allow to get a remote files system file path.
+        Allow to get a file path from a remote file system.
 
         Handles `RemoteFileDialog` instantiation.
 

--- a/spyder/plugins/explorer/widgets/remote_dialog.py
+++ b/spyder/plugins/explorer/widgets/remote_dialog.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+
+from qtpy.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QToolBar,
+    QTreeView,
+    QVBoxLayout,
+)
+
+from spyder.api.translations import _
+from spyder.api.widgets.dialogs import SpyderDialogButtonBox
+from spyder.api.widgets.mixins import SpyderWidgetMixin
+from spyder.plugins.explorer.widgets.remote_explorer import RemoteExplorer
+from spyder.utils.qthelpers import create_waitspinner
+
+
+class RemoteFileDialogWidgets:
+    Spinner = "remote_file_dialog_spinner_widget"
+
+
+class RemoteFileDialogActions:
+    Previous = "remote_file_dialog_previous_action"
+    Next = "remote_file_dialog_next_action"
+    Parent = "remote_file_dialog_parent_action"
+
+
+class RemoteFileDialog(QDialog, SpyderWidgetMixin):
+    
+    def __init__(
+        self,
+        server_id,
+        remote_files_manager,
+        directory,
+        parent=None,
+        class_parent=None,
+    ):
+        super().__init__(parent=parent, class_parent=parent)
+
+        self.setWindowTitle(_("Remote Files"))
+        self.setModal(True)
+        self._directory = None
+
+        # Actions
+        self.previous_action = self.create_action(
+            RemoteFileDialogActions.Previous,
+            text=_("Previous"),
+            icon=self.create_icon("previous"),
+            triggered=self.go_to_previous_directory,
+        )
+        self.next_action = self.create_action(
+            RemoteFileDialogActions.Next,
+            text=_("Next"),
+            icon=self.create_icon("next"),
+            triggered=self.go_to_next_directory,
+        )
+        self.parent_action = self.create_action(
+            RemoteFileDialogActions.Parent,
+            text=_("Parent"),
+            icon=self.create_icon("up"),
+            triggered=self.go_to_parent_directory,
+        )
+        self._spinner = create_waitspinner(
+            size=16, parent=self, name=RemoteFileDialogWidgets.Spinner
+        )
+
+        # Toolbar
+        self.toolbar = QToolBar(self)
+        for action in [
+            self.previous_action,
+            self.next_action,
+            self.parent_action,
+        ]:
+            self.toolbar.addAction(action)
+
+        self.toolbar.addWidget(self._spinner)
+
+        # RemoteExplorer
+        self.remote_treewidget = RemoteExplorer(parent=self, only_dir=True)
+        self.remote_treewidget.previous_action = self.previous_action
+        self.remote_treewidget.next_action = self.next_action
+        self.remote_treewidget.set_single_click_to_open(False)
+        self.remote_treewidget.view.setSelectionMode(QTreeView.SingleSelection)
+
+        self.remote_treewidget.sig_dir_opened.connect(
+            self.set_selected_directory
+        )
+        self.remote_treewidget.sig_start_spinner_requested.connect(
+            self.start_spinner
+        )
+        self.remote_treewidget.sig_stop_spinner_requested.connect(
+            self.stop_spinner
+        )
+
+        # ButtonBox
+        button_box = SpyderDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.rejected)
+
+        # Layout
+        layout = QVBoxLayout()
+        layout.setMenuBar(self.toolbar)
+        layout.addWidget(self.remote_treewidget)
+        layout.addWidget(button_box)
+        self.setLayout(layout)
+
+        self.start_spinner()
+        self.remote_treewidget.chdir(
+            directory=directory,
+            server_id=server_id,
+            remote_files_manager=remote_files_manager,
+        )
+
+    # ---- Public API
+    # -------------------------------------------------------------------------
+    def set_directory(self, directory, server_id, remote_files_manager):
+        self.remote_treewidget.chdir(
+            directory=directory,
+            server_id=server_id,
+            remote_files_manager=remote_files_manager,
+        )
+
+    def start_spinner(self):
+        self._spinner.start()
+
+    def stop_spinner(self):
+        self._spinner.stop()
+
+    def go_to_previous_directory(self):
+        self.remote_treewidget.go_to_previous_directory()
+
+    def go_to_next_directory(self):
+        self.remote_treewidget.go_to_next_directory()
+
+    def go_to_parent_directory(self):
+        self.remote_treewidget.go_to_parent_directory()
+
+    def set_selected_directory(self, directory):
+        if directory:
+            self._directory = directory
+
+    def get_selected_directory(self):
+        return self._directory
+
+    @staticmethod
+    def get_remote_directory(
+        server_id,
+        remote_files_manager,
+        directory,
+        parent=None,
+        class_parent=None,
+    ):
+        dialog = RemoteFileDialog(
+            server_id,
+            remote_files_manager,
+            directory,
+            parent=parent,
+            class_parent=class_parent,
+        )
+        if dialog.exec_():
+            return dialog.get_selected_directory()

--- a/spyder/plugins/explorer/widgets/remote_dialog.py
+++ b/spyder/plugins/explorer/widgets/remote_dialog.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from qtpy.QtCore import QSize
 from qtpy.QtWidgets import (
     QDialog,
     QDialogButtonBox,
@@ -94,10 +95,14 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         self.remote_treewidget = RemoteExplorer(parent=self, only_dir=True)
         self.remote_treewidget.previous_action = self.previous_action
         self.remote_treewidget.next_action = self.next_action
-        self.remote_treewidget.set_single_click_to_open(False)
+        self.remote_treewidget.view.header().hide()
+        self.remote_treewidget.view.setColumnHidden(1, True)
+        self.remote_treewidget.view.setColumnHidden(2, True)
+        self.remote_treewidget.view.setColumnHidden(3, True)
+        self.remote_treewidget.view.setRootIsDecorated(False)
         self.remote_treewidget.view.setSelectionMode(QTreeView.SingleSelection)
-        self.remote_treewidget.view.setColumnHidden(1, True)  # Hide `Size` column
-        self.remote_treewidget.view.setColumnHidden(2, True)  # Hide `Type` column
+        self.remote_treewidget.view.setIconSize(QSize(22, 22))
+        self.remote_treewidget.set_single_click_to_open(False)
 
         self.remote_treewidget.sig_dir_opened.connect(
             self.set_selected_directory

--- a/spyder/plugins/explorer/widgets/remote_dialog.py
+++ b/spyder/plugins/explorer/widgets/remote_dialog.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from qtpy.QtCore import QSize
+from qtpy.QtCore import QSize, Qt
+from qtpy.QtGui import QFontMetrics
 from qtpy.QtWidgets import (
     QDialog,
     QDialogButtonBox,
+    QLabel,
     QToolBar,
     QTreeView,
     QVBoxLayout,
@@ -45,6 +47,7 @@ class RemoteFileDialogActions:
 class RemoteFileDialog(QDialog, SpyderWidgetMixin):
     def __init__(
         self,
+        server_name: str,
         server_id: str,
         remote_files_manager: SpyderRemoteFileServicesAPI,
         directory: str,
@@ -60,7 +63,11 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
             else _("Select remote file")
         )
         self.setModal(True)
-        self._directory = None
+        self.setFixedSize(600, 400)
+        self._server_name = server_name
+        self._current_directory = None
+        self._selected = None
+        self._only_dir = only_dir
 
         # Actions
         self.previous_action = self.create_action(
@@ -87,6 +94,8 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
 
         # Toolbar
         self.toolbar = QToolBar(self)
+        self.current_directory = QLabel(self)
+
         for action in [
             self.previous_action,
             self.next_action,
@@ -94,6 +103,7 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         ]:
             self.toolbar.addAction(action)
 
+        self.toolbar.addWidget(self.current_directory)
         self.toolbar.addWidget(self._spinner)
 
         # RemoteExplorer
@@ -113,13 +123,16 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
 
         # Signals
         self.remote_treewidget.sig_dir_opened.connect(
-            self.set_selected_directory
+            self.set_current_directory
         )
         self.remote_treewidget.sig_start_spinner_requested.connect(
             self.start_spinner
         )
         self.remote_treewidget.sig_stop_spinner_requested.connect(
             self.stop_spinner
+        )
+        self.remote_treewidget.view.selectionModel().currentChanged.connect(
+            self._set_selected
         )
 
         # ButtonBox
@@ -136,18 +149,18 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         layout.addWidget(button_box)
         self.setLayout(layout)
 
-        self.set_directory(directory, server_id, remote_files_manager)
+        self.set_initial_directory(directory, server_id, remote_files_manager)
 
     # ---- Public API
     # -------------------------------------------------------------------------
-    def set_directory(
+    def set_initial_directory(
         self,
         directory: str,
         server_id: str,
         remote_files_manager: SpyderRemoteFileServicesAPI,
     ) -> None:
         """
-        Set current directory being shown by the dialog.
+        Set initial directory being shown by the dialog.
 
         Parameters
         ----------
@@ -185,9 +198,9 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         """Go to parent directory."""
         self.remote_treewidget.go_to_parent_directory()
 
-    def set_selected_directory(self, directory: str) -> None:
+    def set_current_directory(self, directory: str) -> None:
         """
-        Set current selected directory.
+        Set current directory.
 
         Parameters
         ----------
@@ -195,21 +208,66 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
             Path to the currently selected directory.
         """
         if directory:
-            self._directory = directory
+            current_directory = directory
+            if len(directory) > 30:
+                metrics = QFontMetrics(self.font())
+                max_width = 30 * metrics.width("W")
+                current_directory = metrics.elidedText(
+                    directory, Qt.ElideMiddle, max_width
+                )
+            self.current_directory.setText(
+                _(
+                    "Current location: {server_name}:/{current_directory}"
+                ).format(
+                    server_name=self._server_name,
+                    current_directory=current_directory,
+                )
+            )
+            self._current_directory = directory
+            #self.adjustSize()
 
-    def get_selected_directory(self) -> str | None:
+    def get_current_directory(self) -> str:
         """
-        Get currently selected directory.
+        Get currently directory.
+
+        Returns
+        -------
+        str
+            Current directory.
+        """
+        return self._current_directory
+
+    def _set_selected(self, current, previous) -> None:
+        """
+        Set current directory.
+
+        Parameters
+        ----------
+        current : QModelIndex
+            Current selected index.
+        previous : QModelIndex
+            Previously selected index.
+        """
+        data = current.data(role=Qt.UserRole + 1)
+        if data:
+            if not self._only_dir and data["type"] == "directory":
+                return
+            self._selected = data["name"]
+
+    def get_selected(self) -> str | None:
+        """
+        Get currently selected directory/file.
 
         Returns
         -------
         str | None
-            Current selected directory or `None` if nothing has been selected.
+            Current selected directory/file or `None` if nothing has been selected.
         """
-        return self._directory
+        return self._selected
 
     @staticmethod
     def get_remote_directory(
+        server_name: str,
         server_id: str,
         remote_files_manager: SpyderRemoteFileServicesAPI,
         directory: str,
@@ -224,6 +282,8 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
 
         Parameters
         ----------
+        server_name: str
+            Name of the server where the directory is located.
         server_id : str
             Id of the server where the directory is located.
         remote_files_manager : SpyderRemoteFileServicesAPI
@@ -246,11 +306,61 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
             or the dialog is not accepted.
         """
         dialog = RemoteFileDialog(
+            server_name,
             server_id,
             remote_files_manager,
             directory,
             parent=parent,
             class_parent=class_parent,
+            only_dir=True,
         )
         if dialog.exec_():
-            return dialog.get_selected_directory()
+            return dialog.get_selected()
+
+    @staticmethod
+    def get_remote_file(
+        server_name: str,
+        server_id: str,
+        remote_files_manager: SpyderRemoteFileServicesAPI,
+        directory: str,
+        parent: QWidget = None,
+        class_parent: QObject = None,
+    ) -> str | None:
+        """
+        Allow to get a remote files system file path.
+
+        Handles `RemoteFileDialog` instantiation.
+
+        Parameters
+        ----------
+        server_name: str
+            Name of the server where the directory is located.
+        server_id : str
+            Id of the server where the directory is located.
+        remote_files_manager : SpyderRemoteFileServicesAPI
+            API instance to handle remote files access/operations.
+        directory : str
+            Path of the initial directory to show in the dialog.
+        parent : QWidget, optional
+            Parent widget to use for the dialog. The default is `None`.
+        class_parent : QObject, optional
+            Class definition of the parent to use for the dialog. The default
+            is `None`.
+
+        Returns
+        -------
+        str | None
+            Path to the selected file or `None` if no file has been selected
+            or the dialog is not accepted.
+        """
+        dialog = RemoteFileDialog(
+            server_name,
+            server_id,
+            remote_files_manager,
+            directory,
+            parent=parent,
+            class_parent=class_parent,
+            only_dir=False,
+        )
+        if dialog.exec_():
+            return dialog.get_selected()

--- a/spyder/plugins/explorer/widgets/remote_dialog.py
+++ b/spyder/plugins/explorer/widgets/remote_dialog.py
@@ -228,7 +228,6 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
                 )
             )
             self._current_directory = directory
-            #self.adjustSize()
 
     def get_current_directory(self) -> str:
         """
@@ -315,7 +314,7 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
             only_dir=True,
         )
         if dialog.exec_():
-            return dialog.get_selected()
+            return dialog.get_selected() or dialog.get_current_directory()
 
     @staticmethod
     def get_remote_file(

--- a/spyder/plugins/explorer/widgets/remote_dialog.py
+++ b/spyder/plugins/explorer/widgets/remote_dialog.py
@@ -4,6 +4,10 @@
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from qtpy.QtWidgets import (
     QDialog,
     QDialogButtonBox,
@@ -18,6 +22,14 @@ from spyder.api.widgets.mixins import SpyderWidgetMixin
 from spyder.plugins.explorer.widgets.remote_explorer import RemoteExplorer
 from spyder.utils.qthelpers import create_waitspinner
 
+if TYPE_CHECKING:
+    from qtpy.QtCore import QObject
+    from qtpy.QtWidgets import QWidget
+
+    from spyder.plugins.remoteclient.api.modules.file_services import (
+        SpyderRemoteFileServicesAPI,
+    )
+
 
 class RemoteFileDialogWidgets:
     Spinner = "remote_file_dialog_spinner_widget"
@@ -30,15 +42,14 @@ class RemoteFileDialogActions:
 
 
 class RemoteFileDialog(QDialog, SpyderWidgetMixin):
-    
     def __init__(
         self,
-        server_id,
-        remote_files_manager,
-        directory,
-        parent=None,
-        class_parent=None,
-    ):
+        server_id: str,
+        remote_files_manager: SpyderRemoteFileServicesAPI,
+        directory: str,
+        parent: QWidget = None,
+        class_parent: QObject = None,
+    ) -> None:
         super().__init__(parent=parent, class_parent=parent)
 
         self.setWindowTitle(_("Remote Files"))
@@ -85,6 +96,8 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         self.remote_treewidget.next_action = self.next_action
         self.remote_treewidget.set_single_click_to_open(False)
         self.remote_treewidget.view.setSelectionMode(QTreeView.SingleSelection)
+        self.remote_treewidget.view.setColumnHidden(1, True)  # Hide `Size` column
+        self.remote_treewidget.view.setColumnHidden(2, True)  # Hide `Type` column
 
         self.remote_treewidget.sig_dir_opened.connect(
             self.set_selected_directory
@@ -101,7 +114,7 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         )
         button_box.accepted.connect(self.accept)
-        button_box.rejected.connect(self.rejected)
+        button_box.rejected.connect(self.reject)
 
         # Layout
         layout = QVBoxLayout()
@@ -110,6 +123,29 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         layout.addWidget(button_box)
         self.setLayout(layout)
 
+        self.set_directory(directory, server_id, remote_files_manager)
+
+    # ---- Public API
+    # -------------------------------------------------------------------------
+    def set_directory(
+        self,
+        directory: str,
+        server_id: str,
+        remote_files_manager: SpyderRemoteFileServicesAPI,
+    ) -> None:
+        """
+        Set current directory being shown by the dialog.
+
+        Parameters
+        ----------
+        directory : str
+            Path of the directory that should be shown.
+        server_id : str
+            Id of the server where the path is reachable.
+        remote_files_manager : SpyderRemoteFileServicesAPI
+            Instance to handle server retome files access/operations.
+
+        """
         self.start_spinner()
         self.remote_treewidget.chdir(
             directory=directory,
@@ -117,45 +153,82 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
             remote_files_manager=remote_files_manager,
         )
 
-    # ---- Public API
-    # -------------------------------------------------------------------------
-    def set_directory(self, directory, server_id, remote_files_manager):
-        self.remote_treewidget.chdir(
-            directory=directory,
-            server_id=server_id,
-            remote_files_manager=remote_files_manager,
-        )
-
-    def start_spinner(self):
+    def start_spinner(self) -> None:
+        """Start spinner."""
         self._spinner.start()
 
-    def stop_spinner(self):
+    def stop_spinner(self) -> None:
+        """Stop spinner."""
         self._spinner.stop()
 
-    def go_to_previous_directory(self):
+    def go_to_previous_directory(self) -> None:
+        """Go to previous directory."""
         self.remote_treewidget.go_to_previous_directory()
 
-    def go_to_next_directory(self):
+    def go_to_next_directory(self) -> None:
+        """Go to next directory."""
         self.remote_treewidget.go_to_next_directory()
 
-    def go_to_parent_directory(self):
+    def go_to_parent_directory(self) -> None:
+        """Go to parent directory."""
         self.remote_treewidget.go_to_parent_directory()
 
-    def set_selected_directory(self, directory):
+    def set_selected_directory(self, directory: str) -> None:
+        """
+        Set current selected directory.
+
+        Parameters
+        ----------
+        directory : str
+            Path to the currently selected directory.
+
+        """
         if directory:
             self._directory = directory
 
-    def get_selected_directory(self):
+    def get_selected_directory(self) -> str | None:
+        """
+        Give currently selected directory.
+
+        Returns
+        -------
+        str | None
+            Current selected directory path or `None` if nothing has been selected.
+        """
         return self._directory
 
     @staticmethod
     def get_remote_directory(
-        server_id,
-        remote_files_manager,
-        directory,
-        parent=None,
-        class_parent=None,
-    ):
+        server_id: str,
+        remote_files_manager: SpyderRemoteFileServicesAPI,
+        directory: str,
+        parent: QWidget = None,
+        class_parent: QObject = None,
+    ) -> str | None:
+        """
+        Allow to get a remote files system directory path.
+
+        Handles `RemoteFileDialog` instanciation.
+
+        Parameters
+        ----------
+        server_id : str
+            Id of the server where the path is reachable.
+        remote_files_manager : SpyderRemoteFileServicesAPI
+            Instance to handle server retome files access/operations.
+        directory : str
+            Path of the initial directory to show in the `RemoteFileDialog`.
+        parent : QWidget, optional
+            Parent widget to use for the dialog. The default is None.
+        class_parent : QObject, optional
+            Class definition of the parent to use for the dialog. The default is None.
+
+        Returns
+        -------
+        str | None
+            Path to the selected directory or `None` if nothing has been selected
+            or the dialog is not accepted.
+        """
         dialog = RemoteFileDialog(
             server_id,
             remote_files_manager,

--- a/spyder/plugins/explorer/widgets/remote_dialog.py
+++ b/spyder/plugins/explorer/widgets/remote_dialog.py
@@ -50,6 +50,7 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         directory: str,
         parent: QWidget = None,
         class_parent: QObject = None,
+        only_dir: bool = True,
     ) -> None:
         super().__init__(parent=parent, class_parent=parent)
 
@@ -92,7 +93,7 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         self.toolbar.addWidget(self._spinner)
 
         # RemoteExplorer
-        self.remote_treewidget = RemoteExplorer(parent=self, only_dir=True)
+        self.remote_treewidget = RemoteExplorer(parent=self, only_dir=only_dir)
         self.remote_treewidget.previous_action = self.previous_action
         self.remote_treewidget.next_action = self.next_action
         self.remote_treewidget.view.header().hide()
@@ -209,6 +210,7 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         directory: str,
         parent: QWidget = None,
         class_parent: QObject = None,
+        only_dir: bool = True,
     ) -> str | None:
         """
         Allow to get a remote files system directory path.
@@ -224,9 +226,11 @@ class RemoteFileDialog(QDialog, SpyderWidgetMixin):
         directory : str
             Path of the initial directory to show in the `RemoteFileDialog`.
         parent : QWidget, optional
-            Parent widget to use for the dialog. The default is None.
+            Parent widget to use for the dialog. The default is `None`.
         class_parent : QObject, optional
-            Class definition of the parent to use for the dialog. The default is None.
+            Class definition of the parent to use for the dialog. The default is `None`.
+        only_dir : bool, optional
+            If only directories should be shown/listed in the dialog. The default is `True`.
 
         Returns
         -------

--- a/spyder/plugins/explorer/widgets/remote_explorer.py
+++ b/spyder/plugins/explorer/widgets/remote_explorer.py
@@ -131,7 +131,9 @@ class RemoteExplorer(QWidget, SpyderWidgetMixin):
     sig_start_spinner_requested = Signal()
     sig_stop_spinner_requested = Signal()
 
-    def __init__(self, parent=None, class_parent=None, files=None, only_dir=False):
+    def __init__(
+        self, parent=None, class_parent=None, files=None, only_dir=False
+    ):
         super().__init__(parent=parent, class_parent=parent)
 
         # General attributes

--- a/spyder/plugins/explorer/widgets/remote_explorer.py
+++ b/spyder/plugins/explorer/widgets/remote_explorer.py
@@ -131,7 +131,7 @@ class RemoteExplorer(QWidget, SpyderWidgetMixin):
     sig_start_spinner_requested = Signal()
     sig_stop_spinner_requested = Signal()
 
-    def __init__(self, parent=None, class_parent=None, files=None):
+    def __init__(self, parent=None, class_parent=None, files=None, only_dir=False):
         super().__init__(parent=parent, class_parent=parent)
 
         # General attributes
@@ -144,6 +144,7 @@ class RemoteExplorer(QWidget, SpyderWidgetMixin):
         self.more_files_available = False
 
         self.filter_on = False
+        self.only_dir = only_dir
         self.name_filters = []
 
         self.history = []
@@ -157,10 +158,11 @@ class RemoteExplorer(QWidget, SpyderWidgetMixin):
         self._files_to_upload: dict[str, int] = {}
 
         # Model, actions and widget setup
-        self.context_menu = self.create_menu(RemoteViewMenus.Context)
+        self.context_menu = self.create_menu(RemoteViewMenus.Context, register=False)
         new_submenu = self.create_menu(
             RemoteViewMenus.New,
             _('New'),
+            register=False,
         )
 
         self.new_package_action = self.create_action(
@@ -168,65 +170,76 @@ class RemoteExplorer(QWidget, SpyderWidgetMixin):
             text=_("Python package..."),
             icon=self.create_icon('package_new'),
             triggered=self.new_package,
+            register_action=False,
         )
         self.new_module_action = self.create_action(
             RemoteExplorerActions.NewModule,
             text=_("Python file..."),
             icon=self.create_icon('python'),
             triggered=self.new_module,
+            register_action=False,
         )
         self.new_directory_action = self.create_action(
             RemoteExplorerActions.NewDirectory,
             text=_("Folder..."),
             icon=self.create_icon('folder_new'),
             triggered=self.new_directory,
+            register_action=False,
         )
         self.new_file_action = self.create_action(
             RemoteExplorerActions.NewFile,
             text=_("File..."),
             icon=self.create_icon('TextFileIcon'),
             triggered=self.new_file,
+            register_action=False,
         )
         self.copy_action = self.create_action(
             RemoteExplorerActions.Copy,
             _("Copy"),
             icon=self.create_icon("editcopy"),
             triggered=self.copy_items,
+            register_action=False,
         )
         self.paste_action = self.create_action(
             RemoteExplorerActions.Paste,
             _("Paste"),
             icon=self.create_icon("editpaste"),
             triggered=self.paste_items,
+            register_action=False,
         )
         self.rename_action = self.create_action(
             RemoteExplorerActions.Rename,
             _("Rename..."),
             icon=self.create_icon("rename"),
             triggered=self.rename_items,
+            register_action=False,
         )
         self.copy_path_action = self.create_action(
             RemoteExplorerActions.CopyPath,
             _("Copy absolute path"),
             triggered=self.copy_paths,
+            register_action=False,
         )
         self.delete_action = self.create_action(
             RemoteExplorerActions.Delete,
             _("Delete..."),
             icon=self.create_icon("editclear"),
             triggered=self.delete_items,
+            register_action=False,
         )
         self.download_action = self.create_action(
             RemoteExplorerActions.Download,
             _("Download..."),
             icon=self.create_icon("fileimport"),
             triggered=self.download_items,
+            register_action=False,
         )
         self.upload_file_action = self.create_action(
             RemoteExplorerActions.Upload,
             _("Upload files"),
             icon=self.create_icon("fileexport"),
             triggered=self.upload_files,
+            register_action=False,
         )
 
         for item in [self.new_file_action, self.new_directory_action]:
@@ -741,6 +754,10 @@ class RemoteExplorer(QWidget, SpyderWidgetMixin):
                         "show_hidden"
                     ) and file_name.startswith("."):
                         continue
+
+                    if self.only_dir and file_type == "file":
+                        continue
+
                     if (
                         self.name_filters
                         and len(self.name_filters)

--- a/spyder/plugins/explorer/widgets/remote_explorer.py
+++ b/spyder/plugins/explorer/widgets/remote_explorer.py
@@ -132,7 +132,12 @@ class RemoteExplorer(QWidget, SpyderWidgetMixin):
     sig_stop_spinner_requested = Signal()
 
     def __init__(
-        self, parent=None, class_parent=None, files=None, only_dir=False
+        self,
+        parent=None,
+        class_parent=None,
+        files=None,
+        only_dir=False,
+        register_actions_and_menus=True,
     ):
         super().__init__(parent=parent, class_parent=parent)
 
@@ -164,7 +169,7 @@ class RemoteExplorer(QWidget, SpyderWidgetMixin):
         new_submenu = self.create_menu(
             RemoteViewMenus.New,
             _('New'),
-            register=False,
+            register=register_actions_and_menus,
         )
 
         self.new_package_action = self.create_action(
@@ -172,76 +177,76 @@ class RemoteExplorer(QWidget, SpyderWidgetMixin):
             text=_("Python package..."),
             icon=self.create_icon('package_new'),
             triggered=self.new_package,
-            register_action=False,
+            register_action=register_actions_and_menus,
         )
         self.new_module_action = self.create_action(
             RemoteExplorerActions.NewModule,
             text=_("Python file..."),
             icon=self.create_icon('python'),
             triggered=self.new_module,
-            register_action=False,
+            register_action=register_actions_and_menus,
         )
         self.new_directory_action = self.create_action(
             RemoteExplorerActions.NewDirectory,
             text=_("Folder..."),
             icon=self.create_icon('folder_new'),
             triggered=self.new_directory,
-            register_action=False,
+            register_action=register_actions_and_menus,
         )
         self.new_file_action = self.create_action(
             RemoteExplorerActions.NewFile,
             text=_("File..."),
             icon=self.create_icon('TextFileIcon'),
             triggered=self.new_file,
-            register_action=False,
+            register_action=register_actions_and_menus,
         )
         self.copy_action = self.create_action(
             RemoteExplorerActions.Copy,
             _("Copy"),
             icon=self.create_icon("editcopy"),
             triggered=self.copy_items,
-            register_action=False,
+            register_action=register_actions_and_menus,
         )
         self.paste_action = self.create_action(
             RemoteExplorerActions.Paste,
             _("Paste"),
             icon=self.create_icon("editpaste"),
             triggered=self.paste_items,
-            register_action=False,
+            register_action=register_actions_and_menus,
         )
         self.rename_action = self.create_action(
             RemoteExplorerActions.Rename,
             _("Rename..."),
             icon=self.create_icon("rename"),
             triggered=self.rename_items,
-            register_action=False,
+            register_action=register_actions_and_menus,
         )
         self.copy_path_action = self.create_action(
             RemoteExplorerActions.CopyPath,
             _("Copy absolute path"),
             triggered=self.copy_paths,
-            register_action=False,
+            register_action=register_actions_and_menus,
         )
         self.delete_action = self.create_action(
             RemoteExplorerActions.Delete,
             _("Delete..."),
             icon=self.create_icon("editclear"),
             triggered=self.delete_items,
-            register_action=False,
+            register_action=register_actions_and_menus,
         )
         self.download_action = self.create_action(
             RemoteExplorerActions.Download,
             _("Download..."),
             icon=self.create_icon("fileimport"),
             triggered=self.download_items,
-            register_action=False,
+            register_action=register_actions_and_menus,
         )
         self.upload_file_action = self.create_action(
             RemoteExplorerActions.Upload,
             _("Upload files"),
             icon=self.create_icon("fileexport"),
             triggered=self.upload_files,
-            register_action=False,
+            register_action=register_actions_and_menus,
         )
 
         for item in [self.new_file_action, self.new_directory_action]:

--- a/spyder/plugins/explorer/widgets/tests/test_remote_dialog.py
+++ b/spyder/plugins/explorer/widgets/tests/test_remote_dialog.py
@@ -9,7 +9,8 @@
 
 # Third party imports
 import pytest
-from qtpy.QtWidgets import QDialog
+from qtpy.QtCore import QTimer
+from qtpy.QtWidgets import QApplication
 
 # Local imports
 from spyder.plugins.remoteclient.tests.conftest import (
@@ -20,21 +21,24 @@ from spyder.plugins.explorer.widgets.remote_dialog import RemoteFileDialog
 
 
 @mark_remote_test
-def test_remote_directory(
-    remote_explorer, remote_client, remote_client_id, monkeypatch
-):
+def test_remote_directory(qtbot, remote_explorer, remote_client, remote_client_id):
     remote_files_manager = run_async(
         remote_client.get_file_api(remote_client_id)().connect
     ).result()
-    expected_directory = "/home/ubuntu"
+    expected_directory = "/home"
 
-    monkeypatch.setattr(QDialog, "exec_", lambda *args: QDialog.Accepted)
+    def choose_parent_directory():
+        dialog = QApplication.activeModalWidget()
+        dialog.go_to_parent_directory()
+        qtbot.wait(1000)
+        dialog.accept()
 
+    QTimer.singleShot(100, choose_parent_directory)
     directory = RemoteFileDialog.get_remote_directory(
         "Test server",
         remote_client_id,
         remote_files_manager,
-        expected_directory,
+        "/home/ubuntu",
         parent=remote_explorer,
     )
 

--- a/spyder/plugins/explorer/widgets/tests/test_remote_dialog.py
+++ b/spyder/plugins/explorer/widgets/tests/test_remote_dialog.py
@@ -1,0 +1,44 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2009- Spyder Project Contributors
+#
+# Distributed under the terms of the MIT License
+# (see spyder/__init__.py for details)
+# -----------------------------------------------------------------------------
+
+"""Files and Remote client integration tests."""
+
+# Third party imports
+import pytest
+from qtpy.QtWidgets import QDialog
+
+# Local imports
+from spyder.plugins.remoteclient.tests.conftest import (
+    run_async,
+    mark_remote_test,
+)
+from spyder.plugins.explorer.widgets.remote_dialog import RemoteFileDialog
+
+
+@mark_remote_test
+def test_remote_directory(
+    remote_explorer, remote_client, remote_client_id, monkeypatch
+):
+    remote_files_manager = run_async(
+        remote_client.get_file_api(remote_client_id)().connect
+    ).result()
+    expected_directory = "/home/ubuntu"
+
+    monkeypatch.setattr(QDialog, "exec_", lambda *args: QDialog.Accepted)
+
+    directory = RemoteFileDialog.get_remote_directory(
+        remote_client_id,
+        remote_files_manager,
+        expected_directory,
+        parent=remote_explorer,
+    )
+
+    assert directory == expected_directory
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/spyder/plugins/explorer/widgets/tests/test_remote_dialog.py
+++ b/spyder/plugins/explorer/widgets/tests/test_remote_dialog.py
@@ -31,6 +31,7 @@ def test_remote_directory(
     monkeypatch.setattr(QDialog, "exec_", lambda *args: QDialog.Accepted)
 
     directory = RemoteFileDialog.get_remote_directory(
+        "Test server",
         remote_client_id,
         remote_files_manager,
         expected_directory,


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Added a test
* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->

* Select remote file:

<img width="652" height="439" alt="image" src="https://github.com/user-attachments/assets/4474ef2d-d602-4526-851c-679634632013" />

* Select remote directory:

<img width="652" height="439" alt="image" src="https://github.com/user-attachments/assets/5393bb58-4290-4000-8488-d2fcc96c9207" />

- Add `RemoteFileDialog` class definition with static methods to retrieve a directory or a file path
- Add a kwarg to the `RemoteExplorer` to show only directories

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Part of #12828

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
