### PR TITLE
PR: Fix hard crash when restarting kernel of related clients (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/utils/kernel_handler.py
+++ b/spyder/plugins/ipythonconsole/utils/kernel_handler.py
@@ -579,6 +579,10 @@ class KernelHandler(QObject):
             self.kernel_client is not None
             and self.kernel_client.channels_running
         ):
+            # FIXME: Race condition with self.close_comm(). If comms have not
+            # completed closing, then stop_channels here results in
+            # [WARNING] [tornado.general] -> Got events for closed stream
+            #     <zmq.eventloop.zmqstream.ZMQStream object at ...>
             self.kernel_client.stop_channels()
 
     def after_shutdown(self):

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -504,6 +504,12 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):  # noqa: PLR09
         self.shellwidget.disconnect_kernel(shutdown_kernel)
         self.kernel_handler = None
 
+        # FIXME: If shutdown_kernel is False, then when the last reference to
+        # kernel_handler is gone (which happens when this function returns),
+        # "QThread: Destroyed while thread is still running" results. If
+        # shutdown_kernel is True, this does not happen.
+        # See spyder-ide/spyder#25984
+
     @Slot(str)
     def print_stderr(self, stderr):
         """Print stderr written in PIPE."""

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -501,14 +501,14 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):  # noqa: PLR09
         kernel_handler.sig_stdout.disconnect(self.print_stdout)
         kernel_handler.sig_fault.disconnect(self.print_fault)
 
-        self.shellwidget.disconnect_kernel(shutdown_kernel)
-        self.kernel_handler = None
-
         # FIXME: If shutdown_kernel is False, then when the last reference to
         # kernel_handler is gone (which happens when this function returns),
         # "QThread: Destroyed while thread is still running" results. If
         # shutdown_kernel is True, this does not happen.
-        # See spyder-ide/spyder#25984
+        # See spyder-ide/spyder#23973
+        self.shellwidget.disconnect_kernel(shutdown_kernel)
+        self.kernel_handler = None
+
 
     @Slot(str)
     def print_stderr(self, stderr):

--- a/spyder/plugins/ipythonconsole/widgets/client.py
+++ b/spyder/plugins/ipythonconsole/widgets/client.py
@@ -509,7 +509,6 @@ class ClientWidget(QWidget, SaveHistoryMixin, SpyderWidgetMixin):  # noqa: PLR09
         self.shellwidget.disconnect_kernel(shutdown_kernel)
         self.kernel_handler = None
 
-
     @Slot(str)
     def print_stderr(self, stderr):
         """Print stderr written in PIPE."""

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -2573,7 +2573,10 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):  # noqa: PLR090
 
         # Replace in all related clients
         for cl in self.get_related_clients(client):
-            cl.replace_kernel(kernel_handler.copy(), shutdown_kernel=False)
+            # Use shutdown_kernel=True here to prevent
+            # "QThread: Destroyed while thread is still running".
+            # See spyder-ide/spyder#25984
+            cl.replace_kernel(kernel_handler.copy(), shutdown_kernel=True)
 
         client.replace_kernel(kernel_handler, shutdown_kernel=True)
 

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -2575,7 +2575,7 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):  # noqa: PLR090
         for cl in self.get_related_clients(client):
             # Use shutdown_kernel=True here to prevent
             # "QThread: Destroyed while thread is still running".
-            # See spyder-ide/spyder#25984
+            # Fixes spyder-ide/spyder#23973
             cl.replace_kernel(kernel_handler.copy(), shutdown_kernel=True)
 
         client.replace_kernel(kernel_handler, shutdown_kernel=True)


### PR DESCRIPTION
Using `shutdown_kernel=True` when replacing kernels appears to resolve Spyder crashing when restarting a shared kernel. However, this is just a kluge. The underlying issue is still there and I've made notes on pertinent information that I've found.

The bottom line is that when the last reference to a `ClientWidget.kernel_handler` is removed, `QThread: Destroyed while thread is still running` results and Spyder crashes. This only occurs if `shutdown_kernel=False`.

I don't understand why this is. The `kernel_handler` object is different for each client but `kernel_handler.kernel_manager` is the _same_ object instance for each client of a shared kernel. So there must be some `QThread` still associated with the `kernel_handler` (which is destroyed) when `shutdown_kernel=False` but when `shutdown_kernel=True` and the `kernel_manager` shuts down the kernel this `QThread` is quit. I just can't find this thread to properly quit it before the `kernel_handler` is destroyed.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #23973 
