### PR TITLE
PR: Fix issue where `powershell` is not found by Spyder on initial launch from installer

### DIFF
--- a/installers-conda/resources/post-install.bat
+++ b/installers-conda/resources/post-install.bat
@@ -7,6 +7,8 @@ call :redirect 2>&1 >> %PREFIX%\install.log
 @echo Environment Variables:
 set
 
+setlocal
+
 if defined CI set no_launch_spyder=true
 if "%INSTALLER_UNATTENDED%"=="1" set no_launch_spyder=true
 if "%START_SPYDER%"=="False" set no_launch_spyder=true
@@ -16,9 +18,6 @@ if "%no_launch_spyder%"=="true" (
 ) else (
     @echo Launching Spyder after install completed.
 )
-
-@rem Add PowerShell directory to PATH because constructor does not include it
-set "PATH=%PATH%;C:\Windows\System32\WindowsPowerShell\v1.0"
 
 set mode=system
 if exist "%PREFIX%\.nonadmin" set mode=user
@@ -36,6 +35,7 @@ set tmpdir=%TMP%\spyder
 set launch_script=%tmpdir%\launch_script.bat
 
 if not exist "%tmpdir%" mkdir "%tmpdir%"
+
 (
     echo @echo off
     echo :loop
@@ -49,5 +49,10 @@ if not exist "%tmpdir%" mkdir "%tmpdir%"
     echo     exit
     echo ^)
 ) > "%launch_script%"
+
+endlocal
+
+@rem Add PowerShell directory to PATH because constructor does not include it
+set "PATH=%PATH%;C:\Windows\System32\WindowsPowerShell\v1.0"
 
 powershell -WindowStyle hidden -Command "& {Start-Process -FilePath %launch_script% -NoNewWindow}"

--- a/installers-conda/resources/post-install.bat
+++ b/installers-conda/resources/post-install.bat
@@ -50,7 +50,8 @@ if not exist "%tmpdir%" mkdir "%tmpdir%"
     echo ^)
 ) > "%launch_script%"
 
-endlocal
+@rem Allow launch_script to be global
+endlocal & set "launch_script=%launch_script%"
 
 @rem Add PowerShell directory to PATH because constructor does not include it
 set "PATH=%PATH%;C:\Windows\System32\WindowsPowerShell\v1.0"

--- a/installers-conda/resources/post-install.bat
+++ b/installers-conda/resources/post-install.bat
@@ -17,6 +17,9 @@ if "%no_launch_spyder%"=="true" (
     @echo Launching Spyder after install completed.
 )
 
+@rem Add PowerShell directory to PATH because constructor does not include it
+set "PATH=%PATH%;C:\Windows\System32\WindowsPowerShell\v1.0"
+
 set mode=system
 if exist "%PREFIX%\.nonadmin" set mode=user
 
@@ -47,4 +50,4 @@ if not exist "%tmpdir%" mkdir "%tmpdir%"
     echo ^)
 ) > "%launch_script%"
 
-C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe -WindowStyle hidden -Command "& {Start-Process -FilePath %launch_script% -NoNewWindow}"
+powershell -WindowStyle hidden -Command "& {Start-Process -FilePath %launch_script% -NoNewWindow}"


### PR DESCRIPTION
Add `C:\Windows\System32\WindowsPowerShell\v1.0` to `PATH` because constructor removes it.
Also fix issue where Spyder's temp directory was incorrect when launched by installer.

Fixes #25915