### PR TITLE
PR: Handle Layouts plugin being `None` when calling `switch_to_plugin` (Main window)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -100,12 +100,12 @@ else
     popd
 
     # Create environment for Jedi environment tests
-    conda create -n jedi-test-env -q -y python=3.9 flask
+    conda create -n jedi-test-env -q -y python=3.9 flask pip
     install_spyder_kernels jedi-test-env
     conda list -n jedi-test-env
 
     # Create environment to test conda env activation before launching a kernel
-    conda create -n spytest-ž -q -y -c conda-forge python=3.9
+    conda create -n spytest-ž -q -y -c conda-forge python=3.9 pip
     install_spyder_kernels spytest-ž
     conda list -n spytest-ž
 

--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -550,7 +550,11 @@ class MainWindow(QMainWindow, SpyderMainWindowMixin, SpyderShortcutsMixin):
         this plugin to view (if it's hidden) and gives it focus (if
         possible).
         """
-        self.layouts.switch_to_plugin(plugin, force_focus=force_focus)
+        # This is necessary to avoid an error when layouts is not ready.
+        # Fixes spyder-ide/spyder#22639
+        logger.debug(f"Switch to {plugin} while Layouts plugin is {self.layouts}")
+        if self.layouts is not None:
+            self.layouts.switch_to_plugin(plugin, force_focus=force_focus)
 
     def unmaximize_plugin(self, not_this_plugin=None):
         """


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->
Although I was unable to reproduce the issue, adding a validation for the Layouts plugin seems valuable. Thinking about a possible reason for the error to appear, could it be that some plugin triggers a switch to plugin request before the Layout plugin is fully ready (?). This also adds a debug logger entry when calling `switch_to_plugin` for further debug info if necessary in the future.

This also adds pip to the commands that create test environment on the CI (a tests related with test env activation was failing due to the envs not having installed spyder-kernels since there were being created without `pip`): https://github.com/spyder-ide/spyder/actions/runs/26256105144/job/77279039228#step:10:9907

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22639
Supersedes PR https://github.com/spyder-ide/spyder/pull/22672


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
