### PR TITLE
PR: Fix error when trying to format code and make Black the default formatter (Editor/Completions)

### DIFF
--- a/spyder/plugins/completion/providers/languageserver/conftabs/formatting.py
+++ b/spyder/plugins/completion/providers/languageserver/conftabs/formatting.py
@@ -49,22 +49,17 @@ class FormattingConfigTab(SpyderPreferencesTab):
         autopep8_url = (
             "<a href='https://github.com/hhatto/autopep8'>Autopep8</a>"
         )
-        yapf_url = (
-            "<a href='https://github.com/google/yapf'>Yapf</a>"
-        )
         black_url = (
             "<a href='https://black.readthedocs.io/en/stable'>Black</a>"
         )
         ruff_url = (
             "<a href='https://docs.astral.sh/ruff/formatter/'>Ruff</a>"
         )
-        formatter_urls = "".join(
-            f"<li>{url}</li>" for url in (autopep8_url, black_url, ruff_url)
-        )
+        formatter_urls = black_url + ", " + ruff_url + ", " + autopep8_url
         code_fmt_label = QLabel(
             _(
-                "Spyder can use one of the following formatters to format your "
-                " code for conformance to the {0} convention:<ul>{1}</ul>"
+                "Spyder can use one of the following formatters to format "
+                "your code for conformance to the {0} convention: {1}."
             ).format(pep_url, formatter_urls)
         )
         code_fmt_label.setOpenExternalLinks(True)

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -64,7 +64,7 @@ class LanguageServerProvider(SpyderCompletionProvider):
         ('flake8', False),
         ('ruff', False),
         ('no_linting', False),
-        ('formatting', 'autopep8'),
+        ('formatting', 'black'),
         ('format_on_save', False),
         ('flake8/filename', ''),
         ('flake8/exclude', ''),
@@ -95,7 +95,7 @@ class LanguageServerProvider(SpyderCompletionProvider):
     #    want to *rename* options, then you need to do a MAJOR update in
     #    version, e.g. from 0.1.0 to 1.0.0
     # 3. You don't need to touch this value if you're just adding a new option
-    CONF_VERSION = "1.0.0"
+    CONF_VERSION = "1.1.0"
     CONF_TABS = TABS
 
     STOPPED = 'stopped'

--- a/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/lsp_mixin.py
@@ -1022,10 +1022,11 @@ class LSPMixin:
         """Format current document or selected text."""
         formatter = self.get_conf(
             ("provider_configuration", "lsp", "values", "formatting"),
-            "completions",
             default="",
+            section="completions",
         )
         is_ruff = formatter == "ruff"
+
         if (
             self.has_selected_text()
             and self.range_formatting_enabled


### PR DESCRIPTION
## Description of Changes

- This is a regression introduced by PR #25725.
- It's better to use Black instead of Autopep8 as the default formatter because the latter is a bit outdated these days (and Ruff doesn't support selection formatting yet).

### Visual changes

Simplify formatters listing in `Code formatting` tab of `Completions and listing` config page.

Before

<img width="900" height="392" alt="image" src="https://github.com/user-attachments/assets/00513b68-010f-416e-9587-55f1ce0e7919" />

After

<img width="922" height="355" alt="image" src="https://github.com/user-attachments/assets/7e490c28-d28b-4814-93f7-3b2b65ee7110" />

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
