### PR TITLE
PR: Fix copying string, bytes, object and bool arrays in Array editor (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -1005,8 +1005,11 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
                 # We don't know what's inside these arrays, so we can't handle
                 # edits
                 self.readonly = readonly = True
-            elif (dtn not in SUPPORTED_FORMATS and not dtn.startswith('str')
-                    and not dtn.startswith('unicode')):
+            elif (
+                dtn not in SUPPORTED_FORMATS
+                and not dtn.startswith("str")
+                and not dtn.startswith("bytes")
+            ):
                 arr = _("%s arrays") % dtn
                 self.error(_("%s are currently not supported") % arr)
                 return False

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -614,6 +614,7 @@ class ArrayView(QTableView, SpyderWidgetMixin):
         """Copy an array portion to a unicode string"""
         if not cell_range:
             return
+
         row_min, row_max, col_min, col_max = get_idx_rect(cell_range)
         if col_min == 0 and col_max == (self.model().cols_loaded-1):
             # we've selected a whole column. It isn't possible to
@@ -624,17 +625,33 @@ class ArrayView(QTableView, SpyderWidgetMixin):
             row_max = self.model().total_rows-1
 
         _data = self.model().get_data()
-        output = io.BytesIO()
+        output = io.StringIO()
         try:
-            fmt = '%' + self.model().get_format_spec()
-            np.savetxt(output, _data[row_min:row_max+1, col_min:col_max+1],
-                       delimiter='\t', fmt=fmt)
-        except:
-            QMessageBox.warning(self, _("Warning"),
-                                _("It was not possible to copy values for "
-                                  "this array"))
+            # Use the right format to copy non-numeric arrays
+            # Fixes spyder-ide/spyder#26088
+            if any(
+                name in _data.dtype.name
+                for name in ["str", "bytes", "object", "bool"]
+            ):
+                fmt = "%s"
+            else:
+                fmt = '%' + self.model().get_format_spec()
+
+            np.savetxt(
+                output,
+                _data[row_min : row_max + 1, col_min : col_max + 1],
+                delimiter="\t",
+                fmt=fmt,
+            )
+        except Exception:
+            QMessageBox.warning(
+                self,
+                _("Warning"),
+                _("It was not possible to copy values for this array")
+            )
             return
-        contents = output.getvalue().decode('utf-8')
+
+        contents = output.getvalue()
         output.close()
         return contents
 

--- a/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
@@ -488,5 +488,22 @@ def test_copy_string_array(qtbot):
     assert clipboard.text() == "ü\ntest\n"
 
 
+def test_copy_bytes_array(qtbot):
+    arr = np.array([b"\xc3\xb1", b"world"], dtype="S5")
+    dlg = ArrayEditor()
+    assert dlg.setup_and_check(arr, '2D array')
+    with qtbot.waitExposed(dlg):
+        dlg.show()
+
+    # Select all contents and copy them
+    view = dlg.arraywidget.view
+    qtbot.keyPress(view, Qt.Key_A, modifier=Qt.ControlModifier)
+    qtbot.keyPress(view, Qt.Key_C, modifier=Qt.ControlModifier)
+
+    # Check we get the expected result
+    clipboard = QApplication.clipboard()
+    assert clipboard.text() == "b'\\xc3\\xb1'\nb'world'\n"
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
@@ -21,7 +21,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QMessageBox
+from qtpy.QtWidgets import QApplication, QMessageBox
 from scipy.io import loadmat
 
 # Local imports
@@ -469,6 +469,23 @@ def test_arrayeditor_edit_overflow(qtbot, monkeypatch):
         qtbot.wait(500)
         assert np.sum(expected_array ==
                       dialog.get_value()) == len(expected_array)
+
+
+def test_copy_string_array(qtbot):
+    arr = np.array(["ü", "test"])
+    dlg = ArrayEditor()
+    assert dlg.setup_and_check(arr, '2D array')
+    with qtbot.waitExposed(dlg):
+        dlg.show()
+
+    # Select all contents and copy them
+    view = dlg.arraywidget.view
+    qtbot.keyPress(view, Qt.Key_A, modifier=Qt.ControlModifier)
+    qtbot.keyPress(view, Qt.Key_C, modifier=Qt.ControlModifier)
+
+    # Check we get the expected result
+    clipboard = QApplication.clipboard()
+    assert clipboard.text() == "ü\ntest\n"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of Changes

- This was giving an error in Spyder 5 and showing a message in version 6 about not being able to copy the array contents, but the fix was easy.
- Also, add support for generic bytes arrays to the Array editor.

### Issue(s) Resolved

Fixes #26088

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
