### PR TITLE
PR: Fix setting max number of plots through the UI and a couple of regressions in the switcher

### DIFF
--- a/spyder/plugins/plots/widgets/main_widget.py
+++ b/spyder/plugins/plots/widgets/main_widget.py
@@ -523,19 +523,25 @@ class PlotsWidget(ShellConnectMainWidget):
 
             # Set dialog properties
             dialog.setModal(False)
+            dialog.setWindowFlags(
+                dialog.windowFlags() & ~Qt.WindowContextHelpButtonHint
+            )
             dialog.setWindowTitle(_('Max plots'))
             dialog.setLabelText(_('Set maximum number of plots: '))
             dialog.setInputMode(QInputDialog.IntInput)
             dialog.setIntStep(1)
-            dialog.setIntValue(self.get_conf('max_plots'))
-
             dialog.setIntRange(10, 10000)
+            dialog.setIntValue(self.get_conf('max_plots'))
 
             # Connect slot
             dialog.intValueSelected.connect(
                 lambda value: self.set_conf('max_plots', value)
             )
 
+            # Show
             dialog.show()
+
+            # Set min width. It can only be done at this point
+            dialog.setMinimumWidth(250)
         else:
             self.set_conf('max_plots', value)

--- a/spyder/plugins/switcher/widgets/switcher.py
+++ b/spyder/plugins/switcher/widgets/switcher.py
@@ -542,7 +542,6 @@ class Switcher(QDialog, SpyderFontsMixin):
         """Set the current row, center view, skip editor cursor jump."""
         proxy_index = self.proxy.index(row, 0)
         selection_model = self.list.selectionModel()
-        self.initial_flag = True
 
         # Select current item without moving the editor view
         with signals_blocked(self):
@@ -554,15 +553,6 @@ class Switcher(QDialog, SpyderFontsMixin):
 
     def previous_row(self):
         """Select previous row in list widget."""
-        if self.initial_flag:
-            # Move to the beginning of the current symbol
-            current_row = self.current_row()
-            self.list.selectionModel().clear()
-            self.set_current_row(current_row)
-            self.initial_flag = False
-            return
-
-        # Normal march
         steps = 1
         prev_row = self.current_row() - steps
 
@@ -580,15 +570,14 @@ class Switcher(QDialog, SpyderFontsMixin):
 
     def next_row(self):
         """Select next row in list widget."""
-        self.initial_flag = False
         steps = 1
         next_row = self.current_row() + steps
+
         # Need to map the filtered list to the actual model items
         list_index = self.proxy.index(next_row, 0)
         model_index = self.proxy.mapToSource(list_index)
         item = self.model.item(model_index.row(), 0)
 
-        # Normal march
         if next_row >= self.count():
             self.set_current_row(0)
         else:

--- a/spyder/plugins/switcher/widgets/switcher.py
+++ b/spyder/plugins/switcher/widgets/switcher.py
@@ -536,7 +536,7 @@ class Switcher(QDialog, SpyderFontsMixin):
         )
 
         # Ensure that the selected item is visible
-        self.list.scrollTo(proxy_index, QAbstractItemView.PositionAtCenter)
+        self.list.scrollTo(proxy_index, QAbstractItemView.EnsureVisible)
     
     def init_current_row(self, row):
         """Set the current row, center view, skip editor cursor jump."""
@@ -550,7 +550,7 @@ class Switcher(QDialog, SpyderFontsMixin):
                 proxy_index,
                 QItemSelectionModel.ClearAndSelect
             )
-            self.list.scrollTo(proxy_index, QAbstractItemView.PositionAtCenter)
+            self.list.scrollTo(proxy_index, QAbstractItemView.EnsureVisible)
 
     def previous_row(self):
         """Select previous row in list widget."""


### PR DESCRIPTION
## Description of Changes

- The max number of plots entered by the user was not correctly set in the int dialog for that because its range was declared _after_ setting in it the value saved in our config system.
- The switcher was automatically scrolling when selecting entries, which broke the visual reference on the symbol you're seeing right now and the one you want to go to (regression from #25926).
- Revert making Up arrow go to the beginning of the initial symbol in the switcher. Since the editor cursor is not visible while the switcher is open, it was not possible for users to understand what the Up arrow is doing when you want to go to the previous symbol. You only see that you have to press it twice in order to do that (also regression from #25926).

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
