### PR TITLE
PR: Avoid reshaping arrays in place when instantiating `ArrayEditor` for Numpy 2.5+

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -836,7 +836,8 @@ class ArrayEditor(BaseDialog, SpyderWidgetMixin):
             name=ArrayEditorActions.CloseAllEditors,
             text=_("Close all viewers"),
             icon=self.create_icon("filecloseall"),
-            triggered=self.sig_close_all_editors_requested.emit
+            triggered=self.sig_close_all_editors_requested.emit,
+            register_action=False,
         )
         self.close_all_editors_action.setVisible(from_variable_explorer)
 

--- a/spyder/plugins/variableexplorer/widgets/arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/arrayeditor.py
@@ -677,10 +677,10 @@ class ArrayEditorWidget(QWidget):
         self.old_data_shape = None
         if len(self.data.shape) == 1:
             self.old_data_shape = self.data.shape
-            self.data.shape = (self.data.shape[0], 1)
+            self.data = self.data.reshape((self.data.shape[0], 1))
         elif len(self.data.shape) == 0:
             self.old_data_shape = self.data.shape
-            self.data.shape = (1, 1)
+            self.data = self.data.reshape((1, 1))
 
         # Use '' as default format specifier, because 's' does not produce
         # a `str` for arrays with strings, see spyder-ide/spyder#22466
@@ -688,7 +688,9 @@ class ArrayEditorWidget(QWidget):
 
         self.model = ArrayModel(self.data, format_spec=format_spec,
                                 readonly=readonly, parent=self)
-        self.view = ArrayView(self, self.model, data.dtype, data.shape)
+        self.view = ArrayView(
+            self, self.model, self.data.dtype, self.data.shape
+        )
 
         layout = QVBoxLayout()
         layout.addWidget(self.view)
@@ -700,12 +702,12 @@ class ArrayEditorWidget(QWidget):
         for (i, j), value in list(self.model.changes.items()):
             self.data[i, j] = value
         if self.old_data_shape is not None:
-            self.data.shape = self.old_data_shape
+            self.data = self.data.reshape(self.old_data_shape)
 
     def reject_changes(self):
         """Reject changes"""
         if self.old_data_shape is not None:
-            self.data.shape = self.old_data_shape
+            self.data = self.data.reshape(self.old_data_shape)
 
     @Slot()
     def change_format(self):

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -1873,12 +1873,12 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
         )
         self.register_shortcut_for_widget(name='close', triggered=self.reject)
 
-        
         self.close_all_editors_action = self.create_action(
             name=DataframeEditorActions.CloseAllEditors,
             text=_("Close all viewers"),
             icon=self.create_icon("filecloseall"),
-            triggered=self.sig_close_all_editors_requested.emit
+            triggered=self.sig_close_all_editors_requested.emit,
+            register_action=False,
         )
 
         # Destroying the C++ object right after closing the dialog box,

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/objectexplorer.py
@@ -254,7 +254,8 @@ class ObjectExplorer(BaseDialog, SpyderWidgetMixin, SpyderFontsMixin):
             name=ObjectExplorerActions.CloseAllEditors,
             text=_("Close all viewers"),
             icon=self.create_icon("filecloseall"),
-            triggered=self.sig_close_all_editors_requested.emit
+            triggered=self.sig_close_all_editors_requested.emit,
+            register_action=False,
         )
 
         stretcher = self.create_stretcher(

--- a/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/test_objectexplorer.py
+++ b/spyder/plugins/variableexplorer/widgets/objectexplorer/tests/test_objectexplorer.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 # Third party imports
 import numpy as np
+from packaging.version import parse
 import pytest
 from qtpy.QtCore import Qt
 
@@ -106,13 +107,17 @@ def test_objectexplorer(objectexplorer):
     assert model.columnCount() == 11
 
 
+@pytest.mark.skipif(
+    parse(np.__version__) < parse("2.5.0"),
+    reason="Fails for versions older than Numpy 2.5",
+)
 @pytest.mark.parametrize('params', [
     # variable to show, rowCount for different Python 3 versions
     ('kjkj kj k j j kj k jkj', [71, 81]),
     ([1, 3, 4, 'kjkj', None], [45, 48]),
     ({1, 2, 1, 3, None, 'A', 'B', 'C', True, False}, [54, 57]),
     (1.2233, [57, 59]),
-    (np.random.rand(10, 10), [162, 167]),
+    (np.random.rand(10, 10), [162, 168]),
     (datetime.date(1945, 5, 8), [43, 48])
 ])
 def test_objectexplorer_collection_types(objectexplorer, params):

--- a/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_arrayeditor.py
@@ -346,8 +346,10 @@ def test_arrayeditor_edit_1d_array(qtbot):
     qtbot.keyPress(view, Qt.Key_Down)
     qtbot.keyClicks(view, '0')
     qtbot.keyPress(view, Qt.Key_Down)
-    qtbot.keyPress(view, Qt.Key_Return)
-    assert np.sum(exp_arr == dlg.get_value()) == 5
+
+    assert dlg.btn_save_and_close.isEnabled()
+    dlg.btn_save_and_close.clicked.emit()
+    assert_array_equal(dlg.get_value(), exp_arr)
 
 
 @pytest.mark.skipif(sys.platform == 'darwin', reason="It fails on macOS")

--- a/spyder/widgets/collectionseditor.py
+++ b/spyder/widgets/collectionseditor.py
@@ -1875,12 +1875,13 @@ class CollectionsEditorWidget(QWidget, SpyderWidgetMixin):
         self.register_shortcut_for_widget(
             name='close', triggered=self.close_window
         )
-        
+
         self.close_all_editors_action = self.create_action(
             name=CollectionsEditorActions.CloseAllEditors,
             text=_("Close all viewers"),
             icon=self.create_icon("filecloseall"),
-            triggered=self.sig_close_all_editors_requested.emit
+            triggered=self.sig_close_all_editors_requested.emit,
+            register_action=False,
         )
         self.close_all_editors_action.setVisible(from_variable_explorer)
 


### PR DESCRIPTION
## Description of Changes

- Setting `shape` directly (which is what we were doing before) is giving a `DeprecationWarning` now in Numpy 2.5+ (released yesterday).
- Fix `test_objectexplorer_collection_types` and `test_arrayeditor_edit_1d_array` for Numpy 2.5+.
- Don't register action to close all Variable Explorer editors, which was giving a warning that made an `ArrayEditor` test fail.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
