### PR TITLE
PR: Prevent duplicate key sequences from being added when entering shortcuts (Preferences)

### DIFF
--- a/spyder/plugins/shortcuts/widgets/table.py
+++ b/spyder/plugins/shortcuts/widgets/table.py
@@ -325,6 +325,9 @@ class ShortcutEditor(QDialog):
         translator = ShortcutTranslator()
         event_keyseq = translator.keyevent_to_keyseq(event)
         event_keystr = event_keyseq.toString(QKeySequence.PortableText)
+
+        # Prevent repeated sequences when entering shortcuts
+        # Fixes spyder-ide/spyder#26032
         if event_keystr in self._qsequences:
             return
 

--- a/spyder/plugins/shortcuts/widgets/table.py
+++ b/spyder/plugins/shortcuts/widgets/table.py
@@ -325,6 +325,9 @@ class ShortcutEditor(QDialog):
         translator = ShortcutTranslator()
         event_keyseq = translator.keyevent_to_keyseq(event)
         event_keystr = event_keyseq.toString(QKeySequence.PortableText)
+        if event_keystr in self._qsequences:
+            return
+
         self._qsequences.append(event_keystr)
         self.update_warning()
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

Avoids storing duplicate key sequences by checking whether a sequence already exists before adding it to _qsequences.

<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #26032 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@jsbautista 
<!--- Thanks for your help making Spyder better for everyone! --->
