### PR TITLE
PR: Add HTML markup to Preferences tooltips

### DIFF
--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -11,7 +11,7 @@ Helper widgets.
 # Standard imports
 from __future__ import annotations
 import re
-import textwrap
+import math
 from typing import Callable, Dict
 
 # Third party imports
@@ -691,9 +691,7 @@ class TipWidget(QLabel):
     ):
         super().__init__()
 
-        if wrap_text:
-            tip_text = '\n'.join(textwrap.wrap(tip_text, 50))
-        self.tip_text = tip_text
+        self.tip_text = self._format_tooltip(tip_text)
 
         size = size if size is not None else AppStyle.ConfigPageIconSize
         self.icon = icon.pixmap(QSize(size, size))
@@ -737,6 +735,25 @@ class TipWidget(QLabel):
     def mouseReleaseEvent(self, event):
         """Show tooltip when the widget is clicked."""
         self.show_tip()
+
+    def _format_tooltip(self, tip_text, max_width=300):
+        """Wrap tooltip in HTML table and set width."""
+        text = tip_text.replace("\n", "<br>")
+
+        doc = QTextDocument()
+        doc.setDefaultFont(QToolTip.font())
+        doc.setDocumentMargin(0)
+        doc.setTextWidth(max_width)
+        doc.setHtml(text)
+        width = math.ceil(doc.idealWidth()) + 1
+
+        html_tooltip = (
+            '<table cellspacing="0" cellpadding="0" '
+            'style="margin:0;padding:0">'
+            '<tr><td width="{}">{}</td></tr></table>'
+        )
+
+        return html_tooltip.format(width, text)
 
 
 class ValidationLineEdit(QLineEdit):

--- a/spyder/widgets/helperwidgets.py
+++ b/spyder/widgets/helperwidgets.py
@@ -742,10 +742,10 @@ class TipWidget(QLabel):
 
         doc = QTextDocument()
         doc.setDefaultFont(QToolTip.font())
-        doc.setDocumentMargin(0)
+        doc.setDocumentMargin(1)
         doc.setTextWidth(max_width)
         doc.setHtml(text)
-        width = math.ceil(doc.idealWidth()) + 1
+        width = math.ceil(doc.idealWidth())
 
         html_tooltip = (
             '<table cellspacing="0" cellpadding="0" '


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))

<!--- Explain what you've done and why --->

As shown in #26111, the Preferences help tooltips have inconsistent widths. Currently in the dev version, tooltip texts are wrapped at 50 characters by adding newlines (`\n`) : [helperwidgets.py:694](https://github.com/spyder-ide/spyder/blob/4ca304b12c5472813ef04372c6c076c985e15270/spyder/widgets/helperwidgets.py#L694). This works well for plain text but does not apply to text containing HTML markup.

When HTML markup is detected in QToolTip text, Qt automatically uses RichText processing (I guess this is related to the [Qt::TextFormat](https://doc.qt.io/archives/qt-5.15/qt.html#TextFormat-enum) enum, probably used internally), as you can see in the comparison below:

| No HTML in text, no 50-character wrapping | HTML in text, no 50-character wrapping |
|:---------------------------------------------------------:|:-----------------------------------------------------:|
| <img width="441" height="38" alt="whithout_html_no_wrap" src="https://github.com/user-attachments/assets/b7cf0ef4-80bf-4e70-9d99-d68c11a2d4ab" /> | <img width="152" height="81" alt="with_html_no_wrap" src="https://github.com/user-attachments/assets/92892034-99c0-4c8d-9b4d-660c5e4dccfd" /> |

In the default case, Qt seems to choose a wrapping width depending on the text length, probably to avoid very wide or very narrow tooltips. But this behavior is inconsistent with the 50-character wrapping implemented for plain text.
Unfortunately, Qt does not provide a parameter to customize the width of a [QToolTip](https://doc.qt.io/archives/qt-5.15/qtooltip.html#details) (such as "setWidth" or "setMaxWidth").

There are however some ways to customize the RichText processing by using the `white-space` CSS property. Below are some tests for the different allowed values ([Supported HTML Subset](https://doc.qt.io/archives/qt-5.15/richtext-html-subset.html), [white-space property](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/white-space)).

For these tests, I used a long tooltip text containing newlines (`<br>` and `\n`), tabs (`\t`) and multiple spaces (on prevent_closing_box, in the Debugger preferences):

**debugger/confpage.py:45**
```python
prevent_closing_box = newcb(
    _("Prevent editor from closing files while debugging"),
    'pdb_prevent_closing',
    tip=_("This option<br><br> prevents\t the \n\nuserfrom     closing\n    a file <b>while</b> it <br>\t is debugged. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.")
)
```

I then removed the current 50-character wrapping, and applied different formatting to the tooltip:

**helperwidgets.py:694**
```python
#if wrap_text:
#    tip_text = '\n'.join(textwrap.wrap(tip_text, 50))
self.tip_text = '<p white-space="pre">{}</p>'.format(tip_text)  # To test white-space property
self.tip_text = '<p>{}</p>'.format(tip_text)                    # To test RichText use
self.tip_text = tip_text                                        # To test normal case
```

The results are in the table below:

| HTML markup | Result | Comment |
|-----------|:------:|-------|
| no markup<br/><br/> `<p>` tag<br/><br/> `<p style="white-space:normal">` | <img width="250" height="121" alt="Spyder_dev_no_markup" src="https://github.com/user-attachments/assets/17b1aa25-9923-4270-9b8c-6aa20ac05003" /> | Qt automatically detects HTML markup and uses RichText processing. So, the result is the same with or without `<p>` tags.<br/><br/> `white-space:normal` is the default behavior. White-space characters (`\t`, `\n`, ...) are replaced by a space, then multiple spaces are replaced by only one space ([collapsing](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Text/Whitespace#collapsing_and_transformation)). HTML tags are rendered, including `<br>` . Automatic wrapping is applied. |
| `<p style="white-space:pre">`         | <img width="613" height="127" alt="Spyder_dev_p_markup_white-space_pre" src="https://github.com/user-attachments/assets/1f15ff99-3a81-4c7f-9fad-d59b6b815223" /> | `white-space:pre` preserve white spaces (no collapsing), Lines break at new line character (`\n`) and `<br/>` only, no automatic wrapping is applied. |
| `<p style="white-space:nowrap">`      | <img width="528" height="80" alt="Spyder_dev_p_markup_white-space_nowrap" src="https://github.com/user-attachments/assets/7dbf2ade-5aa0-41d6-91b5-cdf621ea2cac" /> | `white-space:nowrap` seems to be like `white-space:normal` but without automatic line wrapping. |
| `<p style="white-space:pre-wrap">`    | <img width="318" height="139" alt="Spyder_dev_p_markup_white-space_prewrap" src="https://github.com/user-attachments/assets/c8b81499-cb6f-4e82-9860-ffdd2eb70346" /> | `white-space:pre-wrap` seems to be like `white-space:pre` but with automatic line wrapping added. |

In this PR, I wrap all the tooltip texts in `<p>` tags, using the default `white-space` behavior. This allows the use of RichText processing on all tooltips consistently, letting Qt choose the best width to fit the content and render HTML markup. This solution is the easiest fix, but it comes with some drawbacks:

* Width consistency: widths are different for each tooltip.
* Narrow widths: widths chosen by Qt seem quite narrow (I find that the 50-character width looks better).
* The newline character `\n` is not rendered

However, this solution:

* Ensure a correct display of the tooltips (no very long lines, no wide empty spaces, ...)
* Render HTML markup in each tooltip using RichText processing
* Collapse whitespaces

I first tried several other solutions to maintain a width closer to the 50-character limit. But doing that while keeping the standard QToolTip is not straightforward. The best fix would probably be to create a custom tooltip class, inheriting QLabel. This is also a matter of choice whether new lines (`\n`) should be used in tooltip text. Using only `<br>` tags might simplify the implementation.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #26111


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ProcyonLotor42

<!--- Thanks for your help making Spyder better for everyone! --->
