### PR TITLE
PR: Add export option to `DataFrameEditor` to save dataframes to CSV, Excel or Json (Variable Explorer)

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -31,6 +31,7 @@ dependencies:
 - markdown-it-py >=3.0.0
 - nbconvert >=4.0
 - numpydoc >=0.6.0
+- openpyxl >=3.0.0
 - packaging >=20.0
 - parso >=0.7.0,<0.9.0
 - pickleshare >=0.4

--- a/installers-conda/resources/runtime_env.yml
+++ b/installers-conda/resources/runtime_env.yml
@@ -11,7 +11,6 @@ dependencies:
   - cython
   - matplotlib-base
   - numpy
-  - openpyxl
   - pandas
   - pyarrow
   - scipy

--- a/requirements/main.yml
+++ b/requirements/main.yml
@@ -29,6 +29,7 @@ dependencies:
   - markdown-it-py >=3.0.0
   - nbconvert >=4.0
   - numpydoc >=0.6.0
+  - openpyxl >=3.0.0
   - packaging >=20.0
   - parso >=0.7.0,<0.9.0
   - pickleshare >=0.4

--- a/setup.py
+++ b/setup.py
@@ -289,6 +289,7 @@ install_requires += [
     'markdown-it-py>=3.0.0',
     'nbconvert>=4.0',
     'numpydoc>=0.6.0',
+    'openpyxl>=3.0.0',
     'packaging>=20.0',
     'parso>=0.7.0,<0.9.0',
     'pickleshare>=0.4',

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -52,6 +52,7 @@ LXML_REQVER = ">=4.9.0"
 MARKDOWN_IT_REQVER = ">=3.0.0"
 NBCONVERT_REQVER = '>=4.0'
 NUMPYDOC_REQVER = '>=0.6.0'
+OPENPYXL_REQVER = '>=3.0.0'
 PACKAGING_REQVER = '>=20.0'
 PARSO_REQVER = '>=0.7.0,<0.9.0'
 PICKLESHARE_REQVER = '>=0.4'
@@ -185,6 +186,10 @@ DESCRIPTIONS = [
      'package_name': "numpydoc",
      'features': _("Improve code completion for objects that use Numpy docstrings"),
      'required_version': NUMPYDOC_REQVER},
+    {'modname': "openpyxl",
+     'package_name': "openpyxl",
+     'features': _("Export DataFrames to Excel files in the Variable Explorer"),
+     'required_version': OPENPYXL_REQVER},
     {'modname': "packaging",
      'package_name': "packaging",
      'features': _("Compare version numbers of Python packages"),

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -41,7 +41,7 @@ from typing import Any, Callable, Optional, TYPE_CHECKING
 
 # Third party imports
 from packaging.version import parse
-from qtpy.compat import from_qvariant, to_qvariant, getsavefilename
+from qtpy.compat import from_qvariant, getsavefilename, to_qvariant
 from qtpy.QtCore import (
     QAbstractTableModel, QEvent, QItemSelectionModel, QModelIndex, QPoint, Qt,
     Signal, Slot)
@@ -146,7 +146,6 @@ class DataframeEditorContextMenuSections:
     Row = 'row_section'
     Column = 'column_section'
     Convert = 'convert_section'
-    Export = 'export_section'
 
 
 class DataframeEditorToolbarSections:
@@ -1020,7 +1019,7 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
         # ---- Create context menu and fill it
 
         menu = self.create_menu(DataframeEditorMenus.Context, register=False)
-        for action in [self.copy_action, self.edit_action]:
+        for action in [self.copy_action, self.edit_action, self.export_action]:
             self.add_item_to_menu(
                 action,
                 menu,
@@ -1040,11 +1039,6 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
                 menu,
                 section=DataframeEditorContextMenuSections.Column
             )
-        self.add_item_to_menu(
-            self.export_action,
-            menu,
-            section=DataframeEditorContextMenuSections.Export
-        )
 
         return menu
 
@@ -1092,7 +1086,10 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
                 if filename.endswith(('.xlsx', '.xls')):
                     df.to_excel(filename, index=index)
                 elif filename.endswith('.json'):
-                    if isinstance(df.index, pd.RangeIndex) and df.index.name is None:
+                    if (
+                        isinstance(df.index, pd.RangeIndex)
+                        and df.index.name is None
+                    ):
                         df.to_json(filename, orient='records', indent=4)
                     else:
                         df.to_json(filename, orient='index', indent=4)
@@ -1102,8 +1099,10 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
                 QMessageBox.critical(
                     self,
                     title,
-                    _("<b>Unable to export DataFrame</b>"
-                      "<br><br>Error message:<br>%s") % str(error)
+                    _(
+                        "It was not possible to export this DataFrame."
+                        "<br><br>The error was:<br>%s"
+                    ) % str(error)
                 )
 
     @Slot()
@@ -2179,9 +2178,9 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
             self.close_all_editors_action,
             stretcher,
             self.dataTable.histogram_action,
+            self.dataTable.export_action,
             self.dataTable.resize_action,
             self.dataTable.resize_columns_action,
-            self.dataTable.export_action,
             self.refresh_action,
             options_button
         ]:

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -41,7 +41,7 @@ from typing import Any, Callable, Optional, TYPE_CHECKING
 
 # Third party imports
 from packaging.version import parse
-from qtpy.compat import from_qvariant, to_qvariant
+from qtpy.compat import from_qvariant, to_qvariant, getsavefilename
 from qtpy.QtCore import (
     QAbstractTableModel, QEvent, QItemSelectionModel, QModelIndex, QPoint, Qt,
     Signal, Slot)
@@ -80,6 +80,7 @@ from spyder.plugins.variableexplorer.widgets.preferences import (
     PreferencesDialog
 )
 from spyder.utils.icon_manager import ima
+from spyder.utils.misc import getcwd_or_home
 from spyder.utils.palette import SpyderPalette
 from spyder.utils.qthelpers import keybinding, qapplication
 from spyder.utils.stylesheet import AppStyle, MAC
@@ -123,6 +124,7 @@ class DataframeEditorActions:
     ResizeColumns = 'resize_columns_action'
     ResizeRows = 'resize_rows_action'
     CloseAllEditors = 'close_all_editors_action'
+    Export = 'export_action'
 
 
 class DataframeEditorMenus:
@@ -144,6 +146,7 @@ class DataframeEditorContextMenuSections:
     Row = 'row_section'
     Column = 'column_section'
     Convert = 'convert_section'
+    Export = 'export_section'
 
 
 class DataframeEditorToolbarSections:
@@ -767,6 +770,8 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
         self.resize_action = None
         self.resize_columns_action = None
         self.histogram_action = None
+        self.export_action = None
+        self.export_filename = None
 
         self.menu = self.setup_menu()
         self.menu_header_h = self.setup_menu_header()
@@ -1003,6 +1008,14 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
             triggered=self.plot_hist,
             register_action=False
         )
+        self.export_action = self.create_action(
+            name=DataframeEditorActions.Export,
+            text=_("Export..."),
+            tip=_("Export DataFrame to CSV, Excel or JSON file"),
+            icon=ima.icon('fileexport'),
+            triggered=self.export_data,
+            register_action=False
+        )
 
         # ---- Create context menu and fill it
 
@@ -1027,8 +1040,71 @@ class DataFrameView(QTableView, SpyderWidgetMixin):
                 menu,
                 section=DataframeEditorContextMenuSections.Column
             )
+        self.add_item_to_menu(
+            self.export_action,
+            menu,
+            section=DataframeEditorContextMenuSections.Export
+        )
 
         return menu
+
+    @Slot()
+    def export_data(self):
+        """Export DataFrame to CSV or Excel file."""
+        title = _("Export DataFrame")
+        if self.export_filename is None:
+            self.export_filename = getcwd_or_home()
+
+        filename, selected_filter = getsavefilename(
+            self,
+            title,
+            self.export_filename,
+            _("CSV file") + " (*.csv);;" +
+            _("Excel file") + " (*.xlsx);;" +
+            _("JSON file") + " (*.json)"
+        )
+
+        if filename:
+            self.export_filename = filename
+            # Append correct extension if missing
+            if "xlsx" in selected_filter:
+                if not filename.endswith(('.xlsx', '.xls')):
+                    filename += '.xlsx'
+                    self.export_filename = filename
+            elif "json" in selected_filter:
+                if not filename.endswith('.json'):
+                    filename += '.json'
+                    self.export_filename = filename
+            elif "csv" in selected_filter:
+                if not filename.endswith('.csv'):
+                    filename += '.csv'
+                    self.export_filename = filename
+
+            df = self.model().get_data()
+
+            # If the index is a RangeIndex with no name, do not export it
+            if isinstance(df.index, pd.RangeIndex) and df.index.name is None:
+                index = False
+            else:
+                index = True
+
+            try:
+                if filename.endswith(('.xlsx', '.xls')):
+                    df.to_excel(filename, index=index)
+                elif filename.endswith('.json'):
+                    if isinstance(df.index, pd.RangeIndex) and df.index.name is None:
+                        df.to_json(filename, orient='records', indent=4)
+                    else:
+                        df.to_json(filename, orient='index', indent=4)
+                else:
+                    df.to_csv(filename, index=index)
+            except Exception as error:
+                QMessageBox.critical(
+                    self,
+                    title,
+                    _("<b>Unable to export DataFrame</b>"
+                      "<br><br>Error message:<br>%s") % str(error)
+                )
 
     @Slot()
     def copy(self):
@@ -2105,6 +2181,7 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
             self.dataTable.histogram_action,
             self.dataTable.resize_action,
             self.dataTable.resize_columns_action,
+            self.dataTable.export_action,
             self.refresh_action,
             options_button
         ]:

--- a/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock, patch, ANY
 from flaky import flaky
 import numpy
 from packaging.version import parse
+import pandas as pd
 from pandas import (
     __version__ as pandas_version, DataFrame, date_range, read_csv, concat,
     Index, RangeIndex, MultiIndex, CategoricalIndex, Series)
@@ -1197,6 +1198,63 @@ def test_dataframeeditor_remove_column_with_strings(qtbot):
     ).getHsvF()
     a = dataframeeditor.BACKGROUND_STRING_ALPHA
     assert colorclose(bgcolor(model, 0, 0), (h, s, v, a))
+
+
+def test_dataframeeditor_export(qtbot, tmpdir):
+    """
+    Test exporting a dataframe from the editor to CSV, Excel, and JSON formats.
+    """
+    test_df = DataFrame(
+        [[1, 2], [3, 4]],
+        columns=['first', 'second']
+    )
+    editor = DataFrameEditor()
+    assert editor.setup_and_check(test_df, 'Test Dataframe')
+    view = editor.dataTable
+
+    # Test exporting to CSV
+    csv_file = os.path.join(str(tmpdir), "export.csv")
+    with patch('spyder.plugins.variableexplorer.widgets.dataframeeditor.getsavefilename', return_value=(csv_file, "CSV file (*.csv)")):
+        view.export_action.trigger()
+
+    assert os.path.exists(csv_file)
+    loaded_df = pd.read_csv(csv_file)
+    expected_df = test_df.reset_index(drop=True)
+    assert_frame_equal(loaded_df, expected_df)
+
+    # Test exporting to Excel (mocking to_excel to avoid dependencies on openpyxl/xlsxwriter)
+    excel_file = os.path.join(str(tmpdir), "export.xlsx")
+    with patch('spyder.plugins.variableexplorer.widgets.dataframeeditor.getsavefilename', return_value=(excel_file, "Excel file (*.xlsx)")):
+        with patch.object(test_df, 'to_excel') as mock_to_excel:
+            view.export_action.trigger()
+            mock_to_excel.assert_called_once_with(excel_file, index=False)
+
+    # Test exporting to JSON
+    json_file = os.path.join(str(tmpdir), "export.json")
+    with patch('spyder.plugins.variableexplorer.widgets.dataframeeditor.getsavefilename', return_value=(json_file, "JSON file (*.json)")):
+        view.export_action.trigger()
+
+    assert os.path.exists(json_file)
+    loaded_df = pd.read_json(json_file)
+    assert_frame_equal(loaded_df, expected_df)
+
+    # Test exporting to JSON with custom index
+    custom_df = DataFrame(
+        [[1, 2], [3, 4]],
+        index=['a', 'b'],
+        columns=['first', 'second']
+    )
+    custom_editor = DataFrameEditor()
+    assert custom_editor.setup_and_check(custom_df, 'Custom Dataframe')
+    custom_view = custom_editor.dataTable
+
+    json_file_custom = os.path.join(str(tmpdir), "export_custom.json")
+    with patch('spyder.plugins.variableexplorer.widgets.dataframeeditor.getsavefilename', return_value=(json_file_custom, "JSON file (*.json)")):
+        custom_view.export_action.trigger()
+
+    assert os.path.exists(json_file_custom)
+    loaded_custom_df = pd.read_json(json_file_custom, orient='index')
+    assert_frame_equal(loaded_custom_df, custom_df)
 
 
 if __name__ == "__main__":

--- a/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_dataframeeditor.py
@@ -20,10 +20,19 @@ from unittest.mock import Mock, patch, ANY
 from flaky import flaky
 import numpy
 from packaging.version import parse
-import pandas as pd
 from pandas import (
-    __version__ as pandas_version, DataFrame, date_range, read_csv, concat,
-    Index, RangeIndex, MultiIndex, CategoricalIndex, Series)
+    __version__ as pandas_version,
+    DataFrame,
+    date_range,
+    read_csv,
+    read_json,
+    concat,
+    Index,
+    RangeIndex,
+    MultiIndex,
+    CategoricalIndex,
+    Series,
+)
 from pandas.testing import assert_frame_equal
 import pytest
 from qtpy.QtGui import QColor
@@ -1214,28 +1223,37 @@ def test_dataframeeditor_export(qtbot, tmpdir):
 
     # Test exporting to CSV
     csv_file = os.path.join(str(tmpdir), "export.csv")
-    with patch('spyder.plugins.variableexplorer.widgets.dataframeeditor.getsavefilename', return_value=(csv_file, "CSV file (*.csv)")):
+    with patch(
+        'spyder.plugins.variableexplorer.widgets.dataframeeditor.getsavefilename',
+        return_value=(csv_file, "CSV file (*.csv)")
+    ):
         view.export_action.trigger()
 
     assert os.path.exists(csv_file)
-    loaded_df = pd.read_csv(csv_file)
+    loaded_df = read_csv(csv_file)
     expected_df = test_df.reset_index(drop=True)
     assert_frame_equal(loaded_df, expected_df)
 
     # Test exporting to Excel (mocking to_excel to avoid dependencies on openpyxl/xlsxwriter)
     excel_file = os.path.join(str(tmpdir), "export.xlsx")
-    with patch('spyder.plugins.variableexplorer.widgets.dataframeeditor.getsavefilename', return_value=(excel_file, "Excel file (*.xlsx)")):
+    with patch(
+        'spyder.plugins.variableexplorer.widgets.dataframeeditor.getsavefilename',
+        return_value=(excel_file, "Excel file (*.xlsx)")
+    ):
         with patch.object(test_df, 'to_excel') as mock_to_excel:
             view.export_action.trigger()
             mock_to_excel.assert_called_once_with(excel_file, index=False)
 
     # Test exporting to JSON
     json_file = os.path.join(str(tmpdir), "export.json")
-    with patch('spyder.plugins.variableexplorer.widgets.dataframeeditor.getsavefilename', return_value=(json_file, "JSON file (*.json)")):
+    with patch(
+        'spyder.plugins.variableexplorer.widgets.dataframeeditor.getsavefilename',
+        return_value=(json_file, "JSON file (*.json)")
+    ):
         view.export_action.trigger()
 
     assert os.path.exists(json_file)
-    loaded_df = pd.read_json(json_file)
+    loaded_df = read_json(json_file)
     assert_frame_equal(loaded_df, expected_df)
 
     # Test exporting to JSON with custom index
@@ -1249,11 +1267,14 @@ def test_dataframeeditor_export(qtbot, tmpdir):
     custom_view = custom_editor.dataTable
 
     json_file_custom = os.path.join(str(tmpdir), "export_custom.json")
-    with patch('spyder.plugins.variableexplorer.widgets.dataframeeditor.getsavefilename', return_value=(json_file_custom, "JSON file (*.json)")):
+    with patch(
+        'spyder.plugins.variableexplorer.widgets.dataframeeditor.getsavefilename',
+        return_value=(json_file_custom, "JSON file (*.json)")
+    ):
         custom_view.export_action.trigger()
 
     assert os.path.exists(json_file_custom)
-    loaded_custom_df = pd.read_json(json_file_custom, orient='index')
+    loaded_custom_df = read_json(json_file_custom, orient='index')
     assert_frame_equal(loaded_custom_df, custom_df)
 
 


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
This PR implements the feature request to allow exporting DataFrames directly to CSV, Excel, or JSON files from the Variable Explorer's DataFrame Editor.

### Screenshot
<img width="755" height="519" alt="spyder_export" src="https://github.com/user-attachments/assets/a9bc6c28-5a20-4284-9b49-c983faff4cee" />


**Changes & Placement details:**
- Added an **Export** option to the **DataFrameEditor** toolbar (using the `fileexport` icon) and a **"Export..."** action to the right-click context menu at the bottom.
- Opens a standard file dialog allowing users to choose between CSV, Excel, and JSON formats.
- Promotes `openpyxl` to a core dependency (`setup.py`, `requirements/main.yml`, `binder/environment.yml`, `spyder/dependencies.py`) and removes it from `installers-conda/resources/runtime_env.yml`.
- Catches export errors gracefully (such as missing optional dependencies) and shows a friendly error popup.

**Index Heuristic:**
- **CSV/Excel:** Excludes the index (`index=False`) when it's a default, unnamed `RangeIndex` to avoid cluttered files. Automatically preserves the index (`index=True`) for custom indices (e.g., `MultiIndex`, `DatetimeIndex`, or any index with a custom name).
- **JSON:** Exports with `orient='records'` (excluding default RangeIndex) or `orient='index'` (preserving custom index names/labels).


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #22617


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: reachout-sreeram