### PR TITLE
PR: Drop support for Python 3.9 and 3.10

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -123,7 +123,7 @@ else
     if [ "$RUN_SLOW" = "false" ]; then
         if [ "$OS" = "linux" ]; then
             curl https://pyenv.run | bash
-            $HOME/.pyenv/bin/pyenv install 3.10.6
+            $HOME/.pyenv/bin/pyenv install 3.12.8
         fi
     fi
 fi

--- a/.github/workflows/test-files.yml
+++ b/.github/workflows/test-files.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.10', '3.12']  # `python-lsp-ruff` conda-forge package `python_min` is 3.10
+        PYTHON_VERSION: ['3.11', '3.13']
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/test-linux-qt6.yml
+++ b/.github/workflows/test-linux-qt6.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         INSTALL_TYPE: ['pip']  # conda has no PyQt6 package
-        PYTHON_VERSION: ['3.10.19']
+        PYTHON_VERSION: ['3.12.12']
         TEST_TYPE: ['fast', 'slow']
         SPYDER_QT_BINDING: ['pyqt6'] # TODO add 'pyside6' once Spyder supports it
     timeout-minutes: 90

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -70,12 +70,8 @@ jobs:
       fail-fast: false
       matrix:
         INSTALL_TYPE: ['pip', 'conda']
-        PYTHON_VERSION: ['3.9', '3.12.12']
+        PYTHON_VERSION: ['3.11', '3.12.12']
         TEST_TYPE: ['fast', 'slow']
-        exclude:
-          # Only test Python 3.9 with pip to save CI time
-          - INSTALL_TYPE: 'conda'
-            PYTHON_VERSION: '3.9'
     timeout-minutes: 90
 
     steps:
@@ -122,15 +118,9 @@ jobs:
 
       - name: Create pip test environment
         if: env.USE_CONDA != 'true'
-        uses: mamba-org/setup-micromamba@v3
+        uses: actions/setup-python@v6
         with:
-          micromamba-version: '1.5.10-0'
-          environment-name: test
-          cache-downloads: true
-          create-args: python=${{ matrix.PYTHON_VERSION }}
-          condarc: |
-            channels:
-              - conda-forge
+          python-version: ${{ matrix.PYTHON_VERSION }}
 
       - name: Install Pixi
         uses: prefix-dev/setup-pixi@v0.9.6

--- a/.github/workflows/test-remoteclient.yml
+++ b/.github/workflows/test-remoteclient.yml
@@ -65,14 +65,9 @@ jobs:
       fail-fast: false
       matrix:
         INSTALL_TYPE: ['pip', 'conda']
-        PYTHON_VERSION: ['3.9', '3.12.12']
-        exclude:
-          - INSTALL_TYPE: 'conda'  # `python-lsp-ruff` conda-forge package `python_min` is 3.10
-            PYTHON_VERSION: '3.9'
-        include:
-          - INSTALL_TYPE: 'conda'  # `python-lsp-ruff` conda-forge package `python_min` is 3.10
-            PYTHON_VERSION: '3.10'
-    timeout-minutes: 90
+        PYTHON_VERSION: ['3.11', '3.13']
+    timeout-minutes: 30
+
     steps:
       - name: Setup Remote SSH Connection
         if: env.ENABLE_SSH == 'true'
@@ -80,26 +75,32 @@ jobs:
         timeout-minutes: 60
         with:
           detached: true
+
       - name: Checkout Pull Requests
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Checkout Push
         if: github.event_name != 'pull_request'
         uses: actions/checkout@v6
+
       - name: Fetch branches
         run: git fetch --prune --unshallow
+
       - name: Install dependencies
         shell: bash
         run: |
           sudo apt-get update --fix-missing
           sudo apt-get install -qq pyqt5-dev-tools libxcb-xinerama0 xterm --fix-missing
+
       - name: Cache pip
         uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-cachepip-install${{ matrix.INSTALL_TYPE }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.py') }}
+
       - name: Create conda test environment
         if: env.USE_CONDA == 'true'
         uses: mamba-org/setup-micromamba@v3
@@ -109,26 +110,24 @@ jobs:
           environment-name: test
           cache-downloads: true
           create-args: python=${{ matrix.PYTHON_VERSION }}
+
       - name: Create pip test environment
         if: env.USE_CONDA != 'true'
-        uses: mamba-org/setup-micromamba@v3
+        uses: actions/setup-python@v6
         with:
-          micromamba-version: '1.5.10-0'
-          environment-name: test
-          cache-downloads: true
-          create-args: python=${{ matrix.PYTHON_VERSION }}
-          condarc: |
-            channels:
-              - conda-forge
+          python-version: ${{ matrix.PYTHON_VERSION }}
+
       - name: Install additional dependencies
         shell: bash -l {0}
         run: bash -l .github/scripts/install.sh
+
       - name: Show conda test environment
         if: env.USE_CONDA == 'true'
         shell: bash -l {0}
         run: |
           micromamba info
           micromamba list
+
       - name: Show pip test environment
         if: env.USE_CONDA != 'true'
         shell: bash -l {0}
@@ -136,6 +135,7 @@ jobs:
           micromamba info
           micromamba list
           pip list
+
       - name: Run tests
         shell: bash -l {0}
         env:

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -117,15 +117,9 @@ jobs:
 
       - name: Create pip test environment
         if: env.USE_CONDA != 'true'
-        uses: mamba-org/setup-micromamba@v3
+        uses: actions/setup-python@v6
         with:
-          micromamba-version: '1.5.10-0'
-          environment-name: test
-          cache-downloads: true
-          create-args: python=${{ matrix.PYTHON_VERSION }}
-          condarc: |
-            channels:
-              - conda-forge
+          python-version: ${{ matrix.PYTHON_VERSION }}
 
       - name: Install Pixi
         uses: prefix-dev/setup-pixi@v0.9.6
@@ -151,9 +145,7 @@ jobs:
         if: env.USE_CONDA != 'true'
         shell: bash -l {0}
         run: |
-          micromamba info
           conda info
-          micromamba list
           pip list
 
       - name: Run manifest checks

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ a Python version equal or greater than 3.8.
 
 The basic dependencies to run Spyder are:
 
-* **Python** 3.9+: The core language Spyder is written in and for.
+* **Python** 3.11+: The core language Spyder is written in and for.
 * **PyQt5** 5.15+: Python bindings for Qt, used for Spyder's GUI.
 
 The rest our dependencies (both required and optional) are declared in

--- a/conftest.py
+++ b/conftest.py
@@ -173,12 +173,7 @@ def reset_conf_before_test(request):
     from spyder.plugins.completion.api import COMPLETION_ENTRYPOINT
     from spyder.plugins.completion.plugin import CompletionPlugin
 
-    # See compatibility note on `group` keyword:
-    # https://docs.python.org/3/library/importlib.metadata.html#entry-points
-    if sys.version_info < (3, 10):  # pragma: no cover
-        from importlib_metadata import entry_points
-    else:  # pragma: no cover
-        from importlib.metadata import entry_points
+    from importlib.metadata import entry_points
 
     # Restore completion clients default settings, since they
     # don't have default values on the configuration.

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ from setuptools.command.install import install
 # Taken from the notebook setup.py -- Modified BSD License
 # =============================================================================
 v = sys.version_info
-if v[:2] < (3, 9):
-    error = "ERROR: Spyder requires Python version 3.9 and above."
+if v[:2] < (3, 11):
+    error = "ERROR: Spyder requires Python version 3.11 and above."
     print(error, file=sys.stderr)
     sys.exit(1)
 

--- a/spyder/api/asyncdispatcher.py
+++ b/spyder/api/asyncdispatcher.py
@@ -28,6 +28,7 @@ import os
 import sys
 import threading
 import typing
+from typing import ParamSpec, TypeAlias
 from asyncio.futures import (
     _chain_future,  # type: ignore[attr-defined] # noqa: PLC2701
 )
@@ -36,13 +37,6 @@ from asyncio.tasks import (
 )
 from concurrent.futures import Future
 from heapq import heappop
-
-if sys.version_info < (3, 10):
-    from typing_extensions import ParamSpec
-    from typing_extensions import TypeAlias
-else:
-    from typing import ParamSpec  # noqa: ICN003
-    from typing import TypeAlias  # noqa: ICN003
 
 # Third party imports
 from qtpy.QtCore import QCoreApplication, QEvent, QObject

--- a/spyder/api/config/decorators.py
+++ b/spyder/api/config/decorators.py
@@ -13,14 +13,8 @@ from __future__ import annotations
 
 # Standard library imports
 import functools
-import sys
 from collections.abc import Callable
-from typing import Union
-
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias  # noqa: ICN003
+from typing import TypeAlias, Union
 
 # Local imports
 from spyder.config.types import ConfigurationKey

--- a/spyder/api/config/mixins.py
+++ b/spyder/api/config/mixins.py
@@ -13,15 +13,9 @@ from __future__ import annotations
 
 # Standard library imports
 import logging
-import sys
 import warnings
 from collections.abc import Callable
-from typing import Union
-
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias  # noqa: ICN003
+from typing import TypeAlias, Union
 
 # Third-party imports
 from qtpy import PYSIDE6

--- a/spyder/api/plugin_registration/registry.py
+++ b/spyder/api/plugin_registration/registry.py
@@ -12,9 +12,8 @@ from __future__ import annotations
 # Standard library imports
 import configparser as cp
 import logging
-import sys
 import traceback
-from typing import Any, Union, TYPE_CHECKING
+from typing import Any, TypeAlias, TYPE_CHECKING, Union
 
 # Third-party library imports
 from qtpy.QtCore import QObject, Signal
@@ -33,12 +32,6 @@ from spyder.api.plugin_registration._confpage import PluginsConfigPage
 from spyder.api.exceptions import SpyderAPIError
 from spyder.api.plugins import Plugins, SpyderDockablePlugin, SpyderPluginV2
 from spyder.utils.icon_manager import ima
-
-
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias  # noqa: ICN003
 
 if TYPE_CHECKING:
     from qtpy.QtGui import QIcon

--- a/spyder/api/preferences.py
+++ b/spyder/api/preferences.py
@@ -13,13 +13,7 @@ from __future__ import annotations
 
 # Standard library imports
 import types
-import sys
-from typing import TYPE_CHECKING
-
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias  # noqa: ICN003
+from typing import TypeAlias, TYPE_CHECKING
 
 # Local imports
 from spyder.api.utils import PrefixedTuple

--- a/spyder/api/shellconnect/status.py
+++ b/spyder/api/shellconnect/status.py
@@ -157,9 +157,7 @@ class ShellConnectStatusBarWidget(StatusBarWidget, ShellConnectMixin):
             functools.partial(self.config_spyder_kernel, shellwidget)
         )
         shellwidget.sig_kernel_is_ready.connect(
-            # We can't use functools.partial here because it gives memory leaks
-            # in Python versions older than 3.10
-            lambda sw=shellwidget: self.on_kernel_start(sw)
+            functools.partial(self.on_kernel_start, shellwidget)
         )
 
         self.shellwidget_to_status[shellwidget] = None

--- a/spyder/api/utils.py
+++ b/spyder/api/utils.py
@@ -13,13 +13,8 @@ from __future__ import annotations
 
 from abc import ABCMeta as BaseABCMeta
 import collections.abc
-import sys
 import typing
-
-if sys.version_info < (3, 10):
-    from typing_extensions import ParamSpec
-else:
-    from typing import ParamSpec  # noqa: ICN003
+from typing import ParamSpec
 
 _P = ParamSpec("_P")
 _T = typing.TypeVar("_T")

--- a/spyder/api/widgets/toolbars.py
+++ b/spyder/api/widgets/toolbars.py
@@ -16,12 +16,7 @@ import os
 import sys
 import uuid
 from collections import OrderedDict
-from typing import Literal, Union, TYPE_CHECKING
-
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias  # noqa: ICN003
+from typing import Literal, TypeAlias, TYPE_CHECKING, Union
 
 # Third part imports
 from qtpy.QtCore import QEvent, QObject, QSize, Qt, Signal

--- a/spyder/app/find_plugins.py
+++ b/spyder/app/find_plugins.py
@@ -8,21 +8,14 @@ Plugin dependency solver.
 """
 
 import importlib
+from importlib.metadata import entry_points
 import logging
-import sys
 import traceback
 
 from spyder.api.exceptions import SpyderAPIError
 from spyder.api.plugins import Plugins
 from spyder.api.utils import get_class_values
 from spyder.config.base import STDERR
-
-# See compatibility note on `group` keyword:
-# https://docs.python.org/3/library/importlib.metadata.html#entry-points
-if sys.version_info < (3, 10):  # pragma: no cover
-    from importlib_metadata import entry_points
-else:  # pragma: no cover
-    from importlib.metadata import entry_points
 
 
 logger = logging.getLogger(__name__)

--- a/spyder/app/tests/spyder-boilerplate/setup.py
+++ b/spyder/app/tests/spyder-boilerplate/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email="spyder.python@gmail.com",
     description="Plugin that registers a programmatic custom layout",
     license="MIT license",
-    python_requires='>= 3.9',
+    python_requires='>= 3.11',
     install_requires=[
         "qtpy",
         "qtawesome",

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -152,10 +152,6 @@ def test_single_instance_and_edit_magic(main_window, qtbot, tmpdir):
 
 @pytest.mark.use_introspection
 @pytest.mark.skipif(os.name == 'nt', reason="Fails on Windows")
-@pytest.mark.skipif(
-    sys.platform.startswith("linux") and sys.version_info < (3, 10),
-    reason="Fails on Linux with Python 3.9"
-)
 def test_leaks(main_window, qtbot):
     """
     Test leaks in mainwindow when closing a file or a console.
@@ -4850,16 +4846,10 @@ def test_tour_message(main_window, qtbot):
 @pytest.mark.order(after="test_debug_unsaved_function")
 @pytest.mark.preload_complex_project
 @pytest.mark.skipif(
-    not sys.platform.startswith('linux'),
-    reason="Only works on Linux"
+    not sys.platform.startswith('linux'), reason="Only works on Linux"
 )
 @pytest.mark.skipif(
-    sys.version_info[:2] < (3, 10),
-    reason="Too flaky in old Python versions"
-)
-@pytest.mark.skipif(
-    not running_in_ci_with_conda(),
-    reason="Too flaky with pip packages"
+    not running_in_ci_with_conda(), reason="Too flaky with pip packages"
 )
 @pytest.mark.known_leak
 @pytest.mark.xfail(
@@ -7831,7 +7821,6 @@ def test_view_own_class_in_variable_explorer(main_window, qtbot):
     assert instance_value.var == 123
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="Fails with Python 3.9")
 def test_help_long_type_alias_rendering(main_window, qtbot):
     """Test that long type annotations from __main__ are readable."""
     shell = main_window.ipyconsole.get_current_shellwidget()

--- a/spyder/plugins/completion/plugin.py
+++ b/spyder/plugins/completion/plugin.py
@@ -13,9 +13,9 @@ introspection providers.
 
 # Standard library imports
 import functools
+from importlib.metadata import entry_points
 import inspect
 import logging
-import sys
 from typing import List, Union
 import weakref
 
@@ -37,13 +37,6 @@ from spyder.plugins.completion.api import (
 )
 from spyder.plugins.completion.confpage import CompletionConfigPage
 from spyder.plugins.completion.container import CompletionContainer
-
-# See compatibility note on `group` keyword:
-# https://docs.python.org/3/library/importlib.metadata.html#entry-points
-if sys.version_info < (3, 10):  # pragma: no cover
-    from importlib_metadata import entry_points
-else:  # pragma: no cover
-    from importlib.metadata import entry_points
 
 
 logger = logging.getLogger(__name__)

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_warnings.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_warnings.py
@@ -243,10 +243,8 @@ def test_update_warnings_after_closequotes(qtbot, completions_codeeditor_linting
         expected = [
             ['unterminated string literal (detected at line 1)', 1]
         ]
-    elif sys.version_info >= (3, 10):
-        expected = [['unterminated string literal (detected at line 1)',1]]
     else:
-        expected = [['EOL while scanning string literal' ,1]]
+        expected = [['unterminated string literal (detected at line 1)',1]]
 
     # Notify changes.
     with qtbot.waitSignal(editor.completions_response_signal, timeout=30000):
@@ -284,15 +282,9 @@ def test_update_warnings_after_closebrackets(qtbot, completions_codeeditor_linti
     editor.textCursor().insertText("print('test'\n")
 
     if sys.version_info >= (3, 12):
-        expected = [
-            ["'(' was never closed", 1]
-        ]
-    elif sys.version_info >= (3, 10):
-        expected = [
-            ["'(' was never closed", 1]
-        ]
+        expected = [["'(' was never closed", 1]]
     else:
-        expected = [['unexpected EOF while parsing', 1]]
+        expected = [["'(' was never closed", 1]]
 
     # Notify changes.
     with qtbot.waitSignal(editor.completions_response_signal, timeout=30000):

--- a/spyder/utils/tests/test_pyenv.py
+++ b/spyder/utils/tests/test_pyenv.py
@@ -25,7 +25,7 @@ if not find_program('pyenv'):
                     reason="Only runs on Linux")
 def test_get_list_pyenv_envs():
     output = get_list_pyenv_envs()
-    expected_envs = ['Pyenv: 3.10.6']
+    expected_envs = ['Pyenv: 3.12.8']
     assert set(expected_envs) == set(output.keys())
 
 


### PR DESCRIPTION
## Description of Changes

- Version 3.9 reached end-of-life last year and 3.10 will do close to the release of 6.2.0
- Use the `setup-python` action to run our tests with pip packages because there are some odd errors when using the Python package from Conda-forge on Linux.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
