### PR TITLE
Correction to FontError exception in mainwindow.py

### DIFF
--- a/spyder/app/mainwindow.py
+++ b/spyder/app/mainwindow.py
@@ -1318,9 +1318,23 @@ def main(options, args):
             mainwindow = create_window(MainWindow, app, splash, options, args)
     except FontError:
         fonts_directory, fonts = get_fonts_info()
-        fonts_list = "".join(
-            [f"<li><code>{font}</code></li>" for font in fonts]
-        )
+        spyder_fonts_directory = osp.normpath(
+            osp.join(osp.dirname(osp.realpath(__file__)), '../fonts'))
+        spyder_font = 'spyder.ttf'
+        
+        fonts_by_directory = {
+            str(fonts_directory): list(fonts),
+            str(spyder_fonts_directory): [spyder_font],
+        }
+
+        fonts_sections = "".join(
+            f"<p><code>{directory}</code></p><ul>"
+            + "".join(f"<li><code>{font}</code></li>" for font in fontlist)
+            + "</ul>"
+            for directory, fontlist in fonts_by_directory.items()
+        )        
+      
+
         fonts_message = QMessageBox(
             QMessageBox.Icon.Information,
             "Spyder",
@@ -1331,14 +1345,17 @@ def main(options, args):
               "supported by Spyder or Microsoft, or your system administrator "
               "has disabled font installation for non-admin users.<br><br>"
               "Please ask your system administrator for help to upgrade "
-              "Windows or to install for all users the following fonts:"
-              "<ul>{fonts_list}</ul>which are located at:<br><br>"
-              "<code>{fonts_directory}</code><br><br>"
+              "Windows, or to install for all users the following fonts, "
+              "grouped by the directory in which each can be found:"
+              "{fonts_sections}"
               "If you have administrator privileges, you can run the "
-              "following command in a Command Prompt to install the required "
-              "fonts:<br><br>"
-              "<code>qta-install-fonts-all-users</code>").format(
-                fonts_list=fonts_list, fonts_directory=fonts_directory,
+              "following command in a Command Prompt to install the fonts "
+              "located in the first directory listed above:<br><br>"
+              "<code>qta-install-fonts-all-users</code><br><br>"
+              "Any font(s) in directories other than the first must be "
+              "installed manually for all users (right-click the file "
+              "and select \"Install for all users\").").format(
+                fonts_sections=fonts_sections,
             ),
             QMessageBox.StandardButton.Ok
         )


### PR DESCRIPTION
## Description of Changes
Changed the FontError exception to also inform the user spyder.ttf font must be installed. 


If a system is configured to disallow untrusted fonts, and the Fonts spyder uses have not been installed for all users, FontError in mainwindow.py provides a list of missing QT fonts that must be installed for all users to start Spyder. This list is incomplete, as detailed in issue #26143. 
If all the fonts on the list are installed for all users, the same error is still thrown and spyder fails to start. The cause lies in utils\icon_manager.py   which includes a qta.load_font call for spyder.ttf, which will silently fail when font installation rights are missing for the user and the loading of untrusted fonts is disabled in group policy. 

This change addresses this problem by changing the error message as created in mainwindow.py. 
The message still provides the original font list and location, but additionally informs the user that the spyder.ttf font must also be installed, and where it can be found.
Screenshot of the new error message: 
<img width="558" height="862" alt="Spyder_FontError_New" src="https://github.com/user-attachments/assets/43a3c163-e48d-4f4f-a235-636f44bcbd83" />

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->
Fixes #26143

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

the above statement is true and correct:
Boohoolean
