### PR TITLE
PR: Remove dependency on `importlib-metadata`

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -18,7 +18,6 @@ dependencies:
 - diff-match-patch >=20181111
 - fcitx-qt5 >=1.2.7
 - fzf >=0.42.0
-- importlib-metadata >=4.6.0
 - intervaltree >=3.0.2
 - ipython >=9.15.0,<10.0.0
 - ipython_pygments_lexers >=1.0

--- a/requirements/main.yml
+++ b/requirements/main.yml
@@ -15,8 +15,6 @@ dependencies:
   - cookiecutter >=1.6.0
   - diff-match-patch >=20181111
   - fzf >=0.42.0
-  # Need at least some compatibility with python 3.10 features
-  - importlib-metadata >=4.6.0
   - intervaltree >=3.0.2
   - ipython >=9.15.0,<10.0.0
   - ipython_pygments_lexers >=1.0

--- a/setup.py
+++ b/setup.py
@@ -274,9 +274,6 @@ install_requires += [
     'cloudpickle>=0.5.0',
     'cookiecutter>=1.6.0',
     'diff-match-patch>=20181111',
-    # While this is only required for python <3.10, it is safe enough to
-    # install in all cases and helps the tests to pass.
-    'importlib-metadata>=4.6.0',
     'intervaltree>=3.0.2',
     'ipython>=9.15.0,<10.0.0',
     'ipython_pygments_lexers>=1.0',

--- a/spyder/dependencies.py
+++ b/spyder/dependencies.py
@@ -39,7 +39,6 @@ CHARDET_REQVER = '>=5.2.0,<8.0.0'
 CLOUDPICKLE_REQVER = '>=0.5.0'
 COOKIECUTTER_REQVER = '>=1.6.0'
 DIFF_MATCH_PATCH_REQVER = '>=20181111'
-IMPORTLIB_METADATA_REQVER = '>=4.6.0'
 INTERVALTREE_REQVER = '>=3.0.2'
 IPYTHON_REQVER = ">=9.15.0,<10.0.0"
 IPYTHON_PYGMENTS_LEXERS_REQVER = ">=1.0"
@@ -132,10 +131,6 @@ DESCRIPTIONS = [
      'package_name': "diff-match-patch",
      'features': _("Compute text file diff changes during edition"),
      'required_version': DIFF_MATCH_PATCH_REQVER},
-    {'modname': 'importlib_metadata',
-     'package_name': 'importlib-metadata',
-     'features': _('Access the metadata for a Python package'),
-     'required_version': IMPORTLIB_METADATA_REQVER},
     {'modname': "intervaltree",
      'package_name': "intervaltree",
      'features': _("Compute folding range nesting levels"),


### PR DESCRIPTION
## Description of Changes

That was needed for Python 3.10 and older versions, which are no longer supported.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
