### PR TITLE
PR: Improve CI robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ spyder_crash.log
 MANIFEST
 .boot_branch.txt
 
+# CI passed-test recording (see conftest.py)
+passed_tests.txt
+passed_tests_skipped_on_first_run.txt
+
 # git .orig files
 *.orig
 

--- a/conftest.py
+++ b/conftest.py
@@ -56,7 +56,15 @@ def get_passed_tests():
             logfile = f.readlines()
 
         # Detect all tests that passed before.
-        test_re = re.compile(r'(spyder.*) [^ ]*(SKIPPED|PASSED|XFAIL)')
+        # Note: capture only the test node id (path::class::test[params]), not
+        # a greedy `.*`. Otherwise output printed inline with the result -- e.g.
+        # a Qt warning on Windows like "... test_x QWindowsWindow::setGeometry:
+        # ... PASSED" -- gets folded into group(1), which then never matches the
+        # clean node id, so the test is never recorded as passed and is re-run
+        # (and possibly re-flakes) on every CI restart.
+        test_re = re.compile(
+            r'(spyder\S*\.py(?:::\w+)*(?:\[.*?\])?) .*(SKIPPED|PASSED|XFAIL)'
+        )
         tests = set()
         for line in logfile:
             match = test_re.match(line)

--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,7 @@ import os
 import os.path as osp
 import re
 import sys
+from unittest.mock import patch
 
 # ---- To activate/deactivate certain things for pytest's only
 # NOTE: Please leave this before any other import here!!
@@ -25,12 +26,13 @@ os.environ['SPYDER_PYTEST'] = 'True'
 # ---- Tests to skip on the first CI run
 SKIP_ON_FIRST_CI_RUN = ["test_mainwindow.py::test_update_outline"]
 
-# ---- File where we record tests that passed, so a CI restart (e.g. after a
-# segfault) can skip them. This is written directly by a pytest hook (see
-# pytest_runtest_logreport), which is robust to output getting printed inline
-# with a test's result line -- unlike parsing the textual log, where e.g. a Qt
-# warning on Windows can split the node id from its PASSED marker and prevent
-# the test from ever being recorded (so it re-runs, and may re-flake, forever).
+# ---- Main file where we record tests that passed
+# This way a CI restart (e.g. after a segfault) can skip them. This is written
+# directly by a pytest hook (see pytest_runtest_logreport), which is robust to
+# output getting printed inline with a test's result line -- unlike parsing
+# the textual log, where e.g. a Qt warning on Windows can split the node id
+# from its PASSED marker and prevent the test from ever being recorded
+# (so it re-runs, and may re-flake, forever).
 PASSED_TESTS_FILE = "passed_tests.txt"
 
 
@@ -40,7 +42,7 @@ import pytest
 
 def pytest_addoption(parser):
     """Add extra options for pytest.
-    
+
     --run-slow: Run slow tests.
     --remote-client: Run remote-client tests.
     """
@@ -57,13 +59,13 @@ def get_passed_tests():
     This is useful on CIs to restart the test suite from the point where a
     segfault was thrown by it.
     """
-    tests = set()
+    tests = []
 
     # Primary source: tests recorded directly by the pytest_runtest_logreport
     # hook. Robust to inline output corrupting the textual result line.
     if osp.isfile(PASSED_TESTS_FILE):
         with open(PASSED_TESTS_FILE) as f:
-            tests.update(line.strip() for line in f if line.strip())
+            tests.extend(line.strip() for line in f if line.strip())
 
     # Fallback source: parse the textual pytest log. Kept for robustness (and
     # to honor the SKIP_ON_FIRST_CI_RUN special-casing below).
@@ -94,18 +96,18 @@ def get_passed_tests():
                     if "PASSED" in line or "XFAIL" in line:
                         with open(passed_first_run, "w+") as f:
                             f.write(match.group(1))
-                            tests.add(match.group(1))
+                            tests.append(match.group(1))
                             continue
                     else:
                         if osp.isfile(passed_first_run):
                             with open(passed_first_run) as f:
                                 passed_first_run_contents = f.readlines()
                             if match.group(1) in passed_first_run_contents:
-                                tests.add(match.group(1))
+                                tests.append(match.group(1))
                             else:
                                 continue
                 else:
-                    tests.add(match.group(1))
+                    tests.append(match.group(1))
 
     return tests
 
@@ -227,7 +229,6 @@ def mute_error_message_box(request):
         yield
         return
 
-    from unittest.mock import patch
     from qtpy.QtWidgets import QMessageBox
 
     with patch.object(

--- a/conftest.py
+++ b/conftest.py
@@ -25,6 +25,14 @@ os.environ['SPYDER_PYTEST'] = 'True'
 # ---- Tests to skip on the first CI run
 SKIP_ON_FIRST_CI_RUN = ["test_mainwindow.py::test_update_outline"]
 
+# ---- File where we record tests that passed, so a CI restart (e.g. after a
+# segfault) can skip them. This is written directly by a pytest hook (see
+# pytest_runtest_logreport), which is robust to output getting printed inline
+# with a test's result line -- unlike parsing the textual log, where e.g. a Qt
+# warning on Windows can split the node id from its PASSED marker and prevent
+# the test from ever being recorded (so it re-runs, and may re-flake, forever).
+PASSED_TESTS_FILE = "passed_tests.txt"
+
 
 # ---- Pytest adjustments
 import pytest
@@ -49,6 +57,16 @@ def get_passed_tests():
     This is useful on CIs to restart the test suite from the point where a
     segfault was thrown by it.
     """
+    tests = set()
+
+    # Primary source: tests recorded directly by the pytest_runtest_logreport
+    # hook. Robust to inline output corrupting the textual result line.
+    if osp.isfile(PASSED_TESTS_FILE):
+        with open(PASSED_TESTS_FILE) as f:
+            tests.update(line.strip() for line in f if line.strip())
+
+    # Fallback source: parse the textual pytest log. Kept for robustness (and
+    # to honor the SKIP_ON_FIRST_CI_RUN special-casing below).
     # This assumes the pytest log is placed next to this file. That's where
     # we put it on CIs.
     if osp.isfile('pytest_log.txt'):
@@ -65,7 +83,6 @@ def get_passed_tests():
         test_re = re.compile(
             r'(spyder\S*\.py(?:::\w+)*(?:\[.*?\])?) .*(SKIPPED|PASSED|XFAIL)'
         )
-        tests = set()
         for line in logfile:
             match = test_re.match(line)
             if match:
@@ -90,9 +107,7 @@ def get_passed_tests():
                 else:
                     tests.add(match.group(1))
 
-        return tests
-    else:
-        return []
+    return tests
 
 
 def pytest_collection_modifyitems(config, items):
@@ -166,6 +181,31 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_passed)
 
     concurrent.futures.ThreadPoolExecutor().map(mark_item, items)
+
+
+def pytest_runtest_logreport(report):
+    """Record tests that pass (or xfail) so a CI restart can skip them.
+
+    Writing the node id directly here -- rather than parsing it back out of
+    the textual pytest log in get_passed_tests() -- is robust to output
+    printed inline with a test's result line (e.g. a Qt "setGeometry" warning
+    on Windows that splits the node id from its PASSED marker), which would
+    otherwise prevent the test from ever being recorded and make it re-run
+    (and possibly re-flake) on every restart.
+
+    Only active on CIs, where the restart mechanism is used. Locally it would
+    otherwise silently skip tests on the next run. A test skipped on the first
+    CI run (see SKIP_ON_FIRST_CI_RUN) is not recorded here: skips are ignored,
+    so it still runs on later attempts until it actually passes.
+    """
+    if not os.environ.get("CI"):
+        return
+
+    passed = report.when == "call" and report.passed
+    xfailed = report.skipped and hasattr(report, "wasxfail")
+    if passed or xfailed:
+        with open(PASSED_TESTS_FILE, "a") as f:
+            f.write(report.nodeid + "\n")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -160,6 +160,35 @@ def pytest_collection_modifyitems(config, items):
     concurrent.futures.ThreadPoolExecutor().map(mark_item, items)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def mute_error_message_box(request):
+    """
+    Prevent modal error dialogs from freezing headless remote-client tests.
+
+    When a remote session drops, the remote explorer's error handler shows a
+    modal ``QMessageBox.critical()``. With no user to dismiss it, that call
+    blocks the Qt event loop forever, hanging the whole test run until the CI
+    job times out (30 min). Turn it into a no-op for the remote-client test
+    session (it can fire from async callbacks at any point, including during
+    fixture setup/teardown, so this is session-scoped).
+
+    Only ``critical`` (the error dialog) is muted; ``warning``/``question`` are
+    used and asserted on by some tests, so they are left untouched.
+    """
+    if not request.config.getoption("--remote-client"):
+        yield
+        return
+
+    from unittest.mock import patch
+    from qtpy.QtWidgets import QMessageBox
+
+    with patch.object(
+        QMessageBox, "critical",
+        return_value=QMessageBox.StandardButton.Ok,
+    ):
+        yield
+
+
 @pytest.fixture(autouse=True)
 def reset_conf_before_test(request):
     # To prevent running this fixture for a specific test, you need to use this

--- a/spyder/api/asyncdispatcher.py
+++ b/spyder/api/asyncdispatcher.py
@@ -265,6 +265,7 @@ class AsyncDispatcher(typing.Generic[_RT]):
                 AsyncDispatcher._running_tasks.append(task)
                 task.add_done_callback(self._callback_task_done)
                 return task
+
             # ``self._timeout`` is None by default, i.e. block indefinitely
             # (the historical behavior). Callers that can't afford to hang
             # forever (e.g. test fixtures closing a possibly-dead remote

--- a/spyder/api/asyncdispatcher.py
+++ b/spyder/api/asyncdispatcher.py
@@ -95,6 +95,7 @@ class AsyncDispatcher(typing.Generic[_RT]):
         loop: LoopID | None = ...,
         early_return: typing.Literal[False] = ...,
         return_awaitable: typing.Literal[False] = ...,
+        timeout: float | None = ...,
     ) -> None: ...
 
     @typing.overload
@@ -112,6 +113,7 @@ class AsyncDispatcher(typing.Generic[_RT]):
         loop: LoopID | None = None,
         early_return: bool = True,
         return_awaitable: bool = False,
+        timeout: float | None = None,
     ) -> None:
         """
         Decorate a coroutine to run in a specific event loop.
@@ -140,6 +142,11 @@ class AsyncDispatcher(typing.Generic[_RT]):
             Return the coroutine as an awaitable :class:`asyncio.Future`
             instead of a :class:`concurrent.futures.Future`, independent of
             the value of ``early_return``. ``False`` by default.
+        timeout : float | None, optional
+            Maximum number of seconds to wait for the result when blocking
+            (i.e. when ``early_return`` and ``return_awaitable`` are both
+            ``False``). ``None`` (the default) waits indefinitely. If the
+            timeout elapses, :exc:`concurrent.futures.TimeoutError` is raised.
 
 
         Examples
@@ -181,6 +188,7 @@ class AsyncDispatcher(typing.Generic[_RT]):
         self._loop = self.get_event_loop(loop)
         self._early_return = early_return
         self._return_awaitable = return_awaitable
+        self._timeout = timeout
 
     @typing.overload
     def __call__(
@@ -257,7 +265,11 @@ class AsyncDispatcher(typing.Generic[_RT]):
                 AsyncDispatcher._running_tasks.append(task)
                 task.add_done_callback(self._callback_task_done)
                 return task
-            return task.result()
+            # ``self._timeout`` is None by default, i.e. block indefinitely
+            # (the historical behavior). Callers that can't afford to hang
+            # forever (e.g. test fixtures closing a possibly-dead remote
+            # connection) can pass a timeout to fail fast instead.
+            return task.result(timeout=self._timeout)
 
         return wrapper
 

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1101,7 +1101,8 @@ def test_debug_and_backend_external_kernel(main_window, qtbot):
     shell = main_window.ipyconsole.get_current_shellwidget()
     qtbot.waitUntil(
         lambda: shell.spyder_kernel_ready and shell._prompt_html is not None,
-        timeout=SHELL_TIMEOUT)
+        timeout=SHELL_TIMEOUT
+    )
 
     # Try enabling a qt backend and debugging
     if os.name != 'nt':

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -1064,18 +1064,6 @@ def test_connection_to_external_kernel(main_window, qtbot):
     assert "runfile" in shell._control.toPlainText()
     assert "3" in shell._control.toPlainText()
 
-    # Try enabling a qt backend and debugging
-    if os.name != 'nt':
-        # Fails on windows
-        with qtbot.waitSignal(shell.executed):
-            shell.execute('%matplotlib qt5')
-    with qtbot.waitSignal(shell.executed):
-        shell.execute('%debug print()')
-    with qtbot.waitSignal(shell.executed):
-        shell.execute('1 + 1')
-    with qtbot.waitSignal(shell.executed):
-        shell.execute('q')
-
     # Try quitting the kernels
     with qtbot.waitSignal(shell.executed):
         shell.execute('quit()')
@@ -1089,6 +1077,51 @@ def test_connection_to_external_kernel(main_window, qtbot):
     # Close the channels
     spykc.stop_channels()
     kc.stop_channels()
+
+
+@flaky(max_runs=3)
+@pytest.mark.skipif(
+    sys.platform == "darwin" and running_in_ci(),
+    reason="Fails frequently on Mac and CI",
+)
+@pytest.mark.order(after="test_connection_to_external_kernel")
+@pytest.mark.close_main_window
+def test_debug_and_backend_external_kernel(main_window, qtbot):
+    """Test enabling a Qt backend and debugging on an external Spyder kernel.
+
+    Split out from test_connection_to_external_kernel: entering the debugger on
+    an external kernel -- especially with a Qt event loop active from
+    ``%matplotlib`` -- can deadlock under load on CI, which made that test
+    flaky. Isolating it here keeps the connection/variable-explorer checks
+    stable while this (inherently flakier) smoke test reruns on its own.
+    """
+    # Connect to an externally-started Spyder kernel
+    spykm, spykc = start_new_kernel(spykernel=True)
+    main_window.ipyconsole.create_client_for_kernel(spykc.connection_file)
+    shell = main_window.ipyconsole.get_current_shellwidget()
+    qtbot.waitUntil(
+        lambda: shell.spyder_kernel_ready and shell._prompt_html is not None,
+        timeout=SHELL_TIMEOUT)
+
+    # Try enabling a qt backend and debugging
+    if os.name != 'nt':
+        # Fails on windows
+        with qtbot.waitSignal(shell.executed):
+            shell.execute('%matplotlib qt5')
+    with qtbot.waitSignal(shell.executed):
+        shell.execute('%debug print()')
+    with qtbot.waitSignal(shell.executed):
+        shell.execute('1 + 1')
+    with qtbot.waitSignal(shell.executed):
+        shell.execute('q')
+
+    # Make sure the kernel quits properly
+    with qtbot.waitSignal(shell.executed):
+        shell.execute('quit()')
+    qtbot.waitUntil(lambda: not spykm.is_alive())
+
+    # Close the channel
+    spykc.stop_channels()
 
 
 @pytest.mark.order(1)

--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -181,6 +181,9 @@ def qt_message_handler(msg_type, msg_log_context, msg_string):
     even if the actual message does not apply. This filter adds a
     blacklist for messages that are unnecessary. Anything else will
     get printed in the internal console.
+
+    Entries are matched as substrings, so messages that embed variable
+    content (e.g. geometry values) can be blacklisted by a stable prefix.
     """
     BLACKLIST = [
         'QMainWidget::resizeDocks: all sizes need to be larger than 0',
@@ -200,19 +203,14 @@ def qt_message_handler(msg_type, msg_log_context, msg_string):
         "QPainter::restore: Unbalanced save/restore",
         # This warning is shown at startup when using PyQt6
         "<use> element image0 in wrong context!",
-    ]
-    # Some messages embed variable content (e.g. geometry values), so they
-    # can't be matched exactly; match a stable substring instead.
-    BLACKLIST_PATTERNS = [
         # On Windows, showing the (large/maximized) main window can emit this.
-        # It's harmless, but because it's printed to stdout it can appear
-        # inline with pytest's result line on CI and split the test node id
-        # from its PASSED marker, breaking passed-test detection on restarts.
+        # It's harmless, but because it's printed to stdout it can appear inline
+        # with pytest's result line on CI and split the test node id from its
+        # PASSED marker, breaking passed-test detection on restarts. It embeds
+        # variable geometry values, hence the substring matching below.
         "QWindowsWindow::setGeometry: Unable to set geometry",
     ]
-    if msg_string not in BLACKLIST and not any(
-        pattern in msg_string for pattern in BLACKLIST_PATTERNS
-    ):
+    if not any(warning in msg_string for warning in BLACKLIST):
         print(msg_string)  # spyder: test-skip
 
 

--- a/spyder/app/utils.py
+++ b/spyder/app/utils.py
@@ -201,7 +201,18 @@ def qt_message_handler(msg_type, msg_log_context, msg_string):
         # This warning is shown at startup when using PyQt6
         "<use> element image0 in wrong context!",
     ]
-    if msg_string not in BLACKLIST:
+    # Some messages embed variable content (e.g. geometry values), so they
+    # can't be matched exactly; match a stable substring instead.
+    BLACKLIST_PATTERNS = [
+        # On Windows, showing the (large/maximized) main window can emit this.
+        # It's harmless, but because it's printed to stdout it can appear
+        # inline with pytest's result line on CI and split the test node id
+        # from its PASSED marker, breaking passed-test detection on restarts.
+        "QWindowsWindow::setGeometry: Unable to set geometry",
+    ]
+    if msg_string not in BLACKLIST and not any(
+        pattern in msg_string for pattern in BLACKLIST_PATTERNS
+    ):
         print(msg_string)  # spyder: test-skip
 
 

--- a/spyder/plugins/remoteclient/tests/fixtures.py
+++ b/spyder/plugins/remoteclient/tests/fixtures.py
@@ -31,6 +31,12 @@ __all__ = [
 USERNAME = "ubuntu"
 PASSWORD = USERNAME
 
+# Max seconds to wait when closing a remote client during fixture teardown.
+# Closing is normally sub-second; a broken connection can otherwise block the
+# close forever and hang the whole test run. On timeout the close raises,
+# failing the teardown, which the CI retry recovers from.
+_CLOSE_TIMEOUT = 30
+
 _COMPOSE_FILE = str(Path(__file__).resolve().parent / "docker-compose.yml")
 _COMPOSE_PROJECT_NAME = "spyder-remote-client-tests"
 
@@ -191,6 +197,7 @@ def ssh_client_id(
         AsyncDispatcher(
             loop="asyncssh",
             early_return=False,
+            timeout=_CLOSE_TIMEOUT,
         )(remote_client._remote_clients[config_id].close)()
 
 
@@ -220,6 +227,7 @@ def jupyterhub_client_id(
         AsyncDispatcher(
             loop="asyncssh",
             early_return=False,
+            timeout=_CLOSE_TIMEOUT,
         )(remote_client._remote_clients[config_id].close)()
 
 

--- a/spyder/plugins/remoteclient/tests/fixtures.py
+++ b/spyder/plugins/remoteclient/tests/fixtures.py
@@ -34,10 +34,21 @@ PASSWORD = USERNAME
 _COMPOSE_FILE = str(Path(__file__).resolve().parent / "docker-compose.yml")
 _COMPOSE_PROJECT_NAME = "spyder-remote-client-tests"
 
+# Upper bound (in seconds) for individual `docker compose` invocations. These
+# are network-dependent (image pull/build) and can otherwise hang
+# indefinitely. Because the remote test suite sets `timeout_func_only` in
+# pytest_remoteclient.ini, a hang in fixture setup (e.g. bringing up the
+# JupyterHub container) is not caught by the per-test timeout and is only
+# stopped by the 30-min CI job timeout -- which wastes the whole job *and* its
+# retries. Failing fast here instead lets the CI retry recover. The value is
+# generous (a healthy container setup takes well under this) so it doesn't
+# turn a slow-but-working build into a false failure.
+_DOCKER_TIMEOUT = 300
+
 
 def start_docker_service(service: str) -> None:
     """docker-compose up for one service only (no deps, build if needed)."""
-    subprocess.check_call(
+    subprocess.run(
         [
             "docker",
             "compose",
@@ -50,12 +61,14 @@ def start_docker_service(service: str) -> None:
             # "--build",
             service,
         ],
+        check=True,
+        timeout=_DOCKER_TIMEOUT,
     )
 
 
 def stop_docker_service(service: str) -> None:
     """docker-compose down for one service only (no deps)."""
-    subprocess.check_call(
+    subprocess.run(
         [
             "docker",
             "compose",
@@ -67,6 +80,8 @@ def stop_docker_service(service: str) -> None:
             "--remove-orphans",
             service
         ],
+        check=True,
+        timeout=_DOCKER_TIMEOUT,
     )
 
 
@@ -84,6 +99,7 @@ def get_addr_for_port(service_name: str, container_port: int):
         check=True,
         capture_output=True,
         text=True,
+        timeout=_DOCKER_TIMEOUT,
     )
     host, port = result.stdout.strip().split(":")
     if host == "0.0.0.0":


### PR DESCRIPTION
To facilitate review of #25422 (and to make life easier here hopefully) here are the CI-hardening commits from #25422 :

1. Add a timeout to the remote-client `docker compose` calls so a stuck container build fails fast instead of hanging until the 30-min CI limit
2. Mute any modal `QMessageBox.critical()` that would otherwise block the event loop headless when a session drops, and bound the client-close in fixture teardown (`AsyncDispatcher` timeout)
3. Tighten the `conftest.py` passed-test regex to capture only the node id, so output printed inline with a result line no longer stops a test being recorded as passed.
4. Record passed tests from a `pytest_runtest_logreport` hook (robust to the Windows `setGeometry` warning that splits the node id from `PASSED`), and filter that warning at its source in `qt_message_handler`

Claude Opus 4.8 helped me figure this stuff out (especially with patiently running tests locally and digging through logs to ferret out these issues) and make the changes, but I understand and take responsibility for the code and edits. (I do a lot of `pytest` monkeying around when working on MNE-Python and related packages!)