### PR TITLE
PR: Catch error when trying to get Matplotlib backend (IPython console)

### DIFF
--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1045,7 +1045,21 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):  # noqa: PLR090
                 else:
                     # Must ask the kernel. Will not work if the kernel was set
                     # to another backend and is not now inline
-                    interactive_backend = sw.get_mpl_interactive_backend()
+                    try:
+                        interactive_backend = sw.get_mpl_interactive_backend()
+                    except TimeoutError:
+                        # Show error message when it's not possible to get the
+                        # backend
+                        # Fixes spyder-ide/spyder#26173
+                        QMessageBox.critical(
+                            self,
+                            _('Error'),
+                            _(
+                                "It was not possible to detect the current "
+                                "Matplotlib backend in the kernel, so the one "
+                                "you selected can't be set."
+                            )
+                        )
 
                 if (
                     # There was an error getting the interactive backend in


### PR DESCRIPTION
## Description of Changes

This can happen if the kernel fails to respond in the max time allowed for kernel callbacks.

### Issue(s) Resolved

Fixes #26173

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
