### PR TITLE
PR: Fix docstring generation bug with nested functions

### DIFF
--- a/spyder/plugins/editor/extensions/docstring.py
+++ b/spyder/plugins/editor/extensions/docstring.py
@@ -1079,20 +1079,19 @@ class DocstringWriterExtension:
 
         # If return values are tuples of different length, return a placeholder
         if tuple_vals:
-            num_elements = [return_val.count(',') + 1
-                            for return_val in tuple_vals]
-            if num_elements.count(num_elements[0]) != len(num_elements):
+            num_each = [return_val.count(',') + 1 for return_val in tuple_vals]
+            if num_each.count(num_each[0]) != len(num_each):
                 return header + placeholder
-            num_elements = num_elements[0]
+            num_elements = num_each[0]
         else:
             num_elements = 1
 
         # If all have the same len but some ambiguous return placeholders
         if len(unambiguous_vals) != len(non_none_vals):
             if expand_tuple:
-                return header + '\n'.join([placeholder] * len(num_elements))
+                return header + '\n'.join([placeholder] * num_elements)
 
-            return_elements_out = ', '.join(['TYPE'] * len(num_elements))
+            return_elements_out = ', '.join(['TYPE'] * num_elements)
             return header + return_element_type.format(
                 return_type=f'tuple[{return_elements_out}]'
             )

--- a/spyder/plugins/editor/extensions/tests/docstring_test_cases/body_nested_function.py
+++ b/spyder/plugins/editor/extensions/tests/docstring_test_cases/body_nested_function.py
@@ -1,0 +1,29 @@
+# %% sig
+def some_top_fnc():
+# %% body
+
+    def some_sub_fnc():
+        return Exception('Some message')
+
+    return 10
+# %% numpy
+    """
+    SUMMARY.
+
+    Returns
+    -------
+    TYPE
+        DESCRIPTION.
+    """
+# %% google
+    """SUMMARY.
+
+    Returns:
+        tuple[TYPE]: DESCRIPTION.
+    """
+# %% sphinx
+    """SUMMARY.
+
+    :rtype: tuple[TYPE]
+    :returns: DESCRIPTION
+    """


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->


<!--- Explain what you've done and why --->

This fixes an exception in the docstring generation in Spyder's Editor that occurs with nested functions, although it may also affect other cases. Specifically, in the return section generation, `num_elements` gets reused for both a list of the number of tuple elements in _each_ return statement found in a function, _and_ the scalar number of return elements in common between all of them if they all have the same number. This resulted in mistaken code where we expect one but get the other (e.g. trying to get `len()` of a scalar), resulting in the issue reported in #26119 .

This PR fixes it by assigning them to different names, and using them correctly accordingly. In addition, it adds a regression test case across the test suite for the reproducible example provided in the issue, to ensure it remains fixed in the future.

To note, I noticed a separate issue where return statements of nested functions weren't excluded from consideration as return types of the parent function, leading to a less accurate return type in some cases, but addressing that would require some unrelated and quite non-trivial changes to the parser, so that can be addressed later.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #26119


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: CAM-Gerlach

<!--- Thanks for your help making Spyder better for everyone! --->
