### PR TITLE
PR: Fix running batch files on paths with spaces (External Terminal)

### DIFF
--- a/spyder/utils/programs.py
+++ b/spyder/utils/programs.py
@@ -777,7 +777,7 @@ def run_general_file_in_terminal(
 
         # python_exe must be quoted in case it has spaces
         cmd = f'start {windows_shell} ""{executable}" '
-        cmd += ' '.join(p_args)  # + '"'
+        cmd += ' '.join(p_args) + '"'
         logger.info('Executing on external console: %s', cmd)
 
         try:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
When running .bat files in the windows command prompt from spyder, file paths with spaces are not properly quoted. Git Blame indicated the removal of the closing quote was originally to make test suite pass, however after many struggles getting testing working locally, I cannot find an instance where this change affects `spyder/app/tests/test_mainwindow.py::test_shell_execution`.



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #26162


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: athompson673

<!--- Thanks for your help making Spyder better for everyone! --->
