### PR TITLE
PR: Explicitly add `conda-forge` to `condarc` channels in subrepo build workflow (Installers)

### DIFF
--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -1,12 +1,4 @@
 on:
-  push:
-    branches:
-      - 'master'
-      - '6.x'
-    paths:
-      - '**.gitrepo'
-      - '.github/workflows/build-subrepos.yml'
-
   workflow_call:
     inputs:
       branch:

--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -27,6 +27,9 @@ concurrency:
 
 name: Create Subrepo Conda Packages
 
+env:
+  ENABLE_SSH: ${{ github.event_name == 'workflow_dispatch' && inputs.ssh }}
+
 jobs:
   build-pkgs:
     name: Build ${{ matrix.pkg }} ${{ matrix.cache-arch }} Python-${{ matrix.python-version }}

--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -57,13 +57,6 @@ jobs:
       pkg: ${{ matrix.pkg }}
 
     steps:
-      - name: Setup Remote SSH Connection
-        if: env.ENABLE_SSH == 'true'
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 60
-        with:
-          detached: true
-
       - name: Checkout Code
         uses: actions/checkout@v6
         with:
@@ -95,9 +88,17 @@ jobs:
           cache-downloads: true
           cache-environment: true
 
+      - name: Setup Remote SSH Connection
+        if: env.ENABLE_SSH == 'true'
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 60
+        with:
+          detached: true
+
       - name: Build ${{ matrix.pkg }} Conda Package
         if: steps.cache.outputs.cache-hit != 'true'
         env:
           CONDA_BLD_PATH: ${{ github.workspace }}/installers-conda/build/conda-bld
           python_min: '3.9'
-        run: python build_conda_pkgs.py --build $pkg
+        run: |
+          python build_conda_pkgs.py --build $pkg

--- a/.github/workflows/build-subrepos.yml
+++ b/.github/workflows/build-subrepos.yml
@@ -77,6 +77,8 @@ jobs:
         uses: mamba-org/setup-micromamba@v3
         with:
           condarc: |
+            channels:
+              - conda-forge
             conda_build:
               pkg_format: '2'
               zstd_compression_level: '19'
@@ -99,6 +101,5 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         env:
           CONDA_BLD_PATH: ${{ github.workspace }}/installers-conda/build/conda-bld
-          python_min: '3.9'
         run: |
           python build_conda_pkgs.py --build $pkg

--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'installers-conda/**'
       - '.github/workflows/installers-conda.yml'
+      - '.github/workflows/build-subrepos.yml'
       - '.github/scripts/installer_test.sh'
       - 'requirements/*.yml'
       - 'MANIFEST.in'


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

It may be that a recent update to setup-micromamba does not automatically include the conda-forge channel in the condarc file. Explicitly adding it seems to resolve the issue.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #26210


