### PR TITLE
PR: Remove usage of old private attribute when merging Jupyter configs (IPython console)

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/spyder-ide/spyder-kernels.git
-	branch = master
-	commit = ef6c6002c389d28ffda9d15d0a15016b6584a9e9
-	parent = 0359628c3510102b44fd84b643979f9978b73d6a
+	remote = https://github.com/ccordoba12/spyder-kernels.git
+	branch = fix-for-traitlets-5.16
+	commit = 8fc56e021984c0ff22261c7562807ed97ddc2205
+	parent = 22befae5eb7a278073eeab26dcea1d1e150a3eaa
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/ccordoba12/spyder-kernels.git
-	branch = fix-for-traitlets-5.16
-	commit = 8fc56e021984c0ff22261c7562807ed97ddc2205
-	parent = 22befae5eb7a278073eeab26dcea1d1e150a3eaa
+	remote = https://github.com/spyder-ide/spyder-kernels.git
+	branch = master
+	commit = e7756d79f61458e1692906615d4c2567840b2217
+	parent = 4417149f659940aae13d2d89e9378a2987920e4c
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/spyder_kernels/console/start.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/start.py
@@ -114,7 +114,7 @@ def kernel_config():
 
     # Merge IPython and Spyder configs. Spyder prefs will have prevalence
     # over IPython ones
-    cfg._merge(spy_cfg)
+    cfg.merge(spy_cfg)
     return cfg
 
 

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1900,7 +1900,7 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):  # noqa: PLR090
 
         # Merge QtConsole and Spyder configs. Spyder prefs will have
         # prevalence over QtConsole ones
-        cfg._merge(spy_cfg)
+        cfg.merge(spy_cfg)
         return cfg
 
     def additional_options(self, special=None):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

- Just followed the indications from the Python error message.
- Depends on https://github.com/spyder-ide/spyder-kernels/pull/601.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #26220


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: Thibaut Lunet

<!--- Thanks for your help making Spyder better for everyone! --->
