### PR TITLE
Backport PR #26221 on branch 6.x (PR: Remove usage of old private attribute when merging Jupyter configs (IPython console))

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = 3.x
-	commit = fdd88b91e717be2e1d67f271fa22d7d349260159
-	parent = b0b8ec1a45a702ec3afe7759655fa731987a91a5
+	commit = b104ee8b01ef434d9fe01afdbbe1b3eacbd6f74d
+	parent = ebef6e8d76a5a29bb21fe9567bc32b64e14d7a32
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/spyder_kernels/console/start.py
+++ b/external-deps/spyder-kernels/spyder_kernels/console/start.py
@@ -120,7 +120,7 @@ def kernel_config():
 
     # Merge IPython and Spyder configs. Spyder prefs will have prevalence
     # over IPython ones
-    cfg._merge(spy_cfg)
+    cfg.merge(spy_cfg)
     return cfg
 
 

--- a/spyder/plugins/ipythonconsole/widgets/main_widget.py
+++ b/spyder/plugins/ipythonconsole/widgets/main_widget.py
@@ -1898,7 +1898,7 @@ class IPythonConsoleWidget(PluginMainWidget, CachedKernelMixin):  # noqa: PLR090
 
         # Merge QtConsole and Spyder configs. Spyder prefs will have
         # prevalence over QtConsole ones
-        cfg._merge(spy_cfg)
+        cfg.merge(spy_cfg)
         return cfg
 
     def additional_options(self, special=None):


### PR DESCRIPTION
Manual backport of PR #26221.