### PR TITLE
PR: Use proper option key to enable/disable only ruff formatter (Completions/Linting)

### DIFF
--- a/spyder/plugins/completion/providers/languageserver/conftabs/formatting.py
+++ b/spyder/plugins/completion/providers/languageserver/conftabs/formatting.py
@@ -101,8 +101,10 @@ class FormattingConfigTab(SpyderPreferencesTab):
             QMessageBox.warning(
                 self,
                 _("Warning"),
-                _("Since Ruff is selected as formatter "
-                  "linting via Ruff will also be enabled"),
+                _(
+                    "Since you selected Ruff as formatter, linting via Ruff "
+                    "will be enabled too"
+                ),
             )
             self.set_option("ruff", True)
             self.set_option("pyflakes", False)

--- a/spyder/plugins/completion/providers/languageserver/conftabs/formatting.py
+++ b/spyder/plugins/completion/providers/languageserver/conftabs/formatting.py
@@ -9,7 +9,7 @@ Language Server Protocol configuration tabs.
 """
 
 # Third party imports
-from qtpy.QtWidgets import QGroupBox, QLabel, QVBoxLayout
+from qtpy.QtWidgets import QGroupBox, QMessageBox, QLabel, QVBoxLayout
 
 # Local imports
 from spyder.api.preferences import SpyderPreferencesTab
@@ -66,7 +66,7 @@ class FormattingConfigTab(SpyderPreferencesTab):
         code_fmt_label.setWordWrap(True)
 
         # Code formatting providers
-        code_fmt_provider = self.create_combobox(
+        self.code_fmt_provider = self.create_combobox(
             _("Choose the code formatting provider: "),
             (("autopep8", "autopep8"), ("black", "black"), ("ruff", "ruff")),
             "formatting",
@@ -83,7 +83,7 @@ class FormattingConfigTab(SpyderPreferencesTab):
         code_fmt_group = QGroupBox(_("Code formatting"))
         code_fmt_layout = QVBoxLayout()
         code_fmt_layout.addWidget(code_fmt_label)
-        code_fmt_layout.addWidget(code_fmt_provider)
+        code_fmt_layout.addWidget(self.code_fmt_provider)
         code_fmt_layout.addWidget(format_on_save_box)
         code_fmt_group.setLayout(code_fmt_layout)
 
@@ -91,3 +91,25 @@ class FormattingConfigTab(SpyderPreferencesTab):
         code_style_fmt_layout.addWidget(code_fmt_group)
         code_style_fmt_layout.addWidget(line_length_group)
         self.setLayout(code_style_fmt_layout)
+
+    def is_valid(self):
+        # Check ruff being selected as linter when ruff is selected as formatter
+        if (
+            self.code_fmt_provider.combobox.currentText() == "ruff"
+            and not self.get_option("ruff")
+        ):
+            QMessageBox.warning(
+                self,
+                _("Warning"),
+                _("Since Ruff is selected as formatter "
+                  "linting via Ruff will also be enabled"),
+            )
+            self.set_option("ruff", True)
+            self.set_option("pyflakes", False)
+            self.set_option("pycodestyle", False)
+            self.set_option("flake8", False)
+            self.set_option("no_linting", False)
+            self.set_option("formatting", "ruff")
+            self.load_from_conf()
+
+        return True

--- a/spyder/plugins/completion/providers/languageserver/conftabs/linting.py
+++ b/spyder/plugins/completion/providers/languageserver/conftabs/linting.py
@@ -61,7 +61,7 @@ class LintingConfigTab(SpyderPreferencesTab):
             'flake8',
             button_group=linting_bg
         )
-        ruff_linting_radio = self.create_radiobutton(
+        self.ruff_linting_radio = self.create_radiobutton(
             _("Ruff (Advanced)"),
             'ruff',
             button_group=linting_bg
@@ -76,7 +76,7 @@ class LintingConfigTab(SpyderPreferencesTab):
         linting_select_layout.addSpacing(3 * AppStyle.MarginSize)
         linting_select_layout.addWidget(basic_linting_radio)
         linting_select_layout.addWidget(flake_linting_radio)
-        linting_select_layout.addWidget(ruff_linting_radio)
+        linting_select_layout.addWidget(self.ruff_linting_radio)
         linting_select_layout.addWidget(disable_linting_radio)
         linting_select_group.setLayout(linting_select_layout)
 
@@ -218,7 +218,7 @@ class LintingConfigTab(SpyderPreferencesTab):
         configuration_options_layout.addWidget(pyflakes_conf_options)
         configuration_options_layout.addWidget(not_select_conf_options)
 
-        ruff_linting_radio.radiobutton.toggled.connect(
+        self.ruff_linting_radio.radiobutton.toggled.connect(
             lambda checked: (
                 ruff_grid_widget.setVisible(checked),
                 flake8_grid_widget.setVisible(False),
@@ -281,6 +281,15 @@ class LintingConfigTab(SpyderPreferencesTab):
 
         QMessageBox.critical(self, _("Error"), msg)
 
+    def report_invalid_linter(self):
+        QMessageBox.warning(
+            self,
+            _("Warning"),
+            _("Since Ruff is selected as formatter "
+              "linting via Ruff needs to be enabled"),
+        )
+        self.ruff_linting_radio.radiobutton.setChecked(True)
+
     def is_valid(self):
         # Check regexs
         try:
@@ -306,6 +315,14 @@ class LintingConfigTab(SpyderPreferencesTab):
 
         except re.error:
             self.report_invalid_regex(files=False)
+            return False
+
+        # Check ruff related config
+        if (
+            not self.ruff_linting_radio.radiobutton.isChecked()
+            and self.get_option("formatting") == "ruff"
+        ):
+            self.report_invalid_linter()
             return False
 
         return True

--- a/spyder/plugins/completion/providers/languageserver/conftabs/linting.py
+++ b/spyder/plugins/completion/providers/languageserver/conftabs/linting.py
@@ -285,8 +285,10 @@ class LintingConfigTab(SpyderPreferencesTab):
         QMessageBox.warning(
             self,
             _("Warning"),
-            _("Since Ruff is selected as formatter "
-              "linting via Ruff needs to be enabled"),
+            _(
+                "Since Ruff is selected as formatter, linting can only be "
+                "provided by Ruff and it can't be disabled"
+            ),
         )
         self.ruff_linting_radio.radiobutton.setChecked(True)
 

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -822,11 +822,6 @@ class LanguageServerProvider(SpyderCompletionProvider):
                 }
             })
 
-        if formatter == 'ruff':
-            # Plugin and therefore ruff linting needs to be enabled if ruff
-            # formatter has been selected
-            ruff["enabled"] = True
-
         # Setting max line length for formatters.
         # Notes:
         # 1. The autopep8 plugin shares the same maxLineLength value with the

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -813,7 +813,7 @@ class LanguageServerProvider(SpyderCompletionProvider):
         formatters = ['autopep8', 'yapf', 'black', 'ruff']
         formatter_options = {}
         for fmt in formatters:
-            # Need to handle a specific key for ruff (`formatEnabled`)
+            # Needed to handle a specific key for ruff (`formatEnabled`)
             # See spyder-ide/spyder#26138
             format_key = 'formatEnabled' if fmt == 'ruff' else 'enabled'
             formatter_options.update({

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -811,12 +811,21 @@ class LanguageServerProvider(SpyderCompletionProvider):
 
         # Enabling/disabling formatters
         formatters = ['autopep8', 'yapf', 'black', 'ruff']
-        formatter_options = {
-            fmt: {
-                'enabled': fmt == formatter
-            }
-            for fmt in formatters
-        }
+        formatter_options = {}
+        for fmt in formatters:
+            # Need to handle an specific key for ruff (`formatEnabled`)
+            # See spyder-ide/spyder#26138
+            format_key = 'formatEnabled' if fmt == 'ruff' else 'enabled'
+            formatter_options.update({
+                fmt: {
+                    format_key: fmt == formatter
+                }
+            })
+
+        if formatter == 'ruff':
+            # Plugin and therefor ruff linting needs to be enabled if ruff
+            # formatter has been selected
+            ruff["enabled"] = True
 
         # Setting max line length for formatters.
         # Notes:

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -813,7 +813,7 @@ class LanguageServerProvider(SpyderCompletionProvider):
         formatters = ['autopep8', 'yapf', 'black', 'ruff']
         formatter_options = {}
         for fmt in formatters:
-            # Need to handle an specific key for ruff (`formatEnabled`)
+            # Need to handle a specific key for ruff (`formatEnabled`)
             # See spyder-ide/spyder#26138
             format_key = 'formatEnabled' if fmt == 'ruff' else 'enabled'
             formatter_options.update({
@@ -823,7 +823,7 @@ class LanguageServerProvider(SpyderCompletionProvider):
             })
 
         if formatter == 'ruff':
-            # Plugin and therefor ruff linting needs to be enabled if ruff
+            # Plugin and therefore ruff linting needs to be enabled if ruff
             # formatter has been selected
             ruff["enabled"] = True
 

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_formatting.py
@@ -37,6 +37,12 @@ def test_document_formatting(formatter, newline, completions_codeeditor,
         ('provider_configuration', 'lsp', 'values', 'formatting'),
         formatter
     )
+    # Enable `ruff` plugin/linting in case the formatter being tested is `ruff`
+    CONF.set(
+        'completions',
+        ('provider_configuration', 'lsp', 'values', 'ruff'),
+        formatter == 'ruff'
+    )
     completion_plugin.after_configuration_update([])
     qtbot.wait(2000)
 
@@ -148,6 +154,12 @@ def test_max_line_length(formatter, completions_codeeditor, qtbot):
         ('provider_configuration', 'lsp', 'values',
          'flake8/max_line_length'),
         max_line_length
+    )
+    # Enable `ruff` plugin/linting in case the formatter being tested is `ruff`
+    CONF.set(
+        'completions',
+        ('provider_configuration', 'lsp', 'values', 'ruff'),
+        formatter == 'ruff'
     )
     completion_plugin.after_configuration_update([])
     qtbot.wait(2000)

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_formatting.py
@@ -27,7 +27,7 @@ from spyder.plugins.editor.widgets.codeeditor.tests.conftest import (
 @pytest.mark.parametrize('newline', ['\r\n', '\r', '\n'])
 def test_document_formatting(formatter, newline, completions_codeeditor,
                              qtbot):
-    """Validate text autoformatting via autopep8, yapf or black."""
+    """Validate text autoformatting via autopep8, yapf, black or ruff."""
     code_editor, completion_plugin = completions_codeeditor
     text, expected = get_formatter_values(formatter, newline)
 

--- a/spyder/plugins/editor/widgets/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/tests/test_formatting.py
@@ -42,6 +42,12 @@ def test_closing_document_formatting(
         ('provider_configuration', 'lsp', 'values', 'formatting'),
         formatter
     )
+    # Enable `ruff` plugin/linting in case the formatter being tested is `ruff`
+    CONF.set(
+        'completions',
+        ('provider_configuration', 'lsp', 'values', 'ruff'),
+        formatter == 'ruff'
+    )
 
     completion_plugin.after_configuration_update([])
     qtbot.wait(2000)
@@ -86,6 +92,12 @@ def test_formatting_on_save(completions_editor, formatter, qtbot):
         'completions',
         ('provider_configuration', 'lsp', 'values', 'formatting'),
         formatter
+    )
+    # Enable `ruff` plugin/linting in case the formatter being tested is `ruff`
+    CONF.set(
+        'completions',
+        ('provider_configuration', 'lsp', 'values', 'ruff'),
+        formatter == 'ruff'
     )
 
     completion_plugin.after_configuration_update([])


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->

Instead of using the proper option key to handle the ruff formatter (`formatEnabled`) the logic was using the the whole ruff plugin `enabled` option. That was causing ruff linting to be coupled with the formatter selection (only working when ruff was being selected as a formatter). The changes here add a validation when setting the formatter options to use the proper key for the ruff case.

Edit: Also, for the formatter to be active the pyls ruff plugin (and therefore the ruff linting) needs to be enabled. Here also a validation is added so if ruff is selected as the formatter, the `ruff.enabled` config is forced to be `True`.

Edit 2: Following feedback, validations when setting preferences are done instead of forcing the ruff plugin/linter to be enabled:

A preview of the behavior and messages shown:

<img width="1227" height="556" alt="ruff_linting_formatting_validations" src="https://github.com/user-attachments/assets/780e0e75-21ff-467f-8101-989b8a5cd107" />

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #26138


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
