### PR TITLE
PR: Fix tests due to error with latest `packaging` version (CI)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -58,6 +58,9 @@ if [ "$USE_CONDA" = "true" ]; then
     # Pin IPykernel to 7.2.0 because version 7.3.0+ causes segfaults
     micromamba install ipykernel=7.2.0
 
+    # Workaround for an error with packaging 26.3 when installing our subrepos
+    micromamba install packaging=26.2
+
 else
     # Update pip and setuptools
     python -m pip install -U pip setuptools wheel build
@@ -79,6 +82,9 @@ else
 
     # Force installation of Jedi 0.20
     pip install jedi==0.20.0
+
+    # Workaround for an error with packaging 26.3 when installing our subrepos
+    pip install packaging==26.2
 fi
 
 # Install subrepos from source


### PR DESCRIPTION
## Description of Changes

Our tests started to fail due to a weird error when installing our subrepos with `packaging` **26.3**.  So, I pinned it to version 26.2.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12.

<!--- Thanks for your help making Spyder better for everyone! --->
