### PR TITLE
PR: Revise parsing conda requirements to get `python-lsp-server version` (CI)

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -58,9 +58,6 @@ if [ "$USE_CONDA" = "true" ]; then
     # Pin IPykernel to 7.2.0 because version 7.3.0+ causes segfaults
     micromamba install ipykernel=7.2.0
 
-    # Workaround for an error with packaging 26.3 when installing our subrepos
-    micromamba install packaging=26.2
-
 else
     # Update pip and setuptools
     python -m pip install -U pip setuptools wheel build
@@ -82,9 +79,6 @@ else
 
     # Force installation of Jedi 0.20
     pip install jedi==0.20.0
-
-    # Workaround for an error with packaging 26.3 when installing our subrepos
-    pip install packaging==26.2
 fi
 
 # Install subrepos from source

--- a/install_dev_repos.py
+++ b/install_dev_repos.py
@@ -8,6 +8,7 @@
 Helper script for installing spyder and external-deps locally in editable mode.
 """
 
+# Standard Library imports
 import argparse
 from importlib.metadata import PackageNotFoundError, distribution
 from json import loads
@@ -17,7 +18,9 @@ from pathlib import Path
 from subprocess import check_output
 import sys
 
+# Third-party imports
 from packaging.requirements import Requirement
+from yaml import safe_load
 
 # Remove current/script directory from sys.path[0] if added by the Python
 # invocation, otherwise Spyder's install status may be incorrectly determined.
@@ -75,15 +78,14 @@ logger.setLevel('INFO')
 def get_python_lsp_version():
     """Get current version to pass it to setuptools-scm."""
     req_file = DEVPATH / 'requirements' / 'main.yml'
-    with open(req_file, 'r', encoding='utf-8') as f:
-        for line in f:
-            if 'python-lsp-server' not in line:
-                continue
-            line = line.split('-')[-1]
-            specifiers = Requirement(line).specifier
-            break
-        else:
-            return "0.0.0"
+    requirements = safe_load(req_file.read_text())
+    for dep in requirements["dependencies"]:
+        if not dep.startswith("python-lsp-server"):
+            continue
+        specifiers = Requirement(dep).specifier
+        break
+    else:
+        return "0.0.0"
 
     for specifier in specifiers:
         if "=" in specifier.operator:


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

When parsing `main.yml` previously a superfluous `\n` character is included in the string argument to `Requirement()`. After `packaging =26.3` this raises an `InvalidRequirement` error.

This PR uses `yaml.safe_laod` to parse `main.yml`, providing a more robust input to `Requirement()`.

#26233 is also reverted in this PR.

<!--- Explain what you've done and why --->


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #26235


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
