### PR TITLE
PR: Fix files being marked as modified when they are not (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -1355,10 +1355,12 @@ class CodeEditor(
         """Rehighlight the whole document."""
         if self.highlighter is not None:
             self.highlighter.rehighlight()
+
         if self.highlight_current_cell_enabled:
             self.highlight_current_cell()
         else:
             self.unhighlight_current_cell()
+
         if self.highlight_current_line_enabled:
             self.highlight_current_line()
         else:
@@ -1892,13 +1894,17 @@ class CodeEditor(
         """Toggle blanks visibility"""
         self.blanks_enabled = state
         option = self.document().defaultTextOption()
-        option.setFlags(option.flags() | \
-                        QTextOption.AddSpaceForLineAndParagraphSeparators)
+        option.setFlags(
+            option.flags() | QTextOption.AddSpaceForLineAndParagraphSeparators
+        )
+
         if self.blanks_enabled:
             option.setFlags(option.flags() | QTextOption.ShowTabsAndSpaces)
         else:
             option.setFlags(option.flags() & ~QTextOption.ShowTabsAndSpaces)
+
         self.document().setDefaultTextOption(option)
+
         # Rehighlight to make the spaces less apparent.
         self.rehighlight()
 

--- a/spyder/plugins/editor/widgets/codeeditor/stack_mixin.py
+++ b/spyder/plugins/editor/widgets/codeeditor/stack_mixin.py
@@ -906,6 +906,20 @@ class EditsStackMixin:
         finally:
             self.__undo_recording_depth -= 1
 
+    @contextmanager
+    def enable_qt_undo_redo(self):
+        """Temporarily enable Qt's undo/redo mechanism.
+
+        Operations inside this context manager **must** not involve any changes
+        to the file's contents.
+        """
+        self.document().setUndoRedoEnabled(True)
+
+        try:
+            yield
+        finally:
+            self.document().setUndoRedoEnabled(False)
+
     def _on_cursor_position_changed(self, *args):
         """Keep the stored cursor state in sync with cursor movements.
 

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -342,7 +342,14 @@ class BaseSH(QSyntaxHighlighter):
 
     def rehighlight(self):
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
-        QSyntaxHighlighter.rehighlight(self)
+
+        # We need to do this because when Qt's undo/redo is disabled,
+        # rehighlights make the file be flagged as modified (seems like a bug
+        # in Qt).
+        if self.editor is not None:
+            with self.editor.enable_qt_undo_redo():
+                QSyntaxHighlighter.rehighlight(self)
+
         QApplication.restoreOverrideCursor()
 
 


### PR DESCRIPTION
## Description of Changes

- Files were being marked as modified at startup and when the editor is splitted, which is wrong.
- This is a small regression introduced by #26042.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
