### PR TITLE
Improve the Browse tabs menu for many open files

### DIFF
--- a/spyder/widgets/tabs.py
+++ b/spyder/widgets/tabs.py
@@ -17,9 +17,10 @@ import os.path as osp
 # Third party imports
 import qstylizer.style
 from qtpy.QtCore import QEvent, QPoint, Qt, Signal, Slot, QSize
-from qtpy.QtGui import QFontMetrics
+from qtpy.QtGui import QFontMetrics, QPainter, QPen
 from qtpy.QtWidgets import (
-    QHBoxLayout, QLineEdit, QTabBar, QTabWidget, QToolButton, QWidget)
+    QApplication, QHBoxLayout, QLineEdit, QTabBar, QTabWidget, QToolButton,
+    QToolTip, QWidget)
 
 # Local imports
 from spyder.api.shortcuts import SpyderShortcutsMixin
@@ -414,6 +415,137 @@ class TabBar(QTabBar):
                 close_btn.index = i
 
 
+class BrowseTabsMenu(SpyderMenu):
+    """Native browse-tabs menu with Shift-drag reordering."""
+
+    sig_tab_moved = Signal(int, int)
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.drag_action = None
+        self.drag_start = QPoint()
+        self.drop_action = None
+        self.drop_after = False
+
+    def event(self, event):
+        """Show full paths only for entries with shortened text."""
+        if event.type() == QEvent.ToolTip:
+            action = self.actionAt(event.pos())
+            tooltip = (
+                action.property("full_path_tooltip")
+                if action is not None else ""
+            )
+            if tooltip:
+                QToolTip.showText(
+                    event.globalPos(),
+                    tooltip,
+                    self,
+                    self.actionGeometry(action),
+                )
+            else:
+                QToolTip.hideText()
+            return True
+        return super().event(event)
+
+    def mousePressEvent(self, event):
+        """Start reordering only for Shift and the left mouse button."""
+        action = self.actionAt(event.pos())
+        if (
+            event.button() == Qt.LeftButton
+            and event.modifiers() & Qt.ShiftModifier
+            and action is not None
+        ):
+            self.drag_action = action
+            self.drag_start = event.pos()
+            self.drop_action = None
+            self.setActiveAction(action)
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+        """Update the insertion position while reordering."""
+        if self.drag_action is not None:
+            self.set_drop_position(event.pos())
+            event.accept()
+            return
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        """Reorder the actions and keep the menu open after a drag."""
+        if self.drag_action is None:
+            super().mouseReleaseEvent(event)
+            return
+
+        source = self.drag_action
+        self.drag_action = None
+        distance = (event.pos() - self.drag_start).manhattanLength()
+        if distance >= QApplication.startDragDistance():
+            self.set_drop_position(event.pos())
+        target = self.drop_action
+        if target is not None and distance >= QApplication.startDragDistance():
+            index_from = source.property("tab_index")
+            insertion_index = target.property("tab_index") + self.drop_after
+            index_to = insertion_index - (index_from < insertion_index)
+            if index_from != index_to:
+                self.removeAction(source)
+                actions = self.actions()
+                if index_to == len(actions):
+                    self.addAction(source)
+                else:
+                    self.insertAction(actions[index_to], source)
+                for index, action in enumerate(self.actions()):
+                    action.setProperty("tab_index", index)
+                self.setActiveAction(source)
+                self.sig_tab_moved.emit(index_from, index_to)
+        self.drop_action = None
+        self.update()
+        event.accept()
+
+    def set_drop_position(self, position):
+        """Set the action and edge used as the insertion position."""
+        action = self.actionAt(position)
+        if action is None:
+            self.drop_action = None
+        else:
+            rect = self.actionGeometry(action)
+            self.drop_action = action
+            self.drop_after = position.y() > rect.center().y()
+        self.setActiveAction(None)
+        self.update()
+
+    def paintEvent(self, event):
+        """Draw drag-source feedback and the insertion line."""
+        super().paintEvent(event)
+        if self.drag_action is None and self.drop_action is None:
+            return
+
+        painter = QPainter(self)
+        if self.drag_action is not None:
+            source_rect = self.actionGeometry(
+                self.drag_action
+            ).adjusted(3, 2, -3, -2)
+            shadow_color = self.palette().shadow().color()
+            shadow_color.setAlpha(70)
+            painter.fillRect(source_rect.translated(2, 2), shadow_color)
+            source_color = self.palette().highlight().color()
+            source_color.setAlpha(55)
+            painter.fillRect(source_rect, source_color)
+            painter.setPen(QPen(self.palette().highlight().color(), 1))
+            painter.drawRect(source_rect)
+
+        if self.drop_action is not None:
+            rect = self.actionGeometry(self.drop_action)
+            y_position = rect.bottom() if self.drop_after else rect.top()
+            painter.setPen(QPen(self.palette().highlight().color(), 2))
+            painter.drawLine(
+                rect.left() + 4,
+                y_position,
+                rect.right() - 4,
+                y_position,
+            )
+
+
 class BaseTabs(QTabWidget):
     """TabWidget with context menu and corner widgets"""
     sig_close_tab = Signal(int)
@@ -450,10 +582,13 @@ class BaseTabs(QTabWidget):
             self, icon=ima.icon('browse_tab'), tip=_("Browse tabs"))
         self.browse_button.setStyleSheet(str(PANES_TABBAR_STYLESHEET))
 
-        self.browse_tabs_menu = SpyderMenu(self)
+        self.browse_tabs_menu = BrowseTabsMenu(self)
         self.browse_button.setMenu(self.browse_tabs_menu)
         self.browse_button.setPopupMode(QToolButton.InstantPopup)
         self.browse_tabs_menu.aboutToShow.connect(self.update_browse_tabs_menu)
+        self.browse_tabs_menu.sig_tab_moved.connect(
+            self.tabBar().moveTab
+        )
         corner_widgets[Qt.TopLeftCorner] += [self.browse_button]
 
         self.set_corner_widgets(corner_widgets)
@@ -485,14 +620,34 @@ class BaseTabs(QTabWidget):
                     # Common path is not a path but a drive letter...
                     offset = None
 
+        screen = self.browse_tabs_menu.screen() or QApplication.primaryScreen()
+        available_width = screen.availableGeometry().width()
+        text_width = max(260, min(480, available_width // 3 - 48))
+        metrics = QFontMetrics(self.browse_tabs_menu.font())
         for index, text in enumerate(names):
-            tab_action = create_action(self, text[offset:],
-                                       icon=self.tabIcon(index),
-                                       toggled=lambda state, index=index:
-                                               self.setCurrentIndex(index),
-                                       tip=self.tabToolTip(index))
+            visible_text = text[offset:]
+            display_text = metrics.elidedText(
+                visible_text, Qt.ElideMiddle, text_width
+            )
+            full_path_tooltip = self.tabToolTip(index)
+            if self.menu_use_tooltips and display_text == text:
+                full_path_tooltip = ""
+            tab_action = create_action(
+                self,
+                display_text,
+                icon=self.tabIcon(index),
+                triggered=self._set_current_from_browse_action,
+                tip=self.tabToolTip(index),
+            )
+            tab_action.setCheckable(True)
+            tab_action.setProperty("tab_index", index)
+            tab_action.setProperty("full_path_tooltip", full_path_tooltip)
             tab_action.setChecked(index == self.currentIndex())
             self.browse_tabs_menu.addAction(tab_action)
+
+    def _set_current_from_browse_action(self, _checked=False):
+        """Select the tab using its current position in the menu."""
+        self.setCurrentIndex(self.sender().property("tab_index"))
 
     def set_corner_widgets(self, corner_widgets):
         """

--- a/spyder/widgets/tests/test_tabs.py
+++ b/spyder/widgets/tests/test_tabs.py
@@ -1,0 +1,180 @@
+"""Tests for tabs widgets."""
+
+from pathlib import Path
+
+from qtpy.QtCore import QEvent, QPoint, QPointF, Qt
+from qtpy.QtGui import QMouseEvent
+from qtpy.QtTest import QTest
+from qtpy.QtWidgets import QApplication, QWidget
+
+from spyder.widgets.tabs import BaseTabs
+
+
+def make_tabs(qtbot, names):
+    """Create tabs whose tooltips contain their paths."""
+    tabs = BaseTabs(None, menu_use_tooltips=True)
+    qtbot.addWidget(tabs)
+    pages = []
+    for name in names:
+        page = QWidget()
+        pages.append(page)
+        index = tabs.addTab(page, Path(name).name)
+        tabs.setTabToolTip(index, name)
+    tabs.update_browse_tabs_menu()
+    return tabs, pages
+
+
+def mouse_event(event_type, position, modifiers):
+    """Create a left-button mouse event."""
+    buttons = (
+        Qt.NoButton
+        if event_type == QEvent.MouseButtonRelease
+        else Qt.LeftButton
+    )
+    return QMouseEvent(
+        event_type,
+        QPointF(position),
+        Qt.LeftButton,
+        buttons,
+        modifiers,
+    )
+
+
+def test_browse_tabs_menu_elides_long_paths(qtbot):
+    """Long paths are elided and only shortened paths get tooltips."""
+    long_path = "C:/" + "very-long-directory/" * 20 + "module.py"
+    tabs, _pages = make_tabs(qtbot, ["first.py", long_path])
+    actions = tabs.browse_tabs_menu.actions()
+
+    assert actions[0].text() == "first.py"
+    assert actions[0].property("full_path_tooltip") == ""
+    assert "…" in actions[1].text()
+    assert actions[1].property("full_path_tooltip") == long_path
+
+
+def test_browse_tabs_menu_tooltip_restores_common_path(qtbot, tmp_path):
+    """The tooltip restores a common directory omitted from menu text."""
+    paths = [tmp_path / "first.py", tmp_path / "second.py"]
+    for path in paths:
+        path.touch()
+
+    tabs, _pages = make_tabs(qtbot, [str(path) for path in paths])
+    actions = tabs.browse_tabs_menu.actions()
+
+    assert actions[0].text() == "first.py"
+    assert actions[0].property("full_path_tooltip") == str(paths[0])
+
+
+def test_regular_browse_action_switches_tabs(qtbot):
+    """A regular click still selects its tab."""
+    tabs, pages = make_tabs(qtbot, ["first.py", "second.py"])
+
+    tabs.browse_tabs_menu.actions()[1].trigger()
+
+    assert tabs.currentWidget() is pages[1]
+
+
+def test_shift_drag_reorders_and_keeps_menu_open(qtbot):
+    """Shift-drag reorders tabs and permits another action afterwards."""
+    tabs, pages = make_tabs(
+        qtbot, ["first.py", "second.py", "third.py", "fourth.py"]
+    )
+    menu = tabs.browse_tabs_menu
+    menu.popup(QPoint(100, 100))
+    qtbot.waitUntil(menu.isVisible)
+    source_position = menu.actionGeometry(menu.actions()[0]).center()
+    target_rect = menu.actionGeometry(menu.actions()[2])
+    target_position = QPoint(
+        target_rect.center().x(),
+        target_rect.center().y() + target_rect.height() // 4,
+    )
+    moved = []
+    tabs.tabBar().tabMoved.connect(lambda old, new: moved.append((old, new)))
+
+    QTest.mousePress(menu, Qt.LeftButton, Qt.ShiftModifier, source_position)
+    assert menu.drag_action is menu.actions()[0]
+    menu.mouseMoveEvent(mouse_event(
+        QEvent.MouseMove, target_position, Qt.ShiftModifier
+    ))
+    assert menu.drop_action is menu.actions()[2]
+    assert menu.drop_after
+    QTest.mouseRelease(menu, Qt.LeftButton, Qt.ShiftModifier, target_position)
+    QApplication.processEvents()
+
+    assert moved == [(0, 2)]
+    assert menu.isVisible()
+    assert [tabs.widget(index) for index in range(tabs.count())] == [
+        pages[1], pages[2], pages[0], pages[3]
+    ]
+    assert [action.text() for action in menu.actions()] == [
+        "second.py", "third.py", "first.py", "fourth.py"
+    ]
+
+    # The moved action must select its new tab index, not its old one.
+    menu.actions()[2].trigger()
+    assert tabs.currentWidget() is pages[0]
+
+
+def test_shift_drag_across_native_columns(qtbot):
+    """Shift-drag works between columns created by the native menu."""
+    names = [f"module-{index:03d}.py" for index in range(100)]
+    tabs, pages = make_tabs(qtbot, names)
+    menu = tabs.browse_tabs_menu
+    menu.popup(QPoint(0, 0))
+    qtbot.waitUntil(menu.isVisible)
+    actions = menu.actions()
+    source_rect = menu.actionGeometry(actions[0])
+    target_index = next(
+        index for index, action in enumerate(actions)
+        if menu.actionGeometry(action).left() > source_rect.left()
+    )
+    target_rect = menu.actionGeometry(actions[target_index])
+    target_position = QPoint(
+        target_rect.center().x(),
+        target_rect.center().y() + target_rect.height() // 4,
+    )
+
+    QTest.mousePress(
+        menu, Qt.LeftButton, Qt.ShiftModifier, source_rect.center()
+    )
+    QTest.mouseRelease(
+        menu, Qt.LeftButton, Qt.ShiftModifier, target_position
+    )
+    QApplication.processEvents()
+
+    assert tabs.widget(target_index) is pages[0]
+    assert menu.isVisible()
+
+
+def test_shift_click_without_movement_does_nothing(qtbot):
+    """Shift-click alone neither selects nor moves a tab."""
+    tabs, pages = make_tabs(qtbot, ["first.py", "second.py"])
+    menu = tabs.browse_tabs_menu
+    menu.ensurePolished()
+    menu.adjustSize()
+    position = menu.actionGeometry(menu.actions()[1]).center()
+
+    menu.mousePressEvent(mouse_event(
+        QEvent.MouseButtonPress, position, Qt.ShiftModifier
+    ))
+    menu.mouseReleaseEvent(mouse_event(
+        QEvent.MouseButtonRelease, position, Qt.ShiftModifier
+    ))
+
+    assert tabs.currentWidget() is pages[0]
+    assert menu.drag_action is None
+
+
+def test_plain_press_does_not_start_drag(qtbot):
+    """A plain left-button press retains native menu behavior."""
+    tabs, _pages = make_tabs(qtbot, ["first.py", "second.py"])
+    menu = tabs.browse_tabs_menu
+    menu.ensurePolished()
+    menu.adjustSize()
+    position = menu.actionGeometry(menu.actions()[0]).center()
+
+    menu.mousePressEvent(mouse_event(
+        QEvent.MouseButtonPress, position, Qt.NoModifier
+    ))
+
+    assert menu.drag_action is None


### PR DESCRIPTION
## Description of Changes

The native Browse tabs menu becomes unnecessarily wide when many files are open because Qt lays the menu out in multiple columns and sizes those columns from long action text. This leaves large empty horizontal regions and makes the list harder to scan.

This PR keeps the existing `SpyderMenu`/`QAction` presentation and:

- elides long paths in the middle using a screen-aware width;
- shows the full path on hover only when the displayed path was shortened;
- allows tabs to be reordered from the menu with Shift + left-button drag;
- keeps the menu open after a reorder so multiple files can be arranged;
- draws a lifted source-row cue and an insertion line during dragging; and
- routes selection through each action's current index so clicks remain correct after reordering.

- [x] Wrote at least one-line docstrings for new functions
- [x] Added unit tests covering the changes
- [ ] Included a screenshot or animation

The new tests cover path elision, conditional full-path tooltips, regular selection, same-column and cross-column reordering, post-reorder selection, menu persistence, Shift-click without movement, and native plain-click behavior.

### Issue(s) Resolved

No existing issue found.

### Validation

- `python -m pytest -q spyder/widgets/tests/test_tabs.py` (7 passed)
- `python -m ruff check spyder/widgets/tabs.py spyder/widgets/tests/test_tabs.py`
- `git diff --check`

### Affirmation

By submitting this Pull Request or typing my (user)name below, I affirm the [Developer Certificate of Origin](https://developercertificate.org) with respect to all commits and content included in this PR, and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: SimpleZion
