### PR TITLE
PR: Fix typos in comments and docstrings

### DIFF
--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -751,7 +751,7 @@ def test_values_dbg(ipyconsole, qtbot):
     qtbot.waitUntil(lambda: not is_defined('aa'))
     with qtbot.waitSignal(shell.executed):
         shell.execute('aa')
-    # Wait until the message is recieved
+    # Wait until the message is received
     assert "*** NameError: name 'aa' is not defined" in control.toPlainText()
 
 

--- a/spyder/plugins/ipythonconsole/widgets/debugging.py
+++ b/spyder/plugins/ipythonconsole/widgets/debugging.py
@@ -218,7 +218,7 @@ class DebuggingWidget(DebuggingHistoryWidget, SpyderConfigurationAccessor):
         self._waiting_pdb_input = False  # Are we waiting on the user
         # Other state
         self._pdb_prompt = None  # prompt
-        self._pdb_prompt_input = False  # wether pdb waits for input or comm
+        self._pdb_prompt_input = False  # whether pdb waits for input or comm
         self._pdb_last_cmd = ''  # last command sent to pdb
         self._pdb_frame_loc = (None, None)  # fname, lineno
         self._pdb_take_focus = True  # Focus to shell after command execution
@@ -355,7 +355,7 @@ class DebuggingWidget(DebuggingHistoryWidget, SpyderConfigurationAccessor):
             If not hidden, if the stack entry should be printed
 
         add_history: bool
-            If not hidden, wether the line should be added to history
+            If not hidden, whether the line should be added to history
         """
         if not self.is_debugging():
             return

--- a/spyder/plugins/remoteclient/api/modules/file_services.py
+++ b/spyder/plugins/remoteclient/api/modules/file_services.py
@@ -382,7 +382,7 @@ class SpyderRemoteFileServicesAPI(SpyderBaseJupyterAPI):
         )
 
     async def ls(self, path: Path, *, detail: bool = True):
-        # The try/except is neccessary to prevent an error on CIs
+        # The try/except is necessary to prevent an error on CIs
         try:
             async with self.session.get(
                 self.api_url / "ls",

--- a/spyder/utils/clipboard_helper.py
+++ b/spyder/utils/clipboard_helper.py
@@ -40,7 +40,7 @@ class ClipboardHelper:
     def remaining_lines_adjustment(self, preceding_text):
         """
         Get remaining lines adjustments needed to keep multiline
-        pasted text consistant.
+        pasted text consistent.
         """
         if self.get_current_hash() == self.metadata_hash:
             return (


### PR DESCRIPTION
A few small typos noticed while reading the code, all in comments and docstrings (no code changes):

- `spyder/plugins/remoteclient/api/modules/file_services.py`: "neccessary" -> "necessary"
- `spyder/utils/clipboard_helper.py`: "consistant" -> "consistent"
- `spyder/plugins/ipythonconsole/widgets/debugging.py`: "wether" -> "whether" (2 occurrences)
- `spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py`: "recieved" -> "received"
