### PR TITLE
PR: Fix rehighlight for the Pygments highlighter (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -450,7 +450,8 @@ class CodeEditor(
         self.timer_syntax_highlight = QTimer(self)
         self.timer_syntax_highlight.setSingleShot(True)
         self.timer_syntax_highlight.timeout.connect(
-            self.run_pygments_highlighter)
+            self.run_pygments_highlighter
+        )
 
         # Mark occurrences timer
         self.occurrence_highlighting = None
@@ -3987,7 +3988,7 @@ class CodeEditor(
     def run_pygments_highlighter(self):
         """Run pygments highlighter."""
         if isinstance(self.highlighter, sh.PygmentsSH):
-            self.highlighter.make_charlist()
+            self.highlighter.rehighlight()
 
     def get_pattern_at(self, coordinates):
         """

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -1906,7 +1906,8 @@ class CodeEditor(
         self.document().setDefaultTextOption(option)
 
         # Rehighlight to make the spaces less apparent.
-        self.rehighlight()
+        if self.blanks_enabled:
+            self.rehighlight()
 
     def set_scrollpastend_enabled(self, state):
         """

--- a/spyder/utils/syntaxhighlighters.py
+++ b/spyder/utils/syntaxhighlighters.py
@@ -1338,7 +1338,7 @@ class PygmentsSH(BaseSH):
             self._charlist = output
             if error is None and output:
                 self._allow_highlight = True
-                self.rehighlight()
+                BaseSH.rehighlight(self)
             self._allow_highlight = False
 
         text = str(self.document().toPlainText())
@@ -1400,6 +1400,9 @@ class PygmentsSH(BaseSH):
                 self.setFormat(i, 1, fmt)
             self.setCurrentBlockState(end)
             self.highlight_extras(text)
+
+    def rehighlight(self):
+        self.make_charlist()
 
 
 class PythonLoggingLexer(RegexLexer):


### PR DESCRIPTION
## Description of Changes

- That was failing at start up and also when enabling the `Show invisible characters` option, or doing anything else that requires rehighlighting the file.
- Also, only rehighlight file when showing invisible space if the option is enabled. That improves performance a bit at startup.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
