### PR TITLE
Backport PR #26227 on branch 6.x: (PR: Use proper option key to enable/disable only ruff formatter (Completions/Linting))

### DIFF
--- a/spyder/plugins/completion/providers/languageserver/conftabs/formatting.py
+++ b/spyder/plugins/completion/providers/languageserver/conftabs/formatting.py
@@ -9,7 +9,7 @@ Language Server Protocol configuration tabs.
 """
 
 # Third party imports
-from qtpy.QtWidgets import QGroupBox, QLabel, QVBoxLayout
+from qtpy.QtWidgets import QGroupBox, QMessageBox, QLabel, QVBoxLayout
 
 # Local imports
 from spyder.api.preferences import SpyderPreferencesTab
@@ -66,7 +66,7 @@ class FormattingConfigTab(SpyderPreferencesTab):
         code_fmt_label.setWordWrap(True)
 
         # Code formatting providers
-        code_fmt_provider = self.create_combobox(
+        self.code_fmt_provider = self.create_combobox(
             _("Choose the code formatting provider: "),
             (("autopep8", "autopep8"), ("black", "black"), ("ruff", "ruff")),
             "formatting",
@@ -83,7 +83,7 @@ class FormattingConfigTab(SpyderPreferencesTab):
         code_fmt_group = QGroupBox(_("Code formatting"))
         code_fmt_layout = QVBoxLayout()
         code_fmt_layout.addWidget(code_fmt_label)
-        code_fmt_layout.addWidget(code_fmt_provider)
+        code_fmt_layout.addWidget(self.code_fmt_provider)
         code_fmt_layout.addWidget(format_on_save_box)
         code_fmt_group.setLayout(code_fmt_layout)
 
@@ -91,3 +91,27 @@ class FormattingConfigTab(SpyderPreferencesTab):
         code_style_fmt_layout.addWidget(code_fmt_group)
         code_style_fmt_layout.addWidget(line_length_group)
         self.setLayout(code_style_fmt_layout)
+
+    def is_valid(self):
+        # Check ruff being selected as linter when ruff is selected as formatter
+        if (
+            self.code_fmt_provider.combobox.currentText() == "ruff"
+            and not self.get_option("ruff")
+        ):
+            QMessageBox.warning(
+                self,
+                _("Warning"),
+                _(
+                    "Since you selected Ruff as formatter, linting via Ruff "
+                    "will be enabled too"
+                ),
+            )
+            self.set_option("ruff", True)
+            self.set_option("pyflakes", False)
+            self.set_option("pycodestyle", False)
+            self.set_option("flake8", False)
+            self.set_option("no_linting", False)
+            self.set_option("formatting", "ruff")
+            self.load_from_conf()
+
+        return True

--- a/spyder/plugins/completion/providers/languageserver/conftabs/linting.py
+++ b/spyder/plugins/completion/providers/languageserver/conftabs/linting.py
@@ -61,7 +61,7 @@ class LintingConfigTab(SpyderPreferencesTab):
             'flake8',
             button_group=linting_bg
         )
-        ruff_linting_radio = self.create_radiobutton(
+        self.ruff_linting_radio = self.create_radiobutton(
             _("Ruff (Advanced)"),
             'ruff',
             button_group=linting_bg
@@ -76,7 +76,7 @@ class LintingConfigTab(SpyderPreferencesTab):
         linting_select_layout.addSpacing(3 * AppStyle.MarginSize)
         linting_select_layout.addWidget(basic_linting_radio)
         linting_select_layout.addWidget(flake_linting_radio)
-        linting_select_layout.addWidget(ruff_linting_radio)
+        linting_select_layout.addWidget(self.ruff_linting_radio)
         linting_select_layout.addWidget(disable_linting_radio)
         linting_select_group.setLayout(linting_select_layout)
 
@@ -218,7 +218,7 @@ class LintingConfigTab(SpyderPreferencesTab):
         configuration_options_layout.addWidget(pyflakes_conf_options)
         configuration_options_layout.addWidget(not_select_conf_options)
 
-        ruff_linting_radio.radiobutton.toggled.connect(
+        self.ruff_linting_radio.radiobutton.toggled.connect(
             lambda checked: (
                 ruff_grid_widget.setVisible(checked),
                 flake8_grid_widget.setVisible(False),
@@ -281,6 +281,17 @@ class LintingConfigTab(SpyderPreferencesTab):
 
         QMessageBox.critical(self, _("Error"), msg)
 
+    def report_invalid_linter(self):
+        QMessageBox.warning(
+            self,
+            _("Warning"),
+            _(
+                "Since Ruff is selected as formatter, linting can only be "
+                "provided by Ruff and it can't be disabled"
+            ),
+        )
+        self.ruff_linting_radio.radiobutton.setChecked(True)
+
     def is_valid(self):
         # Check regexs
         try:
@@ -306,6 +317,14 @@ class LintingConfigTab(SpyderPreferencesTab):
 
         except re.error:
             self.report_invalid_regex(files=False)
+            return False
+
+        # Check ruff related config
+        if (
+            not self.ruff_linting_radio.radiobutton.isChecked()
+            and self.get_option("formatting") == "ruff"
+        ):
+            self.report_invalid_linter()
             return False
 
         return True

--- a/spyder/plugins/completion/providers/languageserver/provider.py
+++ b/spyder/plugins/completion/providers/languageserver/provider.py
@@ -812,12 +812,16 @@ class LanguageServerProvider(SpyderCompletionProvider):
 
         # Enabling/disabling formatters
         formatters = ['autopep8', 'yapf', 'black', 'ruff']
-        formatter_options = {
-            fmt: {
-                'enabled': fmt == formatter
-            }
-            for fmt in formatters
-        }
+        formatter_options = {}
+        for fmt in formatters:
+            # Needed to handle a specific key for ruff (`formatEnabled`)
+            # See spyder-ide/spyder#26138
+            format_key = 'formatEnabled' if fmt == 'ruff' else 'enabled'
+            formatter_options.update({
+                fmt: {
+                    format_key: fmt == formatter
+                }
+            })
 
         # Setting max line length for formatters.
         # Notes:

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_formatting.py
@@ -27,7 +27,7 @@ from spyder.plugins.editor.widgets.codeeditor.tests.conftest import (
 @pytest.mark.parametrize('newline', ['\r\n', '\r', '\n'])
 def test_document_formatting(formatter, newline, completions_codeeditor,
                              qtbot):
-    """Validate text autoformatting via autopep8, yapf or black."""
+    """Validate text autoformatting via autopep8, yapf, black or ruff."""
     code_editor, completion_plugin = completions_codeeditor
     text, expected = get_formatter_values(formatter, newline)
 
@@ -36,6 +36,12 @@ def test_document_formatting(formatter, newline, completions_codeeditor,
         'completions',
         ('provider_configuration', 'lsp', 'values', 'formatting'),
         formatter
+    )
+    # Enable `ruff` plugin/linting in case the formatter being tested is `ruff`
+    CONF.set(
+        'completions',
+        ('provider_configuration', 'lsp', 'values', 'ruff'),
+        formatter == 'ruff'
     )
     completion_plugin.after_configuration_update([])
     qtbot.wait(2000)
@@ -152,6 +158,12 @@ def test_max_line_length(formatter, completions_codeeditor, qtbot):
         ('provider_configuration', 'lsp', 'values',
          'flake8/max_line_length'),
         max_line_length
+    )
+    # Enable `ruff` plugin/linting in case the formatter being tested is `ruff`
+    CONF.set(
+        'completions',
+        ('provider_configuration', 'lsp', 'values', 'ruff'),
+        formatter == 'ruff'
     )
     completion_plugin.after_configuration_update([])
     qtbot.wait(2000)

--- a/spyder/plugins/editor/widgets/tests/test_formatting.py
+++ b/spyder/plugins/editor/widgets/tests/test_formatting.py
@@ -42,6 +42,12 @@ def test_closing_document_formatting(
         ('provider_configuration', 'lsp', 'values', 'formatting'),
         formatter
     )
+    # Enable `ruff` plugin/linting in case the formatter being tested is `ruff`
+    CONF.set(
+        'completions',
+        ('provider_configuration', 'lsp', 'values', 'ruff'),
+        formatter == 'ruff'
+    )
 
     completion_plugin.after_configuration_update([])
     qtbot.wait(2000)
@@ -89,6 +95,12 @@ def test_formatting_on_save(completions_editor, formatter, qtbot):
         'completions',
         ('provider_configuration', 'lsp', 'values', 'formatting'),
         formatter
+    )
+    # Enable `ruff` plugin/linting in case the formatter being tested is `ruff`
+    CONF.set(
+        'completions',
+        ('provider_configuration', 'lsp', 'values', 'ruff'),
+        formatter == 'ruff'
     )
 
     completion_plugin.after_configuration_update([])


### PR DESCRIPTION
Manual backport of PR #26227.