### PR TITLE
PR: Setup keychain before creating installer to fix signing (Installers)

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -269,6 +269,20 @@ jobs:
           conda index $CONDA_BLD_PATH
           conda search -c local --override-channels || true
 
+      - name: Create macOS Keychain
+        if: runner.os == 'macOS' && env.NOTARIZE == 'true'
+        run: |
+          _codesign=$(which codesign)
+          if [[ $_codesign =~ ${CONDA_PREFIX}.* ]]; then
+              # Find correct codesign
+              echo "Moving $_codesign..."
+              mv $_codesign ${_codesign}.bak
+          fi
+
+          ./certkeychain.sh "${MACOS_CERTIFICATE_PWD}" "${MACOS_CERTIFICATE}" "${MACOS_INSTALLER_CERTIFICATE}"
+          CERT_ID=$(security find-identity -p codesigning -v | pcre2grep -o1 "\(([0-9A-Z]+)\)")
+          echo "CERT_ID=$CERT_ID" >> $GITHUB_ENV
+
       - name: Build Package Installer
         run: |
           python build_installers.py
@@ -335,20 +349,6 @@ jobs:
           )
 
           EXIT /B %error_occured%
-
-      - name: Create macOS Keychain
-        if: runner.os == 'macOS' && env.NOTARIZE == 'true'
-        run: |
-          _codesign=$(which codesign)
-          if [[ $_codesign =~ ${CONDA_PREFIX}.* ]]; then
-              # Find correct codesign
-              echo "Moving $_codesign..."
-              mv $_codesign ${_codesign}.bak
-          fi
-
-          ./certkeychain.sh "${MACOS_CERTIFICATE_PWD}" "${MACOS_CERTIFICATE}" "${MACOS_INSTALLER_CERTIFICATE}"
-          CERT_ID=$(security find-identity -p codesigning -v | pcre2grep -o1 "\(([0-9A-Z]+)\)")
-          echo "CERT_ID=$CERT_ID" >> $GITHUB_ENV
 
       - name: Notarize macOS Installer
         if: runner.os == 'macOS' && env.NOTARIZE == 'true'


### PR DESCRIPTION
Fix regression from #26244.
The create keychain step had been moved to immediately prior to notarizing step.
This is moved back to immediately prior to building the installer so that constructor can properly sign the installer.