### PR TITLE
PR: Enable Chromium developer tools for web widgets

### DIFF
--- a/spyder/plugins/application/widgets/appeal.py
+++ b/spyder/plugins/application/widgets/appeal.py
@@ -83,7 +83,7 @@ class InAppAppealDialog(SpyderFontsMixin, QDialog):
 
         # Create webview to render the appeal message and changelog
         self._webview = (
-            WebView(self, handle_links=True)
+            WebView(self, handle_links=True, disable_zoom_with_mouse=True)
             if not DEV
             # We want to have access to Chromium dev tools in development, so
             # we need to use this widget instead.

--- a/spyder/plugins/application/widgets/appeal.py
+++ b/spyder/plugins/application/widgets/appeal.py
@@ -13,11 +13,11 @@ from string import Template
 # Third-party imports
 from markdown_it import MarkdownIt
 from qtpy.QtCore import Qt, QUrl
-from qtpy.QtWidgets import QDialog, QVBoxLayout
+from qtpy.QtWidgets import QDialog, QHBoxLayout
 
 # Local imports
 from spyder.api.fonts import SpyderFontType, SpyderFontsMixin
-from spyder.config.base import get_module_source_path
+from spyder.config.base import DEV, get_module_source_path
 from spyder.utils.icon_manager import ima
 from spyder.utils.qthelpers import start_file
 from spyder.utils.stylesheet import MAC, WIN
@@ -39,15 +39,20 @@ class InAppAppealDialog(SpyderFontsMixin, QDialog):
         super().__init__(parent)
 
         # Leave this import here to make Spyder work without WebEngine.
-        from spyder.widgets.browser import WebView
+        from spyder.widgets.browser import FrameWebView, WebView
 
         # Attributes
         self.setWindowFlags(
             self.windowFlags() & ~Qt.WindowContextHelpButtonHint
         )
-        self.setFixedWidth(self.WIDTH)
-        self.setFixedHeight(self.HEIGHT)
         self.setWindowIcon(ima.icon("inapp_appeal"))
+
+        if DEV:
+            self.setMinimumWidth(self.WIDTH)
+            self.setMinimumHeight(self.HEIGHT)
+        else:
+            self.setFixedWidth(self.WIDTH)
+            self.setFixedHeight(self.HEIGHT)
 
         # Paths to content to be loaded
         appeal_page_dir = osp.join(
@@ -77,7 +82,17 @@ class InAppAppealDialog(SpyderFontsMixin, QDialog):
             self._appeal_page = f.read()
 
         # Create webview to render the appeal message and changelog
-        self._webview = WebView(self, handle_links=True)
+        self._webview = (
+            WebView(self, handle_links=True)
+            if not DEV
+            # We want to have access to Chromium dev tools in development, so
+            # we need to use this widget instead.
+            else FrameWebView(self, handle_links=True, show_border=False)
+        )
+
+        # This is necessary to create the widget's context menu
+        if DEV:
+            self._webview.setup()
 
         # Set font used in the view
         app_font = self.get_font(SpyderFontType.Interface)
@@ -87,16 +102,20 @@ class InAppAppealDialog(SpyderFontsMixin, QDialog):
         self._webview.page().linkClicked.connect(self._handle_link_clicks)
 
         # Layout
-        layout = QVBoxLayout()
+        layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self._webview)
         self.setLayout(layout)
 
+    # ---- Private API
+    # -------------------------------------------------------------------------
     def _handle_link_clicks(self, url):
         url = str(url.toString())
         if url.startswith('http'):
             start_file(url)
 
+    # ---- Public API
+    # -------------------------------------------------------------------------
     def set_message(self, appeal: bool):
         template = Template(self._appeal_page)
 

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -173,7 +173,7 @@ class WebView(SpyderWidgetMixin, QWebEngineView):
         original_inspect_action = self.pageAction(
             QWebEnginePage.WebAction.InspectElement
         )
-        inspect_action = self.create_action(
+        self.inspect_action = self.create_action(
             name=WebViewActions.Inspect,
             text=_("Inspect"),
             triggered=original_inspect_action.trigger,
@@ -224,18 +224,19 @@ class WebView(SpyderWidgetMixin, QWebEngineView):
             )
 
         self.add_item_to_menu(
-            inspect_action,
+            self.inspect_action,
             menu=menu,
             section=WebViewMenuSections.Extras,
         )
 
-        if DEV and not WEBENGINE:
-            settings = self.page().settings()
-            settings.setAttribute(QWebEngineSettings.DeveloperExtrasEnabled,
-                                  True)
-            inspect_action.setVisible(True)
-        else:
-            inspect_action.setVisible(False)
+        if DEV:
+            self.inspect_action.setVisible(True)
+
+            if not WEBENGINE:
+                settings = self.page().settings()
+                settings.setAttribute(
+                    QWebEngineSettings.DeveloperExtrasEnabled, True
+                )
 
     def find_text(self, text, changed=True, forward=True, case=False,
                   word=False, regexp=False):
@@ -572,10 +573,14 @@ class FrameWebView(QFrame):
             handle_links=handle_links,
             class_parent=parent
         )
+        self._devtools_view = None
+
         self._webview.sig_focus_in_event.connect(
-            lambda: self._apply_stylesheet(focus=True))
+            lambda: self._apply_stylesheet(focus=True)
+        )
         self._webview.sig_focus_out_event.connect(
-            lambda: self._apply_stylesheet(focus=False))
+            lambda: self._apply_stylesheet(focus=False)
+        )
 
         layout = QHBoxLayout()
         layout.addWidget(self._webview)
@@ -590,7 +595,7 @@ class FrameWebView(QFrame):
                 self._webview.linkClicked.connect(self.linkClicked)
 
     def __getattr__(self, name):
-        if name == '_webview':
+        if name in ["_webview", "setup"]:
             return super().__getattr__(name)
 
         if hasattr(self._webview, name):
@@ -601,6 +606,10 @@ class FrameWebView(QFrame):
     @property
     def web_widget(self):
         return self._webview
+
+    def setup(self):
+        self._webview.setup()
+        self._webview.inspect_action.triggered.connect(self._show_devtools)
 
     def _apply_stylesheet(self, focus=False):
         """Apply stylesheet according to the current focus."""
@@ -618,6 +627,30 @@ class FrameWebView(QFrame):
         )
 
         self.setStyleSheet(css.toString())
+
+    def _show_devtools(self):
+        """
+        Show Chromium developer tools.
+
+        This only works in development mode, i.e. when starting Spyder from
+        bootstrap.py
+        """
+        if WEBENGINE and self._devtools_view is None:
+            self._devtools_view = QWebEngineView(self)
+            self._webview.page().setDevToolsPage(self._devtools_view.page())
+            self._devtools_view.setMinimumWidth(450)
+            self._devtools_view.page().windowCloseRequested.connect(
+                self._hide_devtools
+            )
+            self.layout().addWidget(self._devtools_view)
+            self._devtools_view.show()
+
+    def _hide_devtools(self):
+        """Show Chromium developer tools."""
+        if self._devtools_view is not None:
+            self._devtools_view.hide()
+            self._devtools_view.deleteLater()
+            self._devtools_view = None
 
 
 def test():

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -95,11 +95,18 @@ class WebView(SpyderWidgetMixin, QWebEngineView):
     This signal is emitted when the widget loses focus.
     """
 
-    def __init__(self, parent, handle_links=True, class_parent=None):
+    def __init__(
+        self,
+        parent,
+        handle_links=True,
+        class_parent=None,
+        disable_zoom_with_mouse=False,
+    ):
         class_parent = parent if class_parent is None else class_parent
         QWebEngineView.__init__(self, parent)
         SpyderWidgetMixin.__init__(self, class_parent=class_parent)
 
+        self._disable_zoom_with_mouse = disable_zoom_with_mouse
         self.zoom_factor = 1.
         self.context_menu = None
 
@@ -415,7 +422,10 @@ class WebView(SpyderWidgetMixin, QWebEngineView):
         if (
             event.type() == QEvent.Wheel
             and event.modifiers() & Qt.ControlModifier
-            and self.get_conf("disable_zoom_mouse", section="main")
+            and (
+                self.get_conf("disable_zoom_mouse", section="main")
+                or self._disable_zoom_with_mouse
+            )
         ):
             return True
 
@@ -565,13 +575,20 @@ class FrameWebView(QFrame):
     """
     linkClicked = Signal(QUrl)
 
-    def __init__(self, parent, handle_links=True, show_border=True):
+    def __init__(
+        self,
+        parent,
+        handle_links=True,
+        show_border=True,
+        disable_zoom_with_mouse=False,
+    ):
         super().__init__(parent)
 
         self._webview = WebView(
             self,
             handle_links=handle_links,
-            class_parent=parent
+            class_parent=parent,
+            disable_zoom_with_mouse=disable_zoom_with_mouse,
         )
         self._devtools_view = None
 

--- a/spyder/widgets/browser.py
+++ b/spyder/widgets/browser.py
@@ -565,7 +565,7 @@ class FrameWebView(QFrame):
     """
     linkClicked = Signal(QUrl)
 
-    def __init__(self, parent, handle_links=True):
+    def __init__(self, parent, handle_links=True, show_border=True):
         super().__init__(parent)
 
         self._webview = WebView(
@@ -574,13 +574,6 @@ class FrameWebView(QFrame):
             class_parent=parent
         )
         self._devtools_view = None
-
-        self._webview.sig_focus_in_event.connect(
-            lambda: self._apply_stylesheet(focus=True)
-        )
-        self._webview.sig_focus_out_event.connect(
-            lambda: self._apply_stylesheet(focus=False)
-        )
 
         layout = QHBoxLayout()
         layout.addWidget(self._webview)
@@ -593,6 +586,14 @@ class FrameWebView(QFrame):
                 self._webview.page().linkClicked.connect(self.linkClicked)
             else:
                 self._webview.linkClicked.connect(self.linkClicked)
+
+        if show_border:
+            self._webview.sig_focus_in_event.connect(
+                lambda: self._apply_stylesheet(focus=True)
+            )
+            self._webview.sig_focus_out_event.connect(
+                lambda: self._apply_stylesheet(focus=False)
+            )
 
     def __getattr__(self, name):
         if name in ["_webview", "setup"]:


### PR DESCRIPTION
## Description of Changes

- The tools were only available for the old WebKit widgets.
- As before, the menu entry to access them is only enabled in `DEV` mode (i.e. when Spyder is started with `bootstrap.py`).
- Also, disable zoom with mouse wheel for the in-app appeal message.

### Visual changes

<img width="981" height="508" alt="image" src="https://github.com/user-attachments/assets/340b659c-1cf3-40e6-a372-88ae9a22e58b" />

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

<!--- Thanks for your help making Spyder better for everyone! --->
