### PR TITLE
PR: Fix issue where assets could not be uploaded (Installers)

### DIFF
--- a/.github/workflows/installers-conda.yml
+++ b/.github/workflows/installers-conda.yml
@@ -53,10 +53,6 @@ concurrency:
   group: installers-conda-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  id-token: write
-  contents: read
-
 name: Weekly conda-based installers
 
 env:


### PR DESCRIPTION
Removed `permissions` declaration in the installer workflow (introduced in #26244).
This is not necessary, and resulted in the following error when attempting to upload release assets.
```
Error: unexpected status code: 403
{"message":"Resource not accessible by integration","request_id":"BC13:94F09:4A820D:5CE554:6A864871","documentation_url":"https://docs.github.com/rest"}
```

Confirmed correct behavior by creating dummy release on my fork.
https://github.com/mrclary/spyder/actions/runs/32332559562