### PR TITLE
PR: Improve option to change close tabs button position (Preferences)

### DIFF
--- a/spyder/plugins/application/confpage.py
+++ b/spyder/plugins/application/confpage.py
@@ -135,10 +135,14 @@ class ApplicationConfigPage(PluginConfigPage):
             (_("Right"), "right")
         ]
         tab_close_combo = self.create_combobox(
-            _("Tabs close button position:"),
+            _("Close button position for tabs:"),
             tab_close_choices,
             "tab_close_position",
-            restart=True
+            tip=(
+                "Decide where you want to locate the button to close tabs "
+                "(e.g. files in the Editor)"
+            ),
+            restart=True,
         )
 
         margin_box = newcb(_("Custom margin for panes:"),
@@ -167,19 +171,23 @@ class ApplicationConfigPage(PluginConfigPage):
         glayout = QGridLayout()
         glayout.addWidget(tab_close_combo.label, 0, 0)
         glayout.addWidget(tab_close_combo.combobox, 0, 1)
+        glayout.addWidget(tab_close_combo.help_label, 0, 2)
         glayout.addWidget(margin_box, 1, 0)
         glayout.addWidget(margin_spin.spinbox, 1, 1)
         glayout.addWidget(margin_spin.slabel, 1, 2)
         glayout.addWidget(cursor_box, 2, 0)
         glayout.addWidget(cursor_spin.spinbox, 2, 1)
         glayout.addWidget(cursor_spin.slabel, 2, 2)
-        glayout.setColumnStretch(2, 100)
+
+        hg_layout = QHBoxLayout()
+        hg_layout.addLayout(glayout)
+        hg_layout.addStretch()
 
         # Layout interface
         interface_layout = QVBoxLayout()
         interface_layout.addWidget(empty_messages_box)
         interface_layout.addWidget(verttabs_box)
-        interface_layout.addLayout(glayout)
+        interface_layout.addLayout(hg_layout)
         interface_group.setLayout(interface_layout)
 
         if sys.platform == "darwin" and not is_conda_based_app():

--- a/spyder/utils/stylesheet.py
+++ b/spyder/utils/stylesheet.py
@@ -535,7 +535,7 @@ class PanesTabBarStyleSheet(
         else:
             # Remove spurious pixel to the left
             css.QTabBar.setValues(
-                marginLeft='-3px' if WIN else '-1px'
+                marginLeft='-3px' if WIN else ("0px" if MAC else '-4px')
             )
 
         # Fix minor visual glitch when hovering tabs


### PR DESCRIPTION
## Description of Changes

Also, add tip widget to that option and remove spurious blank pixel to the left of QTabBar's that was reintroduced after PR #26200, which added that option.

### Visual changes

Before

<img width="347" height="212" alt="image" src="https://github.com/user-attachments/assets/400e227c-fdcd-4808-86eb-83d184015629" />

After

<img width="614" height="199" alt="image" src="https://github.com/user-attachments/assets/4bd0f0e9-52d1-466c-ae1e-629f7be2d66c" />

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
