### PR TITLE
Backport PR #26199 on branch 6.x (PR: Increase threshold to warn about large arrays/dataframes and fix error when showing its message (Variable Explorer))

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/collectionsdelegate.py
@@ -8,6 +8,7 @@
 # -----------------------------------------------------------------------------
 
 # Standard library imports
+import ast
 import copy
 import datetime
 import functools
@@ -59,7 +60,7 @@ from spyder.utils.icon_manager import ima
 
 
 LARGE_COLLECTION = 1e5
-LARGE_ARRAY = 5e6
+LARGE_ARRAY = 5e7
 SELECT_ROW_BUTTON_SIZE = 22
 
 # The maximum length of the text in a QLineEdit is 32_767, so do not allow
@@ -169,7 +170,7 @@ class CollectionsDelegate(QItemDelegate, SpyderFontsMixin):
             # the ones we're looking for above
             try:
                 # From https://blender.stackexchange.com/a/131849
-                shape = [int(s) for s in val_size.strip("()").split(",") if s]
+                shape = ast.literal_eval(val_size)
                 size = functools.reduce(operator.mul, shape)
                 if size > LARGE_ARRAY:
                     return True

--- a/spyder/plugins/variableexplorer/widgets/tests/test_collectionsdelegate.py
+++ b/spyder/plugins/variableexplorer/widgets/tests/test_collectionsdelegate.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+#
+
+"""Tests for collectionsdelegate.py."""
+
+# Third-party imports
+import numpy as np
+import pandas as pd
+from spyder_kernels.utils.nsview import get_size
+
+# Local imports
+from spyder.plugins.variableexplorer.widgets.collectionsdelegate import (
+    CollectionsDelegate,
+)
+from spyder.plugins.variableexplorer.widgets import collectionsdelegate
+
+
+class FakeCell:
+    def __init__(self, value):
+        self.value = value
+
+    def data(self):
+        return self.value
+
+
+class FakeQModelIndex:
+    def __init__(self, obj):
+        self.obj = obj
+
+    def row(self):
+        return 0
+
+    def sibling(self, row, column):
+        if column == 1:
+            return FakeCell("DataFrame")
+        elif column == 2:
+            return FakeCell(str(get_size(self.obj)))
+
+
+def test_show_warning_dataframe(monkeypatch):
+    """Test warning for large DataFrames."""
+    monkeypatch.setattr(collectionsdelegate, "LARGE_ARRAY", 10)
+
+    df = pd.DataFrame(np.random.rand(2, 6))
+    delegate = CollectionsDelegate()
+    assert delegate.show_warning(FakeQModelIndex(df))


### PR DESCRIPTION
Manual backport of PR #26199.