### PR TITLE
PR: Fix error when reading in-app appeal page from disk (Application)

### DIFF
--- a/spyder/plugins/application/container.py
+++ b/spyder/plugins/application/container.py
@@ -1028,9 +1028,11 @@ class ApplicationContainer(PluginMainContainer):
 
         try:
             self._appeal_dialog = InAppAppealDialog(self)
-        except QtModuleNotInstalledError:
-            # QtWebEngineWidgets is optional.
-            # See spyder-ide/spyder#24905 for the details.
+        except (QtModuleNotInstalledError, UnicodeDecodeError):
+            # * QtWebEngineWidgets is optional. See spyder-ide/spyder#24905 for
+            #   the details.
+            # * We can fail to read the appeal page from disk, which makes
+            #   Spyder crash at startup. Fixes spyder-ide/spyder#26284
             self._appeal_dialog = FakeInAppAppealDialog
 
     def _show_dialog(self, show_appeal: bool):


### PR DESCRIPTION
## Description of Changes

In some systems we can't read the page due to an `UnicodeDecodeError`, which makes Spyder crash at startup.

### Issue(s) Resolved

Fixes #26284.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
