### PR TITLE
PR: Simplify `range` calls by removing redundant start arguments

### DIFF
--- a/spyder/plugins/completion/tests/test_configdialog.py
+++ b/spyder/plugins/completion/tests/test_configdialog.py
@@ -39,7 +39,7 @@ def test_config_dialog(config_dialog):
     configpage = config_dialog.get_page()
     assert configpage
     tabs = configpage.tabs
-    for i in range(0, tabs.count()):
+    for i in range(tabs.count()):
         tab_text = tabs.tabText(i)
         assert tab_text in expected_titles
     configpage.save_to_conf()

--- a/spyder/plugins/editor/widgets/codeeditor/tests/test_introspection.py
+++ b/spyder/plugins/editor/widgets/codeeditor/tests/test_introspection.py
@@ -754,7 +754,7 @@ def test_code_snippets(completions_codeeditor, qtbot):
     qtbot.wait(5000)
 
     # Snippets are disabled when there are no more left
-    for _ in range(0, 3):
+    for _ in range(3):
         qtbot.keyPress(code_editor, Qt.Key_Tab)
     assert not snippets.is_snippet_active
 
@@ -803,7 +803,7 @@ def test_code_snippets(completions_codeeditor, qtbot):
     if len(sig.args[0]) > 1:
         qtbot.keyPress(completion, Qt.Key_Tab)
 
-    for _ in range(0, 2):
+    for _ in range(2):
         qtbot.keyPress(code_editor, Qt.Key_Tab)
     assert snippets.active_snippet == 3
 
@@ -849,7 +849,7 @@ def test_code_snippets(completions_codeeditor, qtbot):
         code_editor.undo()
     assert len(snippets.snippets_map) == 4
 
-    for _ in range(0, 2):
+    for _ in range(2):
         qtbot.keyPress(code_editor, Qt.Key_Tab)
 
     cursor = code_editor.textCursor()
@@ -861,7 +861,7 @@ def test_code_snippets(completions_codeeditor, qtbot):
         code_editor.redo()
     assert len(snippets.snippets_map) == 3
 
-    for _ in range(0, 3):
+    for _ in range(3):
         qtbot.keyPress(code_editor, Qt.Key_Tab)
     qtbot.keyPress(code_editor, Qt.Key_Right)
 
@@ -881,7 +881,7 @@ def test_code_snippets(completions_codeeditor, qtbot):
     qtbot.keyPress(code_editor, Qt.Key_Right, delay=300)
     qtbot.keyPress(code_editor, Qt.Key_Backspace)
 
-    for _ in range(0, 3):
+    for _ in range(3):
         qtbot.keyPress(code_editor, Qt.Key_Tab)
 
     cursor = code_editor.textCursor()

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -1773,20 +1773,20 @@ class EditorStack(SpyderWidgetMixin, QWidget):
     def on_close_all_but_this(self):
         """Close all files but the current one"""
         self.close_all_right()
-        for __ in range(0, self.get_stack_count() - 1):
+        for __ in range(self.get_stack_count() - 1):
             self.close_file(0)
 
     def sort_file_tabs_alphabetically(self):
         """Sort open tabs alphabetically."""
         while self.sorted() is False:
-            for i in range(0, self.tabs.tabBar().count()):
+            for i in range(self.tabs.tabBar().count()):
                 if (self.tabs.tabBar().tabText(i) >
                         self.tabs.tabBar().tabText(i + 1)):
                     self.tabs.tabBar().moveTab(i, i + 1)
 
     def sorted(self):
         """Utility function for sort_file_tabs_alphabetically()."""
-        for i in range(0, self.tabs.tabBar().count() - 1):
+        for i in range(self.tabs.tabBar().count() - 1):
             if (self.tabs.tabBar().tabText(i) >
                     self.tabs.tabBar().tabText(i + 1)):
                 return False

--- a/spyder/plugins/layout/api.py
+++ b/spyder/plugins/layout/api.py
@@ -429,9 +429,9 @@ class BaseGridLayoutType:
 
         # Find dock splits in the horizontal direction
         direction = Qt.Horizontal
-        for row in range(0, self._rows + 1):
+        for row in range(self._rows + 1):
             dock = None
-            for col in range(0, self._cols + 1):
+            for col in range(self._cols + 1):
                 key = (row, col)
                 if key in docks:
                     if dock is None:
@@ -450,9 +450,9 @@ class BaseGridLayoutType:
 
         # Find dock splits in the vertical direction
         direction = Qt.Vertical
-        for col in range(0, self._cols + 1):
+        for col in range(self._cols + 1):
             dock = None
-            for row in range(0, self._rows + 1):
+            for row in range(self._rows + 1):
                 key = (row, col)
                 if key in docks:
                     if dock is None:

--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -2599,7 +2599,7 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
         if self.resizeToHeader:
             self.table_header.resizeColumnsToContents()
         column_count = self.table_header.model().columnCount()
-        for index in range(0, column_count):
+        for index in range(column_count):
             if index < column_count:
                 column_width = self.dataTable.columnWidth(index)
                 header_width = self.table_header.columnWidth(index)
@@ -2617,7 +2617,7 @@ class DataFrameEditor(BaseDialog, SpyderWidgetMixin):
 
 
         column_count = self.table_level.model().columnCount()
-        for index in range(0, column_count):
+        for index in range(column_count):
             if index < column_count:
                 column_width = self.table_index.columnWidth(index)
                 header_width = self.table_level.columnWidth(index)

--- a/spyder/widgets/tests/test_collectioneditor.py
+++ b/spyder/widgets/tests/test_collectioneditor.py
@@ -395,7 +395,7 @@ def test_sort_numpy_numeric_collectionsmodel():
     # Sort by index
     cm.sort(0)
     assert data_table(cm, 10, 4) == [
-        list(range(0, 10)),
+        list(range(10)),
         ["float64"] * 10,
         [1] * 10,
         [
@@ -442,7 +442,7 @@ def test_sort_float_collectionsmodel():
     assert cm.rowCount() == 10
     assert cm.columnCount() == 4
     cm.sort(0)  # sort by index
-    assert data_table(cm, 10, 4) == [list(range(0, 10)),
+    assert data_table(cm, 10, 4) == [list(range(10)),
                                      [u'float']*10,
                                      [1]*10,
                                      ['1e+16', '10.0', '1.0', '0.1',

--- a/spyder/widgets/waitingspinner.py
+++ b/spyder/widgets/waitingspinner.py
@@ -88,7 +88,7 @@ class QWaitingSpinner(QWidget):
             self._currentCounter = 0
 
         painter.setPen(Qt.NoPen)
-        for i in range(0, self._numberOfLines):
+        for i in range(self._numberOfLines):
             painter.save()
             painter.translate(self._innerRadius + self._lineLength, self._innerRadius + self._lineLength)
             rotateAngle = float(360 * i) / float(self._numberOfLines)


### PR DESCRIPTION
Simplify `range()` calls by removing the redundant 0 start argument.
