### PR TITLE
PR: Skip `test_single_instance_and_edit_magic` with IPython 9.17.0 and fix Windows/Conda CIs

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -85,7 +85,7 @@ fi
 python -bb -X dev install_dev_repos.py --not-editable --no-install spyder spyder-remote-services
 
 # Install Spyder to test it as if it was properly installed.
-python -bb -X dev -m build
+python -bb -X dev setup.py bdist_wheel
 python -bb -X dev -m pip install --no-deps dist/spyder*.whl
 
 if [ "$SPYDER_TEST_REMOTE_CLIENT" = "true" ]; then

--- a/spyder/app/tests/test_mainwindow.py
+++ b/spyder/app/tests/test_mainwindow.py
@@ -108,7 +108,12 @@ from spyder.widgets.dock import DockTitleBar
 @pytest.mark.single_instance
 @pytest.mark.known_leak
 @pytest.mark.skipif(
-    not running_in_ci(), reason="It's not meant to be run outside of CIs")
+    not running_in_ci(), reason="It's not meant to be run outside of CIs"
+)
+@pytest.mark.skipif(
+    parse(ipy_release.version) == parse('9.17.0'),
+    reason="Fails with IPython 9.17.0"
+)
 def test_single_instance_and_edit_magic(main_window, qtbot, tmpdir):
     """Test single instance mode and %edit magic."""
     editorstack = main_window.editor.get_current_editorstack()


### PR DESCRIPTION
## Description of Changes

- That's because the %edit magic is broken in that version.
- Also, fix installing Spyder on our Windows/conda CI slots due to a new release of `build`.

### Issue(s) Resolved

Fixes #

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12

<!--- Thanks for your help making Spyder better for everyone! --->
