### PR TITLE
PR: Remove unreachable second `BackgroundRole` branch in dataframe editor (Variable Explorer)

### DIFF
--- a/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
+++ b/spyder/plugins/variableexplorer/widgets/dataframeeditor.py
@@ -1869,8 +1869,6 @@ class DataFrameLevelModel(SpyderFontsMixin, QAbstractTableModel):
             return label
         elif role == Qt.BackgroundRole:
             return self._background
-        elif role == Qt.BackgroundRole:
-            return self._palette.window()
         return None
 
 


### PR DESCRIPTION
## Description of Changes

`DataFrameLevelModel.data` tests `role == Qt.BackgroundRole` in two consecutive `elif` branches, so the second one is unreachable and `self._palette.window()` is never returned.

It could not work anyway. `_palette` is not assigned anywhere in the file, the constructor sets only `self._background`, and that name appears exactly once, on the dead line. Reaching it would raise an AttributeError rather than return a colour, which is what makes this a leftover from the switch to `SpyderPalette.COLOR_BACKGROUND_2` rather than a branch someone still wants.

Removed the dead branch. Nothing renders differently, the header background already comes from `self._background`.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot or animation (if affecting the UI)

No new functions, and nothing observable changes, so there is nothing to test or show.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: Dmitry Rantovov
