### PR TITLE
PR: Disable `QVariant` auto-conversion to prevent `inputMethodQuery` `TypeError` (Editor/PyQt6)

### DIFF
--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -24,10 +24,6 @@ from tokenize import generate_tokens, TokenError
 # Third party imports
 from packaging.version import parse
 from qtpy import PYQT6, QT_VERSION
-if PYQT6:
-    from qtpy import sip
-    from qtpy.QtCore import QVariant
-
 from qtpy.QtCore import QPoint, QRegularExpression, Qt, QUrl
 from qtpy.QtGui import (
     QDesktopServices, QFontMetrics, QTextCursor, QTextDocument)
@@ -42,6 +38,10 @@ from spyder.utils.misc import get_error_match
 from spyder.utils.palette import SpyderPalette
 from spyder.widgets.arraybuilder import ArrayBuilderDialog
 
+
+if PYQT6:
+    from qtpy import sip
+    from qtpy.QtCore import QVariant
 
 # ---- Constants
 # -----------------------------------------------------------------------------

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -23,8 +23,8 @@ from tokenize import generate_tokens, TokenError
 
 # Third party imports
 from packaging.version import parse
-from qtpy import QT_VERSION, PYQT6
-from qtpy.QtCore import QPoint, QRegularExpression, Qt, QUrl
+from qtpy import PYQT6, QT_VERSION, sip
+from qtpy.QtCore import QPoint, QRegularExpression, Qt, QUrl, QVariant
 from qtpy.QtGui import (
     QDesktopServices, QFontMetrics, QTextCursor, QTextDocument)
 from qtpy.QtWidgets import QApplication, QPlainTextEdit, QTextEdit
@@ -1583,9 +1583,6 @@ class BaseEditMixin(object):
             # See spyder-ide/spyder#26309
             # Based on https://github.com/saga-soft/novelWriter/issues/2622#issuecomment-3692890124
             if PYQT6:
-                from qtpy import sip
-                from qtpy.QtCore import QVariant
-
                 autoconversion = sip.enableautoconversion(QVariant, False)
                 response = QPlainTextEdit.inputMethodQuery(self, query)
                 sip.enableautoconversion(QVariant, autoconversion)
@@ -1596,9 +1593,6 @@ class BaseEditMixin(object):
             # See spyder-ide/spyder#26309
             # Based on https://github.com/saga-soft/novelWriter/issues/2622#issuecomment-3692890124
             if PYQT6:
-                from qtpy import sip
-                from qtpy.QtCore import QVariant
-
                 autoconversion = sip.enableautoconversion(QVariant, False)
                 response = QTextEdit.inputMethodQuery(self, query)
                 sip.enableautoconversion(QVariant, autoconversion)

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -23,7 +23,7 @@ from tokenize import generate_tokens, TokenError
 
 # Third party imports
 from packaging.version import parse
-from qtpy import QT_VERSION
+from qtpy import QT_VERSION, PYQT6
 from qtpy.QtCore import QPoint, QRegularExpression, Qt, QUrl
 from qtpy.QtGui import (
     QDesktopServices, QFontMetrics, QTextCursor, QTextDocument)
@@ -1579,9 +1579,31 @@ class BaseEditMixin(object):
             )
             response = cursor_rect
         elif isinstance(self, QPlainTextEdit):
-            response = QPlainTextEdit.inputMethodQuery(self, query)
+            # Need to handle `QVariant` auto-conversion to prevent `TypeError`
+            # See spyder-ide/spyder#26309
+            # Based on https://github.com/saga-soft/novelWriter/issues/2622#issuecomment-3692890124
+            if PYQT6:
+                from qtpy import sip
+                from qtpy.QtCore import QVariant
+
+                autoconversion = sip.enableautoconversion(QVariant, False)
+                response = QPlainTextEdit.inputMethodQuery(self, query)
+                sip.enableautoconversion(QVariant, autoconversion)
+            else:
+                response = QPlainTextEdit.inputMethodQuery(self, query)
         elif isinstance(self, QTextEdit):
-            response = QTextEdit.inputMethodQuery(self, query)
+            # Need to handle `QVariant` auto-conversion to prevent `TypeError`
+            # See spyder-ide/spyder#26309
+            # Based on https://github.com/saga-soft/novelWriter/issues/2622#issuecomment-3692890124
+            if PYQT6:
+                from qtpy import sip
+                from qtpy.QtCore import QVariant
+
+                autoconversion = sip.enableautoconversion(QVariant, False)
+                response = QTextEdit.inputMethodQuery(self, query)
+                sip.enableautoconversion(QVariant, autoconversion)
+            else:
+                response = QTextEdit.inputMethodQuery(self, query)
 
         self.setCursorWidth(old_width)  # restore original cursor width
         return response

--- a/spyder/widgets/mixins.py
+++ b/spyder/widgets/mixins.py
@@ -23,8 +23,12 @@ from tokenize import generate_tokens, TokenError
 
 # Third party imports
 from packaging.version import parse
-from qtpy import PYQT6, QT_VERSION, sip
-from qtpy.QtCore import QPoint, QRegularExpression, Qt, QUrl, QVariant
+from qtpy import PYQT6, QT_VERSION
+if PYQT6:
+    from qtpy import sip
+    from qtpy.QtCore import QVariant
+
+from qtpy.QtCore import QPoint, QRegularExpression, Qt, QUrl
 from qtpy.QtGui import (
     QDesktopServices, QFontMetrics, QTextCursor, QTextDocument)
 from qtpy.QtWidgets import QApplication, QPlainTextEdit, QTextEdit


### PR DESCRIPTION

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes

<!--- Explain what you've done and why --->


Seems like changes done over PyQt6 cause the `TypeError` exception. Here a workarond disabling/enabling `QVariant` auto-conversion via SIP is done. See https://www.riverbankcomputing.com/pipermail/pyqt/2025-December/046413.html

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #26309


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: dalthviz

<!--- Thanks for your help making Spyder better for everyone! --->
