### PR TITLE
[WIP] PR: Add editor split navigation shortcuts

### DIFF
--- a/spyder/config/main.py
+++ b/spyder/config/main.py
@@ -558,6 +558,10 @@ DEFAULTS = [
               'editor/fold or unfold current region': 'Ctrl+H',
               'editor/fold all regions': 'Ctrl+J',
               'editor/unfold all regions': 'Ctrl+K',
+              'editor/move to editor stack left': 'Ctrl+Alt+Left',
+              'editor/move to editor stack right': 'Ctrl+Alt+Right',
+              'editor/move to editor stack up': 'Ctrl+Alt+Up',
+              'editor/move to editor stack down': 'Ctrl+Alt+Down',
               # -- Internal console --
               'internal_console/inspect current object': "Ctrl+I",
               'internal_console/clear shell': "Ctrl+L",

--- a/spyder/plugins/editor/api/actions.py
+++ b/spyder/plugins/editor/api/actions.py
@@ -60,3 +60,8 @@ class EditorWidgetActions:
     Unindent = "unindent_action"
     TransformToUppercase = "transform to uppercase"
     TransformToLowercase = "transform to lowercase"
+
+    MoveToEditorStackLeft = "Move to editor stack left"
+    MoveToEditorStackRight = "Move to editor stack right"
+    MoveToEditorStackUp = "Move to editor stack up"
+    MoveToEditorStackDown = "Move to editor stack down"

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -277,6 +277,8 @@ class CodeEditor(
     # Used to signal that a text deletion was triggered
     sig_delete_requested = Signal()
 
+    sig_move_to_editorstack = Signal(str)
+
     def __init__(
         self,
         parent: QWidget | None = None,
@@ -705,7 +707,12 @@ class CodeEditor(
                 self.collapse_expand_current_region,
             ),
             ('fold all regions', self.collapse_all),
-            ('unfold all regions', self.expand_all)
+            ('unfold all regions', self.expand_all),
+            ('move to editor stack left', lambda: self.sig_move_to_editorstack.emit('left')),
+            ('move to editor stack right', lambda: self.sig_move_to_editorstack.emit('right')),
+            ('move to editor stack up', lambda: self.sig_move_to_editorstack.emit('up')),
+            ('move to editor stack down', lambda: self.sig_move_to_editorstack.emit('down'))
+
         )
 
         for name, callback in shortcuts:

--- a/spyder/plugins/editor/widgets/editorstack/editorstack.py
+++ b/spyder/plugins/editor/widgets/editorstack/editorstack.py
@@ -217,6 +217,7 @@ class EditorStack(SpyderWidgetMixin, QWidget):
     --------
     :py:meth:spyder.plugins.editor.widgets.editorstack.EditorStack.send_to_help
     """
+    sig_move_to_editorstack = Signal(str)
 
     def __init__(self, parent, actions, use_switcher=True):
         QWidget.__init__(self, parent)
@@ -2665,6 +2666,9 @@ class EditorStack(SpyderWidgetMixin, QWidget):
             self.sig_update_code_analysis_actions)
         editor.sig_refresh_formatting.connect(self.refresh_formatting)
         editor.sig_save_requested.connect(self.save)
+        editor.sig_move_to_editorstack.connect(
+            self.sig_move_to_editorstack
+        )
         language = get_file_language(fname, txt)
         editor.setup_editor(
             linenumbers=self.linenumbers_enabled,

--- a/spyder/plugins/editor/widgets/main_widget.py
+++ b/spyder/plugins/editor/widgets/main_widget.py
@@ -515,9 +515,38 @@ class EditorMainWidget(PluginMainWidget):
             text=_("Next cursor position"),
             icon=self.create_icon('next_cursor'),
             tip=_("Go to next cursor position"),
-            triggered=self.go_to_next_cursor_position,
+            triggered=lambda: print("============================ACTION FIRED======================================"),
             context=Qt.WidgetShortcut,
             register_shortcut=True
+        )
+
+        self.move_to_editorstack_left_action = self.create_action(
+            EditorWidgetActions.MoveToEditorStackLeft,
+            text=_("Move to editor stack left"),
+            triggered=lambda: logger.debug("============================ACTION FIRED======================================"),
+            register_shortcut=True,
+        )
+
+        self.move_to_editorstack_right_action = self.create_action(
+            EditorWidgetActions.MoveToEditorStackRight,
+            text=_("Move to editor stack right"),
+            triggered=lambda: self.move_to_editorstack("right"),
+            register_shortcut=True,
+        )
+
+        self.move_to_editorstack_up_action = self.create_action(
+            EditorWidgetActions.MoveToEditorStackUp,
+            text=_("Move to editor stack up"),
+            triggered=lambda: self.move_to_editorstack("up"),
+            register_shortcut=True,
+        )
+
+        self.move_to_editorstack_down_action = self.create_action(
+            EditorWidgetActions.MoveToEditorStackDown,
+            text=_("Move to editor stack down"),
+            triggered=lambda: self.move_to_editorstack("down"),
+            context=Qt.WidgetShortcut,
+            register_shortcut=True,
         )
 
         # EOL menu
@@ -1558,6 +1587,29 @@ class EditorMainWidget(PluginMainWidget):
 
     # ---- Accessors
     # -------------------------------------------------------------------------
+    def move_to_editorstack(self, direction):
+        """Move focus to the EditorStack in the given direction."""
+        current_editorstack = self.get_current_editorstack()
+
+        logger.debug(">>>>>>>>>CURRENT EDITORSTACK", current_editorstack)
+
+        for i, stack in enumerate(self.editorstacks):
+            print(i, stack, stack is current_editorstack)
+
+        if current_editorstack is None:
+            return
+
+        splitter = self.editorsplitter
+        target = splitter.get_editorstack_in_direction(
+            current_editorstack,
+            direction
+        )
+        logger.debug(">>>>>>>>>TARGET", target)
+        logger.debug(">>>>>>>>>DIRECTION", direction)
+
+        if target is not None:
+            target.setFocus()
+
     def get_filenames(self):
         return [finfo.filename for finfo in self.editorstacks[0].data]
 

--- a/spyder/plugins/editor/widgets/splitter.py
+++ b/spyder/plugins/editor/widgets/splitter.py
@@ -16,7 +16,7 @@ import logging
 
 # Third party imports
 import qstylizer.style
-from qtpy.QtCore import QByteArray, Qt, Slot
+from qtpy.QtCore import QByteArray, Qt, Signal, Slot
 from qtpy.QtWidgets import QSplitter
 
 # Local imports
@@ -34,6 +34,8 @@ class EditorSplitter(SpyderWidgetMixin, QSplitter):
     """QSplitter for editor windows."""
 
     CONF_SECTION = "editor"
+
+    sig_move_to_editorstack = Signal(object, str)
 
     def __init__(self, parent, main_widget, menu_actions, first=False,
                  register_editorstack_cb=None, unregister_editorstack_cb=None,
@@ -77,6 +79,12 @@ class EditorSplitter(SpyderWidgetMixin, QSplitter):
         self.menu_actions = menu_actions
         self.editorstack = EditorStack(self, menu_actions, use_switcher)
         self.register_editorstack_cb(self.editorstack)
+
+        if first:
+            self.sig_move_to_editorstack.connect(
+                self.move_to_editorstack
+                )
+
         if not first:
             self.main_widget.clone_editorstack(editorstack=self.editorstack)
         self.editorstack.destroyed.connect(self.editorstack_closed)
@@ -84,6 +92,12 @@ class EditorSplitter(SpyderWidgetMixin, QSplitter):
             lambda: self.split(orientation=Qt.Vertical))
         self.editorstack.sig_split_horizontally.connect(
             lambda: self.split(orientation=Qt.Horizontal))
+        self.editorstack.sig_move_to_editorstack.connect(
+            lambda direction: self.sig_move_to_editorstack.emit(
+                self.editorstack,
+                direction,
+            )
+        )
         self.addWidget(self.editorstack)
 
         if not running_under_pytest():
@@ -163,6 +177,9 @@ class EditorSplitter(SpyderWidgetMixin, QSplitter):
             self.menu_actions,
             register_editorstack_cb=self.register_editorstack_cb,
             unregister_editorstack_cb=self.unregister_editorstack_cb
+        )
+        editorsplitter.sig_move_to_editorstack.connect(
+            self.sig_move_to_editorstack
         )
         self.addWidget(editorsplitter)
         editorsplitter.destroyed.connect(self.editorsplitter_closed)
@@ -277,6 +294,50 @@ class EditorSplitter(SpyderWidgetMixin, QSplitter):
         if editor is not None:
             editor.clearFocus()
             editor.setFocus()
+
+    def move_to_editorstack(self, editorstack, direction):
+        target = self.get_editorstack_in_direction(
+            editorstack,
+            direction,
+        )
+
+        if target is not None:
+            editor = target.get_current_editor()
+            if editor is not None:
+                editor.setFocus()
+
+    def get_editorstack_in_direction(self, editorstack, direction):
+        """Return the closest EditorStack in the given direction."""
+        editorstacks = [stack for stack, _ in self.iter_editorstacks()]
+    
+        if editorstack not in editorstacks:
+            return None
+    
+        current = editorstack.mapToGlobal(editorstack.rect().center())
+    
+        candidates = []
+    
+        for stack in editorstacks:
+            if stack is editorstack:
+                continue
+            
+            center = stack.mapToGlobal(stack.rect().center())
+            dx = center.x() - current.x()
+            dy = center.y() - current.y()
+    
+            if direction == 'left' and dx < 0:
+                candidates.append((abs(dx), abs(dy), stack))
+            elif direction == 'right' and dx > 0:
+                candidates.append((abs(dx), abs(dy), stack))
+            elif direction == 'up' and dy < 0:
+                candidates.append((abs(dy), abs(dx), stack))
+            elif direction == 'down' and dy > 0:
+                candidates.append((abs(dy), abs(dx), stack))
+    
+        if not candidates:
+            return None
+    
+        return min(candidates, key=lambda item: (item[0], item[1]))[2]
 
     @property
     def _stylesheet(self):


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


<!--- Explain what you've done and why --->

This PR adds keyboard shortcuts to navigate between split Editor panels.

The new shortcuts allow moving to the Editor panel on the left, right, above, or below the current panel. Navigation is handled through the existing `CodeEditor` → `EditorStack` → `EditorSplitter` signal flow, so the shortcuts work across nested split configurations.

The destination panel is determined based on its position relative to the current Editor panel.


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #10877


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
@jsbautista 
<!--- Thanks for your help making Spyder better for everyone! --->
