### PR TITLE
PR: Support Matplotlib automatic backend detection for Qt6 and enable two tests for it (IPython console) 

### DIFF
--- a/external-deps/spyder-kernels/.gitrepo
+++ b/external-deps/spyder-kernels/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/spyder-ide/spyder-kernels.git
 	branch = master
-	commit = 5533f2937265e0b41021fb50891cb8f282f10ff0
-	parent = 5bd1e322bc926cd5590a839e560359683f41db64
+	commit = a155e21b5acc49299b98ebe04f6d90924d9d9dd2
+	parent = cfb6e22dd9a96955b8ce7667e484fe5c810c7d99
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/spyder-kernels/spyder_kernels/utils/mpl.py
+++ b/external-deps/spyder-kernels/spyder_kernels/utils/mpl.py
@@ -31,10 +31,13 @@ MPL_BACKENDS_TO_SPYDER = {
 
 def automatic_backend():
     """Get Matplolib automatic backend option."""
-    if is_module_installed('PyQt5'):
-        auto_backend = 'qt'
-    elif is_module_installed('_tkinter'):
-        auto_backend = 'tk'
+    for qt_binding in ('PyQt6', 'PySide6', 'PyQt5', 'PySide2'):
+        if is_module_installed(qt_binding):
+            auto_backend = 'qt'
+            break
     else:
-        auto_backend = 'inline'
+        if is_module_installed('_tkinter'):
+            auto_backend = 'tk'
+        else:
+            auto_backend = 'inline'
     return auto_backend

--- a/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
+++ b/spyder/plugins/ipythonconsole/tests/test_ipythonconsole.py
@@ -29,7 +29,7 @@ from flaky import flaky
 import numpy as np
 from packaging.version import parse
 import pytest
-from qtpy import PYQT6, PYSIDE6
+from qtpy import PYQT6
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QTextCursor
 from qtpy.QtWebEngineWidgets import WEBENGINE
@@ -173,7 +173,6 @@ def test_get_calltips(ipyconsole, qtbot, function, signature, documentation):
 
 @flaky(max_runs=3)
 @pytest.mark.auto_backend
-@pytest.mark.skipif(PYQT6 or PYSIDE6, reason="Fails with Qt6")
 def test_auto_backend(ipyconsole, qtbot):
     """Test that the automatic backend was set correctly."""
     # Wait until the window is fully up
@@ -2034,10 +2033,6 @@ def test_pdb_comprehension_namespace(ipyconsole, qtbot, tmpdir):
 
 @flaky(max_runs=10)
 @pytest.mark.auto_backend
-# Note: PySide6 is skipped until our Spyder-kernels copy detects it as a Qt
-# binding in automatic_backend() (otherwise the auto backend resolves to tk);
-# revisit once that change is synced here (see spyder-ide/spyder#25422).
-@pytest.mark.skipif(PYQT6 or PYSIDE6, reason="Fails with Qt6")
 def test_restart_interactive_backend(ipyconsole, qtbot):
     """
     Test that we ask for a restart or not after switching to different


### PR DESCRIPTION
## Description of Changes

- The tests were skipped because there was no support in the kernel to detect the automatic Qt backend for Qt6.
- Depends on https://github.com/spyder-ide/spyder-kernels/pull/600.

### Issue(s) Resolved

Part of #20201.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @ccordoba12 

<!--- Thanks for your help making Spyder better for everyone! --->
