### PR TITLE
PR: Use SVGs as they are when they do not have a colorizer-enabled class (Utils)

### DIFF
--- a/spyder/images/svg/maximize.svg
+++ b/spyder/images/svg/maximize.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
-    <path d="M5 3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2Zm0 2h5v2H7v3H5Zm7 0h7v14h-7zm-7 9h2v3h3v2H5Z" style="clip-rule:evenodd;fill-rule:evenodd"/>
+    <path d="M5 3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2Zm0 2h5v2H7v3H5Zm7 0h7v14h-7zm-7 9h2v3h3v2H5Z" style="clip-rule:evenodd;fill-rule:evenodd"  class="ICON_1"/>
 </svg>

--- a/spyder/utils/svg_colorizer.py
+++ b/spyder/utils/svg_colorizer.py
@@ -177,7 +177,8 @@ class SVGColorize:
                     ...
                 ]
             }
-            Returns None if there was an error
+            Returns None if there was an error, or if the SVG has no
+            theme-classed paths (so callers can render the original file).
         """
         if self.root is None:
             log.warning("No SVG data to extract paths from.")
@@ -204,33 +205,27 @@ class SVGColorize:
             # Find all path elements
             paths = self.root.xpath("//svg:path", namespaces=self.SVG_NAMESPACE)
 
-            # Default color if no match
-            default_color = theme_colors.get('ICON_1', '#FAFAFA')
-
-            # Process each path
+            # Process each path. Only theme-classed paths are colorized; if any
+            # path lacks a theme class, return None so the icon is rendered as-is.
             for path in paths:
-                # Get path data
                 path_data = path.get('d', '')
                 if not path_data:
                     continue
 
-                # Extract class to determine color
                 class_attr = path.get('class')
+                if not (class_attr and class_attr in theme_colors):
+                    return None
 
-                # Determine color based on class
-                color = default_color
-                if class_attr and class_attr in theme_colors:
-                    color = theme_colors[class_attr]
-
-                # Get all attributes except class
+                color = theme_colors[class_attr]
                 attrs = {k: v for k, v in path.items() if k != 'class'}
-
-                # Add to result
                 result['paths'].append({
                     'path_data': path_data,
                     'color': color,
                     'attrs': attrs
                 })
+
+            if not result['paths']:
+                return None
 
             return result
         except Exception as e:


### PR DESCRIPTION
## Description of Changes

`SVGColorize.extract_colored_paths` method was colorizing every SVG file it consumed, using a default color when a class for colorization was not defined. With these modifications, SVG files without a colorizing-enabled class are rendered as they are.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct: @conradolandia 
